### PR TITLE
feat(api): mirror search/domains/compare-validators discovery routes in GraphQL

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -131,8 +131,10 @@ import {
 } from "./health-serving.mjs";
 import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.mjs";
 import {
+  COMPARE_VALIDATORS_MAX,
   loadCompareSubnets,
   loadSubnetHealthTrends,
+  parseCompareHotkeyList,
   loadSubnetPercentiles,
   loadSubnetUptime,
   loadSubnetIncidents,
@@ -166,10 +168,13 @@ import {
   buildNeuronDetail,
   buildSubnetValidators,
   buildValidatorDetail,
+  composeValidatorComparison,
   overlayFeaturedValidators,
 } from "./metagraph-neurons.mjs";
 import { buildAlphaVolume } from "./alpha-volume.mjs";
 import { AGENT_RESOURCES_ARTIFACT } from "./agent-resources-mcp.mjs";
+import { buildDomainOverview, buildDomainSummary } from "./domain-summary.mjs";
+import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import {
   buildSubnetOhlc,
   OHLC_INTERVALS,
@@ -402,6 +407,16 @@ export const SDL = `
     subnet_volume(netuid: Int!): SubnetVolume!
     "The machine-readable AI-resources index: the copyable agent prompt (/agent.md), MCP server install metadata and tool listing, the Bittensor skill, llms.txt, OpenAPI, and links to the agent-facing APIs. Use it to bootstrap an agent integration before calling the catalog/search fields. Null when the index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_agent_resources MCP/REST shape. Mirrors GET /api/v1/agent-resources."
     agent_resources: JSON
+    "The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search."
+    search(limit: Int, cursor: String): SearchDocumentList!
+    "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index."
+    search_index(limit: Int, cursor: String): SearchDocumentList!
+    "The per-domain rollup overview: every tag in the fixed 14-tag capability taxonomy with its member subnet count, total stake, total emission share, and within-domain emission concentration. Computed live from the subnets index + economics tier. Mirrors GET /api/v1/domains."
+    domains: DomainOverview!
+    "One domain/capability tag's own rollup. tag must be one of the 14 fixed domain tags (the same enum ?domain= validates on subnets); an unknown tag is a BAD_USER_INPUT error. Mirrors GET /api/v1/domains/{tag}/summary."
+    domain_summary(tag: String!): DomainSummary!
+    "Several validators side by side for a stake/delegate decision: each hotkey's take, estimated APY, nominator count, identity, and cross-subnet stake/emission/trust aggregates. hotkeys takes 1-16 distinct SS58 addresses (a real GraphQL list, like the sibling compare field's netuids, rather than REST's comma-separated string); the optional netuid adds each validator's membership row in that subnet. The validator equivalent of the compare field. Mirrors GET /api/v1/compare/validators."
+    compare_validators(hotkeys: [String!]!, netuid: Int): ValidatorComparison!
     "One subnet's alpha-price OHLC candles bucketed by interval (1h or 1d, default 1h) over the trailing days window (default 90, max 365), from the same executed-trade stream subnet_volume reads. A subnet with no trades resolves to a schema-stable empty candle list, never null. Mirrors GET /api/v1/subnets/{netuid}/ohlc."
     subnet_ohlc(netuid: Int!, interval: String, days: Int): SubnetOhlc!
     "A read-only quote for a hypothetical stake/unstake against one subnet's live AMM pool: expected amount out, spot vs effective price, and estimated price impact. Computes nothing on-chain and signs nothing. Mirrors GET /api/v1/subnets/{netuid}/stake-quote."
@@ -2333,6 +2348,59 @@ export const SDL = `
     surfaces: JSON!
   }
 
+  type SearchDocumentList {
+    "Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON."
+    documents: [JSON!]!
+    total: Int!
+    next_cursor: String
+  }
+
+  "One domain/capability tag's rollup (#6989). Mirrors GET /api/v1/domains/{tag}/summary."
+  type DomainSummary {
+    schema_version: Int!
+    domain: String!
+    subnet_count: Int!
+    netuids: [Int!]!
+    total_stake_tao: Float!
+    total_emission_share: Float!
+    "Within-domain emission HHI; null when the domain has no members."
+    emission_concentration: Float
+  }
+
+  "The per-domain rollup overview across the fixed capability taxonomy (#6989). Mirrors GET /api/v1/domains."
+  type DomainOverview {
+    schema_version: Int!
+    domain_count: Int!
+    domains: [DomainSummary!]!
+  }
+
+  type ComparedValidator {
+    hotkey: String!
+    coldkey: String
+    "The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape."
+    coldkey_identity: JSON
+    take: Float
+    apy_estimate: Float
+    apy_estimate_eligible_subnet_count: Int!
+    nominator_count: Int
+    total_stake_tao: Float!
+    total_emission_tao: Float!
+    avg_validator_trust: Float
+    max_validator_trust: Float
+    subnet_count: Int!
+    "This validator's membership row in the requested netuid; null when netuid was omitted or it has no permit there. Opaque JSON, matching the REST/MCP shape."
+    subnet_context: JSON
+  }
+
+  "Several validators placed side by side (#6989). Mirrors GET /api/v1/compare/validators."
+  type ValidatorComparison {
+    schema_version: Int!
+    "The optional subnet context the comparison was scoped to."
+    netuid: Int
+    validator_count: Int!
+    validators: [ComparedValidator!]!
+  }
+
   "One subnet's rolling 24h alpha trading volume (#6979). Mirrors GET /api/v1/subnets/{netuid}/volume' data envelope."
   type SubnetVolume {
     schema_version: Int!
@@ -3476,6 +3544,11 @@ export const FIELD_COMPLEXITY = {
   subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_percentiles: RELATIONSHIP_FIELD_COMPLEXITY,
   agent_resources: RELATIONSHIP_FIELD_COMPLEXITY,
+  search: RELATIONSHIP_FIELD_COMPLEXITY,
+  search_index: RELATIONSHIP_FIELD_COMPLEXITY,
+  domains: RELATIONSHIP_FIELD_COMPLEXITY,
+  domain_summary: RELATIONSHIP_FIELD_COMPLEXITY,
+  compare_validators: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_volume: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_ohlc: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_quote: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3770,6 +3843,8 @@ const ARTIFACT = {
   surfaces: "/metagraph/surfaces.json",
   endpoints: "/metagraph/endpoints.json",
   profiles: "/metagraph/profiles.json",
+  search: "/metagraph/search.json",
+  searchIndex: "/metagraph/search-index.json",
 };
 const LIVE_HEALTH_KEY = "live:health";
 const LIVE_ECONOMICS_KEY = "live:economics";
@@ -5058,6 +5133,89 @@ const rootValue = {
       summary: data.summary ?? null,
       surfaces: data.surfaces ?? [],
     };
+  },
+
+  search({ limit, cursor }, context) {
+    // Same baked search artifact + list-window the REST route serves, paged
+    // through the shared listPage helper the other artifact lists use.
+    return listPage(context, ARTIFACT.search, "documents", {
+      limit,
+      cursor,
+      resultKey: "documents",
+      keyFn: (d) => d.id,
+    });
+  },
+
+  search_index({ limit, cursor }, context) {
+    // The slim companion: identical documents minus the per-document token
+    // blobs, served from its own artifact exactly as REST serves it.
+    return listPage(context, ARTIFACT.searchIndex, "documents", {
+      limit,
+      cursor,
+      resultKey: "documents",
+      keyFn: (d) => d.id,
+    });
+  },
+
+  async domains(_args, context) {
+    // Composed live from the subnets index + economics tier (no static file),
+    // via the same buildDomainOverview the REST route calls.
+    const [subnetRows, economicsRows] = await Promise.all([
+      loadRows(context, ARTIFACT.subnets, "subnets"),
+      loadEconomicsRows(context),
+    ]);
+    return buildDomainOverview(subnetRows, economicsRows);
+  },
+
+  async domain_summary({ tag }, context) {
+    // The same fixed 14-tag enum ?domain= validates on subnets -- an unknown
+    // tag is a GraphQL BAD_USER_INPUT error, not an empty rollup.
+    if (!DOMAIN_TAGS.includes(tag)) {
+      throw new GraphQLError(`tag must be one of: ${DOMAIN_TAGS.join(", ")}.`, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const [subnetRows, economicsRows] = await Promise.all([
+      loadRows(context, ARTIFACT.subnets, "subnets"),
+      loadEconomicsRows(context),
+    ]);
+    return buildDomainSummary(tag, subnetRows, economicsRows);
+  },
+
+  async compare_validators({ hotkeys, netuid }, context) {
+    // Same parse/validate contract the REST route + compare_validators MCP
+    // tool share: 1..COMPARE_VALIDATORS_MAX distinct SS58 addresses.
+    const parsed = parseCompareHotkeyList(hotkeys);
+    if (!parsed) {
+      throw new GraphQLError(
+        `hotkeys must be a non-empty list of 1-${COMPARE_VALIDATORS_MAX} distinct valid SS58 validator addresses.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (netuid != null && (!Number.isInteger(netuid) || netuid < 0)) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // One detail load per hotkey via the exact Postgres-tier-or-empty path the
+    // validator detail field uses -- no new data source, just the same
+    // cross-subnet aggregate fetched per compared validator, then projected
+    // side by side. Sequential to keep the request pattern identical to the
+    // REST/MCP fan-out.
+    const details = [];
+    for (const hotkey of parsed) {
+      details.push(
+        (await tryPostgresTier(
+          context.env,
+          postgresTierRequest(
+            context,
+            `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+          ),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildValidatorDetail([], hotkey),
+      );
+    }
+    return composeValidatorComparison(details, { netuid: netuid ?? null });
   },
 
   async agent_resources(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6185,6 +6185,189 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
   });
 });
 
+describe("graphql — discovery parity (#6989, search/domains/compare_validators)", () => {
+  const HOTKEY_A = "5FnPunMdSFTr8swMhMTdSGFqiZAJTBEDaAgTmrKfSpvRQyaR";
+  const HOTKEY_B = "5CXRfP2ZfvGCe8EQoZnjuBVUkado1RyfHf1zPTMhVpvSJHnp";
+
+  test("search pages the baked full index", async () => {
+    const env = fixtureEnv({
+      "/metagraph/search.json": {
+        documents: [
+          { id: "subnet:1", type: "subnet", title: "Alpha", tokens: "a b" },
+          { id: "subnet:2", type: "subnet", title: "Beta", tokens: "c d" },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      "{ search(limit: 1) { documents total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const s = body.data.search;
+    assert.equal(s.total, 2);
+    assert.equal(s.documents.length, 1);
+    assert.equal(s.documents[0].id, "subnet:1");
+    // The full index keeps the per-document token blob.
+    assert.equal(s.documents[0].tokens, "a b");
+    assert.ok(s.next_cursor);
+  });
+
+  test("search_index serves the slim artifact (documents without tokens)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/search-index.json": {
+        documents: [
+          { id: "subnet:1", type: "subnet", title: "Alpha" },
+          { id: "subnet:2", type: "subnet", title: "Beta" },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      "{ search_index(limit: 1) { documents total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.search_index.total, 2);
+    assert.equal(body.data.search_index.documents.length, 1);
+    // The slim index drops the per-document token blob the full index keeps.
+    assert.equal(body.data.search_index.documents[0].tokens, undefined);
+    assert.ok(body.data.search_index.next_cursor);
+  });
+
+  test("search degrades to an empty page on a cold artifact", async () => {
+    const { status, body } = await gql("{ search { documents total } }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.search, { documents: [], total: 0 });
+  });
+
+  test("domains rolls up every tag in the fixed taxonomy", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets.json": {
+        subnets: [{ netuid: 1, name: "A", categories: ["agents"] }],
+      },
+      "/metagraph/economics.json": {
+        subnets: [{ netuid: 1, total_stake_tao: 100, emission_share: 0.5 }],
+      },
+    });
+    const { status, body } = await gql(
+      "{ domains { schema_version domain_count domains { domain subnet_count netuids total_stake_tao } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const d = body.data.domains;
+    assert.equal(d.schema_version, 1);
+    assert.equal(d.domain_count, 14);
+    assert.equal(d.domains.length, 14);
+    const agents = d.domains.find((row) => row.domain === "agents");
+    assert.ok(agents, "expected an agents rollup");
+  });
+
+  test("domain_summary rolls up one tag", async () => {
+    const { status, body } = await gql(
+      '{ domain_summary(tag: "agents") { schema_version domain subnet_count netuids total_stake_tao total_emission_share emission_concentration } }',
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const s = body.data.domain_summary;
+    assert.equal(s.domain, "agents");
+    assert.equal(s.subnet_count, 0);
+    assert.deepEqual(s.netuids, []);
+    assert.equal(s.emission_concentration, null);
+  });
+
+  test("domain_summary rejects a tag outside the fixed taxonomy", async () => {
+    const { body } = await gql(
+      '{ domain_summary(tag: "not-a-domain") { domain } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/tag must be one of/i.test(body.errors[0].message));
+    assert.equal(body.data?.domain_summary ?? null, null);
+  });
+
+  test("compare_validators places validators side by side (cold tier)", async () => {
+    const { status, body } = await gql(
+      `{ compare_validators(hotkeys: ["${HOTKEY_A}", "${HOTKEY_B}"]) {
+          schema_version netuid validator_count
+          validators { hotkey total_stake_tao subnet_count subnet_context }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const c = body.data.compare_validators;
+    assert.equal(c.netuid, null);
+    assert.equal(c.validator_count, 2);
+    assert.equal(c.validators[0].hotkey, HOTKEY_A);
+    assert.equal(c.validators[1].hotkey, HOTKEY_B);
+    assert.equal(c.validators[0].subnet_context, null);
+  });
+
+  test("compare_validators fetches each hotkey from the Postgres tier", async () => {
+    const paths = [];
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          paths.push(new URL(req.url).pathname);
+          return Response.json({
+            schema_version: 1,
+            hotkey: HOTKEY_A,
+            total_stake_tao: 42,
+            subnets: [],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ compare_validators(hotkeys: ["${HOTKEY_A}"], netuid: 3) { netuid validator_count validators { hotkey total_stake_tao } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(paths.length, 1);
+    assert.ok(paths[0].endsWith(`/validators/${HOTKEY_A}`));
+    assert.equal(body.data.compare_validators.netuid, 3);
+    assert.equal(
+      body.data.compare_validators.validators[0].total_stake_tao,
+      42,
+    );
+  });
+
+  test("compare_validators rejects a malformed hotkey list", async () => {
+    const { body } = await gql(
+      '{ compare_validators(hotkeys: ["nope"]) { validator_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/hotkeys must be/i.test(body.errors[0].message));
+  });
+
+  test("compare_validators rejects an empty hotkey list", async () => {
+    const { body } = await gql(
+      "{ compare_validators(hotkeys: []) { validator_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/hotkeys must be/i.test(body.errors[0].message));
+  });
+
+  test("compare_validators rejects a negative netuid", async () => {
+    const { body } = await gql(
+      `{ compare_validators(hotkeys: ["${HOTKEY_A}"], netuid: -1) { validator_count } }`,
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+  });
+
+  test("the discovery fields are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.search, 5);
+    assert.equal(FIELD_COMPLEXITY.search_index, 5);
+    assert.equal(FIELD_COMPLEXITY.domains, 5);
+    assert.equal(FIELD_COMPLEXITY.domain_summary, 5);
+    assert.equal(FIELD_COMPLEXITY.compare_validators, 5);
+  });
+});
+
 describe("graphql — agent_resources (#6987, baked AI-resources index)", () => {
   test("resolves the baked AI-resources index", async () => {
     const env = fixtureEnv({


### PR DESCRIPTION
## Context

Five discovery-oriented REST routes had MCP tools but no GraphQL field, so validator comparison, subnet search, and domain rollups were REST-only.

## Change

Five new `type Query` fields in `src/graphql.mjs`, each reusing the shaping function REST and MCP already call.

**On the issue's open question — one search field or two?** Probing the route table settles it: `/api/v1/search` and `/api/v1/search-index` are genuinely **two routes over two artifacts** (`/metagraph/search.json` vs `/metagraph/search-index.json`, the latter being *the same documents minus the per-document `tokens` blobs*, for fast browser typeahead). So they get **two fields**, not one.

| Field | Mirrors |
|---|---|
| `search(limit, cursor)` | `/search` — full compact index, tokens included |
| `search_index(limit, cursor)` | `/search-index` — slim companion, tokens dropped |
| `domains` | `/domains` — rollup across the fixed 14-tag taxonomy |
| `domain_summary(tag)` | `/domains/{tag}/summary` |
| `compare_validators(hotkeys, netuid)` | `/compare/validators` |

**Design notes:**
- Both index fields page through the same **`listPage`** helper the other artifact lists use; documents are heterogeneous by type, so each passes through as the existing opaque **`JSON`** scalar.
- `domains`/`domain_summary` are composed **live** from the subnets index + economics tier (no static file), via `buildDomainOverview`/`buildDomainSummary`. An unknown `tag` raises `BAD_USER_INPUT` against the same fixed 14-tag enum `?domain=` validates on subnets — not a silently-empty rollup.
- `compare_validators.hotkeys` is a **real GraphQL list** (`[String!]!`), matching the sibling `compare(netuids: [Int!]!)` field and `parseCompareHotkeyList`'s array contract, rather than REST's comma-separated string — GraphQL has native lists, and this is the established convention in this schema. Each hotkey loads via the same Postgres-tier-or-empty path the validator detail field uses, then `composeValidatorComparison` projects them side by side.

## Deliverables

- [x] `compare_validators`, search field(s), `domains`/`domain_summary` added to `type Query`
- [x] New output types (`SearchDocumentList`, `DomainOverview`/`DomainSummary`, `ValidatorComparison`/`ComparedValidator`)
- [x] Test coverage for each new resolver

## Tests

12 new resolver tests: index paging (asserting the slim index drops `tokens` while the full one keeps them), cold-artifact degradation, domain rollups across all 14 tags, unknown-tag rejection, both the cold and Postgres-tier compare paths (verifying one detail fetch per hotkey), and malformed/empty hotkey-list plus negative-netuid errors. Full suite green (714), eslint + prettier clean, public-safety scan clean, **zero uncovered statements or branches** across all five new resolvers.

Closes #6989