### PR TITLE
feat(ui): live-updating chain-events feed via chain firehose SSE

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -5,9 +5,10 @@ import { API_BASE } from "@/lib/metagraphed/config";
 import { ResetFiltersButton, SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
 import { chainEventsInfiniteQuery } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import type { ChainEvent } from "@/lib/metagraphed/types";
+import { chainStreamEventMatchesFilters, useChainStream } from "@/hooks/use-chain-stream";
 
 const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
 
@@ -48,6 +49,11 @@ interface Props {
  * pallet/method filters. Rendered both as an embedded section on /explorer and
  * as the standalone /events route, so it lives here as one shared component to
  * keep the two in sync.
+ *
+ * #7008: also listens to `GET /api/v1/chain/stream` (SSE) so matching
+ * `chain_events` frames trigger a refetch — EventSource auto-reconnects, and
+ * the existing manual/stale-refresh path remains the gap-cover when the stream
+ * is down.
  */
 export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
   const baseParams = chainEventsBaseParams(pallet, method);
@@ -64,11 +70,28 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
     refetch,
   } = useInfiniteQuery(chainEventsInfiniteQuery(baseParams, cursor));
 
+  const { status: streamStatus } = useChainStream({
+    topics: ["chain_events"],
+    matches: (payload) => chainStreamEventMatchesFilters(payload, pallet, method),
+    onEvent: () => {
+      void refetch();
+    },
+  });
+
   const pages = data?.pages ?? [];
   const lastPage = pages[pages.length - 1];
   const cursorInvalid = !!(lastPage as { cursorInvalid?: boolean } | undefined)?.cursorInvalid;
   const events = pages.flatMap((p) => (p.data ?? []) as ChainEvent[]);
   const filtersActive = !!(pallet.trim() || method.trim());
+
+  const streamLabel =
+    streamStatus === "open"
+      ? "Live"
+      : streamStatus === "connecting"
+        ? "Connecting"
+        : streamStatus === "error"
+          ? "Polling"
+          : null;
 
   const filters = (
     <>
@@ -98,6 +121,28 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
         active={filtersActive}
         onReset={() => onFilter({ pallet: "", method: "" })}
       />
+      {streamLabel ? (
+        <span
+          className={classNames(
+            "inline-flex items-center gap-1.5 rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em]",
+            streamStatus === "open"
+              ? "border-accent/40 bg-accent/10 text-accent-text"
+              : "border-border bg-surface text-ink-muted",
+          )}
+          title={
+            streamStatus === "open"
+              ? "Connected to /api/v1/chain/stream — new matching events refresh this feed"
+              : streamStatus === "error"
+                ? "Chain stream unavailable — refresh manually or wait for reconnect"
+                : "Opening /api/v1/chain/stream"
+          }
+          data-testid="chain-events-stream-status"
+          data-stream-status={streamStatus}
+        >
+          {streamStatus === "open" ? <span className="mg-live-dot" aria-hidden /> : null}
+          {streamLabel}
+        </span>
+      ) : null}
     </>
   );
 

--- a/apps/ui/src/hooks/use-chain-stream.test.ts
+++ b/apps/ui/src/hooks/use-chain-stream.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildChainStreamUrl,
+  chainStreamEventMatchesFilters,
+  createDebouncedHandler,
+  parseChainStreamPayload,
+} from "./use-chain-stream";
+
+describe("buildChainStreamUrl", () => {
+  it("targets /api/v1/chain/stream on the current API base", () => {
+    const url = buildChainStreamUrl();
+    expect(url).toContain("/api/v1/chain/stream");
+    expect(url).not.toContain("topics=");
+  });
+
+  it("appends a comma-separated topics filter and drops unknowns", () => {
+    const url = buildChainStreamUrl(["chain_events", "nope", "blocks"]);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("topics")).toBe("chain_events,blocks");
+  });
+});
+
+describe("chainStreamEventMatchesFilters", () => {
+  const row = { table: "chain_events", pallet: "Balances", method: "Deposit", block_number: 1 };
+
+  it("accepts any chain_events row when filters are empty", () => {
+    expect(chainStreamEventMatchesFilters(row, "", "")).toBe(true);
+  });
+
+  it("requires pallet (and method when set) to match", () => {
+    expect(chainStreamEventMatchesFilters(row, "Balances", "")).toBe(true);
+    expect(chainStreamEventMatchesFilters(row, "Balances", "Deposit")).toBe(true);
+    expect(chainStreamEventMatchesFilters(row, "Balances", "Transfer")).toBe(false);
+    expect(chainStreamEventMatchesFilters(row, "SubtensorModule", "")).toBe(false);
+  });
+
+  it("rejects non-chain_events tables and junk payloads", () => {
+    expect(chainStreamEventMatchesFilters({ table: "blocks", block_number: 1 }, "", "")).toBe(
+      false,
+    );
+    expect(chainStreamEventMatchesFilters(null, "", "")).toBe(false);
+    expect(chainStreamEventMatchesFilters("x", "", "")).toBe(false);
+  });
+});
+
+describe("parseChainStreamPayload", () => {
+  it("parses JSON and returns null for empty/malformed", () => {
+    expect(parseChainStreamPayload('{"table":"chain_events"}')).toEqual({
+      table: "chain_events",
+    });
+    expect(parseChainStreamPayload("")).toBeNull();
+    expect(parseChainStreamPayload("{")).toBeNull();
+    expect(parseChainStreamPayload(null)).toBeNull();
+  });
+});
+
+describe("createDebouncedHandler", () => {
+  it("coalesces rapid calls into one invocation", () => {
+    vi.useFakeTimers();
+    const run = vi.fn();
+    const debounced = createDebouncedHandler(run, 400);
+
+    debounced();
+    debounced();
+    debounced();
+    expect(run).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(400);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+});

--- a/apps/ui/src/hooks/use-chain-stream.ts
+++ b/apps/ui/src/hooks/use-chain-stream.ts
@@ -1,0 +1,192 @@
+import { useEffect, useRef, useState } from "react";
+import { applyNetworkPrefix } from "@/lib/metagraphed/client";
+import { getApiBase, onApiBaseChange, onNetworkChange } from "@/lib/metagraphed/config";
+import type { SseStatus } from "@/hooks/use-registry-events";
+
+export type { SseStatus };
+
+/** Tables the chain firehose can filter on via `?topics=` (#4980 / ADR 0015). */
+export const CHAIN_FIREHOSE_TOPICS = [
+  "blocks",
+  "extrinsics",
+  "chain_events",
+  "account_events",
+] as const;
+
+export type ChainFirehoseTopic = (typeof CHAIN_FIREHOSE_TOPICS)[number];
+
+/**
+ * Build the absolute EventSource URL for `GET /api/v1/chain/stream`, applying
+ * the selected network prefix and optional comma-separated `topics` filter
+ * (same contract as `parseChainFirehoseTopics` / `chainFirehoseMatchesTopics`
+ * in `workers/chain-firehose-hub.mjs`).
+ */
+export function buildChainStreamUrl(topics?: readonly string[]): string {
+  const base = getApiBase().replace(/\/$/, "");
+  const path = applyNetworkPrefix("/api/v1/chain/stream");
+  const url = new URL(`${base}${path}`);
+  const cleaned = (topics ?? [])
+    .map((t) => t.trim())
+    .filter((t) => (CHAIN_FIREHOSE_TOPICS as readonly string[]).includes(t));
+  if (cleaned.length > 0) url.searchParams.set("topics", cleaned.join(","));
+  return url.toString();
+}
+
+/**
+ * True when a firehose `chain` payload should refresh the filtered
+ * `/api/v1/chain-events` feed. Unfiltered feeds always match; with a pallet
+ * (and optional method) set, only matching `chain_events` rows qualify.
+ */
+export function chainStreamEventMatchesFilters(
+  payload: unknown,
+  pallet: string,
+  method: string,
+): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const row = payload as Record<string, unknown>;
+  if (row.table != null && row.table !== "chain_events") return false;
+  const p = pallet.trim();
+  const m = method.trim();
+  if (!p) return true;
+  if (String(row.pallet ?? "") !== p) return false;
+  if (m && String(row.method ?? "") !== m) return false;
+  return true;
+}
+
+/** Pure debounce helper; exported for unit tests. */
+export function createDebouncedHandler(run: () => void, waitMs: number): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return () => {
+    if (timer != null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      run();
+    }, waitMs);
+  };
+}
+
+/** Parse an SSE MessageEvent's `data` as JSON; null on empty/malformed. */
+export function parseChainStreamPayload(data: unknown): unknown | null {
+  if (typeof data !== "string" || data.length === 0) return null;
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}
+
+export interface UseChainStreamOptions {
+  /** Topic filter forwarded as `?topics=`. Defaults to `chain_events`. */
+  topics?: readonly string[];
+  /** When false, stay idle (no socket). */
+  enabled?: boolean;
+  /** Called (debounced) for each matching `event: chain` frame. */
+  onEvent?: (payload: unknown) => void;
+  /**
+   * Optional client-side filter before `onEvent`. Defaults to accepting every
+   * frame the server already topic-filtered.
+   */
+  matches?: (payload: unknown) => boolean;
+  /** Coalesce burst fanout from a busy block. Default 400ms. */
+  debounceMs?: number;
+}
+
+/**
+ * #7008: subscribe to the live chain firehose (`GET /api/v1/chain/stream`,
+ * ADR 0015) the same way `useRegistryEvents` opens `/api/v1/events`.
+ *
+ * Complementary to polling/manual refresh, not a replacement: EventSource
+ * auto-reconnects on error, and callers keep their existing refetch path as
+ * the gap-cover. Re-subscribes when the chain network or API base changes;
+ * tears down on unmount.
+ *
+ * Returns live `status` + `lastEventAt` for an optional liveness chip.
+ */
+export function useChainStream(options: UseChainStreamOptions = {}): {
+  status: SseStatus;
+  lastEventAt: string | null;
+} {
+  const { topics = ["chain_events"], enabled = true, onEvent, matches, debounceMs = 400 } = options;
+  const [status, setStatus] = useState<SseStatus>("idle");
+  const [lastEventAt, setLastEventAt] = useState<string | null>(null);
+
+  const onEventRef = useRef(onEvent);
+  const matchesRef = useRef(matches);
+  onEventRef.current = onEvent;
+  matchesRef.current = matches;
+
+  // Serialize topics for a stable effect dep without requiring callers to
+  // memoize the array literal.
+  const topicsKey = topics.join(",");
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined" || typeof EventSource === "undefined") {
+      return;
+    }
+
+    let es: EventSource | null = null;
+    let cancelled = false;
+    const set = (s: SseStatus) => {
+      if (!cancelled) setStatus(s);
+    };
+
+    const teardown = () => {
+      es?.close();
+      es = null;
+    };
+
+    const topicList = topicsKey
+      ? topicsKey.split(",").filter(Boolean)
+      : (["chain_events"] as string[]);
+
+    const connect = () => {
+      teardown();
+      set("connecting");
+      try {
+        es = new EventSource(buildChainStreamUrl(topicList));
+      } catch {
+        es = null;
+        set("error");
+        return;
+      }
+
+      let pending: unknown = null;
+      const flush = createDebouncedHandler(() => {
+        if (pending === null || cancelled) return;
+        const payload = pending;
+        pending = null;
+        onEventRef.current?.(payload);
+      }, debounceMs);
+
+      const handle = (ev: Event) => {
+        if (cancelled) return;
+        const payload = parseChainStreamPayload((ev as MessageEvent).data);
+        if (payload == null) return;
+        const match = matchesRef.current;
+        if (match && !match(payload)) return;
+        if (!cancelled) setLastEventAt(new Date().toISOString());
+        pending = payload;
+        flush();
+      };
+
+      es.addEventListener("chain", handle);
+      // Some proxies strip named SSE events into unnamed `message` frames.
+      es.onmessage = handle;
+      es.addEventListener("open", () => set("open"));
+      // onerror: EventSource auto-reconnects; polling/manual refresh covers the gap.
+      es.addEventListener("error", () => set("error"));
+    };
+
+    connect();
+    const offNetwork = onNetworkChange(connect);
+    const offApiBase = onApiBaseChange(connect);
+    return () => {
+      cancelled = true;
+      offNetwork();
+      offApiBase();
+      teardown();
+    };
+  }, [enabled, topicsKey, debounceMs]);
+
+  return { status, lastEventAt };
+}

--- a/apps/ui/src/routes/events.index.tsx
+++ b/apps/ui/src/routes/events.index.tsx
@@ -70,7 +70,9 @@ function EventsPage() {
         cursor={search.cursor}
         onFilter={onFilter}
       />
-      <ApiSourceFooter paths={["/api/v1/chain-events", "/api/v1/chain-events/stats"]} />
+      <ApiSourceFooter
+        paths={["/api/v1/chain-events", "/api/v1/chain-events/stats", "/api/v1/chain/stream"]}
+      />
     </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `useChainStream` (mirroring `useRegistryEvents`) against `GET /api/v1/chain/stream`, with optional `topics` filter matching the firehose hub contract.
- Wires it into `ChainEventsFeed` so matching `chain_events` frames debounced-refetch the infinite query; EventSource reconnect + existing manual/stale refresh remain the fallback when the stream is down.
- Surfaces a compact Live / Connecting / Polling status chip in the feed filter bar, and lists `/api/v1/chain/stream` on the `/events` API footer.

Closes #7008

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-desktop-light.png)<br><sub>after — Live chip</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-desktop-dark.png)<br><sub>after — Live chip</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7008-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan
- [x] Unit tests for `use-chain-stream` helpers + existing `chain-events-feed` param tests
- [x] `prettier` / `eslint` on touched files; `npm run typecheck --workspace=apps/ui`; `vite build`
- [ ] CI `ui` job green
- [ ] Manual: open `/events`, confirm Live chip when stream is up; disconnect/block stream and confirm Polling chip + manual refresh still works; filtered pallet/method only refetch on matching frames
