### PR TITLE
feat(api): GraphQL + MCP parity for /api/v1/coverage and /api/v1/coverage-depth (#6983)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -446,6 +446,10 @@ export const SDL = `
     domain_summary(tag: String!): DomainSummary!
     "Several validators side by side for a stake/delegate decision: each hotkey's take, estimated APY, nominator count, identity, and cross-subnet stake/emission/trust aggregates. hotkeys takes 1-16 distinct SS58 addresses (a real GraphQL list, like the sibling compare field's netuids, rather than REST's comma-separated string); the optional netuid adds each validator's membership row in that subnet. The validator equivalent of the compare field. Mirrors GET /api/v1/compare/validators."
     compare_validators(hotkeys: [String!]!, netuid: Int): ValidatorComparison!
+    "The registry coverage summary: surface/subnet counts, domain coverage, and overall completeness across the whole Bittensor application layer. Null when the coverage artifact has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_coverage MCP/REST shape. Mirrors GET /api/v1/coverage."
+    coverage: JSON
+    "The machine-usable coverage-depth scorecard and ranked enrichment queue: per-subnet tier/score/priority rows plus the ranked queue of enrichment targets. Null when the coverage-depth artifact has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the /api/v1/coverage-depth REST shape. Mirrors GET /api/v1/coverage-depth."
+    coverage_depth: JSON
     "One subnet's alpha-price OHLC candles bucketed by interval (1h or 1d, default 1h) over the trailing days window (default 90, max 365), from the same executed-trade stream subnet_volume reads. A subnet with no trades resolves to a schema-stable empty candle list, never null. Mirrors GET /api/v1/subnets/{netuid}/ohlc."
     subnet_ohlc(netuid: Int!, interval: String, days: Int): SubnetOhlc!
     "A read-only quote for a hypothetical stake/unstake against one subnet's live AMM pool: expected amount out, spot vs effective price, and estimated price impact. Computes nothing on-chain and signs nothing. Mirrors GET /api/v1/subnets/{netuid}/stake-quote."
@@ -3804,6 +3808,8 @@ export const FIELD_COMPLEXITY = {
   domains: RELATIONSHIP_FIELD_COMPLEXITY,
   domain_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   compare_validators: RELATIONSHIP_FIELD_COMPLEXITY,
+  coverage: RELATIONSHIP_FIELD_COMPLEXITY,
+  coverage_depth: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_volume: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_ohlc: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_quote: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5580,6 +5586,18 @@ const rootValue = {
     // The MCP tool raises not_found when it is absent; GraphQL degrades to
     // null instead, matching every other artifact-backed resolver here.
     return loadArtifact(context, AGENT_RESOURCES_ARTIFACT);
+  },
+
+  async coverage(_args, context) {
+    // Same baked artifact the REST /api/v1/coverage route + get_coverage MCP
+    // tool read; GraphQL degrades to null when cold, like agent_resources.
+    return loadArtifact(context, "/metagraph/coverage.json");
+  },
+
+  async coverage_depth(_args, context) {
+    // Raw passthrough of the /api/v1/coverage-depth artifact (the same one the
+    // list_enrichment_targets MCP tool shapes); degrades to null when cold.
+    return loadArtifact(context, "/metagraph/coverage-depth.json");
   },
 
   async subnet_volume({ netuid }, context) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -10521,6 +10521,23 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_coverage_depth",
+    title: "Get the coverage-depth scorecard",
+    description:
+      "Fetch the machine-usable coverage-depth scorecard and ranked " +
+      "enrichment queue: per-subnet tier/score/priority rows plus the ranked " +
+      "queue of enrichment targets. The raw passthrough companion of the " +
+      "filtered list_enrichment_targets tool. Mirrors GET /api/v1/coverage-depth.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/coverage-depth.json");
+    },
+  },
+  {
     name: "list_enrichment_targets",
     title: "List ranked enrichment targets",
     description:
@@ -15120,6 +15137,17 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   get_coverage: GET_COVERAGE_OUTPUT_SCHEMA,
+  get_coverage_depth: {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      schema_version: { type: "integer" },
+      generated_at: NULLABLE_STRING,
+      coverage_depth_version: { type: ["string", "null"] },
+      rows: { type: "array", items: { type: "object" } },
+      ranked_queue: { type: "array", items: { type: "object" } },
+    },
+  },
   list_enrichment_targets: {
     type: "object",
     additionalProperties: true,

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -17400,3 +17400,53 @@ describe("graphql — adapter (#6984, reuses loadAdapter / MCP get_adapter)", ()
     assert.equal(FIELD_COMPLEXITY.adapter, FIELD_COMPLEXITY.provider);
   });
 });
+
+// --- coverage + coverage_depth (#6983, artifact-backed passthrough parity) ---
+describe("graphql — coverage + coverage_depth", () => {
+  test("coverage resolves the baked registry-coverage artifact", async () => {
+    const env = fixtureEnv({
+      "/metagraph/coverage.json": {
+        generated_at: "2026-07-20T00:00:00.000Z",
+        surface_count: 128,
+        completeness: { level: "broad", pct: 0.62 },
+      },
+    });
+    const { status, body } = await gql("{ coverage }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.coverage.surface_count, 128);
+    assert.equal(body.data.coverage.completeness.level, "broad");
+  });
+
+  test("coverage_depth resolves the baked coverage-depth artifact", async () => {
+    const env = fixtureEnv({
+      "/metagraph/coverage-depth.json": {
+        schema_version: 1,
+        generated_at: "2026-07-20T00:00:00.000Z",
+        rows: [{ netuid: 1, tier: "core", score: 0.9 }],
+        ranked_queue: [{ rank: 1, netuid: 5, severity: "high" }],
+      },
+    });
+    const { status, body } = await gql("{ coverage_depth }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.coverage_depth.rows[0].netuid, 1);
+    assert.equal(body.data.coverage_depth.ranked_queue[0].severity, "high");
+  });
+
+  test("both degrade to null when their artifact has not been baked, never an error", async () => {
+    const { status, body } = await gql("{ coverage coverage_depth }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.coverage, null);
+    assert.equal(body.data.coverage_depth, null);
+  });
+
+  test("both are weighted as fan-out fields like their sibling artifact resolvers", () => {
+    assert.equal(FIELD_COMPLEXITY.coverage, FIELD_COMPLEXITY.agent_resources);
+    assert.equal(
+      FIELD_COMPLEXITY.coverage_depth,
+      FIELD_COMPLEXITY.agent_resources,
+    );
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -20423,3 +20423,40 @@ describe("MCP health-tier analytics tools — Postgres tier wiring", () => {
     }
   });
 });
+
+describe("get_coverage_depth MCP tool (#6983)", () => {
+  test("is registered as a no-arg read-only tool", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "get_coverage_depth");
+    assert.ok(tool, "get_coverage_depth should be registered");
+    assert.equal(typeof tool.description, "string");
+    assert.deepEqual(tool.inputSchema, {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+
+  test("returns the coverage-depth artifact verbatim", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        schema_version: 1,
+        rows: [{ netuid: 1, tier: "core", score: 0.9 }],
+        ranked_queue: [{ rank: 1, netuid: 5, severity: "high" }],
+      },
+    });
+    const res = await callTool("get_coverage_depth", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.rows[0].netuid, 1);
+    assert.equal(out.ranked_queue[0].severity, "high");
+  });
+
+  test("maps a missing artifact to a clean not_found", async () => {
+    const res = await callTool(
+      "get_coverage_depth",
+      {},
+      { deps: makeDeps({}) },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6983. The `/api/v1/coverage` and `/api/v1/coverage-depth` REST artifacts were reachable over REST only — no GraphQL field, and no raw MCP tool for coverage-depth. This adds the missing surfaces.

## Changes

**GraphQL** (`src/graphql.mjs`) — two new `Query` fields cloning the `agent_resources` artifact-passthrough:
- `coverage: JSON` → `/metagraph/coverage.json`
- `coverage_depth: JSON` → `/metagraph/coverage-depth.json`
- Opaque-JSON passthrough of the same baked artifacts the REST routes serve; degrade to `null` when cold; weighted at the shared relationship-field complexity.

**MCP** (`src/mcp-server.mjs`) — new `get_coverage_depth` tool: raw passthrough of `/metagraph/coverage-depth.json` (the raw companion of the existing *filtered* `list_enrichment_targets` tool), cloning the `registry_summary` no-arg tool, with a typed `outputSchema`.

## Note on the "two new MCP tools" deliverable

`get_coverage` already exists on `main`, so coverage's MCP surface is already at parity — adding a duplicate would fail `validate:mcp`. Only `get_coverage_depth` is genuinely new; both routes now reach all three surfaces.

## Tests

- GraphQL: `coverage`/`coverage_depth` resolve, degrade to null when cold, carry the fan-out weight.
- MCP: `get_coverage_depth` registered as a no-arg read-only tool, returns the artifact verbatim, maps a missing artifact to a clean `not_found`.
- Local: `vitest` (graphql + mcp suites) green · `validate:mcp` passes · `eslint`/`prettier` clean · changed lines covered.

## Risk / regen

Pure additive (+133/−0). No contract/OpenAPI regen: GraphQL has no committed SDL snapshot, MCP `tools/list`/agent-tool specs are worker-computed, and `API_ROUTES` is unchanged.