### PR TITLE
feat(api): add GraphQL curation field for /api/v1/curation parity (#6982)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -436,6 +436,8 @@ export const SDL = `
     subnet_volume(netuid: Int!): SubnetVolume!
     "The machine-readable AI-resources index: the copyable agent prompt (/agent.md), MCP server install metadata and tool listing, the Bittensor skill, llms.txt, OpenAPI, and links to the agent-facing APIs. Use it to bootstrap an agent integration before calling the catalog/search fields. Null when the index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_agent_resources MCP/REST shape. Mirrors GET /api/v1/agent-resources."
     agent_resources: JSON
+    "Curation states by subnet — each subnet's registry curation level and review state. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_curation MCP/REST shape. Mirrors GET /api/v1/curation."
+    curation: JSON
     "The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search."
     search(limit: Int, cursor: String): SearchDocumentList!
     "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index."
@@ -3799,6 +3801,7 @@ export const FIELD_COMPLEXITY = {
   subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_percentiles: RELATIONSHIP_FIELD_COMPLEXITY,
   agent_resources: RELATIONSHIP_FIELD_COMPLEXITY,
+  curation: RELATIONSHIP_FIELD_COMPLEXITY,
   search: RELATIONSHIP_FIELD_COMPLEXITY,
   search_index: RELATIONSHIP_FIELD_COMPLEXITY,
   domains: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5580,6 +5583,12 @@ const rootValue = {
     // The MCP tool raises not_found when it is absent; GraphQL degrades to
     // null instead, matching every other artifact-backed resolver here.
     return loadArtifact(context, AGENT_RESOURCES_ARTIFACT);
+  },
+
+  async curation(_args, context) {
+    // Same baked artifact the REST /api/v1/curation route + list_curation MCP
+    // tool read; opaque-JSON passthrough degrading to null on cold.
+    return loadArtifact(context, "/metagraph/curation.json");
   },
 
   async subnet_volume({ netuid }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -17400,3 +17400,31 @@ describe("graphql — adapter (#6984, reuses loadAdapter / MCP get_adapter)", ()
     assert.equal(FIELD_COMPLEXITY.adapter, FIELD_COMPLEXITY.provider);
   });
 });
+
+// --- curation parity (#6982) ---
+describe("graphql — curation parity (#6982)", () => {
+  test("curation resolves the baked curation-states artifact", async () => {
+    const env = fixtureEnv({
+      "/metagraph/curation.json": {
+        subnets: [
+          { netuid: 1, level: "core", review_state: "maintainer-reviewed" },
+        ],
+      },
+    });
+    const { status, body } = await gql("{ curation }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.curation.subnets[0].level, "core");
+  });
+
+  test("curation degrades to null when the artifact has not been baked", async () => {
+    const { status, body } = await gql("{ curation }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.curation, null);
+  });
+
+  test("curation is weighted as a fan-out field like its sibling artifact resolvers", () => {
+    assert.equal(FIELD_COMPLEXITY.curation, FIELD_COMPLEXITY.agent_resources);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6982. `GET /api/v1/curation` (curation states by subnet) was reachable over REST and MCP (`list_curation`) but had **no GraphQL field**. This adds it.

## Change (`src/graphql.mjs`)

- New `curation: JSON` Query field → `loadArtifact(context, "/metagraph/curation.json")` — the same baked artifact the REST route and `list_curation` MCP tool read.
- Opaque-JSON passthrough degrading to `null` on a cold artifact (the established `agent_resources`/`subnet_gaps` resolver convention), weighted at the shared relationship-field complexity.

## Note on the "new MCP tool" deliverable

The issue also asks for a new MCP tool, but **`list_curation` already exists on `main`** (`src/curation-mcp.mjs` → registered in `MCP_TOOLS`), exposing the same `/metagraph/curation.json` data. Adding a second curation tool would duplicate it and fail `validate:mcp`. So curation's MCP surface is already at parity — this closes the remaining **GraphQL-only** gap, making the data reachable from all three surfaces.

## Tests (`tests/graphql.test.mjs`)

- `curation` resolves the baked artifact, degrades to null when cold (never an error), and carries the fan-out complexity weight.

## Validation run locally

- `vitest run tests/graphql.test.mjs` green · `eslint` + `prettier --check` clean · changed lines covered.

## Risk / regen

Pure additive (+37/−0). No contract/OpenAPI regeneration: GraphQL has no committed SDL snapshot (served live + introspected dynamically), and `API_ROUTES` is unchanged, so `validate:contract-drift`/`validate:openapi` are unaffected.