### PR TITLE
test(scripts): cover reconcile-neurons fieldsDiffer drift tolerance (#7232)

### DIFF
--- a/scripts/lib/reconcile-neurons-tolerance.mjs
+++ b/scripts/lib/reconcile-neurons-tolerance.mjs
@@ -1,0 +1,46 @@
+// Pure drift-tolerance helpers for scripts/reconcile-neurons.mjs.
+// Kept dependency-free so unit tests can import without loading Postgres /
+// lib.mjs / observability.
+
+// Below this absolute TAO delta, a mismatch is never flagged regardless of
+// relative size -- avoids false positives on near-zero stakes where a tiny
+// absolute change looks like a huge percentage. Above it, tolerate up to 2%
+// relative drift before flagging a single row: ordinary staking/unstaking
+// activity between refresh-metagraph's last write and this reconciler's own
+// fetch produces real, benign per-row differences at this scale.
+export const ABSOLUTE_FLOOR_TAO = 0.01;
+export const RELATIVE_TOLERANCE = 0.02;
+// RATIO, not a fixed count: refresh-metagraph runs DAILY (not hourly --
+// corrected after live testing against the real box, 2026-07-15), so
+// Postgres can legitimately be up to ~24h stale depending on where in the
+// cycle this job runs relative to it. A fixed small count would alert on
+// every single run purely from that lag (confirmed live: 15% of all rows
+// individually exceeded per-row tolerance after ~7h of staleness, entirely
+// explained by ordinary network-wide staking activity, not a bug). A ratio
+// scales with however stale Postgres happens to be and stays meaningful
+// regardless of network size. 30% is deliberately conservative pending real
+// drift history to tune against -- scheduled to run shortly after
+// refresh-metagraph's own daily fire (roles/data-refresh-node's job vars)
+// specifically to keep legitimate lag-driven drift low, so a genuine
+// systemic break (stalled sync, decode bug) should clear this threshold by
+// a wide margin rather than needing to be tuned razor-close to it.
+export const ALERT_THRESHOLD_RATIO = 0.3;
+
+export function fieldsDiffer(liveValue, storedValue) {
+  const live = Number(liveValue);
+  const stored = storedValue === null ? null : Number(storedValue);
+  if (!Number.isFinite(live)) return false; // fetch didn't produce a value for this field -- not this reconciler's problem
+  if (stored === null || !Number.isFinite(stored)) return true; // Postgres has no comparable value at all
+  const delta = Math.abs(live - stored);
+  if (delta <= ABSOLUTE_FLOOR_TAO) return false;
+  const tolerance = Math.max(
+    ABSOLUTE_FLOOR_TAO,
+    RELATIVE_TOLERANCE * Math.abs(live),
+  );
+  return delta > tolerance;
+}
+
+/** Pure gate for the alert ratio check in reconcile-neurons `main`. */
+export function exceedsAlertThreshold(mismatchRatio) {
+  return mismatchRatio >= ALERT_THRESHOLD_RATIO;
+}

--- a/scripts/reconcile-neurons.mjs
+++ b/scripts/reconcile-neurons.mjs
@@ -26,51 +26,29 @@
 // split every other chain-reading box job already uses).
 //
 // Usage: node scripts/reconcile-neurons.mjs
-import postgres from "postgres";
+import path from "node:path";
 import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
 import { stableStringify } from "./lib.mjs";
 import { initSentry, endSessionAndFlush } from "./observability.mjs";
+import {
+  ABSOLUTE_FLOOR_TAO,
+  ALERT_THRESHOLD_RATIO,
+  RELATIVE_TOLERANCE,
+  exceedsAlertThreshold,
+  fieldsDiffer,
+} from "./lib/reconcile-neurons-tolerance.mjs";
 
-initSentry("reconcile-neurons");
+export {
+  ABSOLUTE_FLOOR_TAO,
+  ALERT_THRESHOLD_RATIO,
+  RELATIVE_TOLERANCE,
+  exceedsAlertThreshold,
+  fieldsDiffer,
+} from "./lib/reconcile-neurons-tolerance.mjs";
 
-// Below this absolute TAO delta, a mismatch is never flagged regardless of
-// relative size -- avoids false positives on near-zero stakes where a tiny
-// absolute change looks like a huge percentage. Above it, tolerate up to 2%
-// relative drift before flagging a single row: ordinary staking/unstaking
-// activity between refresh-metagraph's last write and this reconciler's own
-// fetch produces real, benign per-row differences at this scale.
-const ABSOLUTE_FLOOR_TAO = 0.01;
-const RELATIVE_TOLERANCE = 0.02;
-// RATIO, not a fixed count: refresh-metagraph runs DAILY (not hourly --
-// corrected after live testing against the real box, 2026-07-15), so
-// Postgres can legitimately be up to ~24h stale depending on where in the
-// cycle this job runs relative to it. A fixed small count would alert on
-// every single run purely from that lag (confirmed live: 15% of all rows
-// individually exceeded per-row tolerance after ~7h of staleness, entirely
-// explained by ordinary network-wide staking activity, not a bug). A ratio
-// scales with however stale Postgres happens to be and stays meaningful
-// regardless of network size. 30% is deliberately conservative pending real
-// drift history to tune against -- scheduled to run shortly after
-// refresh-metagraph's own daily fire (roles/data-refresh-node's job vars)
-// specifically to keep legitimate lag-driven drift low, so a genuine
-// systemic break (stalled sync, decode bug) should clear this threshold by
-// a wide margin rather than needing to be tuned razor-close to it.
-const ALERT_THRESHOLD_RATIO = 0.3;
 const MAX_EXAMPLES_IN_ALERT = 10;
-
-function fieldsDiffer(liveValue, storedValue) {
-  const live = Number(liveValue);
-  const stored = storedValue === null ? null : Number(storedValue);
-  if (!Number.isFinite(live)) return false; // fetch didn't produce a value for this field -- not this reconciler's problem
-  if (stored === null || !Number.isFinite(stored)) return true; // Postgres has no comparable value at all
-  const delta = Math.abs(live - stored);
-  if (delta <= ABSOLUTE_FLOOR_TAO) return false;
-  const tolerance = Math.max(
-    ABSOLUTE_FLOOR_TAO,
-    RELATIVE_TOLERANCE * Math.abs(live),
-  );
-  return delta > tolerance;
-}
 
 async function main() {
   const snapshotPath = process.env.LIVE_SNAPSHOT_JSON;
@@ -141,7 +119,7 @@ async function main() {
   };
   console.log(stableStringify(summary));
 
-  if (mismatchRatio >= ALERT_THRESHOLD_RATIO) {
+  if (exceedsAlertThreshold(mismatchRatio)) {
     await sendAlert(summary, mismatches.slice(0, MAX_EXAMPLES_IN_ALERT));
   }
 }
@@ -173,5 +151,12 @@ async function sendAlert(summary, examples) {
   }
 }
 
-await main();
-await endSessionAndFlush();
+// Run as a CLI only when invoked directly (not when imported by a test).
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  initSentry("reconcile-neurons");
+  await main();
+  await endSessionAndFlush();
+}

--- a/tests/reconcile-neurons.test.mjs
+++ b/tests/reconcile-neurons.test.mjs
@@ -1,0 +1,78 @@
+// Unit tests for reconcile-neurons drift-tolerance decision boundary
+// (`fieldsDiffer` + alert-ratio gate). Pure functions only — no Postgres /
+// chain / webhook I/O.
+
+import { describe, expect, it } from "vitest";
+import {
+  ABSOLUTE_FLOOR_TAO,
+  ALERT_THRESHOLD_RATIO,
+  RELATIVE_TOLERANCE,
+  exceedsAlertThreshold,
+  fieldsDiffer,
+} from "../scripts/lib/reconcile-neurons-tolerance.mjs";
+
+describe("fieldsDiffer", () => {
+  it("returns false when live is non-finite (fetch produced no value)", () => {
+    expect(fieldsDiffer(NaN, 1)).toBe(false);
+    expect(fieldsDiffer(Infinity, 1)).toBe(false);
+    expect(fieldsDiffer(-Infinity, 1)).toBe(false);
+    expect(fieldsDiffer("not-a-number", 1)).toBe(false);
+    expect(fieldsDiffer(undefined, 1)).toBe(false);
+  });
+
+  it("returns true when live is finite but stored is null or non-finite", () => {
+    expect(fieldsDiffer(1, null)).toBe(true);
+    expect(fieldsDiffer(1, NaN)).toBe(true);
+    expect(fieldsDiffer(1, Infinity)).toBe(true);
+    expect(fieldsDiffer(1, "not-a-number")).toBe(true);
+    expect(fieldsDiffer(1, undefined)).toBe(true);
+  });
+
+  it("returns false when |delta| is at or under ABSOLUTE_FLOOR_TAO", () => {
+    const live = 1;
+    expect(fieldsDiffer(live, live)).toBe(false);
+    expect(fieldsDiffer(live, live + ABSOLUTE_FLOOR_TAO)).toBe(false);
+    expect(fieldsDiffer(live, live - ABSOLUTE_FLOOR_TAO)).toBe(false);
+    // Near-zero stakes: tiny absolute delta is still under the floor even if
+    // relative % would look huge.
+    expect(fieldsDiffer(0.005, 0.005 + ABSOLUTE_FLOOR_TAO / 2)).toBe(false);
+  });
+
+  it("returns false when delta exceeds the floor but stays within relative tolerance", () => {
+    // live=100 → relative tolerance = max(0.01, 0.02*100) = 2
+    const live = 100;
+    const relativeTol = RELATIVE_TOLERANCE * Math.abs(live);
+    expect(relativeTol).toBeGreaterThan(ABSOLUTE_FLOOR_TAO);
+    // Just over the floor, well under relative.
+    expect(fieldsDiffer(live, live + ABSOLUTE_FLOOR_TAO + 0.001)).toBe(false);
+    // Exactly at relative tolerance: delta > tolerance is false.
+    expect(fieldsDiffer(live, live + relativeTol)).toBe(false);
+  });
+
+  it("returns true when delta exceeds both the floor and relative tolerance", () => {
+    const live = 100;
+    const relativeTol = RELATIVE_TOLERANCE * Math.abs(live);
+    expect(fieldsDiffer(live, live + relativeTol + 0.001)).toBe(true);
+    expect(fieldsDiffer(live, live - relativeTol - 1)).toBe(true);
+  });
+
+  it("uses the absolute floor as tolerance when relative tolerance is smaller", () => {
+    // live=0.1 → relative = 0.002 < floor 0.01, so tolerance = 0.01
+    const live = 0.1;
+    expect(RELATIVE_TOLERANCE * Math.abs(live)).toBeLessThan(
+      ABSOLUTE_FLOOR_TAO,
+    );
+    expect(fieldsDiffer(live, live + ABSOLUTE_FLOOR_TAO)).toBe(false);
+    expect(fieldsDiffer(live, live + ABSOLUTE_FLOOR_TAO + 0.0001)).toBe(true);
+  });
+});
+
+describe("exceedsAlertThreshold", () => {
+  it("alerts at or above ALERT_THRESHOLD_RATIO and not below", () => {
+    expect(exceedsAlertThreshold(ALERT_THRESHOLD_RATIO)).toBe(true);
+    expect(exceedsAlertThreshold(ALERT_THRESHOLD_RATIO + 0.0001)).toBe(true);
+    expect(exceedsAlertThreshold(ALERT_THRESHOLD_RATIO - 0.0001)).toBe(false);
+    expect(exceedsAlertThreshold(0)).toBe(false);
+    expect(exceedsAlertThreshold(1)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the `fieldsDiffer` drift-tolerance decision boundary in the neurons reconciler, plus the `ALERT_THRESHOLD_RATIO` gate. Pure helpers live in a dependency-free module so tests do not load Postgres/Sentry/lib I/O.

Closes #7232

## What Changed

- Extracted `fieldsDiffer`, tolerance constants, and `exceedsAlertThreshold` to `scripts/lib/reconcile-neurons-tolerance.mjs`
- Wired `scripts/reconcile-neurons.mjs` to import those helpers and only run as a CLI when invoked directly
- Added `tests/reconcile-neurons.test.mjs` covering non-finite live, null/non-finite stored, absolute-floor edges, relative-tolerance edges, floor-dominated small stakes, and alert-ratio threshold edges

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7232`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx prettier --check` on touched files
- [x] `npx eslint` on touched files
- [x] `npx vitest run tests/reconcile-neurons.test.mjs` (7 passed)
- [x] `git diff --check`
- [ ] `npm run check` (skipped — Path B fast gate; change is scripts + unit tests only)
- [ ] `npm run validate` (skipped — no registry/API/schema change)
- [ ] `npm run test:coverage` (skipped — no `src/**` / `workers/**` patch)

Made with [Cursor](https://cursor.com)