### PR TITLE
feat(ui): add an emission-share bubble map view to /subnets (#6884)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnets-bubble-view.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-bubble-view.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from "react";
+import { EmptyState } from "@/components/metagraphed/states";
+import { healthColorVar } from "@/lib/health-tokens";
+import {
+  formatShare,
+  packBubbles,
+  type PackedBubble,
+} from "@/lib/metagraphed/subnets-bubble-layout";
+import type { HealthState, Subnet } from "@/lib/metagraphed/types";
+
+// #6884: cryptobubbles-style PACKED bubble map of /subnets over the same filtered
+// list the table renders — bubble AREA = emission share (network weight), COLOUR =
+// health, each labelled with its symbol + emission % so you read the registry at a
+// glance (which subnets carry the emission, and whether they're healthy) instead
+// of scanning sorted rows. Packing + sizing math is in subnets-bubble-layout.ts
+// (unit-tested); rendered as a fixed-viewBox SVG so it draws server-side and is
+// URL-addressable via ?view=bubble, like the table/grid/matrix views.
+
+const HEALTH_STATES: HealthState[] = ["ok", "warn", "down", "unknown"];
+
+function BubbleLabel({ b }: { b: PackedBubble }) {
+  // Only label bubbles big enough to carry legible text; tiny ones stay dots.
+  if (b.r < 24) return null;
+  const symbolSize = Math.min(b.r * 0.62, 34);
+  const shareSize = Math.min(b.r * 0.34, 17);
+  return (
+    <>
+      <text
+        x={b.x}
+        y={b.y - b.r * 0.06}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={symbolSize}
+        fontWeight={600}
+        fill="var(--ink-strong)"
+        style={{ pointerEvents: "none" }}
+      >
+        {b.symbol.length > 6 ? `${b.symbol.slice(0, 5)}…` : b.symbol}
+      </text>
+      <text
+        x={b.x}
+        y={b.y + b.r * 0.4}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={shareSize}
+        fontFamily="monospace"
+        fill="var(--ink-muted)"
+        style={{ pointerEvents: "none" }}
+      >
+        {formatShare(b.emissionShare)}
+      </text>
+    </>
+  );
+}
+
+export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
+  const { bubbles, width, height } = useMemo(() => packBubbles(rows), [rows]);
+
+  if (bubbles.length === 0) {
+    return (
+      <EmptyState
+        title="Nothing to plot"
+        description="No subnets match the current filter. Adjust the filters or switch back to the table."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-xl border border-border bg-card p-3">
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          className="block w-full"
+          style={{ maxHeight: "70vh" }}
+          role="img"
+          aria-label="Subnets as bubbles sized by emission share and coloured by health; each labelled with its symbol and emission percent"
+        >
+          <defs>
+            {HEALTH_STATES.map((h) => (
+              <radialGradient key={h} id={`bubble-${h}`} cx="50%" cy="45%" r="60%">
+                <stop offset="0%" stopColor={healthColorVar(h)} stopOpacity={0.08} />
+                <stop offset="100%" stopColor={healthColorVar(h)} stopOpacity={0.34} />
+              </radialGradient>
+            ))}
+          </defs>
+          {bubbles.map((b) => (
+            <a
+              key={b.netuid}
+              href={`/subnets/${b.netuid}`}
+              aria-label={`${b.name} (${b.symbol}): ${formatShare(b.emissionShare)} emission, ${b.health}`}
+            >
+              <circle
+                cx={b.x}
+                cy={b.y}
+                r={b.r}
+                fill={`url(#bubble-${b.health})`}
+                stroke={b.color}
+                strokeWidth={1.5}
+                strokeOpacity={0.75}
+              >
+                <title>
+                  {b.name} ({b.symbol}) — {formatShare(b.emissionShare)} of network emission,{" "}
+                  {b.health}
+                </title>
+              </circle>
+              <BubbleLabel b={b} />
+            </a>
+          ))}
+        </svg>
+      </div>
+      {/* legend */}
+      <ul className="flex flex-wrap gap-x-4 gap-y-1.5 text-[11px] text-ink-muted">
+        {HEALTH_STATES.map((h) => (
+          <li key={h} className="inline-flex items-center gap-1.5">
+            <span
+              aria-hidden
+              className="inline-block size-2.5 rounded-full"
+              style={{ background: healthColorVar(h) }}
+            />
+            <span className="uppercase tracking-wider">{h}</span>
+          </li>
+        ))}
+        <li className="inline-flex items-center gap-1.5">
+          <span aria-hidden className="inline-block size-3 rounded-full border border-ink-muted" />
+          <span>bubble size = emission share</span>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/subnets-bubble-layout.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnets-bubble-layout.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { bubbleRadius, formatShare, packBubbles } from "./subnets-bubble-layout";
+import type { Subnet } from "./types";
+
+const R_MIN = 16;
+const R_MAX = 90;
+
+function subnet(over: Partial<Subnet>): Subnet {
+  return { netuid: 1, ...over };
+}
+
+describe("bubbleRadius", () => {
+  it("scales area-proportionally (r ∝ sqrt(share)) between the floor and cap", () => {
+    expect(bubbleRadius(1, 1)).toBe(R_MAX); // share == max -> cap
+    expect(bubbleRadius(0.25, 1)).toBeCloseTo(R_MIN + 0.5 * (R_MAX - R_MIN), 6); // sqrt(0.25)=0.5
+    const quarter = bubbleRadius(0.25, 1) - R_MIN;
+    const full = bubbleRadius(1, 1) - R_MIN;
+    expect(quarter).toBeCloseTo(full / 2, 6); // 4x share -> 2x radius delta -> 4x area
+  });
+
+  it("floors non-positive / non-finite share or max to R_MIN (never divide by 0)", () => {
+    expect(bubbleRadius(0, 1)).toBe(R_MIN);
+    expect(bubbleRadius(-1, 1)).toBe(R_MIN);
+    expect(bubbleRadius(NaN, 1)).toBe(R_MIN);
+    expect(bubbleRadius(0.5, 0)).toBe(R_MIN);
+  });
+});
+
+describe("formatShare", () => {
+  it("formats a 0..1 fraction as a percent with adaptive precision", () => {
+    expect(formatShare(0.0541)).toBe("5.41%"); // <10% -> 2dp
+    expect(formatShare(0.1234)).toBe("12.3%"); // >=10% -> 1dp
+    expect(formatShare(1)).toBe("100.0%");
+  });
+
+  it("renders non-positive / non-finite as 0%", () => {
+    expect(formatShare(0)).toBe("0%");
+    expect(formatShare(-0.2)).toBe("0%");
+    expect(formatShare(NaN)).toBe("0%");
+    expect(formatShare(Infinity)).toBe("0%");
+    expect(formatShare(-Infinity)).toBe("0%");
+  });
+});
+
+describe("packBubbles", () => {
+  it("returns an empty pack (no throw) for no rows", () => {
+    expect(packBubbles([])).toEqual({ bubbles: [], width: 0, height: 0 });
+  });
+
+  it("sizes bubbles by emission share, biggest first, and packs without overlap", () => {
+    const { bubbles, width, height } = packBubbles([
+      subnet({ netuid: 1, symbol: "α", name: "One", emission_share: 0.01, health: "ok" }),
+      subnet({ netuid: 2, symbol: "β", name: "Two", emission_share: 0.04, health: "warn" }),
+      subnet({ netuid: 3, symbol: "γ", name: "Three", emission_share: 0.16, health: "down" }),
+    ]);
+    // sorted biggest-first by radius (emission share)
+    expect(bubbles.map((b) => b.netuid)).toEqual([3, 2, 1]);
+    // netuid 3 has the max share -> R_MAX; sqrt scaling gives 2:1 radius deltas
+    expect(bubbles[0]!.r).toBe(R_MAX);
+    // no two placed bubbles overlap
+    for (let i = 0; i < bubbles.length; i += 1) {
+      for (let j = i + 1; j < bubbles.length; j += 1) {
+        const a = bubbles[i]!;
+        const b = bubbles[j]!;
+        expect(Math.hypot(a.x - b.x, a.y - b.y)).toBeGreaterThanOrEqual(a.r + b.r - 1e-6);
+      }
+    }
+    // every bubble lies within the reported 0-origin box
+    for (const b of bubbles) {
+      expect(b.x - b.r).toBeGreaterThanOrEqual(-1e-6);
+      expect(b.y - b.r).toBeGreaterThanOrEqual(-1e-6);
+      expect(b.x + b.r).toBeLessThanOrEqual(width + 1e-6);
+      expect(b.y + b.r).toBeLessThanOrEqual(height + 1e-6);
+    }
+  });
+
+  it("places a single row at a valid origin with the max radius", () => {
+    const { bubbles, width, height } = packBubbles([
+      subnet({ netuid: 7, symbol: "τ", name: "Solo", emission_share: 0.02, health: "ok" }),
+    ]);
+    expect(bubbles).toHaveLength(1);
+    const b = bubbles[0]!;
+    expect(b.r).toBe(R_MAX); // sole row -> its share is the max
+    expect(b.symbol).toBe("τ");
+    expect(b.name).toBe("Solo");
+    expect(width).toBeGreaterThan(0);
+    expect(height).toBeGreaterThan(0);
+  });
+
+  it("falls back for missing symbol/name/health and treats missing share as 0 (R_MIN)", () => {
+    const { bubbles } = packBubbles([
+      subnet({ netuid: 5, emission_share: 0.03 }), // symbol/name/health missing
+    ]);
+    const b = bubbles[0]!;
+    expect(b.symbol).toBe("#5");
+    expect(b.name).toBe("Subnet 5");
+    expect(b.health).toBe("unknown");
+    expect(b.color).toContain("--health-unknown");
+  });
+
+  it("gives zero-emission subnets the floor radius", () => {
+    const { bubbles } = packBubbles([
+      subnet({ netuid: 1, symbol: "α", emission_share: 0.05, health: "ok" }),
+      subnet({ netuid: 2, symbol: "β", emission_share: 0, health: "ok" }),
+    ]);
+    const zero = bubbles.find((b) => b.netuid === 2)!;
+    expect(zero.r).toBe(R_MIN);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnets-bubble-layout.ts
+++ b/apps/ui/src/lib/metagraphed/subnets-bubble-layout.ts
@@ -1,0 +1,129 @@
+// #6884: layout math for the /subnets "bubble" view — a cryptobubbles-style
+// PACKED map (not an axis scatter): one bubble per subnet, area ∝ emission share
+// (the network-weight "market cap" analog, already joined onto the list rows),
+// colour = health, labelled with the symbol + emission % so it reads at a glance.
+// Kept pure + node-testable (no React/SVG) so the sizing / packing / formatting
+// math is unit-tested. A deterministic spiral pack (biggest in the middle) keeps
+// it server-renderable — no client physics, unlike the real cryptobubbles.
+import { healthColorVar } from "@/lib/health-tokens";
+import type { HealthState, Subnet } from "@/lib/metagraphed/types";
+
+const R_MIN = 16; // px in viewBox units — floor so a label still fits-ish
+const R_MAX = 90;
+const GAP = 3; // padding between packed bubbles
+
+export type PackedBubble = {
+  netuid: number;
+  name: string;
+  symbol: string;
+  emissionShare: number; // 0..1 fraction of network emission
+  health: HealthState;
+  color: string;
+  r: number;
+  x: number;
+  y: number;
+};
+
+export type BubblePack = {
+  bubbles: PackedBubble[];
+  width: number;
+  height: number;
+};
+
+/** Area-proportional radius: r ∝ sqrt(share), so a 4× emission reads as 4× area. */
+export function bubbleRadius(share: number, maxShare: number): number {
+  if (!Number.isFinite(share) || share <= 0 || maxShare <= 0) return R_MIN;
+  const scaled = Math.sqrt(share / maxShare); // 0..1
+  return R_MIN + scaled * (R_MAX - R_MIN);
+}
+
+/** Compact emission-share label, e.g. 0.0541 -> "5.41%", 0 -> "0%". */
+export function formatShare(share: number): string {
+  if (!Number.isFinite(share) || share <= 0) return "0%";
+  const pct = share * 100;
+  return `${pct >= 10 ? pct.toFixed(1) : pct.toFixed(2)}%`;
+}
+
+// Place a bubble of radius r at the first point on an outward spiral from the
+// centre that doesn't overlap an already-placed bubble. Deterministic (no RNG),
+// so it renders identically on server + client.
+function placeOnSpiral(
+  r: number,
+  placed: Array<{ x: number; y: number; r: number }>,
+): { x: number; y: number } {
+  if (placed.length === 0) return { x: 0, y: 0 };
+  const step = 6;
+  for (let t = 0; t < 20000; t += 1) {
+    const angle = t * 0.5;
+    const dist = step * Math.sqrt(t);
+    const x = Math.cos(angle) * dist;
+    const y = Math.sin(angle) * dist;
+    let ok = true;
+    for (const p of placed) {
+      const dx = x - p.x;
+      const dy = y - p.y;
+      if (Math.hypot(dx, dy) < r + p.r + GAP) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return { x, y };
+  }
+  return { x: 0, y: 0 };
+}
+
+/**
+ * Pack the filtered subnet rows into a bubble map. Rows are sized by emission
+ * share (area-proportional), coloured by health, sorted biggest-first so the
+ * heaviest subnets land in the centre. Returns bubbles in a 0-origin coordinate
+ * space plus the overall width/height so the caller can centre a viewBox on it.
+ */
+export function packBubbles(rows: Subnet[]): BubblePack {
+  const items = rows.map((s) => ({
+    netuid: s.netuid,
+    name: s.name ?? `Subnet ${s.netuid}`,
+    symbol: (typeof s.symbol === "string" && s.symbol) || `#${s.netuid}`,
+    emissionShare:
+      typeof s.emission_share === "number" && s.emission_share > 0 ? s.emission_share : 0,
+    health: (s.health ?? "unknown") as HealthState,
+  }));
+  if (items.length === 0) return { bubbles: [], width: 0, height: 0 };
+
+  const maxShare = Math.max(...items.map((i) => i.emissionShare), 0);
+  const sized = items
+    .map((i) => ({
+      ...i,
+      r: bubbleRadius(i.emissionShare, maxShare),
+      color: healthColorVar(i.health),
+    }))
+    .sort((a, b) => b.r - a.r);
+
+  const placed: Array<{ x: number; y: number; r: number }> = [];
+  const bubbles: PackedBubble[] = sized.map((b) => {
+    const { x, y } = placeOnSpiral(b.r, placed);
+    placed.push({ x, y, r: b.r });
+    return { ...b, x, y };
+  });
+
+  // Normalise to a 0-origin box with a small margin so nothing clips the edge.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const b of bubbles) {
+    minX = Math.min(minX, b.x - b.r);
+    minY = Math.min(minY, b.y - b.r);
+    maxX = Math.max(maxX, b.x + b.r);
+    maxY = Math.max(maxY, b.y + b.r);
+  }
+  const margin = 8;
+  for (const b of bubbles) {
+    b.x = b.x - minX + margin;
+    b.y = b.y - minY + margin;
+  }
+  return {
+    bubbles,
+    width: maxX - minX + margin * 2,
+    height: maxY - minY + margin * 2,
+  };
+}

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -37,7 +37,7 @@ export const tableSearchSchema = z.object({
   includeRoot: fallback(z.boolean(), true).default(true),
   // Layout state for list routes that support multiple views + row density.
   // Additive + optional with safe fallbacks so the toggles persist in the URL.
-  view: fallback(z.enum(["table", "grid", "matrix"]), "table").default("table"),
+  view: fallback(z.enum(["table", "grid", "matrix", "bubble"]), "table").default("table"),
   density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
 });
 

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { Network, Radio, Layers, Activity, Coins } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { SubnetsBubbleView } from "@/components/metagraphed/subnets-bubble-view";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import {
   BrandIcon,
@@ -184,7 +185,11 @@ function SubnetsPage() {
         description="Every active Finney netuid — root and application — with curation level, surface count, health, and freshness."
         actions={
           <>
-            <ViewModeToggle value={search.view} onChange={setView} />
+            <ViewModeToggle
+              value={search.view}
+              onChange={setView}
+              options={["table", "grid", "matrix", "bubble"]}
+            />
             {search.view === "table" ? (
               <DensityToggle value={effectiveDensity} onChange={setDensity} />
             ) : null}
@@ -641,6 +646,19 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
       cursorInvalid={cursorInvalid}
     />
   );
+
+  // #6884: bubble view — an alternate scatter over the same filtered rows.
+  if (view === "bubble") {
+    return (
+      <div>
+        <div className="sticky top-14 z-20 -mx-4 md:mx-0 mb-3 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5">
+          <div className="flex flex-wrap items-center gap-2">{filters}</div>
+        </div>
+        {rows.length === 0 && !hasNextPage ? emptyNode : <SubnetsBubbleView rows={rows} />}
+        <div className="mt-3">{footerNode}</div>
+      </div>
+    );
+  }
 
   // Grid / matrix views skip ListShell so they're not boxed in a table card.
   if (view === "grid" || view === "matrix") {

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2631,6 +2631,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: lucideReact.Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: lucideReact.ScatterChart,
+    ariaLabel: "Switch to bubble view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,7 +1,7 @@
 import * as React3 from 'react';
 import { useState, useRef, useEffect, useMemo, useCallback, useId } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
+import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ScatterChart, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
@@ -2602,6 +2602,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: ScatterChart,
+    ariaLabel: "Switch to bubble view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
+++ b/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
@@ -1,10 +1,10 @@
-import { LayoutGrid, List, Grid3x3 } from "lucide-react";
+import { LayoutGrid, List, Grid3x3, ScatterChart } from "lucide-react";
 import {
   SegmentedToggle,
   type SegmentedToggleOption,
 } from "@/components/ui/segmented-toggle";
 
-export type ViewMode = "table" | "grid" | "matrix";
+export type ViewMode = "table" | "grid" | "matrix" | "bubble";
 
 const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
   {
@@ -24,6 +24,12 @@ const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view",
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: ScatterChart,
+    ariaLabel: "Switch to bubble view",
   },
 ];
 


### PR DESCRIPTION
## What

Adds an **emission-share bubble map** as a fourth view on `/subnets` (`?view=bubble`), alongside table / grid / matrix. It re-uses the same filtered rows the table renders, but draws each subnet as one packed bubble:

- **Area = share of network emission** — the economic-weight metric already joined onto the list rows (the "market cap" analog). Biggest emitters are drawn largest and land in the centre.
- **Colour = health** (green OK · amber WARN · red DOWN · grey UNKNOWN), with a soft radial glow.
- **Label = symbol + emission %** inside each bubble, so the registry reads _at a glance_ — which subnets carry the emission, and whether they're healthy.

Closes the gap the maintainer called out on the previous attempt: instead of an abstract age×surfaces scatter that "doesn't tell you anything," this follows the cryptobubbles.net pattern — a dense, labelled, magnitude-sized packing that surfaces the emission distribution immediately.

## How

- `subnets-bubble-layout.ts` — pure, node-testable layout math: area-proportional `bubbleRadius` (r ∝ √share), `formatShare`, and `packBubbles`, a **deterministic spiral pack** (no RNG, no client physics) so the view renders identically server-side. This keeps it SSR + URL-addressable (`?view=bubble`) like the other views — no hydration-gated interactivity.
- `subnets-bubble-view.tsx` — renders the pack as a fixed-viewBox SVG: per-health radial-gradient glows, symbol + emission-% labels (only on bubbles large enough to stay legible), click-through to each subnet's detail page, and a small health/size legend.
- Wires a **Bubble** entry into the shared `ViewModeToggle` (ui-kit) and the `url-state` view enum. Unknown/older `?view=bubble` links degrade gracefully to the table via the existing `fallback()`.

## Tests

`subnets-bubble-layout.test.ts` covers the extracted math: √-scaling + floor/cap + divide-by-zero guards in `bubbleRadius`, adaptive precision + non-finite→`0%` in `formatShare`, and `packBubbles` (biggest-first ordering, no-overlap packing, 0-origin bounds, symbol/name/health fallbacks, zero-emission floor). `npx vitest run` green; tsc / eslint / prettier clean.

## Screenshots

Before = current `/subnets` table (its EMISSION column is exactly what the map visualises); after = the new bubble map. Full-viewport, exact sizes (Desktop 1280×800 · Tablet 768×1024 · Mobile 375×812), light + dark.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-dark.png)<br><sub>after</sub> |

Closes #6884
