### PR TITLE
feat(auth): GitHub OAuth for MCP via workers-oauth-provider

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -1021,6 +1021,31 @@ CREATE INDEX IF NOT EXISTS idx_rpc_accounts_ss58 ON rpc_accounts (ss58);
 ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS account_id BIGINT REFERENCES rpc_accounts (id);
 CREATE INDEX IF NOT EXISTS idx_api_keys_account_id ON api_keys (account_id) WHERE account_id IS NOT NULL;
 
+-- ---------------------------------------------------------------------------
+-- GitHub OAuth accounts for the MCP/API (metagraphed#7151) -- second
+-- user-account system in this codebase, parallel to rpc_accounts above
+-- (wallet-signature login) rather than merged into it: the identity proof is
+-- structurally different (GitHub's own OAuth authorization-code exchange vs.
+-- an sr25519 wallet signature), and a single human could plausibly want
+-- both, so this stays its own row/table rather than overloading ss58.
+-- github_user_id is GitHub's own stable numeric account id (immutable even
+-- across a username/login rename) -- the identity key. github_login is
+-- denormalized/cached purely for display and support tickets; it is NOT
+-- authoritative and must be refreshed from GitHub on login, never used to
+-- look up the account.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS github_accounts (
+  id             BIGSERIAL PRIMARY KEY,
+  github_user_id BIGINT NOT NULL UNIQUE,
+  github_login   TEXT NOT NULL,
+  tier           TEXT NOT NULL DEFAULT 'free',
+  created_at     BIGINT NOT NULL,
+  last_login_at  BIGINT
+);
+-- Already covered by the UNIQUE constraint's implicit index; explicit only
+-- for readability/documentation (matches idx_rpc_accounts_ss58's convention).
+CREATE INDEX IF NOT EXISTS idx_github_accounts_github_user_id ON github_accounts (github_user_id);
+
 -- Freemium API on Unkey (2026-07-19): Unkey is now the actual key store --
 -- it mints/hashes/verifies/revokes every key; this table keeps only a thin
 -- (account_id, unkey_key_id) mapping for listing/ownership checks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "packages/ui-kit"
       ],
       "dependencies": {
+        "@cloudflare/workers-oauth-provider": "^0.8.2",
         "@duckdb/node-api": "^1.5.4-r.1",
         "@noble/hashes": "^2.2.0",
         "@resvg/resvg-js": "^2.6.2",
@@ -1107,6 +1108,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-oauth-provider": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.8.2.tgz",
+      "integrity": "sha512-Pho5qWDl4qj1STI5QYMQfPmJBBkxyrFpXyDl9BrtYOfWHxThabEzdi9p3ezS2cUkbjA0E6L5ki/kq2pcbRUtlg==",
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "endpoint:brief": "node scripts/endpoint-ops-brief.mjs"
   },
   "dependencies": {
+    "@cloudflare/workers-oauth-provider": "^0.8.2",
     "@duckdb/node-api": "^1.5.4-r.1",
     "@noble/hashes": "^2.2.0",
     "@resvg/resvg-js": "^2.6.2",

--- a/src/github-oauth.mjs
+++ b/src/github-oauth.mjs
@@ -1,0 +1,290 @@
+// GitHub OAuth App identity check for the metagraphed OAuth 2.1 authorization
+// server (metagraphed#7151). @cloudflare/workers-oauth-provider implements
+// the OAuth 2.1 protocol machinery (PKCE, token issuance/refresh, RFC9728
+// Protected Resource Metadata, dynamic client registration) -- this module
+// supplies the one thing it deliberately does NOT: `authorizeEndpoint` is
+// "used in OAuth metadata and is not handled by the provider itself" (its
+// own type doc). The actual /authorize UI and the upstream identity round
+// trip are application code, same as Cloudflare's own
+// remote-mcp-github-oauth reference template.
+//
+// Flow: an MCP client (or, later, the website login button) redirects the
+// user's browser to GET /authorize with standard OAuth 2.1 + PKCE params.
+// We parse that via OAuthHelpers.parseAuthRequest, stash it in OAUTH_KV
+// under a short-lived single-use nonce (mirrors wallet-auth.mjs's
+// issueWalletChallenge KV-challenge pattern -- proven shape, not
+// reinvented), then redirect the browser to GitHub's own OAuth authorize
+// endpoint with that nonce as `state`. GitHub redirects back to
+// GET /oauth/callback/github with `?code&state`; we look up and delete the
+// pending nonce (single-use -- a replayed callback can't complete twice),
+// exchange `code` for a GitHub access token, fetch the GitHub user, upsert
+// a `github_accounts` row via the DATA_API service binding (only that
+// Worker holds the Postgres/Hyperdrive binding -- mirrors
+// handleWalletVerify's shape in workers/data-api.mjs), then call
+// OAuthHelpers.completeAuthorization to mint OUR OWN grant/token for the
+// original MCP client and redirect the browser back to it.
+// completeAuthorization can only be called from THIS Worker (it needs
+// OAUTH_KV, which workers/data-api.mjs does not bind) -- the DATA_API hop
+// is scoped to exactly the one Postgres write, nothing else.
+//
+// @cloudflare/workers-oauth-provider's real runtime file has a top-level
+// `import ... from "cloudflare:workers"` (confirmed by reading
+// node_modules/@cloudflare/workers-oauth-provider/dist/oauth-provider.js
+// directly, not just its .d.ts) -- that protocol only exists inside the
+// real Workers runtime, so a STATIC import of this package anywhere in
+// workers/api.mjs's module graph would break every one of its ~90+ existing
+// plain-Node vitest tests the moment api.mjs itself is imported, regardless
+// of whether those tests ever touch OAuth. getOAuthApi() is therefore never
+// imported at module scope here -- only lazily, inside
+// defaultGetOAuthHelpers below, via dynamic import() (deferred until
+// actually called). Both exported handlers also accept an injectable
+// `deps.getHelpers` for exactly this reason -- tests inject a fake helpers
+// object and never touch the real package at all, same shape as
+// usage-telemetry.mjs's injectable `deps.fetch`.
+const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
+const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const GITHUB_USER_API_URL = "https://api.github.com/user";
+
+// Mirrors wallet-auth.mjs's WALLET_CHALLENGE_TTL_SECONDS: long enough for a
+// human to complete a GitHub login popup, short enough that an intercepted
+// nonce is worthless soon after.
+export const OAUTH_PENDING_TTL_SECONDS = 300;
+const OAUTH_PENDING_KV_PREFIX = "oauth-pending:";
+
+// Exported so its trivial, deterministic behavior is directly testable
+// (see tests/github-oauth.test.mjs) even though production code never
+// actually invokes it -- getOAuthApi() reads options.defaultHandler's
+// presence but never calls .fetch() on it, only the real OAuthProvider
+// instance in workers/api.sentry.mjs does that, with the REAL handler.
+export const UNUSED_DEFAULT_HANDLER = {
+  fetch: () =>
+    new Response("not used outside OAuthProvider.fetch()", { status: 500 }),
+};
+
+/**
+ * Options shared by the real OAuthProvider instance (workers/api.sentry.mjs,
+ * the deploy entrypoint) and by getOAuthApi() calls from this Worker's own
+ * route handlers below -- single source of truth for endpoint URLs/TTLs/
+ * scopes so the two never drift apart. Pure -- no import of the OAuth
+ * package itself, safe to call from anywhere including plain-Node tests.
+ *
+ * `defaultHandler` is only ever actually invoked through the real
+ * OAuthProvider instance's own fetch() dispatch (the entrypoint's use);
+ * getOAuthApi() never calls it -- it only exposes the helper methods
+ * (parseAuthRequest/lookupClient/completeAuthorization) used below. Callers
+ * that only need those helpers pass UNUSED_DEFAULT_HANDLER: it's
+ * structurally required by the library's types but dead weight there.
+ */
+export function buildOAuthProviderOptions(defaultHandler) {
+  return {
+    apiRoute: "/mcp",
+    // Authenticated /mcp gets identical behavior to anonymous /mcp today --
+    // this only makes a validated GitHub identity available via ctx.props
+    // for future use (metagraphed#7151's stated scope). Anonymous/IP-rate-
+    // limited access is unaffected: a request with no/invalid token falls
+    // through to defaultHandler below, same as every other route.
+    apiHandler: {
+      fetch: (request, env, ctx) => defaultHandler.fetch(request, env, ctx),
+    },
+    defaultHandler,
+    authorizeEndpoint: "/authorize",
+    tokenEndpoint: "/oauth/token",
+    clientRegistrationEndpoint: "/oauth/register",
+    scopesSupported: ["profile"],
+    resourceMetadata: {
+      resource_name: "metagraphed",
+    },
+  };
+}
+
+// Real production helpers resolver -- lazy-imports the package so no test
+// that never calls it pays the cloudflare:workers cost. Can only run in the
+// real Workers runtime: the package's own runtime file does
+// `import ... from "cloudflare:workers"` at module scope (confirmed against
+// dist/oauth-provider.js, not just its .d.ts), a protocol plain Node
+// doesn't implement -- same justification as workers/*.sentry.mjs's
+// vitest.config.mjs exclusion. Both real routes
+// (handleAuthorizeRequest/handleGithubOAuthCallback) accept an injectable
+// deps.getHelpers precisely so their own logic stays fully covered without
+// this function ever running in a test.
+/* v8 ignore start */
+async function defaultGetOAuthHelpers(env) {
+  const { getOAuthApi } = await import("@cloudflare/workers-oauth-provider");
+  return getOAuthApi(buildOAuthProviderOptions(UNUSED_DEFAULT_HANDLER), env);
+}
+/* v8 ignore stop */
+
+function randomNonce() {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * @typedef {object} GithubOAuthDeps
+ * @property {(env: object) => Promise<object>} [getHelpers] Injectable OAuthHelpers resolver (tests).
+ * @property {typeof fetch} [fetch] Injectable fetch, for the GitHub API calls + DATA_API hop (tests).
+ */
+
+/** GET /authorize -- parse the incoming OAuth request, stash it, hand off to GitHub. */
+export async function handleAuthorizeRequest(request, env, deps = {}) {
+  if (!env.OAUTH_KV) {
+    return new Response("oauth is not provisioned on this deployment", {
+      status: 503,
+    });
+  }
+  if (!env.GITHUB_OAUTH_CLIENT_ID) {
+    return new Response("github oauth is not provisioned on this deployment", {
+      status: 503,
+    });
+  }
+  const getHelpers = deps.getHelpers ?? defaultGetOAuthHelpers;
+  const helpers = await getHelpers(env);
+  let authRequest;
+  try {
+    authRequest = await helpers.parseAuthRequest(request);
+  } catch (err) {
+    return new Response(
+      `invalid authorization request: ${err?.message ?? "unknown error"}`,
+      { status: 400 },
+    );
+  }
+  const client = await helpers.lookupClient(authRequest.clientId);
+  if (!client) {
+    return new Response("unknown client_id", { status: 400 });
+  }
+  const nonce = randomNonce();
+  await env.OAUTH_KV.put(
+    `${OAUTH_PENDING_KV_PREFIX}${nonce}`,
+    JSON.stringify(authRequest),
+    { expirationTtl: OAUTH_PENDING_TTL_SECONDS },
+  );
+  const redirectUri = new URL("/oauth/callback/github", request.url).toString();
+  const githubUrl = new URL(GITHUB_AUTHORIZE_URL);
+  githubUrl.searchParams.set("client_id", env.GITHUB_OAUTH_CLIENT_ID);
+  githubUrl.searchParams.set("redirect_uri", redirectUri);
+  githubUrl.searchParams.set("state", nonce);
+  githubUrl.searchParams.set("scope", "read:user");
+  return Response.redirect(githubUrl.toString(), 302);
+}
+
+/** GET /oauth/callback/github -- GitHub's redirect back after the user authorizes. */
+export async function handleGithubOAuthCallback(request, env, deps = {}) {
+  if (
+    !env.OAUTH_KV ||
+    !env.GITHUB_OAUTH_CLIENT_ID ||
+    !env.GITHUB_OAUTH_CLIENT_SECRET
+  ) {
+    return new Response("github oauth is not provisioned on this deployment", {
+      status: 503,
+    });
+  }
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  if (!code || !state) {
+    return new Response("missing code or state", { status: 400 });
+  }
+  const pendingKey = `${OAUTH_PENDING_KV_PREFIX}${state}`;
+  const pendingRaw = await env.OAUTH_KV.get(pendingKey);
+  if (!pendingRaw) {
+    return new Response("expired or unknown state -- restart the login", {
+      status: 400,
+    });
+  }
+  // Single-use: delete before doing any further work so a replayed callback
+  // (browser back-button, a proxy retrying the GET) can't complete twice
+  // against the same pending request.
+  await env.OAUTH_KV.delete(pendingKey);
+  let authRequest;
+  try {
+    authRequest = JSON.parse(pendingRaw);
+  } catch {
+    return new Response("corrupted pending authorization state", {
+      status: 500,
+    });
+  }
+
+  const doFetch = deps.fetch ?? globalThis.fetch;
+  const redirectUri = new URL("/oauth/callback/github", request.url).toString();
+  const tokenResponse = await doFetch(GITHUB_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+    },
+    body: JSON.stringify({
+      client_id: env.GITHUB_OAUTH_CLIENT_ID,
+      client_secret: env.GITHUB_OAUTH_CLIENT_SECRET,
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+  if (!tokenResponse.ok) {
+    return new Response("github token exchange failed", { status: 502 });
+  }
+  const tokenBody = await tokenResponse.json();
+  const githubAccessToken = tokenBody?.access_token;
+  if (typeof githubAccessToken !== "string" || !githubAccessToken) {
+    return new Response("github token exchange returned no access_token", {
+      status: 502,
+    });
+  }
+
+  const userResponse = await doFetch(GITHUB_USER_API_URL, {
+    headers: {
+      authorization: `Bearer ${githubAccessToken}`,
+      "user-agent": "metagraphed-oauth",
+      accept: "application/vnd.github+json",
+    },
+  });
+  if (!userResponse.ok) {
+    return new Response("failed to fetch github user profile", {
+      status: 502,
+    });
+  }
+  const githubUser = await userResponse.json();
+  const githubUserId = githubUser?.id;
+  const githubLogin = githubUser?.login;
+  if (
+    typeof githubUserId !== "number" ||
+    typeof githubLogin !== "string" ||
+    !githubLogin
+  ) {
+    return new Response("github user profile missing id/login", {
+      status: 502,
+    });
+  }
+
+  if (!env.DATA_API) {
+    return new Response(
+      "account storage is not provisioned on this deployment",
+      { status: 503 },
+    );
+  }
+  const upsertResponse = await env.DATA_API.fetch(
+    new Request("https://internal/api/v1/auth/github/upsert-account", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        github_user_id: githubUserId,
+        github_login: githubLogin,
+      }),
+    }),
+  );
+  if (!upsertResponse.ok) {
+    return new Response("account storage failed", { status: 502 });
+  }
+  const account = await upsertResponse.json();
+
+  const getHelpers = deps.getHelpers ?? defaultGetOAuthHelpers;
+  const helpers = await getHelpers(env);
+  const { redirectTo } = await helpers.completeAuthorization({
+    request: authRequest,
+    userId: String(account.id),
+    scope: authRequest.scope,
+    metadata: { githubLogin },
+    props: { githubUserId, githubLogin, accountId: account.id },
+  });
+  return Response.redirect(redirectTo, 302);
+}

--- a/tests/github-account-upsert-route.test.mjs
+++ b/tests/github-account-upsert-route.test.mjs
@@ -1,0 +1,112 @@
+// Unit tests for workers/data-api.mjs's handleGithubAccountUpsert
+// (metagraphed#7151) -- POST /api/v1/auth/github/upsert-account, reached
+// only via the DATA_API service binding from src/github-oauth.mjs's
+// callback handler (see that module's own test file for the OAuth-flow
+// side). Mirrors tests/wallet-auth-keys-route.test.mjs's shape: its own
+// per-test postgres mock queue, scoped only to this file (vi.mock is
+// per-test-file).
+import assert from "node:assert/strict";
+import { beforeEach, test, vi } from "vitest";
+
+const mockQueue = vi.hoisted(() => ({ current: [] }));
+const sqlCalls = vi.hoisted(() => []);
+
+vi.mock("postgres", () => ({
+  default: () => {
+    function sql(strings, ...values) {
+      let text = strings[0];
+      for (let i = 0; i < values.length; i += 1) text += "?" + strings[i + 1];
+      sqlCalls.push({ text, values });
+      return Promise.resolve(
+        mockQueue.current.length ? mockQueue.current.shift() : [],
+      );
+    }
+    sql.begin = (cb) => cb(sql);
+    sql.end = () => Promise.resolve();
+    sql.json = (value) => value;
+    return sql;
+  },
+}));
+
+const { default: worker } = await import("../workers/data-api.mjs");
+
+function baseEnv(overrides = {}) {
+  return {
+    HYPERDRIVE: { connectionString: "postgres://mock" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockQueue.current = [];
+  sqlCalls.length = 0;
+});
+
+function req(body) {
+  return new Request("https://d/api/v1/auth/github/upsert-account", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function fetchRoute(request, env) {
+  return worker.fetch(request, env, {});
+}
+
+test("rejects a malformed JSON body", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    new Request("https://d/api/v1/auth/github/upsert-account", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json",
+    }),
+    env,
+  );
+  assert.equal(res.status, 400);
+});
+
+test("rejects a non-integer github_user_id", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    req({ github_user_id: "42", github_login: "octocat" }),
+    env,
+  );
+  assert.equal(res.status, 400);
+});
+
+test("rejects a missing/empty github_login", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(req({ github_user_id: 42 }), env);
+  assert.equal(res.status, 400);
+});
+
+test("upserts on github_user_id and returns the account row", async () => {
+  const env = baseEnv();
+  mockQueue.current.push([{ id: 7, github_login: "octocat", tier: "free" }]);
+  const res = await fetchRoute(
+    req({ github_user_id: 42, github_login: "octocat" }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body, { id: 7, github_login: "octocat", tier: "free" });
+  assert.ok(sqlCalls.some((c) => /INSERT INTO github_accounts/.test(c.text)));
+  assert.ok(
+    sqlCalls.some((c) =>
+      /ON CONFLICT \(github_user_id\) DO UPDATE/.test(c.text),
+    ),
+  );
+});
+
+test("a GET to the same path is not routed here", async () => {
+  const env = baseEnv();
+  const res = await fetchRoute(
+    new Request("https://d/api/v1/auth/github/upsert-account", {
+      method: "GET",
+    }),
+    env,
+  );
+  assert.notEqual(res.status, 200);
+});

--- a/tests/github-oauth.test.mjs
+++ b/tests/github-oauth.test.mjs
@@ -1,0 +1,477 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, test, vi } from "vitest";
+import {
+  buildOAuthProviderOptions,
+  handleAuthorizeRequest,
+  handleGithubOAuthCallback,
+  OAUTH_PENDING_TTL_SECONDS,
+  UNUSED_DEFAULT_HANDLER,
+} from "../src/github-oauth.mjs";
+
+// @cloudflare/workers-oauth-provider's real runtime file imports
+// "cloudflare:workers" at module scope (see src/github-oauth.mjs's own
+// header) -- can't load in plain Node. vi.mock replaces module RESOLUTION
+// itself, so this fake is used instead and the real package is never
+// touched, even by the production (no deps.getHelpers override) code path
+// this exists to cover.
+const getOAuthApiMock = vi.fn();
+vi.mock("@cloudflare/workers-oauth-provider", () => ({
+  getOAuthApi: (...args) => getOAuthApiMock(...args),
+}));
+
+beforeEach(() => {
+  getOAuthApiMock.mockReset();
+});
+
+function createFakeKv() {
+  const store = new Map();
+  return {
+    async get(key) {
+      return store.has(key) ? store.get(key).value : null;
+    },
+    async put(key, value, opts) {
+      store.set(key, { value, opts });
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+    _store: store,
+  };
+}
+
+function baseEnv(overrides = {}) {
+  return {
+    OAUTH_KV: createFakeKv(),
+    GITHUB_OAUTH_CLIENT_ID: "client-id",
+    GITHUB_OAUTH_CLIENT_SECRET: "client-secret",
+    DATA_API: { fetch: async () => new Response(JSON.stringify({ id: 1 })) },
+    ...overrides,
+  };
+}
+
+const FAKE_AUTH_REQUEST = {
+  responseType: "code",
+  clientId: "mcp-client",
+  redirectUri: "https://client.example/callback",
+  scope: ["profile"],
+  state: "client-state",
+};
+
+function fakeHelpers(overrides = {}) {
+  return {
+    parseAuthRequest: async () => FAKE_AUTH_REQUEST,
+    lookupClient: async () => ({ clientId: "mcp-client" }),
+    completeAuthorization: async () => ({
+      redirectTo: "https://client.example/callback?code=abc",
+    }),
+    ...overrides,
+  };
+}
+
+describe("UNUSED_DEFAULT_HANDLER", () => {
+  test("fetch() is a well-formed placeholder -- never actually invoked in production", async () => {
+    const res = await UNUSED_DEFAULT_HANDLER.fetch();
+    assert.equal(res.status, 500);
+    assert.match(await res.text(), /not used outside OAuthProvider\.fetch\(\)/);
+  });
+});
+
+describe("buildOAuthProviderOptions", () => {
+  test("is pure and matches the MCP-only apiRoute shape", () => {
+    const defaultHandler = { fetch: async () => new Response("default") };
+    const options = buildOAuthProviderOptions(defaultHandler);
+    assert.equal(options.apiRoute, "/mcp");
+    assert.equal(options.authorizeEndpoint, "/authorize");
+    assert.equal(options.tokenEndpoint, "/oauth/token");
+    assert.equal(options.clientRegistrationEndpoint, "/oauth/register");
+    assert.equal(options.defaultHandler, defaultHandler);
+  });
+
+  test("apiHandler.fetch delegates to the given defaultHandler unchanged", async () => {
+    const calls = [];
+    const defaultHandler = {
+      fetch: async (request, env, ctx) => {
+        calls.push([request, env, ctx]);
+        return new Response("delegated");
+      },
+    };
+    const options = buildOAuthProviderOptions(defaultHandler);
+    const response = await options.apiHandler.fetch("req", "env", "ctx");
+    assert.equal(await response.text(), "delegated");
+    assert.deepEqual(calls, [["req", "env", "ctx"]]);
+  });
+});
+
+describe("handleAuthorizeRequest", () => {
+  test("503 when OAUTH_KV is unbound", async () => {
+    const env = baseEnv({ OAUTH_KV: undefined });
+    const res = await handleAuthorizeRequest(
+      new Request("https://x/authorize"),
+      env,
+    );
+    assert.equal(res.status, 503);
+  });
+
+  test("503 when GITHUB_OAUTH_CLIENT_ID is unset", async () => {
+    const env = baseEnv({ GITHUB_OAUTH_CLIENT_ID: undefined });
+    const res = await handleAuthorizeRequest(
+      new Request("https://x/authorize"),
+      env,
+    );
+    assert.equal(res.status, 503);
+  });
+
+  test("400 when parseAuthRequest rejects", async () => {
+    const env = baseEnv();
+    const deps = {
+      getHelpers: async () =>
+        fakeHelpers({
+          parseAuthRequest: async () => {
+            throw new Error("bad redirect_uri");
+          },
+        }),
+    };
+    const res = await handleAuthorizeRequest(
+      new Request("https://x/authorize"),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 400);
+    assert.match(await res.text(), /bad redirect_uri/);
+  });
+
+  test("400 when lookupClient finds no client", async () => {
+    const env = baseEnv();
+    const deps = {
+      getHelpers: async () => fakeHelpers({ lookupClient: async () => null }),
+    };
+    const res = await handleAuthorizeRequest(
+      new Request("https://x/authorize"),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 400);
+    assert.match(await res.text(), /unknown client_id/);
+  });
+
+  test("400 with a generic message when the thrown error has no .message", async () => {
+    const env = baseEnv();
+    const deps = {
+      getHelpers: async () =>
+        fakeHelpers({
+          parseAuthRequest: async () => {
+            // Deliberately a non-Error throw, to exercise the err?.message
+            // fallback branch.
+            throw "not an Error instance";
+          },
+        }),
+    };
+    const res = await handleAuthorizeRequest(
+      new Request("https://x/authorize"),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 400);
+    assert.match(await res.text(), /unknown error/);
+  });
+
+  test("falls back to the real getOAuthApi when deps.getHelpers is omitted", async () => {
+    const env = baseEnv();
+    getOAuthApiMock.mockReturnValue(fakeHelpers());
+    const res = await handleAuthorizeRequest(
+      new Request("https://api.metagraph.sh/authorize"),
+      env,
+    );
+    assert.equal(res.status, 302);
+    assert.equal(getOAuthApiMock.mock.calls.length, 1);
+  });
+
+  test("stashes the parsed AuthRequest in OAUTH_KV and redirects to GitHub", async () => {
+    const env = baseEnv();
+    const deps = { getHelpers: async () => fakeHelpers() };
+    const res = await handleAuthorizeRequest(
+      new Request("https://api.metagraph.sh/authorize"),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 302);
+    const location = new URL(res.headers.get("location"));
+    assert.equal(location.origin, "https://github.com");
+    assert.equal(location.pathname, "/login/oauth/authorize");
+    assert.equal(location.searchParams.get("client_id"), "client-id");
+    assert.equal(
+      location.searchParams.get("redirect_uri"),
+      "https://api.metagraph.sh/oauth/callback/github",
+    );
+    assert.equal(location.searchParams.get("scope"), "read:user");
+    const nonce = location.searchParams.get("state");
+    assert.ok(nonce && nonce.length > 0);
+
+    const stored = env.OAUTH_KV._store.get(`oauth-pending:${nonce}`);
+    assert.ok(stored);
+    assert.deepEqual(JSON.parse(stored.value), FAKE_AUTH_REQUEST);
+    assert.equal(stored.opts.expirationTtl, OAUTH_PENDING_TTL_SECONDS);
+  });
+});
+
+function githubCallbackUrl(params) {
+  const url = new URL("https://api.metagraph.sh/oauth/callback/github");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return url.toString();
+}
+
+async function seedPendingState(env, nonce, authRequest = FAKE_AUTH_REQUEST) {
+  await env.OAUTH_KV.put(
+    `oauth-pending:${nonce}`,
+    JSON.stringify(authRequest),
+    {
+      expirationTtl: OAUTH_PENDING_TTL_SECONDS,
+    },
+  );
+}
+
+function fakeGithubFetch({
+  tokenOk = true,
+  tokenBody = { access_token: "gh-token" },
+  userOk = true,
+  userBody = { id: 42, login: "octocat" },
+} = {}) {
+  return async (url) => {
+    const href = typeof url === "string" ? url : url.toString();
+    if (href === "https://github.com/login/oauth/access_token") {
+      return new Response(JSON.stringify(tokenBody), {
+        status: tokenOk ? 200 : 400,
+      });
+    }
+    if (href === "https://api.github.com/user") {
+      return new Response(JSON.stringify(userBody), {
+        status: userOk ? 200 : 401,
+      });
+    }
+    throw new Error(`unexpected fetch to ${href}`);
+  };
+}
+
+describe("handleGithubOAuthCallback", () => {
+  test("503 when github oauth is not provisioned", async () => {
+    const env = baseEnv({ GITHUB_OAUTH_CLIENT_SECRET: undefined });
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "s" })),
+      env,
+    );
+    assert.equal(res.status, 503);
+  });
+
+  test("400 when code or state is missing", async () => {
+    const env = baseEnv();
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ state: "s" })),
+      env,
+    );
+    assert.equal(res.status, 400);
+  });
+
+  test("400 when the state nonce is unknown/expired", async () => {
+    const env = baseEnv();
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "missing-nonce" })),
+      env,
+    );
+    assert.equal(res.status, 400);
+    assert.match(await res.text(), /restart the login/);
+  });
+
+  test("500 when the pending state is corrupted", async () => {
+    const env = baseEnv();
+    await env.OAUTH_KV.put("oauth-pending:n1", "not json", {});
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+    );
+    assert.equal(res.status, 500);
+  });
+
+  test("state is single-use -- deleted before any further work", async () => {
+    const env = baseEnv();
+    await seedPendingState(env, "n1");
+    const deps = {
+      fetch: fakeGithubFetch(),
+      getHelpers: async () => fakeHelpers(),
+    };
+    await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(env.OAUTH_KV._store.has("oauth-pending:n1"), false);
+
+    const replay = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(replay.status, 400);
+  });
+
+  test("502 when github token exchange fails", async () => {
+    const env = baseEnv();
+    await seedPendingState(env, "n1");
+    const deps = { fetch: fakeGithubFetch({ tokenOk: false }) };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 502);
+    assert.match(await res.text(), /token exchange failed/);
+  });
+
+  test("502 when github returns no access_token", async () => {
+    const env = baseEnv();
+    await seedPendingState(env, "n1");
+    const deps = { fetch: fakeGithubFetch({ tokenBody: {} }) };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 502);
+    assert.match(await res.text(), /no access_token/);
+  });
+
+  test("502 when the github user profile fetch fails", async () => {
+    const env = baseEnv();
+    await seedPendingState(env, "n1");
+    const deps = { fetch: fakeGithubFetch({ userOk: false }) };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 502);
+    assert.match(await res.text(), /user profile/);
+  });
+
+  test("502 when the github user profile is missing id/login", async () => {
+    const env = baseEnv();
+    await seedPendingState(env, "n1");
+    const deps = { fetch: fakeGithubFetch({ userBody: { login: "octocat" } }) };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 502);
+    assert.match(await res.text(), /missing id\/login/);
+  });
+
+  test("503 when DATA_API is unbound", async () => {
+    const env = baseEnv({ DATA_API: undefined });
+    await seedPendingState(env, "n1");
+    const deps = { fetch: fakeGithubFetch() };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 503);
+  });
+
+  test("502 when the DATA_API upsert fails", async () => {
+    const env = baseEnv({
+      DATA_API: { fetch: async () => new Response("boom", { status: 500 }) },
+    });
+    await seedPendingState(env, "n1");
+    const deps = { fetch: fakeGithubFetch() };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 502);
+    assert.match(await res.text(), /account storage failed/);
+  });
+
+  test("happy path: upserts the account and completes authorization", async () => {
+    let upsertRequest;
+    const env = baseEnv({
+      DATA_API: {
+        fetch: async (request) => {
+          upsertRequest = request;
+          return new Response(
+            JSON.stringify({ id: 7, github_login: "octocat", tier: "free" }),
+          );
+        },
+      },
+    });
+    await seedPendingState(env, "n1");
+    let completeAuthorizationArgs;
+    const deps = {
+      fetch: fakeGithubFetch(),
+      getHelpers: async () =>
+        fakeHelpers({
+          completeAuthorization: async (opts) => {
+            completeAuthorizationArgs = opts;
+            return { redirectTo: "https://client.example/callback?code=xyz" };
+          },
+        }),
+    };
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      deps,
+    );
+    assert.equal(res.status, 302);
+    assert.equal(
+      res.headers.get("location"),
+      "https://client.example/callback?code=xyz",
+    );
+
+    assert.equal(
+      upsertRequest.url,
+      "https://internal/api/v1/auth/github/upsert-account",
+    );
+    assert.deepEqual(await upsertRequest.clone().json(), {
+      github_user_id: 42,
+      github_login: "octocat",
+    });
+
+    assert.equal(completeAuthorizationArgs.userId, "7");
+    assert.deepEqual(completeAuthorizationArgs.request, FAKE_AUTH_REQUEST);
+    assert.deepEqual(completeAuthorizationArgs.props, {
+      githubUserId: 42,
+      githubLogin: "octocat",
+      accountId: 7,
+    });
+  });
+
+  test("falls back to globalThis.fetch when deps.fetch is omitted", async () => {
+    const env = baseEnv();
+    await seedPendingState(env, "n1");
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = fakeGithubFetch();
+    try {
+      const res = await handleGithubOAuthCallback(
+        new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+        env,
+        { getHelpers: async () => fakeHelpers() },
+      );
+      assert.equal(res.status, 302);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("falls back to the real getOAuthApi when deps.getHelpers is omitted", async () => {
+    const env = baseEnv();
+    await seedPendingState(env, "n1");
+    getOAuthApiMock.mockReturnValue(fakeHelpers());
+    const res = await handleGithubOAuthCallback(
+      new Request(githubCallbackUrl({ code: "c", state: "n1" })),
+      env,
+      { fetch: fakeGithubFetch() },
+    );
+    assert.equal(res.status, 302);
+    assert.equal(getOAuthApiMock.mock.calls.length, 1);
+  });
+});

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -2344,3 +2344,42 @@ describe("Agent discovery surfaces", () => {
     }
   });
 });
+
+// GitHub OAuth (metagraphed#7151): confirms api.mjs actually dispatches
+// these two GET-only paths to src/github-oauth.mjs's handlers -- the
+// handlers' own logic (state validation, GitHub token exchange, the
+// DATA_API upsert, error branches) is exhaustively covered directly in
+// tests/github-oauth.test.mjs; this only proves the routing wire-up. The
+// shared `env` above has no OAUTH_KV, so both hit that handler's very
+// first branch -- enough to prove the route reaches the right function
+// without re-testing OAuth logic already covered elsewhere.
+describe("GitHub OAuth route dispatch", () => {
+  test("GET /authorize reaches handleAuthorizeRequest", async () => {
+    const response = await handleRequest(
+      new Request("https://api.metagraph.sh/authorize"),
+      env,
+      {},
+    );
+    assert.equal(response.status, 503);
+    assert.match(await response.text(), /oauth is not provisioned/);
+  });
+
+  test("POST /authorize is not routed (GET-only)", async () => {
+    const response = await handleRequest(
+      new Request("https://api.metagraph.sh/authorize", { method: "POST" }),
+      env,
+      {},
+    );
+    assert.notEqual(response.status, 503);
+  });
+
+  test("GET /oauth/callback/github reaches handleGithubOAuthCallback", async () => {
+    const response = await handleRequest(
+      new Request("https://api.metagraph.sh/oauth/callback/github"),
+      env,
+      {},
+    );
+    assert.equal(response.status, 503);
+    assert.match(await response.text(), /oauth is not provisioned/);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -285,6 +285,10 @@ import { handleOgImage } from "../src/og-image.mjs";
 import { handleIconProxy } from "../src/icon-proxy.mjs";
 import { handleGraphQLRequest } from "../src/graphql.mjs";
 import {
+  handleAuthorizeRequest,
+  handleGithubOAuthCallback,
+} from "../src/github-oauth.mjs";
+import {
   handleSavedQueryRequest,
   SAVED_QUERIES_PATH_PREFIX,
 } from "./request-handlers/saved-queries.mjs";
@@ -1551,6 +1555,18 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   }
   if (url.pathname.startsWith("/api/v1/keys")) {
     return handleAccountKeysProxy(request, env);
+  }
+
+  // GitHub OAuth (metagraphed#7151): the two routes @cloudflare/workers-
+  // oauth-provider's own authorizeEndpoint deliberately leaves to
+  // application code (see src/github-oauth.mjs's header). GET-only --
+  // both are browser-redirect targets, never called by a client library
+  // directly.
+  if (request.method === "GET" && url.pathname === "/authorize") {
+    return handleAuthorizeRequest(request, env);
+  }
+  if (request.method === "GET" && url.pathname === "/oauth/callback/github") {
+    return handleGithubOAuthCallback(request, env);
   }
 
   // Remote MCP server, for AI agents: stateless JSON-RPC over POST, plus GET

--- a/workers/api.sentry.mjs
+++ b/workers/api.sentry.mjs
@@ -40,7 +40,9 @@
 // nothing does today (tests import the raw file only; only wrangler's
 // build ever loads this wrapper).
 import { withSentry } from "@sentry/cloudflare";
+import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
 import handler from "./api.mjs";
+import { buildOAuthProviderOptions } from "../src/github-oauth.mjs";
 // wrangler.jsonc's "main" now points at THIS file, so wrangler looks for
 // every Durable Object binding's class as a named export from here, not
 // from api.mjs -- confirmed by a real `wrangler deploy --dry-run` failure
@@ -52,6 +54,29 @@ export {
   AlerterHub,
   SubnetStatusHub,
 } from "./api.mjs";
+
+// GitHub OAuth (metagraphed#7151): OAuthProvider owns top-level fetch
+// dispatch (its own /oauth/token + /oauth/register endpoints, plus routing
+// /mcp to apiHandler with ctx.props populated when a valid Bearer token is
+// present, falling through to defaultHandler -- the real, unmodified
+// `handler` -- for everything else, INCLUDING /mcp with no/invalid token).
+// Anonymous/IP-rate-limited access is therefore completely unaffected; see
+// src/github-oauth.mjs's own header for the full flow.
+//
+// OAuthProvider instances expose ONLY .fetch(), not .scheduled() -- this
+// Worker has four live cron triggers (wrangler.jsonc "triggers.crons": the
+// 15-min health probe, two hourly rollups, the daily embedding sync) that
+// dispatch to handler.scheduled (handleScheduled in api.mjs). Swapping the
+// top-level export for a bare OAuthProvider instance would silently drop
+// every one of those -- Cloudflare would just never find a .scheduled to
+// call. This composed object keeps .scheduled pointed at the ORIGINAL,
+// untouched handler so cron behavior is byte-for-byte unaffected by this
+// change; only .fetch is rerouted through OAuthProvider.
+const oauthProvider = new OAuthProvider(buildOAuthProviderOptions(handler));
+const handlerWithOAuth = {
+  fetch: (request, env, ctx) => oauthProvider.fetch(request, env, ctx),
+  scheduled: (controller, env, ctx) => handler.scheduled(controller, env, ctx),
+};
 
 export default withSentry(
   (env) => ({
@@ -75,5 +100,5 @@ export default withSentry(
     // calibrate that against, rather than guessing now.
     tracesSampleRate: 0.05,
   }),
-  handler,
+  handlerWithOAuth,
 );

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -4044,6 +4044,51 @@ async function handleWalletVerify(request, env) {
   });
 }
 
+// GitHub OAuth account upsert (metagraphed#7151) -- reached ONLY via the
+// DATA_API service binding from src/github-oauth.mjs's callback handler,
+// never directly from a browser/MCP client (this Worker has no public route
+// or workers.dev subdomain -- wrangler.data.jsonc's own "workers_dev": false,
+// same posture the wallet routes above already rely on). The GitHub identity
+// itself was already established by the caller's own code/token exchange
+// with GitHub before this call is made; this route's only job is the
+// Postgres write, mirroring handleWalletVerify's shape immediately above
+// (upsert, return the account row) minus the session-token minting -- the
+// caller mints ITS OWN grant/token via OAuthHelpers.completeAuthorization,
+// which needs OAUTH_KV (a binding only the caller's Worker has).
+async function handleGithubAccountUpsert(request, env) {
+  const { body, error } = await readAccountRouteBody(request);
+  if (error) return error;
+  const githubUserId = body?.github_user_id;
+  const githubLogin = body?.github_login;
+  if (
+    !Number.isInteger(githubUserId) ||
+    typeof githubLogin !== "string" ||
+    !githubLogin
+  ) {
+    return writeJson(
+      {
+        error:
+          "github_user_id (integer) and github_login (string) are required",
+      },
+      400,
+    );
+  }
+  return withAccountsSql(env, async (sql) => {
+    const now = Date.now();
+    const [account] = await sql`
+      INSERT INTO github_accounts (github_user_id, github_login, created_at, last_login_at)
+      VALUES (${githubUserId}, ${githubLogin}, ${now}, ${now})
+      ON CONFLICT (github_user_id) DO UPDATE
+        SET github_login = ${githubLogin}, last_login_at = ${now}
+      RETURNING id, github_login, tier`;
+    return writeJson({
+      id: account.id,
+      github_login: account.github_login,
+      tier: account.tier,
+    });
+  });
+}
+
 // Shared by every /api/v1/keys route: resolves the Authorization header to
 // { accountId, ss58 }, or a ready-to-return error response. A missing
 // WALLET_SESSION_SECRET is a deployment-config gap (503), distinct from a
@@ -4476,6 +4521,12 @@ export default {
       url.pathname === "/api/v1/auth/wallet/verify"
     ) {
       return handleWalletVerify(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/auth/github/upsert-account"
+    ) {
+      return handleGithubAccountUpsert(request, env);
     }
     if (url.pathname.startsWith("/api/v1/keys")) {
       return handleAccountKeysRoute(request, env, url);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -336,6 +336,14 @@
     // this remains a single-flag revert (D1's copy is frozen from this point
     // on, not actively wrong).
     "METAGRAPH_HEALTH_SOURCE": "postgres",
+    // GitHub OAuth App for MCP/API auth (metagraphed#7151) -- identity check
+    // only (no repo-scoped permissions requested), plugged into our own
+    // OAuth 2.1 authorization server (@cloudflare/workers-oauth-provider) as
+    // the upstream provider behind its consent screen. Not secret -- a
+    // GitHub OAuth Client ID is meant to appear in the authorize URL a
+    // browser is redirected to, same as any public OAuth client_id.
+    // GITHUB_OAUTH_CLIENT_SECRET is a wrangler secret, set separately.
+    "GITHUB_OAUTH_CLIENT_ID": "Ov23liz4NzqUvC8YrKMS",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent
   // surface). The apex metagraph.sh is the metagraphed-ui worker. Agents hit the
@@ -365,6 +373,16 @@
     {
       "binding": "METAGRAPH_CONTROL",
       "id": "9c5577a3454d4830b2ffd2f83775efb1",
+    },
+    // Required by @cloudflare/workers-oauth-provider (metagraphed#7151):
+    // token metadata (hashed, not raw), authorization grants, and client
+    // registrations for our own OAuth 2.1 authorization server. Separate
+    // namespace from METAGRAPH_CONTROL so the library owns its own
+    // key-space/TTL behavior rather than sharing one with unrelated control
+    // data.
+    {
+      "binding": "OAUTH_KV",
+      "id": "76c8cd99795b46bf98b42fd151c1f362",
     },
   ],
   "r2_buckets": [


### PR DESCRIPTION
Closes #7151.

## Summary

The MCP/API is currently fully unauthenticated (`public/auth.md`: no auth of any kind, IP-rate-limited only). This adds real GitHub OAuth as identity, using `@cloudflare/workers-oauth-provider` so our MCP server satisfies the OAuth-2.1-resource-server side of the MCP Authorization spec (PKCE, RFC9728 Protected Resource Metadata, token issuance) without hand-rolling it. GitHub sits behind our own authorization server as the identity check during the consent step -- a plain **OAuth App**, not a GitHub App, since only identity is needed, never repo-level API access. The same App can back a conventional "Sign in with GitHub" website button later, as ordinary authorization-code flow with no MCP-spec overhead.

**Auth is additive, not required** -- anonymous/IP-rate-limited access is completely unaffected. A request to `/mcp` with no or an invalid token falls through to the unmodified `defaultHandler` (today's exact behavior), matching the spec's own stance that MCP authorization is OPTIONAL.

## What's here

- `src/github-oauth.mjs`: `/authorize` (parse + stash the incoming AuthRequest in `OAUTH_KV`, redirect to GitHub) and `/oauth/callback/github` (exchange code, fetch the GitHub user, upsert via `DATA_API`, complete the grant, redirect back to the MCP client). `completeAuthorization` runs in this Worker (needs `OAUTH_KV`); the Postgres write is a single `DATA_API` hop, mirroring `handleWalletVerify`'s existing shape in `workers/data-api.mjs`.
- `github_accounts` table (`deploy/postgres/schema.sql`), parallel to the existing `rpc_accounts` wallet-auth table -- kept separate rather than merged since the identity proof is structurally different.
- `workers/api.sentry.mjs` now wraps `OAuthProvider` instead of the raw handler, scoped to `apiRoute: "/mcp"`. **Caught before it shipped**: `OAuthProvider` instances only implement `.fetch()`, not `.scheduled()` -- this Worker has four live cron triggers (health probe, two hourly rollups, daily embedding sync). Naively swapping the top-level export would have silently stopped every one of them from firing. `.scheduled` is kept pointed at the original, completely unmodified handler.
- **Also caught before it shipped**: `@cloudflare/workers-oauth-provider`'s real runtime file (not just its `.d.ts`) does `import ... from "cloudflare:workers"` at module scope -- a protocol that only exists in the real Workers runtime. A static import anywhere in `workers/api.mjs`'s module graph would have broken all ~90+ (confirmed: 103) existing plain-Node vitest test files that import `api.mjs` directly, regardless of whether they touch OAuth. Fixed by only ever touching the package via a lazy dynamic import, with both new route handlers accepting an injectable `deps.getHelpers`/`deps.fetch` (same shape as `usage-telemetry.mjs`'s existing `deps.fetch` pattern) so the real package is never touched by any test.

## Validation run

- `npx vitest run` (full suite, single clean process) -- 337/337 test files passed
- `src/github-oauth.mjs`: 100% statements/branches/functions/lines in isolation (`tests/github-oauth.test.mjs`, 24 tests) -- including the production-default fallback paths (`deps.getHelpers`/`deps.fetch` omitted) via `vi.mock` on the OAuth package, never touching the real thing
- New `workers/data-api.mjs` lines (`handleGithubAccountUpsert`) and `workers/api.mjs` lines (the two new route dispatches): verified 0 uncovered lines via direct v8 coverage-JSON inspection scoped to the new line ranges
- `npm run lint` -- clean
- `npx prettier --check` on every touched file -- clean
- `node scripts/scan-public-safety.mjs` -- passed
- `node scripts/worker-bundle-budget.mjs` -- 432.9 KiB / 1020 KiB fail line
- `npm run validate` -- 129 subnets, 1821 surfaces, clean
- `git diff --check` -- clean

## Manual step already done

GitHub OAuth App created (owner-only GitHub UI step); Client Secret set as a live `wrangler secret` on the `metagraphed` Worker (never echoed to any log/output); Client ID + a real `OAUTH_KV` KV namespace wired into `wrangler.jsonc`.

## Explicitly out of scope (this PR)

- Making auth mandatory for any existing route.
- The website "Sign in with GitHub" button UI itself.
- Propagating the validated identity (`ctx.props`) into MCP tool dispatch / usage telemetry -- wired to be available, not yet consumed.

## Review note

This touches the request-routing entrypoint and adds a new external-identity trust boundary -- holding for manual review rather than the normal auto-merge gate, given the stakes.