### PR TITLE
feat(api): GraphQL + MCP parity for /api/v1/review/* (#7167)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -23,6 +23,15 @@ import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import { loadEndpointPoolsList } from "./endpoint-pools-mcp.mjs";
 import { loadRpcPoolsList } from "./rpc-pools-mcp.mjs";
 import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.mjs";
+// #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
+// reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
+// and page logic REST and MCP already use) -- not a reimplementation.
+import { loadAdapterCandidatesList } from "./adapter-candidates-mcp.mjs";
+import { loadEnrichmentEvidenceList } from "./enrichment-evidence-mcp.mjs";
+import { loadEnrichmentQueueList } from "./enrichment-queue-mcp.mjs";
+import { loadReviewEnrichmentTargetsList } from "./review-enrichment-targets-mcp.mjs";
+import { loadReviewGapsList } from "./review-gaps-mcp.mjs";
+import { loadProfileCompletenessList } from "./profile-completeness-mcp.mjs";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.mjs";
@@ -473,6 +482,18 @@ export const SDL = `
     source_snapshots(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SourceSnapshotList!
     "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
     profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
+    "Subnets worth deeper adapter work -- recommended_adapter_kind, operational and candidate API kinds, priority_score, and reason_codes. Filter by netuid/curation_level/candidate_api_kinds/operational_kinds/recommended_adapter_kind/reason_codes, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/review/adapter-candidates."
+    review_adapter_candidates(netuid: Int, curation_level: String, candidate_api_kinds: String, operational_kinds: String, recommended_adapter_kind: String, reason_codes: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewAdapterCandidateList!
+    "Detailed candidate evidence behind the enrichment queue -- evidence_action, lane, missing kinds, and priority_score per subnet. Filter by netuid/lane/evidence_action/direct_submission_kinds/missing_kinds, search with q, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/review/enrichment-evidence."
+    review_enrichment_evidence(q: String, netuid: Int, lane: String, evidence_action: String, direct_submission_kinds: String, missing_kinds: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewEnrichmentEvidenceList!
+    "Prioritized all-subnet enrichment queue -- lane, priority_score, missing kinds, and recommended_action per subnet. Filter by netuid/lane/evidence_action/identity_level/curation_level/profile_level/direct_submission_kinds/missing_kinds/manual_review_required/reason_codes/review_state, search with q, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/review/enrichment-queue."
+    review_enrichment_queue(q: String, netuid: Int, lane: String, evidence_action: String, identity_level: String, curation_level: String, profile_level: String, direct_submission_kinds: String, missing_kinds: String, manual_review_required: String, reason_codes: String, review_state: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewEnrichmentQueueList!
+    "Contributor-facing enrichment targets -- target_type, target_action, lane, priority_score, and submission_route. Filter by netuid/target_type/target_action/kind/lane/evidence_action/identity_level/profile_level/submission_route/auto_review_candidate/manual_review_required/missing_kinds/reason_codes, search with q, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/review/enrichment-targets."
+    review_enrichment_targets(q: String, netuid: Int, target_type: String, target_action: String, kind: String, lane: String, evidence_action: String, identity_level: String, profile_level: String, submission_route: String, auto_review_candidate: String, manual_review_required: String, missing_kinds: String, reason_codes: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewEnrichmentTargetList!
+    "Contributor-targeted review gap priorities -- priority_score, missing surface kinds, curation_level, and review_state. Distinct from the per-subnet subnet_gaps field and the global gaps ledger. Filter by netuid/curation_level/missing_kinds/review_state, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/review/gaps."
+    review_gaps(netuid: Int, curation_level: String, missing_kinds: String, review_state: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewGapPriorityList!
+    "Contributor review queue of subnet profile-completeness gaps -- identity, native name, confidence, and promotion signals. Filter by netuid/profile_level/confidence/identity_level/identity_promotion_kinds/native_name_quality, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/review/profile-completeness."
+    review_profile_completeness(netuid: Int, profile_level: String, confidence: String, identity_level: String, identity_promotion_kinds: String, native_name_quality: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewProfileCompletenessList!
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
@@ -1733,6 +1754,85 @@ export const SDL = `
 
   type ProfileList {
     captured_at: String
+    profiles: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type ReviewAdapterCandidateList {
+    generated_at: String
+    notes: JSON
+    candidates: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type ReviewEnrichmentEvidenceList {
+    generated_at: String
+    notes: JSON
+    entries: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type ReviewEnrichmentQueueList {
+    generated_at: String
+    notes: JSON
+    queue: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type ReviewEnrichmentTargetList {
+    generated_at: String
+    notes: JSON
+    targets: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type ReviewGapPriorityList {
+    generated_at: String
+    notes: JSON
+    priorities: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type ReviewProfileCompletenessList {
+    generated_at: String
+    notes: JSON
+    summary: JSON
     profiles: [JSON!]!
     total: Int!
     returned: Int!
@@ -3479,6 +3579,12 @@ export const FIELD_COMPLEXITY = {
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
   profiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_adapter_candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_enrichment_evidence: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_enrichment_queue: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_enrichment_targets: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_gaps: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_profile_completeness: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5023,6 +5129,37 @@ const rootValue = {
     return loadProfilesList(context, args, {
       readOptionalArtifact: loadArtifact,
     });
+  },
+
+  // #7167: reuse each review-family list_* MCP loader unchanged. Each validates
+  // its own args and throws on an invalid one -- that throw (inside these async
+  // functions) becomes a rejected promise, which the graphql executor surfaces
+  // as a normal GraphQL error, matching every other field's "an unsupported
+  // filter/sort is a GraphQL error, not a silently substituted default"
+  // convention. A cold/missing artifact is also a GraphQL error (matches
+  // REST 404 / MCP not_found); an empty filtered page is a success with total 0.
+  review_adapter_candidates(args, context) {
+    return loadAdapterCandidatesList(context, args, { readArtifact });
+  },
+
+  review_enrichment_evidence(args, context) {
+    return loadEnrichmentEvidenceList(context, args, { readArtifact });
+  },
+
+  review_enrichment_queue(args, context) {
+    return loadEnrichmentQueueList(context, args, { readArtifact });
+  },
+
+  review_enrichment_targets(args, context) {
+    return loadReviewEnrichmentTargetsList(context, args, { readArtifact });
+  },
+
+  review_gaps(args, context) {
+    return loadReviewGapsList(context, args, { readArtifact });
+  },
+
+  review_profile_completeness(args, context) {
+    return loadProfileCompletenessList(context, args, { readArtifact });
   },
 
   async health(_args, context) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -119,6 +119,12 @@ import {
   loadReviewEnrichmentTargetsList,
 } from "./review-enrichment-targets-mcp.mjs";
 import {
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+  LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+  LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+  loadProfileCompletenessList,
+} from "./profile-completeness-mcp.mjs";
+import {
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS,
   LIST_SUBNET_ENDPOINTS_MCP_TOOL,
   LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
@@ -827,6 +833,7 @@ export const MCP_INSTRUCTIONS =
   LIST_ENRICHMENT_EVIDENCE_INSTRUCTIONS +
   LIST_REVIEW_GAPS_INSTRUCTIONS +
   LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS +
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS +
   LIST_SEARCH_INDEX_INSTRUCTIONS +
   LIST_SEARCH_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
@@ -9792,24 +9799,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_profile_completeness",
-    title: "List subnet profile-completeness gaps",
-    description:
-      "Fetch the contributor review queue of subnet profile-completeness gaps: " +
-      "which subnets have incomplete public-safe profiles (missing identity, " +
-      "native name, confidence, or promotion signals) and are worth profile " +
-      "enrichment. Use it to find high-value profile contributions. Mirrors " +
-      "GET /api/v1/review/profile-completeness.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args, ctx) {
-      return loadArtifactData(
-        ctx,
-        "/metagraph/review/profile-completeness.json",
-      );
+    ...LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadProfileCompletenessList(ctx, args);
     },
   },
   {
@@ -14956,17 +14948,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   },
   list_subnet_endpoints: LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
   list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
-  list_profile_completeness: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      profiles: { type: "array", items: { type: "object" } },
-      summary: { type: "object", additionalProperties: true },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
   list_rpc_endpoints: {
     type: "object",

--- a/src/profile-completeness-mcp.mjs
+++ b/src/profile-completeness-mcp.mjs
@@ -1,0 +1,274 @@
+// Profile completeness list loader for MCP parity on
+// GET /api/v1/review/profile-completeness. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/review/profile-completeness.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const PROFILE_COMPLETENESS_ARTIFACT =
+  "/metagraph/review/profile-completeness.json";
+
+const PROFILE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["profile-completeness"].sort_fields;
+const PROFILE_LEVELS = QUERY_ENUMS.profileLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
+const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"];
+
+export function profileCompletenessMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function profileCompletenessQueryUrl(args) {
+  const url = new URL("https://mcp.internal/review/profile-completeness");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw profileCompletenessMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const profileLevel = optionalEnum(args, "profile_level", PROFILE_LEVELS);
+  if (profileLevel) url.searchParams.set("profile_level", profileLevel);
+  const confidence = optionalEnum(args, "confidence", CONFIDENCE_LEVELS);
+  if (confidence) url.searchParams.set("confidence", confidence);
+  const identityLevel = optionalEnum(args, "identity_level", IDENTITY_LEVELS);
+  if (identityLevel) url.searchParams.set("identity_level", identityLevel);
+  const identityPromotionKinds = optionalEnum(
+    args,
+    "identity_promotion_kinds",
+    SURFACE_KINDS,
+  );
+  if (identityPromotionKinds) {
+    url.searchParams.set("identity_promotion_kinds", identityPromotionKinds);
+  }
+  const nativeNameQuality = optionalEnum(
+    args,
+    "native_name_quality",
+    NATIVE_NAME_QUALITIES,
+  );
+  if (nativeNameQuality) {
+    url.searchParams.set("native_name_quality", nativeNameQuality);
+  }
+  const sort = optionalEnum(args, "sort", PROFILE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw profileCompletenessMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadProfileCompletenessList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const queryUrl = profileCompletenessQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, PROFILE_COMPLETENESS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw profileCompletenessMcpError(
+        "not_found",
+        "Profile completeness snapshot unavailable.",
+      );
+    }
+    throw profileCompletenessMcpError(
+      code,
+      `Could not load ${PROFILE_COMPLETENESS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw profileCompletenessMcpError(
+      "not_found",
+      "Profile completeness snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "profile-completeness",
+    [],
+  );
+  if (transformed.error) {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      transformed.error.message,
+    );
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.profiles) ? data.profiles : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    summary: data.summary ?? null,
+    profiles: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_PROFILE_COMPLETENESS_INSTRUCTIONS =
+  "list_profile_completeness the contributor review queue of subnet " +
+  "profile-completeness gaps (identity, native name, confidence; mirrors " +
+  "GET /api/v1/review/profile-completeness), ";
+
+export const LIST_PROFILE_COMPLETENESS_MCP_TOOL = {
+  name: "list_profile_completeness",
+  title: "List subnet profile-completeness gaps",
+  description:
+    "Fetch the contributor review queue of subnet profile-completeness gaps: " +
+    "which subnets have incomplete public-safe profiles (missing identity, " +
+    "native name, confidence, or promotion signals) and are worth profile " +
+    "enrichment. Filter by netuid, profile_level, confidence, identity_level, " +
+    "identity_promotion_kinds, or native_name_quality; sort with sort + order; " +
+    "and page with limit (1-100) / cursor. Use it to find high-value profile " +
+    "contributions. Mirrors GET /api/v1/review/profile-completeness.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      profile_level: {
+        type: "string",
+        enum: PROFILE_LEVELS,
+        description: "Filter by profile completeness level.",
+      },
+      confidence: {
+        type: "string",
+        enum: CONFIDENCE_LEVELS,
+        description: "Filter by confidence level.",
+      },
+      identity_level: {
+        type: "string",
+        enum: IDENTITY_LEVELS,
+        description: "Filter by subnet identity completeness.",
+      },
+      identity_promotion_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description:
+          "Filter rows whose identity promotion kinds include this surface kind.",
+      },
+      native_name_quality: {
+        type: "string",
+        enum: NATIVE_NAME_QUALITIES,
+        description: "Filter by native name quality.",
+      },
+      sort: {
+        type: "string",
+        enum: PROFILE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of profile row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["profiles"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    summary: { type: ["object", "null"], additionalProperties: true },
+    profiles: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/review-gaps-mcp.mjs
+++ b/src/review-gaps-mcp.mjs
@@ -10,6 +10,7 @@ export const REVIEW_GAPS_ARTIFACT = "/metagraph/review/gap-priorities.json";
 const PRIORITY_SORT_FIELDS =
   API_QUERY_COLLECTIONS["review-gap-priorities"].sort_fields;
 const CURATION_LEVELS = QUERY_ENUMS.curationLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
 
 export function reviewGapsMcpError(code, message) {
   const error = new Error(message);
@@ -61,6 +62,8 @@ export function reviewGapsQueryUrl(args) {
   }
   const curationLevel = optionalEnum(args, "curation_level", CURATION_LEVELS);
   if (curationLevel) url.searchParams.set("curation_level", curationLevel);
+  const missingKinds = optionalEnum(args, "missing_kinds", SURFACE_KINDS);
+  if (missingKinds) url.searchParams.set("missing_kinds", missingKinds);
   const reviewState = optionalString(args, "review_state");
   if (reviewState) url.searchParams.set("review_state", reviewState);
   const sort = optionalEnum(args, "sort", PRIORITY_SORT_FIELDS);
@@ -145,10 +148,10 @@ export const LIST_REVIEW_GAPS_MCP_TOOL = {
   description:
     "Fetch the contributor-targeted review gap priority board from the registry: " +
     "per-subnet priority_score, missing surface kinds, surface and candidate counts, " +
-    "curation_level, and review_state. Filter by netuid, curation_level, or review_state; " +
-    "sort with sort + order; and page with limit (1-100) / cursor. Distinct from list_gaps " +
-    "(interface facet reports at GET /api/v1/gaps) and get_subnet_gaps (one subnet's " +
-    "detailed gap artifact). Mirrors GET /api/v1/review/gaps.",
+    "curation_level, and review_state. Filter by netuid, curation_level, missing_kinds, " +
+    "or review_state; sort with sort + order; and page with limit (1-100) / cursor. " +
+    "Distinct from list_gaps (interface facet reports at GET /api/v1/gaps) and " +
+    "get_subnet_gaps (one subnet's detailed gap artifact). Mirrors GET /api/v1/review/gaps.",
   inputSchema: {
     type: "object",
     properties: {
@@ -161,6 +164,12 @@ export const LIST_REVIEW_GAPS_MCP_TOOL = {
         type: "string",
         enum: CURATION_LEVELS,
         description: "Filter by curation level.",
+      },
+      missing_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description:
+          "Filter rows whose missing_kinds include this surface kind.",
       },
       review_state: {
         type: "string",

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1666,6 +1666,273 @@ describe("graphql — profiles", () => {
   });
 });
 
+// #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
+// reusing each list_* MCP loader unchanged (same filter/sort/page + error
+// behavior as REST and MCP) rather than a GraphQL-only reimplementation.
+describe("graphql — review_* contributor-review family", () => {
+  const ADAPTER_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["adapter shortlist"],
+    candidates: [
+      {
+        netuid: 7,
+        name: "Allways",
+        priority_score: 88,
+        curation_level: "candidate-discovered",
+        recommended_adapter_kind: "generic-openapi-or-custom",
+      },
+      {
+        netuid: 12,
+        name: "Compute",
+        priority_score: 72,
+        curation_level: "maintainer-reviewed",
+        recommended_adapter_kind: "custom-adapter",
+      },
+    ],
+  };
+
+  const EVIDENCE_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["evidence"],
+    entries: [
+      {
+        netuid: 7,
+        name: "Allways",
+        priority_score: 90,
+        lane: "direct-submission",
+        evidence_action: "submit-new-evidence",
+      },
+      {
+        netuid: 12,
+        name: "Compute",
+        priority_score: 40,
+        lane: "monitoring-followup",
+        evidence_action: "monitor",
+      },
+    ],
+  };
+
+  const QUEUE_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["queue"],
+    queue: [
+      {
+        netuid: 7,
+        name: "Allways",
+        priority_score: 95,
+        lane: "direct-submission",
+        curation_level: "candidate-discovered",
+      },
+      {
+        netuid: 12,
+        name: "Compute",
+        priority_score: 50,
+        lane: "baseline-monitoring",
+        curation_level: "maintainer-reviewed",
+      },
+    ],
+  };
+
+  const TARGETS_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["targets"],
+    targets: [
+      {
+        netuid: 7,
+        name: "Allways",
+        priority_score: 91,
+        target_type: "surface-candidate",
+        lane: "direct-submission",
+      },
+      {
+        netuid: 12,
+        name: "Compute",
+        priority_score: 55,
+        target_type: "monitoring-followup",
+        lane: "monitoring-followup",
+      },
+    ],
+  };
+
+  const GAPS_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["gaps"],
+    priorities: [
+      {
+        netuid: 7,
+        name: "Allways",
+        priority_score: 88,
+        curation_level: "candidate-discovered",
+        missing_kinds: ["openapi"],
+      },
+      {
+        netuid: 12,
+        name: "Compute",
+        priority_score: 72,
+        curation_level: "maintainer-reviewed",
+        missing_kinds: ["website"],
+      },
+    ],
+  };
+
+  const PROFILE_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["profile gaps"],
+    summary: { profile_count: 2 },
+    profiles: [
+      {
+        netuid: 7,
+        name: "Allways",
+        priority_score: 80,
+        profile_level: "identity-partial",
+        identity_level: "partial",
+        confidence: "medium",
+      },
+      {
+        netuid: 12,
+        name: "Compute",
+        priority_score: 40,
+        profile_level: "directory-only",
+        identity_level: "none",
+        confidence: "low",
+      },
+    ],
+  };
+
+  const reviewEnv = () =>
+    fixtureEnv({
+      "/metagraph/review/adapter-candidates.json": ADAPTER_BLOB,
+      "/metagraph/review/enrichment-evidence.json": EVIDENCE_BLOB,
+      "/metagraph/review/enrichment-queue.json": QUEUE_BLOB,
+      "/metagraph/review/enrichment-targets.json": TARGETS_BLOB,
+      "/metagraph/review/gap-priorities.json": GAPS_BLOB,
+      "/metagraph/review/profile-completeness.json": PROFILE_BLOB,
+    });
+
+  test("review_adapter_candidates filters by netuid and paginates", async () => {
+    const env = reviewEnv();
+    const filtered = await gql(
+      "{ review_adapter_candidates(netuid: 7) { candidates total generated_at } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.review_adapter_candidates.total, 1);
+    assert.equal(
+      filtered.body.data.review_adapter_candidates.candidates[0].netuid,
+      7,
+    );
+    assert.equal(
+      filtered.body.data.review_adapter_candidates.generated_at,
+      "2026-07-01T00:00:00.000Z",
+    );
+
+    const paged = await gql(
+      "{ review_adapter_candidates(limit: 1) { candidates total returned next_cursor } }",
+      env,
+    );
+    assert.equal(
+      paged.body.data.review_adapter_candidates.candidates.length,
+      1,
+    );
+    assert.equal(paged.body.data.review_adapter_candidates.total, 2);
+    assert.equal(paged.body.data.review_adapter_candidates.returned, 1);
+    assert.ok(paged.body.data.review_adapter_candidates.next_cursor != null);
+  });
+
+  test("review_enrichment_evidence filters by lane and sorts", async () => {
+    const env = reviewEnv();
+    const filtered = await gql(
+      '{ review_enrichment_evidence(lane: "direct-submission") { entries total } }',
+      env,
+    );
+    assert.equal(filtered.body.data.review_enrichment_evidence.total, 1);
+    assert.equal(
+      filtered.body.data.review_enrichment_evidence.entries[0].netuid,
+      7,
+    );
+
+    const sorted = await gql(
+      '{ review_enrichment_evidence(sort: "priority_score", order: "asc") { entries } }',
+      env,
+    );
+    assert.equal(
+      sorted.body.data.review_enrichment_evidence.entries[0].netuid,
+      12,
+    );
+  });
+
+  test("review_enrichment_queue filters by curation_level", async () => {
+    const env = reviewEnv();
+    const { body } = await gql(
+      '{ review_enrichment_queue(curation_level: "maintainer-reviewed") { queue total } }',
+      env,
+    );
+    assert.equal(body.data.review_enrichment_queue.total, 1);
+    assert.equal(body.data.review_enrichment_queue.queue[0].netuid, 12);
+  });
+
+  test("review_enrichment_targets filters by target_type", async () => {
+    const env = reviewEnv();
+    const { body } = await gql(
+      '{ review_enrichment_targets(target_type: "surface-candidate") { targets total } }',
+      env,
+    );
+    assert.equal(body.data.review_enrichment_targets.total, 1);
+    assert.equal(body.data.review_enrichment_targets.targets[0].netuid, 7);
+  });
+
+  test("review_gaps filters by missing_kinds", async () => {
+    const env = reviewEnv();
+    const { body } = await gql(
+      '{ review_gaps(missing_kinds: "openapi") { priorities total } }',
+      env,
+    );
+    assert.equal(body.data.review_gaps.total, 1);
+    assert.equal(body.data.review_gaps.priorities[0].netuid, 7);
+  });
+
+  test("review_profile_completeness filters by identity_level and exposes summary", async () => {
+    const env = reviewEnv();
+    const { body } = await gql(
+      '{ review_profile_completeness(identity_level: "partial") { profiles total summary } }',
+      env,
+    );
+    assert.equal(body.data.review_profile_completeness.total, 1);
+    assert.equal(body.data.review_profile_completeness.profiles[0].netuid, 7);
+    assert.equal(
+      body.data.review_profile_completeness.summary.profile_count,
+      2,
+    );
+  });
+
+  test("surfaces an invalid review filter as a GraphQL error, not a silent default", async () => {
+    const env = reviewEnv();
+    const { body } = await gql(
+      '{ review_adapter_candidates(curation_level: "bogus") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("surfaces a cold/missing review artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql(
+      "{ review_adapter_candidates { total } }",
+      emptyEnv,
+    );
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights each review_* field like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.review_adapter_candidates, 5);
+    assert.equal(FIELD_COMPLEXITY.review_enrichment_evidence, 5);
+    assert.equal(FIELD_COMPLEXITY.review_enrichment_queue, 5);
+    assert.equal(FIELD_COMPLEXITY.review_enrichment_targets, 5);
+    assert.equal(FIELD_COMPLEXITY.review_gaps, 5);
+    assert.equal(FIELD_COMPLEXITY.review_profile_completeness, 5);
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -15694,23 +15694,45 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  test("list_profile_completeness returns the profile-completeness artifact", async () => {
+  test("list_profile_completeness returns filtered profile-completeness rows", async () => {
     const deps = makeDeps({
       "/metagraph/review/profile-completeness.json": {
         generated_at: "2026-01-01T00:00:00Z",
-        profiles: [{ netuid: 7, profile_level: "partial" }],
-        summary: { profile_count: 1 },
+        profiles: [
+          { netuid: 7, profile_level: "partial", identity_level: "partial" },
+          {
+            netuid: 12,
+            profile_level: "directory-only",
+            identity_level: "none",
+          },
+        ],
+        summary: { profile_count: 2 },
       },
     });
-    const res = await callTool("list_profile_completeness", {}, { deps });
+    const res = await callTool(
+      "list_profile_completeness",
+      { identity_level: "partial" },
+      { deps },
+    );
     const out = res.body.result.structuredContent;
+    assert.equal(out.profiles.length, 1);
     assert.equal(out.profiles[0].netuid, 7);
-    assert.equal(out.summary.profile_count, 1);
+    assert.equal(out.total, 1);
+    assert.equal(out.summary.profile_count, 2);
     assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
   });
 
-  test("list_profile_completeness rejects an unexpected argument", async () => {
-    const res = await callTool("list_profile_completeness", { netuid: 7 });
+  test("list_profile_completeness rejects an invalid identity_level", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        profiles: [{ netuid: 7, identity_level: "partial" }],
+      },
+    });
+    const res = await callTool(
+      "list_profile_completeness",
+      { identity_level: "bogus" },
+      { deps },
+    );
     assert.equal(res.body.result.isError, true);
   });
 

--- a/tests/profile-completeness-mcp.test.mjs
+++ b/tests/profile-completeness-mcp.test.mjs
@@ -133,7 +133,9 @@ describe("profile-completeness-mcp", () => {
   });
 
   test("profileCompletenessQueryUrl clamps a non-finite numeric limit to the default", () => {
-    const url = profileCompletenessQueryUrl({ limit: Number.POSITIVE_INFINITY });
+    const url = profileCompletenessQueryUrl({
+      limit: Number.POSITIVE_INFINITY,
+    });
     assert.equal(url.searchParams.get("limit"), "50");
   });
 

--- a/tests/profile-completeness-mcp.test.mjs
+++ b/tests/profile-completeness-mcp.test.mjs
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+  LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+  LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+  PROFILE_COMPLETENESS_ARTIFACT,
+  loadProfileCompletenessList,
+  profileCompletenessMcpError,
+  profileCompletenessQueryUrl,
+} from "../src/profile-completeness-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["profile gaps"],
+  summary: { profile_count: 2 },
+  profiles: [
+    {
+      netuid: 7,
+      name: "Allways",
+      priority_score: 80,
+      profile_level: "identity-partial",
+      identity_level: "partial",
+      confidence: "medium",
+      native_name_quality: "chain",
+      identity_promotion_kinds: ["source-repo"],
+    },
+    {
+      netuid: 12,
+      name: "Compute",
+      priority_score: 40,
+      profile_level: "directory-only",
+      identity_level: "none",
+      confidence: "low",
+      native_name_quality: "empty",
+      identity_promotion_kinds: [],
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === PROFILE_COMPLETENESS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("profile-completeness-mcp", () => {
+  test("profileCompletenessMcpError is shaped for MCP toolError handling", () => {
+    const err = profileCompletenessMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("profileCompletenessQueryUrl validates filters and cursor", () => {
+    const url = profileCompletenessQueryUrl({
+      netuid: 7,
+      profile_level: "identity-partial",
+      confidence: "medium",
+      identity_level: "partial",
+      identity_promotion_kinds: "source-repo",
+      native_name_quality: "chain",
+      sort: "priority_score",
+      order: "desc",
+      fields: "netuid,priority_score",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("profile_level"), "identity-partial");
+    assert.equal(url.searchParams.get("confidence"), "medium");
+    assert.equal(url.searchParams.get("identity_level"), "partial");
+    assert.equal(
+      url.searchParams.get("identity_promotion_kinds"),
+      "source-repo",
+    );
+    assert.equal(url.searchParams.get("native_name_quality"), "chain");
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid identity_level", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ identity_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid netuid and cursor", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProfileCompletenessList filters, sorts, and paginates", async () => {
+    const filtered = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { identity_level: "partial" },
+    );
+    assert.equal(filtered.total, 1);
+    assert.equal(filtered.profiles[0].netuid, 7);
+    assert.equal(filtered.summary.profile_count, 2);
+
+    const sorted = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { sort: "priority_score", order: "asc" },
+    );
+    assert.equal(sorted.profiles[0].netuid, 12);
+
+    const paged = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { limit: 1 },
+    );
+    assert.equal(paged.returned, 1);
+    assert.equal(paged.total, 2);
+    assert.ok(paged.next_cursor != null);
+  });
+
+  test("loadProfileCompletenessList projects row fields when requested", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { fields: "netuid,priority_score", limit: 1 },
+    );
+    assert.deepEqual(out.profiles[0], { netuid: 7, priority_score: 80 });
+  });
+
+  test("loadProfileCompletenessList omits nullable artifact metadata when absent", async () => {
+    const out = await loadProfileCompletenessList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: [{ netuid: 0, priority_score: 1 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+    assert.equal(out.summary, null);
+  });
+
+  test("loadProfileCompletenessList treats a non-array profiles key as empty", async () => {
+    const out = await loadProfileCompletenessList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.profiles, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadProfileCompletenessList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { profiles: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadProfileCompletenessList(
+        { env: {}, readArtifact },
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadProfileCompletenessList rejects a cold artifact", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProfileCompletenessList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProfileCompletenessList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadProfileCompletenessList surfaces applyQueryFilters errors", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      error: { message: "bad fields" },
+    });
+    try {
+      await assert.rejects(
+        () => loadProfileCompletenessList({ env: {}, readArtifact }, {}),
+        (err) =>
+          err.code === "invalid_params" && err.message.includes("bad fields"),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(
+      LIST_PROFILE_COMPLETENESS_MCP_TOOL.name,
+      "list_profile_completeness",
+    );
+    assert.match(
+      LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+      /list_profile_completeness/,
+    );
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_profile_completeness", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_profile_completeness/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_profile_completeness");
+    assert.ok(tool);
+    assert.equal(tool.title, "List subnet profile-completeness gaps");
+    assert.ok(tool.inputSchema.properties.netuid);
+  });
+});

--- a/tests/profile-completeness-mcp.test.mjs
+++ b/tests/profile-completeness-mcp.test.mjs
@@ -90,6 +90,80 @@ describe("profile-completeness-mcp", () => {
     );
   });
 
+  test("profileCompletenessQueryUrl rejects non-string fields and invalid order", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ order: "sideways" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl rejects a non-string enum filter", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ confidence: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl trims and forwards a fields projection", () => {
+    const url = profileCompletenessQueryUrl({
+      fields: " netuid,priority_score ",
+    });
+    assert.equal(url.searchParams.get("fields"), "netuid,priority_score");
+  });
+
+  test("profileCompletenessQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = profileCompletenessQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("profileCompletenessQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = profileCompletenessQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("profileCompletenessQueryUrl clamps a non-finite numeric limit to the default", () => {
+    const url = profileCompletenessQueryUrl({ limit: Number.POSITIVE_INFINITY });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("profileCompletenessQueryUrl clamps limit above the MCP maximum", () => {
+    const url = profileCompletenessQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("profileCompletenessQueryUrl rejects a fractional netuid and cursor", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl omits empty optional string/enum filters", () => {
+    const url = profileCompletenessQueryUrl({
+      fields: "",
+      confidence: "",
+      identity_level: null,
+    });
+    assert.equal(url.searchParams.get("fields"), null);
+    assert.equal(url.searchParams.get("confidence"), null);
+    assert.equal(url.searchParams.get("identity_level"), null);
+  });
+
   test("profileCompletenessQueryUrl rejects invalid netuid and cursor", () => {
     assert.throws(
       () => profileCompletenessQueryUrl({ netuid: -1 }),

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -54,6 +54,7 @@ describe("review-gaps-mcp", () => {
     const url = reviewGapsQueryUrl({
       netuid: 7,
       curation_level: "candidate-discovered",
+      missing_kinds: "openapi",
       review_state: "needs-evidence",
       sort: "priority_score",
       order: "desc",
@@ -66,6 +67,7 @@ describe("review-gaps-mcp", () => {
       url.searchParams.get("curation_level"),
       "candidate-discovered",
     );
+    assert.equal(url.searchParams.get("missing_kinds"), "openapi");
     assert.equal(url.searchParams.get("review_state"), "needs-evidence");
     assert.equal(url.searchParams.get("sort"), "priority_score");
     assert.equal(url.searchParams.get("limit"), "10");


### PR DESCRIPTION
## Summary

- Add GraphQL Query fields for all six `/api/v1/review/*` contributor-review routes, reusing each route's existing MCP list loader (same filter/sort/page + error behavior as REST).
- Upgrade `list_profile_completeness` from a raw artifact dump to a full filter/sort/page loader matching REST (`profile-completeness` collection).
- Wire `missing_kinds` on `list_review_gaps` so MCP/GraphQL match the REST filter surface.

Closes #7167

## What Changed

**GraphQL** (`src/graphql.mjs`):
- `review_adapter_candidates` → `ReviewAdapterCandidateList`
- `review_enrichment_evidence` → `ReviewEnrichmentEvidenceList`
- `review_enrichment_queue` → `ReviewEnrichmentQueueList`
- `review_enrichment_targets` → `ReviewEnrichmentTargetList`
- `review_gaps` → `ReviewGapPriorityList`
- `review_profile_completeness` → `ReviewProfileCompletenessList`

Each field docs with `Mirrors GET /api/v1/review/...`. Invalid filter/sort → GraphQL error; cold artifact → GraphQL error (matches REST 404 / MCP `not_found`); empty filtered page → success with `total: 0`.

**MCP:**
- New `src/profile-completeness-mcp.mjs` replaces the empty-schema inline `list_profile_completeness` handler.
- The other four review tools already existed (`list_adapter_candidates`, `list_enrichment_evidence`, `list_enrichment_queue`, `list_review_gaps`); not duplicated. (`list_enrichment_targets` remains the coverage-depth tool; review targets stay on `list_review_enrichment_targets`.)

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7167`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (GraphQL SDL + MCP tool inputSchema only; no OpenAPI/schema regen)

## Validation

- [x] Focused: `vitest` profile-completeness-mcp, review-gaps-mcp, graphql `review_*`, mcp-server `list_profile_completeness`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run test:coverage`
- [ ] `git diff --check`

## Test plan

- [ ] Query each new GraphQL field with a filter + `limit: 1` against a built artifact set
- [ ] Confirm cold-artifact and invalid-enum queries return GraphQL errors
- [ ] Call `list_profile_completeness` with `identity_level` / `netuid` and confirm pagination metadata
- [ ] Confirm `list_review_gaps` accepts `missing_kinds`