### PR TITLE
feat(ui): surface idle-stake on the subnet detail and explorer pages (#6994)

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   economicsQuery,
   subnetRecycledQuery,
+  subnetIdleStakeQuery,
   subnetStakeMovesQuery,
   subnetStakeTransfersQuery,
   subnetTrajectoryQuery,
@@ -129,6 +130,33 @@ function RecycledTaoTile({ netuid }: { netuid: number }) {
   return <StatTile eyebrow="Recycled TAO" value={value} hint="cumulative · live RPC" />;
 }
 
+// #6994: stake delegated to hotkeys currently earning zero dividends (no permit
+// or zero-weight outcome) — idle capital a delegator could redeploy. idle_stake_tao
+// stays "—" (not "0") on a cold snapshot, since 0 is a real, distinct value.
+function IdleStakeTile({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetIdleStakeQuery(netuid));
+  const idle = res?.data.idle_stake_tao;
+  const count = res?.data.idle_neuron_count;
+  const value = isError
+    ? "—"
+    : isPending && idle == null
+      ? "…"
+      : idle == null
+        ? "—"
+        : formatTao(idle);
+  return (
+    <StatTile
+      eyebrow="Idle stake"
+      value={value}
+      hint={
+        count != null
+          ? `zero-dividend · ${formatNumber(count)} idle hotkey${count === 1 ? "" : "s"}`
+          : "zero-dividend delegated stake"
+      }
+    />
+  );
+}
+
 export function EconomicsPanel({ netuid }: { netuid: number }) {
   const { data: res, isPending } = useQuery(economicsQuery());
   const e = res?.data.find((x) => x.netuid === netuid);
@@ -202,6 +230,7 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
           hint={e.registration_allowed === false ? "closed" : "open"}
         />
         <RecycledTaoTile netuid={netuid} />
+        <IdleStakeTile netuid={netuid} />
         <StakeMovesTile netuid={netuid} />
         <StakeTransfersTile netuid={netuid} />
       </div>

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -186,6 +186,9 @@ import type {
   SubnetHyperparamsHistoryEntry,
   SubnetStakeQuote,
   SubnetRecycled,
+  SubnetIdleStake,
+  ChainIdleStake,
+  ChainIdleStakeSubnet,
   SubnetIdentityHistory,
   SubnetWeightSetter,
   SubnetWeightSetters,
@@ -5241,6 +5244,78 @@ export const subnetRecycledQuery = (netuid: number) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<SubnetRecycled>;
+    },
+    staleTime: STALE_MED,
+  });
+
+/** Per-subnet idle stake (#6994): stake delegated to a hotkey earning zero
+ *  dividends. Flat snapshot, no window param. */
+export const subnetIdleStakeQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-idle-stake", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/subnets/${netuid}/idle-stake`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+          netuid: firstFiniteNumber(d.netuid) ?? netuid,
+          captured_at: firstString(d.captured_at) ?? null,
+          neuron_count: firstFiniteNumber(d.neuron_count) ?? 0,
+          idle_neuron_count: firstFiniteNumber(d.idle_neuron_count) ?? 0,
+          idle_stake_tao: coerceFiniteNumber(d.idle_stake_tao) ?? null,
+        } as SubnetIdleStake,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetIdleStake>;
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeChainIdleStakeSubnet(raw: unknown): ChainIdleStakeSubnet | undefined {
+  if (!isRecord(raw)) return undefined;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return undefined;
+  return {
+    netuid,
+    neuron_count: firstFiniteNumber(raw.neuron_count) ?? 0,
+    idle_neuron_count: firstFiniteNumber(raw.idle_neuron_count) ?? 0,
+    idle_stake_tao: coerceFiniteNumber(raw.idle_stake_tao) ?? null,
+  };
+}
+
+export function normalizeChainIdleStake(raw: unknown): ChainIdleStake {
+  const rec = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(rec.subnets)
+    ? rec.subnets.flatMap((s) => {
+        const normalized = normalizeChainIdleStakeSubnet(s);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    captured_at: firstString(rec.captured_at) ?? null,
+    subnet_count: firstFiniteNumber(rec.subnet_count) ?? subnets.length,
+    total_idle_stake_tao: coerceFiniteNumber(rec.total_idle_stake_tao) ?? null,
+    subnets,
+  };
+}
+
+/** Network-wide idle-stake rollup (#6994), sorted by idle_stake_tao desc. */
+export const chainIdleStakeQuery = () =>
+  queryOptions({
+    queryKey: k("chain-idle-stake"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainIdleStake>>("/api/v1/chain/idle-stake", {
+        signal,
+      });
+      return {
+        data: normalizeChainIdleStake(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1711,6 +1711,35 @@ export interface SubnetRecycled {
   queried_at: string | null;
 }
 
+/** Idle stake for one subnet (#6789 backend, #6994 UI): stake delegated to a
+ *  hotkey currently earning zero dividends. idle_stake_tao is null only on a
+ *  cold/absent snapshot; a real 0 means no idle stake. */
+export interface SubnetIdleStake {
+  schema_version: number;
+  netuid: number;
+  captured_at: string | null;
+  neuron_count: number;
+  idle_neuron_count: number;
+  idle_stake_tao: number | null;
+}
+
+/** One subnet's row in the network-wide idle-stake rollup. */
+export interface ChainIdleStakeSubnet {
+  netuid: number;
+  neuron_count: number;
+  idle_neuron_count: number;
+  idle_stake_tao: number | null;
+}
+
+/** Network-wide idle-stake rollup (GET /api/v1/chain/idle-stake). */
+export interface ChainIdleStake {
+  schema_version: number;
+  captured_at: string | null;
+  subnet_count: number;
+  total_idle_stake_tao: number | null;
+  subnets: ChainIdleStakeSubnet[];
+}
+
 /** Append-only on-chain identity timeline for one subnet (#1647), newest first. */
 export interface SubnetIdentityHistory {
   schema_version: number;

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -39,6 +39,7 @@ import {
   chainTurnoverQuery,
   chainStakeTransfersQuery,
   chainAxonRemovalsQuery,
+  chainIdleStakeQuery,
   chainTransferPairsQuery,
   chainTransfersQuery,
   economicsTrendsQuery,
@@ -54,6 +55,7 @@ import type {
   ChainTurnover,
   EconomicsTrends,
   ChainAxonRemovals,
+  ChainIdleStake,
   ChainRegistrations,
   ChainServing,
   ChainPrometheus,
@@ -813,6 +815,98 @@ function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
 }
 
 /**
+ * Network-wide idle-stake rollup (#6994) — subnets ranked by stake delegated to
+ * hotkeys currently earning zero dividends (no permit / zero-weight outcome).
+ * Chain-direct: GET /api/v1/chain/idle-stake.
+ */
+function NetworkIdleStakeSection({ idleStake }: { idleStake: ChainIdleStake }) {
+  const totalIdleHotkeys = idleStake.subnets.reduce(
+    (sum, s) => sum + (s.idle_neuron_count ?? 0),
+    0,
+  );
+  return (
+    <section className="min-w-0 rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Idle stake
+          </h2>
+          <p className="mt-1 font-mono text-[11px] text-ink-muted">
+            Stake delegated to hotkeys currently earning zero dividends
+          </p>
+        </div>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {formatNumber(idleStake.subnet_count)} subnets
+        </span>
+      </div>
+
+      <div className="mb-5 grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={Coins}
+          eyebrow="Total idle stake"
+          value={formatTao(idleStake.total_idle_stake_tao)}
+          hint="network-wide, zero-dividend"
+          tone="accent"
+        />
+        <StatTile
+          icon={Coins}
+          eyebrow="Idle subnets"
+          value={formatNumber(idleStake.subnet_count)}
+          hint="with idle stake"
+        />
+        <StatTile
+          icon={Coins}
+          eyebrow="Idle hotkeys"
+          value={formatNumber(totalIdleHotkeys)}
+          hint="earning zero dividends"
+        />
+      </div>
+
+      {idleStake.subnets.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className={TH}>Subnet</th>
+                <th className={`${TH} text-right`}>Idle stake</th>
+                <th className={`${TH} text-right`}>Idle hotkeys</th>
+                <th className={`${TH} text-right`}>Neurons</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {idleStake.subnets.map((s) => (
+                <tr key={s.netuid} className="hover:bg-surface/40">
+                  <td className="px-4 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: s.netuid }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                    >
+                      SN{s.netuid}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatTao(s.idle_stake_tao)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatNumber(s.idle_neuron_count)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatNumber(s.neuron_count)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <EmptyState title="No idle stake in this snapshot yet." />
+      )}
+    </section>
+  );
+}
+
+/**
  * Network-wide neuron-registration leaderboard (#3465) — subnets ranked by
  * NeuronRegistered volume over the window. Chain-direct: GET /api/v1/chain/registrations.
  */
@@ -1242,6 +1336,7 @@ function ExplorerDashboard() {
     { data: eventMixRes },
     { data: trendsRes },
     { data: transfersRes },
+    { data: idleStakeRes },
   ] = useSuspenseQueries({
     queries: [
       chainActivityQuery(win),
@@ -1260,6 +1355,7 @@ function ExplorerDashboard() {
       chainEventsStatsQuery(),
       economicsTrendsQuery(win),
       chainTransfersQuery(win),
+      chainIdleStakeQuery(),
     ],
   });
   const activity = activityRes.data;
@@ -1278,6 +1374,7 @@ function ExplorerDashboard() {
   const eventMix = eventMixRes.data;
   const trends = trendsRes.data;
   const transfers = transfersRes.data;
+  const idleStake = idleStakeRes.data;
 
   // The API returns newest-day-first; sparklines want chronological order.
   const chrono = [...activity.days].reverse();
@@ -1626,6 +1723,7 @@ function ExplorerDashboard() {
           <TransferPairsSection win={win} />
           <StakeFlowSection flow={stakeFlow} />
           <StakeMovesSection moves={stakeMoves} />
+          <NetworkIdleStakeSection idleStake={idleStake} />
           {/* stake-transfer leaderboard */}
           <section className="min-w-0 rounded-lg border border-border bg-card p-5">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">


### PR DESCRIPTION
## Summary

Surfaces **idle stake** — stake delegated to a hotkey currently earning zero dividends (no permit / zero-weight outcome) — in the UI. The two backend routes (`GET /api/v1/subnets/{netuid}/idle-stake` and `GET /api/v1/chain/idle-stake`, both with MCP tools) shipped in #6789 but had no UI surface; a delegator could only find idle capital via a raw API call. This adds both the per-subnet and the network-wide view.

## What it adds

- **Subnet detail** — an "Idle stake" `StatTile` in the economics panel (`economics-panel.tsx`), right beside "Recycled TAO", showing the subnet's idle TAO and idle-hotkey count. Mirrors the existing `RecycledTaoTile` (small self-contained `useQuery` → `StatTile`); "—" (not "0") on a cold snapshot, since 0 is a real value.
- **Explorer (Stake tab)** — a network-wide "Idle stake" rollup section (`NetworkIdleStakeSection` in `explorer.tsx`): three `StatTile`s (total idle stake, idle subnets, idle hotkeys) plus a per-subnet table (idle stake / idle hotkeys / neurons), ranked by idle stake. Mirrors the existing `AxonChurnSection` / `NetworkRegistrationsSection` card pattern and slots into the batched `useSuspenseQueries`.
- **Client wiring** — `subnetIdleStakeQuery(netuid)` + `chainIdleStakeQuery()` with a `normalizeChainIdleStake` (mirroring `subnetRecycledQuery` / `chainAxonRemovalsQuery`), and `SubnetIdleStake` / `ChainIdleStake` types. No new data logic — the routes' existing shaping is reused.

## Notes

- Reuses design tokens + shared primitives only (`StatTile`, `formatTao`, `formatNumber`, the `Coins` icon already imported in the explorer); no one-off styling.
- The API returns no share/percentage field, so no derived percentage is invented — the tiles show the raw TAO and counts the route provides.

## Verification

- `eslint` — 0 errors; `tsc --noEmit` (apps/ui) — 0 errors; `prettier --check` — clean; `vite build` — succeeds.
- `test:e2e` responsive-overflow — **all pass on `/subnets/1` and `/explorer`** (both checked routes; the new tile wraps in the existing flex grid and the new section's table is in `overflow-x-auto`, so no viewport overflow — no baseline change needed).
- Screenshots below show both surfaces with live data; "before" is `main` (no idle-stake tile / section).

## Changed (4 files, +231)

- `apps/ui/src/lib/metagraphed/queries.ts`, `types.ts` — queries/normalizer/types
- `apps/ui/src/components/metagraphed/economics-panel.tsx` — `IdleStakeTile`
- `apps/ui/src/routes/explorer.tsx` — `NetworkIdleStakeSection` + batch wiring

## Screenshots

### Subnet detail — economics "Idle stake" tile

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-subnet-idle-after-mobile-dark.png)<br><sub>after</sub> |

### Explorer — network idle-stake section (Stake tab)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6994-explorer-idle-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6994
