### PR TITLE
fix(relay): retry chain-firehose-relay DB queries on transient errors

### DIFF
--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -283,6 +283,17 @@ export const CHAIN_FIREHOSE_BACKOFF_BASE_MS = 500;
 export const CHAIN_FIREHOSE_BACKOFF_MAX_MS = 15_000;
 export const CHAIN_FIREHOSE_FORWARD_TIMEOUT_MS = 10_000;
 
+// A poll/cleanup DB query is retried this many times (with the same capped
+// backoff as forwarding) before its error is allowed to propagate. A
+// transient connection error -- an `ECONNRESET`, or a `PostgresError: the
+// database system is shutting down` (SQLSTATE 57P03) while the box's Postgres
+// is briefly cycling -- must not crash the long-running relay, which restarts
+// from scratch (the container clones this repo fresh at start, see this
+// module's header) on process exit. Given the 500ms/15s backoff, this
+// comfortably outlasts a normal restart window; a genuinely persistent outage
+// still surfaces after the retries are exhausted rather than spinning silently.
+export const CHAIN_FIREHOSE_MAX_QUERY_ATTEMPTS = 6;
+
 // forwardBatch's in-flight concurrency -- forwarding a CHAIN_FIREHOSE_POLL_BATCH_SIZE
 // batch one row at a time (matching src/webhooks.mjs's own ALERT_DELIVERY_CONCURRENCY
 // default) would take minutes to drain any real backlog (each row is a real
@@ -374,6 +385,32 @@ export function computeBackoffDelayMs(
   } = {},
 ) {
   return Math.min(baseMs * 2 ** attempt, maxMs);
+}
+
+// Runs one async DB `operation` with bounded retry/backoff, the same way
+// forwardWithRetry protects the outbound HTTP path -- the difference being a
+// query has no "drop it" fallback, so after CHAIN_FIREHOSE_MAX_QUERY_ATTEMPTS
+// the last error is rethrown rather than swallowed. `sleepImpl` is injected so
+// the backoff schedule is unit-testable without real waits; `onRetry` is
+// invoked (with the caught error and 0-indexed attempt) before each backoff
+// so the caller can log the transient failure it just absorbed.
+export async function runQueryWithRetry(
+  operation,
+  {
+    maxAttempts = CHAIN_FIREHOSE_MAX_QUERY_ATTEMPTS,
+    sleepImpl = (ms) => new Promise((r) => setTimeout(r, ms)),
+    onRetry,
+  } = {},
+) {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= maxAttempts - 1) throw error;
+      onRetry?.(error, attempt);
+      await sleepImpl(computeBackoffDelayMs(attempt));
+    }
+  }
 }
 
 // Ceiling on how long a single retry-after value can pause the relay for --
@@ -615,7 +652,8 @@ async function main() {
   // ingest endpoint's rate limit -- see forwardBatch's own comment for why
   // this is the actual fix, not just per-row retry backoff.
   async function pollOnce() {
-    const rows = await sql`
+    const rows = await runQueryWithRetry(
+      () => sql`
       UPDATE chain_firehose_outbox
       SET delivered_at = now()
       WHERE id IN (
@@ -625,7 +663,15 @@ async function main() {
         LIMIT ${CHAIN_FIREHOSE_POLL_BATCH_SIZE}
         FOR UPDATE SKIP LOCKED
       )
-      RETURNING id, payload`;
+      RETURNING id, payload`,
+      {
+        onRetry: (error, attempt) =>
+          console.error(
+            `[chain-firehose-relay] claim query failed (attempt ${attempt + 1}/${CHAIN_FIREHOSE_MAX_QUERY_ATTEMPTS}), retrying:`,
+            error,
+          ),
+      },
+    );
     if (rows.length === 0)
       return { claimed: 0, requestCount: 0, rateLimitedForMs: 0 };
     let droppedInBatch = 0;
@@ -672,10 +718,19 @@ async function main() {
 
   async function cleanupOnce() {
     const cutoff = new Date(Date.now() - CHAIN_FIREHOSE_OUTBOX_RETENTION_MS);
-    await sql`
+    await runQueryWithRetry(
+      () => sql`
       DELETE FROM chain_firehose_outbox
       WHERE (delivered_at IS NOT NULL AND delivered_at < ${cutoff})
-         OR (delivered_at IS NULL AND created_at < ${cutoff})`;
+         OR (delivered_at IS NULL AND created_at < ${cutoff})`,
+      {
+        onRetry: (error, attempt) =>
+          console.error(
+            `[chain-firehose-relay] cleanup query failed (attempt ${attempt + 1}/${CHAIN_FIREHOSE_MAX_QUERY_ATTEMPTS}), retrying:`,
+            error,
+          ),
+      },
+    );
   }
 
   let lastCleanupAt = Date.now();

--- a/tests/chain-firehose-relay.test.mjs
+++ b/tests/chain-firehose-relay.test.mjs
@@ -46,6 +46,7 @@ import {
   CHAIN_FIREHOSE_INGEST_BATCH_SIZE,
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS,
+  CHAIN_FIREHOSE_MAX_QUERY_ATTEMPTS,
   CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS,
   CHAIN_FIREHOSE_POLL_BATCH_SIZE,
   CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S,
@@ -63,6 +64,7 @@ import {
   parseRelayConfig,
   parseRetryAfterMs,
   reportRateLimitPause,
+  runQueryWithRetry,
   touchHeartbeat,
 } from "../scripts/chain-firehose-relay.mjs";
 import { CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE } from "../workers/chain-firehose-hub.mjs";
@@ -964,4 +966,99 @@ test("touchHeartbeat: a write failure (unwritable path) is swallowed, never thro
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// --- runQueryWithRetry --------------------------------------------------------
+
+test("runQueryWithRetry: returns the operation's result on first success without sleeping or retrying", async () => {
+  let calls = 0;
+  let slept = 0;
+  const result = await runQueryWithRetry(
+    async () => {
+      calls += 1;
+      return ["row"];
+    },
+    {
+      sleepImpl: async () => {
+        slept += 1;
+      },
+    },
+  );
+  assert.deepEqual(result, ["row"]);
+  assert.equal(calls, 1);
+  assert.equal(slept, 0);
+});
+
+test("runQueryWithRetry: retries a transient error with capped-exponential backoff, then returns the eventual success", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const result = await runQueryWithRetry(
+    async () => {
+      calls += 1;
+      if (calls < 3) throw new Error("ECONNRESET");
+      return "ok";
+    },
+    {
+      sleepImpl: async (ms) => {
+        sleeps.push(ms);
+      },
+    },
+  );
+  assert.equal(result, "ok");
+  assert.equal(calls, 3);
+  assert.deepEqual(sleeps, [
+    computeBackoffDelayMs(0),
+    computeBackoffDelayMs(1),
+  ]);
+});
+
+test("runQueryWithRetry: rethrows the last error after exhausting maxAttempts", async () => {
+  let calls = 0;
+  await assert.rejects(
+    runQueryWithRetry(
+      async () => {
+        calls += 1;
+        throw new Error(`fail ${calls}`);
+      },
+      { sleepImpl: async () => {} },
+    ),
+    /fail 6/,
+  );
+  assert.equal(calls, CHAIN_FIREHOSE_MAX_QUERY_ATTEMPTS);
+});
+
+test("runQueryWithRetry: invokes onRetry with the caught error and 0-indexed attempt before each backoff, but not after the final failure", async () => {
+  const observed = [];
+  await assert.rejects(
+    runQueryWithRetry(
+      async () => {
+        throw new Error("boom");
+      },
+      {
+        maxAttempts: 3,
+        sleepImpl: async () => {},
+        onRetry: (error, attempt) => {
+          observed.push([error.message, attempt]);
+        },
+      },
+    ),
+  );
+  assert.deepEqual(observed, [
+    ["boom", 0],
+    ["boom", 1],
+  ]);
+});
+
+test("runQueryWithRetry: honors a custom maxAttempts", async () => {
+  let calls = 0;
+  await assert.rejects(
+    runQueryWithRetry(
+      async () => {
+        calls += 1;
+        throw new Error("down");
+      },
+      { maxAttempts: 2, sleepImpl: async () => {} },
+    ),
+  );
+  assert.equal(calls, 2);
 });


### PR DESCRIPTION
Closes #7157

## Problem
`scripts/chain-firehose-relay.mjs`'s poll loop crashed the whole process on any transient Postgres/network error. `pollOnce()`'s claim query (`UPDATE chain_firehose_outbox … RETURNING`) had no retry, so an `ECONNRESET` or a `PostgresError: the database system is shutting down` (SQLSTATE `57P03`) during a brief Postgres cycle propagated through `main()`'s loop to the top-level `main().catch()` and exited the process — forcing a restart-from-scratch (`git clone` + `npm ci` per `chain-firehose-relay-entrypoint.sh`). The file already had bounded retry/backoff for the outbound HTTP forward (`forwardWithRetry` / `computeBackoffDelayMs`); it just wasn't applied to the DB queries.

## Fix
Add `runQueryWithRetry()` — a small exported helper that runs an async DB operation with the **same** capped exponential backoff the HTTP path uses, retrying a transient failure in-process and rethrowing only after `CHAIN_FIREHOSE_MAX_QUERY_ATTEMPTS` (so a genuinely persistent outage still surfaces rather than spinning silently). Both in-loop queries are wrapped with it: `pollOnce()`'s claim query (the Sentry-observed culprit) and `cleanupOnce()`'s `DELETE`, which shares the identical exposure in the same loop.

Following this file's convention, the retry logic is a pure exported function unit-tested directly (the long-running `main()` loop stays under its `/* v8 ignore */`): success path, retry-then-succeed with the asserted backoff schedule, exhaustion-rethrow, the `onRetry` callback, and a custom `maxAttempts`.