### PR TITLE
fix(ci): fall back to Sentry release when Cloudflare deploy annotation is missing

### DIFF
--- a/.github/workflows/check-worker-deploy-drift.yml
+++ b/.github/workflows/check-worker-deploy-drift.yml
@@ -12,6 +12,14 @@ name: Check Worker Deploy Drift
 # prior scheduled run (see scripts/check-worker-deploy-drift.mjs for the exact
 # grace-window rule -- this only needs to catch a genuinely stuck build, not race a
 # normal in-flight deploy).
+#
+# SENTRY_AUTH_TOKEN (same repo secret ui-sentry-release.yml already uses) is a
+# fallback: if the Cloudflare Deployments API doesn't have a workers/commit_hash
+# annotation for the active deployment, the script falls back to the deployed
+# commit SHA that @sentry/cloudflare's withSentry() already tags every production
+# error event with (workers/api.sentry.mjs), which is independent of Cloudflare's
+# own deployment bookkeeping. Optional: omitting the secret just removes the
+# fallback, not the primary check.
 on:
   schedule:
     - cron: "53 8 * * *"
@@ -60,3 +68,6 @@ jobs:
           MAIN_HEAD_SHA: ${{ steps.main-head.outputs.sha }}
           MAIN_HEAD_COMMITTED_AT: ${{ steps.main-head.outputs.committed_at }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: jsonbored
+          SENTRY_PROJECT: metagraphed

--- a/scripts/check-worker-deploy-drift.mjs
+++ b/scripts/check-worker-deploy-drift.mjs
@@ -11,6 +11,14 @@ import { fileURLToPath } from "node:url";
 
 const DEPLOYMENTS_PATH_TEMPLATE =
   "https://api.cloudflare.com/client/v4/accounts/{accountId}/workers/scripts/{scriptName}/deployments";
+const SENTRY_RELEASES_PATH_TEMPLATE =
+  "https://sentry.io/api/0/projects/{org}/{project}/releases/";
+// A bare 40-hex-char git SHA is a real production release's version (see
+// workers/api.sentry.mjs's `release: env.SENTRY_RELEASE || ...`). PR-preview
+// deploys (apps/ui/.github/workflows/ui-preview-deploy.yml) tag releases
+// "<sha>-preview" -- excluded so a preview build is never mistaken for what's
+// actually live in production.
+const PRODUCTION_RELEASE_VERSION_PATTERN = /^[0-9a-f]{40}$/i;
 
 export function extractDeployedCommitSha(deploymentsJson) {
   const deployments = deploymentsJson?.result?.deployments;
@@ -27,6 +35,52 @@ export function extractDeployedCommitSha(deploymentsJson) {
     );
   }
   return commitSha;
+}
+
+// Fallback for when Cloudflare's Deployments API doesn't populate the
+// workers/commit_hash annotation even though Workers Builds is genuinely
+// deploying on every push (confirmed live, 2026-07-20): @sentry/cloudflare's
+// withSentry() (workers/api.sentry.mjs) already tags every production error
+// event with the real deployed commit SHA as its Sentry release, independent
+// of Cloudflare's own deployment bookkeeping. Sorts by dateCreated rather than
+// trusting response order, since that isn't documented/guaranteed.
+export function selectLatestProductionRelease(releases) {
+  if (!Array.isArray(releases)) {
+    return null;
+  }
+  const candidates = releases.filter(
+    (release) =>
+      typeof release?.version === "string" &&
+      PRODUCTION_RELEASE_VERSION_PATTERN.test(release.version),
+  );
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(
+    (a, b) =>
+      new Date(b.dateCreated).getTime() - new Date(a.dateCreated).getTime(),
+  )[0];
+}
+
+export async function findLatestProductionReleaseCommit({
+  sentryAuthToken,
+  sentryOrg,
+  sentryProject,
+}) {
+  const releasesUrl = SENTRY_RELEASES_PATH_TEMPLATE.replace(
+    "{org}",
+    sentryOrg,
+  ).replace("{project}", sentryProject);
+  const res = await fetch(releasesUrl, {
+    headers: { Authorization: `Bearer ${sentryAuthToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Sentry releases API returned HTTP ${res.status}: ${await res.text()}`,
+    );
+  }
+  const latest = selectLatestProductionRelease(await res.json());
+  return latest?.version ?? null;
 }
 
 export function findPreviousScheduledRunAt(runsJson, currentRunId) {
@@ -135,9 +189,38 @@ async function main() {
   let deployedCommitSha;
   try {
     deployedCommitSha = extractDeployedCommitSha(await deploymentsRes.json());
-  } catch (error) {
-    console.error(`::error::${error.message}`);
-    return 1;
+  } catch (cfError) {
+    // Fall back to Sentry's release tracking (see findLatestProductionReleaseCommit
+    // above) rather than failing outright -- this is what actually let a maintainer
+    // confirm live code was current while this annotation gap was unresolved.
+    const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
+    if (!sentryAuthToken) {
+      console.error(`::error::${cfError.message}`);
+      return 1;
+    }
+    console.error(
+      `::warning::${cfError.message} -- falling back to Sentry's latest release commit.`,
+    );
+    try {
+      deployedCommitSha = await findLatestProductionReleaseCommit({
+        sentryAuthToken,
+        sentryOrg: process.env.SENTRY_ORG || "jsonbored",
+        sentryProject: process.env.SENTRY_PROJECT || "metagraphed",
+      });
+    } catch (sentryError) {
+      console.error(`::error::${cfError.message}`);
+      console.error(
+        `::error::Sentry fallback also failed: ${sentryError.message}`,
+      );
+      return 1;
+    }
+    if (!deployedCommitSha) {
+      console.error(`::error::${cfError.message}`);
+      console.error(
+        "::error::Sentry fallback found no production release either.",
+      );
+      return 1;
+    }
   }
 
   let previousScheduledRunAt = null;

--- a/tests/check-worker-deploy-drift.test.mjs
+++ b/tests/check-worker-deploy-drift.test.mjs
@@ -4,6 +4,7 @@ import {
   evaluateDeployDrift,
   extractDeployedCommitSha,
   findPreviousScheduledRunAt,
+  selectLatestProductionRelease,
 } from "../scripts/check-worker-deploy-drift.mjs";
 
 describe("extractDeployedCommitSha", () => {
@@ -34,6 +35,54 @@ describe("extractDeployedCommitSha", () => {
         }),
       /no workers\/commit_hash annotation/,
     );
+  });
+});
+
+describe("selectLatestProductionRelease", () => {
+  const shaA = "a".repeat(40);
+  const shaB = "b".repeat(40);
+
+  test("picks the most recently created bare-SHA release", () => {
+    const release = selectLatestProductionRelease([
+      { version: shaA, dateCreated: "2026-07-19T00:00:00Z" },
+      { version: shaB, dateCreated: "2026-07-20T00:00:00Z" },
+    ]);
+    assert.equal(release.version, shaB);
+  });
+
+  test("excludes PR-preview releases even if more recent", () => {
+    // apps/ui's ui-preview-deploy.yml tags preview deploys "<sha>-preview" --
+    // a preview build must never be mistaken for what's live in production.
+    const release = selectLatestProductionRelease([
+      { version: shaA, dateCreated: "2026-07-19T00:00:00Z" },
+      { version: `${shaB}-preview`, dateCreated: "2026-07-20T00:00:00Z" },
+    ]);
+    assert.equal(release.version, shaA);
+  });
+
+  test("excludes non-SHA-shaped versions (e.g. a Cloudflare version UUID)", () => {
+    const release = selectLatestProductionRelease([
+      {
+        version: "c40c4e0e-5143-4207-ac02-7b94edebb4d2",
+        dateCreated: "2026-07-20T00:00:00Z",
+      },
+      { version: shaA, dateCreated: "2026-07-19T00:00:00Z" },
+    ]);
+    assert.equal(release.version, shaA);
+  });
+
+  test("returns null when no release is a bare production SHA", () => {
+    assert.equal(
+      selectLatestProductionRelease([
+        { version: `${shaA}-preview`, dateCreated: "2026-07-20T00:00:00Z" },
+      ]),
+      null,
+    );
+  });
+
+  test("tolerates a non-array input", () => {
+    assert.equal(selectLatestProductionRelease(undefined), null);
+    assert.equal(selectLatestProductionRelease(null), null);
   });
 });
 


### PR DESCRIPTION
## Summary

- `Check Worker Deploy Drift` has failed every scheduled run since at least 2026-07-15 with `... has no workers/commit_hash annotation -- Workers Builds may not be linked to git for this script`.
- The code deploy itself is fine (a specific commit was independently confirmed live via Sentry release tags on 2026-07-20) — Cloudflare's Deployments API just isn't populating that one annotation. This makes the drift check resilient to that gap instead of failing outright.

## What Changed

- `scripts/check-worker-deploy-drift.mjs`: when `extractDeployedCommitSha` throws (missing annotation, or no deployments), fall back to Sentry's Releases API for the most recent bare-40-hex-char-SHA release (`selectLatestProductionRelease`/`findLatestProductionReleaseCommit`), excluding `apps/ui`'s `<sha>-preview` PR-preview releases and any non-SHA-shaped version (e.g. a Cloudflare version UUID). `@sentry/cloudflare`'s `withSentry()` (`workers/api.sentry.mjs`) already tags every production error event with the real deployed commit SHA as its Sentry release, independent of Cloudflare's own deployment bookkeeping.
- `.github/workflows/check-worker-deploy-drift.yml`: pass `SENTRY_AUTH_TOKEN` (same secret `ui-sentry-release.yml` already uses), `SENTRY_ORG`, `SENTRY_PROJECT` through. The fallback is optional — no token just means no fallback, not a new failure mode.
- Tests for `selectLatestProductionRelease`: picks the most recent by `dateCreated`, excludes `-preview` releases, excludes non-SHA-shaped versions (e.g. a UUID), returns null when nothing qualifies, tolerates non-array input.

The underlying Cloudflare Deployments API gap is a dashboard-side git-integration question outside this repo — whoever has Cloudflare dashboard access should check Workers & Pages → the `metagraphed` script → Build/Git settings to confirm Workers Builds is actually connected to `main`. This PR doesn't fix that; it keeps the drift check itself working in the meantime.

Closes #7214

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:workflows`
- [x] `npx vitest run tests/check-worker-deploy-drift.test.mjs` (15 passed)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

`npm run validate` (full) requires a prior `npm run build` for generated registry artifacts unrelated to this change (a standalone CI script, not part of the build/registry pipeline) — not run for that reason.