### PR TITLE
feat(api): GraphQL parity for candidates/fixtures/agent-catalog/freshness/top-holders

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -132,6 +132,9 @@ import {
   formatLeaderboards,
   LEADERBOARD_BOARDS,
   loadSubnetTrajectory,
+  mergeFreshness,
+  overlayCatalogDetail,
+  overlayCatalogIndex,
   resolveLiveEconomics,
   resolveLiveHealth,
   subnetBadgeStatus,
@@ -192,6 +195,13 @@ import {
   DEFAULT_ACCOUNTS_LIST_SORT,
   buildAccountsList,
 } from "./accounts-list.mjs";
+import {
+  buildTopHoldersList,
+  DEFAULT_TOP_HOLDERS_SORT,
+  TOP_HOLDERS_LIMIT_DEFAULT,
+  TOP_HOLDERS_LIMIT_MAX,
+  TOP_HOLDERS_SORTS,
+} from "./top-holders.mjs";
 import {
   buildAccountEvents,
   buildAccountSubnets,
@@ -473,6 +483,22 @@ export const SDL = `
     source_snapshots(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SourceSnapshotList!
     "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
     profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
+    "Unpromoted candidate surfaces discovered across all subnets but not yet curated/promoted, each with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state and page with limit/cursor. The network-wide counterpart of subnet_candidates. Mirrors GET /api/v1/candidates."
+    candidates(netuid: Int, kind: String, provider: String, state: String, limit: Int, cursor: String): CandidateList!
+    "Unpromoted candidate surfaces for one subnet -- the per-subnet view of candidates. Opaque JSON passed through verbatim, matching the get_subnet_candidates MCP/REST shape; null when no candidates artifact has been baked for the netuid. Mirrors GET /api/v1/subnets/{netuid}/candidates."
+    subnet_candidates(netuid: Int!): JSON
+    "Index of captured live request/response fixtures: which subnet surfaces carry a sanitized real request/response sample, with capture status and metadata. Fetch one with fixture(surface_id). Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
+    fixtures: JSON
+    "A captured, sanitized live request/response sample for one surface by surface_id (from list_subnet_apis / the fixtures index). Credentials/secrets are redacted and large values truncated in the underlying artifact. Opaque JSON passed through verbatim, matching the get_fixture MCP/REST shape; null when no fixture has been captured for the surface. Mirrors GET /api/v1/fixtures/{surface_id}."
+    fixture(surface_id: String!): JSON
+    "The machine-readable agent capability catalog: the global index of subnets exposing callable services, live-overlaid with each subnet's current probe status when available. Opaque JSON passed through verbatim, matching the get_agent_catalog MCP/REST shape. Mirrors GET /api/v1/agent-catalog."
+    agent_catalog: JSON
+    "One subnet's full per-service agent capability catalog, live-overlaid with each service's current health/callability when available. Opaque JSON passed through verbatim, matching the get_agent_catalog(netuid)/REST shape; null when no catalog has been baked for the netuid. Mirrors GET /api/v1/agent-catalog/{netuid}."
+    subnet_agent_catalog(netuid: Int!): JSON
+    "Registry data freshness and staleness state: per-source last-captured timestamps, staleness windows, and current status for each data lane, with the operational surface-health source live-overlaid from the 15-minute prober's last run when available. Opaque JSON passed through verbatim, matching the get_freshness MCP/REST shape. Mirrors GET /api/v1/freshness."
+    freshness: JSON
+    "Balance-based top-holder leaderboard (#6741/#6743): every account (coldkey) with a nonzero free balance and/or delegated stake position, with free/delegated/total TAO and cross-subnet stake-flow columns. Sortable by total_tao (default), free_tao, delegated_tao, or net_flow_7d/net_flow_30d/net_flow_90d. An unsupported sort is a GraphQL error, not a silently substituted default. The coldkey/balance-centric counterpart to accounts, which is hotkey/neuron-centric. Mirrors GET /api/v1/accounts/top-holders."
+    accounts_top_holders(sort: String, limit: Int): TopHoldersList!
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
@@ -1741,6 +1767,34 @@ export const SDL = `
     next_cursor: Int
     sort: String
     order: String
+  }
+
+  "Unpromoted candidate surfaces (#6991); each row's own shape mirrors the get_subnet_candidates MCP/REST candidate object, passed through as opaque JSON like every other JSON-row list type here (PoolList, IncidentList, SourceSnapshotList, ProfileList)."
+  type CandidateList {
+    candidates: [JSON!]!
+    total: Int!
+    next_cursor: String
+  }
+
+  "Balance-based top-holder leaderboard (#6741/#6743/#6886/#6887, same envelope buildTopHoldersList/get_top_holders already produce)."
+  type TopHoldersList {
+    schema_version: Int
+    sort: String!
+    limit: Int!
+    captured_at: String
+    account_count: Int!
+    accounts: [TopHolderAccount!]!
+  }
+
+  type TopHolderAccount {
+    ss58: String!
+    free_tao: Float!
+    delegated_tao: Float!
+    total_tao: Float!
+    net_flow_7d: Float!
+    net_flow_30d: Float!
+    net_flow_90d: Float!
+    last_updated: String
   }
 
   type GlobalHealth {
@@ -3479,6 +3533,14 @@ export const FIELD_COMPLEXITY = {
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
   profiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  fixtures: RELATIONSHIP_FIELD_COMPLEXITY,
+  fixture: RELATIONSHIP_FIELD_COMPLEXITY,
+  agent_catalog: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_agent_catalog: RELATIONSHIP_FIELD_COMPLEXITY,
+  freshness: RELATIONSHIP_FIELD_COMPLEXITY,
+  accounts_top_holders: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3811,6 +3873,7 @@ const ARTIFACT = {
   surfaces: "/metagraph/surfaces.json",
   endpoints: "/metagraph/endpoints.json",
   profiles: "/metagraph/profiles.json",
+  candidates: "/metagraph/candidates.json",
 };
 const LIVE_HEALTH_KEY = "live:health";
 const LIVE_ECONOMICS_KEY = "live:economics";
@@ -5023,6 +5086,150 @@ const rootValue = {
     return loadProfilesList(context, args, {
       readOptionalArtifact: loadArtifact,
     });
+  },
+
+  // #6991: GraphQL parity for candidates/fixtures/agent-catalog/freshness/
+  // top-holders -- reusing the same artifact reads and overlay/shaping
+  // functions REST and MCP already call (loadArtifact for the static
+  // artifacts, mergeFreshness/overlayCatalogIndex/overlayCatalogDetail from
+  // health-serving.mjs, buildTopHoldersList from top-holders.mjs) rather than
+  // reimplementing any of them. candidates follows the same local-filterFn
+  // convention `subnets` already uses (REST's generic filter engine isn't
+  // importable outside an HTTP request, so the trivial equality predicate is
+  // replicated here, matching list_candidates' own filter semantics exactly);
+  // everything else is a verbatim JSON pass-through, matching the
+  // subnet_gaps/subnet_evidence convention for artifacts with no dedicated
+  // GraphQL type.
+  candidates({ netuid, kind, provider, state, limit, cursor }, context) {
+    const hasCategoricalFilters =
+      kind != null || provider != null || state != null;
+    return listPage(context, ARTIFACT.candidates, "candidates", {
+      limit,
+      cursor,
+      netuid,
+      keyFn: (c) => c.id,
+      resultKey: "candidates",
+      filterFn: hasCategoricalFilters
+        ? (row) =>
+            (kind == null || row.kind === kind) &&
+            (provider == null || row.provider === provider) &&
+            (state == null || row.state === state)
+        : undefined,
+    });
+  },
+
+  async subnet_candidates({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same baked per-subnet candidates artifact get_subnet_candidates MCP
+    // tool/REST route read unchanged; null when no candidates have been
+    // baked for the netuid.
+    return loadArtifact(context, `/metagraph/candidates/${netuid}.json`);
+  },
+
+  fixtures(_args, context) {
+    // Same fixtures index artifact list_fixtures MCP tool/REST route read
+    // unchanged.
+    return loadArtifact(context, "/metagraph/fixtures.json");
+  },
+
+  fixture({ surface_id }, context) {
+    // Same safe slug charset guard providers/adapters already use for an
+    // id-bearing artifact path (readArtifact's static-asset tier collapses
+    // "../", so an unvalidated surface_id could escape the fixtures/
+    // namespace). REST's GET /api/v1/fixtures/{surface_id} reads the literal
+    // surface_id with no alias resolution; get_fixture's extra alias-lookup
+    // convenience (resolveArtifactSurfaceId) is an MCP-only affordance, not
+    // part of the underlying shaping/artifact contract, so it is not
+    // replicated here.
+    if (typeof surface_id !== "string" || !VALID_PROVIDER_ID.test(surface_id)) {
+      throw new GraphQLError("surface_id must be a non-empty slug.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return loadArtifact(context, `/metagraph/fixtures/${surface_id}.json`);
+  },
+
+  async agent_catalog(_args, context) {
+    const [index, live] = await Promise.all([
+      loadArtifact(context, "/metagraph/agent-catalog.json"),
+      loadLiveHealth(context),
+    ]);
+    // Same overlayCatalogIndex REST's liveHealthOverlay + get_agent_catalog
+    // MCP tool call; falls back to the raw static index when the live cron
+    // snapshot is cold (overlayCatalogIndex returns null), matching both
+    // callers' own fallback.
+    return (live && overlayCatalogIndex(index, live)) || index;
+  },
+
+  async subnet_agent_catalog({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const [detail, live] = await Promise.all([
+      loadArtifact(context, `/metagraph/agent-catalog/${netuid}.json`),
+      loadLiveHealth(context),
+    ]);
+    // Same overlayCatalogDetail REST's liveHealthOverlay + get_agent_catalog
+    // (netuid) MCP tool call; falls back to the raw static detail when the
+    // live cron snapshot is cold.
+    return (live && overlayCatalogDetail(detail, live, netuid)) || detail;
+  },
+
+  async freshness(_args, context) {
+    const [base, meta] = await Promise.all([
+      loadArtifact(context, "/metagraph/freshness.json"),
+      readHealthKv(context.env, KV_HEALTH_META),
+    ]);
+    // Same mergeFreshness REST's liveHealthOverlay + get_freshness MCP tool
+    // call; falls back to the raw static freshness artifact when the live
+    // prober meta is cold (mergeFreshness returns null on a cold meta or a
+    // cold static artifact).
+    return mergeFreshness(base, meta) ?? base;
+  },
+
+  async accounts_top_holders({ sort, limit }, context) {
+    // Same sort-validate / limit-clamp / tryPostgresTier(METAGRAPH_TOP_HOLDERS_SOURCE)
+    // -> buildTopHoldersList fallback contract get_top_holders MCP tool and
+    // GET /api/v1/accounts/top-holders already use, mirroring the `accounts`
+    // resolver just above (its own Postgres-tier sibling).
+    const requestedSort = sort ?? DEFAULT_TOP_HOLDERS_SORT;
+    if (!TOP_HOLDERS_SORTS.includes(requestedSort)) {
+      throw new GraphQLError(
+        `"${requestedSort}" is not a supported sort. Supported: ${TOP_HOLDERS_SORTS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: TOP_HOLDERS_LIMIT_DEFAULT,
+      maxLimit: TOP_HOLDERS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("sort", requestedSort);
+    params.set("limit", String(safeLimit));
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/accounts/top-holders", params),
+        "METAGRAPH_TOP_HOLDERS_SOURCE",
+      )) ??
+      buildTopHoldersList([], {
+        sort: requestedSort,
+        limit: safeLimit,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      sort: data.sort ?? requestedSort,
+      limit: data.limit ?? safeLimit,
+      captured_at: data.captured_at ?? null,
+      account_count: data.account_count ?? 0,
+      accounts: data.accounts || [],
+    };
   },
 
   async health(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1666,6 +1666,444 @@ describe("graphql — profiles", () => {
   });
 });
 
+describe("graphql — candidates / subnet_candidates (#6991, GraphQL parity)", () => {
+  const CANDIDATES_BLOB = {
+    generated_at: "2026-07-01T00:00:00Z",
+    candidates: [
+      {
+        id: "sn-7-taomarketcap-website",
+        netuid: 7,
+        name: "Allways website",
+        kind: "website",
+        provider: "taomarketcap",
+        state: "schema-valid",
+        confidence: "medium",
+      },
+      {
+        id: "sn-1-native-chain-github",
+        netuid: 1,
+        name: "Root GitHub",
+        kind: "source-repo",
+        provider: "native",
+        state: "verified",
+        confidence: "high",
+      },
+    ],
+  };
+
+  test("candidates filters by netuid and paginates like the other listPage collections", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES_BLOB });
+    const filtered = await gql(
+      "{ candidates(netuid: 7) { candidates total } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.errors, undefined);
+    assert.equal(filtered.body.data.candidates.total, 1);
+    assert.equal(
+      filtered.body.data.candidates.candidates[0].id,
+      "sn-7-taomarketcap-website",
+    );
+
+    const paged = await gql(
+      "{ candidates(limit: 1) { candidates total next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.candidates.candidates.length, 1);
+    assert.equal(paged.body.data.candidates.total, 2);
+    assert.equal(
+      paged.body.data.candidates.next_cursor,
+      "sn-7-taomarketcap-website",
+    );
+  });
+
+  test("candidates filters by kind/provider/state, matching list_candidates' own equality filters", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES_BLOB });
+    const byKind = await gql(
+      '{ candidates(kind: "source-repo") { candidates total } }',
+      env,
+    );
+    assert.equal(byKind.body.data.candidates.total, 1);
+    assert.equal(
+      byKind.body.data.candidates.candidates[0].id,
+      "sn-1-native-chain-github",
+    );
+
+    const byProvider = await gql(
+      '{ candidates(provider: "taomarketcap") { total } }',
+      env,
+    );
+    assert.equal(byProvider.body.data.candidates.total, 1);
+
+    const byState = await gql(
+      '{ candidates(state: "verified") { total } }',
+      env,
+    );
+    assert.equal(byState.body.data.candidates.total, 1);
+
+    const noMatch = await gql('{ candidates(state: "bogus") { total } }', env);
+    assert.equal(noMatch.body.data.candidates.total, 0);
+  });
+
+  test("candidates degrades to a schema-stable empty page on a cold artifact, matching subnets/surfaces", async () => {
+    const { status, body } = await gql(
+      "{ candidates { candidates total next_cursor } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.candidates, {
+      candidates: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("subnet_candidates resolves the baked per-subnet artifact unchanged", async () => {
+    const env = fixtureEnv({
+      "/metagraph/candidates/7.json": {
+        netuid: 7,
+        candidates: [{ id: "sn-7-taomarketcap-website", kind: "website" }],
+      },
+    });
+    const { status, body } = await gql("{ subnet_candidates(netuid: 7) }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_candidates.netuid, 7);
+    assert.equal(body.data.subnet_candidates.candidates[0].kind, "website");
+  });
+
+  test("subnet_candidates degrades to null when no artifact is baked for the netuid, never an error", async () => {
+    const { status, body } = await gql("{ subnet_candidates(netuid: 999) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_candidates, null);
+  });
+
+  test("subnet_candidates: a negative netuid is a GraphQL error, matching subnet_gaps/subnet_evidence", async () => {
+    const { body } = await gql("{ subnet_candidates(netuid: -1) }");
+    assert.ok(body.errors?.length);
+    assert.ok(/netuid/i.test(body.errors[0].message));
+  });
+
+  test("FIELD_COMPLEXITY weights both fields like their sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.candidates, 5);
+    assert.equal(FIELD_COMPLEXITY.subnet_candidates, 5);
+  });
+});
+
+describe("graphql — fixtures / fixture (#6991, GraphQL parity)", () => {
+  test("fixtures resolves the captured-fixtures index artifact unchanged", async () => {
+    const env = fixtureEnv({
+      "/metagraph/fixtures.json": {
+        generated_at: "2026-07-01T00:00:00Z",
+        fixtures: [{ surface_id: "allways-docs", status: "captured" }],
+      },
+    });
+    const { status, body } = await gql("{ fixtures }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.fixtures.fixtures[0].surface_id, "allways-docs");
+  });
+
+  test("fixtures degrades to null on a cold artifact, never an error", async () => {
+    const { status, body } = await gql("{ fixtures }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.fixtures, null);
+  });
+
+  test("fixture resolves one captured request/response sample by surface_id", async () => {
+    const env = fixtureEnv({
+      "/metagraph/fixtures/allways-docs.json": {
+        surface_id: "allways-docs",
+        request: { method: "GET" },
+        response: { status: 200 },
+      },
+    });
+    const { status, body } = await gql(
+      '{ fixture(surface_id: "allways-docs") }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.fixture.surface_id, "allways-docs");
+    assert.equal(body.data.fixture.response.status, 200);
+  });
+
+  test("fixture degrades to null when no fixture has been captured for the surface", async () => {
+    const { status, body } = await gql(
+      '{ fixture(surface_id: "never-captured") }',
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.fixture, null);
+  });
+
+  test("fixture: a surface_id with path-escaping characters is a GraphQL error, not a traversal attempt", async () => {
+    const { body } = await gql('{ fixture(surface_id: "../../secrets") }');
+    assert.ok(body.errors?.length);
+    assert.ok(/surface_id/i.test(body.errors[0].message));
+  });
+
+  test("FIELD_COMPLEXITY weights both fields like their sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.fixtures, 5);
+    assert.equal(FIELD_COMPLEXITY.fixture, 5);
+  });
+});
+
+describe("graphql — agent_catalog / subnet_agent_catalog (#6991, GraphQL parity)", () => {
+  test("agent_catalog resolves the static index when no live snapshot is available", async () => {
+    const env = fixtureEnv({
+      "/metagraph/agent-catalog.json": {
+        subnets: [{ netuid: 7, service_count: 2 }],
+      },
+    });
+    const { status, body } = await gql("{ agent_catalog }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.agent_catalog.subnets[0].netuid, 7);
+    assert.equal(body.data.agent_catalog.subnets[0].service_count, 2);
+  });
+
+  test("agent_catalog overlays each subnet's live health status when a live snapshot is available", async () => {
+    const env = fixtureEnv(
+      {
+        "/metagraph/agent-catalog.json": {
+          subnets: [{ netuid: 7, service_count: 2 }],
+        },
+      },
+      {
+        kv: {
+          [KV_HEALTH_CURRENT]: {
+            subnets: [{ netuid: 7, status: "ok" }],
+          },
+        },
+      },
+    );
+    const { status, body } = await gql("{ agent_catalog }", env);
+    assert.equal(status, 200);
+    assert.equal(body.data.agent_catalog.subnets[0].health, "ok");
+  });
+
+  test("agent_catalog degrades to null on a cold artifact with no live snapshot either", async () => {
+    const { status, body } = await gql("{ agent_catalog }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.agent_catalog, null);
+  });
+
+  test("subnet_agent_catalog resolves the static per-subnet catalog when no live snapshot is available", async () => {
+    const env = fixtureEnv({
+      "/metagraph/agent-catalog/7.json": {
+        netuid: 7,
+        services: [{ surface_id: "sn-7-api", name: "Inference API" }],
+      },
+    });
+    const { status, body } = await gql(
+      "{ subnet_agent_catalog(netuid: 7) }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(
+      body.data.subnet_agent_catalog.services[0].name,
+      "Inference API",
+    );
+  });
+
+  test("subnet_agent_catalog overlays live per-service health when a live snapshot is available", async () => {
+    const env = fixtureEnv(
+      {
+        "/metagraph/agent-catalog/7.json": {
+          netuid: 7,
+          services: [{ surface_id: "sn-7-api", name: "Inference API" }],
+        },
+      },
+      {
+        kv: {
+          [KV_HEALTH_CURRENT]: {
+            surfaces: [
+              {
+                netuid: 7,
+                surface_id: "sn-7-api",
+                status: "ok",
+                classification: "healthy",
+              },
+            ],
+          },
+        },
+      },
+    );
+    const { status, body } = await gql(
+      "{ subnet_agent_catalog(netuid: 7) }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(
+      body.data.subnet_agent_catalog.services[0].health.status,
+      "ok",
+    );
+    assert.equal(
+      body.data.subnet_agent_catalog.services[0].eligibility.callable,
+      true,
+    );
+  });
+
+  test("subnet_agent_catalog degrades to null when no catalog is baked for the netuid", async () => {
+    const { status, body } = await gql("{ subnet_agent_catalog(netuid: 999) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_agent_catalog, null);
+  });
+
+  test("subnet_agent_catalog: a negative netuid is a GraphQL error, matching subnet_gaps/subnet_evidence", async () => {
+    const { body } = await gql("{ subnet_agent_catalog(netuid: -1) }");
+    assert.ok(body.errors?.length);
+    assert.ok(/netuid/i.test(body.errors[0].message));
+  });
+
+  test("FIELD_COMPLEXITY weights both fields like their sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.agent_catalog, 5);
+    assert.equal(FIELD_COMPLEXITY.subnet_agent_catalog, 5);
+  });
+});
+
+describe("graphql — freshness (#6991, GraphQL parity)", () => {
+  test("freshness resolves the static artifact when no live prober meta is available", async () => {
+    const env = fixtureEnv({
+      "/metagraph/freshness.json": {
+        sources: [{ id: "surface-health", status: "stale" }],
+      },
+    });
+    const { status, body } = await gql("{ freshness }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.freshness.sources[0].status, "stale");
+  });
+
+  test("freshness overlays the live prober's last run onto the surface-health source", async () => {
+    const env = fixtureEnv(
+      {
+        "/metagraph/freshness.json": {
+          sources: [{ id: "surface-health", status: "stale" }],
+        },
+      },
+      { kv: { [KV_HEALTH_META]: { last_run_at: "2026-07-19T00:00:00Z" } } },
+    );
+    const { status, body } = await gql("{ freshness }", env);
+    assert.equal(status, 200);
+    const source = body.data.freshness.sources[0];
+    assert.equal(source.status, "current");
+    assert.equal(source.as_of, "2026-07-19T00:00:00Z");
+  });
+
+  test("freshness degrades to null on a cold artifact, never an error", async () => {
+    const { status, body } = await gql("{ freshness }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.freshness, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.freshness, 5);
+  });
+});
+
+describe("graphql — accounts_top_holders (#6991, GraphQL parity, Postgres-tier leaderboard)", () => {
+  test("cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
+    const { status, body } = await gql(
+      "{ accounts_top_holders { accounts { ss58 } account_count sort limit captured_at } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.accounts_top_holders, {
+      accounts: [],
+      account_count: 0,
+      sort: "total_tao",
+      limit: 20,
+      captured_at: null,
+    });
+  });
+
+  test("resolves Postgres-tier rows", async () => {
+    const env = {
+      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            sort: "total_tao",
+            limit: 5,
+            captured_at: "2026-07-15T00:00:00.000Z",
+            account_count: 1,
+            accounts: [
+              {
+                ss58: "5Holder",
+                free_tao: 100,
+                delegated_tao: 50,
+                total_tao: 150,
+                net_flow_7d: -10,
+                net_flow_30d: 20,
+                net_flow_90d: 30,
+                last_updated: "2026-07-15T00:00:00.000Z",
+              },
+            ],
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      '{ accounts_top_holders(sort: "total_tao", limit: 5) { account_count accounts { ss58 free_tao delegated_tao total_tao net_flow_7d net_flow_30d net_flow_90d last_updated } } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.accounts_top_holders.account_count, 1);
+    const item = body.data.accounts_top_holders.accounts[0];
+    assert.equal(item.ss58, "5Holder");
+    assert.equal(item.total_tao, 150);
+    assert.equal(item.net_flow_7d, -10);
+  });
+
+  test("sort and limit args are forwarded as query params to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            sort: "net_flow_7d",
+            limit: 10,
+            captured_at: null,
+            account_count: 0,
+            accounts: [],
+          });
+        },
+      },
+    };
+    await gql(
+      '{ accounts_top_holders(sort: "net_flow_7d", limit: 10) { account_count } }',
+      env,
+    );
+    assert.equal(capturedUrl.pathname, "/api/v1/accounts/top-holders");
+    assert.equal(capturedUrl.searchParams.get("sort"), "net_flow_7d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "10");
+  });
+
+  test("an unsupported sort is a GraphQL error, not a silently substituted default", async () => {
+    const { body } = await gql(
+      '{ accounts_top_holders(sort: "bogus_sort") { account_count } }',
+    );
+    assert.ok(body.errors?.length);
+    assert.ok(/sort/i.test(body.errors[0].message));
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.accounts_top_holders, 5);
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({


### PR DESCRIPTION
Adds GraphQL `Query` fields for five REST routes that already have MCP tools but no GraphQL field: `candidates`/`subnet_candidates`, `fixtures`/`fixture`, `agent_catalog`/`subnet_agent_catalog`, `freshness`, and `accounts_top_holders`. Each resolver reuses the exact shaping function REST/MCP already call, following the existing `subnets`/`subnet(netuid)` collection+single-item pairing convention.

Closes #6991