### PR TITLE
feat(api): GraphQL parity for candidates/fixtures/agent-catalog/freshness/top-holders (#6991)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -441,6 +441,16 @@ export const SDL = `
     domain_summary(tag: String!): DomainSummary!
     "Several validators side by side for a stake/delegate decision: each hotkey's take, estimated APY, nominator count, identity, and cross-subnet stake/emission/trust aggregates. hotkeys takes 1-16 distinct SS58 addresses (a real GraphQL list, like the sibling compare field's netuids, rather than REST's comma-separated string); the optional netuid adds each validator's membership row in that subnet. The validator equivalent of the compare field. Mirrors GET /api/v1/compare/validators."
     compare_validators(hotkeys: [String!]!, netuid: Int): ValidatorComparison!
+    "Unpromoted candidate surfaces — discovered/proposed surfaces not yet curated. With no argument returns the global candidate catalog (/api/v1/candidates); with a netuid returns that subnet's candidates (/api/v1/subnets/{netuid}/candidates). Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_candidates/get_subnet_candidates MCP shape."
+    candidates(netuid: Int): JSON
+    "The captured-fixtures index — recorded upstream API responses used for reproducible testing. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
+    fixtures: JSON
+    "The machine-readable agent capability catalog. With no argument returns the global index of subnets exposing callable services; with a netuid returns that subnet's full per-service catalog. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the get_agent_catalog MCP shape. Mirrors GET /api/v1/agent-catalog and /api/v1/agent-catalog/{netuid}."
+    agent_catalog(netuid: Int): JSON
+    "The registry freshness report — per-surface and per-pipeline last-verified/last-built timestamps and staleness. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the get_freshness MCP/REST shape. Mirrors GET /api/v1/freshness."
+    freshness: JSON
+    "The balance-based top-holder leaderboard: every coldkey with a nonzero free balance and/or delegated stake, with free/delegated/total TAO columns, sortable (default total_tao) and limited (1-100, default 20). Opaque JSON passed through verbatim, matching the get_top_holders MCP shape. Mirrors GET /api/v1/accounts/top-holders."
+    accounts_top_holders(sort: String, limit: Int): JSON
     "One subnet's alpha-price OHLC candles bucketed by interval (1h or 1d, default 1h) over the trailing days window (default 90, max 365), from the same executed-trade stream subnet_volume reads. A subnet with no trades resolves to a schema-stable empty candle list, never null. Mirrors GET /api/v1/subnets/{netuid}/ohlc."
     subnet_ohlc(netuid: Int!, interval: String, days: Int): SubnetOhlc!
     "A read-only quote for a hypothetical stake/unstake against one subnet's live AMM pool: expected amount out, spot vs effective price, and estimated price impact. Computes nothing on-chain and signs nothing. Mirrors GET /api/v1/subnets/{netuid}/stake-quote."
@@ -3703,6 +3713,11 @@ export const FIELD_COMPLEXITY = {
   domains: RELATIONSHIP_FIELD_COMPLEXITY,
   domain_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   compare_validators: RELATIONSHIP_FIELD_COMPLEXITY,
+  candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  fixtures: RELATIONSHIP_FIELD_COMPLEXITY,
+  agent_catalog: RELATIONSHIP_FIELD_COMPLEXITY,
+  freshness: RELATIONSHIP_FIELD_COMPLEXITY,
+  accounts_top_holders: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_volume: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_ohlc: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_quote: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5412,6 +5427,62 @@ const rootValue = {
     // The MCP tool raises not_found when it is absent; GraphQL degrades to
     // null instead, matching every other artifact-backed resolver here.
     return loadArtifact(context, AGENT_RESOURCES_ARTIFACT);
+  },
+
+  async candidates({ netuid }, context) {
+    // No netuid -> global candidate catalog; a netuid -> that subnet's
+    // candidates, mirroring list_candidates / get_subnet_candidates. Opaque
+    // JSON passthrough degrading to null on cold, like agent_resources.
+    if (netuid === undefined || netuid === null) {
+      return loadArtifact(context, "/metagraph/candidates.json");
+    }
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return loadArtifact(context, `/metagraph/candidates/${netuid}.json`);
+  },
+
+  async fixtures(_args, context) {
+    return loadArtifact(context, "/metagraph/fixtures.json");
+  },
+
+  async agent_catalog({ netuid }, context) {
+    // No netuid -> global capability index; a netuid -> that subnet's per-service
+    // catalog, mirroring the dual-mode get_agent_catalog MCP tool.
+    if (netuid === undefined || netuid === null) {
+      return loadArtifact(context, "/metagraph/agent-catalog.json");
+    }
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return loadArtifact(context, `/metagraph/agent-catalog/${netuid}.json`);
+  },
+
+  async freshness(_args, context) {
+    return loadArtifact(context, "/metagraph/freshness.json");
+  },
+
+  async accounts_top_holders({ sort, limit }, context) {
+    // The balance-based top-holder leaderboard lives only in the Postgres tier
+    // (no baked artifact) — forward sort/limit to the same DATA_API route the
+    // get_top_holders MCP tool reads; the data-api validates + clamps them.
+    // Degrades to null when the tier is unreachable, per the resolver convention.
+    const params = new URLSearchParams();
+    if (sort !== undefined && sort !== null) params.set("sort", String(sort));
+    if (limit !== undefined && limit !== null) {
+      params.set("limit", String(limit));
+    }
+    return (
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/accounts/top-holders", params),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? null
+    );
   },
 
   async subnet_volume({ netuid }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -16778,3 +16778,111 @@ describe("graphql — adapter (#6984, reuses loadAdapter / MCP get_adapter)", ()
     assert.equal(FIELD_COMPLEXITY.adapter, FIELD_COMPLEXITY.provider);
   });
 });
+
+// --- registry-meta parity (#6991: candidates/fixtures/agent_catalog/freshness/top-holders) ---
+describe("graphql — registry-meta parity (#6991)", () => {
+  test("candidates resolves the global catalog and scopes by netuid", async () => {
+    const env = fixtureEnv({
+      "/metagraph/candidates.json": {
+        candidates: [{ netuid: 1, kind: "openapi" }],
+      },
+      "/metagraph/candidates/7.json": {
+        netuid: 7,
+        candidates: [{ kind: "sdk" }],
+      },
+    });
+    const all = await gql("{ candidates }", env);
+    assert.equal(all.body.errors, undefined);
+    assert.equal(all.body.data.candidates.candidates[0].kind, "openapi");
+    const one = await gql("{ candidates(netuid: 7) }", env);
+    assert.equal(one.body.data.candidates.netuid, 7);
+  });
+
+  test("candidates rejects a negative netuid; degrades to null when cold", async () => {
+    const bad = await gql("{ candidates(netuid: -1) }");
+    assert.ok(bad.body.errors?.length > 0);
+    assert.equal(bad.body.errors[0].extensions.code, "BAD_USER_INPUT");
+    const cold = await gql("{ candidates }");
+    assert.equal(cold.body.data.candidates, null);
+  });
+
+  test("fixtures resolves the captured-fixtures index; null when cold", async () => {
+    const env = fixtureEnv({
+      "/metagraph/fixtures.json": { fixtures: [{ surface_id: "sn-1-api" }] },
+    });
+    const hot = await gql("{ fixtures }", env);
+    assert.equal(hot.body.data.fixtures.fixtures[0].surface_id, "sn-1-api");
+    const cold = await gql("{ fixtures }");
+    assert.equal(cold.body.data.fixtures, null);
+  });
+
+  test("agent_catalog resolves index + per-subnet detail; rejects a negative netuid", async () => {
+    const env = fixtureEnv({
+      "/metagraph/agent-catalog.json": { subnets: [{ netuid: 3 }] },
+      "/metagraph/agent-catalog/3.json": {
+        netuid: 3,
+        services: [{ name: "chat" }],
+      },
+    });
+    const idx = await gql("{ agent_catalog }", env);
+    assert.equal(idx.body.data.agent_catalog.subnets[0].netuid, 3);
+    const detail = await gql("{ agent_catalog(netuid: 3) }", env);
+    assert.equal(detail.body.data.agent_catalog.services[0].name, "chat");
+    const bad = await gql("{ agent_catalog(netuid: -2) }");
+    assert.equal(bad.body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("freshness resolves the report; null when cold", async () => {
+    const env = fixtureEnv({
+      "/metagraph/freshness.json": { summary: { stale_count: 0 } },
+    });
+    const hot = await gql("{ freshness }", env);
+    assert.equal(hot.body.data.freshness.summary.stale_count, 0);
+    const cold = await gql("{ freshness }");
+    assert.equal(cold.body.data.freshness, null);
+  });
+
+  test("accounts_top_holders forwards sort/limit to the Postgres tier and passes the body through", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            sort: "free_tao",
+            account_count: 1,
+            accounts: [{ coldkey: "5Abc", total_tao: 10 }],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ accounts_top_holders(sort: "free_tao", limit: 5) }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.accounts_top_holders.accounts[0].coldkey, "5Abc");
+    assert.equal(capturedUrl.pathname, "/api/v1/accounts/top-holders");
+    assert.equal(capturedUrl.searchParams.get("sort"), "free_tao");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+  });
+
+  test("accounts_top_holders degrades to null when the Postgres tier is unreachable", async () => {
+    const { body } = await gql("{ accounts_top_holders }");
+    assert.equal(body.data.accounts_top_holders, null);
+  });
+
+  test("all five parity fields are weighted as fan-out fields", () => {
+    for (const f of [
+      "candidates",
+      "fixtures",
+      "agent_catalog",
+      "freshness",
+      "accounts_top_holders",
+    ]) {
+      assert.equal(FIELD_COMPLEXITY[f], FIELD_COMPLEXITY.agent_resources);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6991. Five registry-meta REST routes had MCP tools but **no GraphQL field**, so an agent using GraphQL alone couldn't reach this data. This adds them to `type Query`, reusing the shaping the REST/MCP layers already call.

## New Query fields (`src/graphql.mjs`)

| Field | Backing | Mirrors |
|---|---|---|
| `candidates(netuid: Int)` | artifact `/metagraph/candidates.json` or `/metagraph/candidates/{netuid}.json` | `list_candidates` / `get_subnet_candidates` |
| `fixtures` | artifact `/metagraph/fixtures.json` | `list_fixtures` |
| `agent_catalog(netuid: Int)` | artifact `/metagraph/agent-catalog.json` or `/metagraph/agent-catalog/{netuid}.json` | dual-mode `get_agent_catalog` |
| `freshness` | artifact `/metagraph/freshness.json` | `get_freshness` |
| `accounts_top_holders(sort, limit)` | Postgres tier `/api/v1/accounts/top-holders` | `get_top_holders` |

- The four artifact-backed fields are **opaque-JSON passthroughs** that degrade to `null` on a cold artifact — the established `agent_resources`/`subnet_gaps` resolver convention. The two with a single-item variant take an optional `netuid` (mirroring the `subnets`/`subnet(netuid)` precedent and the dual-mode MCP tools), validating a non-negative integer.
- `accounts_top_holders` has no baked artifact (it's a live leaderboard), so it **clones the existing `accounts` Postgres-tier resolver** — forwarding `sort`/`limit` to the same DATA_API route `get_top_holders` reads, and degrading to `null` when the tier is unreachable.
- Each field is weighted at the shared relationship-field complexity (`FIELD_COMPLEXITY`).

## Tests (`tests/graphql.test.mjs`)

- `candidates`: global catalog, netuid-scoped, negative-netuid → `BAD_USER_INPUT`, null-on-cold.
- `fixtures` / `freshness`: resolve + null-on-cold.
- `agent_catalog`: index, per-subnet detail, negative-netuid rejection.
- `accounts_top_holders`: forwards `sort`/`limit` to `/api/v1/accounts/top-holders` and passes the body through (asserts the captured URL); degrades to null when the tier is unreachable.
- All five weighted as fan-out fields.

## Validation run locally

- `vitest run tests/graphql.test.mjs` → 722 passed · `graphql.mjs` 100% statement coverage (changed lines covered)
- `eslint` + `prettier --check` clean

## Risk / regen

Pure additive (+179/−0). No contract/OpenAPI regeneration: GraphQL has no committed SDL snapshot (served live + introspected dynamically), and `API_ROUTES` is unchanged, so `validate:contract-drift`/`validate:openapi` are unaffected. The MCP tools for all five already exist — this is GraphQL-only, matching the issue.