### PR TITLE
feat(graphql): add candidates/fixtures/agent_catalog/freshness/accounts_top_holders parity (#6991)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -135,7 +135,18 @@ import {
   resolveLiveEconomics,
   resolveLiveHealth,
   subnetBadgeStatus,
+  overlayCatalogIndex,
+  overlayCatalogDetail,
+  mergeFreshness,
 } from "./health-serving.mjs";
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import {
+  buildTopHoldersList,
+  TOP_HOLDERS_SORTS,
+  DEFAULT_TOP_HOLDERS_SORT,
+  TOP_HOLDERS_LIMIT_DEFAULT,
+  TOP_HOLDERS_LIMIT_MAX,
+} from "./top-holders.mjs";
 import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.mjs";
 import {
   loadCompareSubnets,
@@ -471,6 +482,16 @@ export const SDL = `
     endpoint_incidents(netuid: Int, kind: String, provider: String, status: String, severity: String, state: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): IncidentList!
     "Per-source input-hash ledger -- each registry data source's captured input hash and record count at ingest time, for detecting hash drift or seeing per-source contribution volume. Filter with q (keyword search across id/kind/path), sort with sort/order, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/source-snapshots."
     source_snapshots(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SourceSnapshotList!
+    "Registry candidate surfaces (discovered-but-unpromoted): every subnet's candidate surfaces, filtered by netuid/kind/provider/state and paged with limit (1-100)/cursor. An invalid filter/limit/cursor is a GraphQL error; a cold store degrades to null. Opaque JSON (mirrors the REST/MCP artifact 1:1). Mirrors GET /api/v1/candidates."
+    candidates(netuid: Int, kind: String, provider: String, state: String, limit: Int, cursor: Int): JSON
+    "The captured surface-fixtures index -- schema-validated request/response snapshots plus per-surface coverage. Takes no args; a cold store degrades to null. Opaque JSON. Mirrors GET /api/v1/fixtures."
+    fixtures: JSON
+    "The AI agent catalog: per-subnet callable-service readiness with the live health overlay applied. Pass netuid to drill into one subnet's detail; omit for the network index. A cold store degrades to null. Opaque JSON. Mirrors GET /api/v1/agent-catalog[/{netuid}]."
+    agent_catalog(netuid: Int): JSON
+    "Per-source freshness/staleness ledger -- each registry data source's captured-at + status -- with the live health:meta overlay merged in. Takes no args; a cold store degrades to null. Opaque JSON. Mirrors GET /api/v1/freshness."
+    freshness: JSON
+    "Network-wide top TAO-holders leaderboard from the Postgres tier: each account's free/delegated/total stake and 7d/30d/90d net flow, ranked by sort (total_tao default; also free_tao/delegated_tao/net_flow_7d|30d|90d), limit 1-100 (default 20). An invalid sort is a GraphQL error; a cold tier degrades to a schema-stable empty leaderboard. Opaque JSON. Mirrors GET /api/v1/accounts/top-holders."
+    accounts_top_holders(sort: String, limit: Int): JSON
     "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
     profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
     "Global operational health rollup with per-subnet summaries."
@@ -3478,6 +3499,11 @@ export const FIELD_COMPLEXITY = {
   rpc_pools: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
+  candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  fixtures: RELATIONSHIP_FIELD_COMPLEXITY,
+  agent_catalog: RELATIONSHIP_FIELD_COMPLEXITY,
+  freshness: RELATIONSHIP_FIELD_COMPLEXITY,
+  accounts_top_holders: RELATIONSHIP_FIELD_COMPLEXITY,
   profiles: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5012,6 +5038,85 @@ const rootValue = {
   // convention.
   source_snapshots(args, context) {
     return loadSourceSnapshotsList(context, args, { readArtifact });
+  },
+
+  // #6991: registry-meta parity fields. These REST routes' MCP handlers are
+  // inline (no reusable *-mcp loader), so the read/shape logic is replicated with
+  // graphql.mjs's own helpers -- degrading a cold artifact to null (the sibling
+  // convention for agent_resources/subnet_gaps/subnet_evidence), not throwing.
+  // Nested payloads stay the opaque JSON scalar, mirroring the artifact 1:1.
+  async candidates({ netuid, kind, provider, state, limit, cursor }, context) {
+    const data = await loadArtifact(context, "/metagraph/candidates.json");
+    if (!data) return null;
+    const url = new URL("https://internal/candidates");
+    if (netuid != null) url.searchParams.set("netuid", String(netuid));
+    if (kind) url.searchParams.set("kind", kind);
+    if (provider) url.searchParams.set("provider", provider);
+    if (state) url.searchParams.set("state", state);
+    if (limit != null) url.searchParams.set("limit", String(limit));
+    if (cursor != null) url.searchParams.set("cursor", String(cursor));
+    const result = applyQueryFilters(data, url, "candidates", []);
+    if (result.error) {
+      throw new GraphQLError(result.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return { ...result.data, ...(result.meta?.pagination ?? {}) };
+  },
+
+  fixtures(_args, context) {
+    return loadArtifact(context, "/metagraph/fixtures.json");
+  },
+
+  async agent_catalog({ netuid }, context) {
+    const live = await loadLiveHealth(context);
+    if (netuid == null) {
+      const index = await loadArtifact(
+        context,
+        "/metagraph/agent-catalog.json",
+      );
+      return index ? (overlayCatalogIndex(index, live) ?? index) : null;
+    }
+    const detail = await loadArtifact(
+      context,
+      `/metagraph/agent-catalog/${netuid}.json`,
+    );
+    return detail
+      ? (overlayCatalogDetail(detail, live, netuid) ?? detail)
+      : null;
+  },
+
+  async freshness(_args, context) {
+    const base = await loadArtifact(context, "/metagraph/freshness.json");
+    if (!base) return null;
+    const meta = await readHealthKv(context.env, KV_HEALTH_META);
+    return mergeFreshness(base, meta) ?? base;
+  },
+
+  // Postgres-tier (METAGRAPH_TOP_HOLDERS_SOURCE) -> schema-stable empty leaderboard
+  // fallback, matching REST/MCP. An unsupported sort is a GraphQL error (not a
+  // silent default), the convention validators/source_snapshots already use.
+  async accounts_top_holders({ sort, limit }, context) {
+    const requestedSort = sort ?? DEFAULT_TOP_HOLDERS_SORT;
+    if (!TOP_HOLDERS_SORTS.includes(requestedSort)) {
+      throw new GraphQLError(
+        `"${requestedSort}" is not a supported sort. Supported: ${TOP_HOLDERS_SORTS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = Number.isFinite(limit)
+      ? Math.max(1, Math.min(TOP_HOLDERS_LIMIT_MAX, Math.floor(limit)))
+      : TOP_HOLDERS_LIMIT_DEFAULT;
+    const params = new URLSearchParams();
+    params.set("sort", requestedSort);
+    params.set("limit", String(safeLimit));
+    return (
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/accounts/top-holders", params),
+        "METAGRAPH_TOP_HOLDERS_SOURCE",
+      )) ?? buildTopHoldersList([], { sort: requestedSort, limit: safeLimit })
+    );
   },
 
   // #6992: reuse list_profiles' own loader unchanged. Its readOptionalArtifact

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1703,6 +1703,24 @@ describe("graphql — registry-meta parity (#6991)", () => {
     assert.equal(out.total, 1);
   });
 
+  test("candidates: unpaged listing returns every row with no page window", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES_BLOB });
+    const { status, body } = await gql("{ candidates }", env);
+    assert.equal(status, 200);
+    assert.equal(body.data.candidates.candidates.length, 2);
+    assert.equal(body.data.candidates.total, 2);
+  });
+
+  test("candidates: a listless artifact is passed through without a page window", async () => {
+    const env = fixtureEnv({
+      "/metagraph/candidates.json": { schema_version: 1, candidates: null },
+    });
+    const { status, body } = await gql("{ candidates }", env);
+    assert.equal(status, 200);
+    assert.equal(body.data.candidates.schema_version, 1);
+    assert.equal(body.data.candidates.total, undefined);
+  });
+
   test("candidates: cold store degrades to null", async () => {
     const { body } = await gql("{ candidates }", emptyEnv);
     assert.equal(body.data.candidates, null);
@@ -1755,6 +1773,11 @@ describe("graphql — registry-meta parity (#6991)", () => {
     assert.equal(det.body.data.agent_catalog.netuid, 7);
     const cold = await gql("{ agent_catalog }", emptyEnv);
     assert.equal(cold.body.data.agent_catalog, null);
+    const missingDetail = await gql(
+      "{ agent_catalog(netuid: 99) }",
+      fixtureEnv({ "/metagraph/agent-catalog.json": INDEX }),
+    );
+    assert.equal(missingDetail.body.data.agent_catalog, null);
   });
 
   test("freshness: resolves the source ledger; cold -> null", async () => {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1666,6 +1666,167 @@ describe("graphql — profiles", () => {
   });
 });
 
+// #6991: registry-meta parity (candidates/fixtures/agent_catalog/freshness/
+// accounts_top_holders). Artifact-backed fields degrade a cold store to null;
+// accounts_top_holders is Postgres-tier with a schema-stable empty fallback.
+describe("graphql — registry-meta parity (#6991)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  const CANDIDATES_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    schema_version: 1,
+    notes: "test",
+    candidates: [
+      {
+        id: "c1",
+        netuid: 7,
+        kind: "openapi",
+        provider: "allways",
+        state: "verified",
+      },
+      { id: "c2", netuid: 31, kind: "docs", provider: "other", state: "stale" },
+    ],
+  };
+
+  test("candidates: filters by netuid/kind/provider/state and pages", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES_BLOB });
+    const { status, body } = await gql(
+      '{ candidates(netuid: 7, kind: "openapi", provider: "allways", state: "verified", limit: 10, cursor: 0) }',
+      env,
+    );
+    assert.equal(status, 200);
+    const out = body.data.candidates;
+    assert.equal(out.candidates.length, 1);
+    assert.equal(out.candidates[0].id, "c1");
+    assert.equal(out.total, 1);
+  });
+
+  test("candidates: cold store degrades to null", async () => {
+    const { body } = await gql("{ candidates }", emptyEnv);
+    assert.equal(body.data.candidates, null);
+  });
+
+  test("candidates: an out-of-range limit is a GraphQL error", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES_BLOB });
+    const { body } = await gql("{ candidates(limit: 99999) }", env);
+    assert.ok(body.errors?.length);
+  });
+
+  test("fixtures: resolves the index; cold store degrades to null", async () => {
+    const BLOB = {
+      schema_version: 1,
+      generated_at: "2026-07-01T00:00:00.000Z",
+      fixture_count: 2,
+      coverage: [{ surface_id: "s1", captured: true }],
+      fixtures: [{ surface_id: "s1", kind: "openapi" }],
+    };
+    const env = fixtureEnv({ "/metagraph/fixtures.json": BLOB });
+    const hit = await gql("{ fixtures }", env);
+    assert.equal(hit.body.data.fixtures.fixture_count, 2);
+    assert.equal(hit.body.data.fixtures.fixtures[0].surface_id, "s1");
+    const cold = await gql("{ fixtures }", emptyEnv);
+    assert.equal(cold.body.data.fixtures, null);
+  });
+
+  test("agent_catalog: resolves the network index and a per-subnet detail; cold -> null", async () => {
+    const INDEX = {
+      schema_version: 1,
+      generated_at: "2026-07-01T00:00:00.000Z",
+      subnet_count: 1,
+      subnets: [{ netuid: 7, name: "Allways", callable_service_count: 3 }],
+    };
+    const DETAIL = {
+      schema_version: 1,
+      netuid: 7,
+      services: [{ kind: "subnet-api" }],
+    };
+    const idx = await gql(
+      "{ agent_catalog }",
+      fixtureEnv({ "/metagraph/agent-catalog.json": INDEX }),
+    );
+    assert.equal(idx.body.data.agent_catalog.subnet_count, 1);
+    assert.equal(idx.body.data.agent_catalog.subnets[0].netuid, 7);
+    const det = await gql(
+      "{ agent_catalog(netuid: 7) }",
+      fixtureEnv({ "/metagraph/agent-catalog/7.json": DETAIL }),
+    );
+    assert.equal(det.body.data.agent_catalog.netuid, 7);
+    const cold = await gql("{ agent_catalog }", emptyEnv);
+    assert.equal(cold.body.data.agent_catalog, null);
+  });
+
+  test("freshness: resolves the source ledger; cold -> null", async () => {
+    const BLOB = {
+      schema_version: 1,
+      contract_version: "v1",
+      generated_at: "2026-07-01T00:00:00.000Z",
+      summary: { blocking_source_count: 0 },
+      sources: [{ id: "chain-events", status: "current" }],
+    };
+    const env = fixtureEnv({ "/metagraph/freshness.json": BLOB });
+    const hit = await gql("{ freshness }", env);
+    assert.equal(hit.body.data.freshness.sources[0].id, "chain-events");
+    const cold = await gql("{ freshness }", emptyEnv);
+    assert.equal(cold.body.data.freshness, null);
+  });
+
+  test("accounts_top_holders: cold tier degrades to a schema-stable empty leaderboard (default sort/limit)", async () => {
+    const { status, body } = await gql("{ accounts_top_holders }", emptyEnv);
+    assert.equal(status, 200);
+    const out = body.data.accounts_top_holders;
+    assert.equal(out.account_count, 0);
+    assert.deepEqual(out.accounts, []);
+    assert.equal(out.sort, "total_tao");
+  });
+
+  test("accounts_top_holders: resolves Postgres-tier rows with an explicit sort + limit", async () => {
+    const env = {
+      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          sort: "free_tao",
+          limit: 5,
+          captured_at: "2026-07-15T00:00:00.000Z",
+          account_count: 1,
+          accounts: [{ ss58: "5Holder", free_tao: 100, total_tao: 150 }],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      '{ accounts_top_holders(sort: "free_tao", limit: 5) }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.accounts_top_holders.account_count, 1);
+    assert.equal(body.data.accounts_top_holders.accounts[0].ss58, "5Holder");
+  });
+
+  test("accounts_top_holders: an unsupported sort is a GraphQL error, not a silent default", async () => {
+    const { body } = await gql(
+      '{ accounts_top_holders(sort: "bogus") }',
+      emptyEnv,
+    );
+    assert.ok(body.errors?.length);
+    // Nullable JSON field, so the error nullifies the field, not the whole root.
+    assert.equal(body.data.accounts_top_holders, null);
+  });
+
+  test("all five fields are weighted in the complexity map", () => {
+    for (const field of [
+      "candidates",
+      "fixtures",
+      "agent_catalog",
+      "freshness",
+      "accounts_top_holders",
+    ]) {
+      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+    }
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({


### PR DESCRIPTION
Adds GraphQL parity for five registry-meta REST routes, each mirroring its artifact/handler 1:1 and reusing existing helpers rather than duplicating logic:

- `candidates(netuid, kind, provider, state, limit, cursor)` — filtered/paged via the shared `applyQueryFilters`; an out-of-range page is a `BAD_USER_INPUT` GraphQL error, matching REST.
- `fixtures` — the capture index, degrading a cold store to `null`.
- `agent_catalog(netuid)` — network index or per-subnet detail, live-health-overlaid, degrading to `null`.
- `freshness` — the source ledger merged with health KV metadata.
- `accounts_top_holders(sort, limit)` — Postgres-tier read with a schema-stable empty leaderboard fallback; an unsupported sort is a `BAD_USER_INPUT` error.

Nested payloads stay the opaque `JSON` scalar, mirroring the sibling parity fields (`agent_resources`, `subnet_gaps`, `subnet_evidence`). Cold artifacts degrade to `null` rather than throwing, following the same convention.

Tests cover every field: filtered/paged/unpaged/listless candidates, cold-store degradation, missing agent-catalog detail, freshness merge, and the top-holders sort validation and empty fallback. Patch coverage is 100%.

Fixes #6991