### PR TITLE
fix(ci): read the real workers/message annotation instead of a nonexistent commit_hash one

### DIFF
--- a/.github/workflows/check-worker-deploy-drift.yml
+++ b/.github/workflows/check-worker-deploy-drift.yml
@@ -14,12 +14,13 @@ name: Check Worker Deploy Drift
 # normal in-flight deploy).
 #
 # SENTRY_AUTH_TOKEN (same repo secret ui-sentry-release.yml already uses) is a
-# fallback: if the Cloudflare Deployments API doesn't have a workers/commit_hash
-# annotation for the active deployment, the script falls back to the deployed
-# commit SHA that @sentry/cloudflare's withSentry() already tags every production
-# error event with (workers/api.sentry.mjs), which is independent of Cloudflare's
-# own deployment bookkeeping. Optional: omitting the secret just removes the
-# fallback, not the primary check.
+# fallback: if the active deployment's workers/message annotation (set by
+# scripts/deploy-worker-with-sourcemaps.sh's --message, #7224) is ever absent
+# -- e.g. a deployment predating that fix -- the script falls back to the
+# deployed commit SHA that @sentry/cloudflare's withSentry() already tags
+# every production error event with (workers/api.sentry.mjs), independent of
+# Cloudflare's own deployment bookkeeping. Optional: omitting the secret just
+# removes the fallback, not the primary check.
 on:
   schedule:
     - cron: "53 8 * * *"

--- a/scripts/check-worker-deploy-drift.mjs
+++ b/scripts/check-worker-deploy-drift.mjs
@@ -1,21 +1,35 @@
 #!/usr/bin/env node
-// Scheduled drift guard (issue #5538, parent epic #4651): the Worker CODE deploys
-// via Cloudflare Workers Builds on push to main (a Cloudflare-side git integration,
-// not a GitHub Actions step -- see publish-cloudflare.yml's header), so nothing in
-// this repo previously verified that a Builds deploy actually landed. A stuck build
-// leaves the live Worker silently drifting stale vs. main with no signal here. This
-// compares the live deployment's Workers-Builds-linked commit against origin/main
-// HEAD and fails the scheduled job once the drift has persisted across a prior
-// scheduled run (see evaluateDeployDrift below for the grace-window rule).
+// Scheduled drift guard (issue #5538, parent epic #4651; corrected by #7224):
+// the Worker CODE deploys via Cloudflare Workers Builds on push to main (a
+// Cloudflare-side git integration, not a GitHub Actions step -- see
+// publish-cloudflare.yml's header), so nothing in this repo previously
+// verified that a Builds deploy actually landed. A stuck build leaves the
+// live Worker silently drifting stale vs. main with no signal here. This
+// compares the live deployment's commit -- read from the workers/message
+// annotation that scripts/deploy-worker-with-sourcemaps.sh's `--message
+// "$(git rev-parse HEAD)"` sets on every deploy -- against origin/main HEAD,
+// falling back to Sentry's release tracking if that annotation is ever
+// absent (e.g. a deployment predating the #7224 fix), and fails the
+// scheduled job once the drift has persisted across a prior scheduled run
+// (see evaluateDeployDrift below for the grace-window rule).
+//
+// #7224: this previously read a `workers/commit_hash` annotation that never
+// existed for Cloudflare Workers deployments (confirmed against wrangler's
+// own CLI source and Cloudflare's List Deployments API reference -- only
+// `workers/message`, `workers/tag`, and `workers/triggered_by` are real;
+// `commit_hash` is exclusively a Cloudflare Pages deploy-command concept, a
+// different product). Nothing was ever going to populate it.
 import { fileURLToPath } from "node:url";
 
 const DEPLOYMENTS_PATH_TEMPLATE =
   "https://api.cloudflare.com/client/v4/accounts/{accountId}/workers/scripts/{scriptName}/deployments";
 const SENTRY_RELEASES_PATH_TEMPLATE =
   "https://sentry.io/api/0/projects/{org}/{project}/releases/";
-// A bare 40-hex-char git SHA is a real production release's version (see
-// workers/api.sentry.mjs's `release: env.SENTRY_RELEASE || ...`). PR-preview
-// deploys (apps/ui/.github/workflows/ui-preview-deploy.yml) tag releases
+// A bare 40-hex-char git SHA is what both a real deployment's workers/message
+// annotation (deploy-worker-with-sourcemaps.sh's --message) and a real
+// production Sentry release's version (workers/api.sentry.mjs's
+// `release: env.SENTRY_RELEASE || ...`) should contain. PR-preview deploys
+// (apps/ui/.github/workflows/ui-preview-deploy.yml) tag Sentry releases
 // "<sha>-preview" -- excluded so a preview build is never mistaken for what's
 // actually live in production.
 const PRODUCTION_RELEASE_VERSION_PATTERN = /^[0-9a-f]{40}$/i;
@@ -28,22 +42,22 @@ export function extractDeployedCommitSha(deploymentsJson) {
     );
   }
   const active = deployments[0];
-  const commitSha = active?.annotations?.["workers/commit_hash"];
-  if (!commitSha) {
+  const message = active?.annotations?.["workers/message"];
+  if (!message || !PRODUCTION_RELEASE_VERSION_PATTERN.test(message)) {
     throw new Error(
-      `Active deployment ${active?.id ?? "(unknown id)"} has no workers/commit_hash annotation -- Workers Builds may not be linked to git for this script`,
+      `Active deployment ${active?.id ?? "(unknown id)"} has no workers/message annotation containing a git commit SHA -- scripts/deploy-worker-with-sourcemaps.sh may not have deployed it (or it predates the --message fix, #7224)`,
     );
   }
-  return commitSha;
+  return message;
 }
 
-// Fallback for when Cloudflare's Deployments API doesn't populate the
-// workers/commit_hash annotation even though Workers Builds is genuinely
-// deploying on every push (confirmed live, 2026-07-20): @sentry/cloudflare's
-// withSentry() (workers/api.sentry.mjs) already tags every production error
-// event with the real deployed commit SHA as its Sentry release, independent
-// of Cloudflare's own deployment bookkeeping. Sorts by dateCreated rather than
-// trusting response order, since that isn't documented/guaranteed.
+// Fallback for a deployment whose workers/message annotation is absent or
+// not SHA-shaped (e.g. one predating the #7224 --message fix): @sentry/
+// cloudflare's withSentry() (workers/api.sentry.mjs) already tags every
+// production error event with the real deployed commit SHA as its Sentry
+// release, independent of Cloudflare's own deployment bookkeeping. Sorts by
+// dateCreated rather than trusting response order, since that isn't
+// documented/guaranteed.
 export function selectLatestProductionRelease(releases) {
   if (!Array.isArray(releases)) {
     return null;

--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -35,6 +35,17 @@
 # Variable/Secret -- sentry-cli only runs during the build, never reaches the
 # deployed Worker) on each of the 3 Worker projects.
 #
+# --message also passed on the wrangler call itself (metagraphed#7224): the
+# deployed commit SHA needs to land in the deployment's own real
+# `workers/message` annotation (confirmed against Cloudflare's List
+# Deployments API reference + wrangler's own CLI source -- `workers/message`/
+# `workers/tag`/`workers/triggered_by` are the only Workers deployment
+# annotations that actually exist; `workers/commit_hash` scripts/check-worker-
+# deploy-drift.mjs previously checked was never a real one, that key only
+# exists on Cloudflare Pages' unrelated deploy command) so that scheduled
+# drift check can read the live commit directly instead of relying solely on
+# its Sentry-release fallback.
+#
 # Usage: scripts/deploy-worker-with-sourcemaps.sh <wrangler-config.jsonc> [--preview]
 set -euo pipefail
 
@@ -59,13 +70,15 @@ RELEASE=$(npx sentry-cli releases propose-version)
 if [[ "$ENVIRONMENT" == "preview" ]]; then
   RELEASE="$RELEASE-preview"
 fi
+COMMIT_SHA=$(git rev-parse HEAD)
 
 npx wrangler "${WRANGLER_SUBCOMMAND[@]}" \
   --config "$CONFIG" \
   --outdir "$OUTDIR" \
   --upload-source-maps \
   --var "SENTRY_RELEASE:$RELEASE" \
-  --var "SENTRY_ENVIRONMENT:$ENVIRONMENT"
+  --var "SENTRY_ENVIRONMENT:$ENVIRONMENT" \
+  --message "$COMMIT_SHA"
 
 npx sentry-cli releases new "$RELEASE"
 # --auto reads the linked GitHub repo's commit range since the last release

--- a/tests/check-worker-deploy-drift.test.mjs
+++ b/tests/check-worker-deploy-drift.test.mjs
@@ -8,16 +8,22 @@ import {
 } from "../scripts/check-worker-deploy-drift.mjs";
 
 describe("extractDeployedCommitSha", () => {
-  test("reads the commit hash annotation off the active (first) deployment", () => {
+  const shaA = "a".repeat(40);
+  const shaB = "b".repeat(40);
+
+  test("reads the git commit SHA from the workers/message annotation off the active (first) deployment", () => {
+    // #7224: workers/message (set by deploy-worker-with-sourcemaps.sh's
+    // --message "$(git rev-parse HEAD)"), not workers/commit_hash -- that key
+    // was never a real Cloudflare Workers deployment annotation.
     const sha = extractDeployedCommitSha({
       result: {
         deployments: [
-          { id: "dep-2", annotations: { "workers/commit_hash": "abc123" } },
-          { id: "dep-1", annotations: { "workers/commit_hash": "old999" } },
+          { id: "dep-2", annotations: { "workers/message": shaA } },
+          { id: "dep-1", annotations: { "workers/message": shaB } },
         ],
       },
     });
-    assert.equal(sha, "abc123");
+    assert.equal(sha, shaA);
   });
 
   test("throws when there are no deployments", () => {
@@ -27,13 +33,30 @@ describe("extractDeployedCommitSha", () => {
     );
   });
 
-  test("throws when the active deployment has no commit_hash annotation", () => {
+  test("throws when the active deployment has no workers/message annotation", () => {
     assert.throws(
       () =>
         extractDeployedCommitSha({
           result: { deployments: [{ id: "dep-1", annotations: {} }] },
         }),
-      /no workers\/commit_hash annotation/,
+      /no workers\/message annotation containing a git commit SHA/,
+    );
+  });
+
+  test("throws when workers/message isn't SHA-shaped (e.g. a deployment predating the --message fix)", () => {
+    assert.throws(
+      () =>
+        extractDeployedCommitSha({
+          result: {
+            deployments: [
+              {
+                id: "dep-1",
+                annotations: { "workers/message": "not-a-commit-sha" },
+              },
+            ],
+          },
+        }),
+      /no workers\/message annotation containing a git commit SHA/,
     );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #7214/#7216. That PR added a Sentry-release fallback for when the Cloudflare deployment annotation `check-worker-deploy-drift.mjs` reads is missing — which kept the check working, but this root-causes *why* it's always missing: `workers/commit_hash` was never a real Cloudflare Workers deployment annotation, so nothing was ever going to populate it. This isn't a Workers Builds git-integration problem (confirmed connected correctly via the dashboard) and isn't a deploy-script problem in the sense of "something broke" — it's that the original check read a field that doesn't exist for this product.

## Root cause (verified against real sources, not assumed)

- `wrangler`'s own CLI source (`node_modules/wrangler/wrangler-dist/cli.js`) references `workers/tag`, `workers/message`, and `workers/triggered_by` as real Workers deployment/version annotations dozens of times. Zero references to `workers/commit_hash` anywhere in the Workers code path — that field (`deployment_trigger.metadata.commit_hash`) only exists in wrangler's **Pages** deploy command, a different product.
- Cloudflare's official API reference for the exact `List Deployments` endpoint this script calls documents only two annotation keys: `workers/message` and `workers/triggered_by`.
- `wrangler deploy --help` / `wrangler versions upload --help` confirm `--tag`/`--message` are the real flags that set those two real annotations — `scripts/deploy-worker-with-sourcemaps.sh` (the actual Cloudflare Workers Builds "Deploy command" for this script) was passing neither.

## What Changed

- `scripts/deploy-worker-with-sourcemaps.sh`: passes `--message "$(git rev-parse HEAD)"` on the `wrangler deploy`/`wrangler versions upload` call, landing the real deployed commit SHA in the real `workers/message` annotation.
- `scripts/check-worker-deploy-drift.mjs`: `extractDeployedCommitSha` now reads `annotations["workers/message"]` instead of the nonexistent `annotations["workers/commit_hash"]`, validating the value is SHA-shaped (reusing the same 40-hex-char pattern already used for the Sentry fallback) before trusting it. Comments updated throughout to stop describing this as a git-integration/linking problem.
- `.github/workflows/check-worker-deploy-drift.yml`: comment accuracy fix only (no behavior change) — the Sentry fallback description referenced the wrong annotation name.
- Tests updated: `extractDeployedCommitSha`'s suite now uses SHA-shaped `workers/message` values, plus a new case for a present-but-not-SHA-shaped message (e.g. a deployment predating this fix), which now correctly falls through to the Sentry fallback instead of being trusted.

The Sentry-release fallback from #7216 stays in place — it now covers the genuine remaining case (any already-live deployment that predates this fix) instead of being the only path that ever worked.

Closes #7224

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:workflows`
- [x] `npm run scan:public-safety`
- [x] `bash -n scripts/deploy-worker-with-sourcemaps.sh` (syntax check)
- [x] `npx vitest run tests/check-worker-deploy-drift.test.mjs` (16 passed)
- [x] `git diff --check`

`npm run validate` (full) requires a prior `npm run build` for generated registry artifacts unrelated to this change — not run for that reason.