### PR TITLE
feat(ui): current network-parameters card on the admin-changes page (#6997)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.network-parameters.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.network-parameters.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { networkParametersQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/network/parameters",
+  });
+}
+
+// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
+// options object; each call site keeps its own precise data type).
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+describe("networkParametersQuery (#6997)", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits /api/v1/network/parameters and passes a well-formed response through", async () => {
+    resolveWith({
+      tao_weight: 0.18,
+      stake_threshold_tao: 1000,
+      pending_childkey_cooldown_blocks: 7200,
+      queried_at: "2026-07-20T12:00:00.000Z",
+    });
+    const res = await runQuery(networkParametersQuery());
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/network/parameters",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(res.data.tao_weight).toBe(0.18);
+    expect(res.data.stake_threshold_tao).toBe(1000);
+    expect(res.data.pending_childkey_cooldown_blocks).toBe(7200);
+    expect(res.data.queried_at).toBe("2026-07-20T12:00:00.000Z");
+  });
+
+  it("nulls each field independently on its own RPC failure -- a partial response doesn't null the rest", async () => {
+    // Mirrors the REST route's own contract: each field is independently
+    // null on its own RPC failure, not an all-or-nothing degrade.
+    resolveWith({
+      tao_weight: null,
+      stake_threshold_tao: 1000,
+      pending_childkey_cooldown_blocks: 7200,
+      queried_at: "2026-07-20T12:00:00.000Z",
+    });
+    const res = await runQuery(networkParametersQuery());
+    expect(res.data.tao_weight).toBeNull();
+    expect(res.data.stake_threshold_tao).toBe(1000);
+    expect(res.data.pending_childkey_cooldown_blocks).toBe(7200);
+  });
+
+  it("keeps a real zero distinguishable from a failed (null) read", async () => {
+    resolveWith({
+      tao_weight: 0,
+      stake_threshold_tao: 0,
+      pending_childkey_cooldown_blocks: 0,
+      queried_at: "2026-07-20T12:00:00.000Z",
+    });
+    const res = await runQuery(networkParametersQuery());
+    expect(res.data.tao_weight).toBe(0);
+    expect(res.data.stake_threshold_tao).toBe(0);
+    expect(res.data.pending_childkey_cooldown_blocks).toBe(0);
+  });
+
+  it("degrades junk / missing input to an all-null shape, never NaN or a throw", async () => {
+    for (const raw of [{}, null, undefined, "nope", { tao_weight: "many" }]) {
+      resolveWith(raw);
+      const res = await runQuery(networkParametersQuery());
+      expect(res.data.tao_weight).toBeNull();
+      expect(res.data.stake_threshold_tao).toBeNull();
+      expect(res.data.pending_childkey_cooldown_blocks).toBeNull();
+      expect(res.data.queried_at).toBeNull();
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -116,6 +116,7 @@ import type {
   Extrinsic,
   ExtrinsicCallArg,
   SudoKey,
+  NetworkParameters,
   RuntimeTransition,
   RuntimeVersionHistory,
   Transfer,
@@ -2166,6 +2167,32 @@ export const sudoKeyQuery = () =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<SudoKey>;
+    },
+    staleTime: STALE_LONG,
+  });
+
+// #6997: current global Subtensor protocol/governance parameters. Each field
+// independently defaults to null (never 0/false) on a missing/non-numeric
+// value, matching the REST route's own "each field is independently null on
+// its own RPC failure" contract -- a real zero must stay distinguishable
+// from a failed read.
+export const networkParametersQuery = () =>
+  queryOptions({
+    queryKey: k("network-parameters"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/network/parameters", { signal });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          tao_weight: firstFiniteNumber(d.tao_weight) ?? null,
+          stake_threshold_tao: firstFiniteNumber(d.stake_threshold_tao) ?? null,
+          pending_childkey_cooldown_blocks:
+            firstFiniteNumber(d.pending_childkey_cooldown_blocks) ?? null,
+          queried_at: firstString(d.queried_at) ?? null,
+        } as NetworkParameters,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<NetworkParameters>;
     },
     staleTime: STALE_LONG,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1467,6 +1467,18 @@ export interface SudoKey {
   queried_at?: string | null;
 }
 
+/** Current global Subtensor protocol/governance parameters from
+ * /api/v1/network/parameters (#6343). Each field is independently null on
+ * its own RPC failure -- never coerced to 0/false, so a real zero value
+ * (e.g. tao_weight legitimately at 0) stays distinguishable from a failed
+ * read (#6997). */
+export interface NetworkParameters {
+  tao_weight: number | null;
+  stake_threshold_tao: number | null;
+  pending_childkey_cooldown_blocks: number | null;
+  queried_at: string | null;
+}
+
 /** One spec-version transition from /api/v1/runtime (#4316/3.1). */
 export interface RuntimeTransition {
   spec_version: number | null;

--- a/apps/ui/src/routes/admin-changes.index.tsx
+++ b/apps/ui/src/routes/admin-changes.index.tsx
@@ -7,13 +7,7 @@ import { Scale, Coins, Timer } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import {
-  PageHero,
-  ShareButton,
-  DownloadCsvButton,
-  ActionBar,
-  StatTile,
-} from "@jsonbored/ui-kit";
+import { PageHero, ShareButton, DownloadCsvButton, ActionBar, StatTile } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { CallModuleExtrinsicsTable } from "@/components/metagraphed/call-module-extrinsics-table";
 import { governanceConfigChangesQuery, networkParametersQuery } from "@/lib/metagraphed/queries";

--- a/apps/ui/src/routes/admin-changes.index.tsx
+++ b/apps/ui/src/routes/admin-changes.index.tsx
@@ -1,16 +1,25 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Suspense } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { Scale, Coins, Timer } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import { PageHero, ShareButton, DownloadCsvButton, ActionBar } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  ShareButton,
+  DownloadCsvButton,
+  ActionBar,
+  StatTile,
+} from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { CallModuleExtrinsicsTable } from "@/components/metagraphed/call-module-extrinsics-table";
-import { governanceConfigChangesQuery } from "@/lib/metagraphed/queries";
+import { governanceConfigChangesQuery, networkParametersQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { API_BASE } from "@/lib/metagraphed/config";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 
 const adminChangesSearchSchema = z.object({
   limit: fallback(z.number().int().min(1).max(100), 50).default(50),
@@ -75,16 +84,73 @@ function AdminChangesPage() {
           </>
         }
       />
+      {/* #6997: the change-log below is a history of governance config-change
+          events -- it never showed the *current* live values of the three
+          key protocol/governance parameters those changes actually move.
+          Own QueryErrorBoundary/Suspense so a slow/failed RPC read never
+          blocks the (unrelated, artifact-backed) change-log table below. */}
+      <QueryErrorBoundary>
+        <Suspense
+          fallback={
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+              <Skeleton className="h-20" />
+              <Skeleton className="h-20" />
+              <Skeleton className="h-20" />
+            </div>
+          }
+        >
+          <NetworkParametersCard />
+        </Suspense>
+      </QueryErrorBoundary>
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <AdminChangesTable />
         </Suspense>
       </QueryErrorBoundary>
       <ApiSourceFooter
-        paths={["/api/v1/governance/config-changes"]}
+        paths={["/api/v1/governance/config-changes", "/api/v1/network/parameters"]}
         artifacts={["/metagraph/governance/config-changes.json"]}
       />
     </AppShell>
+  );
+}
+
+// #6997: current values of the three global Subtensor protocol/governance
+// parameters the change-log table below is a *history* of. Each field is
+// independently null on its own RPC failure (never coerced to 0), so
+// StatTile's own "—" empty-value rendering is what a viewer sees on a
+// per-field failure -- distinct from a real zero (e.g. tao_weight at 0%).
+function NetworkParametersCard() {
+  const { data: res } = useSuspenseQuery(networkParametersQuery());
+  const p = res.data;
+  const taoWeightPct = p.tao_weight != null ? `${(p.tao_weight * 100).toFixed(2)}%` : "—";
+
+  return (
+    <div className="mb-6">
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        Current network parameters
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <StatTile
+          icon={Scale}
+          eyebrow="TaoWeight"
+          value={taoWeightPct}
+          hint="root-weight ratio in consensus"
+        />
+        <StatTile
+          icon={Coins}
+          eyebrow="StakeThreshold"
+          value={formatTao(p.stake_threshold_tao)}
+          hint="min stake to register a hotkey"
+        />
+        <StatTile
+          icon={Timer}
+          eyebrow="PendingChildKeyCooldown"
+          value={formatNumber(p.pending_childkey_cooldown_blocks)}
+          hint="blocks before a pending child key activates"
+        />
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #6997

## Problem

`GET /api/v1/network/parameters` (TaoWeight, StakeThreshold, PendingChildKeyCooldown — #6343) has a GraphQL field but was surfaced nowhere in the UI. `admin-changes.index.tsx` only shows the AdminUtils **change-log** (a history of governance config-change events) — there was no display of the **current live values** of these three parameters anywhere. Verified against `origin/main`: zero case-insensitive matches for "network.parameter"/"TaoWeight"/"StakeThreshold"/"PendingChildKeyCooldown" in `apps/ui/src` prior to this PR.

## Fix

Added a `NetworkParametersCard` above the change-log table on `admin-changes.index.tsx` (the natural "current state" home per the issue's own reasoning, since this page is already about the AdminUtils pallet that controls these three parameters). It's in its own `QueryErrorBoundary`/`Suspense`, so a slow or failed RPC read never blocks the unrelated, artifact-backed change-log table below.

- `networkParametersQuery()` + `NetworkParameters` type: each field independently defaults to `null` on its own missing/non-numeric value — matching the REST route's own "each field is independently null on its own RPC failure" contract. A real zero (e.g. `tao_weight` legitimately at 0) never gets coerced into looking like a failed read.
- `TaoWeight` renders as a percentage (it's a 0-1 consensus ratio, confirmed via `src/network-parameters.mjs`'s own doc comment: `U64F64 fixed-point ratio`). `StakeThreshold`/`PendingChildKeyCooldown` use the app's existing `formatTao`/`formatNumber` helpers, which already fall back to "—" on null.
- 4 new tests: well-formed pass-through, independent-null-per-field (a partial RPC failure doesn't null the other two), a real zero staying distinguishable from a failed read, and junk/missing input degrading to an all-null shape without throwing.

Note: a prior submission of this same fix (#7186) was auto-closed for a single Prettier formatting violation (an import block wrapped across multiple lines instead of collapsed to fit `printWidth: 100`) — no functional change here, just that one line collapsed and full verification (typecheck/lint/tests) re-run clean.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6997-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `npx tsc --noEmit -p apps/ui`: clean
- `npx eslint` on changed files: 0 errors (pre-existing repo-wide `react-refresh/only-export-components` warnings unrelated to this change)
- `npx prettier --check` on changed files: clean
- `npx vitest run` (queries.network-parameters.test.ts): 4/4 passing