### PR TITLE
test(apply-migrations): cover parseArgs, ordering, and the idempotency guard (#7230)

### DIFF
--- a/scripts/apply-migrations.mjs
+++ b/scripts/apply-migrations.mjs
@@ -37,9 +37,10 @@
 //       normal apply path from then on).
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { repoRoot } from "./lib.mjs";
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const opts = { dryRun: false, databaseUrl: process.env.DATABASE_URL };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -51,8 +52,9 @@ function parseArgs(argv) {
   return opts;
 }
 
-async function loadMigrationFiles() {
-  const migrationsRoot = path.join(repoRoot, "migrations");
+export async function loadMigrationFiles(
+  migrationsRoot = path.join(repoRoot, "migrations"),
+) {
   const names = (await fs.readdir(migrationsRoot))
     .filter((name) => name.endsWith(".sql"))
     .sort();
@@ -63,6 +65,16 @@ async function loadMigrationFiles() {
       sql: await fs.readFile(path.join(migrationsRoot, name), "utf8"),
     })),
   );
+}
+
+// The idempotency guard: the migrations whose version isn't already recorded in
+// schema_migrations, preserving loadMigrationFiles' order. Applying twice is a
+// no-op because the second run sees every version already applied and returns
+// []. Pulled out of main() as a pure function so the "what runs on this pass"
+// decision is testable without a live database.
+export function pendingMigrations(migrations, appliedVersions) {
+  const applied = new Set(appliedVersions);
+  return migrations.filter((m) => !applied.has(m.version));
 }
 
 async function main() {
@@ -133,8 +145,10 @@ async function main() {
     }
 
     const appliedRows = await sql`SELECT version FROM schema_migrations`;
-    const applied = new Set(appliedRows.map((r) => r.version));
-    const pending = migrations.filter((m) => !applied.has(m.version));
+    const pending = pendingMigrations(
+      migrations,
+      appliedRows.map((r) => r.version),
+    );
 
     if (pending.length === 0) {
       console.log(
@@ -167,7 +181,14 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
-});
+// Only run the apply when invoked as a CLI (node scripts/apply-migrations.mjs),
+// not when imported for unit testing — importing must not open a DB connection.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/tests/apply-migrations.test.mjs
+++ b/tests/apply-migrations.test.mjs
@@ -1,0 +1,141 @@
+// Unit tests for scripts/apply-migrations.mjs's pure, DB-independent pieces
+// (#7230): CLI argument parsing, migration file loading/ordering, and the
+// idempotency guard that decides which migrations run on a given pass.
+// Importing the module must NOT open a DB connection (the CLI entrypoint is
+// import.meta.url-guarded), so these run without a live Postgres.
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import {
+  loadMigrationFiles,
+  parseArgs,
+  pendingMigrations,
+} from "../scripts/apply-migrations.mjs";
+
+describe("parseArgs", () => {
+  const savedDbUrl = process.env.DATABASE_URL;
+  afterEach(() => {
+    if (savedDbUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = savedDbUrl;
+  });
+
+  test("defaults dryRun to false and databaseUrl to $DATABASE_URL", () => {
+    process.env.DATABASE_URL = "postgres://env-default";
+    const opts = parseArgs([]);
+    assert.equal(opts.dryRun, false);
+    assert.equal(opts.databaseUrl, "postgres://env-default");
+    assert.equal(opts.bootstrapThrough, undefined);
+  });
+
+  test("parses --dry-run", () => {
+    assert.equal(parseArgs(["--dry-run"]).dryRun, true);
+  });
+
+  test("--database-url overrides the env default", () => {
+    process.env.DATABASE_URL = "postgres://env-default";
+    assert.equal(
+      parseArgs(["--database-url", "postgres://explicit"]).databaseUrl,
+      "postgres://explicit",
+    );
+  });
+
+  test("parses --bootstrap-through with its value", () => {
+    assert.equal(
+      parseArgs(["--bootstrap-through", "0007"]).bootstrapThrough,
+      "0007",
+    );
+  });
+
+  test("parses a combination of flags in any order", () => {
+    const opts = parseArgs([
+      "--dry-run",
+      "--bootstrap-through",
+      "0012",
+      "--database-url",
+      "postgres://x",
+    ]);
+    assert.equal(opts.dryRun, true);
+    assert.equal(opts.bootstrapThrough, "0012");
+    assert.equal(opts.databaseUrl, "postgres://x");
+  });
+
+  test("throws on an unrecognized argument rather than guessing", () => {
+    assert.throws(() => parseArgs(["--wat"]), /unrecognized argument: --wat/);
+  });
+});
+
+describe("pendingMigrations (idempotency guard)", () => {
+  const migrations = [
+    { version: "0001", name: "0001_init.sql" },
+    { version: "0002", name: "0002_add.sql" },
+    { version: "0003", name: "0003_more.sql" },
+  ];
+
+  test("returns every migration when none are applied yet", () => {
+    assert.deepEqual(
+      pendingMigrations(migrations, []).map((m) => m.version),
+      ["0001", "0002", "0003"],
+    );
+  });
+
+  test("returns [] when every version is already applied (a re-run is a no-op)", () => {
+    assert.deepEqual(
+      pendingMigrations(migrations, ["0001", "0002", "0003"]),
+      [],
+    );
+  });
+
+  test("returns only the un-applied versions, preserving load order", () => {
+    const pending = pendingMigrations(migrations, ["0001"]);
+    assert.deepEqual(
+      pending.map((m) => m.version),
+      ["0002", "0003"],
+    );
+  });
+
+  test("ignores recorded versions that no longer exist as files (extra applied rows)", () => {
+    assert.deepEqual(
+      pendingMigrations(migrations, ["0001", "0002", "0003", "0099"]),
+      [],
+    );
+  });
+});
+
+describe("loadMigrationFiles (ordering + filtering)", () => {
+  let dir;
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  test("returns .sql files sorted by name, each {version, name, sql}, ignoring non-sql files", async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "apply-migrations-"));
+    // Written out of order, plus a non-.sql file that must be ignored.
+    await writeFile(path.join(dir, "0002_b.sql"), "SELECT 2;");
+    await writeFile(path.join(dir, "0001_a.sql"), "SELECT 1;");
+    await writeFile(path.join(dir, "0003_c.sql"), "SELECT 3;");
+    await writeFile(path.join(dir, "README.md"), "not a migration");
+
+    const migrations = await loadMigrationFiles(dir);
+
+    assert.deepEqual(
+      migrations.map((m) => m.name),
+      ["0001_a.sql", "0002_b.sql", "0003_c.sql"],
+    );
+    assert.deepEqual(
+      migrations.map((m) => m.version),
+      ["0001", "0002", "0003"],
+    );
+    assert.equal(migrations[0].sql, "SELECT 1;");
+    // The .md is filtered out; only the three .sql files load.
+    assert.equal(migrations.length, 3);
+  });
+
+  test("returns [] for a directory with no .sql files", async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "apply-migrations-empty-"));
+    await writeFile(path.join(dir, ".gitkeep"), "");
+    assert.deepEqual(await loadMigrationFiles(dir), []);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #7230. `scripts/apply-migrations.mjs` had no coverage for its pure decision logic. This makes the pure pieces importable and tests them without a live Postgres.

## Changes

- Export `parseArgs` and `loadMigrationFiles`; `loadMigrationFiles` gains an optional migrations-root arg (defaults to the repo's `migrations/`, **behavior unchanged**) so ordering/filtering is testable against a temp fixture dir.
- Extract the inline "pending = migrations not already applied" filter into a pure, exported `pendingMigrations(migrations, appliedVersions)` — the idempotency guard — and call it from `main()`.
- Guard the `main()` CLI entrypoint behind an `import.meta.url === pathToFileURL(process.argv[1]).href` check, so **importing the module for tests never opens a DB connection** (verified: importing prints only the exports, runs no `main`).

## Tests (`tests/apply-migrations.test.mjs`, 12 tests)

- **parseArgs** — `--dry-run`, `--database-url`, `--bootstrap-through`, flags in any order, the `$DATABASE_URL` default, and the unrecognized-argument throw.
- **pendingMigrations** — none/all/some applied, load-order preserved, and extra recorded rows (versions no longer on disk) ignored.
- **loadMigrationFiles** — out-of-order `.sql` files load sorted with the 4-char `version` prefix and SQL body, non-`.sql` files filtered out, and the empty-dir case → `[]`.

## Validation

- `vitest run tests/apply-migrations.test.mjs` → 12 passed.
- `npm run validate:migrations` still green (the script's CLI behavior is unchanged); `eslint` + `prettier --check` clean.

## Risk

`scripts/**` is outside the `codecov/patch` gate. The only runtime change is a pure-function extraction + a standard CLI guard — no change to what the script does when run as `node scripts/apply-migrations.mjs`.