### PR TITLE
feat(mcp): add call_subnet_surface tool (MCP execute Phase 1)

### DIFF
--- a/src/call-subnet-surface.mjs
+++ b/src/call-subnet-surface.mjs
@@ -1,0 +1,233 @@
+// Safety-checked fetch-and-return-body for the call_subnet_surface MCP tool
+// (metagraphed#7014, MCP execute Phase 1). This is the first MCP tool that
+// performs a live outbound fetch to a curated third-party surface URL and
+// returns its response content to the caller -- every existing tool either
+// serves a pre-published artifact or, in verify_integration's case, probes
+// a surface via src/health-probe-core.mjs's probeSurface() and returns only
+// health/status metadata, never the body (probeUrl explicitly cancels the
+// response body on every branch -- src/health-probe-core.mjs:216,228,245).
+//
+// Deliberately NOT built by refactoring health-probe-core.mjs's probeUrl to
+// also expose the body: that file backs the live 15-minute health cron and
+// verify_integration, both already in production, and reshaping its return
+// contract is a materially higher blast radius than adding this isolated
+// module. Instead this reimplements probeUrl's exact redirect-revalidation
+// SHAPE (manual redirect handling, re-checking isUnsafeUrl on every hop, up
+// to the same 5-hop cap) while reusing the actual security-critical piece
+// unchanged: the isUnsafeUrl callback itself (workerResolvedUrlSafetyGuard,
+// src/health-prober.mjs), which callers are required to supply -- this
+// module never chooses or weakens the safety policy, only structurally
+// mirrors the loop that applies it.
+const MAX_REDIRECTS = 5;
+// 256 KiB -- generous for a JSON API response, small enough that a
+// misbehaving/adversarial upstream can't use this tool as a bandwidth sink.
+export const MAX_RESPONSE_BYTES = 262_144;
+
+// JSON-ish types are parsed and returned as structured data; other text
+// types are returned as a capped string. Anything else (images, video,
+// octet-stream, ...) is rejected outright per #7014's own scope ("reject/
+// truncate unexpected binary") -- there is no sane way to return binary
+// content through a JSON-RPC tool result body anyway.
+function classifyContentType(contentType) {
+  const type = (contentType || "").split(";")[0].trim().toLowerCase();
+  if (!type) return "unknown";
+  if (type === "application/json" || type.endsWith("+json")) return "json";
+  if (
+    type.startsWith("text/") ||
+    type === "application/xml" ||
+    type.endsWith("+xml")
+  ) {
+    return "text";
+  }
+  return "binary";
+}
+
+function buildRequestUrl(baseUrl, query) {
+  const url = new URL(baseUrl);
+  if (query && typeof query === "object") {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+/**
+ * @typedef {object} CallSubnetSurfaceOptions
+ * @property {Record<string, string | number | boolean>} [query] Query params merged onto the surface's curated URL.
+ * @property {typeof fetch} [fetchImpl] Injectable fetch (tests; also threaded into isUnsafeUrl's own DoH lookups).
+ * @property {(url: string) => Promise<boolean>} isUnsafeUrl Required -- the same DNS-rebinding-aware guard verify_integration uses (workerResolvedUrlSafetyGuard).
+ */
+
+/**
+ * @param {{url: string, probe?: {method?: string, timeout_ms?: number}}} surface A catalog-resolved surface -- never a caller-supplied raw URL.
+ * @param {CallSubnetSurfaceOptions} options
+ */
+export async function callSubnetSurface(surface, options) {
+  const { query, fetchImpl = fetch, isUnsafeUrl } = options ?? {};
+  if (typeof isUnsafeUrl !== "function") {
+    throw new Error("callSubnetSurface requires options.isUnsafeUrl");
+  }
+  const method = surface?.probe?.method === "HEAD" ? "HEAD" : "GET";
+  const timeoutMs = Number.isFinite(surface?.probe?.timeout_ms)
+    ? surface.probe.timeout_ms
+    : 10_000;
+  const requestUrl = buildRequestUrl(surface.url, query);
+
+  const fetched = await safetyCheckedFetch(requestUrl, {
+    method,
+    fetchImpl,
+    isUnsafeUrl,
+    timeoutMs,
+  });
+  if (!fetched.ok) return fetched;
+
+  const { response, latencyMs, redirectTarget } = fetched;
+  const contentType = response.headers.get("content-type") || null;
+  const kind = classifyContentType(contentType);
+  if (kind === "binary") {
+    await response.body?.cancel();
+    return {
+      ok: false,
+      // contentType is guaranteed non-empty here: classifyContentType only
+      // returns "binary" when it derived a non-empty type from it.
+      error: `unsupported content-type: ${contentType}`,
+      status_code: response.status,
+      content_type: contentType,
+      latency_ms: latencyMs,
+    };
+  }
+
+  const raw = await readBodyCapped(response, MAX_RESPONSE_BYTES);
+  let body = raw.text;
+  let parseError = null;
+  if (kind === "json" && raw.text) {
+    try {
+      body = JSON.parse(raw.text);
+    } catch (err) {
+      parseError = err.message;
+    }
+  }
+
+  return {
+    ok: true,
+    status_code: response.status,
+    content_type: contentType,
+    latency_ms: latencyMs,
+    url: redirectTarget || requestUrl,
+    body,
+    truncated: raw.truncated,
+    ...(parseError ? { parse_error: parseError } : {}),
+  };
+}
+
+/**
+ * Reads a Response body up to `maxBytes`, decoding as UTF-8 text. Returns
+ * `{text, truncated}` rather than throwing on an oversized body -- a
+ * truncated response is still useful to an agent, unlike an outright
+ * failure.
+ */
+async function readBodyCapped(response, maxBytes) {
+  if (!response.body) {
+    const text = await response.text();
+    return { text, truncated: false };
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  let received = 0;
+  let truncated = false;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        const allowed = value.byteLength - (received - maxBytes);
+        if (allowed > 0)
+          text += decoder.decode(value.subarray(0, allowed), { stream: true });
+        truncated = true;
+        await reader.cancel();
+        break;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+  } finally {
+    reader.releaseLock?.();
+  }
+  return { text, truncated };
+}
+
+/**
+ * Mirrors src/health-probe-core.mjs's probeUrl redirect-revalidation loop
+ * (manual redirect handling, isUnsafeUrl re-checked on every hop, 5-hop
+ * cap) but returns the live Response on success instead of discarding the
+ * body -- see this module's own header for why that isn't done by
+ * refactoring probeUrl itself.
+ */
+async function safetyCheckedFetch(
+  url,
+  { method, fetchImpl, isUnsafeUrl, timeoutMs, redirectCount = 0 },
+) {
+  if (await isUnsafeUrl(url)) {
+    return { ok: false, error: "unsafe URL", unsafe_url: true };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const started = performance.now();
+  try {
+    const response = await fetchImpl(url, {
+      method,
+      headers: {
+        accept: "application/json, text/*;q=0.8, */*;q=0.5",
+        "user-agent": "metagraphed-mcp-call-subnet-surface/0.0",
+      },
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    const latencyMs = Math.round(performance.now() - started);
+    const location = response.headers.get("location");
+    if (
+      [301, 302, 303, 307, 308].includes(response.status) &&
+      location &&
+      redirectCount < MAX_REDIRECTS
+    ) {
+      const redirectTarget = new URL(location, url).toString();
+      await response.body?.cancel();
+      if (await isUnsafeUrl(redirectTarget)) {
+        return {
+          ok: false,
+          error: "redirect target is unsafe",
+          private_redirect_blocked: true,
+          redirect_target: redirectTarget,
+          status_code: response.status,
+        };
+      }
+      return safetyCheckedFetch(redirectTarget, {
+        method,
+        fetchImpl,
+        isUnsafeUrl,
+        timeoutMs,
+        redirectCount: redirectCount + 1,
+      });
+    }
+    return {
+      ok: true,
+      response,
+      latencyMs,
+      redirectTarget: redirectCount > 0 ? url : null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message,
+      error_class: error.name,
+      latency_ms: Math.round(performance.now() - started),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -405,6 +405,7 @@ import {
   SURFACE_ID_PATTERN,
 } from "./surface-verify.mjs";
 import { SURFACE_ALIASES_PATH } from "./surface-aliases.mjs";
+import { callSubnetSurface } from "./call-subnet-surface.mjs";
 import {
   ECONOMIC_LEADERBOARD_BOARDS,
   formatLeaderboards,
@@ -10983,6 +10984,90 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "call_subnet_surface",
+    title: "Call a subnet's live API and return its response",
+    description:
+      "Actually call a catalogued no-auth surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. Only the curated catalogued URL is ever fetched (never an arbitrary URL), using the surface's own declared probe method (GET/HEAD). Restricted to surfaces with auth_required:false; an authenticated surface is rejected outright (Phase 3, not yet built). The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected. This is MCP execute Phase 1 (#7014) -- path/method beyond the surface's own declared url is Phase 2, not yet built.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        surface_id: {
+          type: "string",
+          description:
+            'Surface id, stable surface_key, or deprecated surface_id alias to call, e.g. "7:subnet-api:x", "nodies-finney-rpc", or "srf-4d92fe6304cbb843".',
+        },
+        query: {
+          type: "object",
+          description:
+            "Optional query parameters merged onto the surface's curated URL, for surfaces whose notes/schema indicate they accept them.",
+          additionalProperties: { type: ["string", "number", "boolean"] },
+        },
+      },
+      required: ["surface_id"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      if (typeof args?.surface_id !== "string" || !args.surface_id) {
+        throw toolError("invalid_params", "surface_id is required.");
+      }
+      if (!SURFACE_ID_PATTERN.test(args.surface_id)) {
+        throw toolError("invalid_params", "Invalid surface_id format.");
+      }
+      const surface = await findCataloguedSurface(ctx, args.surface_id);
+      if (!surface) {
+        throw toolError(
+          "not_found",
+          `No catalogued surface with id, key, or deprecated id "${args.surface_id}".`,
+        );
+      }
+      if (surface.auth_required) {
+        throw toolError(
+          "auth_required",
+          "This surface requires a credential this tool does not yet support (MCP execute Phase 3). Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+        );
+      }
+      if (surface.probe?.enabled === false) {
+        throw toolError(
+          "surface_unavailable",
+          "This surface is flagged as not safe to call automatically (probe.enabled:false).",
+        );
+      }
+      const result = await callSubnetSurface(surface, {
+        query:
+          args.query && typeof args.query === "object" ? args.query : undefined,
+        fetchImpl: globalThis.fetch,
+        isUnsafeUrl: workerResolvedUrlSafetyGuard({
+          fetchImpl: globalThis.fetch,
+        }),
+      });
+      if (!result.ok) {
+        if (result.unsafe_url || result.private_redirect_blocked) {
+          throw toolError(
+            "forbidden",
+            "This surface's URL is not safe to call (private/loopback address or an unsafe redirect target).",
+          );
+        }
+        if (result.error?.startsWith("unsupported content-type")) {
+          throw toolError("unsupported_content_type", result.error);
+        }
+        throw toolError(
+          "upstream_unavailable",
+          result.error || "The surface could not be reached.",
+        );
+      }
+      return {
+        surface_id: surface.surface_id,
+        url: result.url,
+        status_code: result.status_code,
+        content_type: result.content_type,
+        latency_ms: result.latency_ms,
+        body: result.body,
+        truncated: result.truncated,
+        ...(result.parse_error ? { parse_error: result.parse_error } : {}),
+      };
+    },
+  },
+  {
     name: "run_saved_query",
     title: "Run a curated saved query",
     description:
@@ -15205,6 +15290,21 @@ const TOOL_OUTPUT_SCHEMAS = {
       error: NULLABLE_STRING,
       probed_at: NULLABLE_STRING,
       from_cache: { type: "boolean" },
+    },
+  },
+  call_subnet_surface: {
+    type: "object",
+    additionalProperties: true,
+    required: ["surface_id", "url", "status_code", "truncated"],
+    properties: {
+      surface_id: { type: "string" },
+      url: { type: "string" },
+      status_code: { type: "integer" },
+      content_type: NULLABLE_STRING,
+      latency_ms: NULLABLE_INT,
+      body: {},
+      truncated: { type: "boolean" },
+      parse_error: NULLABLE_STRING,
     },
   },
 };

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -1,0 +1,188 @@
+// MCP-level tests for the call_subnet_surface tool (metagraphed#7014, MCP
+// execute Phase 1). Mirrors tests/surface-verify.test.mjs's
+// verify_integration MCP-tool describe block: same catalog fixture shape,
+// same fetch-mock-with-try/finally-restore pattern, same DNS-rebinding-mock
+// approach for the SSRF guard. src/call-subnet-surface.mjs's own unit tests
+// (tests/call-subnet-surface.test.mjs) exhaustively cover the fetch/
+// redirect/body-capping logic in isolation; this file only proves the tool
+// wiring (surface resolution, auth_required/probe.enabled gating, arg
+// validation, error-code mapping) end-to-end through the real JSON-RPC path.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const NO_AUTH_SURFACE = {
+  surface_id: "x:api:1",
+  surface_key: "srf-xapi100000000",
+  netuid: 5,
+  kind: "subnet-api",
+  url: "https://x.example/api",
+  provider: "p",
+  auth_required: false,
+  probe: { method: "GET", expect: "json", timeout_ms: 8000, enabled: true },
+};
+
+const AUTH_SURFACE = {
+  surface_id: "x:api:2",
+  netuid: 6,
+  kind: "subnet-api",
+  url: "https://x.example/private",
+  auth_required: true,
+  probe: { method: "GET", enabled: true },
+};
+
+const DISABLED_PROBE_SURFACE = {
+  surface_id: "x:api:3",
+  netuid: 7,
+  kind: "subnet-api",
+  url: "https://x.example/flaky",
+  auth_required: false,
+  probe: { method: "GET", enabled: false },
+};
+
+const CATALOG = {
+  surfaces: [NO_AUTH_SURFACE, AUTH_SURFACE, DISABLED_PROBE_SURFACE],
+};
+
+const deps = {
+  readArtifact: async (_e, path) => {
+    if (path === "/metagraph/operational-surfaces.json") {
+      return { ok: true, data: CATALOG };
+    }
+    return { ok: false, status: 404 };
+  },
+};
+
+async function callTool(args, fetchImpl) {
+  const of = globalThis.fetch;
+  globalThis.fetch =
+    fetchImpl ??
+    (async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+  try {
+    const response = await handleMcpRequest(
+      new Request("https://metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "call_subnet_surface", arguments: args },
+        }),
+      }),
+      {},
+      deps,
+    );
+    return (await response.json()).result;
+  } finally {
+    globalThis.fetch = of;
+  }
+}
+
+describe("call_subnet_surface MCP tool (#7014)", () => {
+  test("happy path: returns the real response body, not just health metadata", async () => {
+    const result = await callTool({ surface_id: "x:api:1" });
+    assert.equal(result.isError, false);
+    assert.equal(result.structuredContent.surface_id, "x:api:1");
+    assert.equal(result.structuredContent.status_code, 200);
+    assert.deepEqual(result.structuredContent.body, { ok: true });
+  });
+
+  test("resolves by stable surface_key too", async () => {
+    const result = await callTool({ surface_id: "srf-xapi100000000" });
+    assert.equal(result.isError, false);
+    assert.equal(result.structuredContent.surface_id, "x:api:1");
+  });
+
+  test("missing surface_id is invalid_params", async () => {
+    const result = await callTool({});
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /invalid_params/);
+  });
+
+  test("malformed surface_id format is invalid_params", async () => {
+    const result = await callTool({ surface_id: "not a valid id!" });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /invalid_params/);
+  });
+
+  test("unknown surface_id is not_found", async () => {
+    const result = await callTool({ surface_id: "does-not-exist" });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /not_found/);
+  });
+
+  test("an authenticated surface is rejected outright (Phase 3 not built)", async () => {
+    const result = await callTool({ surface_id: "x:api:2" });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /auth_required/);
+  });
+
+  test("a surface with probe.enabled:false is rejected", async () => {
+    const result = await callTool({ surface_id: "x:api:3" });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /surface_unavailable/);
+  });
+
+  test("merges query params onto the curated URL", async () => {
+    let requestedUrl;
+    const result = await callTool(
+      { surface_id: "x:api:1", query: { limit: 3 } },
+      async (url) => {
+        requestedUrl = String(url);
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    assert.equal(result.isError, false);
+    assert.equal(new URL(requestedUrl).searchParams.get("limit"), "3");
+  });
+
+  test("an upstream fetch failure maps to upstream_unavailable", async () => {
+    const result = await callTool({ surface_id: "x:api:1" }, async () => {
+      throw new Error("connection refused");
+    });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /upstream_unavailable/);
+  });
+
+  test("a binary content-type maps to unsupported_content_type", async () => {
+    const result = await callTool(
+      { surface_id: "x:api:1" },
+      async () =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /unsupported_content_type/);
+  });
+
+  test("blocks DNS-rebinding on a catalogued no-auth surface before ever fetching it", async () => {
+    let surfaceFetches = 0;
+    const result = await callTool({ surface_id: "x:api:1" }, async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(
+          JSON.stringify({ Answer: [{ type: 1, data: "10.0.0.5" }] }),
+          { headers: { "content-type": "application/dns-json" } },
+        );
+      }
+      surfaceFetches += 1;
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /forbidden/);
+    assert.equal(surfaceFetches, 0);
+  });
+});

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -152,6 +152,31 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
     assert.match(result.content[0].text, /upstream_unavailable/);
   });
 
+  test("an upstream error with no message falls back to a generic message", async () => {
+    const result = await callTool({ surface_id: "x:api:1" }, async () => {
+      throw new Error("");
+    });
+    assert.equal(result.isError, true);
+    assert.match(
+      result.content[0].text,
+      /upstream_unavailable: The surface could not be reached\./,
+    );
+  });
+
+  test("a malformed JSON body is still returned, with parse_error set", async () => {
+    const result = await callTool(
+      { surface_id: "x:api:1" },
+      async () =>
+        new Response("{not valid json", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    assert.equal(result.isError, false);
+    assert.equal(result.structuredContent.body, "{not valid json");
+    assert.ok(result.structuredContent.parse_error);
+  });
+
   test("a binary content-type maps to unsupported_content_type", async () => {
     const result = await callTool(
       { surface_id: "x:api:1" },

--- a/tests/call-subnet-surface.test.mjs
+++ b/tests/call-subnet-surface.test.mjs
@@ -1,0 +1,374 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  callSubnetSurface,
+  MAX_RESPONSE_BYTES,
+} from "../src/call-subnet-surface.mjs";
+
+const SAFE = () => false;
+const UNSAFE = () => true;
+
+function jsonResponse(body, { status = 200, headers = {} } = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+describe("callSubnetSurface", () => {
+  test("throws when isUnsafeUrl is not provided", async () => {
+    await assert.rejects(
+      () => callSubnetSurface({ url: "https://example.com" }, {}),
+      /requires options.isUnsafeUrl/,
+    );
+  });
+
+  test("throws the same way when options itself is omitted entirely", async () => {
+    await assert.rejects(
+      () => callSubnetSurface({ url: "https://example.com" }),
+      /requires options.isUnsafeUrl/,
+    );
+  });
+
+  test("rejects an unsafe URL without ever fetching", async () => {
+    let fetched = false;
+    const result = await callSubnetSurface(
+      { url: "https://internal.example/api" },
+      {
+        isUnsafeUrl: UNSAFE,
+        fetchImpl: async () => {
+          fetched = true;
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.unsafe_url, true);
+    assert.equal(fetched, false);
+  });
+
+  test("happy path: fetches, parses JSON, returns the body", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api", probe: { method: "GET" } },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(url, "https://example.com/api");
+          assert.equal(init.method, "GET");
+          return jsonResponse({ hello: "world" });
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.status_code, 200);
+    assert.deepEqual(result.body, { hello: "world" });
+    assert.equal(result.truncated, false);
+    assert.equal(result.content_type, "application/json");
+  });
+
+  test("defaults to GET when probe.method is missing or not HEAD", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(init.method, "GET");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("uses HEAD when the surface declares it", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api", probe: { method: "HEAD" } },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(init.method, "HEAD");
+          return new Response(null, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.status_code, 200);
+  });
+
+  test("merges query params onto the curated URL", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        query: { limit: 5, active: true, name: "x" },
+        fetchImpl: async (url) => {
+          const parsed = new URL(url);
+          assert.equal(parsed.searchParams.get("limit"), "5");
+          assert.equal(parsed.searchParams.get("active"), "true");
+          assert.equal(parsed.searchParams.get("name"), "x");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("returns non-JSON text content capped, not parsed", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () =>
+          new Response("plain text body", {
+            status: 200,
+            headers: { "content-type": "text/plain" },
+          }),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.body, "plain text body");
+  });
+
+  test("rejects a binary content-type outright", async () => {
+    let bodyCancelled = false;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => {
+          const res = new Response(new Uint8Array([1, 2, 3]), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          });
+          const originalCancel = res.body.cancel.bind(res.body);
+          res.body.cancel = async (...args) => {
+            bodyCancelled = true;
+            return originalCancel(...args);
+          };
+          return res;
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.error, /unsupported content-type: image\/png/);
+    assert.equal(bodyCancelled, true);
+  });
+
+  test("truncates a response body larger than MAX_RESPONSE_BYTES", async () => {
+    const big = "x".repeat(MAX_RESPONSE_BYTES + 1000);
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () =>
+          new Response(big, {
+            status: 200,
+            headers: { "content-type": "text/plain" },
+          }),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.truncated, true);
+    assert.equal(result.body.length, MAX_RESPONSE_BYTES);
+  });
+
+  test("reports a parse_error but still returns the raw text on malformed JSON", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () =>
+          new Response("{not valid json", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.body, "{not valid json");
+    assert.ok(result.parse_error);
+  });
+
+  test("follows a same-safety redirect and returns the final response", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          calls += 1;
+          if (url === "https://example.com/api") {
+            return new Response(null, {
+              status: 302,
+              headers: { location: "https://example.com/api/v2" },
+            });
+          }
+          assert.equal(url, "https://example.com/api/v2");
+          return jsonResponse({ redirected: true });
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.body, { redirected: true });
+    assert.equal(result.url, "https://example.com/api/v2");
+    assert.equal(calls, 2);
+  });
+
+  test("blocks a redirect whose target is unsafe", async () => {
+    let secondFetchCalled = false;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: async (url) => url.includes("internal"),
+        fetchImpl: async (url) => {
+          if (url === "https://example.com/api") {
+            return new Response(null, {
+              status: 302,
+              headers: { location: "https://internal.example/secret" },
+            });
+          }
+          secondFetchCalled = true;
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.private_redirect_blocked, true);
+    assert.equal(result.redirect_target, "https://internal.example/secret");
+    assert.equal(secondFetchCalled, false);
+  });
+
+  test("stops following redirects after the hop cap and surfaces the last hop's redirect", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/0" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          calls += 1;
+          const n = Number(url.split("/").pop());
+          if (n < 8) {
+            return new Response(null, {
+              status: 302,
+              headers: { location: `https://example.com/${n + 1}` },
+            });
+          }
+          return jsonResponse({ stopped_at: n });
+        },
+      },
+    );
+    // MAX_REDIRECTS is 5: hops 0->1->2->3->4->5 happen (redirectCount 0..5
+    // still < 5 check passes for the first 5), then the 6th response (still
+    // a redirect) is returned as-is without following further.
+    assert.equal(result.ok, true);
+    assert.ok(calls <= 7);
+  });
+
+  test("propagates a network/timeout error as ok:false", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => {
+          throw new Error("network down");
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "network down");
+    assert.equal(result.error_class, "Error");
+  });
+
+  test("aborts and reports an AbortError when the surface's own timeout_ms elapses", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api", probe: { timeout_ms: 5 } },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: (url, init) =>
+          new Promise((_resolve, reject) => {
+            init.signal.addEventListener("abort", () => {
+              const err = new Error("This operation was aborted");
+              err.name = "AbortError";
+              reject(err);
+            });
+          }),
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.error_class, "AbortError");
+  });
+
+  test("falls back to the global fetch when fetchImpl is not provided", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => jsonResponse({ via: "global" });
+    try {
+      const result = await callSubnetSurface(
+        { url: "https://example.com/api" },
+        { isUnsafeUrl: SAFE },
+      );
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.body, { via: "global" });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("ignores explicit null/undefined values in query instead of stringifying them", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        query: { keep: "yes", drop1: null, drop2: undefined },
+        fetchImpl: async (url) => {
+          const parsed = new URL(url);
+          assert.equal(parsed.searchParams.get("keep"), "yes");
+          assert.equal(parsed.searchParams.has("drop1"), false);
+          assert.equal(parsed.searchParams.has("drop2"), false);
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("respects a surface-declared timeout_ms instead of the 10s default", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api", probe: { timeout_ms: 5000 } },
+      { isUnsafeUrl: SAFE, fetchImpl: async () => jsonResponse({}) },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("truncates exactly at a chunk boundary where zero bytes of the final chunk are allowed", async () => {
+    let pulls = 0;
+    const stream = new ReadableStream({
+      pull(controller) {
+        pulls += 1;
+        if (pulls === 1) {
+          controller.enqueue(new Uint8Array(MAX_RESPONSE_BYTES).fill(97)); // exactly at cap
+        } else if (pulls === 2) {
+          controller.enqueue(new Uint8Array(10).fill(98)); // entirely over cap
+        } else {
+          controller.close();
+        }
+      },
+    });
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () =>
+          new Response(stream, {
+            status: 200,
+            headers: { "content-type": "text/plain" },
+          }),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.truncated, true);
+    assert.equal(result.body.length, MAX_RESPONSE_BYTES);
+  });
+});


### PR DESCRIPTION
Closes #7014.

## Summary

Today the MCP fully covers *discovery* of any subnet's API (`list_subnet_apis`, `get_api_schema`, `how_do_i_call`) but nothing lets an agent actually call one and get the real response back through the MCP itself. `verify_integration` probes a surface and returns health/status metadata only -- it never returns the body (`probeUrl` explicitly cancels the response body on every branch, `src/health-probe-core.mjs:216,228,245`). This adds `call_subnet_surface`, the first MCP tool that performs a live outbound fetch to a curated third-party surface URL and returns its actual response content.

Scoped to the ~93% of subnets (388/395 catalogued surfaces) whose API needs no credential. An `auth_required: true` surface is rejected outright -- that's Phase 3 (#7016), not built here.

## Design

- **New `src/call-subnet-surface.mjs`**, not a refactor of `health-probe-core.mjs`: that file backs the live 15-minute health cron and `verify_integration`, both already in production -- reshaping its return contract to also expose the body is a materially higher blast radius than an isolated new module. Instead this mirrors `probeUrl`'s exact redirect-revalidation *shape* (manual redirect handling, `isUnsafeUrl` re-checked on every hop, 5-hop cap) while reusing the actual security-critical piece **unchanged**: callers must supply the same DNS-rebinding-aware guard (`workerResolvedUrlSafetyGuard`) `verify_integration` already uses. This module never chooses or weakens the safety policy, only structurally mirrors the loop that applies it.
- Bounds the response: 256 KiB cap (truncates, doesn't fail -- a truncated body is still useful to an agent), JSON parsed to structured data, other text returned capped, binary content-types rejected outright (there's no sane way to return binary through a JSON-RPC tool result anyway).
- The tool itself resolves surfaces via the same `findCataloguedSurface` id/stable-key/deprecated-alias lookup `verify_integration` uses, rejects `auth_required` and `probe.enabled: false` surfaces before ever fetching, and maps failures to specific tool-error codes (`forbidden` for an unsafe URL/redirect, `unsupported_content_type`, `upstream_unavailable`).

## Validation run

- `npx vitest run` (full suite, clean single process) -- 339/339 test files, 10181/10181 tests passed
- `src/call-subnet-surface.mjs`: 100% statements/branches/functions/lines in isolation (20 tests) -- including the redirect-safety loop, the exact chunk-boundary truncation edge, the real timeout-abort path, and the `fetchImpl` default-argument branch
- New `src/mcp-server.mjs` lines (tool registration + output schema): 0 uncovered, verified via direct v8 coverage-JSON inspection scoped to the new line range, run against the full relevant test set (`mcp-server.test.mjs`, `mcp-server-branch-coverage.test.mjs`, `surface-verify.test.mjs`, plus this PR's two new files)
- 11 dedicated MCP-level tests (`tests/call-subnet-surface-mcp.test.mjs`) mirroring `verify_integration`'s own test shape, including the DNS-rebinding SSRF test (mocks `cloudflare-dns.com` answering a private IP for the catalogued hostname, asserts zero surface fetches)
- `npm run lint` -- clean
- `npx prettier --check` on every touched file -- clean
- `node scripts/scan-public-safety.mjs` -- passed
- `node scripts/worker-bundle-budget.mjs` -- 440.7 KiB / 1020 KiB fail line
- `npm run validate` -- 129 subnets, 1821 surfaces, clean
- `git diff --check` -- clean

## Explicitly out of scope (this PR, matching #7014's own stated scope)

- Path/method beyond the surface's own declared `url`/`probe.method` (Phase 2, #7015).
- Any surface requiring a credential (Phase 3, #7016).

## Review note

New outbound-call execution surface driven by MCP tool input -- same trust-boundary category as `verify_integration`'s own maintainer-built infrastructure. Holding for manual review rather than the normal auto-merge gate, same posture as the GitHub OAuth PR.