### PR TITLE
feat(graphql): add changelog, contracts, health_history Query fields

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -26,6 +26,12 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.mjs";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.mjs";
+// #7170: GraphQL parity for the changelog/contracts/health-history REST routes,
+// reusing the same loaders MCP get_changelog/get_contracts/get_health_history
+// already call -- not a reimplementation.
+import { loadChangelog } from "./changelog-mcp.mjs";
+import { loadContracts } from "./contracts-mcp.mjs";
+import { loadHealthHistory } from "./health-history-mcp.mjs";
 import {
   buildChainAxonRemovals,
   CHAIN_AXON_REMOVALS_WINDOWS,
@@ -518,6 +524,12 @@ export const SDL = `
     lineage: JSON
     "The full catalog of monitored Bittensor base-layer RPC endpoints and their status (each endpoint's URL, network, and probe-derived health/latency), with the same live 15-minute cron RPC-pool overlay REST and MCP apply before serving. Null when the catalog has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the list_rpc_endpoints MCP/REST shape. Mirrors GET /api/v1/rpc/endpoints."
     rpc_endpoints: JSON
+    "The latest generated registry changelog: artifact added/modified/removed rows, subnet added/removed/renamed events, and coverage deltas since the previous publish. Resolves to a GraphQL error (not null) when the changelog artifact has not been baked in this environment, matching the REST route's 404 and the get_changelog MCP tool. Mirrors GET /api/v1/changelog."
+    changelog: Changelog
+    "The registry's public artifact contract metadata: every baked artifact path, storage tier, schema reference, and consumer notes. Resolves to a GraphQL error (not null) when the contracts artifact has not been baked in this environment, matching the REST route's 404 and the get_contracts MCP tool. Mirrors GET /api/v1/contracts."
+    contracts: Contracts
+    "A compact daily operational health snapshot for one UTC date (YYYY-MM-DD): per-surface status/latency plus summary incident counts from the archived health/history tier. Filter by netuid/kind/provider/status/classification, sort with sort/order, and page with limit (1-1000)/cursor. An invalid date/filter/sort/limit/cursor or a missing snapshot is a GraphQL error, not a silently substituted default. Distinct from the live health rollup and health_trends. Mirrors GET /api/v1/health/history/{date}."
+    health_history(date: String!, netuid: Int, kind: String, provider: String, status: String, classification: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): HealthHistory!
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
@@ -1801,6 +1813,42 @@ export const SDL = `
   type ProfileList {
     captured_at: String
     profiles: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type Changelog {
+    generated_at: String
+    source: String
+    notes: JSON
+    summary: JSON
+    artifacts: JSON
+    subnets: JSON
+    coverage_delta: JSON
+  }
+
+  type Contracts {
+    schema_version: Int
+    contract_version: String
+    generated_at: String
+    name: String
+    base_path: String
+    primary_domain: String
+    openapi_url: String
+    type_definitions_url: String
+    notes: JSON
+    artifacts: [JSON!]!
+  }
+
+  type HealthHistory {
+    date: String
+    summary: JSON
+    surfaces: [JSON!]!
     total: Int!
     returned: Int!
     limit: Int!
@@ -3761,6 +3809,9 @@ export const FIELD_COMPLEXITY = {
   source_health: RELATIONSHIP_FIELD_COMPLEXITY,
   lineage: RELATIONSHIP_FIELD_COMPLEXITY,
   rpc_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
+  changelog: RELATIONSHIP_FIELD_COMPLEXITY,
+  contracts: RELATIONSHIP_FIELD_COMPLEXITY,
+  health_history: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5383,6 +5434,31 @@ const rootValue = {
     );
     const pool = await readHealthKv(context.env, KV_HEALTH_RPC_POOL);
     return pool ? mergeRpcEndpoints(staticData, pool) : staticData;
+  },
+
+  // #7170: reuse get_changelog's/get_contracts's own loaders unchanged (the same
+  // baked artifact read REST and MCP already use). Each takes { readArtifact }
+  // as the module-level storage reader -- exactly what MCP's own registrations
+  // pass. A cold/absent artifact makes the loader throw, which the graphql
+  // executor surfaces as a normal GraphQL error, matching REST's 404 and the
+  // source_snapshots convention for a missing artifact.
+  changelog(_args, context) {
+    return loadChangelog(context, { readArtifact });
+  },
+
+  contracts(_args, context) {
+    return loadContracts(context, { readArtifact });
+  },
+
+  // #7170: reuse get_health_history's own loader unchanged. It takes deps as
+  // { readArtifact } called (ctx, path) returning data-or-null -- this file's
+  // own loadArtifact has exactly that shape, so it's reused directly (like
+  // profiles' readOptionalArtifact). The loader validates its date + filters
+  // and throws invalid_params on a bad one / not_found on a missing snapshot;
+  // that throw becomes a GraphQL error, matching every other field's "an
+  // unsupported filter/sort is a GraphQL error, not a silent default".
+  health_history(args, context) {
+    return loadHealthHistory(context, args, { readArtifact: loadArtifact });
   },
 
   async health(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1575,6 +1575,215 @@ describe("graphql — source_snapshots", () => {
   });
 });
 
+// #7170: GraphQL parity for changelog/contracts/health-history, reusing the same
+// loaders MCP get_changelog/get_contracts/get_health_history already call (same
+// artifact read + error behavior as REST and MCP) rather than a GraphQL-only
+// reimplementation.
+describe("graphql — changelog", () => {
+  const CHANGELOG_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    source: "publish",
+    notes: ["one", "two"],
+    summary: { artifacts_changed: 3, subnets_changed: 1 },
+    artifacts: { added: ["adapters.json"], modified: [], removed: [] },
+    subnets: { added: [], removed: [], renamed: ["sn-7"] },
+    coverage_delta: { surfaces: 4 },
+  };
+
+  test("serves the baked changelog artifact verbatim", async () => {
+    const env = fixtureEnv({ "/metagraph/changelog.json": CHANGELOG_BLOB });
+    const { status, body } = await gql(
+      "{ changelog { generated_at source notes summary artifacts subnets coverage_delta } }",
+      env,
+    );
+    assert.equal(status, 200);
+    const changelog = body.data.changelog;
+    assert.equal(changelog.generated_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(changelog.source, "publish");
+    assert.deepEqual(changelog.notes, ["one", "two"]);
+    assert.equal(changelog.summary.artifacts_changed, 3);
+    assert.deepEqual(changelog.artifacts.added, ["adapters.json"]);
+    assert.deepEqual(changelog.subnets.renamed, ["sn-7"]);
+    assert.equal(changelog.coverage_delta.surfaces, 4);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ changelog { generated_at } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data.changelog, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.changelog, 5);
+  });
+});
+
+describe("graphql — contracts", () => {
+  const CONTRACTS_BLOB = {
+    schema_version: 2,
+    contract_version: "abc123",
+    generated_at: "2026-07-01T00:00:00.000Z",
+    name: "metagraph",
+    base_path: "/metagraph",
+    primary_domain: "api.metagraph.sh",
+    openapi_url: "https://api.metagraph.sh/openapi.json",
+    type_definitions_url: "https://api.metagraph.sh/types.d.ts",
+    notes: ["read-only"],
+    artifacts: [
+      { path: "/metagraph/subnets.json", tier: "r2", schema_ref: "subnets" },
+      {
+        path: "/metagraph/changelog.json",
+        tier: "r2",
+        schema_ref: "changelog",
+      },
+    ],
+  };
+
+  test("serves the baked contracts artifact verbatim", async () => {
+    const env = fixtureEnv({ "/metagraph/contracts.json": CONTRACTS_BLOB });
+    const { status, body } = await gql(
+      "{ contracts { schema_version contract_version generated_at name base_path primary_domain openapi_url type_definitions_url notes artifacts } }",
+      env,
+    );
+    assert.equal(status, 200);
+    const contracts = body.data.contracts;
+    assert.equal(contracts.schema_version, 2);
+    assert.equal(contracts.contract_version, "abc123");
+    assert.equal(contracts.name, "metagraph");
+    assert.equal(contracts.base_path, "/metagraph");
+    assert.equal(contracts.primary_domain, "api.metagraph.sh");
+    assert.equal(
+      contracts.openapi_url,
+      "https://api.metagraph.sh/openapi.json",
+    );
+    assert.deepEqual(contracts.notes, ["read-only"]);
+    assert.equal(contracts.artifacts.length, 2);
+    assert.equal(contracts.artifacts[0].path, "/metagraph/subnets.json");
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ contracts { schema_version } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data.contracts, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.contracts, 5);
+  });
+});
+
+describe("graphql — health_history", () => {
+  const SURFACE_ROW = {
+    netuid: 7,
+    surface_id: "sn-7-example",
+    kind: "openapi",
+    provider: "allways",
+    status: "ok",
+    classification: "live",
+    latency_ms: 120,
+  };
+  const HISTORY_BLOB = {
+    date: "2026-07-01",
+    summary: { incident_count: 0, surface_count: 2 },
+    surfaces: [
+      SURFACE_ROW,
+      {
+        ...SURFACE_ROW,
+        netuid: 1,
+        surface_id: "sn-1-example",
+        latency_ms: 300,
+      },
+    ],
+  };
+
+  test("serves a dated snapshot and paginates its surfaces", async () => {
+    const env = fixtureEnv({
+      "/metagraph/health/history/2026-07-01.json": HISTORY_BLOB,
+    });
+    const { status, body } = await gql(
+      '{ health_history(date: "2026-07-01") { date summary surfaces total returned limit cursor next_cursor } }',
+      env,
+    );
+    assert.equal(status, 200);
+    const history = body.data.health_history;
+    assert.equal(history.date, "2026-07-01");
+    assert.equal(history.summary.surface_count, 2);
+    assert.equal(history.total, 2);
+    assert.equal(history.surfaces.length, 2);
+
+    const paged = await gql(
+      '{ health_history(date: "2026-07-01", limit: 1) { surfaces total returned next_cursor } }',
+      env,
+    );
+    assert.equal(paged.body.data.health_history.surfaces.length, 1);
+    assert.equal(paged.body.data.health_history.total, 2);
+    assert.equal(paged.body.data.health_history.returned, 1);
+    assert.ok(paged.body.data.health_history.next_cursor != null);
+  });
+
+  test("filters surfaces by netuid and sorts by latency", async () => {
+    const env = fixtureEnv({
+      "/metagraph/health/history/2026-07-01.json": HISTORY_BLOB,
+    });
+    const filtered = await gql(
+      '{ health_history(date: "2026-07-01", netuid: 1) { total surfaces } }',
+      env,
+    );
+    assert.equal(filtered.body.data.health_history.total, 1);
+    assert.equal(
+      filtered.body.data.health_history.surfaces[0].surface_id,
+      "sn-1-example",
+    );
+
+    const sorted = await gql(
+      '{ health_history(date: "2026-07-01", sort: "latency_ms", order: "desc") { surfaces sort order } }',
+      env,
+    );
+    assert.equal(sorted.body.data.health_history.surfaces[0].netuid, 1);
+    assert.equal(sorted.body.data.health_history.sort, "latency_ms");
+    assert.equal(sorted.body.data.health_history.order, "desc");
+  });
+
+  test("an invalid date is a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({
+      "/metagraph/health/history/2026-07-01.json": HISTORY_BLOB,
+    });
+    const { body } = await gql(
+      '{ health_history(date: "not-a-day") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("an unsupported filter is a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({
+      "/metagraph/health/history/2026-07-01.json": HISTORY_BLOB,
+    });
+    const { body } = await gql(
+      '{ health_history(date: "2026-07-01", status: "alive") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("surfaces a missing snapshot as a GraphQL error, matching REST/MCP", async () => {
+    const env = fixtureEnv({
+      "/metagraph/health/history/2026-07-01.json": HISTORY_BLOB,
+    });
+    const { body } = await gql(
+      '{ health_history(date: "2026-07-02") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.health_history, 5);
+  });
+});
+
 // #6992: GraphQL parity for profiles, reusing list_profiles' own loader
 // unchanged (same filter/sort/page + error behavior as REST and MCP) rather
 // than a GraphQL-only reimplementation.


### PR DESCRIPTION
feat(graphql): add changelog, contracts, health_history Query fields

Give the changelog/contracts/health-history REST routes GraphQL parity,
reusing the same loaders MCP get_changelog/get_contracts/get_health_history
already call rather than a GraphQL-only reimplementation. A cold/absent
artifact or an invalid date/filter surfaces as a GraphQL error, matching the
REST route and the source_snapshots convention.

Closes #7170

