### PR TITLE
feat(api): GraphQL parity for registry_summary, source_health, lineage, rpc_endpoints

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -132,6 +132,7 @@ import {
   formatLeaderboards,
   LEADERBOARD_BOARDS,
   loadSubnetTrajectory,
+  mergeRpcEndpoints,
   resolveLiveEconomics,
   resolveLiveHealth,
   subnetBadgeStatus,
@@ -252,7 +253,7 @@ import {
   buildCounterparties,
   buildCounterpartyRelationship,
 } from "./counterparties.mjs";
-import { KV_HEALTH_META } from "./kv-keys.mjs";
+import { KV_HEALTH_META, KV_HEALTH_RPC_POOL } from "./kv-keys.mjs";
 import {
   ANALYTICS_WINDOWS,
   DEFAULT_ANALYTICS_WINDOW,
@@ -473,6 +474,14 @@ export const SDL = `
     source_snapshots(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SourceSnapshotList!
     "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
     profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
+    "The registry-wide summary: overall subnet count, coverage/curation-level/profile-level counts, recent registry changes, and the most-complete top subnets. A fast orientation for the whole Bittensor application layer. Null when the summary has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the registry_summary MCP/REST shape. Mirrors GET /api/v1/registry/summary."
+    registry_summary: JSON
+    "The per-provider source-health rollup: for each provider/source, the candidate-surface count and its live/redirected/dead classification, endpoint and RPC-endpoint counts, verification-result count, and an overall status. Null when the rollup has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_source_health MCP/REST shape. Mirrors GET /api/v1/source-health."
+    source_health: JSON
+    "The maintainer-approved cross-network subnet lineage: which testnet subnets have graduated to mainnet (mainnet <-> testnet pairs with match evidence), plus any flagged broken links. Null when the lineage has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_lineage MCP/REST shape. Mirrors GET /api/v1/lineage."
+    lineage: JSON
+    "The full catalog of monitored Bittensor base-layer RPC endpoints and their status (each endpoint's URL, network, and probe-derived health/latency), with the same live 15-minute cron RPC-pool overlay REST and MCP apply before serving. Null when the catalog has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the list_rpc_endpoints MCP/REST shape. Mirrors GET /api/v1/rpc/endpoints."
+    rpc_endpoints: JSON
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
@@ -3479,6 +3488,10 @@ export const FIELD_COMPLEXITY = {
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
   profiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  registry_summary: RELATIONSHIP_FIELD_COMPLEXITY,
+  source_health: RELATIONSHIP_FIELD_COMPLEXITY,
+  lineage: RELATIONSHIP_FIELD_COMPLEXITY,
+  rpc_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5023,6 +5036,37 @@ const rootValue = {
     return loadProfilesList(context, args, {
       readOptionalArtifact: loadArtifact,
     });
+  },
+
+  registry_summary(_args, context) {
+    // Same baked artifact the REST route + registry_summary MCP tool read.
+    // Degrades to null when cold instead of erroring, matching every other
+    // artifact-backed resolver here.
+    return loadArtifact(context, "/metagraph/registry-summary.json");
+  },
+
+  source_health(_args, context) {
+    // Same baked artifact the REST route + get_source_health MCP tool read.
+    return loadArtifact(context, "/metagraph/source-health.json");
+  },
+
+  lineage(_args, context) {
+    // Same baked artifact the REST route + get_lineage MCP tool read.
+    return loadArtifact(context, "/metagraph/lineage.json");
+  },
+
+  async rpc_endpoints(_args, context) {
+    // Same baked catalog the REST route + list_rpc_endpoints MCP tool read,
+    // with the same live overlay: the 15-minute cron RPC-pool KV snapshot
+    // replaces the stale build-time health/latency (mergeRpcEndpoints). With no
+    // live snapshot the static catalog passes through; a cold artifact degrades
+    // to null instead of erroring, matching the other artifact-backed resolvers.
+    const staticData = await loadArtifact(
+      context,
+      "/metagraph/rpc-endpoints.json",
+    );
+    const pool = await readHealthKv(context.env, KV_HEALTH_RPC_POOL);
+    return pool ? mergeRpcEndpoints(staticData, pool) : staticData;
   },
 
   async health(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6304,6 +6304,148 @@ describe("graphql — agent_resources (#6987, baked AI-resources index)", () => 
   });
 });
 
+// #7168: GraphQL parity for the registry-summary / source-health / lineage /
+// rpc-endpoints REST routes, each reusing the same baked artifact its MCP tool
+// (registry_summary / get_source_health / get_lineage / list_rpc_endpoints)
+// reads -- a cold artifact degrades to null (schema-stable), never a GraphQL
+// error, matching agent_resources and the other artifact-backed resolvers.
+describe("graphql — registry_summary / source_health / lineage / rpc_endpoints (#7168)", () => {
+  test("registry_summary resolves the baked summary artifact", async () => {
+    const env = fixtureEnv({
+      "/metagraph/registry-summary.json": {
+        subnet_count: 128,
+        counts: { verified: 40 },
+        generated_at: "2026-07-01T00:00:00.000Z",
+      },
+    });
+    const { status, body } = await gql("{ registry_summary }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.registry_summary.subnet_count, 128);
+    assert.equal(body.data.registry_summary.counts.verified, 40);
+  });
+
+  test("source_health resolves the baked per-provider rollup", async () => {
+    const env = fixtureEnv({
+      "/metagraph/source-health.json": {
+        providers: [{ provider: "gittensor", status: "healthy" }],
+        generated_at: "2026-07-01T00:00:00.000Z",
+      },
+    });
+    const { status, body } = await gql("{ source_health }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.source_health.providers[0].provider, "gittensor");
+  });
+
+  test("lineage resolves the baked cross-network lineage", async () => {
+    const env = fixtureEnv({
+      "/metagraph/lineage.json": {
+        link_count: 3,
+        links: [{ mainnet_netuid: 64, testnet_netuid: 165 }],
+        generated_at: "2026-07-01T00:00:00.000Z",
+      },
+    });
+    const { status, body } = await gql("{ lineage }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.lineage.link_count, 3);
+    assert.equal(body.data.lineage.links[0].mainnet_netuid, 64);
+  });
+
+  const RPC_ENDPOINTS_BLOB = {
+    schema_version: 1,
+    generated_at: "2026-07-01T00:00:00.000Z",
+    summary: { endpoint_count: 2 },
+    endpoints: [
+      {
+        id: "finney-wss",
+        url: "wss://entrypoint-finney.opentensor.ai",
+        network: "finney",
+        status: "degraded",
+        archive_support: false,
+      },
+      {
+        id: "subvortex",
+        url: "wss://subvortex.example",
+        network: "finney",
+        status: "degraded",
+        archive_support: true,
+      },
+    ],
+  };
+
+  test("rpc_endpoints resolves the static catalog with no live overlay", async () => {
+    const env = fixtureEnv({
+      "/metagraph/rpc-endpoints.json": RPC_ENDPOINTS_BLOB,
+    });
+    const { status, body } = await gql("{ rpc_endpoints }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.rpc_endpoints.endpoints.length, 2);
+    assert.equal(body.data.rpc_endpoints.endpoints[0].id, "finney-wss");
+    // No live snapshot -> the static catalog passes through unchanged.
+    assert.equal(body.data.rpc_endpoints.source, undefined);
+  });
+
+  test("rpc_endpoints applies the live 15-minute RPC-pool overlay", async () => {
+    const env = fixtureEnv(
+      { "/metagraph/rpc-endpoints.json": RPC_ENDPOINTS_BLOB },
+      {
+        kv: {
+          [KV_HEALTH_RPC_POOL]: {
+            last_run_at: "2026-07-20T12:00:00.000Z",
+            endpoints: [
+              {
+                id: "finney-wss",
+                status: "healthy",
+                classification: "live",
+                latency_ms: 42,
+              },
+            ],
+          },
+        },
+      },
+    );
+    const { body } = await gql("{ rpc_endpoints }", env);
+    assert.equal(body.data.rpc_endpoints.source, "live-cron-prober");
+    assert.equal(
+      body.data.rpc_endpoints.operational_observed_at,
+      "2026-07-20T12:00:00.000Z",
+    );
+    const overlaid = body.data.rpc_endpoints.endpoints.find(
+      (e) => e.id === "finney-wss",
+    );
+    assert.equal(overlaid.latency_ms, 42);
+    assert.equal(overlaid.health_source, "probe-derived");
+  });
+
+  test("each field degrades to null on a cold artifact, never a GraphQL error", async () => {
+    for (const field of [
+      "registry_summary",
+      "source_health",
+      "lineage",
+      "rpc_endpoints",
+    ]) {
+      const { status, body } = await gql(`{ ${field} }`);
+      assert.equal(status, 200, `${field} should not error`);
+      assert.equal(body.errors, undefined, `${field} should not error`);
+      assert.equal(body.data[field], null, `${field} should degrade to null`);
+    }
+  });
+
+  test("FIELD_COMPLEXITY weights all four new fields like their sibling relationship fields", () => {
+    for (const field of [
+      "registry_summary",
+      "source_health",
+      "lineage",
+      "rpc_endpoints",
+    ]) {
+      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+    }
+  });
+});
+
 describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validators)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## What & why

Four live, public REST routes have an existing MCP tool but no GraphQL field. This adds them to `type Query` in `src/graphql.mjs`, closing #7168:

| GraphQL field | REST route | MCP tool |
| --- | --- | --- |
| `registry_summary` | `GET /api/v1/registry/summary` | `registry_summary` |
| `source_health` | `GET /api/v1/source-health` | `get_source_health` |
| `lineage` | `GET /api/v1/lineage` | `get_lineage` |
| `rpc_endpoints` | `GET /api/v1/rpc/endpoints` | `list_rpc_endpoints` |

## Approach

Each resolver reuses the **same baked artifact** its REST route + MCP tool already read (`loadArtifact(context, "/metagraph/…")`), degrading to `null` on a cold artifact — schema-stable, never a GraphQL error — exactly like `agent_resources` and every other artifact-backed resolver in the file. All four are opaque `JSON` passthrough, matching their MCP/REST shape (no new object types).

`rpc_endpoints` additionally applies the **same live 15-minute cron RPC-pool KV overlay** that REST and MCP apply before serving (`mergeRpcEndpoints(staticData, pool)` — byte-identical to `workers/api.mjs` and the `list_rpc_endpoints` handler), so the GraphQL field returns the same live-health/latency view, not the stale build-time snapshot. With no live snapshot the static catalog passes through unchanged.

Complexity-map entries added for all four (weighted like their sibling relationship fields). Scope is the two files every parity PR touches — `src/graphql.mjs` + `tests/graphql.test.mjs`.

## Verification

- `npx vitest run tests/graphql.test.mjs` — **721 passed** (8 new tests: each field resolving its artifact, the `rpc_endpoints` live-overlay, the no-overlay passthrough, all-four cold-degrade-to-null, and the complexity weighting).
- `prettier --check` + `eslint` on both files — clean.

Verified against `origin/main` (2026-07-20): none of the four fields existed in the `type Query` block.