### PR TITLE
feat(ui): surface all 10 registry leaderboards on /leaderboards (#6995)

### DIFF
--- a/apps/ui/src/components/metagraphed/leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards.tsx
@@ -1,79 +1,65 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { leaderboardsQuery } from "@/lib/metagraphed/queries";
+import {
+  ECONOMIC_BOARD_KEYS,
+  OPERATIONAL_BOARD_KEYS,
+  REGISTRY_BOARD_SPECS,
+} from "@/lib/metagraphed/registry-leaderboard-boards";
 import { BrandIcon } from "@jsonbored/ui-kit";
 import type { LeaderboardBoardKey, LeaderboardRow } from "@/lib/metagraphed/types";
 
-// #1111: surface the five live, D1-computed registry leaderboards
-// (/api/v1/registry/leaderboards) as a homepage discovery module. Each board's
-// ranked rows link straight to the subnet detail page. Self-contained: the whole
-// section hides on error/empty so a discovery extra never breaks the homepage.
+// #1111 / #6995: surface live registry leaderboards (/api/v1/registry/leaderboards)
+// as a homepage discovery module. Economic opportunity boards are listed first;
+// operational boards follow. Self-contained: the whole section hides on
+// error/empty so a discovery extra never breaks the homepage.
 
 const ROWS_PER_BOARD = 5;
 
-const BOARDS: Array<{
-  key: LeaderboardBoardKey;
-  label: string;
-  metric: (row: LeaderboardRow) => string | null;
-}> = [
-  {
-    key: "healthiest",
-    label: "Healthiest",
-    metric: (r) => (r.uptime_ratio != null ? `${Math.round(r.uptime_ratio * 100)}% up` : null),
-  },
-  {
-    key: "fastest-rpc",
-    label: "Fastest RPC",
-    metric: (r) => (r.latency_ms != null ? `${Math.round(r.latency_ms)}ms` : null),
-  },
-  {
-    key: "most-complete",
-    label: "Most complete",
-    metric: (r) => (r.completeness_score != null ? `${Math.round(r.completeness_score)}%` : null),
-  },
-  {
-    key: "most-enriched",
-    label: "Most enriched",
-    metric: (r) =>
-      r.surface_count != null
-        ? `${r.surface_count} surface${r.surface_count === 1 ? "" : "s"}`
-        : null,
-  },
-  {
-    key: "fastest-growing",
-    label: "Fastest growing",
-    metric: (r) =>
-      r.completeness_delta != null ? `+${Math.round(r.completeness_delta)} pts` : null,
-  },
+const HOMEPAGE_BOARD_KEYS: LeaderboardBoardKey[] = [
+  ...ECONOMIC_BOARD_KEYS,
+  ...OPERATIONAL_BOARD_KEYS,
 ];
 
 export function LeaderboardsModule() {
   const { data: res, isError } = useQuery(leaderboardsQuery());
   const boards = res?.data;
 
-  // Discovery extra — never break the homepage. Hide entirely on error, and until
-  // at least one board has rows to show.
   if (isError || !boards) return null;
-  const populated = BOARDS.map((board) => ({
-    ...board,
-    rows: (boards[board.key] ?? []).slice(0, ROWS_PER_BOARD),
-  })).filter((board) => board.rows.length > 0);
+  const populated = HOMEPAGE_BOARD_KEYS.map((key) => {
+    const spec = REGISTRY_BOARD_SPECS[key];
+    return {
+      key,
+      label: spec.label,
+      metric: spec.primaryMetric,
+      rows: (boards[key] ?? []).slice(0, ROWS_PER_BOARD),
+    };
+  }).filter((board) => board.rows.length > 0);
   if (populated.length === 0) return null;
 
   return (
     <section className="mt-section-gap">
-      <div className="mb-8 max-w-2xl">
-        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted inline-flex items-center gap-2">
-          <span className="mg-live-dot" />
-          Discover
+      <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+        <div className="max-w-2xl">
+          <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted inline-flex items-center gap-2">
+            <span className="mg-live-dot" />
+            Discover
+          </div>
+          <h2 className="mt-2 font-display text-2xl md:text-3xl font-semibold tracking-tight text-ink-strong">
+            Top subnets, ranked live.
+          </h2>
+          <p className="mt-2 text-sm text-ink-muted leading-relaxed">
+            Registry leaderboards from live data — open slots, registration cost, emission share,
+            validator headroom, uptime, completeness, and more.
+          </p>
         </div>
-        <h2 className="mt-2 font-display text-2xl md:text-3xl font-semibold tracking-tight text-ink-strong">
-          Top subnets, ranked live.
-        </h2>
-        <p className="mt-2 text-sm text-ink-muted leading-relaxed">
-          Five leaderboards computed from live registry data — by uptime, RPC latency, interface
-          completeness, surface coverage, and recent growth.
-        </p>
+        <Link
+          to="/leaderboards"
+          search={{ view: "opportunity", window: "7d" }}
+          className="font-mono text-[11px] uppercase tracking-[0.18em] text-accent-text hover:underline"
+        >
+          View all leaderboards
+        </Link>
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {populated.map((board) => (

--- a/apps/ui/src/lib/metagraphed/queries.registry-leaderboards.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.registry-leaderboards.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  ECONOMIC_BOARD_KEYS,
+  OPERATIONAL_BOARD_KEYS,
+  REGISTRY_BOARD_SPECS,
+} from "./registry-leaderboard-boards";
+import { LEADERBOARD_BOARD_KEYS, normalizeLeaderboards } from "./queries";
+
+describe("normalizeLeaderboards (#6995)", () => {
+  it("keeps all ten registry board keys, including economic opportunity", () => {
+    expect(LEADERBOARD_BOARD_KEYS).toEqual([
+      "healthiest",
+      "fastest-rpc",
+      "most-complete",
+      "most-enriched",
+      "fastest-growing",
+      "most-reliable",
+      "open-slots",
+      "cheapest-registration",
+      "highest-emission",
+      "validator-headroom",
+    ]);
+    expect([...ECONOMIC_BOARD_KEYS, ...OPERATIONAL_BOARD_KEYS].sort()).toEqual(
+      [...LEADERBOARD_BOARD_KEYS].sort(),
+    );
+  });
+
+  it("normalizes economic + reliability fields and defaults missing boards to []", () => {
+    const boards = normalizeLeaderboards({
+      "open-slots": [
+        {
+          netuid: 10,
+          slug: "ten",
+          name: "Ten",
+          open_slots: 200,
+          max_uids: 256,
+          registration_cost_tao: 0.5,
+          registration_allowed: true,
+        },
+      ],
+      "most-reliable": [
+        {
+          netuid: 7,
+          score: 98,
+          grade: "A",
+          uptime_ratio: 0.99,
+          avg_latency_ms: 40,
+          sample_count: 100,
+          latency_sample_count: 80,
+        },
+      ],
+      "highest-emission": "not-an-array",
+    });
+
+    expect(boards["open-slots"]).toHaveLength(1);
+    expect(boards["open-slots"][0]).toMatchObject({
+      netuid: 10,
+      slug: "ten",
+      name: "Ten",
+      open_slots: 200,
+      max_uids: 256,
+      registration_cost_tao: 0.5,
+      registration_allowed: true,
+    });
+    expect(boards["most-reliable"][0]).toMatchObject({
+      netuid: 7,
+      score: 98,
+      grade: "A",
+      uptime_ratio: 0.99,
+      avg_latency_ms: 40,
+      sample_count: 100,
+      latency_sample_count: 80,
+    });
+    expect(boards["highest-emission"]).toEqual([]);
+    expect(boards.healthiest).toEqual([]);
+    expect(boards["validator-headroom"]).toEqual([]);
+  });
+
+  it("drops rows without a numeric netuid", () => {
+    const boards = normalizeLeaderboards({
+      "cheapest-registration": [{ slug: "bad" }, { netuid: 3, registration_cost_tao: 1 }],
+    });
+    expect(boards["cheapest-registration"]).toHaveLength(1);
+    expect(boards["cheapest-registration"][0].netuid).toBe(3);
+  });
+});
+
+describe("REGISTRY_BOARD_SPECS (#6995)", () => {
+  it("defines labels and columns for every board key", () => {
+    for (const key of LEADERBOARD_BOARD_KEYS) {
+      const spec = REGISTRY_BOARD_SPECS[key];
+      expect(spec.key).toBe(key);
+      expect(spec.label.length).toBeGreaterThan(0);
+      expect(spec.columns.length).toBeGreaterThan(0);
+      expect(spec.primaryMetric({ netuid: 1 })).toBeNull();
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -758,12 +758,18 @@ export const economicsQuery = () =>
     staleTime: STALE_MED,
   });
 
-const LEADERBOARD_BOARD_KEYS: LeaderboardBoardKey[] = [
+/** Canonical order matching `LEADERBOARD_BOARDS` in src/health-serving.mjs (#6995). */
+export const LEADERBOARD_BOARD_KEYS: LeaderboardBoardKey[] = [
   "healthiest",
   "fastest-rpc",
   "most-complete",
   "most-enriched",
   "fastest-growing",
+  "most-reliable",
+  "open-slots",
+  "cheapest-registration",
+  "highest-emission",
+  "validator-headroom",
 ];
 
 function normalizeLeaderboardRow(raw: unknown): LeaderboardRow | null {
@@ -772,6 +778,7 @@ function normalizeLeaderboardRow(raw: unknown): LeaderboardRow | null {
   if (typeof r.netuid !== "number") return null;
   const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
   const str = (v: unknown) => (typeof v === "string" ? v : undefined);
+  const bool = (v: unknown) => (typeof v === "boolean" ? v : undefined);
   return {
     netuid: r.netuid,
     slug: str(r.slug),
@@ -785,10 +792,25 @@ function normalizeLeaderboardRow(raw: unknown): LeaderboardRow | null {
     surface_count: num(r.surface_count),
     operational_interface_count: num(r.operational_interface_count),
     completeness_delta: num(r.completeness_delta),
+    score: num(r.score),
+    grade: str(r.grade),
+    sample_count: num(r.sample_count),
+    latency_sample_count: num(r.latency_sample_count),
+    open_slots: num(r.open_slots),
+    max_uids: num(r.max_uids),
+    registration_cost_tao: num(r.registration_cost_tao),
+    registration_allowed: bool(r.registration_allowed),
+    emission_share: num(r.emission_share),
+    total_stake_tao: num(r.total_stake_tao),
+    validator_count: num(r.validator_count),
+    miner_count: num(r.miner_count),
+    validator_headroom: num(r.validator_headroom),
+    max_validators: num(r.max_validators),
   };
 }
 
-function normalizeLeaderboards(raw: unknown): Leaderboards {
+/** Normalize the `boards` object from GET /api/v1/registry/leaderboards. */
+export function normalizeLeaderboards(raw: unknown): Leaderboards {
   const boards = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
   const out = {} as Leaderboards;
   for (const key of LEADERBOARD_BOARD_KEYS) {
@@ -800,9 +822,9 @@ function normalizeLeaderboards(raw: unknown): Leaderboards {
   return out;
 }
 
-// #1111: registry leaderboards — five live, D1-computed boards (healthiest,
-// fastest-rpc, most-complete, most-enriched, fastest-growing). One artifact carries
-// all boards; the homepage discovery module renders the top rows of each.
+// #1111 / #6995: registry leaderboards — ten boards (6 operational + 4 economic).
+// One artifact carries all boards; the homepage module and /leaderboards page
+// each render ranked rows from the same normalized payload.
 function normalizeSubnetMover(raw: unknown): SubnetMover | null {
   if (!isRecord(raw)) return null;
   const netuid = coerceFiniteNumber(raw.netuid);

--- a/apps/ui/src/lib/metagraphed/registry-leaderboard-boards.ts
+++ b/apps/ui/src/lib/metagraphed/registry-leaderboard-boards.ts
@@ -1,0 +1,293 @@
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import type { LeaderboardBoardKey, LeaderboardRow } from "@/lib/metagraphed/types";
+
+/** Economic opportunity boards (miners / validators) — prominent on /leaderboards (#6995). */
+export const ECONOMIC_BOARD_KEYS = [
+  "open-slots",
+  "cheapest-registration",
+  "highest-emission",
+  "validator-headroom",
+] as const satisfies readonly LeaderboardBoardKey[];
+
+/** Operational / registry-profile boards. */
+export const OPERATIONAL_BOARD_KEYS = [
+  "healthiest",
+  "fastest-rpc",
+  "most-complete",
+  "most-enriched",
+  "fastest-growing",
+  "most-reliable",
+] as const satisfies readonly LeaderboardBoardKey[];
+
+export type RegistryBoardColumn = {
+  key: string;
+  label: string;
+  align?: "left" | "right";
+  format: (row: LeaderboardRow) => string;
+};
+
+export type RegistryBoardSpec = {
+  key: LeaderboardBoardKey;
+  label: string;
+  description: string;
+  /** Compact homepage / card metric. */
+  primaryMetric: (row: LeaderboardRow) => string | null;
+  columns: RegistryBoardColumn[];
+};
+
+function pct01(v: number | undefined, digits = 1): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${(v * 100).toFixed(digits)}%`;
+}
+
+function ms(v: number | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${Math.round(v)} ms`;
+}
+
+export const REGISTRY_BOARD_SPECS: Record<LeaderboardBoardKey, RegistryBoardSpec> = {
+  healthiest: {
+    key: "healthiest",
+    label: "Healthiest",
+    description: "Subnets ranked by live surface uptime, then average latency.",
+    primaryMetric: (r) =>
+      r.uptime_ratio != null ? `${Math.round(r.uptime_ratio * 100)}% up` : null,
+    columns: [
+      {
+        key: "uptime",
+        label: "Uptime",
+        align: "right",
+        format: (r) => pct01(r.uptime_ratio, 0),
+      },
+      {
+        key: "surfaces",
+        label: "Surfaces OK",
+        align: "right",
+        format: (r) =>
+          r.surfaces_ok != null && r.surfaces_total != null
+            ? `${formatNumber(r.surfaces_ok)}/${formatNumber(r.surfaces_total)}`
+            : "—",
+      },
+      {
+        key: "latency",
+        label: "Avg latency",
+        align: "right",
+        format: (r) => ms(r.avg_latency_ms),
+      },
+    ],
+  },
+  "fastest-rpc": {
+    key: "fastest-rpc",
+    label: "Fastest RPC",
+    description: "Subnets with the lowest observed RPC probe latency.",
+    primaryMetric: (r) => (r.latency_ms != null ? `${Math.round(r.latency_ms)}ms` : null),
+    columns: [
+      {
+        key: "latency",
+        label: "Latency",
+        align: "right",
+        format: (r) => ms(r.latency_ms),
+      },
+    ],
+  },
+  "most-complete": {
+    key: "most-complete",
+    label: "Most complete",
+    description: "Subnets ranked by registry profile completeness score.",
+    primaryMetric: (r) =>
+      r.completeness_score != null ? `${Math.round(r.completeness_score)}%` : null,
+    columns: [
+      {
+        key: "completeness",
+        label: "Completeness",
+        align: "right",
+        format: (r) =>
+          r.completeness_score != null ? `${Math.round(r.completeness_score)}%` : "—",
+      },
+    ],
+  },
+  "most-enriched": {
+    key: "most-enriched",
+    label: "Most enriched",
+    description: "Subnets ranked by curated surface count, then operational interfaces.",
+    primaryMetric: (r) =>
+      r.surface_count != null
+        ? `${r.surface_count} surface${r.surface_count === 1 ? "" : "s"}`
+        : null,
+    columns: [
+      {
+        key: "surfaces",
+        label: "Surfaces",
+        align: "right",
+        format: (r) => (r.surface_count != null ? formatNumber(r.surface_count) : "—"),
+      },
+      {
+        key: "operational",
+        label: "Operational",
+        align: "right",
+        format: (r) =>
+          r.operational_interface_count != null ? formatNumber(r.operational_interface_count) : "—",
+      },
+    ],
+  },
+  "fastest-growing": {
+    key: "fastest-growing",
+    label: "Fastest growing",
+    description: "Subnets with the largest recent completeness gains.",
+    primaryMetric: (r) =>
+      r.completeness_delta != null ? `+${Math.round(r.completeness_delta)} pts` : null,
+    columns: [
+      {
+        key: "delta",
+        label: "Δ Completeness",
+        align: "right",
+        format: (r) =>
+          r.completeness_delta != null ? `+${Math.round(r.completeness_delta)}` : "—",
+      },
+    ],
+  },
+  "most-reliable": {
+    key: "most-reliable",
+    label: "Most reliable",
+    description: "Windowed reliability score (uptime minus latency penalty), graded A–F.",
+    primaryMetric: (r) =>
+      r.score != null ? `${Math.round(r.score)}${r.grade ? ` (${r.grade})` : ""}` : null,
+    columns: [
+      {
+        key: "score",
+        label: "Score",
+        align: "right",
+        format: (r) => (r.score != null ? formatNumber(r.score) : "—"),
+      },
+      {
+        key: "grade",
+        label: "Grade",
+        align: "right",
+        format: (r) => r.grade ?? "—",
+      },
+      {
+        key: "uptime",
+        label: "Uptime",
+        align: "right",
+        format: (r) => pct01(r.uptime_ratio, 0),
+      },
+      {
+        key: "latency",
+        label: "Avg latency",
+        align: "right",
+        format: (r) => ms(r.avg_latency_ms),
+      },
+    ],
+  },
+  "open-slots": {
+    key: "open-slots",
+    label: "Open slots",
+    description: "Where there is still room to register a neuron — most open UIDs first.",
+    primaryMetric: (r) => (r.open_slots != null ? `${formatNumber(r.open_slots)} open` : null),
+    columns: [
+      {
+        key: "open",
+        label: "Open slots",
+        align: "right",
+        format: (r) => (r.open_slots != null ? formatNumber(r.open_slots) : "—"),
+      },
+      {
+        key: "max",
+        label: "Max UIDs",
+        align: "right",
+        format: (r) => (r.max_uids != null ? formatNumber(r.max_uids) : "—"),
+      },
+      {
+        key: "cost",
+        label: "Reg. cost",
+        align: "right",
+        format: (r) => formatTao(r.registration_cost_tao),
+      },
+    ],
+  },
+  "cheapest-registration": {
+    key: "cheapest-registration",
+    label: "Cheapest registration",
+    description: "Open subnets ranked by lowest registration cost in TAO.",
+    primaryMetric: (r) =>
+      r.registration_cost_tao != null ? formatTao(r.registration_cost_tao) : null,
+    columns: [
+      {
+        key: "cost",
+        label: "Reg. cost",
+        align: "right",
+        format: (r) => formatTao(r.registration_cost_tao),
+      },
+      {
+        key: "open",
+        label: "Open slots",
+        align: "right",
+        format: (r) => (r.open_slots != null ? formatNumber(r.open_slots) : "—"),
+      },
+    ],
+  },
+  "highest-emission": {
+    key: "highest-emission",
+    label: "Highest emission",
+    description: "Subnets ranked by share of network emissions.",
+    primaryMetric: (r) => (r.emission_share != null ? pct01(r.emission_share, 2) : null),
+    columns: [
+      {
+        key: "emission",
+        label: "Emission share",
+        align: "right",
+        format: (r) => pct01(r.emission_share, 2),
+      },
+      {
+        key: "stake",
+        label: "Total stake",
+        align: "right",
+        format: (r) => formatTao(r.total_stake_tao),
+      },
+      {
+        key: "validators",
+        label: "Validators",
+        align: "right",
+        format: (r) => (r.validator_count != null ? formatNumber(r.validator_count) : "—"),
+      },
+      {
+        key: "miners",
+        label: "Miners",
+        align: "right",
+        format: (r) => (r.miner_count != null ? formatNumber(r.miner_count) : "—"),
+      },
+    ],
+  },
+  "validator-headroom": {
+    key: "validator-headroom",
+    label: "Validator headroom",
+    description: "Subnets with open validator permits, ranked by remaining headroom.",
+    primaryMetric: (r) =>
+      r.validator_headroom != null ? `${formatNumber(r.validator_headroom)} open` : null,
+    columns: [
+      {
+        key: "headroom",
+        label: "Headroom",
+        align: "right",
+        format: (r) => (r.validator_headroom != null ? formatNumber(r.validator_headroom) : "—"),
+      },
+      {
+        key: "validators",
+        label: "Validators",
+        align: "right",
+        format: (r) =>
+          r.validator_count != null && r.max_validators != null
+            ? `${formatNumber(r.validator_count)}/${formatNumber(r.max_validators)}`
+            : r.validator_count != null
+              ? formatNumber(r.validator_count)
+              : "—",
+      },
+      {
+        key: "emission",
+        label: "Emission share",
+        align: "right",
+        format: (r) => pct01(r.emission_share, 2),
+      },
+    ],
+  },
+};

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -670,28 +670,54 @@ export interface Lineage {
   links: LineageLink[];
 }
 
-/** The five D1-computed registry leaderboards from /api/v1/registry/leaderboards. */
+/**
+ * All ten boards from GET /api/v1/registry/leaderboards (#6995): six operational
+ * plus four economic-opportunity boards for miners/validators.
+ */
 export type LeaderboardBoardKey =
-  "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing";
+  | "healthiest"
+  | "fastest-rpc"
+  | "most-complete"
+  | "most-enriched"
+  | "fastest-growing"
+  | "most-reliable"
+  | "open-slots"
+  | "cheapest-registration"
+  | "highest-emission"
+  | "validator-headroom";
 
 /**
  * One ranked subnet in a leaderboard. Every row carries netuid/slug/name; only
- * the metric field relevant to its board is populated (e.g. `uptime_ratio` for
- * `healthiest`, `latency_ms` for `fastest-rpc`).
+ * the metric fields relevant to its board are populated (e.g. `uptime_ratio` for
+ * `healthiest`, `open_slots` for `open-slots`).
  */
 export interface LeaderboardRow {
   netuid: number;
   slug?: string;
   name?: string;
-  uptime_ratio?: number; // healthiest (0–1)
+  uptime_ratio?: number; // healthiest / most-reliable (0–1)
   surfaces_ok?: number; // healthiest
   surfaces_total?: number; // healthiest
-  avg_latency_ms?: number; // healthiest
+  avg_latency_ms?: number; // healthiest / most-reliable
   latency_ms?: number; // fastest-rpc
   completeness_score?: number; // most-complete (0–100)
   surface_count?: number; // most-enriched
   operational_interface_count?: number; // most-enriched
   completeness_delta?: number; // fastest-growing (points)
+  score?: number; // most-reliable (0–100)
+  grade?: string; // most-reliable (A–F)
+  sample_count?: number; // most-reliable
+  latency_sample_count?: number; // most-reliable
+  open_slots?: number; // open-slots / cheapest-registration
+  max_uids?: number; // open-slots
+  registration_cost_tao?: number; // open-slots / cheapest-registration
+  registration_allowed?: boolean; // open-slots / cheapest-registration
+  emission_share?: number; // highest-emission / validator-headroom (0–1)
+  total_stake_tao?: number; // highest-emission
+  validator_count?: number; // highest-emission / validator-headroom
+  miner_count?: number; // highest-emission
+  validator_headroom?: number; // validator-headroom
+  max_validators?: number; // validator-headroom
 }
 
 export type Leaderboards = Record<LeaderboardBoardKey, LeaderboardRow[]>;

--- a/apps/ui/src/routes/leaderboards-registry-views.test.ts
+++ b/apps/ui/src/routes/leaderboards-registry-views.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6995: /leaderboards gained registry opportunity + operational views. This
+// suite is node-environment source assertions (same convention as
+// leaderboards-csv-export-menu.test.ts) so TanStack Router/Query context does
+// not need to be stood up.
+const source = readFileSync(fileURLToPath(new URL("./leaderboards.tsx", import.meta.url)), "utf8");
+
+describe("leaderboards registry views (#6995)", () => {
+  it("defaults the view to opportunity and lists all three view chips", () => {
+    expect(source).toContain(
+      'fallback(z.enum(["opportunity", "registry", "chain"]), "opportunity")',
+    );
+    expect(source).toContain('{ id: "opportunity", label: "Opportunity" }');
+    expect(source).toContain('{ id: "registry", label: "Registry" }');
+    expect(source).toContain('{ id: "chain", label: "Chain" }');
+  });
+
+  it("wires both economic and operational board groups from the shared specs", () => {
+    expect(source).toContain("ECONOMIC_BOARD_KEYS");
+    expect(source).toContain("OPERATIONAL_BOARD_KEYS");
+    expect(source).toContain("REGISTRY_BOARD_SPECS");
+    expect(source).toContain("leaderboardsQuery");
+    expect(source).toContain('"/api/v1/registry/leaderboards"');
+  });
+
+  it("keeps chain CSV export gated to the chain view only", () => {
+    const actionBar = source.slice(source.indexOf("<ActionBar>"), source.indexOf("</ActionBar>"));
+    expect(actionBar).toContain('view === "chain" ? <CsvExportMenu');
+  });
+});

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -24,17 +24,34 @@ import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
   economicsQuery,
+  leaderboardsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
-import type { Subnet, SubnetEconomics } from "@/lib/metagraphed/types";
+import {
+  ECONOMIC_BOARD_KEYS,
+  OPERATIONAL_BOARD_KEYS,
+  REGISTRY_BOARD_SPECS,
+  type RegistryBoardSpec,
+} from "@/lib/metagraphed/registry-leaderboard-boards";
+import type {
+  LeaderboardBoardKey,
+  LeaderboardRow,
+  Subnet,
+  SubnetEconomics,
+} from "@/lib/metagraphed/types";
 
 const leaderboardsSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  // #6995: opportunity (economic) first — answers "where should I register/validate".
+  view: fallback(z.enum(["opportunity", "registry", "chain"]), "opportunity").default(
+    "opportunity",
+  ),
 });
 
 type LeaderboardWindow = z.infer<typeof leaderboardsSearchSchema>["window"];
+type LeaderboardView = z.infer<typeof leaderboardsSearchSchema>["view"];
 
 export const Route = createFileRoute("/leaderboards")({
   validateSearch: zodValidator(leaderboardsSearchSchema),
@@ -44,13 +61,13 @@ export const Route = createFileRoute("/leaderboards")({
       {
         name: "description",
         content:
-          "Network-wide Bittensor leaderboards — validator weight-setting activity and neuron deregistrations ranked by subnet over 7d and 30d windows.",
+          "Registry and chain leaderboards — open registration slots, cheapest entry, highest emission, validator headroom, healthiest subnets, and weight-setting / deregistration activity.",
       },
       { property: "og:title", content: "Leaderboards — Metagraphed" },
       {
         property: "og:description",
         content:
-          "Network-wide Bittensor leaderboards — validator weight-setting activity and neuron deregistrations ranked by subnet over 7d and 30d windows.",
+          "Registry and chain leaderboards — open registration slots, cheapest entry, highest emission, validator headroom, healthiest subnets, and weight-setting / deregistration activity.",
       },
     ],
   }),
@@ -85,12 +102,17 @@ function LeaderboardSkeleton() {
   );
 }
 
-// Every board on this route ranks the same 7d/30d window, so the window control lives at the page
-// level and governs both sections rather than each board owning a duplicate toggle.
+const VIEW_OPTIONS: Array<{ id: LeaderboardView; label: string }> = [
+  { id: "opportunity", label: "Opportunity" },
+  { id: "registry", label: "Registry" },
+  { id: "chain", label: "Chain" },
+];
+
 function LeaderboardsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const win = search.window;
+  const view = search.view;
 
   return (
     <AppShell>
@@ -98,50 +120,280 @@ function LeaderboardsPage() {
         eyebrow="Explorer"
         live
         title="Leaderboards"
-        description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
+        description="Economic opportunity, registry health, and chain activity — ranked by subnet from live registry and chain-direct analytics."
         actions={
           <ActionBar>
-            <CsvExportMenu win={win} />
+            {view === "chain" ? <CsvExportMenu win={win} /> : null}
             <ShareButton bare />
           </ActionBar>
         }
       />
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Window
-        </span>
-        {(["7d", "30d"] as const).map((w) => (
-          <button
-            key={w}
-            type="button"
-            onClick={() => navigate({ search: { window: w } })}
-            className={w === win ? WINDOW_BTN_ACTIVE : WINDOW_BTN}
-          >
-            {w}
-          </button>
-        ))}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            View
+          </span>
+          {VIEW_OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => navigate({ search: (prev) => ({ ...prev, view: opt.id }) })}
+              className={opt.id === view ? WINDOW_BTN_ACTIVE : WINDOW_BTN}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        {view === "chain" ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+              Window
+            </span>
+            {(["7d", "30d"] as const).map((w) => (
+              <button
+                key={w}
+                type="button"
+                onClick={() => navigate({ search: (prev) => ({ ...prev, window: w }) })}
+                className={w === win ? WINDOW_BTN_ACTIVE : WINDOW_BTN}
+              >
+                {w}
+              </button>
+            ))}
+          </div>
+        ) : null}
       </div>
       <div className="space-y-12">
-        <QueryErrorBoundary>
-          <Suspense fallback={<LeaderboardSkeleton />}>
-            <WeightSettingLeaderboard win={win} />
-          </Suspense>
-        </QueryErrorBoundary>
-        <QueryErrorBoundary>
-          <Suspense fallback={<LeaderboardSkeleton />}>
-            <DeregistrationsLeaderboard win={win} />
-          </Suspense>
-        </QueryErrorBoundary>
-        <QueryErrorBoundary>
-          <Suspense fallback={<LeaderboardSkeleton />}>
-            <EmissionsLeaderboard />
-          </Suspense>
-        </QueryErrorBoundary>
+        {view === "opportunity" ? (
+          <QueryErrorBoundary>
+            <Suspense fallback={<LeaderboardSkeleton />}>
+              <RegistryBoardsGroup
+                title="Economic opportunity"
+                description="Where to register or validate — open slots, cheapest entry, highest emission, and validator headroom."
+                boardKeys={ECONOMIC_BOARD_KEYS}
+              />
+            </Suspense>
+          </QueryErrorBoundary>
+        ) : null}
+        {view === "registry" ? (
+          <QueryErrorBoundary>
+            <Suspense fallback={<LeaderboardSkeleton />}>
+              <RegistryBoardsGroup
+                title="Registry operational"
+                description="Live registry rankings — health, RPC latency, completeness, enrichment, growth, and reliability."
+                boardKeys={OPERATIONAL_BOARD_KEYS}
+              />
+            </Suspense>
+          </QueryErrorBoundary>
+        ) : null}
+        {view === "chain" ? (
+          <>
+            <QueryErrorBoundary>
+              <Suspense fallback={<LeaderboardSkeleton />}>
+                <WeightSettingLeaderboard win={win} />
+              </Suspense>
+            </QueryErrorBoundary>
+            <QueryErrorBoundary>
+              <Suspense fallback={<LeaderboardSkeleton />}>
+                <DeregistrationsLeaderboard win={win} />
+              </Suspense>
+            </QueryErrorBoundary>
+            <QueryErrorBoundary>
+              <Suspense fallback={<LeaderboardSkeleton />}>
+                <EmissionsLeaderboard />
+              </Suspense>
+            </QueryErrorBoundary>
+          </>
+        ) : null}
       </div>
       <ApiSourceFooter
-        paths={["/api/v1/chain/weights", "/api/v1/chain/deregistrations", "/api/v1/economics"]}
+        paths={
+          view === "chain"
+            ? ["/api/v1/chain/weights", "/api/v1/chain/deregistrations", "/api/v1/economics"]
+            : ["/api/v1/registry/leaderboards"]
+        }
       />
     </AppShell>
+  );
+}
+
+function RegistryBoardsGroup({
+  title,
+  description,
+  boardKeys,
+}: {
+  title: string;
+  description: string;
+  boardKeys: readonly LeaderboardBoardKey[];
+}) {
+  const { data: res } = useSuspenseQuery(leaderboardsQuery());
+  const boards = res.data;
+  const subnetById = useSubnetById();
+
+  return (
+    <div className="space-y-12">
+      <div>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          {title}
+        </h2>
+        <p className="mt-1 text-sm text-ink-muted">{description}</p>
+      </div>
+      {boardKeys.map((key) => (
+        <RegistryBoardTable
+          key={key}
+          spec={REGISTRY_BOARD_SPECS[key]}
+          rows={boards[key] ?? []}
+          subnetById={subnetById}
+        />
+      ))}
+    </div>
+  );
+}
+
+function RegistryBoardTable({
+  spec,
+  rows,
+  subnetById,
+}: {
+  spec: RegistryBoardSpec;
+  rows: LeaderboardRow[];
+  subnetById: Map<number, Subnet>;
+}) {
+  return (
+    <div className="space-y-4" id={`board-${spec.key}`}>
+      <div>
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          {spec.label}
+        </h3>
+        <p className="mt-1 text-sm text-ink-muted">{spec.description}</p>
+      </div>
+      {rows.length === 0 ? (
+        <EmptyState
+          title={`No ${spec.label.toLowerCase()} rankings yet`}
+          description="This board has no ranked subnets in the current registry snapshot."
+        />
+      ) : (
+        <section className="rounded-lg border border-border bg-card">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+              Per-subnet rankings
+            </span>
+            <span className="font-mono text-[11px] text-ink-muted">
+              {formatNumber(rows.length)} subnet{rows.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          <div className="md:hidden space-y-2 p-3">
+            {rows.map((row, i) => {
+              const subnet = subnetById.get(row.netuid);
+              const name = subnet?.name ?? row.name ?? `Subnet ${row.netuid}`;
+              const slug =
+                typeof subnet?.slug === "string"
+                  ? subnet.slug
+                  : typeof row.slug === "string"
+                    ? row.slug
+                    : undefined;
+              return (
+                <div key={row.netuid} className="rounded border border-border bg-card p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: row.netuid }}
+                      className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                    >
+                      <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </span>
+                      <BrandIcon
+                        size={18}
+                        name={name}
+                        fallback={row.netuid}
+                        netuid={row.netuid}
+                        subnetSlug={slug}
+                      />
+                      <span className="truncate text-sm text-ink-strong">{name}</span>
+                    </Link>
+                    <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-strong">
+                      {spec.primaryMetric(row) ?? "—"}
+                    </span>
+                  </div>
+                  {spec.columns.length > 1 ? (
+                    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 font-mono text-[11px] tabular-nums text-ink-muted">
+                      {spec.columns.slice(1).map((col) => (
+                        <span key={col.key}>
+                          {col.label}: {col.format(row)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Rank</th>
+                  <th className={TH}>Subnet</th>
+                  {spec.columns.map((col) => (
+                    <th
+                      key={col.key}
+                      className={`${TH} ${col.align === "right" ? "text-right" : ""}`}
+                    >
+                      {col.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {rows.map((row, i) => {
+                  const subnet = subnetById.get(row.netuid);
+                  const name = subnet?.name ?? row.name ?? `Subnet ${row.netuid}`;
+                  const slug =
+                    typeof subnet?.slug === "string"
+                      ? subnet.slug
+                      : typeof row.slug === "string"
+                        ? row.slug
+                        : undefined;
+                  return (
+                    <tr key={row.netuid} className="hover:bg-surface/40">
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: row.netuid }}
+                          className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                        >
+                          <BrandIcon
+                            size={18}
+                            name={name}
+                            fallback={row.netuid}
+                            netuid={row.netuid}
+                            subnetSlug={slug}
+                          />
+                          <span className="truncate text-sm text-ink-strong">{name}</span>
+                        </Link>
+                      </td>
+                      {spec.columns.map((col) => (
+                        <td
+                          key={col.key}
+                          className={`px-4 py-2.5 font-mono text-[11px] tabular-nums ${
+                            col.align === "right" ? "text-right" : ""
+                          } text-ink-strong`}
+                        >
+                          {col.format(row)}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
﻿## Summary

Surface all 10 registry leaderboards from `GET /api/v1/registry/leaderboards` on `/leaderboards`, with economic-opportunity boards first.

Closes #6995.

### What changed

- Extended `LeaderboardBoardKey` / `normalizeLeaderboards` to all 10 boards (6 operational + 4 economic), including reliability and opportunity metric fields.
- Added `?view=opportunity|registry|chain` on `/leaderboards` (default `opportunity`):
  - **Opportunity:** open-slots, cheapest-registration, highest-emission, validator-headroom
  - **Registry:** healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable
  - **Chain:** existing weight-setting / deregistrations / emissions boards (unchanged; window + CSV stay here)
- Shared board column specs in `registry-leaderboard-boards.ts` (correct per-board metrics).
- Homepage `LeaderboardsModule` now includes opportunity boards + `View all leaderboards` link.

### Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/6995-registry-lb-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] `npm run typecheck --workspace=apps/ui`
- [x] Focused vitest for normalize + route source asserts + CSV menu
- [x] `npx vite build` (apps/ui)
- [x] Before/after screenshot matrix (3 viewports × 2 themes)
- [ ] GitHub Validate CI green
- [ ] Manual: `/leaderboards` Opportunity / Registry / Chain views; empty states for unpopulated operational boards; homepage module link
