### PR TITLE
feat(ui): add child/parent-hotkey delegation + entity-labels sections to the account page (#6999)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -47,6 +47,12 @@ import type {
   AccountEvent,
   AccountEventsPage,
   AccountCounterparties,
+  AccountDelegation,
+  AccountDelegationEntry,
+  AccountDelegationSubnet,
+  AccountEntities,
+  AccountEntityLabel,
+  AccountOwnershipTie,
   AccountCounterparty,
   AccountStakeFlow,
   AccountStakeFlowSubnet,
@@ -2699,6 +2705,133 @@ export const accountCounterpartiesQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountCounterparties>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// Child (route key "child") and parent ("parent") delegation share one shape;
+// `accountKey` picks which nested field holds the counterpart hotkey (#6999).
+function normalizeDelegation(
+  account: string,
+  raw: unknown,
+  accountKey: "child" | "parent",
+): AccountDelegation {
+  const d = isRecord(raw) ? raw : {};
+  // `subnets: null` (RPC failure) is preserved distinctly from [] (genuinely none).
+  const subnets: AccountDelegationSubnet[] | null = Array.isArray(d.subnets)
+    ? d.subnets.flatMap((row) => {
+        if (!isRecord(row)) return [];
+        const netuid = firstFiniteNumber(row.netuid);
+        if (netuid == null) return [];
+        const entries: AccountDelegationEntry[] = Array.isArray(row.entries)
+          ? row.entries.flatMap((e) => {
+              if (!isRecord(e)) return [];
+              const hotkey = firstString(e[accountKey]);
+              if (!hotkey) return [];
+              return [
+                {
+                  hotkey,
+                  proportion: firstString(e.proportion) ?? null,
+                  proportion_fraction: coerceFiniteNumber(e.proportion_fraction) ?? null,
+                },
+              ];
+            })
+          : [];
+        return entries.length > 0 ? [{ netuid, entries }] : [];
+      })
+    : d.subnets === null
+      ? null
+      : [];
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    account: firstString(d.account) ?? account,
+    subnets,
+    queried_at: firstString(d.queried_at) ?? null,
+  };
+}
+
+/** Child hotkeys this account delegates stake-weight to (#6999). */
+export const accountChildrenQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-children", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/children`, {
+        signal,
+      });
+      return { data: normalizeDelegation(ss58, res.data, "child"), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+/** Parent hotkeys that delegate stake-weight to this account (#6999). */
+export const accountParentsQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-parents", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/parents`, {
+        signal,
+      });
+      return { data: normalizeDelegation(ss58, res.data, "parent"), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeEntityLabel(raw: unknown): AccountEntityLabel | null {
+  if (!isRecord(raw)) return null;
+  return {
+    name: firstString(raw.name) ?? null,
+    category: firstString(raw.category) ?? null,
+    notes: firstString(raw.notes) ?? null,
+    source_urls: Array.isArray(raw.source_urls)
+      ? raw.source_urls.filter((u): u is string => typeof u === "string")
+      : [],
+  };
+}
+
+function normalizeOwnershipTie(raw: unknown): AccountOwnershipTie | null {
+  if (!isRecord(raw)) return null;
+  const role = firstString(raw.role);
+  if (!role) return null;
+  return {
+    netuid: firstFiniteNumber(raw.netuid) ?? null,
+    role,
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+  };
+}
+
+/** Community entity labels + subnet-ownership ties for an account (#6999). */
+export const accountEntitiesQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-entities", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/entities`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const labels = Array.isArray(d.labels)
+        ? d.labels.flatMap((l) => {
+            const n = normalizeEntityLabel(l);
+            return n ? [n] : [];
+          })
+        : [];
+      const ties = Array.isArray(d.ownership_ties)
+        ? d.ownership_ties.flatMap((t) => {
+            const n = normalizeOwnershipTie(t);
+            return n ? [n] : [];
+          })
+        : [];
+      return {
+        data: {
+          schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+          ss58: firstString(d.ss58) ?? ss58,
+          labels,
+          ownership_tie_count: firstFiniteNumber(d.ownership_tie_count) ?? ties.length,
+          ownership_ties: ties,
+        } as AccountEntities,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountEntities>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1320,6 +1320,53 @@ export interface AccountCounterparties {
   counterparties: AccountCounterparty[];
   [key: string]: unknown;
 }
+
+/** One child/parent delegation entry (#6999). `hotkey` is normalized from the
+ *  route's `child` / `parent` key so children and parents share one shape. */
+export interface AccountDelegationEntry {
+  hotkey: string;
+  proportion: string | null;
+  proportion_fraction: number | null;
+}
+
+export interface AccountDelegationSubnet {
+  netuid: number;
+  entries: AccountDelegationEntry[];
+}
+
+/** Child- or parent-hotkey delegation graph (#6721/#6723). `subnets` is null on
+ *  an RPC failure (distinct from [] = genuinely none). */
+export interface AccountDelegation {
+  schema_version: number;
+  account: string;
+  subnets: AccountDelegationSubnet[] | null;
+  queried_at: string | null;
+}
+
+/** One community-contributed entity label for an account (#6737-#6740). */
+export interface AccountEntityLabel {
+  name: string | null;
+  category: string | null;
+  notes: string | null;
+  source_urls: string[];
+}
+
+/** One subnet-ownership tie (gained/lost ownership via SubnetOwnerChanged). */
+export interface AccountOwnershipTie {
+  netuid: number | null;
+  role: string;
+  block_number: number | null;
+  observed_at: string | null;
+}
+
+/** Entity labels + subnet-ownership ties for an account (#6999). */
+export interface AccountEntities {
+  schema_version: number;
+  ss58: string;
+  labels: AccountEntityLabel[];
+  ownership_tie_count: number;
+  ownership_ties: AccountOwnershipTie[];
+}
 /** One per-subnet stake/unstake flow row in /accounts/{ss58}/stake-flow. */
 export interface AccountStakeFlowSubnet {
   netuid: number;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -50,6 +50,9 @@ import { AccountPositionHistoryChart } from "@/components/metagraphed/account-po
 import {
   accountAxonRemovalsQuery,
   accountCounterpartiesQuery,
+  accountChildrenQuery,
+  accountParentsQuery,
+  accountEntitiesQuery,
   accountStakeFlowQuery,
   accountPortfolioQuery,
   accountStakeMovesQuery,
@@ -398,6 +401,10 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       />
       {/* #3340: the aggregated fund-flow view over the same transfer data. */}
       <AccountCounterpartiesSection ss58={ss58} />
+
+      {/* #6999: child/parent-hotkey delegation graph + community entity labels. */}
+      <AccountDelegationSection ss58={ss58} />
+      <AccountEntitiesSection ss58={ss58} />
 
       {/* #6432: deliberately NOT "← All accounts" like the other detail pages'
           back-links. /accounts is a lookup form, not an index -- there is no
@@ -1061,6 +1068,299 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
         <p className="mt-3 font-mono text-[10px] text-ink-muted">
           Showing the {rows.length} highest-volume of {formatNumber(parties.length)} counterparties.
         </p>
+      ) : null}
+    </SectionAnchor>
+  );
+}
+
+// Flatten a delegation graph's per-subnet entries into flat rows for a table.
+function flattenDelegation(
+  subnets:
+    | { netuid: number; entries: { hotkey: string; proportion_fraction: number | null }[] }[]
+    | null
+    | undefined,
+): { hotkey: string; netuid: number; proportion_fraction: number | null }[] {
+  if (!subnets) return [];
+  return subnets.flatMap((s) =>
+    s.entries.map((e) => ({
+      hotkey: e.hotkey,
+      netuid: s.netuid,
+      proportion_fraction: e.proportion_fraction,
+    })),
+  );
+}
+
+function DelegationTable({
+  title,
+  rows,
+  emptyLabel,
+}: {
+  title: string;
+  rows: { hotkey: string; netuid: number; proportion_fraction: number | null }[];
+  emptyLabel: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <h3 className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        {title}
+      </h3>
+      {rows.length === 0 ? (
+        <p className="font-mono text-[11px] text-ink-muted">{emptyLabel}</p>
+      ) : (
+        <DataPanel>
+          <table className="w-full text-left text-sm">
+            <thead className="bg-surface/50">
+              <tr>
+                <th className={TH}>Hotkey</th>
+                <th className={`${TH} text-right`}>Subnet</th>
+                <th className={`${TH} text-right`}>Proportion</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {rows.map((r, i) => (
+                <tr key={`${r.hotkey}-${r.netuid}-${i}`} className="hover:bg-surface/30">
+                  <td className="px-5 py-3 font-mono text-[11px] text-ink-muted" title={r.hotkey}>
+                    <Link
+                      to="/accounts/$ss58"
+                      params={{ ss58: r.hotkey }}
+                      className="hover:text-accent hover:underline"
+                    >
+                      {shortHash(r.hotkey) ?? r.hotkey}
+                    </Link>
+                  </td>
+                  <td className="px-5 py-3 text-right font-mono text-[11px]">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: r.netuid }}
+                      className="text-ink hover:text-accent hover:underline"
+                    >
+                      SN{r.netuid}
+                    </Link>
+                  </td>
+                  <td className="px-5 py-3 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {r.proportion_fraction != null
+                      ? `${(r.proportion_fraction * 100).toFixed(2)}%`
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </DataPanel>
+      )}
+    </div>
+  );
+}
+
+// #6999: child/parent-hotkey stake-weight delegation graph. Optional enrichment
+// -- soft-hides when this account has no delegations either way.
+function AccountDelegationSection({ ss58 }: { ss58: string }) {
+  const childrenRes = useQuery(accountChildrenQuery(ss58));
+  const parentsRes = useQuery(accountParentsQuery(ss58));
+  const SUBTITLE =
+    "Child-hotkey and parent-hotkey stake-weight delegation — who this hotkey delegates to, and who delegates to it, per subnet.";
+
+  if ((childrenRes.isPending && !childrenRes.data) || (parentsRes.isPending && !parentsRes.data)) {
+    return <AccountFeedSectionSkeleton id="delegation" title="Delegation" subtitle={SUBTITLE} />;
+  }
+  if (childrenRes.isError && parentsRes.isError) {
+    return (
+      <SectionAnchor id="delegation" title="Delegation" subtitle={SUBTITLE} tone="accent">
+        <TableState
+          variant="error"
+          title="Couldn't load delegation"
+          description="The child/parent-hotkey delegation graph is optional enrichment — the rest of the account page is unaffected."
+          error={childrenRes.error ?? parentsRes.error}
+          onRetry={() => {
+            void childrenRes.refetch();
+            void parentsRes.refetch();
+          }}
+        />
+      </SectionAnchor>
+    );
+  }
+  const childRows = flattenDelegation(childrenRes.data?.data.subnets);
+  const parentRows = flattenDelegation(parentsRes.data?.data.subnets);
+  if (childRows.length === 0 && parentRows.length === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="delegation"
+      title="Delegation"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="GET /api/v1/accounts/{ss58}/children and /parents — the live child-hotkey / parent-hotkey stake-weight delegation graph, per subnet, with each edge's proportion."
+      right={
+        <SectionBadge tone="accent">
+          {formatNumber(childRows.length + parentRows.length)} edges
+        </SectionBadge>
+      }
+    >
+      <div className="grid gap-6 lg:grid-cols-2">
+        <DelegationTable
+          title="Delegates to (child hotkeys)"
+          rows={childRows}
+          emptyLabel="This hotkey has no child-key delegations."
+        />
+        <DelegationTable
+          title="Delegated by (parent hotkeys)"
+          rows={parentRows}
+          emptyLabel="No parent hotkeys delegate to this account."
+        />
+      </div>
+    </SectionAnchor>
+  );
+}
+
+// #6999: community entity labels + subnet-ownership ties. Optional enrichment --
+// soft-hides when the address has neither a label nor an ownership tie.
+function AccountEntitiesSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountEntitiesQuery(ss58));
+  const e = result.data?.data;
+  const SUBTITLE =
+    "Community-contributed identity labels for this address, plus any subnet-ownership ties from the on-chain SubnetOwnerChanged stream.";
+
+  if (result.isPending && !e) {
+    return (
+      <AccountFeedSectionSkeleton id="entity-labels" title="Entity labels" subtitle={SUBTITLE} />
+    );
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor id="entity-labels" title="Entity labels" subtitle={SUBTITLE} tone="accent">
+        <TableState
+          variant="error"
+          title="Couldn't load entity labels"
+          description="Entity labels are optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+  const labels = e?.labels ?? [];
+  const ties = e?.ownership_ties ?? [];
+  if (labels.length === 0 && ties.length === 0) return null;
+
+  return (
+    <SectionAnchor
+      id="entity-labels"
+      title="Entity labels"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="GET /api/v1/accounts/{ss58}/entities — community-contributed labels and subnet-ownership ties (gained/lost ownership via the SubnetOwnerChanged stream)."
+      right={
+        ties.length > 0 ? (
+          <SectionBadge tone="accent">
+            {formatNumber(e?.ownership_tie_count ?? ties.length)} ownership ties
+          </SectionBadge>
+        ) : undefined
+      }
+    >
+      {labels.length > 0 ? (
+        <div className="mb-4 space-y-2">
+          {labels.map((label, i) => (
+            <div
+              key={`${label.name ?? "label"}-${i}`}
+              className="rounded-lg border border-border bg-card p-3"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Fingerprint className="size-3.5 text-accent" aria-hidden />
+                <span className="font-medium text-ink-strong">
+                  {label.name ?? "Unnamed entity"}
+                </span>
+                {label.category ? (
+                  <span className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+                    {label.category}
+                  </span>
+                ) : null}
+              </div>
+              {label.notes ? (
+                <p className="mt-1 text-[12px] text-ink-muted">{label.notes}</p>
+              ) : null}
+              {label.source_urls.length > 0 ? (
+                <div className="mt-1.5 flex flex-wrap gap-2">
+                  {label.source_urls.map((u) => (
+                    <a
+                      key={u}
+                      href={u}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="font-mono text-[10px] text-accent hover:underline"
+                    >
+                      {u}
+                    </a>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {ties.length > 0 ? (
+        <DataPanel>
+          <table className="w-full text-left text-sm">
+            <thead className="bg-surface/50">
+              <tr>
+                <th className={TH}>Subnet</th>
+                <th className={TH}>Role</th>
+                <th className={`${TH} text-right`}>Block</th>
+                <th className={`${TH} text-right`}>When</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {ties.map((t, i) => (
+                <tr key={`${t.netuid}-${t.block_number}-${i}`} className="hover:bg-surface/30">
+                  <td className="px-5 py-3 font-mono text-[11px]">
+                    {t.netuid != null ? (
+                      <Link
+                        to="/subnets/$netuid"
+                        params={{ netuid: t.netuid }}
+                        className="text-ink hover:text-accent hover:underline"
+                      >
+                        SN{t.netuid}
+                      </Link>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-5 py-3">
+                    <span
+                      className={classNames(
+                        "inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider",
+                        t.role === "gained_ownership"
+                          ? "border-health-ok/40 bg-health-ok/10 text-health-ok"
+                          : "border-health-warn/40 bg-health-warn/10 text-health-warn-text",
+                      )}
+                    >
+                      {t.role === "gained_ownership"
+                        ? "Gained"
+                        : t.role === "lost_ownership"
+                          ? "Lost"
+                          : t.role}
+                    </span>
+                  </td>
+                  <td className="px-5 py-3 text-right font-mono text-[11px]">
+                    {t.block_number != null ? (
+                      <Link
+                        to="/blocks/$ref"
+                        params={{ ref: String(t.block_number) }}
+                        className="text-ink hover:text-accent hover:underline"
+                      >
+                        #{formatNumber(t.block_number)}
+                      </Link>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-5 py-3 text-right font-mono text-[11px] text-ink-muted">
+                    {t.observed_at ? <TimeAgo at={t.observed_at} /> : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </DataPanel>
       ) : null}
     </SectionAnchor>
   );


### PR DESCRIPTION
## Summary

Adds two account sub-resource sections to the account detail page — the child/parent-hotkey delegation graph (#6721/#6723) and community entity labels + subnet-ownership ties (#6737-#6740). Both routes (`/children`, `/parents`, `/entities`, all with MCP tools) shipped with no UI; this brings the account page up to the coverage level of its other sub-resources, mirroring the existing `AccountCounterpartiesSection` pattern.

## What it adds

- **Delegation section** — child hotkeys this account delegates stake-weight to ("Delegates to") and parent hotkeys that delegate to it ("Delegated by"), per subnet, each edge with its proportion. Two side-by-side tables; links to each hotkey's account page and each subnet.
- **Entity-labels section** — any community-contributed labels (name / category / notes / source links) plus subnet-ownership ties (gained/lost ownership, decoded from the `SubnetOwnerChanged` stream) as a table.
- Both are **optional-enrichment sections** matching the sibling `AccountCounterpartiesSection`: they soft-hide (render nothing) when the account has no delegations / labels, show a skeleton while loading, and a self-contained error state that doesn't affect the rest of the page.
- **Client wiring** — `accountChildrenQuery` / `accountParentsQuery` / `accountEntitiesQuery` + normalizers (mirroring `accountCounterpartiesQuery`) and `AccountDelegation` / `AccountEntities` types. Children and parents share one `AccountDelegation` shape (the `child`/`parent` key is normalized to `hotkey`); the `subnets: null` (RPC failure) vs `[]` (none) distinction is preserved.

## A note on the screenshots

Childkey delegations and community entity labels are sparse on-chain — every sampled account returns none — so both sections soft-hide against live data. To show them render honestly, the "after" shots intercept **only** the three account sub-resource endpoints with fixed, representative data; every other request on the page hits the real dev server. The empty/soft-hide behavior is exactly as coded. "Before" is `main` (neither section present).

## Verification

- `eslint` — 0 errors; `tsc --noEmit` (apps/ui) — 0 errors; `prettier --check` — clean; `vite build` — succeeds.
- `test:e2e` responsive-overflow — unaffected (the account page isn't a checked route; the change is additive).

## Changed (3 files, +480)

- `apps/ui/src/lib/metagraphed/queries.ts`, `types.ts` — 3 queries/normalizers + types (null-vs-[] preserving)
- `apps/ui/src/routes/accounts.$ss58.tsx` — two inline sections + wire-in

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6999-account-delegation-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6999
