### PR TITLE
feat(api): GraphQL parity for account relationship routes (children, parents, weight-setters, entities)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -160,6 +160,23 @@ import { buildChainYield } from "./chain-yield.mjs";
 import { loadSubnetRecycled, isU16Netuid } from "./subnet-recycled.mjs";
 import { loadSubnetBurn } from "./subnet-burn.mjs";
 import { loadAccountBalance, isFinneySs58Address } from "./account-balance.mjs";
+// #6976: GraphQL parity for the children/parents/weight-setters/entities account
+// relationship routes, reusing the same loaders/builders REST + MCP already call.
+import {
+  loadAccountChildren,
+  loadAccountParents,
+} from "./child-hotkey-delegation.mjs";
+import {
+  buildAccountWeightSetters,
+  ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+} from "./account-weight-setters.mjs";
+import {
+  ENTITY_LABELS_ARTIFACT,
+  buildAccountEntities,
+  entityLabelsIndex,
+  labelsForSs58,
+} from "./entity-labels.mjs";
 import { loadSudoKey } from "./sudo-key.mjs";
 import { loadNetworkParameters } from "./network-parameters.mjs";
 import { loadRandomnessStatus } from "./randomness.mjs";
@@ -529,6 +546,10 @@ export const SDL = `
     account_axon_removals(ss58: String!, window: String): AccountAxonRemovals!
     "One account's per-subnet StakeMoved footprint over a 7d/30d/90d window (default 30d): movement count, first/last timestamps, and the alpha price (TAO) at its most recent move per subnet, an HHI concentration of where its re-delegation churn is focused, and the dominant subnet; an address with no moves in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/stake-moves."
     account_stake_moves(ss58: String!, window: String): AccountStakeMoves!
+    "One account's (validator hotkey's) WeightsSet weight-setting footprint per subnet over a 7d/30d window (default 7d): each subnet's weight-set count with the first/last WeightsSet timestamps, plus account totals, an HHI concentration of where its weight-setting activity is focused, and the dominant subnet. An address with no weight-sets in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/weight-setters."
+    account_weight_setters(ss58: String!, window: String): AccountWeightSetters!
+    "One coldkey's community-contributed entity labels (exchange/foundation/operator/other) plus every subnet-ownership tie it has via the chain_events SubnetOwnerChanged stream (either side of an automatic conviction-contest transfer). Only tracks automatic SubnetOwnerChanged transfers, not genesis ownership -- a coldkey that has held a subnet since registration and never lost it to a challenger will not appear in ownership_ties. An address with no labels or ties resolves to a schema-stable empty card, never null. Mirrors GET /api/v1/accounts/{ss58}/entities."
+    account_entities(ss58: String!): AccountEntities!
     "One account's on-chain identity (its latest set_identity values, sanitized at serve time). has_identity is false with every field null for an account that never set one -- the common case, so this is a schema-stable card, never null and never a GraphQL error. Mirrors GET /api/v1/accounts/{ss58}/identity."
     account_identity(ss58: String!): AccountIdentity!
     "One account's on-chain identity change history, newest first -- an append-only diff-tracking timeline (name/url/github/image/discord/description/additional plus a stable hash per entry). Page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). An address with no identity-history rows resolves to a schema-stable empty timeline, never null. Mirrors GET /api/v1/accounts/{ss58}/identity-history."
@@ -607,6 +628,10 @@ export const SDL = `
     subnet_turnover(netuid: Int!, window: String): SubnetTurnover!
     "Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached, not the Postgres tier). balance_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/accounts/{ss58}/balance."
     account_balance(ss58: String!): AccountBalance
+    "Live child-hotkey delegation graph (#6723) for one Finney ss58 account -- every child hotkey it currently delegates stake-weight to, per subnet, with the proportion charged -- read directly from chain via RPC (KV-cached, not the Postgres tier). subnets is null on RPC failure, distinct from a confirmed-empty [] (the account genuinely has no children on any subnet). Companion to account_parents. Mirrors GET /api/v1/accounts/{ss58}/children."
+    account_children(ss58: String!): AccountChildren
+    "Live parent-hotkey delegation graph (#6723) for one Finney ss58 account -- every hotkey currently delegating stake-weight to it, per subnet -- read directly from chain via RPC (KV-cached, not the Postgres tier). subnets is null on RPC failure, distinct from a confirmed-empty [] (the account genuinely has no parents on any subnet). Companion to account_children. Mirrors GET /api/v1/accounts/{ss58}/parents."
+    account_parents(ss58: String!): AccountParents
     "The network's on-chain sudo (superuser) key hotkey, read live from chain via RPC (not the Postgres tier). hotkey is null on RPC failure or a renounced sudo, schema-stable, never a GraphQL error. Mirrors GET /api/v1/sudo/key."
     sudo_key: SudoKey
     "Live global Subtensor protocol/governance parameters (TaoWeight, StakeThreshold, PendingChildKeyCooldown), read directly from chain via RPC (not the Postgres tier). Each field is independently null on its own RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/network/parameters."
@@ -2598,6 +2623,48 @@ export const SDL = `
     queried_at: String!
   }
 
+  "Live child-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/children."
+  type AccountChildren {
+    schema_version: Int!
+    account: String!
+    subnets: [AccountChildSubnet!]
+    queried_at: String!
+  }
+
+  "One subnet's child-hotkey delegation entries in an account's live children graph."
+  type AccountChildSubnet {
+    netuid: Int!
+    entries: [AccountChildEntry!]!
+  }
+
+  "One child hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float."
+  type AccountChildEntry {
+    child: String!
+    proportion: String!
+    proportion_fraction: Float!
+  }
+
+  "Live parent-hotkey delegation graph (#6723) for one Finney ss58 account, read directly from chain via RPC (KV-cached). subnets is null on RPC failure, distinct from a confirmed-empty [] (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/parents."
+  type AccountParents {
+    schema_version: Int!
+    account: String!
+    subnets: [AccountParentSubnet!]
+    queried_at: String!
+  }
+
+  "One subnet's parent-hotkey delegation entries in an account's live parents graph."
+  type AccountParentSubnet {
+    netuid: Int!
+    entries: [AccountParentEntry!]!
+  }
+
+  "One parent hotkey's delegated-stake proportion on a subnet. proportion is the raw stringified u64 (0..u64::MAX represents 0..100%); proportion_fraction is the same value pre-divided to a 0..1 float."
+  type AccountParentEntry {
+    parent: String!
+    proportion: String!
+    proportion_fraction: Float!
+  }
+
   "The network's on-chain sudo (superuser) key, read live from chain via RPC. hotkey is null on RPC failure or a renounced sudo (schema-stable). Mirrors GET /api/v1/sudo/key's data envelope."
   type SudoKey {
     schema_version: Int!
@@ -3217,6 +3284,52 @@ export const SDL = `
     last_announced_at: String
   }
 
+  "One account's (validator hotkey's) WeightsSet weight-setting footprint across subnets over a 7d/30d window. Mirrors GET /api/v1/accounts/{ss58}/weight-setters."
+  type AccountWeightSetters {
+    schema_version: Int!
+    address: String!
+    window: String
+    total_weight_sets: Int!
+    subnet_count: Int!
+    "Herfindahl-Hirschman index of weight-sets across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no weight-sets."
+    concentration: Float
+    dominant_netuid: Int
+    subnets: [AccountWeightSettersSubnet!]!
+  }
+
+  "One subnet's WeightsSet activity in an account's weight-setting footprint, ranked most-active-first."
+  type AccountWeightSettersSubnet {
+    netuid: Int!
+    weight_sets: Int!
+    first_set_at: String
+    last_set_at: String
+  }
+
+  "One coldkey's community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities."
+  type AccountEntities {
+    schema_version: Int!
+    ss58: String!
+    labels: [AccountEntityLabel!]!
+    ownership_tie_count: Int!
+    ownership_ties: [AccountOwnershipTie!]!
+  }
+
+  "A community-contributed entity label for an address (exchange/foundation/operator/other)."
+  type AccountEntityLabel {
+    name: String
+    category: String
+    notes: String
+    source_urls: [String!]!
+  }
+
+  "One SubnetOwnerChanged transfer tying this coldkey to a subnet, either as the gaining or losing side, newest first."
+  type AccountOwnershipTie {
+    netuid: Int
+    role: String!
+    block_number: Int
+    observed_at: String
+  }
+
   "One account's StakeAdded/StakeRemoved staking-behavior scorecard (#5706) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/stake-flow."
   type AccountStakeFlow {
     schema_version: Int!
@@ -3578,12 +3691,16 @@ export const FIELD_COMPLEXITY = {
   account_portfolio: RELATIONSHIP_FIELD_COMPLEXITY,
   account_positions: RELATIONSHIP_FIELD_COMPLEXITY,
   account_subnets: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_entities: RELATIONSHIP_FIELD_COMPLEXITY,
   // Fans out into leaderboardProfilesProjection plus several D1 reads and the
   // economics tier -- same cost class as the other relationship fields.
   registry_leaderboards: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_recycled: LIVE_RPC_FIELD_COMPLEXITY,
   subnet_burn: LIVE_RPC_FIELD_COMPLEXITY,
   account_balance: LIVE_RPC_FIELD_COMPLEXITY,
+  account_children: LIVE_RPC_FIELD_COMPLEXITY,
+  account_parents: LIVE_RPC_FIELD_COMPLEXITY,
   sudo_key: LIVE_RPC_FIELD_COMPLEXITY,
   network_parameters: LIVE_RPC_FIELD_COMPLEXITY,
   network_randomness: LIVE_RPC_FIELD_COMPLEXITY,
@@ -6386,6 +6503,90 @@ const rootValue = {
     };
   },
 
+  async account_weight_setters({ ss58, window }, context) {
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const requestedWindow = window ?? DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW;
+    if (!Object.hasOwn(ACCOUNT_WEIGHT_SETTERS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(
+          requestedWindow,
+          ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+        ),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> { data, generatedAt }
+    // envelope handleAccountWeightSetters (makeAccountEventHandler) uses; a cold
+    // or absent tier degrades to buildAccountWeightSetters' own zeroed card.
+    const pg = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(
+        context,
+        `/api/v1/accounts/${encodeURIComponent(ss58)}/weight-setters`,
+        params,
+      ),
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    );
+    const data =
+      pg?.data ??
+      buildAccountWeightSetters([], ss58, { window: requestedWindow });
+    return {
+      schema_version: data.schema_version ?? 1,
+      address: data.address ?? ss58,
+      window: data.window ?? requestedWindow,
+      total_weight_sets: data.total_weight_sets ?? 0,
+      subnet_count: data.subnet_count ?? 0,
+      concentration: data.concentration ?? null,
+      dominant_netuid: data.dominant_netuid ?? null,
+      subnets: data.subnets || [],
+    };
+  },
+
+  async account_entities({ ss58 }, context) {
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same R2 entities.json + Postgres-tier ownership join handleAccountEntities
+    // uses (workers/request-handlers/entities.mjs): the entity-label artifact
+    // read and the SubnetOwnerChanged ownership-tie lookup are independent
+    // sources, fetched in parallel. A cold/absent Postgres tier degrades to
+    // buildAccountEntities' own zeroed card; a cold/absent R2 artifact degrades
+    // to an empty labels list.
+    const [entitiesArtifact, ownershipData] = await Promise.all([
+      readArtifact(context.env, ENTITY_LABELS_ARTIFACT),
+      tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/entities`,
+        ),
+        "METAGRAPH_SUBNET_OWNERSHIP_SOURCE",
+      ),
+    ]);
+    const data = ownershipData ?? buildAccountEntities(ss58, { entities: [] });
+    const labels = labelsForSs58(
+      entityLabelsIndex(
+        entitiesArtifact.ok ? entitiesArtifact.data?.entities : [],
+      ),
+      ss58,
+    );
+    return {
+      schema_version: data.schema_version ?? 1,
+      ss58: data.ss58 ?? ss58,
+      labels,
+      ownership_tie_count: data.ownership_tie_count ?? 0,
+      ownership_ties: data.ownership_ties || [],
+    };
+  },
+
   async account_identity({ ss58 }, context) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty card.
@@ -8235,6 +8436,34 @@ const rootValue = {
     // loadAccountBalance always sets schema_version/ss58/queried_at
     // unconditionally, so no `??` fallback is needed for those.
     return loadAccountBalance(context.env, ss58);
+  },
+
+  async account_children({ ss58 }, context) {
+    if (!isFinneySs58Address(ss58)) {
+      throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Live chain RPC, not the Postgres tier -- reuses loadAccountChildren's own
+    // KV cache/TTL, matching REST's handleAccountChildren exactly. subnets stays
+    // null on RPC failure (schema-stable), distinct from a confirmed-empty [].
+    // loadAccountChildren always sets schema_version/account/queried_at
+    // unconditionally, so no `??` fallback is needed for those.
+    return loadAccountChildren(context.env, ss58);
+  },
+
+  async account_parents({ ss58 }, context) {
+    if (!isFinneySs58Address(ss58)) {
+      throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Live chain RPC, not the Postgres tier -- reuses loadAccountParents' own
+    // KV cache/TTL, matching REST's handleAccountParents exactly. subnets stays
+    // null on RPC failure (schema-stable), distinct from a confirmed-empty [].
+    // loadAccountParents always sets schema_version/account/queried_at
+    // unconditionally, so no `??` fallback is needed for those.
+    return loadAccountParents(context.env, ss58);
   },
 
   async sudo_key(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -9052,6 +9052,427 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
   });
 });
 
+describe("graphql — account_children / account_parents (#6976, live chain RPC via child-hotkey-delegation.mjs)", () => {
+  const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+  const CHILD_SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+  function stubFetch(handler) {
+    const orig = globalThis.fetch;
+    globalThis.fetch = handler;
+    return () => {
+      globalThis.fetch = orig;
+    };
+  }
+
+  for (const [field, cacheKeyPrefix, counterpartKey] of [
+    ["account_children", "children", "child"],
+    ["account_parents", "parents", "parent"],
+  ]) {
+    function query(argsClause) {
+      return `{ ${field}${argsClause} {
+        schema_version account queried_at
+        subnets { netuid entries { ${counterpartKey} proportion proportion_fraction } }
+      } }`;
+    }
+
+    test(`${field}: an invalid ss58 is BAD_USER_INPUT and never reaches the RPC`, async () => {
+      let called = false;
+      const restore = stubFetch(async () => {
+        called = true;
+        return { ok: false };
+      });
+      try {
+        const { status, body } = await gql(query('(ss58: "not-an-address")'));
+        assert.equal(status, 200);
+        assert.equal(body.data[field], null);
+        assert.ok(
+          body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+        );
+        assert.equal(called, false);
+      } finally {
+        restore();
+      }
+    });
+
+    test(`${field}: subnets is null on an RPC failure, distinct from confirmed-empty`, async () => {
+      const restore = stubFetch(async () => ({ ok: false }));
+      try {
+        const { status, body } = await gql(query(`(ss58: "${SS58}")`));
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        assert.equal(body.data[field].subnets, null);
+      } finally {
+        restore();
+      }
+    });
+
+    test(`${field}: subnets:[] when the account genuinely has none, schema-stable`, async () => {
+      const restore = stubFetch(async (_url, init) => {
+        const parsedBody = JSON.parse(init.body);
+        if (parsedBody.method === "state_getKeysPaged") {
+          return { ok: true, json: async () => ({ result: [] }) };
+        }
+        throw new Error("should not reach state_getStorage");
+      });
+      try {
+        const { status, body } = await gql(query(`(ss58: "${SS58}")`));
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        assert.deepEqual(body.data[field].subnets, []);
+        assert.equal(body.data[field].account, SS58);
+        assert.equal(body.data[field].schema_version, 1);
+        assert.ok(body.data[field].queried_at);
+      } finally {
+        restore();
+      }
+    });
+
+    test(`${field}: happy path resolves every field from a KV-cached payload`, async () => {
+      const cached = {
+        schema_version: 1,
+        account: SS58,
+        subnets: [
+          {
+            netuid: 3,
+            entries: [
+              {
+                [counterpartKey]: CHILD_SS58,
+                proportion: "9223372036854775807",
+                proportion_fraction: 0.5,
+              },
+            ],
+          },
+        ],
+        queried_at: "2026-07-19T00:00:00.000Z",
+      };
+      const env = fixtureEnv(
+        {},
+        { kv: { [`${cacheKeyPrefix}:${SS58}`]: cached } },
+      );
+      let fetchCalled = false;
+      const restore = stubFetch(async () => {
+        fetchCalled = true;
+        return { ok: false };
+      });
+      try {
+        const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        assert.deepEqual(body.data[field], cached);
+        assert.equal(fetchCalled, false);
+      } finally {
+        restore();
+      }
+    });
+  }
+
+  test("account_children/account_parents are weighted at the live-RPC complexity", () => {
+    assert.equal(FIELD_COMPLEXITY.account_children, 10);
+    assert.equal(FIELD_COMPLEXITY.account_parents, 10);
+  });
+});
+
+describe("graphql — account_weight_setters (#6976, Postgres-tier { data, generatedAt } + zeroed-card fallback)", () => {
+  const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function query(argsClause) {
+    return `{ account_weight_setters${argsClause} {
+      schema_version address window total_weight_sets subnet_count concentration dominant_netuid
+      subnets { netuid weight_sets first_set_at last_set_at }
+    } }`;
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_weight_setters, {
+      schema_version: 1,
+      address: SS58,
+      window: "7d",
+      total_weight_sets: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves the Postgres-tier footprint for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            data: {
+              schema_version: 1,
+              address: SS58,
+              window: "30d",
+              total_weight_sets: 12,
+              subnet_count: 2,
+              concentration: 0.61,
+              dominant_netuid: 5,
+              subnets: [
+                {
+                  netuid: 5,
+                  weight_sets: 9,
+                  first_set_at: "2026-06-01T00:00:00.000Z",
+                  last_set_at: "2026-07-01T00:00:00.000Z",
+                },
+                {
+                  netuid: 11,
+                  weight_sets: 3,
+                  first_set_at: "2026-06-15T00:00:00.000Z",
+                  last_set_at: "2026-06-20T00:00:00.000Z",
+                },
+              ],
+            },
+            generatedAt: "2026-07-01T00:00:00.000Z",
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", window: "30d")`),
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.account_weight_setters;
+    assert.equal(r.window, "30d");
+    assert.equal(r.total_weight_sets, 12);
+    assert.equal(r.subnet_count, 2);
+    assert.equal(r.concentration, 0.61);
+    assert.equal(r.dominant_netuid, 5);
+    assert.equal(r.subnets[0].netuid, 5);
+    assert.equal(r.subnets[0].weight_sets, 9);
+    assert.equal(r.subnets[1].netuid, 11);
+  });
+
+  test("window is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            data: { schema_version: 1, address: SS58, subnets: [] },
+            generatedAt: null,
+          });
+        },
+      },
+    };
+    await gql(query(`(ss58: "${SS58}", window: "30d")`), env);
+    assert.equal(
+      capturedUrl.pathname,
+      `/api/v1/accounts/${SS58}/weight-setters`,
+    );
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+  });
+
+  test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_weight_setters, {
+      schema_version: 1,
+      address: SS58,
+      window: "7d",
+      total_weight_sets: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
+  });
+
+  test("a partial data envelope degrades missing fields to their defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => Response.json({ data: {}, generatedAt: null }),
+      },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_weight_setters, {
+      schema_version: 1,
+      address: SS58,
+      window: "7d",
+      total_weight_sets: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      query('(ss58: "not-a-valid-address")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", window: "99d")`),
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data, null);
+  });
+
+  test("account_weight_setters is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_weight_setters, 5);
+  });
+});
+
+describe("graphql — account_entities (#6976, R2 entity labels + Postgres-tier ownership-ties join)", () => {
+  const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+  const ENTITIES_ARTIFACT_PATH = "/metagraph/entities.json";
+
+  function query(argsClause) {
+    return `{ account_entities${argsClause} {
+      schema_version ss58 ownership_tie_count
+      labels { name category notes source_urls }
+      ownership_ties { netuid role block_number observed_at }
+    } }`;
+  }
+
+  test("cold store: no artifact, no Postgres flag resolves a schema-stable empty card, never null", async () => {
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_entities, {
+      schema_version: 1,
+      ss58: SS58,
+      ownership_tie_count: 0,
+      labels: [],
+      ownership_ties: [],
+    });
+  });
+
+  test("joins a populated entities.json artifact's labels for this ss58", async () => {
+    const env = fixtureEnv({
+      [ENTITIES_ARTIFACT_PATH]: {
+        schema_version: 1,
+        generated_at: null,
+        entities: [
+          {
+            schema_version: 1,
+            ss58: SS58,
+            name: "Example Foundation",
+            category: "foundation",
+            notes: "Verified operator",
+            source_urls: ["https://example.org/proof"],
+            review: { state: "maintainer-reviewed" },
+          },
+        ],
+      },
+    });
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_entities.labels, [
+      {
+        name: "Example Foundation",
+        category: "foundation",
+        notes: "Verified operator",
+        source_urls: ["https://example.org/proof"],
+      },
+    ]);
+  });
+
+  test("resolves ownership ties from the Postgres tier", async () => {
+    const env = {
+      METAGRAPH_SUBNET_OWNERSHIP_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            ss58: SS58,
+            labels: [],
+            ownership_tie_count: 1,
+            ownership_ties: [
+              {
+                netuid: 4,
+                role: "gained_ownership",
+                block_number: 123,
+                observed_at: "2026-07-01T00:00:00.000Z",
+              },
+            ],
+          }),
+      },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    const r = body.data.account_entities;
+    assert.equal(r.ownership_tie_count, 1);
+    assert.equal(r.ownership_ties[0].netuid, 4);
+    assert.equal(r.ownership_ties[0].role, "gained_ownership");
+    assert.equal(r.ownership_ties[0].block_number, 123);
+  });
+
+  test("a malformed Postgres-tier body degrades to a schema-stable empty ownership card", async () => {
+    const env = {
+      METAGRAPH_SUBNET_OWNERSHIP_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_entities, {
+      schema_version: 1,
+      ss58: SS58,
+      ownership_tie_count: 0,
+      labels: [],
+      ownership_ties: [],
+    });
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the artifact or Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_SUBNET_OWNERSHIP_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      query('(ss58: "not-a-valid-address")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("account_entities is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_entities, 5);
+  });
+});
+
 describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 zero card)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
   const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";


### PR DESCRIPTION
## Summary

Adds 4 new `Query` fields to `src/graphql.mjs`, giving GraphQL parity with REST/MCP for the account-relationship routes that had no GraphQL field yet. Each field reuses an existing shared loader/builder unchanged -- no reimplemented data-fetching or shaping logic.

- `account_children(ss58: String!): AccountChildren` -- live ChildKeys delegation graph via `loadAccountChildren` (`src/child-hotkey-delegation.mjs`), same live-RPC/KV-cache tier as `account_balance`. `subnets` is null on RPC failure, distinct from a confirmed-empty `[]`.
- `account_parents(ss58: String!): AccountParents` -- structurally identical, reading ParentKeys via `loadAccountParents`.
- `account_weight_setters(ss58: String!, window: String): AccountWeightSetters!` -- Postgres-tier-backed via `buildAccountWeightSetters` (`src/account-weight-setters.mjs`), following the `account_prometheus` resolver's validation/fallback pattern exactly (7d/30d windows, `{ data, generatedAt }` envelope, zeroed-card cold fallback).
- `account_entities(ss58: String!): AccountEntities!` -- joins the R2 `entities.json` community-label artifact with the Postgres-tier subnet-ownership-tie lookup, replicating `handleAccountEntities`'s exact join (`workers/request-handlers/entities.mjs`).

Each field carries a `FIELD_COMPLEXITY` entry matching its REST-tier counterpart (`LIVE_RPC_FIELD_COMPLEXITY` for children/parents, `RELATIONSHIP_FIELD_COMPLEXITY` for weight-setters/entities) and a doc comment ending `Mirrors GET /api/v1/accounts/{ss58}/...`.

## Testing

Added `tests/graphql.test.mjs` coverage for all 4 fields: invalid-ss58 → `BAD_USER_INPUT` (loader/tier never called), the schema-stable cold/no-data shape, a full happy-path resolving every field, an invalid-window case for `account_weight_setters`, and malformed-Postgres-tier-body degradation for the two Postgres-tier fields. Live-RPC fields (`account_children`/`account_parents`) are tested via a `globalThis.fetch` stub (matching `tests/child-hotkey-delegation.test.mjs`'s own convention) plus a KV-cache pre-seed for the full happy-path assertion.

- `npx eslint src/graphql.mjs tests/graphql.test.mjs` -- clean.
- `npx prettier --check src/graphql.mjs tests/graphql.test.mjs` -- clean.
- `npx vitest run tests/graphql.test.mjs` -- all passing.
- `npx vitest run --coverage tests/graphql.test.mjs` -- every `DA:`/`BRDA:` record on the changed line ranges in `src/graphql.mjs` shows a nonzero hit count (verified via `coverage/lcov.info`).
- `node scripts/scan-public-safety.mjs` -- clean.
- Full `npx vitest run` -- 335 files / 10015 tests passing (no collateral breakage).
- Rebased clean onto the current `upstream/main` tip.

Closes #6976