### PR TITLE
feat(ui): add a validator-comparison drawer mirroring the subnet compare drawer (#6998)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -3,6 +3,7 @@ import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { AccountAddress } from "@/components/metagraphed/account-address";
+import { ValidatorCompareToggle } from "@/components/metagraphed/validators-compare-drawer";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
@@ -40,6 +41,9 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
                 {f.hotkeyShort}
               </Link>
               <CopyButton value={v.hotkey} label="hotkey" compact />
+              <span className="ml-auto shrink-0">
+                <ValidatorCompareToggle hotkey={v.hotkey} />
+              </span>
             </div>
             {/* Mirrors the hotkey row above: a flex row so the copy button's 44px
                 touch target centers against the value. `compact` folds that height

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -1,0 +1,289 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { X, BarChart3, ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { useValidatorCompareSelection } from "@/lib/metagraphed/validator-compare-selection";
+import { validatorCompareQuery } from "@/lib/metagraphed/queries";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
+import type { ValidatorComparisonEntry } from "@/lib/metagraphed/types";
+
+/**
+ * Floating bottom dock + expandable side-by-side compare drawer for selected
+ * validators (#6998) — the hotkey-keyed sibling of SubnetsCompareDrawer.
+ * Selection lives in localStorage via useValidatorCompareSelection so it
+ * survives navigation. Pure presentation — does not mutate URL.
+ */
+export function ValidatorsCompareDrawer() {
+  const { selected, max, remove, clear } = useValidatorCompareSelection();
+  const [expanded, setExpanded] = useState(false);
+
+  if (selected.length === 0) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
+      <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
+        <div
+          className={classNames(
+            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
+            "mg-fade-in",
+          )}
+        >
+          {/* Dock */}
+          <div className="flex flex-wrap items-center gap-2 px-3 py-2">
+            <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <BarChart3 className="size-3 text-accent" />
+              Compare validators
+              <span className="text-ink-strong tabular-nums">
+                {selected.length}/{max}
+              </span>
+            </span>
+            <span aria-hidden className="h-4 w-px bg-border" />
+            <div className="flex flex-wrap gap-1.5 min-w-0">
+              {selected.map((hotkey) => (
+                <span
+                  key={hotkey}
+                  className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-paper pl-2.5 pr-1 font-mono text-[10px] text-ink-strong"
+                >
+                  {shortHash(hotkey) ?? hotkey}
+                  <button
+                    type="button"
+                    onClick={() => remove(hotkey)}
+                    aria-label={`Remove ${shortHash(hotkey) ?? hotkey}`}
+                    className="ml-0.5 inline-flex size-4 items-center justify-center rounded-full text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+                  >
+                    <X className="size-2.5" />
+                  </button>
+                </span>
+              ))}
+            </div>
+            <div className="ml-auto flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                disabled={selected.length < 2}
+                className={classNames(
+                  "inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                  selected.length < 2
+                    ? "opacity-50 cursor-not-allowed"
+                    : "hover:border-accent/60 hover:text-accent text-ink-strong",
+                )}
+              >
+                {expanded ? "Hide" : "Compare"}
+              </button>
+              <button
+                type="button"
+                onClick={clear}
+                className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-paper px-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong transition-colors"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+
+          {/* Expanded side-by-side */}
+          {expanded && selected.length >= 2 ? <CompareGrid hotkeys={selected} /> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function trustValue(v: number | null | undefined): string {
+  return typeof v === "number" && Number.isFinite(v) ? v.toFixed(3) : "—";
+}
+
+function CompareGrid({ hotkeys }: { hotkeys: string[] }) {
+  const { data, isPending, isError, refetch } = useQuery({
+    ...validatorCompareQuery(hotkeys),
+    retry: 0,
+  });
+
+  const byHotkey = new Map<string, ValidatorComparisonEntry>();
+  for (const v of data?.data?.validators ?? []) byHotkey.set(v.hotkey, v);
+
+  const rows: Array<{ label: string; render: (hotkey: string) => React.ReactNode }> = [
+    {
+      label: "Operator",
+      render: (hotkey) => {
+        const v = byHotkey.get(hotkey);
+        const name =
+          v?.coldkey_identity?.has_identity && v.coldkey_identity.name
+            ? v.coldkey_identity.name
+            : (shortHash(hotkey) ?? hotkey);
+        return (
+          <Link
+            to="/validators/$hotkey"
+            params={{ hotkey }}
+            className="font-medium text-ink-strong hover:text-accent inline-flex items-center gap-1"
+          >
+            {name}
+            <ExternalLink className="size-3 opacity-60" />
+          </Link>
+        );
+      },
+    },
+    {
+      label: "Take",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {formatTakePct(byHotkey.get(hotkey)?.take)}
+        </span>
+      ),
+    },
+    {
+      label: "Est. APY",
+      render: (hotkey) => {
+        const apy = byHotkey.get(hotkey)?.apy_estimate;
+        return (
+          <span className="font-mono tabular-nums text-ink-strong">
+            {formatApyPct(apy != null ? apy * 100 : null)}
+          </span>
+        );
+      },
+    },
+    {
+      label: "Nominators",
+      render: (hotkey) => {
+        const n = byHotkey.get(hotkey)?.nominator_count;
+        return (
+          <span className="font-mono tabular-nums text-ink-strong">
+            {n != null ? formatNumber(n) : "—"}
+          </span>
+        );
+      },
+    },
+    {
+      label: "Total stake",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {taoCompact(byHotkey.get(hotkey)?.total_stake_tao)}
+        </span>
+      ),
+    },
+    {
+      label: "Total emission",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {taoCompact(byHotkey.get(hotkey)?.total_emission_tao)}
+        </span>
+      ),
+    },
+    {
+      label: "Avg trust",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {trustValue(byHotkey.get(hotkey)?.avg_validator_trust)}
+        </span>
+      ),
+    },
+    {
+      label: "Active subnets",
+      render: (hotkey) => {
+        const c = byHotkey.get(hotkey)?.subnet_count;
+        return (
+          <span className="font-mono tabular-nums text-ink-strong">
+            {c != null ? formatNumber(c) : "—"}
+          </span>
+        );
+      },
+    },
+  ];
+
+  if (isError) {
+    return (
+      <div className="border-t border-border px-3 py-6 text-center">
+        <p className="font-mono text-[11px] text-ink-muted">Could not load comparison.</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest text-ink-strong hover:border-accent/60 hover:text-accent transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-border max-h-[55vh] overflow-auto">
+      <table className="min-w-full text-[12px]">
+        <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
+          <tr>
+            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted backdrop-blur">
+              Metric
+            </th>
+            {hotkeys.map((h) => (
+              <th
+                key={h}
+                className="min-w-[7rem] whitespace-nowrap px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-strong"
+              >
+                {shortHash(h) ?? h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td className="sticky left-0 z-[1] bg-card px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                {row.label}
+              </td>
+              {hotkeys.map((h) => (
+                <td key={h} className="px-3 py-2">
+                  {isPending ? (
+                    <span className="inline-block h-3 w-12 animate-pulse rounded bg-border/60" />
+                  ) : (
+                    row.render(h)
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Inline checkbox-style toggle for validator table/card rows. */
+export function ValidatorCompareToggle({ hotkey }: { hotkey: string }) {
+  const { has, toggle, selected, max } = useValidatorCompareSelection();
+  const on = has(hotkey);
+  const disabled = !on && selected.length >= max;
+  const label = shortHash(hotkey) ?? hotkey;
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={on}
+      aria-label={on ? `Remove ${label} from compare` : `Add ${label} to compare`}
+      disabled={disabled}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!disabled) toggle(hotkey);
+      }}
+      title={disabled ? `Compare is full (${max})` : on ? "Remove from compare" : "Add to compare"}
+      className={classNames(
+        "inline-flex size-4 shrink-0 items-center justify-center rounded border transition-colors",
+        on ? "bg-accent border-accent text-paper" : "border-border bg-paper hover:border-accent/60",
+        disabled && "opacity-40 cursor-not-allowed",
+      )}
+    >
+      {on ? (
+        <svg viewBox="0 0 12 12" fill="none" className="size-2.5" aria-hidden>
+          <path
+            d="M2 6.5l2.5 2.5L10 3.5"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -122,6 +122,8 @@ import type {
   Candidate,
   Compare,
   CompareSubnet,
+  ValidatorComparison,
+  ValidatorComparisonEntry,
   BlockEvent,
   BlockEvents,
   BlockChainEvents,
@@ -6767,6 +6769,85 @@ export const compareQuery = (netuids: number[]) =>
       return { data: normalizeCompare(res.data), meta: res.meta, url: res.url };
     },
     enabled: netuids.length > 0,
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeValidatorComparisonEntry(raw: unknown): ValidatorComparisonEntry | undefined {
+  if (!isRecord(raw)) return undefined;
+  const hotkey = optionalString(raw.hotkey);
+  if (!hotkey) return undefined;
+  const id = raw.coldkey_identity;
+  const coldkey_identity = isRecord(id)
+    ? {
+        has_identity: id.has_identity === true,
+        name: optionalString(id.name) ?? null,
+        url: optionalString(id.url) ?? null,
+        github: optionalString(id.github) ?? null,
+        image: optionalString(id.image) ?? null,
+        discord: optionalString(id.discord) ?? null,
+        description: optionalString(id.description) ?? null,
+        additional: optionalString(id.additional) ?? null,
+        captured_at: optionalString(id.captured_at) ?? null,
+      }
+    : null;
+  return {
+    hotkey,
+    coldkey: optionalString(raw.coldkey) ?? null,
+    coldkey_identity,
+    take: optionalNumber(raw.take) ?? null,
+    apy_estimate: optionalNumber(raw.apy_estimate) ?? null,
+    apy_estimate_eligible_subnet_count:
+      optionalNumber(raw.apy_estimate_eligible_subnet_count) ?? null,
+    nominator_count: optionalNumber(raw.nominator_count) ?? null,
+    total_stake_tao: optionalNumber(raw.total_stake_tao) ?? null,
+    total_emission_tao: optionalNumber(raw.total_emission_tao) ?? null,
+    avg_validator_trust: optionalNumber(raw.avg_validator_trust) ?? null,
+    max_validator_trust: optionalNumber(raw.max_validator_trust) ?? null,
+    subnet_count: optionalNumber(raw.subnet_count) ?? null,
+    subnet_context: isRecord(raw.subnet_context) ? raw.subnet_context : null,
+  };
+}
+
+export function normalizeValidatorComparison(raw: unknown): ValidatorComparison {
+  const d = isRecord(raw) ? raw : {};
+  const validators = Array.isArray(d.validators)
+    ? d.validators.flatMap((v) => {
+        const normalized = normalizeValidatorComparisonEntry(v);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: optionalNumber(d.schema_version),
+    netuid: optionalNumber(d.netuid) ?? null,
+    validator_count: optionalNumber(d.validator_count) ?? validators.length,
+    validators,
+  };
+}
+
+/**
+ * Composed side-by-side comparison for 1–16 validator hotkeys in one request
+ * (#6998, the validator-side sibling of compareQuery). Fuses take rate, APY
+ * estimate, nominator counts, on-chain identity, and cross-subnet
+ * stake/emission/trust so the validator compare drawer renders from one call.
+ */
+export const validatorCompareQuery = (hotkeys: string[], netuid?: number) =>
+  queryOptions({
+    queryKey: k("compare-validators", [...hotkeys].sort(), netuid ?? null),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/compare/validators", {
+        params: {
+          hotkeys: hotkeys.join(","),
+          ...(netuid != null ? { netuid } : {}),
+        },
+        signal,
+      });
+      return {
+        data: normalizeValidatorComparison(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    enabled: hotkeys.length > 0,
     staleTime: STALE_SHORT,
   });
 

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1557,6 +1557,35 @@ export interface Compare {
   source?: string;
 }
 
+/** One validator in a /api/v1/compare/validators side-by-side (#6998). Mirrors
+ *  composeValidatorComparison's per-validator shape (metagraph-neurons.mjs). */
+export interface ValidatorComparisonEntry {
+  hotkey: string;
+  coldkey?: string | null;
+  coldkey_identity?: ColdkeyIdentity | null;
+  /** Take rate as a 0..1 fraction. */
+  take?: number | null;
+  /** Estimated APY as a 0..1 fraction. */
+  apy_estimate?: number | null;
+  apy_estimate_eligible_subnet_count?: number | null;
+  nominator_count?: number | null;
+  total_stake_tao?: number | null;
+  total_emission_tao?: number | null;
+  avg_validator_trust?: number | null;
+  max_validator_trust?: number | null;
+  subnet_count?: number | null;
+  /** Populated only when a ?netuid context is requested; the membership row. */
+  subnet_context?: Record<string, unknown> | null;
+}
+
+/** Composed side-by-side comparison for 1–16 validator hotkeys (#6998). */
+export interface ValidatorComparison {
+  schema_version?: number;
+  netuid: number | null;
+  validator_count: number;
+  validators: ValidatorComparisonEntry[];
+}
+
 /** One daily on-chain snapshot from /subnets/{n}/history. */
 export interface SubnetHistoryPoint {
   snapshot_date: string;

--- a/apps/ui/src/lib/metagraphed/validator-compare-selection.test.ts
+++ b/apps/ui/src/lib/metagraphed/validator-compare-selection.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const KEY = "metagraphed:compare-validators";
+const A = "5A".padEnd(48, "a");
+const B = "5B".padEnd(48, "b");
+const C = "5C".padEnd(48, "c");
+const D = "5D".padEnd(48, "d");
+const E = "5E".padEnd(48, "e");
+
+// An EventTarget-based fake `window` (so subscribe's storage-event wiring works)
+// plus a Map-backed localStorage. Mirrors compare-selection.test.ts.
+function makeWindow(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  const win = new EventTarget() as EventTarget & {
+    localStorage: Pick<Storage, "getItem" | "setItem" | "removeItem">;
+    store: Map<string, string>;
+  };
+  win.store = store;
+  win.localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  return win;
+}
+
+// The store caches raw/value + listeners at module scope, so a fresh module per
+// case is the only way to observe cache behaviour deterministically.
+async function freshStore(win?: ReturnType<typeof makeWindow>) {
+  vi.resetModules();
+  if (win) vi.stubGlobal("window", win);
+  return import("./validator-compare-selection");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("parseRaw", () => {
+  it("returns [] for null/empty/non-array/malformed input", async () => {
+    const { parseRaw } = await freshStore(makeWindow());
+    expect(parseRaw(null)).toEqual([]);
+    expect(parseRaw("")).toEqual([]);
+    expect(parseRaw("{}")).toEqual([]);
+    expect(parseRaw("not json")).toEqual([]);
+  });
+
+  it("keeps only non-empty string hotkeys and caps at 4", async () => {
+    const { parseRaw } = await freshStore(makeWindow());
+    expect(parseRaw(JSON.stringify([A, 7, "", "  ", B, null]))).toEqual([A, B]);
+    expect(parseRaw(JSON.stringify([A, B, C, D, E]))).toEqual([A, B, C, D]);
+  });
+});
+
+describe("readSnapshot / writeRaw", () => {
+  it("round-trips through localStorage and caps at 4", async () => {
+    const win = makeWindow();
+    const { readSnapshot, writeRaw } = await freshStore(win);
+    writeRaw([A, B]);
+    expect(readSnapshot()).toEqual([A, B]);
+    writeRaw([A, B, C, D, E]);
+    expect(readSnapshot()).toEqual([A, B, C, D]);
+    expect(JSON.parse(win.store.get(KEY)!)).toEqual([A, B, C, D]);
+  });
+
+  it("drops non-string entries on write", async () => {
+    const { readSnapshot, writeRaw } = await freshStore(makeWindow());
+    // @ts-expect-error exercising defensive runtime filtering
+    writeRaw([A, 5, "", B]);
+    expect(readSnapshot()).toEqual([A, B]);
+  });
+});
+
+describe("subscribe", () => {
+  it("notifies listeners on writeRaw and stops after unsubscribe", async () => {
+    const { subscribe, writeRaw } = await freshStore(makeWindow());
+    let hits = 0;
+    const unsubscribe = subscribe(() => {
+      hits += 1;
+    });
+    writeRaw([A]);
+    writeRaw([A, B]);
+    expect(hits).toBe(2);
+    unsubscribe();
+    writeRaw([A, B, C]);
+    expect(hits).toBe(2);
+  });
+
+  it("readSnapshot reflects an externally-seeded value and empties on clear", async () => {
+    const { readSnapshot, writeRaw } = await freshStore(
+      makeWindow({ [KEY]: JSON.stringify([A, B, C]) }),
+    );
+    expect(readSnapshot()).toEqual([A, B, C]);
+    writeRaw([]);
+    expect(readSnapshot()).toEqual([]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/validator-compare-selection.ts
+++ b/apps/ui/src/lib/metagraphed/validator-compare-selection.ts
@@ -1,0 +1,110 @@
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+/**
+ * Tiny localStorage-backed selection store for validator comparison (#6998) --
+ * the hotkey-keyed sibling of compare-selection.ts (which is netuid-keyed for
+ * subnets). Holds up to MAX validator hotkeys and notifies subscribers across
+ * components. GET /api/v1/compare/validators accepts up to 16 hotkeys, but the
+ * side-by-side drawer caps at MAX to mirror the subnet drawer and keep the
+ * sticky-column table usable on mobile.
+ */
+const KEY = "metagraphed:compare-validators";
+const MAX = 4;
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+let cachedRaw: string | null = null;
+let cachedValue: string[] = [];
+
+function isHotkey(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+// parseRaw / readSnapshot / writeRaw / subscribe are the store primitives the
+// hook composes; they are exported for unit testing (mirrors compare-selection).
+export function parseRaw(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isHotkey).slice(0, MAX);
+  } catch {
+    return [];
+  }
+}
+
+export function readSnapshot(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (raw === cachedRaw) return cachedValue;
+    cachedRaw = raw;
+    cachedValue = parseRaw(raw);
+    return cachedValue;
+  } catch {
+    if (cachedRaw === null) return cachedValue;
+    cachedRaw = null;
+    cachedValue = [];
+    return cachedValue;
+  }
+}
+
+export function writeRaw(next: string[]) {
+  if (typeof window === "undefined") return;
+  const clean = next.filter(isHotkey).slice(0, MAX);
+  const raw = JSON.stringify(clean);
+  try {
+    window.localStorage.setItem(KEY, raw);
+  } catch {
+    /* ignore quota errors */
+  }
+  cachedRaw = raw;
+  cachedValue = clean;
+  for (const l of listeners) l();
+}
+
+export function subscribe(l: Listener) {
+  listeners.add(l);
+  if (typeof window !== "undefined") {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === KEY) {
+        cachedRaw = null;
+        cachedValue = [];
+        l();
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      listeners.delete(l);
+      window.removeEventListener("storage", onStorage);
+    };
+  }
+  return () => listeners.delete(l);
+}
+
+const EMPTY: string[] = [];
+
+export function useValidatorCompareSelection() {
+  // Avoid SSR/CSR snapshot mismatch — start empty on the server, hydrate on mount.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  const value = useSyncExternalStore(
+    subscribe,
+    () => (hydrated ? readSnapshot() : EMPTY),
+    () => EMPTY,
+  );
+
+  return {
+    selected: value,
+    max: MAX,
+    has: (hotkey: string) => value.includes(hotkey),
+    toggle: (hotkey: string) => {
+      if (!isHotkey(hotkey)) return;
+      const cur = readSnapshot();
+      if (cur.includes(hotkey)) writeRaw(cur.filter((h) => h !== hotkey));
+      else if (cur.length < MAX) writeRaw([...cur, hotkey]);
+    },
+    remove: (hotkey: string) => writeRaw(readSnapshot().filter((h) => h !== hotkey)),
+    clear: () => writeRaw([]),
+  };
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -26,6 +26,10 @@ import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-form
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";
+import {
+  ValidatorsCompareDrawer,
+  ValidatorCompareToggle,
+} from "@/components/metagraphed/validators-compare-drawer";
 import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
@@ -154,6 +158,8 @@ function ValidatorsPage() {
         </QueryErrorBoundary>
       </div>
       <ApiSourceFooter paths={["/api/v1/validators"]} />
+      {/* #6998: floating compare dock — self-hides when nothing is selected. */}
+      <ValidatorsCompareDrawer />
     </AppShell>
   );
 }
@@ -204,6 +210,9 @@ function ValidatorsTable({
           >
             <thead className="bg-surface/50">
               <tr>
+                <th className="w-8 px-3 py-2">
+                  <span className="sr-only">Add to compare</span>
+                </th>
                 {VALIDATOR_COLUMNS.map((col) => (
                   <th
                     key={col.header}
@@ -229,6 +238,9 @@ function ValidatorsTable({
             <tbody className="divide-y divide-border">
               {validators.map((v) => (
                 <tr key={v.hotkey} className="hover:bg-surface/40">
+                  <td className="px-3 py-2 align-middle">
+                    <ValidatorCompareToggle hotkey={v.hotkey} />
+                  </td>
                   {VALIDATOR_COLUMNS.map((col) => (
                     <td key={col.header} className={col.tdClassName}>
                       {col.cell(v)}


### PR DESCRIPTION
## Summary

Adds a validator-comparison drawer — the validator-side equivalent of the existing subnet compare drawer — so a delegator can put several validators side by side (take rate, estimated APY, nominators, on-chain identity, cross-subnet stake/emission/trust) the same way they can already compare subnets. It's backed by the live `GET /api/v1/compare/validators` route (already exposed via REST + the `compare_validators` MCP tool), which had no UI until now.

## What it mirrors

The whole feature is a faithful hotkey-keyed clone of the subnet pattern (`subnets-compare-drawer.tsx` + `compare-selection.ts`):

- **`validator-compare-selection.ts`** — a tiny localStorage-backed selection store (`useValidatorCompareSelection`), the `string[]`/hotkey sibling of the netuid-keyed subnet store. Survives navigation; caps at 4.
- **`validators-compare-drawer.tsx`** — `ValidatorsCompareDrawer` (a floating bottom dock that expands into a side-by-side table) + `ValidatorCompareToggle` (the per-row add-to-compare checkbox). Rows: Operator (identity/hotkey, links to the validator), Take, Est. APY, Nominators, Total stake, Total emission, Avg trust, Active subnets.
- **`validatorCompareQuery` + `normalizeValidatorComparison`** (queries.ts) — a mirror of `compareQuery`, hitting `/api/v1/compare/validators` with the selected `hotkeys` (and optional `netuid`); a `ValidatorComparison` type (types.ts) mirroring `Compare`. No new data logic — it reuses the route's existing `composeValidatorComparison` shaping.

## Entry points

The `ValidatorCompareToggle` is added to the validators directory: a leading column on the desktop table and the card header on the mobile `ValidatorCardList`. The dock is mounted once on `/validators` and self-hides when nothing is selected — mirroring how the subnet multi-select dock lives on `subnets.index.tsx`, not the detail page.

## Notes

- **Cap = 4** mirrors the subnet drawer and keeps the sticky-column table usable on mobile. The route/MCP tool still accept up to 16 for API/agent callers; only the side-by-side UI caps at 4.
- Reuses design tokens + shared primitives throughout (no one-off styling); the drawer imports only the same `shortHash`/`formatTakePct`/`formatApyPct`/`taoCompact`/`formatNumber` formatters the validators table already uses.

## Verification

- `eslint` — clean (0 errors); `tsc --noEmit` (apps/ui) — 0 errors; `prettier --check` — clean; `vite build` — succeeds.
- `test:e2e` responsive-overflow — all pass (the new table lives in the fixed dock / `overflow-auto`; `/validators` adds no viewport overflow).
- New unit test `validator-compare-selection.test.ts` — 6/6 pass (parse/cap/subscribe/clear).
- The "after" screenshots show the drawer engaged with two real validators (live `/api/v1/compare/validators` data); "before" is `/validators` on `main` (no compare column or dock).

## Changed (7 files, +622)

- `apps/ui/src/lib/metagraphed/validator-compare-selection.ts` (new) + `.test.ts` (new)
- `apps/ui/src/components/metagraphed/validators-compare-drawer.tsx` (new)
- `apps/ui/src/lib/metagraphed/queries.ts`, `types.ts` — query/normalizer/type
- `apps/ui/src/routes/validators.index.tsx` — toggle column + dock mount
- `apps/ui/src/components/metagraphed/validator-card-list.tsx` — card toggle

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6998-validators-compare-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6998
