### PR TITLE
fix(ci): exempt curated subnet docs from wallet/key-wording false positives

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -942,6 +942,21 @@ const schemaDroppedContentKeys = new Set([
   "examples",
 ]);
 const schemaAbsoluteUrlPattern = /\b(?:https?|wss?):\/\/[^\s<>"'`)}\]]+/gi;
+// Local absolute filesystem paths, scheme-less so distinct from the URL
+// pattern above. Mirrors scan-public-safety.mjs's "local absolute path" hard
+// pattern, which has no soft-content exemption for mirrored/captured fixture
+// bodies by design (a real leak shape, not terminology) -- a live-captured
+// third-party response can echo one back regardless (e.g. a genomics
+// subnet's per-miner submitted log text carrying a real path from whoever
+// ran their own tooling locally, live-confirmed 2026-07-20), so it must be
+// redacted here at capture time rather than relied on to be caught/allowed
+// downstream.
+const localAbsolutePathPattern =
+  /\/Users\/[^\s"'`<>]+|\/home\/[^\s"'`<>]+|C:\\Users\\[^\s"'`<>]+/g;
+
+function redactLocalAbsolutePaths(value) {
+  return value.replace(localAbsolutePathPattern, "[redacted-local-path]");
+}
 
 function isSchemaExtensionKey(key) {
   return String(key || "")
@@ -966,10 +981,13 @@ function sanitizeSchemaUrlString(value) {
 }
 
 function sanitizeSchemaText(value) {
-  return value.replace(schemaAbsoluteUrlPattern, (match) => {
-    const sanitized = sanitizeSchemaUrlString(match);
-    return sanitized || "[redacted-unsafe-url]";
-  });
+  return redactLocalAbsolutePaths(value).replace(
+    schemaAbsoluteUrlPattern,
+    (match) => {
+      const sanitized = sanitizeSchemaUrlString(match);
+      return sanitized || "[redacted-unsafe-url]";
+    },
+  );
 }
 
 function sanitizeSchemaKey(key) {

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -518,12 +518,31 @@ function scanCapturedFixtureBody(relativePath, content) {
     return;
   }
 
+  // "openapi" and "subnet-api" fixture kinds are the subnet operator's own
+  // curated, authored self-description (a formal OpenAPI spec, or a custom
+  // discovery/quick-start doc) — confirmed false positives in production
+  // (2026-07-20): a WalletCreate JSON-Schema's `private_key` property name
+  // (and its sibling `required` array entry) is schema metadata, not prose,
+  // and a quick-start's `Wallet.createRandom()` tutorial snippet demonstrates
+  // generating a brand-new wallet, disclosing nothing. Neither is a
+  // description/summary/title field, so isOpenApiDocumentationField below
+  // doesn't reach them. "data-artifact" fixtures are deliberately excluded
+  // from this broader exemption: they're live OPERATIONAL data (e.g. a
+  // genomics subnet's per-miner submitted scores/logs) that can echo back
+  // arbitrary third-party free text, not the operator's own curated docs, so
+  // they keep the full wallet/key-wording re-check below.
+  const isCuratedDocumentationKind =
+    fixture?.kind === "openapi" || fixture?.kind === "subnet-api";
+
   for (const { valuePath, value, kind } of walkJsonStrings(body)) {
     for (const pattern of patterns) {
       // Keep broad Bittensor terminology exempt for mirrored fixture bodies, but
       // still scan security-sensitive wallet/key phrases that can appear under
       // generic live-response keys after sanitization.
       if (pattern.soft && !pattern.scanFixtureBody) {
+        continue;
+      }
+      if (pattern.soft && isCuratedDocumentationKind) {
         continue;
       }
       // OpenAPI documentation fields (description/summary/title) are human API

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -1117,6 +1117,26 @@ describe("sanitizeFixtureBody (#352)", () => {
     assert.equal(out.jwtUrl, "https://api.example.io/x");
     assert.equal(out.sigUrl, "https://api.example.io/x");
   });
+  test("redacts local absolute filesystem paths embedded in free text", () => {
+    // A live-captured third-party response can echo back a real local path
+    // incidentally (e.g. a genomics subnet's per-miner submitted log text
+    // carrying a path from whoever ran their own tooling), which
+    // scan-public-safety.mjs's "local absolute path" hard pattern has no
+    // soft-content exemption for by design -- must be redacted here instead.
+    const out = sanitizeFixtureBody({
+      macLog: "Processing dataset at /Users/researcher/data/output.csv now",
+      linuxLog: "wrote results to /home/miner/out/scores.json",
+      windowsLog: "saved to C:\\Users\\alice\\Documents\\run.log",
+      clean: "no path here",
+    });
+    assert.ok(!out.macLog.includes("/Users/researcher"));
+    assert.ok(out.macLog.includes("[redacted-local-path]"));
+    assert.ok(!out.linuxLog.includes("/home/miner"));
+    assert.ok(out.linuxLog.includes("[redacted-local-path]"));
+    assert.ok(!out.windowsLog.includes("C:\\Users\\alice"));
+    assert.ok(out.windowsLog.includes("[redacted-local-path]"));
+    assert.equal(out.clean, "no path here");
+  });
   test("bounds array length, string length, depth, and key count", () => {
     const out = sanitizeFixtureBody(
       {

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -38,11 +38,11 @@ const SCANNER_TEST_TIMEOUT_MS = 15000;
 
 vi.setConfig({ testTimeout: SCANNER_TEST_TIMEOUT_MS });
 
-async function writeTestFixture(body) {
+async function writeTestFixture(body, { kind } = {}) {
   await fs.mkdir(FIXTURE_DIR, { recursive: true });
   await fs.writeFile(
     TEST_FIXTURE_PATH,
-    JSON.stringify({ response: { body } }),
+    JSON.stringify({ kind, response: { body } }),
     "utf8",
   );
 }
@@ -419,6 +419,73 @@ describe("captured-fixture body scan", () => {
     assert.ok(
       output.includes(`${TEST_FIXTURE}:response.body`),
       `hard secrets must fire even inside doc fields; got:\n${output}`,
+    );
+  });
+
+  test("exempts wallet/key wording anywhere in an openapi-kind fixture body, not just doc fields", async () => {
+    // Regression for the live sn-33 publish failure (2026-07-20): a
+    // WalletCreate JSON-Schema's own property name (`private_key`) and its
+    // sibling `required` array entry are schema metadata, not a
+    // description/summary/title documentation field, so the existing
+    // isOpenApiDocumentationField exemption above doesn't reach them.
+    await writeTestFixture(
+      {
+        components: {
+          schemas: {
+            WalletCreate: {
+              properties: { private_key: "[redacted]" },
+              required: ["name", "private_key"],
+            },
+          },
+        },
+      },
+      { kind: "openapi" },
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_FIXTURE),
+      false,
+      `openapi-kind schema metadata should be exempt; got:\n${output}`,
+    );
+  });
+
+  test("exempts wallet/key wording in a subnet-api-kind quick-start tutorial", async () => {
+    // Regression for the live sn-58 publish failure (2026-07-20): a
+    // quick-start step showing how to generate a brand-new wallet locally
+    // (`Wallet.createRandom()`) legitimately mentions "privateKey" while
+    // disclosing no actual secret. Not OpenAPI-shaped at all, so
+    // isOpenApiDocumentationField's isOpenApiBody gate never applies here.
+    await writeTestFixture(
+      {
+        quick_start: {
+          step2_wallet:
+            "node -e \"const w=require('ethers').Wallet.createRandom();console.log(w.address, w.privateKey)\"",
+        },
+      },
+      { kind: "subnet-api" },
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_FIXTURE),
+      false,
+      `subnet-api-kind quick-start prose should be exempt; got:\n${output}`,
+    );
+  });
+
+  test("does not extend the curated-kind exemption to data-artifact fixtures", async () => {
+    // data-artifact fixtures are live operational data (e.g. a genomics
+    // subnet's arbitrary per-miner submitted log text), not the operator's
+    // own curated docs -- wallet/key wording must still be caught there.
+    await writeTestFixture(
+      {
+        note: "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      },
+      { kind: "data-artifact" },
+    );
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_FIXTURE}:response.body.note: wallet/key wording`),
+      `data-artifact fixtures must still be scanned; got:\n${output}`,
     );
   });
 


### PR DESCRIPTION
## Summary

- Every `Publish Cloudflare Backend` run has failed at `scan:public-safety` since at least 2026-07-18, blocking R2/KV publishes entirely. Confirmed live via `/health`: `freshness.published_at` stuck at 2026-07-17T11:21:50Z, `stale: true`, `age_hours` past the 48h budget.
- The specific fixtures that trip the scan vary run to run (they're live-captured each run, not checked in) — this fixes the general false-positive class, not a fixed list of lines.

## What Changed

- `scripts/scan-public-safety.mjs`: `scanCapturedFixtureBody` now exempts the wallet/key-wording soft check entirely for `"openapi"`/`"subnet-api"`-kind fixture bodies — the subnet operator's own curated, authored self-description (a formal spec, or a quick-start doc), not arbitrary data. The existing `isOpenApiDocumentationField` exemption only covers `description`/`summary`/`title` fields, so it missed:
  - A JSON-Schema property **name** (e.g. `WalletCreate.properties.private_key`) and the same name repeated in a sibling `required` array entry — schema metadata, not a value; the actual value is already redacted by `sanitizeFixtureBody`.
  - A non-OpenAPI `subnet-api`-kind quick-start tutorial (e.g. a `Wallet.createRandom()` snippet demonstrating how to generate a brand-new wallet, disclosing nothing).
  - An OpenAPI `paths` object's own route-template key (e.g. `/auth/mnemonic/`), which documents that an endpoint exists, not a secret.

  `"data-artifact"`-kind fixtures (arbitrary live operational data, e.g. a genomics subnet's per-miner submitted scores/logs) are deliberately excluded from this broader exemption and keep the full wallet/key-wording re-check.
- `scripts/lib.mjs`: `sanitizeFixtureBody`'s `sanitizeSchemaText` now also redacts local absolute filesystem paths (`/Users/…`, `/home/…`, `C:\Users\…`), alongside its existing credentialed-URL redaction. A data-artifact fixture's arbitrary free text (e.g. a per-item log field) can echo back a real path from whoever ran their own tooling — unpredictable per-capture content, not something safe to allowlist in the scanner, so it's redacted at capture/sanitize time instead.
- Tests: 3 new scanner tests (openapi-kind schema metadata exempt, subnet-api-kind quick-start exempt, data-artifact-kind still flagged) and 1 new sanitizer test (all three path forms redacted, unrelated text passes through).

Closes #7213

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`
- [x] `npm run test:coverage` (unsharded, full suite: 337 files / 10157 tests passed; overall 98.95% stmts / 97.6% branches / 99.22% funcs / 99.18% lines, all above the configured thresholds; zero uncovered lines/branches in the changed `lib.mjs` ranges per `coverage/lcov.info`)
- [x] `git diff --check`

`npm run validate` (full) requires a prior `npm run build` for generated registry artifacts unrelated to this change — not run for that reason.