### PR TITLE
feat(api): add GraphQL parity for curation (#6982)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -26,6 +26,10 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.mjs";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.mjs";
+// #6982: GraphQL parity for GET /api/v1/curation, reusing list_curation's own
+// loader unchanged (same artifact read, filter, sort, and page logic REST and
+// MCP already use) -- not a reimplementation.
+import { loadCurationList } from "./curation-mcp.mjs";
 import {
   buildChainAxonRemovals,
   CHAIN_AXON_REMOVALS_WINDOWS,
@@ -518,6 +522,8 @@ export const SDL = `
     lineage: JSON
     "The full catalog of monitored Bittensor base-layer RPC endpoints and their status (each endpoint's URL, network, and probe-derived health/latency), with the same live 15-minute cron RPC-pool overlay REST and MCP apply before serving. Null when the catalog has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the list_rpc_endpoints MCP/REST shape. Mirrors GET /api/v1/rpc/endpoints."
     rpc_endpoints: JSON
+    "Per-subnet curation states -- coverage_level, curation_level, source counts, and review posture for every active subnet. Filter by netuid/coverage_level/curation_level, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/curation."
+    curation(netuid: Int, coverage_level: String, curation_level: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): CurationList!
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
@@ -1801,6 +1807,19 @@ export const SDL = `
   type ProfileList {
     captured_at: String
     profiles: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type CurationList {
+    generated_at: String
+    notes: String
+    curation: [JSON!]!
     total: Int!
     returned: Int!
     limit: Int!
@@ -3761,6 +3780,7 @@ export const FIELD_COMPLEXITY = {
   source_health: RELATIONSHIP_FIELD_COMPLEXITY,
   lineage: RELATIONSHIP_FIELD_COMPLEXITY,
   rpc_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
+  curation: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5383,6 +5403,10 @@ const rootValue = {
     );
     const pool = await readHealthKv(context.env, KV_HEALTH_RPC_POOL);
     return pool ? mergeRpcEndpoints(staticData, pool) : staticData;
+  },
+
+  curation(args, context) {
+    return loadCurationList(context, args, { readArtifact });
   },
 
   async health(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1804,6 +1804,92 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
   });
 });
 
+describe("graphql — curation", () => {
+  const CURATION_ROW = {
+    netuid: 7,
+    slug: "allways",
+    name: "Allways",
+    coverage_level: "manifested",
+    curation_level: "maintainer-reviewed",
+    source_count: 3,
+  };
+
+  const CURATION_BLOB = {
+    generated_at: "2026-06-20T00:00:00Z",
+    notes: "test fixture",
+    curation: [
+      CURATION_ROW,
+      {
+        ...CURATION_ROW,
+        netuid: 1,
+        slug: "alpha",
+        name: "Alpha",
+        coverage_level: "probed",
+        source_count: 5,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const filtered = await gql(
+      "{ curation(netuid: 7) { curation total generated_at } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.curation.total, 1);
+    assert.equal(filtered.body.data.curation.curation[0].slug, "allways");
+    assert.equal(
+      filtered.body.data.curation.generated_at,
+      "2026-06-20T00:00:00Z",
+    );
+
+    const paged = await gql(
+      "{ curation(limit: 1) { curation total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.curation.curation.length, 1);
+    assert.equal(paged.body.data.curation.total, 2);
+    assert.equal(paged.body.data.curation.returned, 1);
+    assert.ok(paged.body.data.curation.next_cursor != null);
+  });
+
+  test("filters by coverage_level and sorts by netuid", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const filtered = await gql(
+      '{ curation(coverage_level: "probed") { curation total } }',
+      env,
+    );
+    assert.equal(filtered.body.data.curation.total, 1);
+    assert.equal(filtered.body.data.curation.curation[0].slug, "alpha");
+
+    const sorted = await gql(
+      '{ curation(sort: "netuid", order: "desc") { curation } }',
+      env,
+    );
+    assert.equal(sorted.body.data.curation.curation[0].slug, "allways");
+  });
+
+  test("surfaces an invalid coverage_level as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({ "/metagraph/curation.json": CURATION_BLOB });
+    const { body } = await gql(
+      '{ curation(coverage_level: "bogus") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ curation { total } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.curation, 5);
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({


### PR DESCRIPTION
## Summary

Closes #6982. `GET /api/v1/curation` (curation states by subnet — coverage_level, curation_level, source counts, review posture) was reachable over REST and MCP (`list_curation`) but had **no GraphQL field**. This adds a full-parity `curation` field, not just an opaque passthrough — it mirrors the REST route's filter/sort/pagination contract exactly.

## Change (`src/graphql.mjs`)

- New `CurationList` SDL type: `curation: [JSON!]!`, `total`/`returned`/`limit`/`cursor`/`next_cursor`/`sort`/`order`/`generated_at`/`notes`.
- New `curation(netuid, coverage_level, curation_level, sort, order, fields, limit, cursor): CurationList!` Query field, resolved via the existing `loadCurationList` from `src/curation-mcp.mjs` (the same function backing the REST route and the `list_curation` MCP tool) — no duplicated business logic.
- An invalid filter/sort/limit/cursor surfaces as a GraphQL error, matching the REST/MCP behavior, not a silently substituted default.
- `RELATIONSHIP_FIELD_COMPLEXITY` entry for `curation`.

## Note on the MCP tool

`list_curation` already exists on `main` (`src/curation-mcp.mjs`) — this PR closes the remaining GraphQL-only gap in #6982 by reusing that same loader, so all three surfaces (REST/MCP/GraphQL) now share one filtering/pagination implementation.

## Tests (`tests/graphql.test.mjs`)

- Filters by `netuid` and paginates.
- Filters by `coverage_level` and sorts by `netuid`.
- An invalid `coverage_level` surfaces as a GraphQL error, not a silent default.
- A cold/missing artifact surfaces as a GraphQL error, matching REST/MCP.
- `FIELD_COMPLEXITY` weight parity with sibling relationship fields.

## Validation run locally

- `npx vitest run tests/graphql.test.mjs` — green (783 tests).
- `npx eslint src/graphql.mjs tests/graphql.test.mjs` — clean.
- `npx prettier --check` — clean.
- `npm run validate` — clean (129 native subnets, 129 curated overlays, 1821 surfaces, 136 providers, 2037 candidates).

## Risk / regen

Pure additive. No contract/OpenAPI regeneration needed: GraphQL has no committed SDL snapshot (served live + introspected dynamically), and `API_ROUTES` is unchanged, so `validate:contract-drift`/`validate:openapi` are unaffected.
