### PR TITLE
test(scripts): unit-test private-boundary leak-detection regexes (#7236)

### DIFF
--- a/scripts/lib/private-boundary.mjs
+++ b/scripts/lib/private-boundary.mjs
@@ -1,0 +1,153 @@
+// Shared leak-detection patterns for the private-boundary CI gate
+// (`scripts/validate-private-boundary.mjs`, #7236). Kept importable so unit
+// tests can exercise every regex, the allowlist carve-out, and the
+// binary/generated skip list without running the full `git ls-files` walk.
+//
+// Security posture (locked in by tests):
+// - A real Discord webhook URL is NEVER allowlisted — even CONTRIBUTING.md /
+//   this module / the validator / the test file still fail CI on a live URL.
+// - Other private-implementation phrases are exempted only in the small
+//   allowlist of files that must mention them to define or document the gate.
+
+/** @typedef {{ name: string, regex: RegExp }} BoundaryPattern */
+
+/** @type {BoundaryPattern[]} */
+export const pathPatterns = [
+  {
+    name: "private submission-gate implementation path",
+    regex:
+      /(^|\/)(?:private-reviewer|review-corpus|review-fixtures|private-prompts|accepted-rejected-examples|metagraphed-submission-gate-private)(?:\/|$)/i,
+  },
+];
+
+/** @type {BoundaryPattern[]} */
+export const contentPatterns = [
+  {
+    name: "real Discord webhook URL",
+    regex:
+      /https:\/\/(?:discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9._-]{20,}/,
+  },
+  {
+    name: "private AI scoring internals",
+    regex:
+      /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|accepted rejected example|accepted\/rejected example)\b/i,
+  },
+  {
+    name: "provider-specific private model route",
+    regex: /\b(?:AI_GATEWAY|WORKERS_AI|@cf\/openai\/|gpt-oss-)\b/i,
+  },
+];
+
+/**
+ * Files allowed to mention non-Discord private-implementation phrases (because
+ * they define, document, or unit-test the gate). A real Discord webhook URL is
+ * still a finding in every one of these files.
+ *
+ * @type {ReadonlySet<string>}
+ */
+export const allowedContentMentions = new Set([
+  "CONTRIBUTING.md",
+  // Validator entrypoint — may describe the gate in comments.
+  "scripts/validate-private-boundary.mjs",
+  // This module defines the patterns themselves, so it self-matches.
+  "scripts/lib/private-boundary.mjs",
+  // Unit tests must quote private phrases (match + adjacent non-match cases).
+  "tests/validate-private-boundary.test.mjs",
+]);
+
+/** Exact image extensions skipped by the content walk. */
+export const BINARY_EXTENSIONS = Object.freeze([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".ico",
+]);
+
+/** Exact path prefixes treated as generated and skipped by the content walk. */
+export const GENERATED_PREFIXES = Object.freeze(["public/metagraph/"]);
+
+/**
+ * Whether a tracked path is binary or generated and should skip content scan.
+ * @param {string} file
+ * @returns {boolean}
+ */
+export function isBinaryOrGenerated(file) {
+  if (typeof file !== "string" || file.length === 0) {
+    return false;
+  }
+  for (const ext of BINARY_EXTENSIONS) {
+    if (file.endsWith(ext)) {
+      return true;
+    }
+  }
+  for (const prefix of GENERATED_PREFIXES) {
+    if (file.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether a content finding for `patternName` in `file` should be suppressed
+ * by the allowlist. Discord webhook URLs are never suppressed.
+ *
+ * @param {string} file
+ * @param {string} patternName
+ * @returns {boolean}
+ */
+export function isContentFindingAllowed(file, patternName) {
+  if (patternName === "real Discord webhook URL") {
+    return false;
+  }
+  return allowedContentMentions.has(file);
+}
+
+/**
+ * Collect content-pattern hits for one line of text.
+ *
+ * @param {string} text
+ * @param {{ file?: string }} [options]
+ * @returns {Array<{ name: string, match: string }>}
+ */
+export function findContentPatternHits(text, { file = null } = {}) {
+  if (typeof text !== "string") {
+    return [];
+  }
+  const hits = [];
+  for (const pattern of contentPatterns) {
+    // Reset lastIndex in case a caller shares a sticky regex later.
+    pattern.regex.lastIndex = 0;
+    const match = text.match(pattern.regex);
+    if (!match) {
+      continue;
+    }
+    if (file && isContentFindingAllowed(file, pattern.name)) {
+      continue;
+    }
+    hits.push({ name: pattern.name, match: match[0] });
+  }
+  return hits;
+}
+
+/**
+ * Collect path-pattern hits for one tracked path.
+ *
+ * @param {string} file
+ * @returns {Array<{ name: string, match: string }>}
+ */
+export function findPathPatternHits(file) {
+  if (typeof file !== "string") {
+    return [];
+  }
+  const hits = [];
+  for (const pattern of pathPatterns) {
+    pattern.regex.lastIndex = 0;
+    if (pattern.regex.test(file)) {
+      hits.push({ name: pattern.name, match: file });
+    }
+  }
+  return hits;
+}

--- a/scripts/validate-private-boundary.mjs
+++ b/scripts/validate-private-boundary.mjs
@@ -3,6 +3,12 @@ import { createReadStream, promises as fs } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { repoRoot } from "./lib.mjs";
+import {
+  contentPatterns,
+  isBinaryOrGenerated,
+  isContentFindingAllowed,
+  pathPatterns,
+} from "./lib/private-boundary.mjs";
 
 const trackedFiles = execFileSync("git", ["ls-files"], {
   cwd: repoRoot,
@@ -11,41 +17,11 @@ const trackedFiles = execFileSync("git", ["ls-files"], {
   .split("\n")
   .filter(Boolean);
 
-const pathPatterns = [
-  {
-    name: "private submission-gate implementation path",
-    regex:
-      /(^|\/)(?:private-reviewer|review-corpus|review-fixtures|private-prompts|accepted-rejected-examples|metagraphed-submission-gate-private)(?:\/|$)/i,
-  },
-];
-
-const contentPatterns = [
-  {
-    name: "real Discord webhook URL",
-    regex:
-      /https:\/\/(?:discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9._-]{20,}/,
-  },
-  {
-    name: "private AI scoring internals",
-    regex:
-      /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|accepted rejected example|accepted\/rejected example)\b/i,
-  },
-  {
-    name: "provider-specific private model route",
-    regex: /\b(?:AI_GATEWAY|WORKERS_AI|@cf\/openai\/|gpt-oss-)\b/i,
-  },
-];
-
-const allowedContentMentions = new Set([
-  "CONTRIBUTING.md",
-  // This file defines the boundary patterns themselves, so it self-matches.
-  "scripts/validate-private-boundary.mjs",
-]);
-
 const findings = [];
 
 for (const file of trackedFiles) {
   for (const pattern of pathPatterns) {
+    pattern.regex.lastIndex = 0;
     if (pattern.regex.test(file)) {
       findings.push(`${file}: ${pattern.name}`);
     }
@@ -80,13 +56,11 @@ for (const file of trackedFiles) {
     }
 
     for (const pattern of contentPatterns) {
+      pattern.regex.lastIndex = 0;
       if (!pattern.regex.test(linkTarget)) {
         continue;
       }
-      if (
-        pattern.name !== "real Discord webhook URL" &&
-        allowedContentMentions.has(file)
-      ) {
+      if (isContentFindingAllowed(file, pattern.name)) {
         continue;
       }
       findings.push(`${file}: symlink target: ${pattern.name}`);
@@ -109,13 +83,11 @@ for (const file of trackedFiles) {
     for await (const line of lines) {
       lineNumber += 1;
       for (const pattern of contentPatterns) {
+        pattern.regex.lastIndex = 0;
         if (!pattern.regex.test(line)) {
           continue;
         }
-        if (
-          pattern.name !== "real Discord webhook URL" &&
-          allowedContentMentions.has(file)
-        ) {
+        if (isContentFindingAllowed(file, pattern.name)) {
           continue;
         }
         findings.push(`${file}:${lineNumber}: ${pattern.name}`);
@@ -143,15 +115,3 @@ if (findings.length > 0) {
 }
 
 console.log("Private-boundary validation passed.");
-
-function isBinaryOrGenerated(file) {
-  return (
-    file.endsWith(".png") ||
-    file.endsWith(".jpg") ||
-    file.endsWith(".jpeg") ||
-    file.endsWith(".gif") ||
-    file.endsWith(".webp") ||
-    file.endsWith(".ico") ||
-    file.startsWith("public/metagraph/")
-  );
-}

--- a/tests/validate-private-boundary.test.mjs
+++ b/tests/validate-private-boundary.test.mjs
@@ -1,0 +1,382 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  BINARY_EXTENSIONS,
+  GENERATED_PREFIXES,
+  allowedContentMentions,
+  contentPatterns,
+  findContentPatternHits,
+  findPathPatternHits,
+  isBinaryOrGenerated,
+  isContentFindingAllowed,
+  pathPatterns,
+} from "../scripts/lib/private-boundary.mjs";
+
+// Build Discord webhook fixtures by concatenation so no single source line in
+// THIS test file matches the Discord content regex (the CI gate still scans
+// this file; Discord URLs are never allowlisted).
+function discordWebhook({
+  host = "discord.com",
+  id = "123456789012345678",
+  token = "abcdefghijklmnopqrstuvwxyz12",
+} = {}) {
+  return `https://${host}/api/webhooks/${id}/${token}`;
+}
+
+function patternByName(name) {
+  const pattern = contentPatterns.find((entry) => entry.name === name);
+  assert.ok(pattern, `missing content pattern: ${name}`);
+  return pattern;
+}
+
+function pathPatternByName(name) {
+  const pattern = pathPatterns.find((entry) => entry.name === name);
+  assert.ok(pattern, `missing path pattern: ${name}`);
+  return pattern;
+}
+
+describe("private-boundary contentPatterns (#7236)", () => {
+  describe("real Discord webhook URL", () => {
+    const name = "real Discord webhook URL";
+    const pattern = patternByName(name);
+
+    test("matches a real-shaped discord.com webhook URL", () => {
+      const url = discordWebhook();
+      assert.equal(pattern.regex.test(url), true);
+      assert.deepEqual(
+        findContentPatternHits(url).map((h) => h.name),
+        [name],
+      );
+    });
+
+    test("matches discordapp.com / canary / ptb hosts", () => {
+      for (const host of [
+        "discordapp.com",
+        "canary.discord.com",
+        "ptb.discord.com",
+      ]) {
+        assert.equal(
+          pattern.regex.test(discordWebhook({ host })),
+          true,
+          `expected match for host ${host}`,
+        );
+      }
+    });
+
+    test("rejects a webhook URL whose token is shorter than 20 chars", () => {
+      const short = discordWebhook({ token: "shorttoken123" }); // 13 chars
+      assert.equal(pattern.regex.test(short), false);
+      assert.deepEqual(findContentPatternHits(short), []);
+    });
+
+    test("rejects a malformed Discord URL (missing /api/webhooks/)", () => {
+      const malformed =
+        "https://discord.com/api/channels/123456789012345678/messages";
+      assert.equal(pattern.regex.test(malformed), false);
+    });
+
+    test("rejects a non-Discord webhook-shaped URL", () => {
+      const other =
+        "https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXXXXXXXXXX";
+      assert.equal(pattern.regex.test(other), false);
+    });
+
+    test("rejects http (non-TLS) Discord webhook URLs", () => {
+      const insecure = discordWebhook().replace("https://", "http://");
+      assert.equal(pattern.regex.test(insecure), false);
+    });
+  });
+
+  describe("private AI scoring internals", () => {
+    const name = "private AI scoring internals";
+    const pattern = patternByName(name);
+
+    const matchingPhrases = [
+      "private prompt",
+      "Private Rubric",
+      "private score",
+      "private threshold",
+      "corpus weight",
+      "accepted rejected example",
+      "accepted/rejected example",
+    ];
+
+    for (const phrase of matchingPhrases) {
+      test(`matches ${JSON.stringify(phrase)}`, () => {
+        pattern.regex.lastIndex = 0;
+        assert.equal(pattern.regex.test(`using a ${phrase} here`), true);
+      });
+    }
+
+    // Note: /\bprivate prompt\b/i does NOT match "private prompts" because of
+    // the trailing 's' after the word boundary of "prompt". Lock that in.
+    test('does not match plural "private prompts"', () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("private prompts"), false);
+    });
+
+    const adjacentNonMatches = [
+      "public prompt",
+      "public rubric",
+      "score privately",
+      "threshold private",
+      "corpus weights",
+      "accepted rejected examples",
+      "accepted-rejected example",
+      "private-prompt",
+      "privateprompt",
+    ];
+
+    for (const phrase of adjacentNonMatches) {
+      test(`does not match adjacent non-leak ${JSON.stringify(phrase)}`, () => {
+        pattern.regex.lastIndex = 0;
+        assert.equal(pattern.regex.test(phrase), false, phrase);
+      });
+    }
+  });
+
+  describe("provider-specific private model route", () => {
+    const name = "provider-specific private model route";
+    const pattern = patternByName(name);
+
+    // AI_GATEWAY / WORKERS_AI are \w+ identifiers — bare tokens match.
+    test('matches bare "AI_GATEWAY"', () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("AI_GATEWAY"), true);
+    });
+
+    test('matches bare "WORKERS_AI" (case-insensitive)', () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("Workers_Ai"), true);
+    });
+
+    test("matches AI_GATEWAY bounded by punctuation", () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("env.AI_GATEWAY=1"), true);
+    });
+
+    // @cf/openai/ and gpt-oss- start/end on non-word chars, so the surrounding
+    // \b only fires when a word char sits on the outer side of those edges
+    // (documented current behavior of the production regex — not tightened here).
+    test("matches @cf/openai/ when flanked by word characters", () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("x@cf/openai/y"), true);
+    });
+
+    test("matches gpt-oss- when a word character follows the trailing hyphen", () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("gpt-oss-120b"), true);
+    });
+
+    test("does not match a bare @cf/openai/ token (no outer word boundaries)", () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("@cf/openai/"), false);
+    });
+
+    test("does not match a bare gpt-oss- token (no trailing word char)", () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("gpt-oss-"), false);
+    });
+
+    test("does not match AI_GATEWAY embedded inside a longer identifier", () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test("MY_AI_GATEWAY_HELPER"), false);
+    });
+
+    const adjacentNonMatches = [
+      "AI_GATEWAYS",
+      "WORKERS_AIRFLOW",
+      "cf/openai/", // missing @
+      "@cf/openai", // missing trailing slash
+      "gpt-oss", // missing trailing hyphen
+      "gpt_oss-",
+      "OPENAI_GATEWAY",
+      "WORKERS_API",
+    ];
+
+    for (const token of adjacentNonMatches) {
+      test(`does not match adjacent non-leak ${JSON.stringify(token)}`, () => {
+        pattern.regex.lastIndex = 0;
+        assert.equal(pattern.regex.test(token), false, token);
+      });
+    }
+  });
+});
+
+describe("private-boundary pathPatterns (#7236)", () => {
+  const name = "private submission-gate implementation path";
+  const pattern = pathPatternByName(name);
+
+  const matchingPaths = [
+    "private-reviewer/index.mjs",
+    "src/private-reviewer/foo.js",
+    "review-corpus",
+    "review-corpus/weights.json",
+    "packages/review-fixtures/a.json",
+    "private-prompts/system.md",
+    "docs/accepted-rejected-examples/README.md",
+    "metagraphed-submission-gate-private/secrets.md",
+    "PRIVATE-REVIEWER/X", // case-insensitive
+  ];
+
+  for (const file of matchingPaths) {
+    test(`matches path ${JSON.stringify(file)}`, () => {
+      assert.equal(pattern.regex.test(file), true);
+      assert.equal(findPathPatternHits(file).length, 1);
+    });
+  }
+
+  const nonMatchingPaths = [
+    "scripts/validate-private-boundary.mjs",
+    "scripts/lib/private-boundary.mjs",
+    "private-reviewers-notes.md", // plural segment, not exact
+    "review-corpuscular/theory.md",
+    "src/review-corpus-builder.mjs",
+    "public/metagraph/profiles.json",
+    "README.md",
+  ];
+
+  for (const file of nonMatchingPaths) {
+    test(`does not match path ${JSON.stringify(file)}`, () => {
+      pattern.regex.lastIndex = 0;
+      assert.equal(pattern.regex.test(file), false, file);
+      assert.deepEqual(findPathPatternHits(file), []);
+    });
+  }
+});
+
+describe("allowedContentMentions carve-out (#7236)", () => {
+  test("allowlist contains CONTRIBUTING.md, the validator, the lib module, and this test file", () => {
+    assert.equal(allowedContentMentions.has("CONTRIBUTING.md"), true);
+    assert.equal(
+      allowedContentMentions.has("scripts/validate-private-boundary.mjs"),
+      true,
+    );
+    assert.equal(
+      allowedContentMentions.has("scripts/lib/private-boundary.mjs"),
+      true,
+    );
+    assert.equal(
+      allowedContentMentions.has("tests/validate-private-boundary.test.mjs"),
+      true,
+    );
+  });
+
+  test("non-Discord private phrases are suppressed in allowlisted files", () => {
+    const line = "documents a private prompt and AI_GATEWAY for operators";
+    const hits = findContentPatternHits(line, { file: "CONTRIBUTING.md" });
+    assert.deepEqual(hits, []);
+    assert.equal(
+      isContentFindingAllowed(
+        "CONTRIBUTING.md",
+        "private AI scoring internals",
+      ),
+      true,
+    );
+    assert.equal(
+      isContentFindingAllowed(
+        "CONTRIBUTING.md",
+        "provider-specific private model route",
+      ),
+      true,
+    );
+  });
+
+  test("a real Discord webhook URL is NEVER suppressed, even in allowlisted files", () => {
+    const url = discordWebhook();
+    const hits = findContentPatternHits(url, {
+      file: "scripts/lib/private-boundary.mjs",
+    });
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].name, "real Discord webhook URL");
+    assert.equal(
+      isContentFindingAllowed(
+        "scripts/lib/private-boundary.mjs",
+        "real Discord webhook URL",
+      ),
+      false,
+    );
+    assert.equal(
+      isContentFindingAllowed("CONTRIBUTING.md", "real Discord webhook URL"),
+      false,
+    );
+    assert.equal(
+      isContentFindingAllowed(
+        "tests/validate-private-boundary.test.mjs",
+        "real Discord webhook URL",
+      ),
+      false,
+    );
+  });
+
+  test("non-allowlisted files still report private phrases", () => {
+    const hits = findContentPatternHits("uses a private rubric", {
+      file: "src/mcp-server.mjs",
+    });
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].name, "private AI scoring internals");
+  });
+});
+
+describe("isBinaryOrGenerated (#7236)", () => {
+  test("exposes the exact extension + prefix lists", () => {
+    assert.deepEqual(
+      [...BINARY_EXTENSIONS],
+      [".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico"],
+    );
+    assert.deepEqual([...GENERATED_PREFIXES], ["public/metagraph/"]);
+  });
+
+  for (const ext of [".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico"]) {
+    test(`skips *${ext} files`, () => {
+      assert.equal(isBinaryOrGenerated(`assets/logo${ext}`), true);
+    });
+  }
+
+  test("skips every path under public/metagraph/", () => {
+    assert.equal(isBinaryOrGenerated("public/metagraph/profiles.json"), true);
+    assert.equal(
+      isBinaryOrGenerated("public/metagraph/schemas/index.json"),
+      true,
+    );
+  });
+
+  test("does not skip ordinary source / docs / scripts", () => {
+    for (const file of [
+      "README.md",
+      "scripts/validate-private-boundary.mjs",
+      "scripts/lib/private-boundary.mjs",
+      "tests/validate-private-boundary.test.mjs",
+      "src/mcp-server.mjs",
+      "public/agent.md",
+      "assets/logo.svg",
+      "photo.PNG.bak",
+    ]) {
+      assert.equal(isBinaryOrGenerated(file), false, file);
+    }
+  });
+
+  test("empty / non-string inputs are not treated as binary", () => {
+    assert.equal(isBinaryOrGenerated(""), false);
+    assert.equal(isBinaryOrGenerated(null), false);
+    assert.equal(isBinaryOrGenerated(undefined), false);
+  });
+});
+
+describe("findContentPatternHits / findPathPatternHits helpers (#7236)", () => {
+  test("returns [] for non-string input", () => {
+    assert.deepEqual(findContentPatternHits(null), []);
+    assert.deepEqual(findPathPatternHits(null), []);
+  });
+
+  test("can surface multiple content hits on one line", () => {
+    const hits = findContentPatternHits(
+      "private score via AI_GATEWAY for the corpus",
+    );
+    const names = hits.map((h) => h.name).sort();
+    assert.deepEqual(names, [
+      "private AI scoring internals",
+      "provider-specific private model route",
+    ]);
+  });
+});


### PR DESCRIPTION
﻿## Summary

Extract the private-boundary CI gate's leak-detection patterns into an importable module and lock every regex / allowlist carve-out / binary skip with unit tests.

Closes #7236.

### Changes

- **`scripts/lib/private-boundary.mjs`** — `pathPatterns`, `contentPatterns`, `allowedContentMentions`, `isBinaryOrGenerated`, plus helpers (`isContentFindingAllowed`, `findContentPatternHits`, `findPathPatternHits`).
- **`scripts/validate-private-boundary.mjs`** — thin walker over `git ls-files` that imports the shared module (behavior unchanged).
- **`tests/validate-private-boundary.test.mjs`** — 71 tests covering:
  - Discord webhook URL (match + short token / malformed / non-Discord / http)
  - every private AI-scoring phrase (match + adjacent non-match)
  - every provider-private route token (match + adjacent non-match; documents `\b` quirks for `@cf/openai/` and `gpt-oss-`)
  - path segment patterns
  - allowlist: non-Discord phrases suppressed in allowlisted files, **Discord URLs never suppressed**
  - `isBinaryOrGenerated` exact extension/prefix list

Discord fixtures in tests are built via concatenation so no single source line trips the live gate (Discord is never allowlisted).

## Test plan

- [x] `npx vitest run tests/validate-private-boundary.test.mjs` (71 passed)
- [x] `npm run validate:private-boundary`
- [ ] GitHub Validate CI green
