### PR TITLE
feat(graphql): add block extrinsics/events/chain-events parity (#6977)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -152,8 +152,10 @@ import {
   buildAccountExtrinsics,
   buildExtrinsic,
   buildExtrinsicFeed,
+  buildBlockExtrinsics,
 } from "./extrinsics.mjs";
 import { buildBlock, buildBlockFeed } from "./blocks.mjs";
+import { loadBlockChainEvents } from "./data-api-mcp.mjs";
 import { buildBlocksSummary } from "./blocks-summary.mjs";
 import { buildRuntimeVersionHistory } from "./runtime-versions.mjs";
 import { buildChainYield } from "./chain-yield.mjs";
@@ -203,6 +205,7 @@ import {
   SUBNET_EVENT_SUMMARY_WINDOWS,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  buildBlockEvents,
 } from "./account-events.mjs";
 import {
   DEFAULT_PROMETHEUS_WINDOW,
@@ -491,6 +494,12 @@ export const SDL = `
     blocks(limit: Int, offset: Int, cursor: String): BlockList!
     "One block by numeric height or 0x block hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}."
     block(ref: String!): BlockDetail
+    "The extrinsics in one block by ref (numeric block_number or 0x hash), in natural read order (extrinsic_index ASC), paginated with limit (1-100, default 50)/offset. Returns block_number:null + extrinsics:[] for an unknown ref or cold store, never a GraphQL error. Mirrors GET /api/v1/blocks/{ref}/extrinsics."
+    block_extrinsics(ref: String!, limit: Int, offset: Int): BlockExtrinsics!
+    "The decoded, account-attributed chain events in one block by ref, in read order (event_index ASC), paginated with limit (1-1000, default 100)/offset. Returns block_number:null + events:[] for an unknown ref or cold store, never a GraphQL error. Mirrors GET /api/v1/blocks/{ref}/events."
+    block_events(ref: String!, limit: Int, offset: Int): BlockEvents!
+    "Every raw pallet.method event in one block from the Postgres all-events tier (ADR 0013), by numeric block_number, in read order. Distinct from block_events (the curated account-attributed D1 stream); requires the all-events data Worker, so it is a GraphQL error where that tier is unavailable (e.g. preview deploys). Mirrors GET /api/v1/blocks/{block_number}/chain-events."
+    block_chain_events(block_number: Int!): BlockChainEvents!
     "Block-production summary over the recent-block window -- counts, inter-block timing, throughput, and author-concentration. Every aggregate is null (never a GraphQL error) when the retired-D1 store is cold. Mirrors GET /api/v1/blocks/summary."
     blocks_summary: BlocksSummary!
     "Site-wide runtime spec-version transition timeline: the earliest known block at each distinct spec_version observed (ascending), the current spec_version, and where coverage starts. The empty shape (transition_count 0, current_spec_version null) is schema-stable, never a GraphQL error, when the store has no reading yet. Mirrors GET /api/v1/runtime."
@@ -2699,6 +2708,36 @@ export const SDL = `
     entropy_normalized: Float
   }
 
+  "One block's extrinsics list (#6977). Rows are the opaque JSON extrinsic shape the extrinsics feed uses; block_number is null for an unknown ref."
+  type BlockExtrinsics {
+    schema_version: Int
+    ref: String
+    block_number: Int
+    extrinsic_count: Int!
+    limit: Int
+    offset: Int
+    extrinsics: [JSON!]!
+  }
+
+  "One block's decoded, account-attributed events list (#6977). Rows are opaque JSON; block_number is null for an unknown ref."
+  type BlockEvents {
+    schema_version: Int
+    ref: String
+    block_number: Int
+    event_count: Int!
+    limit: Int
+    offset: Int
+    events: [JSON!]!
+  }
+
+  "One block's raw all-events-tier events (#6977) -- every pallet.method event, distinct from the curated block_events stream. Rows are opaque JSON."
+  type BlockChainEvents {
+    schema_version: Int
+    block_number: Int
+    event_count: Int!
+    events: [JSON!]!
+  }
+
   type BlockDetail {
     ref: String
     block: Block
@@ -3478,6 +3517,9 @@ export const FIELD_COMPLEXITY = {
   rpc_pools: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
+  block_extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
+  block_events: RELATIONSHIP_FIELD_COMPLEXITY,
+  block_chain_events: RELATIONSHIP_FIELD_COMPLEXITY,
   profiles: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5701,6 +5743,71 @@ const rootValue = {
       prev_block_number: data.prev_block_number ?? null,
       next_block_number: data.next_block_number ?? null,
     };
+  },
+
+  // #6977: block-scoped extrinsics/events/chain-events lists, mirroring the same
+  // Postgres tier + schema-stable fallback builder REST and MCP already use. The
+  // /blocks/:ref/{extrinsics,events} routes wrap their body in `{ data }` (unlike
+  // the flat /blocks/:ref route), so the tier result is destructured accordingly.
+  async block_extrinsics({ ref, limit, offset }, context) {
+    const safeLimit = Number.isFinite(limit)
+      ? Math.max(1, Math.min(100, Math.floor(limit)))
+      : 50;
+    const safeOffset = Number.isFinite(offset)
+      ? Math.max(0, Math.floor(offset))
+      : 0;
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    const { data } = (await tryPostgresTier(
+      context.env,
+      postgresTierRequest(
+        context,
+        `/api/v1/blocks/${encodeURIComponent(ref)}/extrinsics`,
+        params,
+      ),
+      "METAGRAPH_EXTRINSICS_SOURCE",
+    )) ?? {
+      data: buildBlockExtrinsics([], ref, null, {
+        limit: safeLimit,
+        offset: safeOffset,
+      }),
+    };
+    return data;
+  },
+
+  async block_events({ ref, limit, offset }, context) {
+    const safeLimit = Number.isFinite(limit)
+      ? Math.max(1, Math.min(1000, Math.floor(limit)))
+      : 100;
+    const safeOffset = Number.isFinite(offset)
+      ? Math.max(0, Math.floor(offset))
+      : 0;
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    const { data } = (await tryPostgresTier(
+      context.env,
+      postgresTierRequest(
+        context,
+        `/api/v1/blocks/${encodeURIComponent(ref)}/events`,
+        params,
+      ),
+      "METAGRAPH_EXTRINSICS_SOURCE",
+    )) ?? {
+      data: buildBlockEvents([], ref, null, {
+        limit: safeLimit,
+        offset: safeOffset,
+      }),
+    };
+    return data;
+  },
+
+  // Reuses loadBlockChainEvents unchanged (the get_block_chain_events tool's own
+  // loader); it throws invalid_params on a bad block_number and tier_unavailable
+  // where the all-events Worker is absent -- both surface as normal GraphQL errors.
+  block_chain_events({ block_number: blockNumber }, context) {
+    return loadBlockChainEvents(context, blockNumber);
   },
 
   async validators({ sort, limit }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1666,6 +1666,144 @@ describe("graphql — profiles", () => {
   });
 });
 
+// #6977: block-scoped extrinsics/events/chain-events lists mirror the same
+// Postgres tier + schema-stable fallback the block/extrinsics feeds already use.
+describe("graphql — block_extrinsics / block_events / block_chain_events (#6977)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("block_extrinsics: cold store returns a schema-stable empty list, never an error", async () => {
+    const { status, body } = await gql(
+      '{ block_extrinsics(ref: "9") { block_number extrinsic_count extrinsics } }',
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block_extrinsics.block_number, null);
+    assert.equal(body.data.block_extrinsics.extrinsic_count, 0);
+    assert.deepEqual(body.data.block_extrinsics.extrinsics, []);
+  });
+
+  test("block_extrinsics: resolves Postgres-tier rows (the /blocks/:ref/extrinsics { data } envelope)", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          data: {
+            schema_version: 1,
+            ref: "9",
+            block_number: 9,
+            extrinsic_count: 1,
+            limit: 50,
+            offset: 0,
+            extrinsics: [
+              {
+                block_number: 9,
+                extrinsic_index: 0,
+                call_module: "Timestamp",
+                call_function: "set",
+                success: true,
+              },
+            ],
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      '{ block_extrinsics(ref: "9", limit: 10, offset: 2) { block_number extrinsic_count extrinsics } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block_extrinsics.block_number, 9);
+    assert.equal(body.data.block_extrinsics.extrinsic_count, 1);
+    assert.equal(
+      body.data.block_extrinsics.extrinsics[0].call_module,
+      "Timestamp",
+    );
+  });
+
+  test("block_events: cold store returns a schema-stable empty list, never an error", async () => {
+    const { status, body } = await gql(
+      '{ block_events(ref: "9") { block_number event_count events } }',
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block_events.event_count, 0);
+    assert.deepEqual(body.data.block_events.events, []);
+  });
+
+  test("block_events: resolves Postgres-tier rows (the /blocks/:ref/events { data } envelope)", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          data: {
+            schema_version: 1,
+            ref: "9",
+            block_number: 9,
+            event_count: 1,
+            limit: 100,
+            offset: 0,
+            events: [
+              { block_number: 9, event_index: 0, kind: "Balances.Transfer" },
+            ],
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      '{ block_events(ref: "9", limit: 20, offset: 3) { block_number event_count events } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block_events.event_count, 1);
+    assert.equal(body.data.block_events.events[0].kind, "Balances.Transfer");
+  });
+
+  test("block_chain_events: resolves the all-events tier by block_number", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({
+          block_number: 9,
+          event_count: 2,
+          events: [
+            { event_index: 0, pallet: "System", method: "ExtrinsicSuccess" },
+            { event_index: 1, pallet: "Balances", method: "Transfer" },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ block_chain_events(block_number: 9) { block_number event_count events } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block_chain_events.block_number, 9);
+    assert.equal(body.data.block_chain_events.event_count, 2);
+    assert.equal(body.data.block_chain_events.events[1].method, "Transfer");
+  });
+
+  test("block_chain_events: an absent all-events tier is a GraphQL error, not null-degrade", async () => {
+    const { body } = await gql(
+      "{ block_chain_events(block_number: 9) { event_count } }",
+      emptyEnv,
+    );
+    assert.ok(
+      body.errors?.length,
+      "expected a GraphQL error when the tier is unavailable",
+    );
+    assert.equal(body.data, null);
+  });
+
+  test("all three fields are weighted in the complexity map", () => {
+    for (const field of [
+      "block_extrinsics",
+      "block_events",
+      "block_chain_events",
+    ]) {
+      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+    }
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({


### PR DESCRIPTION
Closes #6977

## Summary

`type Block` exposed only header fields — GraphQL had no way to fetch a block's actual extrinsics or events, though REST and MCP both do (`list_block_extrinsics`, `get_block_events`, `get_block_chain_events`).

## What Changed

Add three `Query` fields, each reusing the exact shaping the REST route + MCP tool already use — no read/aggregation logic duplicated:

- `block_extrinsics(ref: String!, limit: Int, offset: Int): BlockExtrinsics!` — Postgres-tier `/blocks/:ref/extrinsics` + `buildBlockExtrinsics` fallback.
- `block_events(ref: String!, limit: Int, offset: Int): BlockEvents!` — Postgres-tier `/blocks/:ref/events` + `buildBlockEvents` fallback.
- `block_chain_events(block_number: Int!): BlockChainEvents!` — reuses `loadBlockChainEvents` (the all-events tier, ADR 0013).

Details: the `/blocks/:ref/{extrinsics,events}` tier bodies are wrapped in `{ data }` (unlike the flat `/blocks/:ref` route), destructured accordingly. Row payloads use the opaque `JSON` scalar (same convention as `PoolList.pools`/`source_snapshots`). An unknown ref or cold store degrades to an empty list for extrinsics/events (never an error), matching REST; `block_chain_events` surfaces the all-events tier's unavailability as a GraphQL error, matching `get_block_chain_events`.

## Deliverables
- [x] `block_extrinsics`, `block_events`, `block_chain_events` added to `type Query`
- [x] Test coverage (tier-injected + cold-store, per field)

## Registry Safety
- [x] Links a tracked, currently-open issue (`Closes #6977`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(GraphQL schema only; mirrors existing REST/MCP)*

## Validation
- [x] `npx vitest run tests/graphql.test.mjs` — 714 passing (7 new)
- [x] Patch coverage 100% (verified via lcov)
- [x] `npx prettier --check` / `npx eslint` — clean
- [x] `git diff --check` clean; `behind: 0`
