### PR TITLE
feat(api): GraphQL parity for compare/validators, search, domains

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -142,6 +142,8 @@ import {
   loadSubnetIncidents,
   parseCompareDimensionList,
   parseCompareNetuidList,
+  parseCompareHotkeyList,
+  COMPARE_VALIDATORS_MAX,
   parseUptimeWindow,
 } from "./analytics-live.mjs";
 import { UPTIME_WINDOWS } from "../workers/config.mjs";
@@ -170,8 +172,16 @@ import {
   buildNeuronDetail,
   buildSubnetValidators,
   buildValidatorDetail,
+  composeValidatorComparison,
   overlayFeaturedValidators,
 } from "./metagraph-neurons.mjs";
+// #6989: GraphQL parity for compare/validators, search/search-index, and
+// domains/domain-summary, reusing the exact shaping functions REST + MCP
+// already call -- not a reimplementation.
+import { loadSearchList } from "./search-mcp.mjs";
+import { loadSearchIndexList } from "./search-index-mcp.mjs";
+import { buildDomainOverview, buildDomainSummary } from "./domain-summary.mjs";
+import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import { buildAlphaVolume } from "./alpha-volume.mjs";
 import { AGENT_RESOURCES_ARTIFACT } from "./agent-resources-mcp.mjs";
 import {
@@ -612,6 +622,16 @@ export const SDL = `
     evm_address(h160: String!): EvmAddressMapping
     "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
     sudo(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
+    "Place several validators side by side for a stake/delegate decision: for each hotkey, its take rate, estimated APY, nominator count, and on-chain (coldkey) identity, plus the cross-subnet stake/emission/trust aggregates that give those numbers context, in requested order. Pass an optional netuid to add each validator's membership row in that one subnet (subnet_context). Mirrors GET /api/v1/compare/validators."
+    compare_validators(hotkeys: [String!]!, netuid: Int): CompareValidators!
+    "Keyword search across the registry's subnet, surface, and provider documents, WITH the per-document token blobs. Filter with q, sort with sort/order, project with fields, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/search."
+    search(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SearchDocumentList!
+    "The slim registry search index -- the same subnet/surface/provider documents as search WITHOUT the per-document token blobs, for fast typeahead/listing. Same filter/sort/page surface as search. Mirrors GET /api/v1/search-index."
+    search_index(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SearchDocumentList!
+    "Every domain/category tag's rollup in one call: subnet_count, total_stake_tao, total_emission_share, and within-domain emission_concentration for each of the fixed 14 curated domain tags. Pure composition of the registry + live economics tier, no new capture. Mirrors GET /api/v1/domains."
+    domains: DomainOverview!
+    "One domain tag's own rollup -- subnet_count, total_stake_tao, total_emission_share, and within-domain emission_concentration across just that tag's member subnets. An unknown tag is a GraphQL error (BAD_USER_INPUT), matching the fixed 14-tag enum ?domain= already validates on /api/v1/subnets. Mirrors GET /api/v1/domains/{tag}/summary."
+    domain_summary(tag: String!): DomainSummary!
   }
 
   type SubnetList {
@@ -1822,6 +1842,63 @@ export const SDL = `
     surface_count: Int
     ok_count: Int
     avg_latency_ms: Int
+  }
+
+  "Place several validators side by side for a stake/delegate decision (#6989). Mirrors GET /api/v1/compare/validators / the compare_validators MCP tool."
+  type CompareValidators {
+    schema_version: Int!
+    netuid: Int
+    validator_count: Int!
+    validators: [ComparedValidator!]!
+  }
+
+  "One validator projected down to the decision-relevant fields compare_validators exposes -- take rate, estimated APY, nominator count, on-chain identity, and the cross-subnet stake/emission/trust aggregates that give those numbers context -- plus its membership row in the requested netuid (subnet_context), or null when it holds no permit there / no netuid was requested."
+  type ComparedValidator {
+    hotkey: String
+    coldkey: String
+    coldkey_identity: Identity
+    take: Float
+    apy_estimate: Float
+    apy_estimate_eligible_subnet_count: Int
+    nominator_count: Int
+    total_stake_tao: Float
+    total_emission_tao: Float
+    avg_validator_trust: Float
+    max_validator_trust: Float
+    subnet_count: Int
+    subnet_context: ValidatorSubnet
+  }
+
+  "Paginated envelope shared by search and search_index (#6989). documents is opaque JSON -- subnet/surface/provider rows with heterogeneous fields; search's documents additionally carry a per-document token blob that search_index's slim documents omit."
+  type SearchDocumentList {
+    generated_at: String
+    notes: JSON
+    documents: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  "Every domain/category tag's rollup in one call (#6989). Mirrors GET /api/v1/domains."
+  type DomainOverview {
+    schema_version: Int!
+    domain_count: Int!
+    domains: [DomainSummary!]!
+  }
+
+  "One domain tag's own rollup -- how many subnets carry it, how much of the network's stake/emission they collectively hold, and how concentrated that emission is across just this domain's own subnets (#6989). Mirrors GET /api/v1/domains/{tag}/summary."
+  type DomainSummary {
+    schema_version: Int!
+    domain: String!
+    subnet_count: Int!
+    netuids: [Int!]!
+    total_stake_tao: Float
+    total_emission_share: Float
+    emission_concentration: ConcentrationMetrics
   }
 
   "Append-only on-chain subnet identity timeline (#1647 / #5721). Empty entries on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/identity-history."
@@ -3460,6 +3537,11 @@ export const FIELD_COMPLEXITY = {
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
+  compare_validators: RELATIONSHIP_FIELD_COMPLEXITY,
+  search: RELATIONSHIP_FIELD_COMPLEXITY,
+  search_index: RELATIONSHIP_FIELD_COMPLEXITY,
+  domains: RELATIONSHIP_FIELD_COMPLEXITY,
+  domain_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   sudo: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5053,6 +5135,97 @@ const rootValue = {
       dimensions: parsedDimensions,
       observedAt: await loadObservedAt(context),
     });
+  },
+
+  // #6989: reuse the exact per-hotkey tryPostgresTier(METAGRAPH_NEURONS_SOURCE)
+  // ?? buildValidatorDetail([], hotkey) fallback the `validator` field above
+  // uses, then composeValidatorComparison's own projection -- the identical
+  // shaping function REST's handleCompareValidators and the compare_validators
+  // MCP tool both call, so all three surfaces never drift. parseCompareHotkeyList
+  // is the same hotkey-list contract (distinctness + SS58 + COMPARE_VALIDATORS_MAX
+  // cap) compare's own parseCompareNetuidList mirrors for netuids.
+  async compare_validators({ hotkeys, netuid }, context) {
+    const parsedHotkeys = parseCompareHotkeyList(hotkeys);
+    if (!parsedHotkeys) {
+      throw new GraphQLError(
+        `hotkeys must be a non-empty array of 1-${COMPARE_VALIDATORS_MAX} distinct valid SS58 validator addresses.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (netuid != null && (!Number.isInteger(netuid) || netuid < 0)) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Sequential, not parallel -- matches compare_validators' own fan-out
+    // pattern exactly (N individual validator-detail-shaped loads) rather than
+    // diverging into a GraphQL-only concurrency strategy.
+    const details = [];
+    for (const hotkey of parsedHotkeys) {
+      details.push(
+        (await tryPostgresTier(
+          context.env,
+          postgresTierRequest(
+            context,
+            `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+          ),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildValidatorDetail([], hotkey),
+      );
+    }
+    return composeValidatorComparison(details, { netuid: netuid ?? null });
+  },
+
+  // #6989: reuse list_search's own loader unchanged (same artifact read,
+  // filter, sort, and page logic REST and MCP already use) -- not a
+  // reimplementation. It validates its own args and throws on an invalid one --
+  // that throw (inside this async function) becomes a rejected promise, which
+  // the graphql executor surfaces as a normal GraphQL error, matching every
+  // other field's "an unsupported filter/sort is a GraphQL error, not a
+  // silently substituted default" convention (see endpoint_pools/
+  // source_snapshots above).
+  search(args, context) {
+    return loadSearchList(context, args, { readArtifact });
+  },
+
+  // #6989: search and search-index are genuinely distinct artifacts (full
+  // documents WITH per-document token blobs vs. the slim variant without),
+  // each already a separate REST route/MCP tool with its own loader -- so this
+  // is two fields, not one, mirroring how endpoint_pools/rpc_pools stayed
+  // separate fields despite sharing the PoolList shape.
+  search_index(args, context) {
+    return loadSearchIndexList(context, args, { readArtifact });
+  },
+
+  // #6989: reuse buildDomainOverview unchanged -- pure composition of the
+  // subnets index + live economics tier, the same registry+economics pattern
+  // `compare` above uses for its own inputs, feeding the identical shaping
+  // function REST's handleDomains calls.
+  async domains(_args, context) {
+    const [subnetRows, economicsRows] = await Promise.all([
+      loadRows(context, ARTIFACT.subnets, "subnets"),
+      loadEconomicsRows(context),
+    ]);
+    return buildDomainOverview(subnetRows, economicsRows);
+  },
+
+  // #6989: same subnets + live-economics inputs as `domains` above, feeding
+  // the identical buildDomainSummary shaping function REST's
+  // handleDomainSummary calls for one tag. An unknown tag is a GraphQL error,
+  // not a silently empty rollup -- matching handleDomainSummary's own 400 on
+  // an unrecognized tag against the fixed DOMAIN_TAGS enum.
+  async domain_summary({ tag }, context) {
+    if (!DOMAIN_TAGS.includes(tag)) {
+      throw new GraphQLError(
+        `Unknown domain tag "${tag}". Valid tags: ${DOMAIN_TAGS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const [subnetRows, economicsRows] = await Promise.all([
+      loadRows(context, ARTIFACT.subnets, "subnets"),
+      loadEconomicsRows(context),
+    ]);
+    return buildDomainSummary(tag, subnetRows, economicsRows);
   },
 
   async incidents({ window }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -27,6 +27,8 @@ import { CHAIN_SIGNERS_SORTS } from "../src/chain-query-loaders.mjs";
 import { CHAIN_DEREGISTRATIONS_WINDOWS } from "../src/chain-deregistrations.mjs";
 import { CHAIN_REGISTRATIONS_WINDOWS } from "../src/chain-registrations.mjs";
 import { CHAIN_AXON_REMOVALS_WINDOWS } from "../src/chain-axon-removals.mjs";
+import { COMPARE_VALIDATORS_MAX } from "../src/analytics-live.mjs";
+import { DOMAIN_TAGS } from "../src/domain-tags.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp, DAY_MS } from "../workers/config.mjs";
 import {
@@ -16086,5 +16088,407 @@ describe("graphql — chain_transfers (#6975, Postgres-tier + cold-store fallbac
       FIELD_COMPLEXITY.chain_transfers,
       FIELD_COMPLEXITY.chain_weights,
     );
+  });
+});
+
+// #6989: GraphQL parity for compare/validators, search/search-index, and
+// domains/domain-summary -- each reuses the exact shaping function REST + MCP
+// already call, not a GraphQL-only reimplementation.
+describe("graphql — compare_validators (#6989, reuse compare_validators' shared shaping)", () => {
+  const HOTKEY_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+  const HOTKEY_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+  const BASE58_SAFE =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+  function dataApiByHotkey(responses) {
+    return {
+      fetch: async (req) => {
+        const url = new URL(req.url);
+        const hotkey = decodeURIComponent(
+          url.pathname.replace("/api/v1/validators/", ""),
+        );
+        return responses[hotkey] ?? Response.json({});
+      },
+    };
+  }
+
+  test("cold store: every hotkey resolves to the same schema-stable zeroed aggregate validator() falls back to", async () => {
+    const { status, body } = await gql(
+      `{ compare_validators(hotkeys: ["${HOTKEY_A}", "${HOTKEY_B}"]) {
+          schema_version netuid validator_count
+          validators { hotkey subnet_count total_stake_tao subnet_context { netuid } }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.compare_validators.schema_version, 1);
+    assert.equal(body.data.compare_validators.netuid, null);
+    assert.equal(body.data.compare_validators.validator_count, 2);
+    assert.deepEqual(
+      body.data.compare_validators.validators.map((v) => v.hotkey),
+      [HOTKEY_A, HOTKEY_B],
+    );
+    for (const v of body.data.compare_validators.validators) {
+      assert.equal(v.subnet_count, 0);
+      assert.equal(v.total_stake_tao, 0);
+      assert.equal(v.subnet_context, null);
+    }
+  });
+
+  test("resolves Postgres-tier detail per hotkey and projects the decision-relevant fields, preserving requested order", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApiByHotkey({
+        [HOTKEY_A]: Response.json({
+          schema_version: 1,
+          hotkey: HOTKEY_A,
+          coldkey: "5ColdA",
+          coldkey_identity: { has_identity: true, name: "Alice" },
+          take: 0.1,
+          apy_estimate: 0.15,
+          apy_estimate_eligible_subnet_count: 3,
+          nominator_count: 10,
+          total_stake_tao: 5000,
+          total_emission_tao: 20,
+          avg_validator_trust: 0.8,
+          max_validator_trust: 0.9,
+          subnet_count: 2,
+          subnets: [
+            {
+              netuid: 1,
+              uid: 5,
+              stake_tao: 2000,
+              emission_tao: 10,
+              validator_trust: 0.85,
+            },
+            {
+              netuid: 3,
+              uid: 9,
+              stake_tao: 3000,
+              emission_tao: 10,
+              validator_trust: 0.75,
+            },
+          ],
+        }),
+        [HOTKEY_B]: Response.json({
+          schema_version: 1,
+          hotkey: HOTKEY_B,
+          coldkey: "5ColdB",
+          take: 0.2,
+          subnet_count: 1,
+          subnets: [{ netuid: 1, uid: 2, stake_tao: 100, emission_tao: 1 }],
+        }),
+      }),
+    };
+    const { status, body } = await gql(
+      `{ compare_validators(hotkeys: ["${HOTKEY_A}", "${HOTKEY_B}"], netuid: 1) {
+          validator_count netuid
+          validators { hotkey coldkey coldkey_identity { name } take nominator_count total_stake_tao subnet_context { netuid uid stake_tao } }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.compare_validators.netuid, 1);
+    const [a, b] = body.data.compare_validators.validators;
+    assert.equal(a.hotkey, HOTKEY_A);
+    assert.equal(a.coldkey, "5ColdA");
+    assert.equal(a.coldkey_identity.name, "Alice");
+    assert.equal(a.take, 0.1);
+    assert.equal(a.nominator_count, 10);
+    assert.equal(a.total_stake_tao, 5000);
+    assert.deepEqual(a.subnet_context, { netuid: 1, uid: 5, stake_tao: 2000 });
+    assert.equal(b.hotkey, HOTKEY_B);
+    assert.deepEqual(b.subnet_context, { netuid: 1, uid: 2, stake_tao: 100 });
+  });
+
+  test("a netuid the validator holds no permit in yields a null subnet_context, not an error", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApiByHotkey({
+        [HOTKEY_A]: Response.json({
+          schema_version: 1,
+          hotkey: HOTKEY_A,
+          subnet_count: 1,
+          subnets: [{ netuid: 1, uid: 5, stake_tao: 100, emission_tao: 1 }],
+        }),
+      }),
+    };
+    const { status, body } = await gql(
+      `{ compare_validators(hotkeys: ["${HOTKEY_A}"], netuid: 99) { validators { subnet_context { netuid } } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(
+      body.data.compare_validators.validators[0].subnet_context,
+      null,
+    );
+  });
+
+  test("an empty hotkeys array is BAD_USER_INPUT", async () => {
+    const { status, body } = await gql(
+      "{ compare_validators(hotkeys: []) { validator_count } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("a malformed (non-SS58) hotkey is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("must not be called -- validation happens first");
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ compare_validators(hotkeys: ["not-an-ss58"]) { validator_count } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("more than COMPARE_VALIDATORS_MAX distinct hotkeys is BAD_USER_INPUT", async () => {
+    const many = Array.from(
+      { length: COMPARE_VALIDATORS_MAX + 1 },
+      (_, i) => "5" + BASE58_SAFE[i % BASE58_SAFE.length].repeat(47),
+    );
+    const { status, body } = await gql(
+      `{ compare_validators(hotkeys: ${JSON.stringify(many)}) { validator_count } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("a negative netuid is BAD_USER_INPUT", async () => {
+    const { status, body } = await gql(
+      `{ compare_validators(hotkeys: ["${HOTKEY_A}"], netuid: -1) { validator_count } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("is weighted as a fan-out field like compare/validator", () => {
+    assert.equal(FIELD_COMPLEXITY.compare_validators, FIELD_COMPLEXITY.compare);
+  });
+});
+
+describe("graphql — search / search_index (#6989, reuse list_search's/list_search_index's shared loaders)", () => {
+  const SEARCH_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["full index"],
+    documents: [
+      {
+        id: "subnet-7",
+        type: "subnet",
+        netuid: 7,
+        slug: "sn-7",
+        title: "Subnet Seven",
+        tokens: ["seven", "sn"],
+      },
+      {
+        id: "surface-7-openapi",
+        type: "surface",
+        netuid: 7,
+        slug: "sn-7-openapi",
+        title: "Seven OpenAPI",
+        tokens: ["openapi", "spec"],
+      },
+      {
+        id: "provider-datura",
+        type: "provider",
+        slug: "datura",
+        title: "Datura",
+        tokens: ["datura", "gpu"],
+      },
+    ],
+  };
+  const SEARCH_INDEX_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: null,
+    documents: [
+      {
+        id: "subnet-7",
+        type: "subnet",
+        netuid: 7,
+        slug: "sn-7",
+        title: "Subnet Seven",
+      },
+      {
+        id: "provider-datura",
+        type: "provider",
+        slug: "datura",
+        title: "Datura",
+      },
+    ],
+  };
+
+  test("search filters by keyword across title/slug/tokens and paginates", async () => {
+    const env = fixtureEnv({ "/metagraph/search.json": SEARCH_BLOB });
+    const filtered = await gql(
+      '{ search(q: "seven") { documents total generated_at notes } }',
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.search.total, 2);
+    assert.deepEqual(
+      filtered.body.data.search.documents.map((d) => d.id).sort(),
+      ["subnet-7", "surface-7-openapi"],
+    );
+    assert.equal(
+      filtered.body.data.search.generated_at,
+      "2026-07-01T00:00:00.000Z",
+    );
+    assert.deepEqual(filtered.body.data.search.notes, ["full index"]);
+
+    const paged = await gql(
+      "{ search(limit: 1) { documents total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.search.documents.length, 1);
+    assert.equal(paged.body.data.search.total, 3);
+    assert.equal(paged.body.data.search.returned, 1);
+    assert.ok(paged.body.data.search.next_cursor != null);
+  });
+
+  test("search's documents keep the per-document token blob", async () => {
+    const env = fixtureEnv({ "/metagraph/search.json": SEARCH_BLOB });
+    const { body } = await gql('{ search(q: "datura") { documents } }', env);
+    assert.deepEqual(body.data.search.documents[0].tokens, ["datura", "gpu"]);
+  });
+
+  test("search accepts sort/order and surfaces an invalid sort as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({ "/metagraph/search.json": SEARCH_BLOB });
+    const sorted = await gql(
+      '{ search(sort: "slug", order: "desc") { total } }',
+      env,
+    );
+    assert.equal(sorted.status, 200);
+    assert.equal(sorted.body.data.search.total, 3);
+
+    const bad = await gql('{ search(sort: "bogus") { total } }', env);
+    assert.ok(bad.body.errors?.length);
+  });
+
+  test("search surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ search { total } }", emptyEnv);
+    assert.ok(body.errors?.length);
+  });
+
+  test("search_index reads the SLIM artifact -- a genuinely distinct document set/shape from search, not a re-filter of it", async () => {
+    const env = fixtureEnv({
+      "/metagraph/search.json": SEARCH_BLOB,
+      "/metagraph/search-index.json": SEARCH_INDEX_BLOB,
+    });
+    const { status, body } = await gql(
+      "{ search_index { documents total generated_at } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.search_index.total, 2);
+    assert.equal(body.data.search_index.documents[0].tokens, undefined);
+  });
+
+  test("search_index surfaces a cold/missing artifact as a GraphQL error", async () => {
+    const { body } = await gql("{ search_index { total } }", emptyEnv);
+    assert.ok(body.errors?.length);
+  });
+
+  test("search / search_index are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.search, 5);
+    assert.equal(FIELD_COMPLEXITY.search_index, 5);
+  });
+});
+
+describe("graphql — domains / domain_summary (#6989, reuse buildDomainOverview/buildDomainSummary)", () => {
+  const SUBNETS = [
+    { netuid: 1, categories: ["inference"], derived_categories: [] },
+    { netuid: 2, categories: [], derived_categories: ["inference", "agents"] },
+    { netuid: 3, categories: ["finance"], derived_categories: [] },
+  ];
+  const ECONOMICS = [
+    { netuid: 1, total_stake_tao: 100, emission_share: 0.4 },
+    { netuid: 2, total_stake_tao: 50, emission_share: 0.1 },
+    { netuid: 3, total_stake_tao: 25, emission_share: 0.2 },
+  ];
+  const domainEnv = () =>
+    fixtureEnv({
+      "/metagraph/subnets.json": { subnets: SUBNETS },
+      "/metagraph/economics.json": { subnets: ECONOMICS },
+    });
+
+  test("domains returns one entry per fixed domain tag, matching the taxonomy", async () => {
+    const { status, body } = await gql(
+      "{ domains { schema_version domain_count domains { domain subnet_count netuids total_stake_tao total_emission_share } } }",
+      domainEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.domains.schema_version, 1);
+    assert.equal(body.data.domains.domain_count, DOMAIN_TAGS.length);
+    assert.equal(body.data.domains.domains.length, DOMAIN_TAGS.length);
+    const inference = body.data.domains.domains.find(
+      (d) => d.domain === "inference",
+    );
+    assert.deepEqual(inference.netuids, [1, 2]);
+    assert.equal(inference.total_stake_tao, 150);
+    assert.equal(inference.total_emission_share, 0.5);
+  });
+
+  test("domain_summary returns one tag's own rollup, including within-domain emission_concentration", async () => {
+    const { status, body } = await gql(
+      '{ domain_summary(tag: "inference") { schema_version domain subnet_count netuids total_stake_tao total_emission_share emission_concentration { holders gini } } }',
+      domainEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.domain_summary.domain, "inference");
+    assert.deepEqual(body.data.domain_summary.netuids, [1, 2]);
+    assert.equal(body.data.domain_summary.emission_concentration.holders, 2);
+  });
+
+  test("a tag with zero member subnets returns a schema-stable empty rollup, never null", async () => {
+    const { status, body } = await gql(
+      '{ domain_summary(tag: "security") { subnet_count netuids total_stake_tao emission_concentration { holders } } }',
+      domainEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.domain_summary.subnet_count, 0);
+    assert.deepEqual(body.data.domain_summary.netuids, []);
+    assert.equal(body.data.domain_summary.total_stake_tao, 0);
+    assert.equal(body.data.domain_summary.emission_concentration, null);
+  });
+
+  test("an unknown domain tag is BAD_USER_INPUT, matching handleDomainSummary's 400", async () => {
+    const { status, body } = await gql(
+      '{ domain_summary(tag: "bogus") { subnet_count } }',
+      domainEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("degrades to a schema-stable empty overview when both artifacts are cold, never a GraphQL error", async () => {
+    const { status, body } = await gql(
+      "{ domains { domain_count domains { subnet_count } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.domains.domain_count, DOMAIN_TAGS.length);
+    for (const d of body.data.domains.domains) {
+      assert.equal(d.subnet_count, 0);
+    }
+  });
+
+  test("domains / domain_summary are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.domains, 5);
+    assert.equal(FIELD_COMPLEXITY.domain_summary, 5);
   });
 });


### PR DESCRIPTION
## Summary

Adds GraphQL `Query` fields for the three REST routes called out in #6989 that had MCP tools but no GraphQL parity:

- `compare_validators(hotkeys: [String!]!, netuid: Int): CompareValidators!` — mirrors `GET /api/v1/compare/validators` / the `compare_validators` MCP tool.
- `search(...)` / `search_index(...)` — mirror `GET /api/v1/search` and `GET /api/v1/search-index`.
- `domains: DomainOverview!` / `domain_summary(tag: String!): DomainSummary!` — mirror `GET /api/v1/domains` and `GET /api/v1/domains/{tag}/summary`.

Every resolver reuses the exact shaping function REST/MCP already call — nothing is reimplemented:

- `compare_validators` calls the same per-hotkey `tryPostgresTier(METAGRAPH_NEURONS_SOURCE) ?? buildValidatorDetail([], hotkey)` fallback the existing `validator` field already uses, then `composeValidatorComparison` (the identical function `handleCompareValidators` and the MCP tool call). `parseCompareHotkeyList`/`COMPARE_VALIDATORS_MAX` give it the same hotkey-list contract (distinctness + SS58 + cap) `compare`'s own `parseCompareNetuidList` gives netuids.
- `search`/`search_index` call `loadSearchList`/`loadSearchIndexList` (`src/search-mcp.mjs` / `src/search-index-mcp.mjs`) unchanged — the same loaders already backing the `list_search`/`list_search_index` MCP tools.
- `domains`/`domain_summary` call `buildDomainOverview`/`buildDomainSummary` (`src/domain-summary.mjs`) unchanged, fed by the same subnets-index + live-economics-tier composition `compare` already uses for its own inputs.

### search vs. search_index: kept as two fields, not one

Per the issue's own guidance, I checked `workers/request-handlers/analytics-routes.mjs`/`src/contracts.mjs` before deciding. `/api/v1/search` and `/api/v1/search-index` read two genuinely distinct artifacts (`search.json`, with per-document token blobs, vs. the slim `search-index.json` without them) — already two separate REST routes and two separate MCP tools (`list_search`, `list_search_index`) with independent loaders. That's a real behavioral difference, not just two paths to the same shape, so this PR keeps them as two GraphQL fields sharing one `SearchDocumentList!` envelope type — mirroring how `endpoint_pools`/`rpc_pools` stayed separate fields despite sharing a `PoolList!` shape.

### New types

- `CompareValidators` / `ComparedValidator` (the latter reuses `ValidatorSubnet` for `subnet_context` and `Identity` for `coldkey_identity`, both already in the schema).
- `SearchDocumentList` — `documents: [JSON!]!` (opaque JSON, matching this schema's existing convention for heterogeneous rows, e.g. `source_snapshots.sources: [JSON!]!`, `endpoint_incidents.incidents: [JSON!]!`).
- `DomainOverview` / `DomainSummary` (the latter reuses the existing `ConcentrationMetrics` type for `emission_concentration`, matching `computeConcentration`'s output shape exactly).

All five new fields are weighted `RELATIONSHIP_FIELD_COMPLEXITY` in `FIELD_COMPLEXITY`, matching every other fan-out field including `compare`.

## Test plan

- [x] `npx vitest run tests/graphql.test.mjs` — 728/728 passing (21 new tests added: cold-store fallback, Postgres-tier resolution + field projection, `subnet_context` presence/absence, invalid-hotkey/empty-array/over-cap/negative-netuid `BAD_USER_INPUT` errors, and `FIELD_COMPLEXITY` weight assertions for `compare_validators`; keyword filter/paginate/sort/cold-artifact-error/token-blob-presence for `search`/`search_index`; taxonomy coverage, one-tag rollup + `emission_concentration`, unknown-tag error, and cold-artifact degrade-to-empty for `domains`/`domain_summary`).
- [x] `npx eslint .` — clean (repo-wide).
- [x] `npx prettier --check .` — clean (repo-wide).
- [x] `node scripts/validate-docs.mjs` (`validate:docs`) — passed.
- [x] `node scripts/validate-contract-drift.mjs`, `node scripts/validate-api.mjs`, `node scripts/validate-mcp.mjs` — passed (no REST/MCP contract touched, GraphQL SDL is served live via introspection so there's no static schema snapshot to regenerate).
- [x] `node scripts/scan-public-safety.mjs` — passed.
- [x] Coverage: `graphql.mjs` at 100% lines / 100% functions / 99.75% branches from `graphql.test.mjs` alone; the ~0.25% branch gap is pre-existing code outside this diff (`health`/`opportunity_boards` resolvers) — every line/branch this PR actually touches is exercised.
- [x] Rebased cleanly onto current `upstream/main`.

Closes #6989
