### PR TITLE
feat(api): add subnet_metagraph, subnet_overview, subnet_profile GraphQL fields (#7169)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -142,10 +142,12 @@ import {
   LEADERBOARD_BOARDS,
   loadSubnetTrajectory,
   mergeRpcEndpoints,
+  overlayOverviewHealth,
   resolveLiveEconomics,
   resolveLiveHealth,
   subnetBadgeStatus,
 } from "./health-serving.mjs";
+import { loadSubnetProfile } from "./profiles-mcp.mjs";
 import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.mjs";
 import {
   COMPARE_VALIDATORS_MAX,
@@ -203,6 +205,7 @@ import {
   GLOBAL_VALIDATOR_SORTS,
   buildGlobalValidators,
   buildNeuronDetail,
+  buildSubnetMetagraph,
   buildSubnetValidators,
   buildValidatorDetail,
   composeValidatorComparison,
@@ -497,6 +500,12 @@ export const SDL = `
     subnet_identity_history(netuid: Int!, limit: Int, offset: Int, cursor: String): SubnetIdentityHistory!
     "One subnet's weekly structural + economics trajectory from the daily snapshots: a chronological series of points (completeness/surface/endpoint counts plus validator/miner counts and economics — stake, alpha price, emission share, pool reserves, volume), and the latest-vs-window-ago deltas for the 7d and 30d windows. A subnet with no snapshots resolves to a schema-stable empty trajectory (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/trajectory."
     subnet_trajectory(netuid: Int!): SubnetTrajectory!
+    "One subnet's live metagraph: every neuron with its uid, keys, stake, trust/consensus/incentive/dividends, emission, and axon, plus the subnet's aggregate counters. Set validator_permit to true to return only permit-holding validators. A subnet with no indexed neurons resolves to a schema-stable empty metagraph, never null. Opaque JSON passed through verbatim, matching the get_subnet_metagraph MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/metagraph."
+    subnet_metagraph(netuid: Int!, validator_permit: Boolean): JSON
+    "One subnet's composed overview card: the baked static subnet record overlaid with live probe-derived health, exactly as the REST route composes it. Null when no overview has been baked for that netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/overview."
+    subnet_overview(netuid: Int!): JSON
+    "One subnet's contributor-review profile: candidate surfaces, contract version, endpoints, and completeness/curation metadata. Null when no profile has been baked for that netuid (rather than a GraphQL error); a negative netuid is a BAD_USER_INPUT error. Opaque JSON passed through verbatim, matching the get_subnet_profile MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/profile."
+    subnet_profile(netuid: Int!): JSON
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -3893,6 +3902,9 @@ export const FIELD_COMPLEXITY = {
   neuron_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_trajectory: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_metagraph: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_overview: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_profile: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4596,6 +4608,61 @@ const rootValue = {
       next_cursor: data.next_cursor ?? null,
       entries: data.entries ?? [],
     };
+  },
+
+  // #7169: the three composed subnet routes that had no GraphQL mirror. Each
+  // reuses exactly what REST/MCP already call, so the three surfaces can't
+  // drift.
+  async subnet_metagraph({ netuid, validator_permit }, context) {
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetMetagraph
+    // fallback contract get_subnet_metagraph uses; a subnet with no indexed
+    // neurons is a schema-stable empty metagraph, never a GraphQL error.
+    const params = new URLSearchParams();
+    if (validator_permit) params.set("validator_permit", "true");
+    return (
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/metagraph`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildSubnetMetagraph([], netuid)
+    );
+  },
+
+  async subnet_overview({ netuid }, context) {
+    // Same baked-overview + overlayOverviewHealth composition the REST
+    // "subnet-overview" case and the get_subnet MCP tool perform. An
+    // un-baked netuid resolves to null rather than a GraphQL error.
+    const overview = await loadArtifact(
+      context,
+      `/metagraph/overview/${netuid}.json`,
+    );
+    if (!overview) return null;
+    const live = await loadLiveHealth(context);
+    return overlayOverviewHealth(overview, live, netuid) || overview;
+  },
+
+  async subnet_profile({ netuid }, context) {
+    // Reuse loadSubnetProfile (the loader get_subnet_profile already calls)
+    // unchanged; its deps.readArtifact is invoked as (ctx, path) -- exactly
+    // loadArtifact's shape -- so the read shares the request-scoped once()
+    // cache. Its only throw is an invalid netuid, which becomes BAD_USER_INPUT
+    // (mirroring REST's invalid_params 400); an un-baked profile is null.
+    try {
+      return await loadSubnetProfile(context, netuid, {
+        readArtifact: loadArtifact,
+      });
+    } catch (err) {
+      if (err?.profilesMcp) {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      throw err;
+    }
   },
 
   async subnet_trajectory({ netuid }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7109,6 +7109,136 @@ describe("graphql — registry_summary / source_health / lineage / rpc_endpoints
   });
 });
 
+describe("graphql — subnet metagraph / overview / profile (#7169, composed-route parity)", () => {
+  function tierEnv(sourceKey, payload, onUrl) {
+    return {
+      [sourceKey]: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          onUrl?.(new URL(r.url));
+          return Response.json(payload);
+        },
+      },
+    };
+  }
+
+  test("subnet_metagraph resolves the postgres-tier payload", async () => {
+    let url;
+    const env = tierEnv(
+      "METAGRAPH_NEURONS_SOURCE",
+      { schema_version: 1, netuid: 3, neuron_count: 1, neurons: [{ uid: 0 }] },
+      (u) => {
+        url = u;
+      },
+    );
+    const { status, body } = await gql("{ subnet_metagraph(netuid: 3) }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_metagraph.neuron_count, 1);
+    assert.equal(url.pathname, "/api/v1/subnets/3/metagraph");
+    assert.equal(url.searchParams.get("validator_permit"), null);
+  });
+
+  test("subnet_metagraph forwards validator_permit to the tier", async () => {
+    let url;
+    const env = tierEnv(
+      "METAGRAPH_NEURONS_SOURCE",
+      { schema_version: 1, netuid: 3, neuron_count: 0, neurons: [] },
+      (u) => {
+        url = u;
+      },
+    );
+    const { body } = await gql(
+      "{ subnet_metagraph(netuid: 3, validator_permit: true) }",
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(url.searchParams.get("validator_permit"), "true");
+  });
+
+  test("subnet_metagraph falls back to a schema-stable empty metagraph, never null", async () => {
+    const { status, body } = await gql("{ subnet_metagraph(netuid: 3) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_metagraph, {
+      schema_version: 1,
+      netuid: 3,
+      neuron_count: 0,
+      captured_at: null,
+      block_number: null,
+      neurons: [],
+    });
+  });
+
+  test("subnet_overview composes the baked overview with live health", async () => {
+    const env = fixtureEnv({
+      "/metagraph/overview/3.json": { netuid: 3, name: "Three" },
+    });
+    const { status, body } = await gql("{ subnet_overview(netuid: 3) }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_overview.netuid, 3);
+    assert.equal(body.data.subnet_overview.name, "Three");
+  });
+
+  test("subnet_overview resolves to null when no overview is baked", async () => {
+    const { status, body } = await gql("{ subnet_overview(netuid: 3) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_overview, null);
+  });
+
+  test("subnet_profile resolves the baked contributor-review profile", async () => {
+    const env = fixtureEnv({
+      "/metagraph/profiles/3.json": { netuid: 3, completeness_score: 88 },
+    });
+    const { status, body } = await gql("{ subnet_profile(netuid: 3) }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_profile.completeness_score, 88);
+  });
+
+  test("subnet_profile resolves to null when no profile is baked", async () => {
+    const { status, body } = await gql("{ subnet_profile(netuid: 3) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_profile, null);
+  });
+
+  test("subnet_profile rejects a negative netuid with BAD_USER_INPUT", async () => {
+    const { body } = await gql("{ subnet_profile(netuid: -1) }");
+    assert.equal(body.errors?.[0]?.extensions?.code, "BAD_USER_INPUT");
+    assert.match(body.errors[0].message, /non-negative integer/);
+  });
+
+  test("subnet_profile surfaces a non-loader fault instead of reporting null", async () => {
+    // An unparseable artifact body throws out of readR2's .json() as a plain
+    // Error -- not a loader profilesMcp error -- so it must surface rather than
+    // being silently reported as "no profile baked".
+    const env = {
+      METAGRAPH_R2_LATEST_PREFIX: "latest/",
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              throw new Error("malformed artifact body");
+            },
+          };
+        },
+      },
+    };
+    const { body } = await gql("{ subnet_profile(netuid: 3) }", env);
+    assert.ok(body.errors?.length, "expected a GraphQL error");
+    assert.equal(body.data?.subnet_profile ?? null, null);
+  });
+
+  test("the three fields are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_metagraph, 5);
+    assert.equal(FIELD_COMPLEXITY.subnet_overview, 5);
+    assert.equal(FIELD_COMPLEXITY.subnet_profile, 5);
+  });
+});
+
 describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validators)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Three subnet-scoped REST routes returned composed artifacts with no GraphQL mirror:

- `GET /api/v1/subnets/{netuid}/metagraph`
- `GET /api/v1/subnets/{netuid}/overview`
- `GET /api/v1/subnets/{netuid}/profile`

This adds `subnet_metagraph(netuid, validator_permit)`, `subnet_overview(netuid)`, and `subnet_profile(netuid)` to `type Query`.

Closes #7169

## Convention chosen

Top-level `Query` fields, following the **`subnet_trajectory(netuid: Int!)` precedent** rather than nesting on `type Subnet`. These three are composed, separately-loaded artifacts (postgres tier / health overlay / review artifact), matching how `subnet_trajectory`, `subnet_hyperparameters`, and `subnet_volume` are already exposed — `type Subnet`'s nested fields (`health`, `economics`, `surfaces`, `endpoints`) are all rows of the subnet's own record.

## Scope note

The issue also asked for MCP tools for overview and profile. Both are **already on `main`** — overview is served by `get_subnet` ("Get subnet overview", which does the same `/metagraph/overview/{netuid}.json` + `overlayOverviewHealth` composition) and `get_subnet_profile` exists; `get_subnet_metagraph` was already noted as existing. So all three routes already had MCP coverage and this PR closes the remaining GraphQL gap.

## Change

`src/graphql.mjs` (+67) — each resolver reuses exactly what REST/MCP already call, so the three surfaces can't drift:

- **`subnet_metagraph`** — same `tryPostgresTier(METAGRAPH_NEURONS_SOURCE)` → `buildSubnetMetagraph([], netuid)` fallback contract `get_subnet_metagraph` uses, via the existing `postgresTierRequest()` helper. Optional `validator_permit: Boolean` is forwarded as the same query param the REST route takes. A subnet with no indexed neurons is a schema-stable empty metagraph, never null.
- **`subnet_overview`** — the baked `/metagraph/overview/{netuid}.json` + `overlayOverviewHealth(...)` composition the REST `"subnet-overview"` case and `get_subnet` perform. An un-baked netuid resolves to null.
- **`subnet_profile`** — reuses `loadSubnetProfile` (the loader `get_subnet_profile` calls) unchanged; its `deps.readArtifact` is invoked as `(ctx, path)`, exactly `loadArtifact`'s shape, so the read shares the request-scoped `once()` cache. Its only throw (invalid netuid) becomes `BAD_USER_INPUT`, mirroring REST's `invalid_params` 400; an un-baked profile is null.

All three typed as the `JSON` scalar (opaque passthrough), matching the `agent_resources` precedent for verbatim REST/MCP-shaped payloads. `FIELD_COMPLEXITY`: all three weighted as fan-out fields (5).

## Tests

`tests/graphql.test.mjs` (+130) — 10 tests covering **every added line**:

- `subnet_metagraph` resolves the postgres-tier payload (asserting the forwarded path)
- `subnet_metagraph` forwards `validator_permit` to the tier
- `subnet_metagraph` falls back to a schema-stable empty metagraph, never null
- `subnet_overview` composes the baked overview with live health
- `subnet_overview` resolves to null when no overview is baked
- `subnet_profile` resolves the baked profile
- `subnet_profile` resolves to null when no profile is baked
- `subnet_profile` rejects a negative netuid with `BAD_USER_INPUT`
- `subnet_profile` surfaces a genuine fault (unparseable artifact body) as a GraphQL error instead of silently reporting null — a loader *miss* is null, a loader *fault* is not swallowed
- all three are weighted as fan-out fields

## Validation

- `npx vitest run tests/graphql.test.mjs` → **724 passed** (incl. the 10 new)
- Scoped coverage (`--coverage.include=src/graphql.mjs`) → **100% statements / 100% lines**; every line in this diff is exercised (the only residual uncovered lines are pre-existing partial branches far outside this change)
- `npx eslint` → clean · `npx prettier --check` → clean (verified LF-normalized; local checkout is CRLF)
- Purely additive: `+197 / -0`; no SDL removals, no changes to existing resolvers or loaders.
