### PR TITLE
feat(api): GraphQL parity for subnet idle-stake, stake-flow, events, history, and prometheus

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -194,6 +194,7 @@ import {
 } from "./accounts-list.mjs";
 import {
   buildAccountEvents,
+  buildSubnetEvents,
   buildAccountSubnets,
   buildAccountSummary,
   buildAccountTransfers,
@@ -218,6 +219,7 @@ import { buildAccountPositionHistory } from "./account-position-history.mjs";
 import {
   DEFAULT_STAKE_FLOW_DIRECTION,
   STAKE_FLOW_DIRECTIONS,
+  buildStakeFlow,
 } from "./stake-flow.mjs";
 import { buildAccountPortfolio } from "./account-portfolio.mjs";
 import { buildAccountPositions } from "./account-nominator-positions.mjs";
@@ -266,6 +268,7 @@ import {
 } from "./chain-query-loaders.mjs";
 import {
   buildNeuronHistory,
+  buildSubnetHistory,
   parseHistoryWindow,
   unsupportedWindowMessage,
 } from "./neuron-history.mjs";
@@ -329,7 +332,15 @@ import {
   CHAIN_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW,
 } from "./chain-weight-setters.mjs";
-import { buildChainIdleStake } from "./subnet-idle-stake.mjs";
+import {
+  buildChainIdleStake,
+  buildSubnetIdleStake,
+} from "./subnet-idle-stake.mjs";
+import {
+  buildSubnetPrometheus,
+  SUBNET_PROMETHEUS_WINDOWS,
+  DEFAULT_SUBNET_PROMETHEUS_WINDOW,
+} from "./subnet-prometheus.mjs";
 import {
   buildChainStakeFlow,
   CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
@@ -429,6 +440,16 @@ export const SDL = `
     subnet_stake_moves(netuid: Int!, window: String): SubnetStakeMoves!
     "Per-subnet stake-transfer activity over a 7d/30d window (distinct senders, StakeTransferred count, and transfers per sender); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers."
     subnet_stake_transfers(netuid: Int!, window: String): SubnetStakeTransfers!
+    "Per-subnet idle-stake scorecard from the current neurons snapshot: stake delegated to a hotkey currently earning zero dividends (no validator permit, or a permitted hotkey whose weight-setting output is zero), plus the neuron and idle-neuron counts; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/idle-stake."
+    subnet_idle_stake(netuid: Int!): SubnetIdleStake!
+    "Per-subnet net stake flow over a 7d/30d/90d window (default 30d): TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net capital flow, and event counts, summed live from the account_events stream. direction narrows to inflow (in) or outflow (out); all (default) reports both. A subnet with no events resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/stake-flow."
+    subnet_stake_flow(netuid: Int!, window: String, direction: String): SubnetStakeFlow!
+    "One subnet's paginated first-party chain-event feed (newest first): each event's kind, block, UID, hot/cold keys, amount, and timestamp. Filter by kind and by block_start/block_end (inclusive block bounds); page with limit (1-1000, default 100)/offset. event_count is the page count, not a grand total. A subnet with no matching events resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/subnets/{netuid}/events."
+    subnet_events(netuid: Int!, kind: String, block_start: Int, block_end: Int, limit: Int, offset: Int): SubnetEvents!
+    "One subnet's daily history from the neuron_daily rollup over a 7d/30d/90d/1y/all window (default 30d): neuron count, validator count, total stake (TAO), and total emission (TAO) per snapshot_date, newest first. A subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/history."
+    subnet_history(netuid: Int!, window: String): SubnetHistory!
+    "Per-subnet Prometheus telemetry-endpoint serving activity over a 7d/30d window (default 7d): distinct exporters (hotkeys), PrometheusServed announcement count, and announcements per exporter, summed live from the account_events stream. A subnet with no announcements resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/prometheus."
+    subnet_prometheus(netuid: Int!, window: String): SubnetPrometheus!
     "Per-subnet weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators behind /weights ranked by WeightsSet activity, each with count, share, and first/last set times; a subnet with no events resolves to a schema-stable empty leaderboard, never null. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
     subnet_weight_setters(netuid: Int!, window: String): SubnetWeightSetters!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
@@ -2068,6 +2089,68 @@ export const SDL = `
     transfers_per_sender: Float
   }
 
+  "Per-subnet idle-stake scorecard (#7172). Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/idle-stake."
+  type SubnetIdleStake {
+    schema_version: Int!
+    netuid: Int!
+    captured_at: String
+    neuron_count: Int!
+    idle_neuron_count: Int!
+    idle_stake_tao: Float!
+  }
+
+  "Per-subnet net stake flow (#7172) over a 7d/30d/90d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-flow."
+  type SubnetStakeFlow {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    total_staked_tao: Float!
+    total_unstaked_tao: Float!
+    net_flow_tao: Float!
+    stake_events: Int!
+    unstake_events: Int!
+  }
+
+  "One subnet's paginated first-party chain-event feed (#7172), newest first, offset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/subnets/{netuid}/events' data envelope. Each item is an AccountEvent."
+  type SubnetEvents {
+    schema_version: Int!
+    netuid: Int!
+    event_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    events: [AccountEvent!]!
+  }
+
+  "One daily-rollup point on a subnet's history (#7172). Economics fields are null on days captured before those columns existed / when unavailable."
+  type SubnetHistoryPoint {
+    snapshot_date: String
+    neuron_count: Int
+    validator_count: Int
+    total_stake_tao: Float
+    total_emission_tao: Float
+  }
+
+  "One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope."
+  type SubnetHistory {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    point_count: Int!
+    points: [SubnetHistoryPoint!]!
+  }
+
+  "Per-subnet Prometheus-endpoint serving activity (#7172) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/prometheus."
+  type SubnetPrometheus {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_exporters: Int!
+    announcements: Int!
+    announcements_per_exporter: Float
+  }
+
   "Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
   type SubnetWeightSetters {
     schema_version: Int!
@@ -3528,6 +3611,11 @@ export const FIELD_COMPLEXITY = {
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_idle_stake: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_stake_flow: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_events: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_history: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield_history: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5137,6 +5225,232 @@ const rootValue = {
     // The MCP tool raises not_found when it is absent; GraphQL degrades to
     // null instead, matching every other artifact-backed resolver here.
     return loadArtifact(context, AGENT_RESOURCES_ARTIFACT);
+  },
+
+  async subnet_idle_stake({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetIdleStake([])
+    // zeroed-card fallback the REST route + get_subnet_idle_stake MCP tool use; a
+    // subnet with no neurons is a schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, `/api/v1/subnets/${netuid}/idle-stake`),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildSubnetIdleStake([], netuid);
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      captured_at: data.captured_at ?? null,
+      neuron_count: data.neuron_count ?? 0,
+      idle_neuron_count: data.idle_neuron_count ?? 0,
+      idle_stake_tao: data.idle_stake_tao ?? 0,
+    };
+  },
+
+  async subnet_stake_flow({ netuid, window, direction }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same window/direction validation get_subnet_stake_flow + the REST route
+    // apply -- an unsupported value is a GraphQL BAD_USER_INPUT error, not a
+    // silent card.
+    const windowParam = window ?? DEFAULT_STAKE_FLOW_WINDOW;
+    if (!Object.hasOwn(STAKE_FLOW_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, STAKE_FLOW_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const directionParam = direction ?? DEFAULT_STAKE_FLOW_DIRECTION;
+    if (!STAKE_FLOW_DIRECTIONS.includes(directionParam)) {
+      throw new GraphQLError(
+        `direction must be one of: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    params.set("direction", directionParam);
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> { data } ->
+    // buildStakeFlow([]) zeroed-card fallback the REST route + MCP tool use.
+    // direction only narrows the live query; the fallback builder takes no
+    // direction, so a cold tier degrades to the same zeroed card.
+    const tier = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(
+        context,
+        `/api/v1/subnets/${netuid}/stake-flow`,
+        params,
+      ),
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    );
+    const data =
+      tier?.data ?? buildStakeFlow([], netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      total_staked_tao: data.total_staked_tao ?? 0,
+      total_unstaked_tao: data.total_unstaked_tao ?? 0,
+      net_flow_tao: data.net_flow_tao ?? 0,
+      stake_events: data.stake_events ?? 0,
+      unstake_events: data.unstake_events ?? 0,
+    };
+  },
+
+  async subnet_events(
+    { netuid, kind, block_start, block_end, limit, offset },
+    context,
+  ) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same FEED_PAGINATION bounds the /events route's clampEventsLimit applies,
+    // so a GraphQL caller cannot request a wider page than REST allows;
+    // kind/block_start/block_end are forwarded verbatim for the route to
+    // re-parse, matching account_events and the sibling feeds.
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (kind != null) params.set("kind", kind);
+    if (block_start != null) params.set("block_start", String(block_start));
+    if (block_end != null) params.set("block_end", String(block_end));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) the REST handler and
+    // MCP get_subnet_events tool use; the account_events D1 write path is retired
+    // (#4772), so a tier miss resolves through buildSubnetEvents over an empty
+    // scan -- a schema-stable empty feed, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/events`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      buildSubnetEvents([], netuid, {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      event_count: data.event_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      events: (data.events ?? []).map((e) => ({
+        block_number: e.block_number ?? null,
+        event_index: e.event_index ?? null,
+        event_kind: e.event_kind ?? null,
+        hotkey: e.hotkey ?? null,
+        coldkey: e.coldkey ?? null,
+        netuid: e.netuid ?? null,
+        uid: e.uid ?? null,
+        amount_tao: e.amount_tao ?? null,
+        alpha_amount: e.alpha_amount ?? null,
+        observed_at: e.observed_at ?? null,
+        extrinsic_index: e.extrinsic_index ?? null,
+      })),
+    };
+  },
+
+  async subnet_history({ netuid, window }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same parseHistoryWindow REST's handleSubnetHistory + loadSubnetHistory (MCP)
+    // use, so accepted window labels (7d/30d/90d/1y/all, default 30d) match exactly.
+    const { label, error } = parseHistoryWindow(window);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const params = new URLSearchParams();
+    params.set("window", label);
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetHistory([])
+    // empty-series fallback the REST route + loadSubnetHistory use; a subnet with
+    // no daily rollup is a schema-stable point_count:0 series, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/history`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildSubnetHistory([], netuid, { window: label });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? label,
+      point_count: data.point_count ?? 0,
+      points: (data.points ?? []).map((p) => ({
+        snapshot_date: p.snapshot_date ?? null,
+        neuron_count: p.neuron_count ?? null,
+        validator_count: p.validator_count ?? null,
+        total_stake_tao: p.total_stake_tao ?? null,
+        total_emission_tao: p.total_emission_tao ?? null,
+      })),
+    };
+  },
+
+  async subnet_prometheus({ netuid, window }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same 7d/30d window validation get_subnet_prometheus + the REST route use --
+    // an unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_PROMETHEUS_WINDOW;
+    if (!Object.hasOwn(SUBNET_PROMETHEUS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_PROMETHEUS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetPrometheus(null)
+    // zeroed-card fallback the REST route + MCP tool use; a subnet with no
+    // PrometheusServed events is a schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/prometheus`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetPrometheus(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_exporters: data.distinct_exporters ?? 0,
+      announcements: data.announcements ?? 0,
+      announcements_per_exporter: data.announcements_per_exporter ?? null,
+    };
   },
 
   async subnet_volume({ netuid }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6304,6 +6304,484 @@ describe("graphql — agent_resources (#6987, baked AI-resources index)", () => 
   });
 });
 
+// #7172: GraphQL parity for the subnet idle-stake / stake-flow / events /
+// history / prometheus REST routes, each reusing the same shaping fn its MCP
+// tool + REST handler use (buildSubnetIdleStake / buildStakeFlow /
+// buildSubnetEvents / buildSubnetHistory / buildSubnetPrometheus) rather than a
+// GraphQL-only reimplementation. A cold tier degrades to a schema-stable card.
+describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7172)", () => {
+  const tierEnv = (source, payload, captured) => ({
+    [source]: "postgres",
+    DATA_API: {
+      fetch: async (req) => {
+        if (captured) captured.url = new URL(req.url);
+        return Response.json(payload);
+      },
+    },
+  });
+
+  test("subnet_idle_stake cold store returns a schema-stable zeroed card", async () => {
+    const { status, body } = await gql(
+      "{ subnet_idle_stake(netuid: 5) { schema_version netuid captured_at neuron_count idle_neuron_count idle_stake_tao } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const c = body.data.subnet_idle_stake;
+    assert.equal(c.schema_version, 1);
+    assert.equal(c.netuid, 5);
+    assert.equal(c.neuron_count, 0);
+    assert.equal(c.idle_neuron_count, 0);
+    assert.equal(c.idle_stake_tao, 0);
+    assert.equal(c.captured_at, null);
+  });
+
+  test("subnet_idle_stake returns the tier card", async () => {
+    const captured = {};
+    const env = tierEnv(
+      "METAGRAPH_NEURONS_SOURCE",
+      {
+        schema_version: 1,
+        netuid: 7,
+        captured_at: "2026-07-01T00:00:00.000Z",
+        neuron_count: 200,
+        idle_neuron_count: 30,
+        idle_stake_tao: 1234.5,
+      },
+      captured,
+    );
+    const { body } = await gql(
+      "{ subnet_idle_stake(netuid: 7) { netuid idle_neuron_count idle_stake_tao captured_at } }",
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.ok(captured.url.pathname.endsWith("/subnets/7/idle-stake"));
+    assert.equal(body.data.subnet_idle_stake.idle_neuron_count, 30);
+    assert.equal(body.data.subnet_idle_stake.idle_stake_tao, 1234.5);
+  });
+
+  test("subnet_stake_flow cold store returns a schema-stable zeroed card", async () => {
+    const { status, body } = await gql(
+      "{ subnet_stake_flow(netuid: 5) { schema_version netuid window net_flow_tao stake_events unstake_events } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const f = body.data.subnet_stake_flow;
+    assert.equal(f.schema_version, 1);
+    assert.equal(f.net_flow_tao, 0);
+    assert.equal(f.window, "30d");
+  });
+
+  test("subnet_stake_flow forwards window/direction and unwraps { data }", async () => {
+    const captured = {};
+    const env = tierEnv(
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      {
+        data: {
+          schema_version: 1,
+          netuid: 7,
+          window: "7d",
+          total_staked_tao: 10,
+          total_unstaked_tao: 4,
+          net_flow_tao: 6,
+          stake_events: 3,
+          unstake_events: 1,
+        },
+      },
+      captured,
+    );
+    const { body } = await gql(
+      '{ subnet_stake_flow(netuid: 7, window: "7d", direction: "in") { window net_flow_tao stake_events } }',
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.ok(captured.url.pathname.endsWith("/subnets/7/stake-flow"));
+    assert.equal(captured.url.searchParams.get("window"), "7d");
+    assert.equal(captured.url.searchParams.get("direction"), "in");
+    assert.equal(body.data.subnet_stake_flow.net_flow_tao, 6);
+  });
+
+  test("subnet_stake_flow rejects an invalid window or direction", async () => {
+    const bad1 = await gql(
+      '{ subnet_stake_flow(netuid: 7, window: "bogus") { netuid } }',
+    );
+    assert.ok(bad1.body.errors?.length);
+    const bad2 = await gql(
+      '{ subnet_stake_flow(netuid: 7, direction: "sideways") { netuid } }',
+    );
+    assert.ok(bad2.body.errors?.length);
+  });
+
+  test("subnet_events cold store returns a schema-stable empty feed", async () => {
+    const { status, body } = await gql(
+      "{ subnet_events(netuid: 5) { schema_version netuid event_count limit offset next_cursor events { event_kind } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const f = body.data.subnet_events;
+    assert.equal(f.event_count, 0);
+    assert.deepEqual(f.events, []);
+    assert.equal(f.limit, 100);
+  });
+
+  test("subnet_events forwards kind/block bounds/pagination and maps rows", async () => {
+    const captured = {};
+    const env = tierEnv(
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      {
+        schema_version: 1,
+        netuid: 7,
+        event_count: 1,
+        limit: 50,
+        offset: 0,
+        next_cursor: null,
+        events: [
+          {
+            block_number: 100,
+            event_index: 2,
+            event_kind: "StakeAdded",
+            hotkey: "5F",
+            coldkey: "5G",
+            netuid: 7,
+            uid: 3,
+            amount_tao: 1.5,
+            alpha_amount: 2.5,
+            observed_at: "2026-07-01T00:00:00.000Z",
+            extrinsic_index: 4,
+          },
+        ],
+      },
+      captured,
+    );
+    const { body } = await gql(
+      '{ subnet_events(netuid: 7, kind: "StakeAdded", block_start: 10, block_end: 200, limit: 50) { event_count events { event_kind amount_tao uid } } }',
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.ok(captured.url.pathname.endsWith("/subnets/7/events"));
+    assert.equal(captured.url.searchParams.get("kind"), "StakeAdded");
+    assert.equal(captured.url.searchParams.get("block_start"), "10");
+    assert.equal(captured.url.searchParams.get("block_end"), "200");
+    assert.equal(captured.url.searchParams.get("limit"), "50");
+    assert.equal(body.data.subnet_events.events[0].event_kind, "StakeAdded");
+    assert.equal(body.data.subnet_events.events[0].amount_tao, 1.5);
+  });
+
+  test("subnet_history cold store returns a schema-stable empty series", async () => {
+    const { status, body } = await gql(
+      "{ subnet_history(netuid: 5) { schema_version netuid window point_count points { snapshot_date } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const h = body.data.subnet_history;
+    assert.equal(h.point_count, 0);
+    assert.deepEqual(h.points, []);
+    assert.equal(h.window, "30d");
+  });
+
+  test("subnet_history forwards window and maps points", async () => {
+    const captured = {};
+    const env = tierEnv(
+      "METAGRAPH_NEURONS_SOURCE",
+      {
+        schema_version: 1,
+        netuid: 7,
+        window: "7d",
+        point_count: 1,
+        points: [
+          {
+            snapshot_date: "2026-06-30",
+            neuron_count: 200,
+            validator_count: 64,
+            total_stake_tao: 1000.5,
+            total_emission_tao: 12.25,
+          },
+        ],
+      },
+      captured,
+    );
+    const { body } = await gql(
+      '{ subnet_history(netuid: 7, window: "7d") { window point_count points { snapshot_date neuron_count total_stake_tao } } }',
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.ok(captured.url.pathname.endsWith("/subnets/7/history"));
+    assert.equal(captured.url.searchParams.get("window"), "7d");
+    assert.equal(body.data.subnet_history.points[0].total_stake_tao, 1000.5);
+  });
+
+  test("subnet_history rejects an invalid window", async () => {
+    const { body } = await gql(
+      '{ subnet_history(netuid: 7, window: "bogus") { netuid } }',
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("subnet_prometheus cold store returns a schema-stable zeroed card", async () => {
+    const { status, body } = await gql(
+      "{ subnet_prometheus(netuid: 5) { schema_version netuid window observed_at distinct_exporters announcements announcements_per_exporter } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const p = body.data.subnet_prometheus;
+    assert.equal(p.distinct_exporters, 0);
+    assert.equal(p.announcements, 0);
+    assert.equal(p.announcements_per_exporter, null);
+    assert.equal(p.window, "7d");
+  });
+
+  test("subnet_prometheus forwards window and returns the tier card", async () => {
+    const captured = {};
+    const env = tierEnv(
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      {
+        schema_version: 1,
+        netuid: 7,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00.000Z",
+        distinct_exporters: 5,
+        announcements: 12,
+        announcements_per_exporter: 2.4,
+      },
+      captured,
+    );
+    const { body } = await gql(
+      '{ subnet_prometheus(netuid: 7, window: "30d") { window distinct_exporters announcements announcements_per_exporter } }',
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(captured.url.searchParams.get("window"), "30d");
+    assert.equal(body.data.subnet_prometheus.announcements_per_exporter, 2.4);
+  });
+
+  test("subnet_prometheus rejects an invalid window", async () => {
+    const { body } = await gql(
+      '{ subnet_prometheus(netuid: 7, window: "bogus") { netuid } }',
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("subnet_idle_stake degrades a partial tier body to defaults", async () => {
+    const { body } = await gql(
+      "{ subnet_idle_stake(netuid: 9) { schema_version netuid captured_at neuron_count idle_neuron_count idle_stake_tao } }",
+      tierEnv("METAGRAPH_NEURONS_SOURCE", {}, {}),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_idle_stake, {
+      schema_version: 1,
+      netuid: 9,
+      captured_at: null,
+      neuron_count: 0,
+      idle_neuron_count: 0,
+      idle_stake_tao: 0,
+    });
+  });
+
+  test("subnet_stake_flow degrades a partial tier body to defaults", async () => {
+    const { body } = await gql(
+      '{ subnet_stake_flow(netuid: 9, window: "7d") { schema_version netuid window total_staked_tao total_unstaked_tao net_flow_tao stake_events unstake_events } }',
+      tierEnv("METAGRAPH_ACCOUNT_EVENTS_SOURCE", { data: {} }, {}),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_stake_flow, {
+      schema_version: 1,
+      netuid: 9,
+      window: "7d",
+      total_staked_tao: 0,
+      total_unstaked_tao: 0,
+      net_flow_tao: 0,
+      stake_events: 0,
+      unstake_events: 0,
+    });
+  });
+
+  test("subnet_events maps a full tier row through every field", async () => {
+    const { body } = await gql(
+      "{ subnet_events(netuid: 9, limit: 50) { event_count limit offset next_cursor events { block_number event_index event_kind hotkey coldkey netuid uid amount_tao alpha_amount observed_at extrinsic_index } } }",
+      tierEnv(
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+        {
+          event_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: "cur-1",
+          events: [
+            {
+              block_number: 10,
+              event_index: 1,
+              event_kind: "StakeAdded",
+              hotkey: "hk",
+              coldkey: "ck",
+              netuid: 9,
+              uid: 3,
+              amount_tao: 1.5,
+              alpha_amount: 2.5,
+              observed_at: "2026-07-01T00:00:00.000Z",
+              extrinsic_index: 4,
+            },
+          ],
+        },
+        {},
+      ),
+    );
+    assert.equal(body.errors, undefined);
+    const f = body.data.subnet_events;
+    assert.equal(f.event_count, 1);
+    assert.equal(f.next_cursor, "cur-1");
+    assert.deepEqual(f.events[0], {
+      block_number: 10,
+      event_index: 1,
+      event_kind: "StakeAdded",
+      hotkey: "hk",
+      coldkey: "ck",
+      netuid: 9,
+      uid: 3,
+      amount_tao: 1.5,
+      alpha_amount: 2.5,
+      observed_at: "2026-07-01T00:00:00.000Z",
+      extrinsic_index: 4,
+    });
+  });
+
+  test("subnet_events maps a sparse tier row to nulled fields and defaults", async () => {
+    const { body } = await gql(
+      "{ subnet_events(netuid: 9) { schema_version netuid event_count next_cursor events { block_number event_index event_kind hotkey coldkey netuid uid amount_tao alpha_amount observed_at extrinsic_index } } }",
+      tierEnv("METAGRAPH_ACCOUNT_EVENTS_SOURCE", { events: [{}] }, {}),
+    );
+    assert.equal(body.errors, undefined);
+    const f = body.data.subnet_events;
+    assert.equal(f.schema_version, 1);
+    assert.equal(f.netuid, 9);
+    assert.equal(f.event_count, 0);
+    assert.equal(f.next_cursor, null);
+    assert.equal(f.events.length, 1);
+    assert.deepEqual(f.events[0], {
+      block_number: null,
+      event_index: null,
+      event_kind: null,
+      hotkey: null,
+      coldkey: null,
+      netuid: null,
+      uid: null,
+      amount_tao: null,
+      alpha_amount: null,
+      observed_at: null,
+      extrinsic_index: null,
+    });
+  });
+
+  test("subnet_events defaults an absent events array to an empty feed", async () => {
+    const { body } = await gql(
+      "{ subnet_events(netuid: 9) { event_count events { event_kind } } }",
+      tierEnv("METAGRAPH_ACCOUNT_EVENTS_SOURCE", {}, {}),
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_events.event_count, 0);
+    assert.deepEqual(body.data.subnet_events.events, []);
+  });
+
+  test("subnet_history maps a full tier point through every field", async () => {
+    const { body } = await gql(
+      '{ subnet_history(netuid: 9, window: "7d") { point_count points { snapshot_date neuron_count validator_count total_stake_tao total_emission_tao } } }',
+      tierEnv(
+        "METAGRAPH_NEURONS_SOURCE",
+        {
+          point_count: 1,
+          points: [
+            {
+              snapshot_date: "2026-07-01",
+              neuron_count: 5,
+              validator_count: 2,
+              total_stake_tao: 1000.5,
+              total_emission_tao: 3.3,
+            },
+          ],
+        },
+        {},
+      ),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_history.points[0], {
+      snapshot_date: "2026-07-01",
+      neuron_count: 5,
+      validator_count: 2,
+      total_stake_tao: 1000.5,
+      total_emission_tao: 3.3,
+    });
+  });
+
+  test("subnet_history maps a sparse tier point to nulled fields and defaults", async () => {
+    const { body } = await gql(
+      "{ subnet_history(netuid: 9) { schema_version netuid point_count points { snapshot_date neuron_count validator_count total_stake_tao total_emission_tao } } }",
+      tierEnv("METAGRAPH_NEURONS_SOURCE", { points: [{}] }, {}),
+    );
+    assert.equal(body.errors, undefined);
+    const h = body.data.subnet_history;
+    assert.equal(h.schema_version, 1);
+    assert.equal(h.netuid, 9);
+    assert.equal(h.point_count, 0);
+    assert.equal(h.points.length, 1);
+    assert.deepEqual(h.points[0], {
+      snapshot_date: null,
+      neuron_count: null,
+      validator_count: null,
+      total_stake_tao: null,
+      total_emission_tao: null,
+    });
+  });
+
+  test("subnet_history defaults an absent points array to an empty series", async () => {
+    const { body } = await gql(
+      "{ subnet_history(netuid: 9) { point_count points { snapshot_date } } }",
+      tierEnv("METAGRAPH_NEURONS_SOURCE", {}, {}),
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_history.point_count, 0);
+    assert.deepEqual(body.data.subnet_history.points, []);
+  });
+
+  test("subnet_prometheus degrades a partial tier body to defaults", async () => {
+    const { body } = await gql(
+      '{ subnet_prometheus(netuid: 9, window: "7d") { schema_version netuid window observed_at distinct_exporters announcements announcements_per_exporter } }',
+      tierEnv("METAGRAPH_ACCOUNT_EVENTS_SOURCE", {}, {}),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_prometheus, {
+      schema_version: 1,
+      netuid: 9,
+      window: "7d",
+      observed_at: null,
+      distinct_exporters: 0,
+      announcements: 0,
+      announcements_per_exporter: null,
+    });
+  });
+
+  test("all five reject a negative netuid as BAD_USER_INPUT", async () => {
+    for (const q of [
+      "{ subnet_idle_stake(netuid: -1) { netuid } }",
+      "{ subnet_stake_flow(netuid: -1) { netuid } }",
+      "{ subnet_events(netuid: -1) { netuid } }",
+      "{ subnet_history(netuid: -1) { netuid } }",
+      "{ subnet_prometheus(netuid: -1) { netuid } }",
+    ]) {
+      const { body } = await gql(q);
+      assert.ok(body.errors?.length, q);
+    }
+  });
+
+  test("FIELD_COMPLEXITY weights all five new fields like their sibling relationship fields", () => {
+    for (const field of [
+      "subnet_idle_stake",
+      "subnet_stake_flow",
+      "subnet_events",
+      "subnet_history",
+      "subnet_prometheus",
+    ]) {
+      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+    }
+  });
+});
+
 describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validators)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Closes #7172

Mirrors five subnet REST endpoints into the GraphQL schema so a GraphQL caller reaches the same data as REST + the MCP tools, reusing the same shaping functions and Postgres tier the REST routes use:

| GraphQL field | Mirrors |
| --- | --- |
| `subnet_idle_stake(netuid)` | `GET /api/v1/subnets/:id/idle-stake` |
| `subnet_stake_flow(netuid, window, direction)` | `GET /api/v1/subnets/:id/stake-flow` |
| `subnet_events(netuid, kind, block_start, block_end, limit, offset)` | `GET /api/v1/subnets/:id/events` |
| `subnet_history(netuid, window)` | `GET /api/v1/subnets/:id/history` |
| `subnet_prometheus(netuid, window)` | `GET /api/v1/subnets/:id/prometheus` |

**Parity details**
- Each resolver calls `tryPostgresTier(...)` against the same source binding as its REST route (`METAGRAPH_NEURONS_SOURCE` for idle-stake/history, `METAGRAPH_ACCOUNT_EVENTS_SOURCE` for stake-flow/events/prometheus) and, on a cold tier, degrades through the same `buildX(...)` fallback to a schema-stable zeroed/empty card — never a GraphQL error.
- Window/direction/netuid are validated exactly as the REST routes + MCP tools validate them (`BAD_USER_INPUT` on an unsupported value), using the shared `STAKE_FLOW_WINDOWS`/`STAKE_FLOW_DIRECTIONS`, `parseHistoryWindow`, and `SUBNET_PROMETHEUS_WINDOWS`.
- `subnet_events` reuses the existing `AccountEvent` type and `FEED_PAGINATION`/`clampLimit`/`clampOffset` bounds.
- All five fields are weighted `RELATIONSHIP_FIELD_COMPLEXITY` in the complexity map.

**Tests** (`tests/graphql.test.mjs`): cold-store fallback, tier forwarding (asserting forwarded query params + mapped rows), partial-tier-body-degrades-to-defaults, full/sparse/absent row mapping for the events + history feeds, invalid-window/direction rejection, negative-netuid `BAD_USER_INPUT`, and complexity weighting for all five fields.