### PR TITLE
feat(api): add GraphQL parity for curation (#6982)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -39,6 +39,10 @@ import { loadProviderEndpointsList } from "./provider-endpoints-mcp.mjs";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.mjs";
+// #6982: GraphQL parity for GET /api/v1/curation, reusing list_curation's own
+// loader unchanged (same artifact read, filter, sort, and page logic REST and
+// MCP already use) -- not a reimplementation.
+import { loadCurationList } from "./curation-mcp.mjs";
 // #7170: GraphQL parity for the changelog/contracts/health-history REST routes,
 // reusing the same loaders MCP get_changelog/get_contracts/get_health_history
 // already call -- not a reimplementation.
@@ -542,6 +546,8 @@ export const SDL = `
     evidence(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): EvidenceList!
     "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
     profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
+    "Per-subnet curation states -- coverage_level, curation_level, source counts, and review posture for every active subnet. Filter by netuid/coverage_level/curation_level, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/curation."
+    curation(netuid: Int, coverage_level: String, curation_level: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): CurationList!
     "The registry-wide summary: overall subnet count, coverage/curation-level/profile-level counts, recent registry changes, and the most-complete top subnets. A fast orientation for the whole Bittensor application layer. Null when the summary has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the registry_summary MCP/REST shape. Mirrors GET /api/v1/registry/summary."
     registry_summary: JSON
     "The per-provider source-health rollup: for each provider/source, the candidate-surface count and its live/redirected/dead classification, endpoint and RPC-endpoint counts, verification-result count, and an overall status. Null when the rollup has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_source_health MCP/REST shape. Mirrors GET /api/v1/source-health."
@@ -1928,6 +1934,19 @@ export const SDL = `
     date: String
     summary: JSON
     surfaces: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type CurationList {
+    generated_at: String
+    notes: String
+    curation: [JSON!]!
     total: Int!
     returned: Int!
     limit: Int!
@@ -3886,6 +3905,7 @@ export const FIELD_COMPLEXITY = {
   block_events: RELATIONSHIP_FIELD_COMPLEXITY,
   block_chain_events: RELATIONSHIP_FIELD_COMPLEXITY,
   profiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  curation: RELATIONSHIP_FIELD_COMPLEXITY,
   registry_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   source_health: RELATIONSHIP_FIELD_COMPLEXITY,
   lineage: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5634,6 +5654,10 @@ const rootValue = {
   // unsupported filter/sort is a GraphQL error, not a silent default".
   health_history(args, context) {
     return loadHealthHistory(context, args, { readArtifact: loadArtifact });
+  },
+
+  curation(args, context) {
+    return loadCurationList(context, args, { readArtifact });
   },
 
   async health(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2055,6 +2055,92 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
   });
 });
 
+describe("graphql — curation", () => {
+  const CURATION_ROW = {
+    netuid: 7,
+    slug: "allways",
+    name: "Allways",
+    coverage_level: "manifested",
+    curation_level: "maintainer-reviewed",
+    source_count: 3,
+  };
+
+  const CURATION_BLOB = {
+    generated_at: "2026-06-20T00:00:00Z",
+    notes: "test fixture",
+    curation: [
+      CURATION_ROW,
+      {
+        ...CURATION_ROW,
+        netuid: 1,
+        slug: "alpha",
+        name: "Alpha",
+        coverage_level: "probed",
+        source_count: 5,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const filtered = await gql(
+      "{ curation(netuid: 7) { curation total generated_at } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.curation.total, 1);
+    assert.equal(filtered.body.data.curation.curation[0].slug, "allways");
+    assert.equal(
+      filtered.body.data.curation.generated_at,
+      "2026-06-20T00:00:00Z",
+    );
+
+    const paged = await gql(
+      "{ curation(limit: 1) { curation total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.curation.curation.length, 1);
+    assert.equal(paged.body.data.curation.total, 2);
+    assert.equal(paged.body.data.curation.returned, 1);
+    assert.ok(paged.body.data.curation.next_cursor != null);
+  });
+
+  test("filters by coverage_level and sorts by netuid", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const filtered = await gql(
+      '{ curation(coverage_level: "probed") { curation total } }',
+      env,
+    );
+    assert.equal(filtered.body.data.curation.total, 1);
+    assert.equal(filtered.body.data.curation.curation[0].slug, "alpha");
+
+    const sorted = await gql(
+      '{ curation(sort: "netuid", order: "desc") { curation } }',
+      env,
+    );
+    assert.equal(sorted.body.data.curation.curation[0].slug, "allways");
+  });
+
+  test("surfaces an invalid coverage_level as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const { body } = await gql(
+      '{ curation(coverage_level: "bogus") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ curation { total } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.curation, 5);
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({


### PR DESCRIPTION
## What

`GET /api/v1/curation` already has an MCP tool (`list_curation`) but no GraphQL field — an agent using GraphQL alone can't reach the per-subnet curation states that REST and MCP both serve. This closes that gap.

## How

- Adds `Query.curation(netuid, coverage_level, curation_level, sort, order, fields, limit, cursor): CurationList!` to `src/graphql.mjs`, mirroring `profiles`' SDL shape and filter/sort/page surface exactly — the closest existing precedent (same generic `queryCollection` artifact pattern).
- The resolver reuses `loadCurationList` from `src/curation-mcp.mjs` **unchanged** — the same artifact read, filter, sort, and page logic REST and MCP already share — passing the already-imported `readArtifact` as its dep. Not a reimplementation.
- `CurationList` output type mirrors `ProfileList` (`curation: [JSON!]!` passthrough + pagination metadata); `curation` weighted in `FIELD_COMPLEXITY` like its sibling relationship fields.
- An invalid filter/sort/limit/cursor and a cold/absent artifact both surface as GraphQL errors, matching REST/MCP and every sibling field in this file (never a silently substituted default).

## Tests

Five cases in `tests/graphql.test.mjs`: netuid filter + pagination, `coverage_level` filter + sort, invalid-`coverage_level` → GraphQL error, cold artifact → GraphQL error, and the `FIELD_COMPLEXITY` weight. `vitest run tests/graphql.test.mjs` green (826 passed); eslint + prettier clean.

Closes #6982
