### PR TITLE
feat(ui): surface subnet lease state and history on the detail page

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
@@ -1,0 +1,263 @@
+import { useQuery } from "@tanstack/react-query";
+import { subnetLeaseHistoryQuery, subnetLeaseQuery } from "@/lib/metagraphed/queries";
+import type { SubnetLeaseEvent, SubnetLeaseTerms } from "@/lib/metagraphed/types";
+import { CopyableCode, StatTile, TimeAgo } from "@jsonbored/ui-kit";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+
+/**
+ * Live lease state + lease-created/terminated history for one subnet (#6993).
+ * Sibling of SubnetOwnershipHistory / SubnetConvictionLeaderboard for the
+ * leasing epic (#6717). Three distinct live states:
+ *   - leased: true  → terms + dividend accrual
+ *   - leased: false → confirmed not currently leased
+ *   - leased: null  → RPC failure (must not look like "not leased")
+ * When leased:true but lease terms are null, show a retry notice — transient
+ * decode/race, not "no lease".
+ */
+export function SubnetLeasePanel({ netuid }: { netuid: number }) {
+  const leaseQ = useQuery(subnetLeaseQuery(netuid));
+  const histQ = useQuery(subnetLeaseHistoryQuery(netuid));
+
+  if (leaseQ.isError) {
+    return (
+      <ErrorState
+        error={leaseQ.error}
+        onRetry={() => leaseQ.refetch()}
+        context="subnet lease state"
+      />
+    );
+  }
+
+  if (leaseQ.isLoading) {
+    return <Skeleton className="h-40 w-full" />;
+  }
+
+  const state = leaseQ.data?.data;
+  const leased = state?.leased ?? null;
+  const lease = state?.lease ?? null;
+
+  return (
+    <div className="space-y-6">
+      <LeaseStatusCard
+        netuid={netuid}
+        leased={leased}
+        lease={lease}
+        queriedAt={state?.queried_at ?? null}
+        onRetry={() => leaseQ.refetch()}
+      />
+      <LeaseHistorySection
+        netuid={netuid}
+        isLoading={histQ.isLoading}
+        isError={histQ.isError}
+        error={histQ.error}
+        onRetry={() => histQ.refetch()}
+        events={histQ.data?.data.lease_events ?? []}
+      />
+    </div>
+  );
+}
+
+function RetryNotice({
+  title,
+  description,
+  onRetry,
+}: {
+  title: string;
+  description: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="rounded border border-dashed border-ink-subtle bg-surface/30 p-6 text-center">
+      <div className="font-display text-sm font-medium text-ink-strong">{title}</div>
+      <p className="mx-auto mt-1 max-w-md text-xs text-ink-muted">{description}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 rounded border border-border bg-card px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest text-ink hover:border-ink/30"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function LeaseStatusCard({
+  netuid,
+  leased,
+  lease,
+  queriedAt,
+  onRetry,
+}: {
+  netuid: number;
+  leased: boolean | null;
+  lease: SubnetLeaseTerms | null;
+  queriedAt: string | null;
+  onRetry: () => void;
+}) {
+  if (leased === null) {
+    return (
+      <RetryNotice
+        title="Lease status unavailable"
+        description={`Live RPC for SN${netuid} lease state failed — this is not the same as "not leased". Retry to re-query SubnetUidToLeaseId.`}
+        onRetry={onRetry}
+      />
+    );
+  }
+
+  if (leased === false) {
+    return (
+      <EmptyState
+        title="Not currently leased"
+        description="This subnet has no active lease on-chain right now. Past lease-created/terminated events (if any) appear in the history below."
+      />
+    );
+  }
+
+  if (!lease) {
+    return (
+      <RetryNotice
+        title="Lease terms unavailable"
+        description="A lease is active, but its details couldn't be decoded this request (transient RPC failure or a race against termination). Retry — do not treat this as unleased."
+        onRetry={onRetry}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent-text">
+            Leased
+          </span>
+          <span className="font-mono text-[11px] text-ink-muted">lease #{lease.lease_id}</span>
+        </div>
+        {queriedAt ? (
+          <span className="font-mono text-[11px] text-ink-muted">
+            queried <TimeAgo at={queriedAt} />
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap gap-3 [&>*]:grow [&>*]:basis-[160px]">
+        <StatTile
+          eyebrow="Emissions share"
+          tone="accent"
+          value={`${lease.emissions_share_percent}%`}
+        />
+        <StatTile eyebrow="Cost" value={formatTao(lease.cost_tao)} />
+        <StatTile
+          eyebrow="End block"
+          value={lease.end_block != null ? `#${formatNumber(lease.end_block)}` : "perpetual"}
+        />
+        <StatTile
+          eyebrow="Accumulated α"
+          value={
+            lease.accumulated_dividends_alpha == null
+              ? "—"
+              : formatAlpha(lease.accumulated_dividends_alpha)
+          }
+          hint="undistributed"
+        />
+      </div>
+
+      <dl className="grid gap-2 border-t border-border pt-3 sm:grid-cols-3">
+        <KeySs58 label="Beneficiary" value={lease.beneficiary} />
+        <KeySs58 label="Coldkey" value={lease.coldkey} />
+        <KeySs58 label="Hotkey" value={lease.hotkey} />
+      </dl>
+    </div>
+  );
+}
+
+function KeySs58({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">{label}</dt>
+      <dd className="mt-1">
+        <CopyableCode value={value} className="max-w-full" />
+      </dd>
+    </div>
+  );
+}
+
+function formatAlpha(whole: number): string {
+  if (!Number.isFinite(whole)) return "—";
+  const magnitude = Math.abs(whole);
+  if (magnitude >= 1_000_000) return `${(whole / 1_000_000).toFixed(2)}M α`;
+  if (magnitude >= 1_000) return `${(whole / 1_000).toFixed(1)}k α`;
+  if (magnitude >= 1) return `${whole.toFixed(2)} α`;
+  if (whole === 0) return "0 α";
+  return `${whole.toFixed(4)} α`;
+}
+
+function LeaseHistorySection({
+  netuid,
+  isLoading,
+  isError,
+  error,
+  onRetry,
+  events,
+}: {
+  netuid: number;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  onRetry: () => void;
+  events: SubnetLeaseEvent[];
+}) {
+  return (
+    <div>
+      <h3 className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+        Lease history
+      </h3>
+      {isError ? (
+        <ErrorState error={error} onRetry={onRetry} context="subnet lease history" />
+      ) : isLoading ? (
+        <Skeleton className="h-24 w-full" />
+      ) : events.length === 0 ? (
+        <EmptyState
+          title="No lease events"
+          description={`SN${netuid} has no SubnetLeaseCreated / SubnetLeaseTerminated events in the captured window — the common case for never-leased subnets.`}
+        />
+      ) : (
+        <ol className="space-y-2">
+          {events.map((ev, i) => (
+            <li
+              key={`${ev.block_number ?? i}-${ev.event_kind ?? i}-${ev.observed_at ?? i}`}
+              className="rounded-lg border border-border bg-card p-3"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <span
+                    className={
+                      ev.event_kind === "SubnetLeaseTerminated"
+                        ? "rounded-full border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted"
+                        : "rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent-text"
+                    }
+                  >
+                    {ev.event_kind === "SubnetLeaseTerminated"
+                      ? "Terminated"
+                      : ev.event_kind === "SubnetLeaseCreated"
+                        ? "Created"
+                        : (ev.event_kind ?? "event")}
+                  </span>
+                  {ev.beneficiary ? (
+                    <CopyableCode value={ev.beneficiary} className="max-w-full" />
+                  ) : (
+                    <span className="font-mono text-[11px] text-ink-muted">no beneficiary</span>
+                  )}
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-ink-muted">
+                  {ev.block_number != null ? `block #${formatNumber(ev.block_number)} · ` : ""}
+                  {ev.observed_at ? <TimeAgo at={ev.observed_at} /> : "unknown time"}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-lease.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-lease.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  normalizeSubnetLeaseHistory,
+  normalizeSubnetLeaseState,
+  subnetLeaseHistoryQuery,
+  subnetLeaseQuery,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(url: string, data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url,
+  });
+}
+
+async function runLease(netuid: number) {
+  const opts = subnetLeaseQuery(netuid);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+async function runHistory(netuid: number) {
+  const opts = subnetLeaseHistoryQuery(netuid);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeSubnetLeaseState", () => {
+  it("passes a confirmed no-lease card through", () => {
+    expect(
+      normalizeSubnetLeaseState(7, {
+        schema_version: 1,
+        netuid: 7,
+        leased: false,
+        lease: null,
+        queried_at: "2026-07-20T00:00:00Z",
+      }),
+    ).toEqual({
+      schema_version: 1,
+      netuid: 7,
+      leased: false,
+      lease: null,
+      queried_at: "2026-07-20T00:00:00Z",
+    });
+  });
+
+  it("preserves leased:null (RPC failure) — never coerces to false", () => {
+    expect(normalizeSubnetLeaseState(7, { leased: null }).leased).toBeNull();
+    expect(normalizeSubnetLeaseState(7, {}).leased).toBeNull();
+    expect(normalizeSubnetLeaseState(7, null).leased).toBeNull();
+  });
+
+  it("normalizes active lease terms and keeps null dividends", () => {
+    const out = normalizeSubnetLeaseState(7, {
+      leased: true,
+      lease: {
+        lease_id: 3,
+        beneficiary: "5Ben",
+        coldkey: "5Cold",
+        hotkey: "5Hot",
+        emissions_share_percent: 40,
+        end_block: null,
+        netuid: 7,
+        cost_tao: 12.5,
+        accumulated_dividends_alpha: null,
+      },
+    });
+    expect(out.leased).toBe(true);
+    expect(out.lease?.lease_id).toBe(3);
+    expect(out.lease?.end_block).toBeNull();
+    expect(out.lease?.accumulated_dividends_alpha).toBeNull();
+  });
+
+  it("drops a malformed lease object to null", () => {
+    const out = normalizeSubnetLeaseState(7, {
+      leased: true,
+      lease: { lease_id: 1 },
+    });
+    expect(out.leased).toBe(true);
+    expect(out.lease).toBeNull();
+  });
+});
+
+describe("normalizeSubnetLeaseHistory", () => {
+  it("passes events through and defaults metadata", () => {
+    const out = normalizeSubnetLeaseHistory(7, {
+      lease_events: [
+        {
+          event_kind: "SubnetLeaseCreated",
+          beneficiary: "5Ben",
+          block_number: 100,
+          observed_at: "2026-07-01T00:00:00Z",
+        },
+      ],
+    });
+    expect(out.netuid).toBe(7);
+    expect(out.count).toBe(1);
+    expect(out.event_pallet).toBe("SubtensorModule");
+    expect(out.lease_events).toHaveLength(1);
+  });
+
+  it("degrades junk to an empty history", () => {
+    for (const raw of [{}, null, "x"]) {
+      const out = normalizeSubnetLeaseHistory(7, raw);
+      expect(out.lease_events).toEqual([]);
+      expect(out.count).toBe(0);
+    }
+  });
+});
+
+describe("subnetLeaseQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits /api/v1/subnets/{netuid}/lease", async () => {
+    resolveWith("/api/v1/subnets/7/lease", { leased: false, lease: null });
+    const res = await runLease(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/lease",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(res.data.leased).toBe(false);
+  });
+});
+
+describe("subnetLeaseHistoryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits /api/v1/subnets/{netuid}/lease/history", async () => {
+    resolveWith("/api/v1/subnets/7/lease/history", { lease_events: [], count: 0 });
+    const res = await runHistory(7);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/lease/history",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(res.data.lease_events).toEqual([]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -207,6 +207,10 @@ import type {
   SubnetConviction,
   SubnetConvictionEntry,
   SubnetOwnershipHistory,
+  SubnetLeaseState,
+  SubnetLeaseTerms,
+  SubnetLeaseHistory,
+  SubnetLeaseEvent,
   SubnetOwnershipChange,
   SubnetMovers,
   SubnetMover,
@@ -4896,6 +4900,105 @@ export const subnetOwnershipHistoryQuery = (netuid: number) =>
       );
       return {
         data: normalizeSubnetOwnershipHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeSubnetLeaseTerms(raw: unknown): SubnetLeaseTerms | null {
+  if (!isRecord(raw)) return null;
+  const leaseId = firstFiniteNumber(raw.lease_id);
+  const beneficiary = firstString(raw.beneficiary);
+  const coldkey = firstString(raw.coldkey);
+  const hotkey = firstString(raw.hotkey);
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (leaseId == null || !beneficiary || !coldkey || !hotkey || netuid == null) return null;
+  return {
+    lease_id: leaseId,
+    beneficiary,
+    coldkey,
+    hotkey,
+    emissions_share_percent: firstFiniteNumber(raw.emissions_share_percent) ?? 0,
+    end_block: firstFiniteNumber(raw.end_block) ?? null,
+    netuid,
+    cost_tao: coerceFiniteNumber(raw.cost_tao) ?? 0,
+    // Preserve null (sub-read failure) — never coerce to 0.
+    accumulated_dividends_alpha: coerceFiniteNumber(raw.accumulated_dividends_alpha) ?? null,
+  };
+}
+
+// #6993: live lease state. `leased: null` means RPC failure (distinct from
+// confirmed no-lease). Missing/junk `leased` also degrades to null so we
+// never invent a "not leased" signal from a broken payload.
+export function normalizeSubnetLeaseState(netuid: number, raw: unknown): SubnetLeaseState {
+  const d = isRecord(raw) ? raw : {};
+  const leasedRaw = d.leased;
+  const leased: boolean | null = leasedRaw === true || leasedRaw === false ? leasedRaw : null;
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    leased,
+    lease: normalizeSubnetLeaseTerms(d.lease),
+    queried_at: firstString(d.queried_at) ?? null,
+  };
+}
+
+export const subnetLeaseQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-lease", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetLeaseState>>(`/api/v1/subnets/${netuid}/lease`, {
+        signal,
+      });
+      return {
+        data: normalizeSubnetLeaseState(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeSubnetLeaseEvent(raw: unknown): SubnetLeaseEvent | null {
+  if (!isRecord(raw)) return null;
+  return {
+    event_kind: firstString(raw.event_kind) ?? null,
+    beneficiary: firstString(raw.beneficiary) ?? null,
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+  };
+}
+
+export function normalizeSubnetLeaseHistory(netuid: number, raw: unknown): SubnetLeaseHistory {
+  const d = isRecord(raw) ? raw : {};
+  const events = Array.isArray(d.lease_events)
+    ? d.lease_events.map(normalizeSubnetLeaseEvent).filter((e): e is SubnetLeaseEvent => e != null)
+    : [];
+  const kinds = Array.isArray(d.event_kinds)
+    ? d.event_kinds.filter((k): k is string => typeof k === "string" && k.length > 0)
+    : [];
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    event_pallet: firstString(d.event_pallet) ?? "SubtensorModule",
+    event_kinds: kinds,
+    count: firstFiniteNumber(d.count) ?? events.length,
+    lease_events: events,
+  };
+}
+
+export const subnetLeaseHistoryQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-lease-history", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetLeaseHistory>>(
+        `/api/v1/subnets/${netuid}/lease/history`,
+        { signal },
+      );
+      return {
+        data: normalizeSubnetLeaseHistory(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2044,6 +2044,58 @@ export interface SubnetOwnershipHistory {
   ownership_changes: SubnetOwnershipChange[];
 }
 
+/**
+ * Terms of one active subnet lease from GET /api/v1/subnets/{netuid}/lease
+ * (#6993 / #6719). beneficiary/coldkey/hotkey are SS58. end_block is null
+ * for a perpetual lease. accumulated_dividends_alpha is null only when that
+ * sub-read failed independently.
+ */
+export interface SubnetLeaseTerms {
+  lease_id: number;
+  beneficiary: string;
+  coldkey: string;
+  hotkey: string;
+  emissions_share_percent: number;
+  end_block: number | null;
+  netuid: number;
+  cost_tao: number;
+  accumulated_dividends_alpha: number | null;
+}
+
+/**
+ * Live subnet-lease state (#6993). `leased: null` is RPC failure — distinct
+ * from confirmed no-lease (`leased: false`). `lease` may be null while
+ * `leased: true` when terms couldn't be decoded this request (retry).
+ */
+export interface SubnetLeaseState {
+  schema_version: number;
+  netuid: number;
+  leased: boolean | null;
+  lease: SubnetLeaseTerms | null;
+  queried_at: string | null;
+}
+
+/** One SubnetLeaseCreated/SubnetLeaseTerminated event (#6718). */
+export interface SubnetLeaseEvent {
+  event_kind: string | null;
+  beneficiary: string | null;
+  block_number: number | null;
+  observed_at: string | null;
+}
+
+/**
+ * Lease-created/terminated event log from
+ * GET /api/v1/subnets/{netuid}/lease/history (#6993). Never-leased → empty list.
+ */
+export interface SubnetLeaseHistory {
+  schema_version: number;
+  netuid: number;
+  event_pallet: string;
+  event_kinds: string[];
+  count: number;
+  lease_events: SubnetLeaseEvent[];
+}
+
 /** One subnet's movement over the comparison window on the /subnets/movers board. */
 export interface SubnetMover {
   netuid: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -49,6 +49,7 @@ import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-char
 import { SubnetOhlcChart } from "@/components/metagraphed/subnet-ohlc-chart";
 import { SubnetConvictionLeaderboard } from "@/components/metagraphed/subnet-conviction-leaderboard";
 import { SubnetOwnershipHistory } from "@/components/metagraphed/subnet-ownership-history";
+import { SubnetLeasePanel } from "@/components/metagraphed/subnet-lease-panel";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
@@ -373,6 +374,8 @@ function ProfileShell({ netuid }: { netuid: number }) {
             `/api/v1/subnets/${netuid}/profile`,
             `/api/v1/subnets/${netuid}/overview`,
             `/api/v1/subnets/${netuid}/identity-history`,
+            `/api/v1/subnets/${netuid}/lease`,
+            `/api/v1/subnets/${netuid}/lease/history`,
           ]}
         />
       </SubnetFilterProvider>
@@ -528,6 +531,20 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
       >
         <QueryErrorBoundary>
           <SubnetOwnershipHistory netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      {/* 5a6 — Subnet lease state + history (#6993, backend #6719/#6813,
+          part of leasing epic #6717): live lease terms + created/terminated
+          event log. Sibling of the ownership-contest panels above. */}
+      <SectionAnchor
+        id="lease"
+        title="Subnet lease"
+        subtitle="Live lease status, terms, and created/terminated history."
+        info="GET /api/v1/subnets/{netuid}/lease and /lease/history — live RPC for current lease state (leased null = RPC failure, distinct from not leased) plus the SubnetLeaseCreated/Terminated event log."
+      >
+        <QueryErrorBoundary>
+          <SubnetLeasePanel netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
 


### PR DESCRIPTION
## Summary

Surfaces **subnet lease** state and history on the subnet detail page. Backend routes `GET /api/v1/subnets/{netuid}/lease` and `/lease/history` (#6719/#6813) already shipped; this wires the sibling UI next to the ownership-contest panels.

## What it adds

- **`SubnetLeasePanel`** (`apps/ui/src/components/metagraphed/subnet-lease-panel.tsx`) with three distinct live states:
  - `leased: true` — terms tiles (emissions share, cost, end block / perpetual, accumulated α) + beneficiary/coldkey/hotkey
  - `leased: false` — confirmed “not currently leased” empty state
  - `leased: null` — RPC failure notice with retry (never conflated with not-leased)
  - `leased: true` + `lease: null` — terms unavailable / retry (transient decode race)
- **Lease history** — created/terminated event log under the same panel (ownership-history pattern)
- **Client wiring** — `subnetLeaseQuery` / `subnetLeaseHistoryQuery` + normalizers that preserve `leased: null` and null dividends
- Section `#lease` on `subnets.$netuid.tsx` after ownership history; footer paths updated

## Verification

- `eslint` (changed files) — 0 errors
- `tsc --noEmit` (apps/ui) — pass
- `vitest run queries.subnet-lease` — 8 pass
- Screenshots below (fixed viewport × theme matrix; before = `main`, after = this branch; scrolled to `#lease` / fallback `#ownership-history`)

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6993-lease-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6993