### PR TITLE
feat(api): GraphQL parity for candidates, fixtures, agent-catalog, freshness, top-holders (#6991)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -145,11 +145,21 @@ import {
   formatLeaderboards,
   LEADERBOARD_BOARDS,
   loadSubnetTrajectory,
+  mergeFreshness,
   mergeRpcEndpoints,
+  overlayCatalogDetail,
+  overlayCatalogIndex,
   resolveLiveEconomics,
   resolveLiveHealth,
   subnetBadgeStatus,
 } from "./health-serving.mjs";
+import {
+  buildTopHoldersList,
+  DEFAULT_TOP_HOLDERS_SORT,
+  TOP_HOLDERS_LIMIT_DEFAULT,
+  TOP_HOLDERS_LIMIT_MAX,
+  TOP_HOLDERS_SORTS,
+} from "./top-holders.mjs";
 import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.mjs";
 import {
   COMPARE_VALIDATORS_MAX,
@@ -449,6 +459,16 @@ export const SDL = `
     subnet_volume(netuid: Int!): SubnetVolume!
     "The machine-readable AI-resources index: the copyable agent prompt (/agent.md), MCP server install metadata and tool listing, the Bittensor skill, llms.txt, OpenAPI, and links to the agent-facing APIs. Use it to bootstrap an agent integration before calling the catalog/search fields. Null when the index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_agent_resources MCP/REST shape. Mirrors GET /api/v1/agent-resources."
     agent_resources: JSON
+    "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state and page with limit/cursor, exactly like the REST route. Resolves to {items,total,next_cursor} as opaque JSON. Mirrors GET /api/v1/candidates."
+    candidates(netuid: Int, kind: String, provider: String, state: String, limit: Int, cursor: String): JSON
+    "The recorded response fixtures for registered surfaces, used to replay/verify a surface without calling it. Null when no fixture index has been baked in this environment. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
+    fixtures: JSON
+    "The agent-callable service catalog: without a netuid, the global index of subnets exposing callable services; with one, that subnet's full per-service catalog. Both are overlaid with live health exactly as REST composes them. Null when the catalog has not been baked. Opaque JSON, matching the get_agent_catalog MCP/REST shape. Mirrors GET /api/v1/agent-catalog."
+    agent_catalog(netuid: Int): JSON
+    "Artifact freshness: each published artifact's generated_at/age, merged with the live cron snapshot stamp when the health store is warm. Null when no freshness artifact has been baked. Opaque JSON, matching the get_freshness MCP/REST shape. Mirrors GET /api/v1/freshness."
+    freshness: JSON
+    "The largest TAO holders ranked by the chosen sort (total_tao by default), limit 1-100 (default 20). An unknown sort is a BAD_USER_INPUT error. Resolves to a schema-stable empty list when the holders tier is cold, never null. Opaque JSON, matching the get_top_holders MCP/REST shape. Mirrors GET /api/v1/accounts/top-holders."
+    top_holders(sort: String, limit: Int): JSON
     "The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search."
     search(limit: Int, cursor: String): SearchDocumentList!
     "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index."
@@ -3872,6 +3892,11 @@ export const FIELD_COMPLEXITY = {
   subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_percentiles: RELATIONSHIP_FIELD_COMPLEXITY,
   agent_resources: RELATIONSHIP_FIELD_COMPLEXITY,
+  candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  fixtures: RELATIONSHIP_FIELD_COMPLEXITY,
+  agent_catalog: RELATIONSHIP_FIELD_COMPLEXITY,
+  freshness: RELATIONSHIP_FIELD_COMPLEXITY,
+  top_holders: RELATIONSHIP_FIELD_COMPLEXITY,
   search: RELATIONSHIP_FIELD_COMPLEXITY,
   search_index: RELATIONSHIP_FIELD_COMPLEXITY,
   domains: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4624,6 +4649,85 @@ const rootValue = {
       next_cursor: data.next_cursor ?? null,
       entries: data.entries ?? [],
     };
+  },
+
+  // #6991: five registry-meta routes that had an MCP tool but no GraphQL
+  // field. Each reads the same baked artifact (and applies the same overlay /
+  // builder) its MCP tool does, so REST, MCP, and GraphQL can't drift.
+  async candidates({ netuid, kind, provider, state, limit, cursor }, context) {
+    const data = await loadArtifact(context, "/metagraph/candidates.json");
+    const all = Array.isArray(data?.candidates) ? data.candidates : [];
+    const filtered = all.filter(
+      (c) =>
+        (netuid == null || c.netuid === netuid) &&
+        (kind == null || c.kind === kind) &&
+        (provider == null || c.provider === provider) &&
+        (state == null || c.state === state),
+    );
+    const { page, total, nextCursor } = paginate(
+      filtered,
+      limit,
+      cursor,
+      (c) => c.id ?? c.key,
+    );
+    return { items: page, total, next_cursor: nextCursor };
+  },
+
+  fixtures(_args, context) {
+    return loadArtifact(context, "/metagraph/fixtures.json");
+  },
+
+  async agent_catalog({ netuid }, context) {
+    const live = await loadLiveHealth(context);
+    if (netuid == null) {
+      const index = await loadArtifact(
+        context,
+        "/metagraph/agent-catalog.json",
+      );
+      return index && (overlayCatalogIndex(index, live) || index);
+    }
+    const detail = await loadArtifact(
+      context,
+      `/metagraph/agent-catalog/${netuid}.json`,
+    );
+    return detail && (overlayCatalogDetail(detail, live, netuid) || detail);
+  },
+
+  async freshness(_args, context) {
+    // Same baked-artifact + live KV meta merge loadFreshness performs for MCP.
+    const base = await loadArtifact(context, "/metagraph/freshness.json");
+    if (!base) return null;
+    const meta = await readHealthKv(context.env, KV_HEALTH_META);
+    return mergeFreshness(base, meta) ?? base;
+  },
+
+  async top_holders({ sort, limit }, context) {
+    // Same allowlist REST enforces -- an unknown sort is BAD_USER_INPUT rather
+    // than silently falling back, mirroring the route's invalid_query 400.
+    if (sort != null && !TOP_HOLDERS_SORTS.includes(sort)) {
+      throw new GraphQLError(
+        `sort must be one of: ${TOP_HOLDERS_SORTS.join(", ")}.`,
+        {
+          extensions: { code: "BAD_USER_INPUT" },
+        },
+      );
+    }
+    const safeSort = sort ?? DEFAULT_TOP_HOLDERS_SORT;
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: TOP_HOLDERS_LIMIT_DEFAULT,
+      maxLimit: TOP_HOLDERS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams({
+      sort: safeSort,
+      limit: String(safeLimit),
+    });
+    return (
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/accounts/top-holders", params),
+        "METAGRAPH_TOP_HOLDERS_SOURCE",
+      )) ?? buildTopHoldersList([], { sort: safeSort, limit: safeLimit })
+    );
   },
 
   async subnet_trajectory({ netuid }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7009,6 +7009,166 @@ describe("graphql — agent_resources (#6987, baked AI-resources index)", () => 
   });
 });
 
+describe("graphql — candidates / fixtures / agent_catalog / freshness / top_holders (#6991)", () => {
+  const CANDIDATES = {
+    candidates: [
+      { id: "c1", netuid: 1, kind: "docs", provider: "acme", state: "new" },
+      { id: "c2", netuid: 2, kind: "api", provider: "beta", state: "verified" },
+    ],
+  };
+
+  test("candidates resolves the ledger with total and next_cursor", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { status, body } = await gql("{ candidates }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.total, 2);
+    assert.equal(body.data.candidates.items.length, 2);
+  });
+
+  test("candidates applies the netuid/kind/provider/state filters", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql(
+      '{ candidates(netuid: 2, kind: "api", provider: "beta", state: "verified") }',
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.total, 1);
+    assert.equal(body.data.candidates.items[0].id, "c2");
+  });
+
+  test("candidates pages with limit and hands back a next_cursor", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql("{ candidates(limit: 1) }", env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.items.length, 1);
+    assert.equal(body.data.candidates.total, 2);
+    assert.equal(body.data.candidates.next_cursor, "c1");
+  });
+
+  test("candidates resolves an empty ledger when the artifact is cold", async () => {
+    const { body } = await gql("{ candidates }");
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.candidates, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("fixtures resolves the baked fixture index", async () => {
+    const env = fixtureEnv({
+      "/metagraph/fixtures.json": {
+        schema_version: 1,
+        fixtures: [{ id: "f1" }],
+      },
+    });
+    const { body } = await gql("{ fixtures }", env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.fixtures.fixtures[0].id, "f1");
+  });
+
+  test("fixtures degrades to null when not baked", async () => {
+    const { body } = await gql("{ fixtures }");
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.fixtures, null);
+  });
+
+  test("agent_catalog resolves the global index", async () => {
+    const env = fixtureEnv({
+      "/metagraph/agent-catalog.json": {
+        schema_version: 1,
+        subnets: [{ netuid: 1 }],
+      },
+    });
+    const { body } = await gql("{ agent_catalog }", env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.agent_catalog.subnets[0].netuid, 1);
+  });
+
+  test("agent_catalog resolves one subnet's per-service detail", async () => {
+    const env = fixtureEnv({
+      "/metagraph/agent-catalog/7.json": {
+        netuid: 7,
+        services: [{ id: "s1" }],
+      },
+    });
+    const { body } = await gql("{ agent_catalog(netuid: 7) }", env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.agent_catalog.services[0].id, "s1");
+  });
+
+  test("agent_catalog degrades to null when not baked", async () => {
+    const { body } = await gql("{ agent_catalog }");
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.agent_catalog, null);
+  });
+
+  test("freshness resolves the baked artifact", async () => {
+    const env = fixtureEnv({
+      "/metagraph/freshness.json": {
+        schema_version: 1,
+        artifacts: [{ path: "/x.json" }],
+      },
+    });
+    const { body } = await gql("{ freshness }", env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.freshness.artifacts[0].path, "/x.json");
+  });
+
+  test("freshness degrades to null when not baked", async () => {
+    const { body } = await gql("{ freshness }");
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.freshness, null);
+  });
+
+  test("top_holders resolves the postgres tier payload", async () => {
+    let url;
+    const env = {
+      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          url = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            holders: [{ ss58: "5A" }],
+          });
+        },
+      },
+    };
+    const { body } = await gql("{ top_holders(limit: 5) }", env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.top_holders.holders[0].ss58, "5A");
+    assert.equal(url.pathname, "/api/v1/accounts/top-holders");
+    assert.equal(url.searchParams.get("limit"), "5");
+    assert.equal(url.searchParams.get("sort"), "total_tao");
+  });
+
+  test("top_holders falls back to a schema-stable empty list when the tier is cold", async () => {
+    const { body } = await gql("{ top_holders }");
+    assert.equal(body.errors, undefined);
+    assert.ok(body.data.top_holders);
+    assert.deepEqual(body.data.top_holders.holders ?? [], []);
+  });
+
+  test("top_holders rejects an unknown sort with BAD_USER_INPUT", async () => {
+    const { body } = await gql('{ top_holders(sort: "nope") }');
+    assert.equal(body.errors?.[0]?.extensions?.code, "BAD_USER_INPUT");
+  });
+
+  test("the five fields are weighted as fan-out fields", () => {
+    for (const f of [
+      "candidates",
+      "fixtures",
+      "agent_catalog",
+      "freshness",
+      "top_holders",
+    ]) {
+      assert.equal(FIELD_COMPLEXITY[f], 5, `${f} should be weighted`);
+    }
+  });
+});
+
 // #7168: GraphQL parity for the registry-summary / source-health / lineage /
 // rpc-endpoints REST routes, each reusing the same baked artifact its MCP tool
 // (registry_summary / get_source_health / get_lineage / list_rpc_endpoints)


### PR DESCRIPTION
## Summary

Five registry-meta REST routes had an MCP tool but no GraphQL field. This adds all five to `type Query`, each reading the **same baked artifact (and applying the same overlay/builder)** its MCP tool does, so REST, MCP, and GraphQL can't drift:

| Field | Mirrors | Reuses |
| --- | --- | --- |
| `candidates(netuid, kind, provider, state, limit, cursor)` | `GET /api/v1/candidates` | `/metagraph/candidates.json` + the same filters, paged with graphql's own `paginate` |
| `fixtures` | `GET /api/v1/fixtures` | `/metagraph/fixtures.json` |
| `agent_catalog(netuid)` | `GET /api/v1/agent-catalog` | index/detail artifact + `overlayCatalogIndex` / `overlayCatalogDetail` |
| `freshness` | `GET /api/v1/freshness` | `/metagraph/freshness.json` + `mergeFreshness` with the live KV meta stamp |
| `top_holders(sort, limit)` | `GET /api/v1/accounts/top-holders` | `tryPostgresTier(METAGRAPH_TOP_HOLDERS_SOURCE)` → `buildTopHoldersList` |

Closes #6991

## Conventions

- All five return the `JSON` scalar (opaque passthrough), matching the `agent_resources` precedent for verbatim REST/MCP-shaped payloads — no new output types needed.
- **Cold artifact → `null`**, never a GraphQL error (`fixtures`, `agent_catalog`, `freshness`), matching the established artifact-backed convention.
- **Schema-stable empties** where the route guarantees a shape: `candidates` resolves `{items: [], total: 0, next_cursor: null}` and `top_holders` falls back to `buildTopHoldersList([], …)`.
- `top_holders` validates `sort` against the same `TOP_HOLDERS_SORTS` allowlist REST enforces — an unknown sort is `BAD_USER_INPUT` (mirroring the route's `invalid_query` 400) rather than a silent fallback. `limit` is clamped with the shared `clampLimit` (default 20, max 100).
- `FIELD_COMPLEXITY`: all five weighted as fan-out fields (5).

## Tests

`tests/graphql.test.mjs` (+160) — 15 tests covering **every added line**:

- `candidates`: full ledger with total; the netuid/kind/provider/state filters; paging with `limit` returning a `next_cursor`; cold-artifact empty ledger
- `fixtures`: resolves baked index; degrades to null
- `agent_catalog`: global index; per-subnet detail via `netuid`; degrades to null
- `freshness`: resolves baked artifact; degrades to null
- `top_holders`: postgres-tier payload (asserting the forwarded path, `sort`, and `limit`); schema-stable empty list when the tier is cold; unknown sort → `BAD_USER_INPUT`
- all five weighted as fan-out fields

## Validation

- `npx vitest run tests/graphql.test.mjs` → **814 passed** (incl. the 15 new)
- Scoped coverage (`--coverage.include=src/graphql.mjs`) → **100% statements / lines / functions**; every line in this diff is exercised (residual uncovered lines are pre-existing partial branches far outside this change)
- `npx eslint` → clean · `npx prettier --check` → clean (verified LF-normalized; local checkout is CRLF)
- Purely additive: `+264 / -0`; no SDL removals, no changes to existing resolvers, loaders, or artifact paths.
