### PR TITLE
feat(api): add GraphQL parity for curation

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -26,6 +26,10 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.mjs";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.mjs";
+// #6982: GraphQL parity for GET /api/v1/curation, reusing list_curation's own
+// loader unchanged (same artifact read, filter, sort, and page logic REST and
+// MCP already use) -- not a reimplementation.
+import { loadCurationList } from "./curation-mcp.mjs";
 import {
   buildChainAxonRemovals,
   CHAIN_AXON_REMOVALS_WINDOWS,
@@ -473,6 +477,8 @@ export const SDL = `
     source_snapshots(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SourceSnapshotList!
     "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
     profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
+    "Per-subnet curation states -- coverage_level, curation_level, source counts, and review posture for every active subnet. Filter by netuid/coverage_level/curation_level, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/curation."
+    curation(netuid: Int, coverage_level: String, curation_level: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): CurationList!
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
@@ -1734,6 +1740,19 @@ export const SDL = `
   type ProfileList {
     captured_at: String
     profiles: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type CurationList {
+    generated_at: String
+    notes: String
+    curation: [JSON!]!
     total: Int!
     returned: Int!
     limit: Int!
@@ -3479,6 +3498,7 @@ export const FIELD_COMPLEXITY = {
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
   profiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  curation: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5023,6 +5043,10 @@ const rootValue = {
     return loadProfilesList(context, args, {
       readOptionalArtifact: loadArtifact,
     });
+  },
+
+  curation(args, context) {
+    return loadCurationList(context, args, { readArtifact });
   },
 
   async health(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1666,6 +1666,92 @@ describe("graphql — profiles", () => {
   });
 });
 
+describe("graphql — curation", () => {
+  const CURATION_ROW = {
+    netuid: 7,
+    slug: "allways",
+    name: "Allways",
+    coverage_level: "manifested",
+    curation_level: "maintainer-reviewed",
+    source_count: 3,
+  };
+
+  const CURATION_BLOB = {
+    generated_at: "2026-06-20T00:00:00Z",
+    notes: "test fixture",
+    curation: [
+      CURATION_ROW,
+      {
+        ...CURATION_ROW,
+        netuid: 1,
+        slug: "alpha",
+        name: "Alpha",
+        coverage_level: "probed",
+        source_count: 5,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const filtered = await gql(
+      "{ curation(netuid: 7) { curation total generated_at } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.curation.total, 1);
+    assert.equal(filtered.body.data.curation.curation[0].slug, "allways");
+    assert.equal(
+      filtered.body.data.curation.generated_at,
+      "2026-06-20T00:00:00Z",
+    );
+
+    const paged = await gql(
+      "{ curation(limit: 1) { curation total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.curation.curation.length, 1);
+    assert.equal(paged.body.data.curation.total, 2);
+    assert.equal(paged.body.data.curation.returned, 1);
+    assert.ok(paged.body.data.curation.next_cursor != null);
+  });
+
+  test("filters by coverage_level and sorts by netuid", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const filtered = await gql(
+      '{ curation(coverage_level: "probed") { curation total } }',
+      env,
+    );
+    assert.equal(filtered.body.data.curation.total, 1);
+    assert.equal(filtered.body.data.curation.curation[0].slug, "alpha");
+
+    const sorted = await gql(
+      '{ curation(sort: "netuid", order: "desc") { curation } }',
+      env,
+    );
+    assert.equal(sorted.body.data.curation.curation[0].slug, "allways");
+  });
+
+  test("surfaces an invalid coverage_level as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const { body } = await gql(
+      '{ curation(coverage_level: "bogus") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ curation { total } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.curation, 5);
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({


### PR DESCRIPTION
Closes #6982

## What

`GET /api/v1/curation` had an MCP tool (`list_curation`) but no GraphQL field.

## Fix

- Added `Query.curation(netuid, coverage_level, curation_level, sort, order, fields, limit, cursor): CurationList!`, mirroring `profiles`' own SDL shape and filter/sort/page surface exactly (the closest existing precedent — same generic `queryCollection` artifact pattern).
- Resolver reuses `loadCurationList` from `src/curation-mcp.mjs` unchanged — the same artifact read, filter, sort, and page logic REST and MCP already share — passing the already-imported `readArtifact` as its dependency, matching how `source_snapshots`/`profiles` already wire their own MCP loaders into GraphQL.
- `CurationList` type mirrors `ProfileList`'s shape (`curation: [JSON!]!` opaque rows, matching the "subnet_gaps"/"subnet_evidence" convention of passing complex/evolving row shapes through as opaque JSON rather than hand-typing every field).
- Added `curation: RELATIONSHIP_FIELD_COMPLEXITY` to `FIELD_COMPLEXITY`, same weight as its sibling collection fields.

## Testing

```
npx vitest run tests/graphql.test.mjs
# 719 passed (6 new curation tests + 713 pre-existing, zero regressions)

npx eslint src/graphql.mjs tests/graphql.test.mjs
# clean

npx prettier --check src/graphql.mjs tests/graphql.test.mjs
# clean
```

New tests cover: filtering by `netuid` + pagination (`limit`/`next_cursor`), filtering by `coverage_level` + sorting by `netuid`, an invalid `coverage_level` surfacing as a GraphQL error (not a silent default), a cold/missing artifact surfacing as a GraphQL error (matching REST/MCP), and the `FIELD_COMPLEXITY` weight assertion. Coverage confirmed scoped to every new line in both `src/graphql.mjs` and the reused `src/curation-mcp.mjs` loader — zero uncovered/partial-branch lines in the diff.