### PR TITLE
fix(relay): retry transient Postgres errors in chain-firehose-relay's poll loop

### DIFF
--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -376,6 +376,41 @@ export function computeBackoffDelayMs(
   return Math.min(baseMs * 2 ** attempt, maxMs);
 }
 
+// Codes worth retrying a poll iteration in-process for, rather than crashing the whole relay (#7157):
+// postgres.js's own connection-lifecycle codes (mirrors workers/data-api.mjs's
+// RETRYABLE_CONNECTION_ERROR_CODES -- same underlying Postgres instance, same failure shapes), the raw
+// Node socket codes a dead TCP connection surfaces with on THIS build (this is plain `postgres`, not
+// postgres/cf's Cloudflare polyfill -- a socket 'error' event's native code passes through un-wrapped,
+// which is what a real `Error: read ECONNRESET` event showed), and the Postgres "operator intervention"
+// SQLSTATE class 57 (admin shutdown / crash / cannot connect now -- a real `PostgresError: the database
+// system is shutting down` event was 57P03). Anything outside this set (a syntax error, a constraint
+// violation) is a real bug, not a blip, and should still surface/crash rather than retry forever.
+const CHAIN_FIREHOSE_RETRYABLE_POLL_ERROR_CODES = new Set([
+  "CONNECTION_CLOSED",
+  "CONNECTION_DESTROYED",
+  "CONNECT_TIMEOUT",
+  "CONNECTION_ENDED",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "57P01", // admin_shutdown
+  "57P02", // crash_shutdown
+  "57P03", // cannot_connect_now
+]);
+
+export function isRetryablePollError(error) {
+  return (
+    typeof error?.code === "string" &&
+    CHAIN_FIREHOSE_RETRYABLE_POLL_ERROR_CODES.has(error.code)
+  );
+}
+
+// A transient blip retries indefinitely-ish but bounded per burst -- this many CONSECUTIVE retryable
+// failures (reset by any successful poll) still exits the process, preserving the container-restart
+// safety net for a genuinely stuck connection rather than looping forever.
+export const CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
 // Ceiling on how long a single retry-after value can pause the relay for --
 // protects against a pathological/misconfigured server value stalling the
 // relay indefinitely (a real incident's own root cause was the OPPOSITE
@@ -679,13 +714,38 @@ async function main() {
   }
 
   let lastCleanupAt = Date.now();
+  let consecutivePollFailures = 0; // reset on any successful poll -- see CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES's own comment
   touchHeartbeat(); // write once at startup so HEALTHCHECK's --start-period grace doesn't immediately expire on a quiet first poll
   console.log(
     `[chain-firehose-relay] polling chain_firehose_outbox every ${CHAIN_FIREHOSE_POLL_INTERVAL_MS}ms, forwarding to ${config.ingestUrl}`,
   );
   while (!shuttingDown) {
     const pollStartedAt = Date.now();
-    const { claimed, requestCount, rateLimitedForMs } = await pollOnce();
+    let claimed, requestCount, rateLimitedForMs;
+    try {
+      ({ claimed, requestCount, rateLimitedForMs } = await pollOnce());
+      consecutivePollFailures = 0;
+    } catch (err) {
+      // #7157: a transient connection blip (the Postgres instance restarting, a dropped TCP socket) used
+      // to crash the whole process on the very next query -- retry it in-process with backoff instead,
+      // the same way forwardWithRetry already does for the outbound HTTP leg. A non-retryable error (a
+      // real bug) or a burst that outlasts CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES still falls
+      // through to the crash+container-restart safety net below.
+      if (
+        !isRetryablePollError(err) ||
+        consecutivePollFailures >= CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES
+      ) {
+        throw err;
+      }
+      consecutivePollFailures += 1;
+      console.error(
+        `[chain-firehose-relay] poll failed (${err.code}), retrying in-process (${consecutivePollFailures}/${CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES}): ${err.message}`,
+      );
+      await new Promise((r) =>
+        setTimeout(r, computeBackoffDelayMs(consecutivePollFailures - 1)),
+      );
+      continue;
+    }
     touchHeartbeat(); // tracks poll-loop liveness, independent of claim/forward outcome -- see HEARTBEAT_FILE's own comment
     if (Date.now() - lastCleanupAt >= CHAIN_FIREHOSE_CLEANUP_INTERVAL_MS) {
       await cleanupOnce();

--- a/tests/chain-firehose-relay.test.mjs
+++ b/tests/chain-firehose-relay.test.mjs
@@ -45,6 +45,7 @@ import {
   CHAIN_FIREHOSE_FORWARD_TIMEOUT_MS,
   CHAIN_FIREHOSE_INGEST_BATCH_SIZE,
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
+  CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES,
   CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS,
   CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS,
   CHAIN_FIREHOSE_POLL_BATCH_SIZE,
@@ -59,6 +60,7 @@ import {
   forwardWithRetry,
   initSentry,
   isHeartbeatFresh,
+  isRetryablePollError,
   mapBounded,
   parseRelayConfig,
   parseRetryAfterMs,
@@ -175,6 +177,48 @@ test("computeBackoffDelayMs: doubles per attempt, capped at maxMs", () => {
 test("computeBackoffDelayMs: honors custom baseMs/maxMs", () => {
   assert.equal(computeBackoffDelayMs(1, { baseMs: 100, maxMs: 1000 }), 200);
   assert.equal(computeBackoffDelayMs(10, { baseMs: 100, maxMs: 1000 }), 1000);
+});
+
+// --- isRetryablePollError -----------------------------------------------------
+
+test("isRetryablePollError: true for postgres.js's own connection-lifecycle codes", () => {
+  assert.equal(isRetryablePollError({ code: "CONNECTION_CLOSED" }), true);
+  assert.equal(isRetryablePollError({ code: "CONNECTION_DESTROYED" }), true);
+  assert.equal(isRetryablePollError({ code: "CONNECT_TIMEOUT" }), true);
+  assert.equal(isRetryablePollError({ code: "CONNECTION_ENDED" }), true);
+});
+
+test("isRetryablePollError: true for a raw Node socket error code (e.g. read ECONNRESET)", () => {
+  assert.equal(
+    isRetryablePollError({ code: "ECONNRESET", errno: -104, syscall: "read" }),
+    true,
+  );
+  assert.equal(isRetryablePollError({ code: "ECONNREFUSED" }), true);
+  assert.equal(isRetryablePollError({ code: "ETIMEDOUT" }), true);
+  assert.equal(isRetryablePollError({ code: "EPIPE" }), true);
+});
+
+test("isRetryablePollError: true for Postgres SQLSTATE class 57 (operator intervention)", () => {
+  assert.equal(isRetryablePollError({ code: "57P01" }), true);
+  assert.equal(isRetryablePollError({ code: "57P02" }), true);
+  // real event: PostgresError "the database system is shutting down"
+  assert.equal(isRetryablePollError({ code: "57P03" }), true);
+});
+
+test("isRetryablePollError: false for a real bug (e.g. a syntax error), not just anything thrown", () => {
+  assert.equal(isRetryablePollError({ code: "42601" }), false);
+  assert.equal(isRetryablePollError(new Error("boom")), false); // no .code at all
+});
+
+test("isRetryablePollError: false when error is null/undefined or .code isn't a string", () => {
+  assert.equal(isRetryablePollError(undefined), false);
+  assert.equal(isRetryablePollError(null), false);
+  assert.equal(isRetryablePollError({ code: 42 }), false);
+});
+
+test("CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES is a positive bound, not unlimited", () => {
+  assert.ok(Number.isInteger(CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES));
+  assert.ok(CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES > 0);
 });
 
 // --- computeBatchPaceDelayMs -------------------------------------------------


### PR DESCRIPTION
## Summary

`scripts/chain-firehose-relay.mjs`'s poll loop crashed the whole process on any transient Postgres/network error instead of retrying. Sentry shows `Error: read ECONNRESET` and `PostgresError: the database system is shutting down` (SQLSTATE `57P03`), both culprit `pollOnce`, during a window where the underlying Postgres instance was cycling — each crash triggers a full container restart (fresh `git clone` + `npm ci`).

## What Changed

- Added `isRetryablePollError` (`scripts/chain-firehose-relay.mjs`): classifies postgres.js's own connection-lifecycle codes (mirrors `workers/data-api.mjs`'s `RETRYABLE_CONNECTION_ERROR_CODES` — same underlying Postgres instance, same failure shapes), the raw Node socket codes this build's plain `postgres` package can surface with (e.g. `ECONNRESET`), and the Postgres "operator intervention" SQLSTATE class 57 (admin shutdown / crash / cannot connect now).
- `main()`'s poll loop now catches a failed `pollOnce()`, and for a retryable error, logs, backs off (reusing the existing `computeBackoffDelayMs`), and continues — instead of crashing. A non-retryable error, or more than `CHAIN_FIREHOSE_MAX_CONSECUTIVE_POLL_FAILURES` (5) consecutive retryable ones, still falls through to the existing crash-and-restart path.
- 6 new unit tests for `isRetryablePollError` (postgres.js codes, raw Node codes, SQLSTATE class 57, the negative case for a real bug like a syntax error, and the null/undefined-input edge cases) plus a sanity check on the new bound constant.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7157`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed. (N/A.)
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no API/schema surface touched; this is a standalone deploy script.)

Closes #7157

## Validation

- [x] `npm run test:coverage` — full unsharded suite (335 files) green; the changed file's new code is 100% covered (verified in isolation via `vitest run tests/chain-firehose-relay.test.mjs --coverage`); `main()`'s poll/cleanup loop is pre-existing `/* v8 ignore */`'d (needs a real Postgres connection + process lifecycle, documented at the top of the test file) — the new retry/backoff decision is pulled out into the tested `isRetryablePollError` function instead, matching that file's existing convention for `forwardWithRetry`/`computeBackoffDelayMs`.
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] `npm run lint` / `npm run format:check` (scoped to the 2 changed files)

Not run (orthogonal to this change — no schema/registry/API/contract files touched): `npm run validate`, `validate:schemas`, `validate:api`, `validate:openapi`, `validate:types`, `validate:artifact-budgets`, `validate:docs`, `validate:intake`, `validate:workflows`, `worker:test`. This PR only touches a standalone Node deploy script (`scripts/chain-firehose-relay.mjs`) and its test file.

## Notes

- Root-caused via Sentry triage. A sibling fix (`ecde90f3`, already merged and confirmed deployed) added a similar retry for the Cloudflare Worker side of the same underlying Postgres instance; this closes the same gap for the standalone relay script, which had no error handling around its DB query at all.
