### PR TITLE
feat(ui): wire GraphQL subscriptions into the GraphiQL Explorer

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -46,6 +46,7 @@
     "fumadocs-ui": "^16.11.5",
     "graphiql": "^4.1.2",
     "graphql": "^17.0.2",
+    "graphql-ws": "^6.1.0",
     "lucide-react": "^0.575.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/ui/src/components/metagraphed/graphiql-explorer-body.tsx
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer-body.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { GraphiQL } from "graphiql";
 import { createGraphiQLFetcher } from "@graphiql/toolkit";
+import { createClient, type Client } from "graphql-ws";
 import { useTheme } from "@/lib/theme";
 import { classNames } from "@/lib/metagraphed/format";
 import "graphiql/style.css";
@@ -47,12 +48,45 @@ const DEFAULT_QUERY = `{
 
 export interface GraphiqlExplorerBodyProps {
   endpoint: string;
+  /**
+   * WebSocket URL for `graphql-transport-ws` subscriptions (#7009 / #4983).
+   * Same path as the HTTP GraphQL endpoint (`/api/v1/graphql`), with
+   * `https`→`wss` / `http`→`ws`. When omitted, subscriptions stay unsupported.
+   */
+  subscriptionUrl?: string;
   heightClassName: string;
 }
 
-export function GraphiqlExplorerBody({ endpoint, heightClassName }: GraphiqlExplorerBodyProps) {
+export function GraphiqlExplorerBody({
+  endpoint,
+  subscriptionUrl,
+  heightClassName,
+}: GraphiqlExplorerBodyProps) {
   const { resolved } = useTheme();
-  const fetcher = useMemo(() => createGraphiQLFetcher({ url: endpoint }), [endpoint]);
+
+  const wsClient = useMemo<Client | undefined>(() => {
+    if (!subscriptionUrl) return undefined;
+    return createClient({
+      url: subscriptionUrl,
+      // Open the socket only when a subscription actually runs.
+      lazy: true,
+    });
+  }, [subscriptionUrl]);
+
+  useEffect(() => {
+    return () => {
+      wsClient?.dispose();
+    };
+  }, [wsClient]);
+
+  const fetcher = useMemo(
+    () =>
+      createGraphiQLFetcher({
+        url: endpoint,
+        ...(wsClient ? { wsClient } : {}),
+      }),
+    [endpoint, wsClient],
+  );
 
   return (
     <div

--- a/apps/ui/src/components/metagraphed/graphiql-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer.tsx
@@ -10,16 +10,30 @@ const DEFAULT_HEIGHT_CLASSNAME = "h-[460px] md:h-[540px] lg:h-[640px]";
 
 export interface GraphiqlExplorerProps {
   endpoint: string;
+  /**
+   * WebSocket URL for live GraphQL subscriptions (`graphql-transport-ws` on
+   * the same `/api/v1/graphql` path — #7009 / #4983). Optional so embedded
+   * callers can stay query-only.
+   */
+  subscriptionUrl?: string;
   /** Tailwind height classes; overrides the compact docs-embed default. */
   heightClassName?: string;
 }
 
-export function GraphiqlExplorer({ endpoint, heightClassName }: GraphiqlExplorerProps) {
+export function GraphiqlExplorer({
+  endpoint,
+  subscriptionUrl,
+  heightClassName,
+}: GraphiqlExplorerProps) {
   const height = heightClassName ?? DEFAULT_HEIGHT_CLASSNAME;
   return (
     <ClientOnly fallback={<ExplorerFallback heightClassName={height} />}>
       <Suspense fallback={<ExplorerFallback heightClassName={height} />}>
-        <GraphiqlExplorerBody endpoint={endpoint} heightClassName={height} />
+        <GraphiqlExplorerBody
+          endpoint={endpoint}
+          subscriptionUrl={subscriptionUrl}
+          heightClassName={height}
+        />
       </Suspense>
     </ClientOnly>
   );

--- a/apps/ui/src/lib/metagraphed/graphql-subscription-url.test.ts
+++ b/apps/ui/src/lib/metagraphed/graphql-subscription-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { toGraphqlSubscriptionUrl } from "./graphql-subscription-url";
+
+describe("toGraphqlSubscriptionUrl", () => {
+  it("maps https GraphQL endpoints to wss on the same path", () => {
+    expect(toGraphqlSubscriptionUrl("https://api.metagraph.sh/api/v1/graphql")).toBe(
+      "wss://api.metagraph.sh/api/v1/graphql",
+    );
+  });
+
+  it("maps http to ws (local/dev)", () => {
+    expect(toGraphqlSubscriptionUrl("http://127.0.0.1:8787/api/v1/graphql")).toBe(
+      "ws://127.0.0.1:8787/api/v1/graphql",
+    );
+  });
+
+  it("returns null for non-http(s) or malformed URLs", () => {
+    expect(toGraphqlSubscriptionUrl("ftp://example.com/api/v1/graphql")).toBeNull();
+    expect(toGraphqlSubscriptionUrl("not a url")).toBeNull();
+    expect(toGraphqlSubscriptionUrl("")).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/graphql-subscription-url.ts
+++ b/apps/ui/src/lib/metagraphed/graphql-subscription-url.ts
@@ -1,0 +1,16 @@
+/**
+ * Convert an HTTP(S) GraphQL endpoint URL to the WebSocket URL used for
+ * `graphql-transport-ws` subscriptions on the same path (#4983 / #7009).
+ * Returns null for non-http(s) inputs so callers can skip wiring.
+ */
+export function toGraphqlSubscriptionUrl(endpoint: string): string | null {
+  try {
+    const url = new URL(endpoint);
+    if (url.protocol === "https:") url.protocol = "wss:";
+    else if (url.protocol === "http:") url.protocol = "ws:";
+    else return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}

--- a/apps/ui/src/routes/graphql.explorer.tsx
+++ b/apps/ui/src/routes/graphql.explorer.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { GraphiqlExplorer } from "@/components/metagraphed/graphiql-explorer";
 import { API_BASE } from "@/lib/metagraphed/config";
+import { toGraphqlSubscriptionUrl } from "@/lib/metagraphed/graphql-subscription-url";
 
 // GraphQL's one published, mainnet-only path -- content/docs/graphql.mdx
 // (the docs page this explorer links back to) states the same literal.
@@ -15,7 +16,7 @@ export const Route = createFileRoute("/graphql/explorer")({
       {
         name: "description",
         content:
-          "Interactive GraphiQL explorer for the Metagraphed API — schema-aware autocomplete, docs, and live queries against the public /api/v1/graphql endpoint. No API key.",
+          "Interactive GraphiQL explorer for the Metagraphed API — schema-aware autocomplete, docs, live queries, and chainEvents subscriptions against the public /api/v1/graphql endpoint. No API key.",
       },
     ],
   }),
@@ -23,6 +24,7 @@ export const Route = createFileRoute("/graphql/explorer")({
 });
 
 const ENDPOINT_URL = `${API_BASE}${GRAPHQL_ENDPOINT_PATH}`;
+const SUBSCRIPTION_URL = toGraphqlSubscriptionUrl(ENDPOINT_URL) ?? undefined;
 
 function GraphqlExplorerPage() {
   return (
@@ -39,11 +41,24 @@ function GraphqlExplorerPage() {
         Explorer
       </h1>
       <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-ink-muted">
-        Schema-aware autocomplete, docs, and history against the live endpoint. No API key.
+        Schema-aware autocomplete, docs, and history against the live endpoint — including{" "}
+        <code className="font-mono text-[12px] text-ink">chainEvents</code> subscriptions over{" "}
+        <code className="font-mono text-[12px] text-ink">graphql-transport-ws</code>. No API key.
       </p>
+      {SUBSCRIPTION_URL ? (
+        <p
+          className="mt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-muted"
+          data-testid="graphql-subscription-endpoint"
+        >
+          POST {ENDPOINT_URL}
+          <span className="mx-2 text-border">·</span>
+          WSS {SUBSCRIPTION_URL}
+        </p>
+      ) : null}
       <div className="mt-6">
         <GraphiqlExplorer
           endpoint={ENDPOINT_URL}
+          subscriptionUrl={SUBSCRIPTION_URL}
           heightClassName="h-[70vh] min-h-[520px] max-h-[900px]"
         />
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "fumadocs-ui": "^16.11.5",
         "graphiql": "^4.1.2",
         "graphql": "^17.0.2",
+        "graphql-ws": "^6.1.0",
         "lucide-react": "^0.575.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",


### PR DESCRIPTION
## Summary
- Adds optional `subscriptionUrl` to `GraphiqlExplorer` / `GraphiqlExplorerBody` and wires a `graphql-ws` `createClient` into `createGraphiQLFetcher` so subscription operations use `graphql-transport-ws`.
- Resolves `wss://…/api/v1/graphql` from the existing HTTP endpoint (same path the hub already upgrades — #4983), and surfaces POST + WSS on the public `/graphql/explorer` page.
- Adds a small `toGraphqlSubscriptionUrl` helper + unit tests; scopes the change to the Explorer only.

Closes #7009

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-desktop-light.png)<br><sub>after — WSS caption</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-desktop-dark.png)<br><sub>after — WSS caption</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/7009-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan
- [x] Unit tests for `toGraphqlSubscriptionUrl`
- [x] `prettier` / `eslint` on touched files; `typecheck`; `vite build`
- [ ] CI `ui` job green
- [ ] Manual: open `/graphql/explorer`, run

```graphql
subscription {
  chainEvents(tables: [chain_events]) {
    table
    block_number
    pallet
    method
  }
}
```

  and confirm framed `next` results stream in the response pane

