### PR TITLE
feat(ui): add a validator-comparison drawer (#6998)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -3,6 +3,7 @@ import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { AccountAddress } from "@/components/metagraphed/account-address";
+import { ValidatorCompareToggle } from "@/components/metagraphed/validators-compare-drawer";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
@@ -30,6 +31,7 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
             className="min-w-0 space-y-2 rounded-lg border border-border bg-card p-3"
           >
             <div className="flex min-w-0 items-center gap-1.5">
+              <ValidatorCompareToggle hotkey={v.hotkey} />
               {v.featured ? <SponsoredBadge /> : null}
               <Link
                 to="/validators/$hotkey"

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -1,0 +1,285 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { X, BarChart3, ExternalLink } from "lucide-react";
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { useValidatorCompareSelection } from "@/lib/metagraphed/validator-compare-selection";
+import { validatorCompareQuery } from "@/lib/metagraphed/queries";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
+import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
+import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import type { CompareValidator } from "@/lib/metagraphed/types";
+
+/**
+ * Floating bottom dock + expandable side-by-side compare drawer for selected
+ * validators — the hotkey-keyed sibling of SubnetsCompareDrawer. Selection state
+ * lives in localStorage via useValidatorCompareSelection so it survives
+ * navigation. Pure presentation — does not mutate the URL.
+ */
+export function ValidatorsCompareDrawer() {
+  const { selected, max, remove, clear } = useValidatorCompareSelection();
+  const [expanded, setExpanded] = useState(false);
+
+  if (selected.length === 0) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
+      <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
+        <div
+          className={classNames(
+            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
+            "mg-fade-in",
+          )}
+        >
+          {/* Dock */}
+          <div className="flex flex-wrap items-center gap-2 px-3 py-2">
+            <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <BarChart3 className="size-3 text-accent" />
+              Compare validators
+              <span className="text-ink-strong tabular-nums">
+                {selected.length}/{max}
+              </span>
+            </span>
+            <span aria-hidden className="h-4 w-px bg-border" />
+            <div className="flex flex-wrap gap-1.5 min-w-0">
+              {selected.map((hotkey) => (
+                <span
+                  key={hotkey}
+                  className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-paper pl-2.5 pr-1 font-mono text-[10px] text-ink-strong"
+                >
+                  {shortHash(hotkey) ?? hotkey}
+                  <button
+                    type="button"
+                    onClick={() => remove(hotkey)}
+                    aria-label={`Remove ${shortHash(hotkey) ?? hotkey}`}
+                    className="ml-0.5 inline-flex size-4 items-center justify-center rounded-full text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+                  >
+                    <X className="size-2.5" />
+                  </button>
+                </span>
+              ))}
+            </div>
+            <div className="ml-auto flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                disabled={selected.length < 2}
+                className={classNames(
+                  "inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                  selected.length < 2
+                    ? "opacity-50 cursor-not-allowed"
+                    : "hover:border-accent/60 hover:text-accent text-ink-strong",
+                )}
+              >
+                {expanded ? "Hide" : "Compare"}
+              </button>
+              <button
+                type="button"
+                onClick={clear}
+                className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-paper px-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong transition-colors"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+
+          {/* Expanded side-by-side */}
+          {expanded && selected.length >= 2 ? <CompareGrid hotkeys={selected} /> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function pct(fraction: number | null, digits = 2): string {
+  return fraction != null ? `${(fraction * 100).toFixed(digits)}%` : "—";
+}
+
+function CompareGrid({ hotkeys }: { hotkeys: string[] }) {
+  const { data, isPending, isError, refetch } = useQuery({
+    ...validatorCompareQuery(hotkeys),
+    retry: 0,
+  });
+
+  const byHotkey = new Map<string, CompareValidator>();
+  for (const v of data?.data?.validators ?? []) byHotkey.set(v.hotkey, v);
+
+  const rows: Array<{ label: string; render: (hotkey: string) => ReactNode }> = [
+    {
+      label: "Validator",
+      render: (hotkey) => {
+        const v = byHotkey.get(hotkey);
+        return (
+          <Link
+            to="/validators/$hotkey"
+            params={{ hotkey }}
+            className="inline-flex items-center gap-1.5 font-medium text-ink-strong hover:text-accent"
+          >
+            <ValidatorIdentityChip
+              hotkey={hotkey}
+              identity={v?.coldkey_identity ?? null}
+              size={18}
+            />
+            <ExternalLink className="size-3 opacity-60" />
+          </Link>
+        );
+      },
+    },
+    {
+      label: "Take",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {formatTakePct(byHotkey.get(hotkey)?.take ?? null)}
+        </span>
+      ),
+    },
+    {
+      label: "Est. APY",
+      render: (hotkey) => {
+        const a = byHotkey.get(hotkey)?.apy_estimate;
+        return (
+          <span className="font-mono tabular-nums text-ink-strong">
+            {formatApyPct(a != null ? a * 100 : null)}
+          </span>
+        );
+      },
+    },
+    {
+      label: "Nominators",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {formatNumber(byHotkey.get(hotkey)?.nominator_count ?? undefined)}
+        </span>
+      ),
+    },
+    {
+      label: "Total stake",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {taoCompact(byHotkey.get(hotkey)?.total_stake_tao ?? null)}
+        </span>
+      ),
+    },
+    {
+      label: "Total emission",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {taoCompact(byHotkey.get(hotkey)?.total_emission_tao ?? null)}
+        </span>
+      ),
+    },
+    {
+      label: "Avg trust",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {pct(byHotkey.get(hotkey)?.avg_validator_trust ?? null)}
+        </span>
+      ),
+    },
+    {
+      label: "Subnets",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {formatNumber(byHotkey.get(hotkey)?.subnet_count ?? undefined)}
+        </span>
+      ),
+    },
+  ];
+
+  if (isError) {
+    return (
+      <div className="border-t border-border px-3 py-6 text-center">
+        <p className="font-mono text-[11px] text-ink-muted">Could not load comparison.</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest text-ink-strong hover:border-accent/60 hover:text-accent transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-border max-h-[55vh] overflow-auto">
+      <table className="min-w-full text-[12px]">
+        <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
+          <tr>
+            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted backdrop-blur">
+              Metric
+            </th>
+            {hotkeys.map((h) => (
+              <th
+                key={h}
+                className="min-w-[7rem] whitespace-nowrap px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-strong"
+              >
+                {shortHash(h) ?? h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td className="sticky left-0 z-[1] bg-card px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                {row.label}
+              </td>
+              {hotkeys.map((h) => (
+                <td key={h} className="px-3 py-2">
+                  {isPending ? (
+                    <span className="inline-block h-3 w-12 animate-pulse rounded bg-border/60" />
+                  ) : (
+                    row.render(h)
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Inline checkbox-style toggle for validator table/card rows. */
+export function ValidatorCompareToggle({ hotkey }: { hotkey: string }) {
+  const { has, toggle, selected, max } = useValidatorCompareSelection();
+  const on = has(hotkey);
+  const disabled = !on && selected.length >= max;
+  const label = shortHash(hotkey) ?? hotkey;
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={on}
+      aria-label={on ? `Remove ${label} from compare` : `Add ${label} to compare`}
+      disabled={disabled}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!disabled) toggle(hotkey);
+      }}
+      title={disabled ? `Compare is full (${max})` : on ? "Remove from compare" : "Add to compare"}
+      className={classNames(
+        "inline-flex size-4 shrink-0 items-center justify-center rounded border transition-colors",
+        on ? "bg-accent border-accent text-paper" : "border-border bg-paper hover:border-accent/60",
+        disabled && "opacity-40 cursor-not-allowed",
+      )}
+    >
+      {on ? (
+        <svg viewBox="0 0 12 12" fill="none" className="size-2.5" aria-hidden>
+          <path
+            d="M2 6.5l2.5 2.5L10 3.5"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -123,6 +123,8 @@ import type {
   Candidate,
   Compare,
   CompareSubnet,
+  CompareValidator,
+  ValidatorComparison,
   BlockEvent,
   BlockEvents,
   BlockChainEvents,
@@ -6952,6 +6954,49 @@ export function normalizeCompare(raw: unknown): Compare {
   };
 }
 
+function normalizeCompareValidator(raw: unknown): CompareValidator | undefined {
+  if (!isRecord(raw)) return undefined;
+  const hotkey = optionalString(raw.hotkey);
+  if (!hotkey) return undefined;
+  return {
+    hotkey,
+    coldkey: optionalString(raw.coldkey) ?? null,
+    // Identity + subnet_context are opaque nested blocks the endpoint already
+    // shapes; pass through (or null) rather than re-deriving.
+    coldkey_identity: isRecord(raw.coldkey_identity)
+      ? (raw.coldkey_identity as unknown as CompareValidator["coldkey_identity"])
+      : null,
+    take: optionalNumber(raw.take) ?? null,
+    apy_estimate: optionalNumber(raw.apy_estimate) ?? null,
+    apy_estimate_eligible_subnet_count:
+      optionalNumber(raw.apy_estimate_eligible_subnet_count) ?? null,
+    nominator_count: optionalNumber(raw.nominator_count) ?? null,
+    total_stake_tao: optionalNumber(raw.total_stake_tao) ?? null,
+    total_emission_tao: optionalNumber(raw.total_emission_tao) ?? null,
+    avg_validator_trust: optionalNumber(raw.avg_validator_trust) ?? null,
+    max_validator_trust: optionalNumber(raw.max_validator_trust) ?? null,
+    subnet_count: optionalNumber(raw.subnet_count) ?? null,
+    subnet_context: isRecord(raw.subnet_context)
+      ? (raw.subnet_context as unknown as CompareValidator["subnet_context"])
+      : null,
+  };
+}
+
+export function normalizeValidatorComparison(raw: unknown): ValidatorComparison {
+  const d = isRecord(raw) ? raw : {};
+  const validators = Array.isArray(d.validators)
+    ? d.validators.flatMap((v) => {
+        const normalized = normalizeCompareValidator(v);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    netuid: optionalNumber(d.netuid) ?? null,
+    validator_count: optionalNumber(d.validator_count) ?? validators.length,
+    validators,
+  };
+}
+
 /**
  * Composed side-by-side comparison for up to 128 netuids in one request. Fuses
  * registry structure + on-chain economics + live probe health per subnet, so the
@@ -6972,6 +7017,29 @@ export const compareQuery = (netuids: number[]) =>
       return { data: normalizeCompare(res.data), meta: res.meta, url: res.url };
     },
     enabled: netuids.length > 0,
+    staleTime: STALE_SHORT,
+  });
+
+/**
+ * Side-by-side comparison of up to 16 validators by hotkey — the validator
+ * equivalent of compareQuery (#6035/#6325). Fans out one neurons-tier read per
+ * hotkey server-side, so the compare drawer renders its grid from a single call.
+ */
+export const validatorCompareQuery = (hotkeys: string[]) =>
+  queryOptions({
+    queryKey: k("compare-validators", [...hotkeys].sort()),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/compare/validators", {
+        params: { hotkeys: hotkeys.join(",") },
+        signal,
+      });
+      return {
+        data: normalizeValidatorComparison(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    enabled: hotkeys.length > 0,
     staleTime: STALE_SHORT,
   });
 

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1569,6 +1569,36 @@ export interface Compare {
   source?: string;
 }
 
+/**
+ * One validator projected down to the stake/delegate-decision fields from
+ * GET /api/v1/compare/validators (#6035/#6325) — the take rate, estimated APY,
+ * nominator count, on-chain identity, and cross-subnet aggregates, plus the
+ * optional single-subnet membership context.
+ */
+export interface CompareValidator {
+  hotkey: string;
+  coldkey: string | null;
+  coldkey_identity: ColdkeyIdentity | null;
+  take: number | null;
+  apy_estimate: number | null;
+  apy_estimate_eligible_subnet_count: number | null;
+  nominator_count: number | null;
+  total_stake_tao: number | null;
+  total_emission_tao: number | null;
+  avg_validator_trust: number | null;
+  max_validator_trust: number | null;
+  subnet_count: number | null;
+  /** This validator's membership row in the context subnet, when a netuid was supplied; null otherwise or when it holds no permit there. */
+  subnet_context: GlobalValidatorSubnet | null;
+}
+
+/** Response shape of GET /api/v1/compare/validators. */
+export interface ValidatorComparison {
+  netuid: number | null;
+  validator_count: number;
+  validators: CompareValidator[];
+}
+
 /** One daily on-chain snapshot from /subnets/{n}/history. */
 export interface SubnetHistoryPoint {
   snapshot_date: string;

--- a/apps/ui/src/lib/metagraphed/validator-compare-selection.test.ts
+++ b/apps/ui/src/lib/metagraphed/validator-compare-selection.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const KEY = "metagraphed:compare-validators";
+
+// An EventTarget-based fake `window` (so subscribe's add/remove/dispatch of the
+// "storage" event work) plus a Map-backed localStorage. Mirrors compare-selection.test.ts.
+function makeWindow(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  const win = new EventTarget() as EventTarget & {
+    localStorage: Pick<Storage, "getItem" | "setItem" | "removeItem">;
+    store: Map<string, string>;
+    throwOnRead?: boolean;
+  };
+  win.store = store;
+  win.localStorage = {
+    getItem: (k: string) => {
+      if (win.throwOnRead) throw new Error("blocked");
+      return store.has(k) ? store.get(k)! : null;
+    },
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  return win;
+}
+
+// Module-scope cache/listeners → a fresh module per case is the only way to observe
+// first-read/cache behaviour deterministically. Stub `window` before importing.
+async function freshStore(win?: ReturnType<typeof makeWindow>) {
+  vi.resetModules();
+  if (win) vi.stubGlobal("window", win);
+  return import("./validator-compare-selection");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const HK = (n: number) => `5Hotkey${n}`;
+
+describe("parseRaw", () => {
+  it("returns [] for null/empty/non-array/malformed input", async () => {
+    const { parseRaw } = await freshStore(makeWindow());
+    expect(parseRaw(null)).toEqual([]);
+    expect(parseRaw("")).toEqual([]);
+    expect(parseRaw("{not json")).toEqual([]);
+    expect(parseRaw(JSON.stringify({ a: 1 }))).toEqual([]);
+  });
+
+  it("keeps only non-empty strings and caps at 4", async () => {
+    const { parseRaw } = await freshStore(makeWindow());
+    expect(parseRaw(JSON.stringify([HK(1), 5, "", null, HK(2)]))).toEqual([HK(1), HK(2)]);
+    expect(parseRaw(JSON.stringify([HK(1), HK(2), HK(3), HK(4), HK(5)]))).toEqual([
+      HK(1),
+      HK(2),
+      HK(3),
+      HK(4),
+    ]);
+  });
+});
+
+describe("readSnapshot", () => {
+  it("returns [] during SSR (no window)", async () => {
+    const { readSnapshot } = await freshStore();
+    expect(readSnapshot()).toEqual([]);
+  });
+
+  it("reads + parses the persisted selection", async () => {
+    const { readSnapshot } = await freshStore(
+      makeWindow({ [KEY]: JSON.stringify([HK(7), HK(12)]) }),
+    );
+    expect(readSnapshot()).toEqual([HK(7), HK(12)]);
+  });
+
+  it("serves an unchanged snapshot from cache (same reference)", async () => {
+    const { readSnapshot } = await freshStore(
+      makeWindow({ [KEY]: JSON.stringify([HK(1), HK(2)]) }),
+    );
+    expect(readSnapshot()).toBe(readSnapshot());
+  });
+
+  it("degrades to [] when localStorage access throws", async () => {
+    const win = makeWindow();
+    win.throwOnRead = true;
+    const { readSnapshot } = await freshStore(win);
+    expect(readSnapshot()).toEqual([]);
+  });
+});
+
+describe("writeRaw", () => {
+  it("is a no-op during SSR (no window)", async () => {
+    const { writeRaw, readSnapshot } = await freshStore();
+    expect(() => writeRaw([HK(1)])).not.toThrow();
+    expect(readSnapshot()).toEqual([]);
+  });
+
+  it("cleans (non-empty-string-only), caps at 4, and persists", async () => {
+    const win = makeWindow();
+    const { writeRaw, readSnapshot } = await freshStore(win);
+    writeRaw([HK(1), "", HK(2), HK(3), HK(4), HK(5)]);
+    expect(win.store.get(KEY)).toBe(JSON.stringify([HK(1), HK(2), HK(3), HK(4)]));
+    expect(readSnapshot()).toEqual([HK(1), HK(2), HK(3), HK(4)]);
+  });
+
+  it("notifies registered subscribers", async () => {
+    const { writeRaw, subscribe } = await freshStore(makeWindow());
+    const calls: number[] = [];
+    subscribe(() => calls.push(1));
+    writeRaw([HK(9)]);
+    expect(calls).toEqual([1]);
+  });
+});
+
+describe("subscribe", () => {
+  it("stops notifying after the returned unsubscribe runs", async () => {
+    const { writeRaw, subscribe } = await freshStore(makeWindow());
+    let count = 0;
+    const off = subscribe(() => (count += 1));
+    writeRaw([HK(1)]);
+    off();
+    writeRaw([HK(2)]);
+    expect(count).toBe(1);
+  });
+
+  it("re-notifies on a cross-tab 'storage' event for this key, and ignores other keys", async () => {
+    const win = makeWindow({ [KEY]: JSON.stringify([HK(1)]) });
+    const { subscribe, readSnapshot } = await freshStore(win);
+    let count = 0;
+    subscribe(() => (count += 1));
+    readSnapshot();
+
+    const other = new Event("storage") as Event & { key: string };
+    other.key = "some-other-key";
+    win.dispatchEvent(other);
+    expect(count).toBe(0);
+
+    win.store.set(KEY, JSON.stringify([HK(1), HK(2)]));
+    const ours = new Event("storage") as Event & { key: string };
+    ours.key = KEY;
+    win.dispatchEvent(ours);
+    expect(count).toBe(1);
+    expect(readSnapshot()).toEqual([HK(1), HK(2)]);
+  });
+
+  it("returns a no-op unsubscribe during SSR without throwing", async () => {
+    const { subscribe } = await freshStore();
+    const off = subscribe(() => {});
+    expect(typeof off).toBe("function");
+    expect(() => off()).not.toThrow();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/validator-compare-selection.ts
+++ b/apps/ui/src/lib/metagraphed/validator-compare-selection.ts
@@ -1,0 +1,109 @@
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+/**
+ * Tiny localStorage-backed selection store for validator comparison — the
+ * hotkey-keyed sibling of compare-selection.ts (subnets). Holds up to MAX
+ * distinct SS58 hotkeys and notifies subscribers across components. Kept under
+ * its own key so a validator selection and a subnet selection are independent.
+ *
+ * MAX mirrors the subnet compare drawer (4) for a consistent side-by-side UX,
+ * well within the 1-16 the /api/v1/compare/validators route accepts.
+ */
+const KEY = "metagraphed:compare-validators";
+const MAX = 4;
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+let cachedRaw: string | null = null;
+let cachedValue: string[] = [];
+
+// parseRaw / readSnapshot / writeRaw / subscribe are the store primitives the
+// hook composes; exported for unit testing. The public component API stays
+// `useValidatorCompareSelection`.
+export function parseRaw(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((h): h is string => typeof h === "string" && h.length > 0).slice(0, MAX);
+  } catch {
+    return [];
+  }
+}
+
+export function readSnapshot(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (raw === cachedRaw) return cachedValue;
+    cachedRaw = raw;
+    cachedValue = parseRaw(raw);
+    return cachedValue;
+  } catch {
+    if (cachedRaw === null) return cachedValue;
+    cachedRaw = null;
+    cachedValue = [];
+    return cachedValue;
+  }
+}
+
+export function writeRaw(next: string[]) {
+  if (typeof window === "undefined") return;
+  const clean = next
+    .filter((h): h is string => typeof h === "string" && h.length > 0)
+    .slice(0, MAX);
+  const raw = JSON.stringify(clean);
+  try {
+    window.localStorage.setItem(KEY, raw);
+  } catch {
+    /* ignore quota errors */
+  }
+  cachedRaw = raw;
+  cachedValue = clean;
+  for (const l of listeners) l();
+}
+
+export function subscribe(l: Listener) {
+  listeners.add(l);
+  if (typeof window !== "undefined") {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === KEY) {
+        cachedRaw = null;
+        cachedValue = [];
+        l();
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      listeners.delete(l);
+      window.removeEventListener("storage", onStorage);
+    };
+  }
+  return () => listeners.delete(l);
+}
+
+const EMPTY: string[] = [];
+
+export function useValidatorCompareSelection() {
+  // Avoid SSR/CSR snapshot mismatch — start empty on the server, hydrate on mount.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  const value = useSyncExternalStore(
+    subscribe,
+    () => (hydrated ? readSnapshot() : EMPTY),
+    () => EMPTY,
+  );
+
+  return {
+    selected: value,
+    max: MAX,
+    has: (hotkey: string) => value.includes(hotkey),
+    toggle: (hotkey: string) => {
+      const cur = readSnapshot();
+      if (cur.includes(hotkey)) writeRaw(cur.filter((h) => h !== hotkey));
+      else if (cur.length < MAX) writeRaw([...cur, hotkey]);
+    },
+    remove: (hotkey: string) => writeRaw(readSnapshot().filter((h) => h !== hotkey)),
+    clear: () => writeRaw([]),
+  };
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -26,6 +26,10 @@ import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-form
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";
+import {
+  ValidatorsCompareDrawer,
+  ValidatorCompareToggle,
+} from "@/components/metagraphed/validators-compare-drawer";
 import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
@@ -154,6 +158,7 @@ function ValidatorsPage() {
         </QueryErrorBoundary>
       </div>
       <ApiSourceFooter paths={["/api/v1/validators"]} />
+      <ValidatorsCompareDrawer />
     </AppShell>
   );
 }
@@ -204,6 +209,9 @@ function ValidatorsTable({
           >
             <thead className="bg-surface/50">
               <tr>
+                <th className="w-8 px-3 py-2">
+                  <span className="sr-only">Add to compare</span>
+                </th>
                 {VALIDATOR_COLUMNS.map((col) => (
                   <th
                     key={col.header}
@@ -229,6 +237,9 @@ function ValidatorsTable({
             <tbody className="divide-y divide-border">
               {validators.map((v) => (
                 <tr key={v.hotkey} className="hover:bg-surface/40">
+                  <td className="px-3 py-2">
+                    <ValidatorCompareToggle hotkey={v.hotkey} />
+                  </td>
                   {VALIDATOR_COLUMNS.map((col) => (
                     <td key={col.header} className={col.tdClassName}>
                       {col.cell(v)}


### PR DESCRIPTION
## Summary

`GET /api/v1/compare/validators` — "the validator equivalent of `/api/v1/compare`" — placed 1-16 validators side by side (take rate, estimated APY, nominator count, on-chain identity, cross-subnet aggregates) and had an MCP tool, but there was **no validator-comparison UI**. The subnet side already ships a full feature (`subnets-compare-drawer.tsx`); this adds the hotkey-keyed sibling.

Closes #6998

## Change — mirrors the subnet compare feature exactly

- **`validator-compare-selection.ts`** — a localStorage-backed selection store keyed by SS58 hotkey, the string sibling of `compare-selection.ts`. Its own key (`metagraphed:compare-validators`) so a validator selection and a subnet selection stay independent. Caps at **4** to mirror the subnet drawer's side-by-side UX, well within the route's 1-16.
- **`validators-compare-drawer.tsx`** — `ValidatorsCompareDrawer` (floating bottom dock + expandable side-by-side grid) and `ValidatorCompareToggle` (inline checkbox), structured 1:1 with `subnets-compare-drawer.tsx`. The grid rows: Validator (identity chip + link), Take, Est. APY, Nominators, Total stake, Total emission, Avg trust, Subnets. Load error → Retry; loading → skeletons.
- **`validatorCompareQuery` + `normalizeValidatorComparison`** (queries.ts) and **`CompareValidator` / `ValidatorComparison`** (types.ts) — one call to `/api/v1/compare/validators`, so the grid renders from a single request.
- **Entry points**: a leading compare-toggle column on the validators table (`validators.index.tsx`) **and** the mobile card view (`validator-card-list.tsx`), plus `<ValidatorsCompareDrawer/>` on the page. Design-system tokens throughout (no one-off values).

## Screenshots

`/validators`. **Before** = no comparison UI. **After** = the compare-toggle column/affordance, the bottom dock with selected validators, and the expanded side-by-side grid (real data: tao.bot / 1T1B.AI / 5FLoWC…). Desktop (1280) / tablet (768) show the table + dock; **mobile (375)** shows the card toggles + drawer (full page).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop 1280 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/before-desktop-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/after-desktop-light.png) |
| Desktop 1280 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/after-desktop-dark.png) |
| Tablet 768 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/before-tablet-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/after-tablet-light.png) |
| Tablet 768 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/after-tablet-dark.png) |
| Mobile 375 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/before-mobile-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/after-mobile-light.png) |
| Mobile 375 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/6998/6998/after-mobile-dark.png) |

## Validation

- `npx tsc --noEmit` (apps/ui) → clean
- `npx vitest run …/validator-compare-selection.test.ts` → 12 passed (mirrors the subnet selection-store tests)
- `npx eslint` → clean (0 errors)
- Screenshots captured against the live `/api/v1/compare/validators` with real validator data.
