### PR TITLE
feat(api): add GraphQL curation field for /api/v1/curation parity (#6982)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -223,6 +223,7 @@ import {
 } from "./metagraph-neurons.mjs";
 import { buildAlphaVolume } from "./alpha-volume.mjs";
 import { AGENT_RESOURCES_ARTIFACT } from "./agent-resources-mcp.mjs";
+import { CURATION_ARTIFACT } from "./curation-mcp.mjs";
 import { buildDomainOverview, buildDomainSummary } from "./domain-summary.mjs";
 import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import {
@@ -458,6 +459,8 @@ export const SDL = `
     subnet_volume(netuid: Int!): SubnetVolume!
     "The machine-readable AI-resources index: the copyable agent prompt (/agent.md), MCP server install metadata and tool listing, the Bittensor skill, llms.txt, OpenAPI, and links to the agent-facing APIs. Use it to bootstrap an agent integration before calling the catalog/search fields. Null when the index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_agent_resources MCP/REST shape. Mirrors GET /api/v1/agent-resources."
     agent_resources: JSON
+    "Curation states by subnet — each subnet's registry curation level and review state. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_curation MCP/REST shape. Mirrors GET /api/v1/curation."
+    curation: JSON
     "The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search."
     search(limit: Int, cursor: String): SearchDocumentList!
     "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index."
@@ -3932,6 +3935,7 @@ export const FIELD_COMPLEXITY = {
   subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_percentiles: RELATIONSHIP_FIELD_COMPLEXITY,
   agent_resources: RELATIONSHIP_FIELD_COMPLEXITY,
+  curation: RELATIONSHIP_FIELD_COMPLEXITY,
   search: RELATIONSHIP_FIELD_COMPLEXITY,
   search_index: RELATIONSHIP_FIELD_COMPLEXITY,
   domains: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5831,6 +5835,12 @@ const rootValue = {
     // The MCP tool raises not_found when it is absent; GraphQL degrades to
     // null instead, matching every other artifact-backed resolver here.
     return loadArtifact(context, AGENT_RESOURCES_ARTIFACT);
+  },
+
+  async curation(_args, context) {
+    // Same baked artifact the REST /api/v1/curation route + list_curation MCP
+    // tool read; opaque-JSON passthrough degrading to null on cold.
+    return loadArtifact(context, CURATION_ARTIFACT);
   },
 
   async subnet_volume({ netuid }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -18150,3 +18150,31 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
     assert.equal(FIELD_COMPLEXITY.chain_events, FIELD_COMPLEXITY.extrinsics);
   });
 });
+
+// --- curation parity (#6982) ---
+describe("graphql — curation parity (#6982)", () => {
+  test("curation resolves the baked curation-states artifact", async () => {
+    const env = fixtureEnv({
+      "/metagraph/curation.json": {
+        subnets: [
+          { netuid: 1, level: "core", review_state: "maintainer-reviewed" },
+        ],
+      },
+    });
+    const { status, body } = await gql("{ curation }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.curation.subnets[0].level, "core");
+  });
+
+  test("curation degrades to null when the artifact has not been baked", async () => {
+    const { status, body } = await gql("{ curation }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.curation, null);
+  });
+
+  test("curation is weighted as a fan-out field like its sibling artifact resolvers", () => {
+    assert.equal(FIELD_COMPLEXITY.curation, FIELD_COMPLEXITY.agent_resources);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6982. `GET /api/v1/curation` (curation states by subnet) was reachable over REST and MCP (`list_curation`) but had **no GraphQL field**. This adds it.

## What Changed

`src/graphql.mjs`:

- New `curation: JSON` Query field
- Resolver reuses `CURATION_ARTIFACT` from `src/curation-mcp.mjs` (same path REST + `list_curation` already use — addresses the prior review nit about a hardcoded string)
- Opaque-JSON passthrough degrading to `null` on a cold artifact (`agent_resources` convention)
- Weighted at `RELATIONSHIP_FIELD_COMPLEXITY`

## Note on the MCP deliverable

The issue also asks for a new MCP tool, but `list_curation` **already exists on main** (`src/curation-mcp.mjs`). Adding a second curation tool would duplicate it and fail `validate:mcp`. So curation's MCP surface is already at parity — this closes the remaining GraphQL-only gap.

## Tests

`tests/graphql.test.mjs`:

- resolves the baked artifact
- degrades to null when cold (never an error)
- carries the fan-out complexity weight

## Validation

- [x] `npx vitest run tests/graphql.test.mjs -t "curation parity"` — 3 passed
- [x] `npx eslint` / `npx prettier --check` on touched files — clean
- [x] `npm run validate:mcp` — passed (197 tools)
- [x] `git diff --check` — clean
- [x] Rebased onto current `upstream/main` (no conflicts)

## Template Used

backend-code

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6982`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (GraphQL SDL only — no OpenAPI/schema JSON change.)

## Risk / tradeoffs

Pure additive (+38/−0). No contract/OpenAPI regeneration: GraphQL has no committed SDL snapshot; `API_ROUTES` unchanged.
