### PR TITLE
feat(ui): add a subnet-lease state + history panel to the subnet detail page (#6993)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
@@ -1,0 +1,188 @@
+import { useQuery } from "@tanstack/react-query";
+import { KeyRound } from "lucide-react";
+import { subnetLeaseQuery, subnetLeaseHistoryQuery } from "@/lib/metagraphed/queries";
+import { CopyableCode, TimeAgo } from "@jsonbored/ui-kit";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import type { SubnetLeaseTerms } from "@/lib/metagraphed/types";
+
+// accumulated_dividends_alpha arrives already in display (÷1e9) alpha units.
+function fmtAlpha(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  const mag = Math.abs(v);
+  if (mag >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M α`;
+  if (mag >= 1_000) return `${(v / 1_000).toFixed(1)}k α`;
+  if (mag >= 1) return `${v.toFixed(2)} α`;
+  return v === 0 ? "0 α" : `${v.toFixed(4)} α`;
+}
+
+function Term({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="min-w-0 space-y-0.5">
+      <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">{label}</dt>
+      <dd className="font-mono text-[12px] text-ink-strong">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * Live subnet-lease state (#6993, part of the crowdfunded-leasing epic #6717):
+ * whether this subnet is operated under a lease, its terms, and its lease
+ * event history. `leased` is a tri-state -- true / false / null (RPC failure) --
+ * rendered distinctly so an unavailable read never reads as "not leased".
+ */
+export function SubnetLeasePanel({ netuid }: { netuid: number }) {
+  return (
+    <div className="space-y-4">
+      <LeaseStateBlock netuid={netuid} />
+      <LeaseHistoryBlock netuid={netuid} />
+    </div>
+  );
+}
+
+function LeaseStateBlock({ netuid }: { netuid: number }) {
+  const { data: res, isLoading, isError, error, refetch } = useQuery(subnetLeaseQuery(netuid));
+
+  if (isError) {
+    return <ErrorState error={error} onRetry={() => refetch()} context="subnet lease" />;
+  }
+  if (isLoading) {
+    return <Skeleton className="h-40 w-full" />;
+  }
+
+  const data = res?.data;
+  const leased = data?.leased ?? null;
+
+  // null — RPC read failed; distinct from a confirmed "not leased".
+  if (leased === null) {
+    return (
+      <EmptyState
+        title="Lease state unavailable"
+        description="The on-chain lease read did not return in time. This is a transient RPC failure, not a confirmation that the subnet is unleased -- retry shortly."
+      />
+    );
+  }
+
+  // false — confirmed not leased (the common case).
+  if (leased === false) {
+    return (
+      <EmptyState
+        title="Not currently leased"
+        description="This subnet is not operated under a crowdfunded lease. A lease appears here once one is registered on-chain."
+      />
+    );
+  }
+
+  // true — leased. Terms may still be null if the detail read failed this pass.
+  const lease: SubnetLeaseTerms | null = data?.lease ?? null;
+  if (!lease) {
+    return (
+      <EmptyState
+        title="Lease active — details unavailable"
+        description="This subnet is under an active lease, but its terms could not be decoded this request. Retry shortly."
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-accent/30 bg-accent-surface/40 p-4">
+      <div className="mb-3 inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent">
+        <KeyRound className="size-3" aria-hidden />
+        Active lease
+      </div>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3">
+        <Term label="Operator (beneficiary)">
+          <CopyableCode value={lease.beneficiary} className="max-w-full" />
+        </Term>
+        <Term label="Lessor coldkey">
+          <CopyableCode value={lease.coldkey} className="max-w-full" />
+        </Term>
+        <Term label="Lessor hotkey">
+          <CopyableCode value={lease.hotkey} className="max-w-full" />
+        </Term>
+        <Term label="Emissions share">
+          <span className="tabular-nums">{lease.emissions_share_percent}%</span>
+        </Term>
+        <Term label="Cost">
+          <span className="tabular-nums">{formatTao(lease.cost_tao)}</span>
+        </Term>
+        <Term label="Accrued dividends">
+          <span className="tabular-nums">{fmtAlpha(lease.accumulated_dividends_alpha)}</span>
+        </Term>
+        <Term label="End block">
+          <span className="tabular-nums">
+            {lease.end_block != null ? `#${formatNumber(lease.end_block)}` : "Perpetual"}
+          </span>
+        </Term>
+        <Term label="Lease ID">
+          <span className="tabular-nums">{formatNumber(lease.lease_id)}</span>
+        </Term>
+      </dl>
+    </div>
+  );
+}
+
+function eventLabel(kind: string): { text: string; className: string } {
+  if (kind === "SubnetLeaseCreated") {
+    return { text: "Created", className: "border-health-ok/40 bg-health-ok/10 text-health-ok" };
+  }
+  if (kind === "SubnetLeaseTerminated") {
+    return {
+      text: "Terminated",
+      className: "border-health-down/40 bg-health-down/10 text-health-down",
+    };
+  }
+  return { text: kind, className: "border-border bg-surface/40 text-ink-muted" };
+}
+
+function LeaseHistoryBlock({ netuid }: { netuid: number }) {
+  const { data: res, isError } = useQuery(subnetLeaseHistoryQuery(netuid));
+  // History is supplementary — stay quiet on load/error and when there are no
+  // events (the common case), so it never clutters an unleased subnet's panel.
+  if (isError) return null;
+  const events = res?.data.lease_events ?? [];
+  if (events.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <h3 className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        Lease history
+      </h3>
+      <ol className="space-y-2">
+        {events.map((event, i) => {
+          const label = eventLabel(event.event_kind);
+          return (
+            <li
+              key={`${event.block_number ?? i}-${event.event_kind}`}
+              className="rounded-lg border border-border bg-card p-3"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <span
+                    className={classNames(
+                      "inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+                      label.className,
+                    )}
+                  >
+                    {label.text}
+                  </span>
+                  {event.beneficiary ? (
+                    <CopyableCode value={event.beneficiary} className="max-w-full" />
+                  ) : (
+                    <span className="font-mono text-[11px] text-ink-muted">unknown operator</span>
+                  )}
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-ink-muted">
+                  {event.block_number != null
+                    ? `block #${formatNumber(event.block_number)} · `
+                    : ""}
+                  {event.observed_at ? <TimeAgo at={event.observed_at} /> : "unknown time"}
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -207,6 +207,10 @@ import type {
   SubnetConviction,
   SubnetConvictionEntry,
   SubnetOwnershipHistory,
+  SubnetLease,
+  SubnetLeaseTerms,
+  SubnetLeaseHistory,
+  SubnetLeaseEvent,
   SubnetOwnershipChange,
   SubnetMovers,
   SubnetMover,
@@ -4896,6 +4900,96 @@ export const subnetOwnershipHistoryQuery = (netuid: number) =>
       );
       return {
         data: normalizeSubnetOwnershipHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeSubnetLeaseTerms(raw: unknown): SubnetLeaseTerms | null {
+  if (!isRecord(raw)) return null;
+  return {
+    lease_id: firstFiniteNumber(raw.lease_id) ?? 0,
+    beneficiary: firstString(raw.beneficiary) ?? "",
+    coldkey: firstString(raw.coldkey) ?? "",
+    hotkey: firstString(raw.hotkey) ?? "",
+    emissions_share_percent: firstFiniteNumber(raw.emissions_share_percent) ?? 0,
+    end_block: firstFiniteNumber(raw.end_block) ?? null,
+    netuid: firstFiniteNumber(raw.netuid) ?? 0,
+    cost_tao: coerceFiniteNumber(raw.cost_tao) ?? 0,
+    accumulated_dividends_alpha: coerceFiniteNumber(raw.accumulated_dividends_alpha) ?? null,
+  };
+}
+
+export function normalizeSubnetLease(netuid: number, raw: unknown): SubnetLease {
+  const d = isRecord(raw) ? raw : {};
+  // Preserve the leased tri-state — true / false / null (RPC failure). Never
+  // coerce, or the RPC-failure state collapses into "not leased".
+  const leased = d.leased === true ? true : d.leased === false ? false : null;
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    leased,
+    lease: leased === true ? normalizeSubnetLeaseTerms(d.lease) : null,
+    queried_at: firstString(d.queried_at) ?? null,
+  };
+}
+
+/** Live subnet-lease state (#6993). */
+export const subnetLeaseQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-lease", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetLease>>(`/api/v1/subnets/${netuid}/lease`, {
+        signal,
+      });
+      return { data: normalizeSubnetLease(netuid, res.data), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeSubnetLeaseEvent(raw: unknown): SubnetLeaseEvent | null {
+  if (!isRecord(raw)) return null;
+  const kind = firstString(raw.event_kind);
+  if (!kind) return null;
+  return {
+    event_kind: kind,
+    beneficiary: firstString(raw.beneficiary) ?? null,
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+  };
+}
+
+export function normalizeSubnetLeaseHistory(netuid: number, raw: unknown): SubnetLeaseHistory {
+  const d = isRecord(raw) ? raw : {};
+  const events = Array.isArray(d.lease_events)
+    ? d.lease_events.map(normalizeSubnetLeaseEvent).filter((e): e is SubnetLeaseEvent => e != null)
+    : [];
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    event_pallet: firstString(d.event_pallet) ?? "SubtensorModule",
+    event_kinds: Array.isArray(d.event_kinds)
+      ? d.event_kinds.filter((x): x is string => typeof x === "string")
+      : [],
+    count: firstFiniteNumber(d.count) ?? events.length,
+    lease_events: events,
+  };
+}
+
+/** Lease event log (#6993) — SubnetLeaseCreated/Terminated, empty (not 404) for
+ *  a never-leased subnet. */
+export const subnetLeaseHistoryQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-lease-history", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetLeaseHistory>>(
+        `/api/v1/subnets/${netuid}/lease/history`,
+        { signal },
+      );
+      return {
+        data: normalizeSubnetLeaseHistory(netuid, res.data),
         meta: res.meta,
         url: res.url,
       };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2044,6 +2044,49 @@ export interface SubnetOwnershipHistory {
   ownership_changes: SubnetOwnershipChange[];
 }
 
+/** Terms of an active subnet lease (#6993). Present only when leased === true
+ *  and the detail read succeeded; can be null even while leased (retry). */
+export interface SubnetLeaseTerms {
+  lease_id: number;
+  beneficiary: string;
+  coldkey: string;
+  hotkey: string;
+  emissions_share_percent: number;
+  end_block: number | null;
+  netuid: number;
+  cost_tao: number;
+  accumulated_dividends_alpha: number | null;
+}
+
+/** Live subnet-lease state (GET /api/v1/subnets/{netuid}/lease). `leased` is a
+ *  tri-state: true (leased), false (confirmed not leased), null (RPC failure —
+ *  distinct from "not leased"). */
+export interface SubnetLease {
+  schema_version: number;
+  netuid: number;
+  leased: boolean | null;
+  lease: SubnetLeaseTerms | null;
+  queried_at: string | null;
+}
+
+/** One lease lifecycle event (SubnetLeaseCreated / SubnetLeaseTerminated). */
+export interface SubnetLeaseEvent {
+  event_kind: string;
+  beneficiary: string | null;
+  block_number: number | null;
+  observed_at: string | null;
+}
+
+/** Lease event log (GET /api/v1/subnets/{netuid}/lease/history). */
+export interface SubnetLeaseHistory {
+  schema_version: number;
+  netuid: number;
+  event_pallet: string;
+  event_kinds: string[];
+  count: number;
+  lease_events: SubnetLeaseEvent[];
+}
+
 /** One subnet's movement over the comparison window on the /subnets/movers board. */
 export interface SubnetMover {
   netuid: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -49,6 +49,7 @@ import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-char
 import { SubnetOhlcChart } from "@/components/metagraphed/subnet-ohlc-chart";
 import { SubnetConvictionLeaderboard } from "@/components/metagraphed/subnet-conviction-leaderboard";
 import { SubnetOwnershipHistory } from "@/components/metagraphed/subnet-ownership-history";
+import { SubnetLeasePanel } from "@/components/metagraphed/subnet-lease-panel";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
@@ -209,6 +210,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   economics: "overview",
   "volume-24h": "overview",
   "stake-quote": "overview",
+  lease: "overview",
   reliability: "overview",
   lineage: "overview",
   // #6434: the Overview embed is a preview and owns `evidence-preview`; the
@@ -528,6 +530,21 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
       >
         <QueryErrorBoundary>
           <SubnetOwnershipHistory netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      {/* 5a6 — Subnet lease (#6717 crowdfunded-leasing epic, routes #6719/#6813):
+          whether this subnet is operated under a lease, its terms + accrued
+          dividends, and the lease-created/terminated event history. Most subnets
+          are not leased -- rendered as an empty state, not an error. */}
+      <SectionAnchor
+        id="lease"
+        title="Subnet lease"
+        subtitle="Whether this subnet is currently operated under a crowdfunded lease, and its terms."
+        info="GET /api/v1/subnets/{netuid}/lease — live chain state (leased is a tri-state: leased / not leased / unavailable). GET /api/v1/subnets/{netuid}/lease/history — the SubnetLeaseCreated/Terminated event log."
+      >
+        <QueryErrorBoundary>
+          <SubnetLeasePanel netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
 


### PR DESCRIPTION
## Summary

Adds a subnet-lease panel to the subnet detail page — the UI for the crowdfunded-leasing epic (#6717), whose two routes (`GET /api/v1/subnets/{netuid}/lease` and `/lease/history`, both with MCP tools) shipped in #6719/#6813 with no UI. A subnet under an active lease now shows its terms and dividend accrual, and its lease event history, matching the UI coverage the sibling ownership-contest feature already has.

## What it adds

- **`SubnetLeasePanel`** (new component), wired into `subnets.$netuid.tsx` as a "Subnet lease" `SectionAnchor` right after the ownership-contest sections — mirroring the `SubnetConvictionLeaderboard` / `SubnetOwnershipHistory` pattern (same `Skeleton` / `EmptyState` / `ErrorState` handling, `CopyableCode` / `TimeAgo` primitives).
- **All three lease states handled distinctly**, per the route's tri-state `leased`:
  - `leased: true` → an "Active lease" card with the terms (operator/lessor keys, emissions share, cost, accrued alpha dividends, end block, lease ID).
  - `leased: false` → a "Not currently leased" empty state (the common case).
  - `leased: null` → a distinct "Lease state unavailable" empty state — an RPC failure is **not** conflated with "not leased".
- **Lease history** — a "Created / Terminated" event log below the terms, shown only when events exist (stays quiet on an unleased subnet).
- **Client wiring** — `subnetLeaseQuery` + `subnetLeaseHistoryQuery` with normalizers (mirroring `subnetConvictionQuery` / `subnetOwnershipHistoryQuery`) and `SubnetLease` / `SubnetLeaseHistory` types. The `leased` tri-state is preserved through normalization (`=== true / === false / else null`), never truthy-coerced.

## A note on the screenshots

No subnet is currently under a lease in live data (every `leased` returns `false`), so the panel's populated state is unreachable against production. To show the terms + history render honestly, the "after" shots intercept **only** the two lease endpoints with one fixed, representative active lease; every other request hits the real dev server. The `leased: false` and `null` states render exactly as coded (empty states). "Before" is `main` (no lease section).

## Verification

- `eslint` — 0 errors; `tsc --noEmit` (apps/ui) — 0 errors; `prettier --check` — clean; `vite build` — succeeds.
- `test:e2e` responsive-overflow — **all pass on `/subnets/1`** (the checked route the panel lives on); no baseline change needed.

## Changed (4 files, +342)

- `apps/ui/src/components/metagraphed/subnet-lease-panel.tsx` (new)
- `apps/ui/src/lib/metagraphed/queries.ts`, `types.ts` — queries/normalizers/types (tri-state-preserving)
- `apps/ui/src/routes/subnets.$netuid.tsx` — section wire-in + `SECTION_TO_TAB` entry

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6993-subnet-lease-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6993
