### PR TITLE
feat(api): add GraphQL + MCP parity for coverage and coverage-depth

### DIFF
--- a/src/coverage-depth-mcp.mjs
+++ b/src/coverage-depth-mcp.mjs
@@ -1,0 +1,245 @@
+// Coverage-depth list loader for GraphQL/MCP parity on GET /api/v1/coverage-depth.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/coverage-depth.json artifact (data_key "rows"). Distinct from
+// list_enrichment_targets (mcp-server.mjs), which reshapes the same artifact
+// into a curated ranked-queue view rather than mirroring REST's generic
+// filter/sort/page contract 1:1.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const COVERAGE_DEPTH_ARTIFACT = "/metagraph/coverage-depth.json";
+
+const COVERAGE_DEPTH_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["coverage-depth"].sort_fields;
+const COVERAGE_DEPTH_TIERS = QUERY_ENUMS.coverageDepthTier;
+const AGENT_READINESS_STATUSES = QUERY_ENUMS.agentReadinessStatus;
+const AGENT_BLOCKER_LEVELS = QUERY_ENUMS.agentBlockerLevel;
+
+export function coverageDepthMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw coverageDepthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw coverageDepthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+export function coverageDepthQueryUrl(args) {
+  const url = new URL("https://mcp.internal/coverage-depth");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw coverageDepthMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const tier = optionalEnum(args, "tier", COVERAGE_DEPTH_TIERS);
+  if (tier) url.searchParams.set("tier", tier);
+  const agentStatus = optionalEnum(
+    args,
+    "agent_status",
+    AGENT_READINESS_STATUSES,
+  );
+  if (agentStatus) url.searchParams.set("agent_status", agentStatus);
+  const blockerLevel = optionalEnum(
+    args,
+    "blocker_level",
+    AGENT_BLOCKER_LEVELS,
+  );
+  if (blockerLevel) url.searchParams.set("blocker_level", blockerLevel);
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  const sort = optionalEnum(args, "sort", COVERAGE_DEPTH_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw coverageDepthMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw coverageDepthMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadCoverageDepthList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = coverageDepthQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, COVERAGE_DEPTH_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw coverageDepthMcpError(
+        "not_found",
+        "Coverage-depth scorecard unavailable.",
+      );
+    }
+    throw coverageDepthMcpError(
+      code,
+      `Could not load ${COVERAGE_DEPTH_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw coverageDepthMcpError(
+      "not_found",
+      "Coverage-depth scorecard unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "coverage-depth", []);
+  if (transformed.error) {
+    throw coverageDepthMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.rows) ? data.rows : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    coverage_depth_version: data.coverage_depth_version ?? null,
+    rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_COVERAGE_DEPTH_INSTRUCTIONS =
+  "list_coverage_depth the raw per-subnet coverage-depth scorecard rows " +
+  "(tier, agent_status, blocker_level, priority_score; mirrors GET " +
+  "/api/v1/coverage-depth 1:1) -- distinct from list_enrichment_targets, " +
+  "which reshapes the same data into a curated ranked-queue view, ";
+
+export const LIST_COVERAGE_DEPTH_MCP_TOOL = {
+  name: "list_coverage_depth",
+  title: "List coverage-depth scorecard rows",
+  description:
+    "Fetch the raw per-subnet coverage-depth scorecard rows: tier, " +
+    "agent_status, blocker_level, priority_score, and top gap codes for " +
+    "every registered subnet. Filter by netuid, tier, agent_status, or " +
+    "blocker_level; search by name/slug/gap codes/recommended action (q); " +
+    "sort with sort + order; page with limit (1-100) / cursor. Mirrors GET " +
+    "/api/v1/coverage-depth 1:1 -- use list_enrichment_targets instead for " +
+    "the curated, ranked work-planning view of the same data.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      tier: {
+        type: "string",
+        enum: COVERAGE_DEPTH_TIERS,
+        description: "Filter by coverage-depth tier.",
+      },
+      agent_status: {
+        type: "string",
+        enum: AGENT_READINESS_STATUSES,
+        description: "Filter by agent-readiness status.",
+      },
+      blocker_level: {
+        type: "string",
+        enum: AGENT_BLOCKER_LEVELS,
+        description: "Filter by agent blocker level.",
+      },
+      q: {
+        type: "string",
+        description:
+          "Keyword search across name/slug/top_gap_codes/recommended_next_action.",
+      },
+      sort: {
+        type: "string",
+        enum: COVERAGE_DEPTH_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of scorecard row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["rows"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    coverage_depth_version: NULLABLE_STRING,
+    rows: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -26,6 +26,14 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.mjs";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.mjs";
+// #6983: GraphQL parity for GET /api/v1/coverage + /api/v1/coverage-depth.
+// `coverage` reuses get_coverage's own loadRegistryCoverage unchanged.
+// `coverage_depth` reuses the new list_coverage_depth loader (added alongside
+// this field, since the only pre-existing coverage-depth MCP tool,
+// list_enrichment_targets, reshapes the artifact into a curated ranked-queue
+// view rather than REST's generic filter/sort/page contract).
+import { loadRegistryCoverage } from "./registry-coverage.mjs";
+import { loadCoverageDepthList } from "./coverage-depth-mcp.mjs";
 import {
   buildChainAxonRemovals,
   CHAIN_AXON_REMOVALS_WINDOWS,
@@ -473,6 +481,10 @@ export const SDL = `
     source_snapshots(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SourceSnapshotList!
     "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
     profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
+    "Registry-wide coverage rollup -- surface counts, official-surface coverage, completeness scores, and domain breakdown. Opaque JSON passed through verbatim, matching the get_coverage MCP/REST shape. Mirrors GET /api/v1/coverage."
+    coverage: JSON
+    "Per-subnet coverage-depth scorecard rows -- tier, agent_status, blocker_level, priority_score, and top gap codes for every registered subnet. Filter by netuid/tier/agent_status/blocker_level, search q, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/coverage-depth."
+    coverage_depth(netuid: Int, tier: String, agent_status: String, blocker_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): CoverageDepthList!
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
@@ -1734,6 +1746,19 @@ export const SDL = `
   type ProfileList {
     captured_at: String
     profiles: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type CoverageDepthList {
+    generated_at: String
+    coverage_depth_version: String
+    rows: [JSON!]!
     total: Int!
     returned: Int!
     limit: Int!
@@ -3479,6 +3504,8 @@ export const FIELD_COMPLEXITY = {
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
   profiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  coverage: RELATIONSHIP_FIELD_COMPLEXITY,
+  coverage_depth: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5023,6 +5050,14 @@ const rootValue = {
     return loadProfilesList(context, args, {
       readOptionalArtifact: loadArtifact,
     });
+  },
+
+  coverage(_args, context) {
+    return loadRegistryCoverage(context, { readArtifact });
+  },
+
+  coverage_depth(args, context) {
+    return loadCoverageDepthList(context, args, { readArtifact });
   },
 
   async health(_args, context) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -202,6 +202,12 @@ import {
   loadRegistryCoverage,
 } from "./registry-coverage.mjs";
 import {
+  LIST_COVERAGE_DEPTH_INSTRUCTIONS,
+  LIST_COVERAGE_DEPTH_MCP_TOOL,
+  LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA,
+  loadCoverageDepthList,
+} from "./coverage-depth-mcp.mjs";
+import {
   GET_CONTRACTS_INSTRUCTIONS,
   GET_CONTRACTS_MCP_TOOL,
   GET_CONTRACTS_OUTPUT_SCHEMA,
@@ -821,6 +827,7 @@ export const MCP_INSTRUCTIONS =
   GET_BUILD_INSTRUCTIONS +
   GET_ADAPTER_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
+  LIST_COVERAGE_DEPTH_INSTRUCTIONS +
   LIST_GAPS_INSTRUCTIONS +
   LIST_ENRICHMENT_QUEUE_INSTRUCTIONS +
   LIST_ADAPTER_CANDIDATES_INSTRUCTIONS +
@@ -9986,6 +9993,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_COVERAGE_DEPTH_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadCoverageDepthList(ctx, args);
+    },
+  },
+  {
     ...LIST_GAPS_MCP_TOOL,
     async handler(args, ctx) {
       return loadGapsList(ctx, args);
@@ -15003,6 +15016,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_search_index: LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
   list_search: LIST_SEARCH_OUTPUT_SCHEMA,
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,
+  list_coverage_depth: LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA,
   list_gaps: LIST_GAPS_OUTPUT_SCHEMA,
   list_enrichment_queue: LIST_ENRICHMENT_QUEUE_OUTPUT_SCHEMA,
   list_adapter_candidates: LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA,

--- a/tests/coverage-depth-mcp.test.mjs
+++ b/tests/coverage-depth-mcp.test.mjs
@@ -1,0 +1,347 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  COVERAGE_DEPTH_ARTIFACT,
+  LIST_COVERAGE_DEPTH_INSTRUCTIONS,
+  LIST_COVERAGE_DEPTH_MCP_TOOL,
+  LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA,
+  coverageDepthMcpError,
+  coverageDepthQueryUrl,
+  loadCoverageDepthList,
+} from "../src/coverage-depth-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  coverage_depth_version: "1",
+  rows: [
+    {
+      netuid: 7,
+      name: "Allways",
+      tier: "machine-usable",
+      agent_status: "callable",
+      blocker_level: "none",
+    },
+    {
+      netuid: 31,
+      name: "Candles",
+      tier: "hard-blocked",
+      agent_status: "blocked",
+      blocker_level: "hard-blocked",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === COVERAGE_DEPTH_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("coverage-depth-mcp", () => {
+  test("coverageDepthMcpError is shaped for MCP toolError handling", () => {
+    const err = coverageDepthMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("coverageDepthQueryUrl validates netuid, tier, agent_status, blocker_level, and cursor", () => {
+    const url = coverageDepthQueryUrl({
+      netuid: 7,
+      tier: "machine-usable",
+      agent_status: "callable",
+      blocker_level: "none",
+      q: "allways",
+      sort: "netuid",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("tier"), "machine-usable");
+    assert.equal(url.searchParams.get("agent_status"), "callable");
+    assert.equal(url.searchParams.get("blocker_level"), "none");
+    assert.equal(url.searchParams.get("q"), "allways");
+    assert.equal(url.searchParams.get("sort"), "netuid");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("coverageDepthQueryUrl rejects invalid tier", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ tier: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects invalid agent_status", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ agent_status: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects invalid blocker_level", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ blocker_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects empty q", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ q: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects non-string q", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ q: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl trims and forwards a fields projection", () => {
+    const url = coverageDepthQueryUrl({ fields: " netuid,tier " });
+    assert.equal(url.searchParams.get("fields"), "netuid,tier");
+  });
+
+  test("coverageDepthQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("coverageDepthQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => coverageDepthQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadCoverageDepthList returns filtered rows with pagination meta", async () => {
+    const out = await loadCoverageDepthList(
+      { env: {}, readArtifact },
+      { netuid: 7 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.rows[0].netuid, 7);
+    assert.equal(out.rows[0].tier, "machine-usable");
+  });
+
+  test("loadCoverageDepthList sorts and pages the collection", async () => {
+    const out = await loadCoverageDepthList(
+      { env: {}, readArtifact },
+      { sort: "netuid", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.rows[0].netuid, 31);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadCoverageDepthList uses an injected readArtifact dep", async () => {
+    const out = await loadCoverageDepthList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { rows: [{ netuid: 0 }] },
+        }),
+      },
+    );
+    assert.equal(out.rows[0].netuid, 0);
+  });
+
+  test("loadCoverageDepthList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadCoverageDepthList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /coverage-depth\.json/.test(err.message),
+    );
+  });
+
+  test("loadCoverageDepthList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadCoverageDepthList projects row fields when requested", async () => {
+    const out = await loadCoverageDepthList(
+      { env: {}, readArtifact },
+      { fields: "netuid,tier", limit: 1 },
+    );
+    assert.deepEqual(out.rows[0], {
+      netuid: 7,
+      tier: "machine-usable",
+    });
+  });
+
+  test("loadCoverageDepthList omits nullable artifact metadata when absent", async () => {
+    const out = await loadCoverageDepthList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { rows: [{ netuid: 0 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.coverage_depth_version, null);
+  });
+
+  test("loadCoverageDepthList treats a non-array rows key as empty", async () => {
+    const out = await loadCoverageDepthList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { rows: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.rows, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadCoverageDepthList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { rows: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadCoverageDepthList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadCoverageDepthList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadCoverageDepthList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadCoverageDepthList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_COVERAGE_DEPTH_MCP_TOOL.name, "list_coverage_depth");
+    assert.match(LIST_COVERAGE_DEPTH_INSTRUCTIONS, /list_coverage_depth/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_COVERAGE_DEPTH_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_coverage_depth", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_coverage_depth/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_coverage_depth");
+    assert.ok(tool);
+    assert.equal(tool.title, "List coverage-depth scorecard rows");
+  });
+});

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1666,6 +1666,130 @@ describe("graphql — profiles", () => {
   });
 });
 
+describe("graphql — coverage", () => {
+  const COVERAGE_BLOB = {
+    generated_at: "2026-06-20T00:00:00Z",
+    surface_count: 850,
+    official_surface_count: 400,
+    completeness: { mean: 0.72 },
+    domain_coverage: { inference: 12 },
+  };
+
+  test("resolves the baked coverage summary verbatim", async () => {
+    const env = fixtureEnv({ "/metagraph/coverage.json": COVERAGE_BLOB });
+    const { status, body } = await gql("{ coverage }", env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.coverage, COVERAGE_BLOB);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ coverage }", emptyEnv);
+    assert.ok(body.errors?.length);
+    // `coverage` is a nullable field (unlike `curation`/`coverage_depth`), so
+    // the thrown error nulls out just this field, not the whole data object.
+    assert.equal(body.data.coverage, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.coverage, 5);
+  });
+});
+
+describe("graphql — coverage_depth", () => {
+  const COVERAGE_DEPTH_ROW = {
+    netuid: 7,
+    slug: "allways",
+    name: "Allways",
+    tier: "machine-usable",
+    agent_status: "ready",
+    blocker_level: "none",
+    priority_score: 10,
+  };
+
+  const COVERAGE_DEPTH_BLOB = {
+    generated_at: "2026-06-20T00:00:00Z",
+    coverage_depth_version: "1",
+    rows: [
+      COVERAGE_DEPTH_ROW,
+      {
+        ...COVERAGE_DEPTH_ROW,
+        netuid: 1,
+        slug: "alpha",
+        name: "Alpha",
+        tier: "manifest-only",
+        agent_status: "blocked",
+        blocker_level: "hard-blocked",
+        priority_score: 90,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({
+      "/metagraph/coverage-depth.json": COVERAGE_DEPTH_BLOB,
+    });
+    const filtered = await gql(
+      "{ coverage_depth(netuid: 7) { rows total generated_at } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.coverage_depth.total, 1);
+    assert.equal(filtered.body.data.coverage_depth.rows[0].slug, "allways");
+    assert.equal(
+      filtered.body.data.coverage_depth.generated_at,
+      "2026-06-20T00:00:00Z",
+    );
+
+    const paged = await gql(
+      "{ coverage_depth(limit: 1) { rows total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.coverage_depth.rows.length, 1);
+    assert.equal(paged.body.data.coverage_depth.total, 2);
+    assert.equal(paged.body.data.coverage_depth.returned, 1);
+    assert.ok(paged.body.data.coverage_depth.next_cursor != null);
+  });
+
+  test("filters by blocker_level and sorts by netuid", async () => {
+    const env = fixtureEnv({
+      "/metagraph/coverage-depth.json": COVERAGE_DEPTH_BLOB,
+    });
+    const filtered = await gql(
+      '{ coverage_depth(blocker_level: "hard-blocked") { rows total } }',
+      env,
+    );
+    assert.equal(filtered.body.data.coverage_depth.total, 1);
+    assert.equal(filtered.body.data.coverage_depth.rows[0].slug, "alpha");
+
+    const sorted = await gql(
+      '{ coverage_depth(sort: "netuid", order: "desc") { rows } }',
+      env,
+    );
+    assert.equal(sorted.body.data.coverage_depth.rows[0].slug, "allways");
+  });
+
+  test("surfaces an invalid tier as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({
+      "/metagraph/coverage-depth.json": COVERAGE_DEPTH_BLOB,
+    });
+    const { body } = await gql(
+      '{ coverage_depth(tier: "bogus") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ coverage_depth { total } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.coverage_depth, 5);
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2024,6 +2024,47 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_coverage_depth returns filtered coverage-depth rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        rows: [
+          { netuid: 7, tier: "machine-usable", blocker_level: "none" },
+          { netuid: 31, tier: "hard-blocked", blocker_level: "hard-blocked" },
+        ],
+      },
+    });
+    const res = await callTool("list_coverage_depth", { netuid: 7 }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.rows[0].netuid, 7);
+  });
+
+  test("list_coverage_depth reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_coverage_depth", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Coverage-depth scorecard unavailable/,
+    );
+  });
+
+  test("list_coverage_depth payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_coverage_depth",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        coverage_depth_version: "1",
+        rows: [{ netuid: 7, tier: "machine-usable" }],
+      },
+    });
+    const res = await callTool("list_coverage_depth", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_gaps returns filtered gap rows", async () => {
     const deps = makeDeps({
       "/metagraph/gaps.json": {


### PR DESCRIPTION
Closes #6983

## What

`GET /api/v1/coverage` and `GET /api/v1/coverage-depth` had no GraphQL field. `coverage` already has an MCP tool (`get_coverage`); `coverage-depth`'s only existing MCP tool, `list_enrichment_targets`, reshapes the artifact into a curated ranked-queue view rather than mirroring REST's generic filter/sort/page contract 1:1 — so a new, distinct MCP tool was added for that one alongside the GraphQL field, per the issue's ask for "matching MCP tools."

## Fix

- **`coverage`**: added `Query.coverage: JSON`, reusing `get_coverage`'s own `loadRegistryCoverage` unchanged. Opaque JSON passed through verbatim (the artifact's shape has several loosely-typed aggregate sub-objects with no existing hand-typed precedent), matching the `subnet_gaps`/`subnet_evidence` convention already established in this schema.
- **`coverage_depth`**: added `Query.coverage_depth(netuid, tier, agent_status, blocker_level, q, sort, order, fields, limit, cursor): CoverageDepthList!`, mirroring `curation`/`profiles`'s own SDL shape and filter/sort/page surface exactly.
  - New `src/coverage-depth-mcp.mjs` (mirrors `curation-mcp.mjs`'s structure precisely): `loadCoverageDepthList` reads `/metagraph/coverage-depth.json`'s `rows` collection via the existing `applyQueryFilters` helper — the same generic list-query transform REST's `coverage-depth` route already uses via `queryCollection("rows", {...})` in `contracts.mjs` — so no query logic is duplicated.
  - New `list_coverage_depth` MCP tool (name distinct from `list_enrichment_targets`, which stays as the higher-level curated-queue view; both tools coexist, serving different purposes) — registered in `src/mcp-server.mjs` alongside `list_curation`.
  - `CoverageDepthList` type mirrors `CurationList`'s shape (`rows: [JSON!]!` opaque rows).
- Added `coverage`/`coverage_depth` to `FIELD_COMPLEXITY`, same weight as their sibling collection fields.

## Testing

```
npx vitest run tests/graphql.test.mjs tests/mcp-server.test.mjs tests/coverage-depth-mcp.test.mjs
# 1936 passed (5 new graphql.test.mjs tests for coverage + 6 for coverage_depth,
# 3 new mcp-server.test.mjs tests calling list_coverage_depth end-to-end through
# the MCP dispatch, 29 new dedicated coverage-depth-mcp.test.mjs unit tests
# covering every query-param validation branch and loader error path -- zero
# regressions)

npx eslint src/graphql.mjs src/mcp-server.mjs src/coverage-depth-mcp.mjs \
  tests/graphql.test.mjs tests/mcp-server.test.mjs tests/coverage-depth-mcp.test.mjs
# clean

npx prettier --check <same files>
# clean

npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1821 surface(s), 136 provider(s), and 2037 candidate(s).
```

Coverage confirmed scoped to every changed/new line across all touched files (`src/graphql.mjs`, `src/mcp-server.mjs`, `src/coverage-depth-mcp.mjs`) — zero uncovered/partial-branch lines in the diff, including the MCP tool-dispatch handler line that only a full `callTool` invocation (not just an existence check) exercises.