### PR TITLE
feat(graphql): add review-family Query fields for /api/v1/review/

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -16,6 +16,14 @@ import { loadSourceSnapshotsList } from "./source-snapshots-mcp.mjs";
 // transforms REST and MCP already use) -- not a reimplementation.
 import { loadGapsList } from "./gaps-mcp.mjs";
 import { loadEvidenceList } from "./evidence-mcp.mjs";
+// #7167: GraphQL parity for GET /api/v1/review/* contributor-review family,
+// reusing the same list loaders MCP already calls -- not a reimplementation.
+import { loadAdapterCandidatesList } from "./adapter-candidates-mcp.mjs";
+import { loadEnrichmentEvidenceList } from "./enrichment-evidence-mcp.mjs";
+import { loadEnrichmentQueueList } from "./enrichment-queue-mcp.mjs";
+import { loadReviewEnrichmentTargetsList } from "./review-enrichment-targets-mcp.mjs";
+import { loadReviewGapsList } from "./review-gaps-mcp.mjs";
+import { loadProfileCompletenessList } from "./profile-completeness-mcp.mjs";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
@@ -540,6 +548,18 @@ export const SDL = `
     gaps(netuid: Int, coverage_level: String, curation_level: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): GapsList!
     "Network-wide public evidence ledger -- the append-only provenance record behind registry surfaces. Search with q across subject/claim/source_url/support_summary, sort with sort/order, project with fields, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Distinct from subnet_evidence(netuid) (one subnet's claims). Mirrors GET /api/v1/evidence."
     evidence(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): EvidenceList!
+    "Subnets worth deeper adapter work -- recommended_adapter_kind, operational/candidate API kinds, and priority_score. Filter by netuid/curation_level/candidate_api_kinds/operational_kinds/recommended_adapter_kind/reason_codes, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Mirrors GET /api/v1/review/adapter-candidates."
+    review_adapter_candidates(netuid: Int, curation_level: String, candidate_api_kinds: String, operational_kinds: String, recommended_adapter_kind: String, reason_codes: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewAdapterCandidatesList!
+    "Detailed candidate evidence behind the enrichment queue -- evidence_action, lane, missing kinds, and priority_score. Filter by netuid/lane/evidence_action/direct_submission_kinds/missing_kinds, search with q, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Distinct from evidence (network ledger) and subnet_evidence. Mirrors GET /api/v1/review/enrichment-evidence."
+    review_enrichment_evidence(q: String, netuid: Int, lane: String, evidence_action: String, direct_submission_kinds: String, missing_kinds: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewEnrichmentEvidenceList!
+    "Prioritized all-subnet contributor enrichment queue -- lane, priority_score, missing kinds, and recommended_action. Filter by netuid/lane/evidence_action/identity_level/curation_level/profile_level/direct_submission_kinds/missing_kinds/manual_review_required/reason_codes/review_state, search with q, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Distinct from review_enrichment_targets and coverage-depth enrichment targets. Mirrors GET /api/v1/review/enrichment-queue."
+    review_enrichment_queue(q: String, netuid: Int, lane: String, evidence_action: String, identity_level: String, curation_level: String, profile_level: String, direct_submission_kinds: String, missing_kinds: String, manual_review_required: String, reason_codes: String, review_state: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewEnrichmentQueueList!
+    "Contributor-facing enrichment target board -- target_type, target_action, lane, and priority_score. Filter by netuid/target_type/target_action/kind/lane/evidence_action/identity_level/profile_level/submission_route/auto_review_candidate/manual_review_required/missing_kinds/reason_codes, search with q, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Distinct from review_enrichment_queue and the coverage-depth list_enrichment_targets MCP tool. Mirrors GET /api/v1/review/enrichment-targets."
+    review_enrichment_targets(q: String, netuid: Int, target_type: String, target_action: String, kind: String, lane: String, evidence_action: String, identity_level: String, profile_level: String, submission_route: String, auto_review_candidate: String, manual_review_required: String, missing_kinds: String, reason_codes: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewEnrichmentTargetsList!
+    "Contributor-targeted review gap priority board -- priority_score, missing kinds, curation_level, and review_state. Filter by netuid/curation_level/missing_kinds/review_state, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Distinct from gaps (interface facet report) and subnet_gaps(netuid). Mirrors GET /api/v1/review/gaps."
+    review_gaps(netuid: Int, curation_level: String, missing_kinds: String, review_state: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewGapsList!
+    "Contributor review queue of subnet profile-completeness gaps -- identity_level, profile_level, priority_score, and promotion signals. Filter by netuid/profile_level/confidence/identity_level/identity_promotion_kinds/native_name_quality, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Distinct from profiles (full profile index). Mirrors GET /api/v1/review/profile-completeness."
+    review_profile_completeness(netuid: Int, profile_level: String, confidence: String, identity_level: String, identity_promotion_kinds: String, native_name_quality: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewProfileCompletenessList!
     "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
     profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
     "The registry-wide summary: overall subnet count, coverage/curation-level/profile-level counts, recent registry changes, and the most-complete top subnets. A fast orientation for the whole Bittensor application layer. Null when the summary has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the registry_summary MCP/REST shape. Mirrors GET /api/v1/registry/summary."
@@ -1860,6 +1880,91 @@ export const SDL = `
     schema_version: String
     summary: JSON
     claims: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  "Review adapter-candidates page. Mirrors GET /api/v1/review/adapter-candidates (and MCP list_adapter_candidates)."
+  type ReviewAdapterCandidatesList {
+    generated_at: String
+    notes: JSON
+    candidates: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  "Review enrichment-evidence page. Mirrors GET /api/v1/review/enrichment-evidence (and MCP list_enrichment_evidence)."
+  type ReviewEnrichmentEvidenceList {
+    generated_at: String
+    notes: JSON
+    entries: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  "Review enrichment-queue page. Mirrors GET /api/v1/review/enrichment-queue (and MCP list_enrichment_queue)."
+  type ReviewEnrichmentQueueList {
+    generated_at: String
+    notes: JSON
+    queue: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  "Review enrichment-targets page. Mirrors GET /api/v1/review/enrichment-targets (and MCP list_review_enrichment_targets)."
+  type ReviewEnrichmentTargetsList {
+    generated_at: String
+    notes: JSON
+    targets: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  "Review gap-priorities page. Mirrors GET /api/v1/review/gaps (and MCP list_review_gaps). Distinct from GapsList."
+  type ReviewGapsList {
+    generated_at: String
+    notes: JSON
+    priorities: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  "Review profile-completeness page. Mirrors GET /api/v1/review/profile-completeness (and MCP list_profile_completeness)."
+  type ReviewProfileCompletenessList {
+    generated_at: String
+    schema_version: String
+    summary: JSON
+    profiles: [JSON!]!
     total: Int!
     returned: Int!
     limit: Int!
@@ -3882,6 +3987,12 @@ export const FIELD_COMPLEXITY = {
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
   gaps: RELATIONSHIP_FIELD_COMPLEXITY,
   evidence: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_adapter_candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_enrichment_evidence: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_enrichment_queue: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_enrichment_targets: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_gaps: RELATIONSHIP_FIELD_COMPLEXITY,
+  review_profile_completeness: RELATIONSHIP_FIELD_COMPLEXITY,
   block_extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   block_events: RELATIONSHIP_FIELD_COMPLEXITY,
   block_chain_events: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5567,6 +5678,34 @@ const rootValue = {
 
   evidence(args, context) {
     return loadEvidenceList(context, args, { readArtifact });
+  },
+
+  // #7167: reuse the review-family MCP loaders unchanged. Each validates its
+  // own args and throws on an invalid one -- that throw becomes a GraphQL
+  // error. A cold/absent artifact is likewise a GraphQL error (matching
+  // REST/MCP not_found), consistent with gaps / source_snapshots.
+  review_adapter_candidates(args, context) {
+    return loadAdapterCandidatesList(context, args, { readArtifact });
+  },
+
+  review_enrichment_evidence(args, context) {
+    return loadEnrichmentEvidenceList(context, args, { readArtifact });
+  },
+
+  review_enrichment_queue(args, context) {
+    return loadEnrichmentQueueList(context, args, { readArtifact });
+  },
+
+  review_enrichment_targets(args, context) {
+    return loadReviewEnrichmentTargetsList(context, args, { readArtifact });
+  },
+
+  review_gaps(args, context) {
+    return loadReviewGapsList(context, args, { readArtifact });
+  },
+
+  review_profile_completeness(args, context) {
+    return loadProfileCompletenessList(context, args, { readArtifact });
   },
 
   // #6992: reuse list_profiles' own loader unchanged. Its readOptionalArtifact

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -119,6 +119,12 @@ import {
   loadReviewEnrichmentTargetsList,
 } from "./review-enrichment-targets-mcp.mjs";
 import {
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+  LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+  LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+  loadProfileCompletenessList,
+} from "./profile-completeness-mcp.mjs";
+import {
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS,
   LIST_SUBNET_ENDPOINTS_MCP_TOOL,
   LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
@@ -828,6 +834,7 @@ export const MCP_INSTRUCTIONS =
   LIST_ENRICHMENT_EVIDENCE_INSTRUCTIONS +
   LIST_REVIEW_GAPS_INSTRUCTIONS +
   LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS +
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS +
   LIST_SEARCH_INDEX_INSTRUCTIONS +
   LIST_SEARCH_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
@@ -9725,24 +9732,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_profile_completeness",
-    title: "List subnet profile-completeness gaps",
-    description:
-      "Fetch the contributor review queue of subnet profile-completeness gaps: " +
-      "which subnets have incomplete public-safe profiles (missing identity, " +
-      "native name, confidence, or promotion signals) and are worth profile " +
-      "enrichment. Use it to find high-value profile contributions. Mirrors " +
-      "GET /api/v1/review/profile-completeness.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args, ctx) {
-      return loadArtifactData(
-        ctx,
-        "/metagraph/review/profile-completeness.json",
-      );
+    ...LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadProfileCompletenessList(ctx, args);
     },
   },
   {
@@ -14889,17 +14881,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   },
   list_subnet_endpoints: LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
   list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
-  list_profile_completeness: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      profiles: { type: "array", items: { type: "object" } },
-      summary: { type: "object", additionalProperties: true },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
   list_rpc_endpoints: {
     type: "object",

--- a/src/profile-completeness-mcp.mjs
+++ b/src/profile-completeness-mcp.mjs
@@ -1,0 +1,271 @@
+// Profile-completeness list loader for MCP + GraphQL parity on
+// GET /api/v1/review/profile-completeness. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/review/profile-completeness.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const PROFILE_COMPLETENESS_ARTIFACT =
+  "/metagraph/review/profile-completeness.json";
+
+const PROFILE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["profile-completeness"].sort_fields;
+const PROFILE_LEVELS = QUERY_ENUMS.profileLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
+const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"];
+
+export function profileCompletenessMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function profileCompletenessQueryUrl(args) {
+  const url = new URL("https://mcp.internal/review/profile-completeness");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw profileCompletenessMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const profileLevel = optionalEnum(args, "profile_level", PROFILE_LEVELS);
+  if (profileLevel) url.searchParams.set("profile_level", profileLevel);
+  const confidence = optionalEnum(args, "confidence", CONFIDENCE_LEVELS);
+  if (confidence) url.searchParams.set("confidence", confidence);
+  const identityLevel = optionalEnum(args, "identity_level", IDENTITY_LEVELS);
+  if (identityLevel) url.searchParams.set("identity_level", identityLevel);
+  const identityPromotionKinds = optionalEnum(
+    args,
+    "identity_promotion_kinds",
+    SURFACE_KINDS,
+  );
+  if (identityPromotionKinds) {
+    url.searchParams.set("identity_promotion_kinds", identityPromotionKinds);
+  }
+  const nativeNameQuality = optionalEnum(
+    args,
+    "native_name_quality",
+    NATIVE_NAME_QUALITIES,
+  );
+  if (nativeNameQuality) {
+    url.searchParams.set("native_name_quality", nativeNameQuality);
+  }
+  const sort = optionalEnum(args, "sort", PROFILE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw profileCompletenessMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadProfileCompletenessList(
+  ctx,
+  args,
+  { readArtifact } = {},
+) {
+  const queryUrl = profileCompletenessQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, PROFILE_COMPLETENESS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw profileCompletenessMcpError(
+        "not_found",
+        "Profile completeness snapshot unavailable.",
+      );
+    }
+    throw profileCompletenessMcpError(
+      code,
+      `Could not load ${PROFILE_COMPLETENESS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw profileCompletenessMcpError(
+      "not_found",
+      "Profile completeness snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "profile-completeness",
+    [],
+  );
+  if (transformed.error) {
+    throw profileCompletenessMcpError(
+      "invalid_params",
+      transformed.error.message,
+    );
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.profiles) ? data.profiles : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    schema_version: data.schema_version ?? null,
+    summary: data.summary ?? null,
+    profiles: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_PROFILE_COMPLETENESS_INSTRUCTIONS =
+  "list_profile_completeness the contributor review queue of subnet profile-completeness " +
+  "gaps (identity_level, profile_level, priority_score; mirrors " +
+  "GET /api/v1/review/profile-completeness), ";
+
+export const LIST_PROFILE_COMPLETENESS_MCP_TOOL = {
+  name: "list_profile_completeness",
+  title: "List subnet profile-completeness gaps",
+  description:
+    "Fetch the contributor review queue of subnet profile-completeness gaps: " +
+    "which subnets have incomplete public-safe profiles (missing identity, " +
+    "native name, confidence, or promotion signals) and are worth profile " +
+    "enrichment. Filter by netuid, profile_level, confidence, identity_level, " +
+    "identity_promotion_kinds, or native_name_quality; sort with sort + order; " +
+    "and page with limit (1-100) / cursor. Distinct from list_profiles (full " +
+    "profile index). Mirrors GET /api/v1/review/profile-completeness.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      profile_level: {
+        type: "string",
+        enum: PROFILE_LEVELS,
+        description: "Filter by profile completeness level.",
+      },
+      confidence: {
+        type: "string",
+        enum: CONFIDENCE_LEVELS,
+        description: "Filter by confidence level.",
+      },
+      identity_level: {
+        type: "string",
+        enum: IDENTITY_LEVELS,
+        description: "Filter by identity completeness.",
+      },
+      identity_promotion_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description:
+          "Filter rows whose identity_promotion_kinds include this kind.",
+      },
+      native_name_quality: {
+        type: "string",
+        enum: NATIVE_NAME_QUALITIES,
+        description: "Filter by native name quality.",
+      },
+      sort: {
+        type: "string",
+        enum: PROFILE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of profile row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["profiles"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    schema_version: { type: ["string", "integer", "null"] },
+    summary: { type: ["object", "null"], additionalProperties: true },
+    profiles: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/review-gaps-mcp.mjs
+++ b/src/review-gaps-mcp.mjs
@@ -10,6 +10,7 @@ export const REVIEW_GAPS_ARTIFACT = "/metagraph/review/gap-priorities.json";
 const PRIORITY_SORT_FIELDS =
   API_QUERY_COLLECTIONS["review-gap-priorities"].sort_fields;
 const CURATION_LEVELS = QUERY_ENUMS.curationLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
 
 export function reviewGapsMcpError(code, message) {
   const error = new Error(message);
@@ -61,6 +62,8 @@ export function reviewGapsQueryUrl(args) {
   }
   const curationLevel = optionalEnum(args, "curation_level", CURATION_LEVELS);
   if (curationLevel) url.searchParams.set("curation_level", curationLevel);
+  const missingKinds = optionalEnum(args, "missing_kinds", SURFACE_KINDS);
+  if (missingKinds) url.searchParams.set("missing_kinds", missingKinds);
   const reviewState = optionalString(args, "review_state");
   if (reviewState) url.searchParams.set("review_state", reviewState);
   const sort = optionalEnum(args, "sort", PRIORITY_SORT_FIELDS);
@@ -145,10 +148,10 @@ export const LIST_REVIEW_GAPS_MCP_TOOL = {
   description:
     "Fetch the contributor-targeted review gap priority board from the registry: " +
     "per-subnet priority_score, missing surface kinds, surface and candidate counts, " +
-    "curation_level, and review_state. Filter by netuid, curation_level, or review_state; " +
-    "sort with sort + order; and page with limit (1-100) / cursor. Distinct from list_gaps " +
-    "(interface facet reports at GET /api/v1/gaps) and get_subnet_gaps (one subnet's " +
-    "detailed gap artifact). Mirrors GET /api/v1/review/gaps.",
+    "curation_level, and review_state. Filter by netuid, curation_level, missing_kinds, " +
+    "or review_state; sort with sort + order; and page with limit (1-100) / cursor. " +
+    "Distinct from list_gaps (interface facet reports at GET /api/v1/gaps) and " +
+    "get_subnet_gaps (one subnet's detailed gap artifact). Mirrors GET /api/v1/review/gaps.",
   inputSchema: {
     type: "object",
     properties: {
@@ -161,6 +164,11 @@ export const LIST_REVIEW_GAPS_MCP_TOOL = {
         type: "string",
         enum: CURATION_LEVELS,
         description: "Filter by curation level.",
+      },
+      missing_kinds: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter rows whose missing_kinds include this kind.",
       },
       review_state: {
         type: "string",

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -18150,3 +18150,416 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
     assert.equal(FIELD_COMPLEXITY.chain_events, FIELD_COMPLEXITY.extrinsics);
   });
 });
+
+// #7167: GraphQL parity for GET /api/v1/review/* contributor-review family.
+describe("graphql — review_adapter_candidates", () => {
+  const BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["fixture"],
+    candidates: [
+      {
+        netuid: 7,
+        name: "Allways",
+        curation_level: "candidate-discovered",
+        recommended_adapter_kind: "custom-adapter",
+        priority_score: 90,
+      },
+      {
+        netuid: 31,
+        name: "Candles",
+        curation_level: "maintainer-reviewed",
+        recommended_adapter_kind: "stream-adapter",
+        priority_score: 40,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/adapter-candidates.json": BLOB,
+    });
+    const filtered = await gql(
+      "{ review_adapter_candidates(netuid: 7) { candidates total generated_at } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.errors, undefined);
+    assert.equal(filtered.body.data.review_adapter_candidates.total, 1);
+    assert.equal(
+      filtered.body.data.review_adapter_candidates.candidates[0].name,
+      "Allways",
+    );
+
+    const paged = await gql(
+      "{ review_adapter_candidates(limit: 1) { candidates total returned next_cursor } }",
+      env,
+    );
+    assert.equal(
+      paged.body.data.review_adapter_candidates.candidates.length,
+      1,
+    );
+    assert.equal(paged.body.data.review_adapter_candidates.total, 2);
+    assert.ok(paged.body.data.review_adapter_candidates.next_cursor != null);
+  });
+
+  test("surfaces invalid sort and cold artifact as GraphQL errors", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/adapter-candidates.json": BLOB,
+    });
+    const bad = await gql(
+      '{ review_adapter_candidates(sort: "bogus") { total } }',
+      env,
+    );
+    assert.ok(bad.body.errors?.length);
+    const cold = await gql("{ review_adapter_candidates { total } }", emptyEnv);
+    assert.ok(cold.body.errors?.length);
+  });
+
+  test("FIELD_COMPLEXITY weights it like sibling relationship fields", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.review_adapter_candidates,
+      FIELD_COMPLEXITY.gaps,
+    );
+  });
+});
+
+describe("graphql — review_enrichment_evidence", () => {
+  const BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["fixture"],
+    entries: [
+      {
+        netuid: 7,
+        name: "Allways",
+        lane: "direct-submission",
+        evidence_action: "submit-new-evidence",
+        priority_score: 80,
+      },
+      {
+        netuid: 31,
+        name: "Candles",
+        lane: "monitoring-followup",
+        evidence_action: "monitor",
+        priority_score: 20,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/enrichment-evidence.json": BLOB,
+    });
+    const filtered = await gql(
+      "{ review_enrichment_evidence(netuid: 7) { entries total } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.review_enrichment_evidence.total, 1);
+    assert.equal(
+      filtered.body.data.review_enrichment_evidence.entries[0].lane,
+      "direct-submission",
+    );
+    const paged = await gql(
+      "{ review_enrichment_evidence(limit: 1) { entries total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.review_enrichment_evidence.returned, 1);
+    assert.equal(paged.body.data.review_enrichment_evidence.total, 2);
+  });
+
+  test("surfaces invalid sort and cold artifact as GraphQL errors", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/enrichment-evidence.json": BLOB,
+    });
+    assert.ok(
+      (
+        await gql(
+          '{ review_enrichment_evidence(sort: "bogus") { total } }',
+          env,
+        )
+      ).body.errors?.length,
+    );
+    assert.ok(
+      (await gql("{ review_enrichment_evidence { total } }", emptyEnv)).body
+        .errors?.length,
+    );
+  });
+
+  test("FIELD_COMPLEXITY weights it like sibling relationship fields", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.review_enrichment_evidence,
+      FIELD_COMPLEXITY.gaps,
+    );
+  });
+});
+
+describe("graphql — review_enrichment_queue", () => {
+  const BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["fixture"],
+    queue: [
+      {
+        netuid: 7,
+        name: "Allways",
+        lane: "direct-submission",
+        profile_level: "directory-only",
+        priority_score: 95,
+      },
+      {
+        netuid: 31,
+        name: "Candles",
+        lane: "baseline-monitoring",
+        profile_level: "adapter-backed",
+        priority_score: 10,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/enrichment-queue.json": BLOB,
+    });
+    const filtered = await gql(
+      "{ review_enrichment_queue(netuid: 7) { queue total } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.review_enrichment_queue.total, 1);
+    assert.equal(
+      filtered.body.data.review_enrichment_queue.queue[0].name,
+      "Allways",
+    );
+    const paged = await gql(
+      "{ review_enrichment_queue(limit: 1) { queue total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.review_enrichment_queue.returned, 1);
+    assert.equal(paged.body.data.review_enrichment_queue.total, 2);
+  });
+
+  test("surfaces invalid sort and cold artifact as GraphQL errors", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/enrichment-queue.json": BLOB,
+    });
+    assert.ok(
+      (await gql('{ review_enrichment_queue(sort: "bogus") { total } }', env))
+        .body.errors?.length,
+    );
+    assert.ok(
+      (await gql("{ review_enrichment_queue { total } }", emptyEnv)).body.errors
+        ?.length,
+    );
+  });
+
+  test("FIELD_COMPLEXITY weights it like sibling relationship fields", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.review_enrichment_queue,
+      FIELD_COMPLEXITY.gaps,
+    );
+  });
+});
+
+describe("graphql — review_enrichment_targets", () => {
+  const BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["fixture"],
+    targets: [
+      {
+        netuid: 7,
+        name: "Allways",
+        target_type: "surface-candidate",
+        target_action: "submit-surface",
+        lane: "direct-submission",
+        priority_score: 88,
+      },
+      {
+        netuid: 31,
+        name: "Candles",
+        target_type: "adapter-review",
+        target_action: "review-adapter",
+        lane: "adapter-candidate",
+        priority_score: 22,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/enrichment-targets.json": BLOB,
+    });
+    const filtered = await gql(
+      "{ review_enrichment_targets(netuid: 7) { targets total } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.review_enrichment_targets.total, 1);
+    assert.equal(
+      filtered.body.data.review_enrichment_targets.targets[0].target_type,
+      "surface-candidate",
+    );
+    const paged = await gql(
+      "{ review_enrichment_targets(limit: 1) { targets total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.review_enrichment_targets.returned, 1);
+    assert.equal(paged.body.data.review_enrichment_targets.total, 2);
+  });
+
+  test("surfaces invalid sort and cold artifact as GraphQL errors", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/enrichment-targets.json": BLOB,
+    });
+    assert.ok(
+      (await gql('{ review_enrichment_targets(sort: "bogus") { total } }', env))
+        .body.errors?.length,
+    );
+    assert.ok(
+      (await gql("{ review_enrichment_targets { total } }", emptyEnv)).body
+        .errors?.length,
+    );
+  });
+
+  test("FIELD_COMPLEXITY weights it like sibling relationship fields", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.review_enrichment_targets,
+      FIELD_COMPLEXITY.gaps,
+    );
+  });
+});
+
+describe("graphql — review_gaps", () => {
+  const BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["fixture"],
+    priorities: [
+      {
+        netuid: 7,
+        name: "Allways",
+        curation_level: "candidate-discovered",
+        missing_kinds: ["openapi"],
+        priority_score: 88,
+      },
+      {
+        netuid: 31,
+        name: "Candles",
+        curation_level: "maintainer-reviewed",
+        missing_kinds: ["website"],
+        priority_score: 40,
+      },
+    ],
+  };
+
+  test("filters by netuid and missing_kinds, and paginates", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gap-priorities.json": BLOB,
+    });
+    const filtered = await gql(
+      '{ review_gaps(missing_kinds: "openapi") { priorities total } }',
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.review_gaps.total, 1);
+    assert.equal(filtered.body.data.review_gaps.priorities[0].netuid, 7);
+    const paged = await gql(
+      "{ review_gaps(limit: 1) { priorities total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.review_gaps.returned, 1);
+    assert.equal(paged.body.data.review_gaps.total, 2);
+  });
+
+  test("surfaces invalid sort and cold artifact as GraphQL errors", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gap-priorities.json": BLOB,
+    });
+    assert.ok(
+      (await gql('{ review_gaps(sort: "bogus") { total } }', env)).body.errors
+        ?.length,
+    );
+    assert.ok(
+      (await gql("{ review_gaps { total } }", emptyEnv)).body.errors?.length,
+    );
+  });
+
+  test("FIELD_COMPLEXITY weights it like sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.review_gaps, FIELD_COMPLEXITY.gaps);
+  });
+});
+
+describe("graphql — review_profile_completeness", () => {
+  const BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    schema_version: 1,
+    summary: { profile_count: 2 },
+    profiles: [
+      {
+        netuid: 7,
+        name: "Allways",
+        profile_level: "directory-only",
+        identity_level: "partial",
+        confidence: "low",
+        priority_score: 70,
+      },
+      {
+        netuid: 31,
+        name: "Candles",
+        profile_level: "adapter-backed",
+        identity_level: "complete",
+        confidence: "high",
+        priority_score: 5,
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/profile-completeness.json": BLOB,
+    });
+    const filtered = await gql(
+      "{ review_profile_completeness(netuid: 7) { profiles total summary generated_at } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.errors, undefined);
+    assert.equal(filtered.body.data.review_profile_completeness.total, 1);
+    assert.equal(
+      filtered.body.data.review_profile_completeness.profiles[0].identity_level,
+      "partial",
+    );
+    assert.equal(
+      filtered.body.data.review_profile_completeness.summary.profile_count,
+      2,
+    );
+    const paged = await gql(
+      "{ review_profile_completeness(limit: 1) { profiles total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.review_profile_completeness.returned, 1);
+    assert.equal(paged.body.data.review_profile_completeness.total, 2);
+  });
+
+  test("surfaces invalid sort and cold artifact as GraphQL errors", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/profile-completeness.json": BLOB,
+    });
+    assert.ok(
+      (
+        await gql(
+          '{ review_profile_completeness(sort: "bogus") { total } }',
+          env,
+        )
+      ).body.errors?.length,
+    );
+    assert.ok(
+      (await gql("{ review_profile_completeness { total } }", emptyEnv)).body
+        .errors?.length,
+    );
+  });
+
+  test("FIELD_COMPLEXITY weights it like sibling relationship fields", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.review_profile_completeness,
+      FIELD_COMPLEXITY.gaps,
+    );
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -15694,23 +15694,49 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  test("list_profile_completeness returns the profile-completeness artifact", async () => {
+  test("list_profile_completeness returns filtered profile-completeness rows", async () => {
     const deps = makeDeps({
       "/metagraph/review/profile-completeness.json": {
         generated_at: "2026-01-01T00:00:00Z",
-        profiles: [{ netuid: 7, profile_level: "partial" }],
-        summary: { profile_count: 1 },
+        profiles: [
+          {
+            netuid: 7,
+            profile_level: "directory-only",
+            identity_level: "partial",
+          },
+          {
+            netuid: 31,
+            profile_level: "adapter-backed",
+            identity_level: "complete",
+          },
+        ],
+        summary: { profile_count: 2 },
       },
     });
-    const res = await callTool("list_profile_completeness", {}, { deps });
+    const res = await callTool(
+      "list_profile_completeness",
+      { netuid: 7 },
+      { deps },
+    );
     const out = res.body.result.structuredContent;
+    assert.equal(out.profiles.length, 1);
     assert.equal(out.profiles[0].netuid, 7);
-    assert.equal(out.summary.profile_count, 1);
+    assert.equal(out.summary.profile_count, 2);
     assert.equal(out.generated_at, "2026-01-01T00:00:00Z");
+    assert.equal(out.total, 1);
   });
 
-  test("list_profile_completeness rejects an unexpected argument", async () => {
-    const res = await callTool("list_profile_completeness", { netuid: 7 });
+  test("list_profile_completeness rejects an invalid sort", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/profile-completeness.json": {
+        profiles: [{ netuid: 7 }],
+      },
+    });
+    const res = await callTool(
+      "list_profile_completeness",
+      { sort: "not_a_column" },
+      { deps },
+    );
     assert.equal(res.body.result.isError, true);
   });
 

--- a/tests/profile-completeness-mcp.test.mjs
+++ b/tests/profile-completeness-mcp.test.mjs
@@ -1,0 +1,340 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+  LIST_PROFILE_COMPLETENESS_MCP_TOOL,
+  LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+  PROFILE_COMPLETENESS_ARTIFACT,
+  loadProfileCompletenessList,
+  profileCompletenessMcpError,
+  profileCompletenessQueryUrl,
+} from "../src/profile-completeness-mcp.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  summary: { profile_count: 2 },
+  profiles: [
+    {
+      netuid: 7,
+      name: "Allways",
+      profile_level: "directory-only",
+      identity_level: "partial",
+      confidence: "low",
+      priority_score: 70,
+      native_name_quality: "placeholder",
+    },
+    {
+      netuid: 31,
+      name: "Candles",
+      profile_level: "adapter-backed",
+      identity_level: "complete",
+      confidence: "high",
+      priority_score: 5,
+      native_name_quality: "chain",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === PROFILE_COMPLETENESS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("profile-completeness-mcp", () => {
+  test("profileCompletenessMcpError is shaped for MCP toolError handling", () => {
+    const err = profileCompletenessMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("profileCompletenessQueryUrl validates filters and cursor", () => {
+    const url = profileCompletenessQueryUrl({
+      netuid: 7,
+      profile_level: "directory-only",
+      confidence: "low",
+      identity_level: "partial",
+      identity_promotion_kinds: "source-repo",
+      native_name_quality: "placeholder",
+      sort: "priority_score",
+      order: "desc",
+      fields: "netuid,priority_score",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("profile_level"), "directory-only");
+    assert.equal(url.searchParams.get("confidence"), "low");
+    assert.equal(url.searchParams.get("identity_level"), "partial");
+    assert.equal(
+      url.searchParams.get("identity_promotion_kinds"),
+      "source-repo",
+    );
+    assert.equal(url.searchParams.get("native_name_quality"), "placeholder");
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("profileCompletenessQueryUrl rejects invalid enums and netuid", () => {
+    assert.throws(
+      () => profileCompletenessQueryUrl({ profile_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ confidence: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ identity_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ native_name_quality: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ sort: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => profileCompletenessQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("profileCompletenessQueryUrl clamps limit", () => {
+    assert.equal(
+      profileCompletenessQueryUrl({ limit: 500 }).searchParams.get("limit"),
+      "100",
+    );
+    assert.equal(
+      profileCompletenessQueryUrl({ limit: 0 }).searchParams.get("limit"),
+      "50",
+    );
+    assert.equal(
+      profileCompletenessQueryUrl({ limit: "lots" }).searchParams.get("limit"),
+      "50",
+    );
+  });
+
+  test("profileCompletenessQueryUrl ignores empty optional enums", () => {
+    const url = profileCompletenessQueryUrl({
+      profile_level: "",
+      confidence: null,
+      identity_level: undefined,
+    });
+    assert.equal(url.searchParams.get("profile_level"), null);
+    assert.equal(url.searchParams.get("confidence"), null);
+    assert.equal(url.searchParams.get("identity_level"), null);
+  });
+
+  test("loadProfileCompletenessList returns filtered rows with pagination meta", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { identity_level: "partial" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.profiles[0].netuid, 7);
+    assert.equal(out.summary.profile_count, 2);
+    assert.equal(out.generated_at, SAMPLE_BLOB.generated_at);
+  });
+
+  test("loadProfileCompletenessList sorts and pages the collection", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact },
+      { sort: "priority_score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.profiles[0].netuid, 7);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadProfileCompletenessList uses an injected readArtifact dep", async () => {
+    const out = await loadProfileCompletenessList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: [{ netuid: 0, priority_score: 1 }] },
+        }),
+      },
+    );
+    assert.equal(out.profiles[0].netuid, 0);
+  });
+
+  test("loadProfileCompletenessList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProfileCompletenessList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" &&
+        /profile-completeness\.json/.test(err.message),
+    );
+  });
+
+  test("loadProfileCompletenessList defaults a missing failure code", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadProfileCompletenessList rejects a non-object blob", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadProfileCompletenessList rejects invalid list-query params", async () => {
+    await assert.rejects(
+      () =>
+        loadProfileCompletenessList(
+          { env: {}, readArtifact },
+          { fields: "not_a_column" },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadProfileCompletenessList omits nullable artifact metadata when absent", async () => {
+    const out = await loadProfileCompletenessList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: [{ netuid: 0, priority_score: 1 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.schema_version, null);
+    assert.equal(out.summary, null);
+  });
+
+  test("loadProfileCompletenessList treats a non-array profiles key as empty", async () => {
+    const out = await loadProfileCompletenessList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { profiles: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.profiles, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadProfileCompletenessList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { profiles: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadProfileCompletenessList(
+        { env: {}, readArtifact },
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("tool is registered and instructions mention list_profile_completeness", () => {
+    assert.ok(MCP_TOOLS.some((t) => t.name === "list_profile_completeness"));
+    assert.match(MCP_INSTRUCTIONS, /list_profile_completeness/);
+    assert.match(
+      LIST_PROFILE_COMPLETENESS_INSTRUCTIONS,
+      /profile-completeness/,
+    );
+    assert.equal(
+      LIST_PROFILE_COMPLETENESS_MCP_TOOL.name,
+      "list_profile_completeness",
+    );
+  });
+
+  test("output schema accepts a successful payload", () => {
+    const validate = new Ajv2020({ strict: false }).compile(
+      LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
+    );
+    assert.ok(
+      validate({
+        generated_at: "2026-07-01T00:00:00.000Z",
+        profiles: [{ netuid: 7 }],
+        total: 1,
+        returned: 1,
+        limit: 1,
+        cursor: 0,
+        next_cursor: null,
+        sort: null,
+        order: null,
+      }),
+    );
+  });
+});

--- a/tests/review-gaps-mcp.test.mjs
+++ b/tests/review-gaps-mcp.test.mjs
@@ -54,6 +54,7 @@ describe("review-gaps-mcp", () => {
     const url = reviewGapsQueryUrl({
       netuid: 7,
       curation_level: "candidate-discovered",
+      missing_kinds: "openapi",
       review_state: "needs-evidence",
       sort: "priority_score",
       order: "desc",
@@ -66,10 +67,18 @@ describe("review-gaps-mcp", () => {
       url.searchParams.get("curation_level"),
       "candidate-discovered",
     );
+    assert.equal(url.searchParams.get("missing_kinds"), "openapi");
     assert.equal(url.searchParams.get("review_state"), "needs-evidence");
     assert.equal(url.searchParams.get("sort"), "priority_score");
     assert.equal(url.searchParams.get("limit"), "10");
     assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("reviewGapsQueryUrl rejects invalid missing_kinds", () => {
+    assert.throws(
+      () => reviewGapsQueryUrl({ missing_kinds: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("reviewGapsQueryUrl rejects invalid curation_level", () => {


### PR DESCRIPTION
## Summary

Adds GraphQL `Query` parity for the six `/api/v1/review/*` contributor-review routes, and upgrades `list_profile_completeness` to the same list-query surface REST already exposes.

| Field                         | Mirrors                                   | MCP                                                                |
| ----------------------------- | ----------------------------------------- | ------------------------------------------------------------------ |
| `review_adapter_candidates`   | `GET /api/v1/review/adapter-candidates`   | existing `list_adapter_candidates`                                 |
| `review_enrichment_evidence`  | `GET /api/v1/review/enrichment-evidence`  | existing `list_enrichment_evidence`                                |
| `review_enrichment_queue`     | `GET /api/v1/review/enrichment-queue`     | existing `list_enrichment_queue`                                   |
| `review_enrichment_targets`   | `GET /api/v1/review/enrichment-targets`   | existing `list_review_enrichment_targets`                          |
| `review_gaps`                 | `GET /api/v1/review/gaps`                 | existing `list_review_gaps` (+ `missing_kinds` filter)             |
| `review_profile_completeness` | `GET /api/v1/review/profile-completeness` | `list_profile_completeness` now list-query (was raw artifact dump) |

## What Changed

- Six `Query` fields reuse the existing review-family MCP loaders unchanged (same filter/sort/page as REST). Cold/absent artifact or invalid filter/sort → GraphQL error (matching `gaps` / `source_snapshots`).
- Extracted `src/profile-completeness-mcp.mjs` so MCP and GraphQL share one loader with REST's list-query filters.
- `list_review_gaps` gains the REST `missing_kinds` filter that was previously omitted.
- MCP tools for the other four review routes already existed on main — no duplicate tools added.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7167`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] Focused tests: GraphQL review family + `profile-completeness-mcp` + `review-gaps` `missing_kinds` + MCP `list_profile_completeness`
- [x] `npm run lint` + `npm run format:check`
- [x] Pre-build drift: `validate:contract-drift` / `schema-enums` / `openapi-examples` / `generated-client` / `committed-seed`
- [x] `METAGRAPH_PRESERVE_PROBE_HEALTH=1 npm run build`
- [x] Post-build validators: `validate`, `validate:schemas|api|mcp|ai|openapi|types|artifact-budgets|docs|intake|surface|workflows|migrations`, cloudflare/r2/kv/worker dry-runs
- [x] `npm run scan:public-safety` + `npm run validate:private-boundary`
- [x] `npm run test:ci` — 333 files / 10109 tests; coverage stmts 98.95% / branches 97.61% / lines 99.17%; changed modules at 100% (graphql branches 99.77% overall)
- [x] `npm run test:ci:artifacts` — 5 files / 78 tests
- [x] `npm run pipeline:check` — local fail (`uvx` missing for `sync:subnets:dry-run`; CI has uv)
- [x] `npm run worker:bundle:budget` — local fail (missing `@cloudflare/workers-oauth-provider` resolve; env/install)

Closes #7167
