### PR TITLE
test(export-parquet): cover libpqConnString escaping + attachPostgres credential redaction

### DIFF
--- a/scripts/export-parquet.mjs
+++ b/scripts/export-parquet.mjs
@@ -87,7 +87,7 @@ function requireEnv(name) {
 // Minimal libpq escaping (backslash, single-quote) for robustness; this
 // project's generated passwords are alphanumeric-only in practice, but the
 // escaping costs nothing.
-function libpqConnString({ host, port, dbname, user, password }) {
+export function libpqConnString({ host, port, dbname, user, password }) {
   const esc = (value) => String(value).replace(/([\\'])/g, "\\$1");
   return `host=${esc(host)} port=${esc(port)} dbname=${esc(dbname)} user=${esc(user)} password=${esc(password)}`;
 }
@@ -97,7 +97,7 @@ function libpqConnString({ host, port, dbname, user, password }) {
 // during local testing printed the plaintext password to stderr). Never let
 // that reach a log/journal: attach with a scrubbed error on failure instead
 // of letting DuckDB's own message propagate.
-async function attachPostgres(connection, alias, conn) {
+export async function attachPostgres(connection, alias, conn) {
   try {
     await connection.run(
       `ATTACH '${libpqConnString(conn)}' AS ${alias} (TYPE postgres, READ_ONLY)`,
@@ -244,5 +244,9 @@ function summarize(manifest) {
   };
 }
 
-await main();
-await endSessionAndFlush();
+// Only auto-run when invoked as the CLI entry point, not when imported by the unit
+// tests (which exercise the exported libpqConnString / attachPostgres directly).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+  await endSessionAndFlush();
+}

--- a/tests/export-parquet.test.mjs
+++ b/tests/export-parquet.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { attachPostgres, libpqConnString } from "../scripts/export-parquet.mjs";
+
+const BASE = { host: "h", port: 5432, dbname: "d", user: "u" };
+
+describe("export-parquet libpqConnString", () => {
+  test("escapes a single quote in a field value (would otherwise break out of its field)", () => {
+    assert.equal(
+      libpqConnString({ ...BASE, password: "pa'ss" }),
+      "host=h port=5432 dbname=d user=u password=pa\\'ss",
+    );
+  });
+
+  test("escapes a backslash", () => {
+    assert.equal(
+      libpqConnString({ ...BASE, password: "pa\\ss" }),
+      "host=h port=5432 dbname=d user=u password=pa\\\\ss",
+    );
+  });
+
+  test("escapes both a backslash and a single quote in one value", () => {
+    assert.equal(
+      libpqConnString({ ...BASE, password: "a\\b'c" }),
+      "host=h port=5432 dbname=d user=u password=a\\\\b\\'c",
+    );
+  });
+
+  test("leaves a value containing neither untouched", () => {
+    assert.equal(
+      libpqConnString({
+        host: "db.internal",
+        port: 5432,
+        dbname: "reg",
+        user: "ro",
+        password: "plain123",
+      }),
+      "host=db.internal port=5432 dbname=reg user=ro password=plain123",
+    );
+  });
+});
+
+describe("export-parquet attachPostgres", () => {
+  const conn = {
+    host: "db.internal",
+    port: 5432,
+    dbname: "reg",
+    user: "ro",
+    password: "s3cr3t-PLAINTEXT",
+  };
+
+  test("re-throws a scrubbed error that never contains the plaintext password on ATTACH failure", async () => {
+    const connection = {
+      // DuckDB's own ATTACH failure embeds the whole connection string, password
+      // included -- the exact leak this function's comment says it prevents.
+      run: async () => {
+        throw new Error(
+          `IO Error: could not connect: host=db.internal password=${conn.password} port=5432`,
+        );
+      },
+    };
+    await assert.rejects(
+      attachPostgres(connection, "registry", conn),
+      (err) => {
+        assert.ok(
+          !err.message.includes(conn.password),
+          "re-thrown error leaked the plaintext password",
+        );
+        assert.match(err.message, /credentials redacted/);
+        assert.match(
+          err.message,
+          /failed to attach registry Postgres at db\.internal:5432\/reg/,
+        );
+        return true;
+      },
+    );
+  });
+
+  test("passes an ATTACH statement built from libpqConnString to connection.run on success", async () => {
+    let ran;
+    const connection = {
+      run: async (statement) => {
+        ran = statement;
+      },
+    };
+    await attachPostgres(connection, "indexer", conn);
+    assert.match(ran, /^ATTACH '.*' AS indexer \(TYPE postgres, READ_ONLY\)$/);
+    assert.ok(ran.includes(libpqConnString(conn)));
+  });
+});


### PR DESCRIPTION
Closes #7231

`scripts/export-parquet.mjs` had **zero** test coverage for two pieces of its own documented security-adjacent behavior. This exports both functions (behavior-preserving — `main()` now runs only under an `import.meta` entry guard) and adds `tests/export-parquet.test.mjs`.

## `libpqConnString` — connection-string escaping
Covers a value containing a single quote, a backslash, both, and neither, asserting the **exact** escaped output. This is connection-string-injection-adjacent: an unescaped quote in a password could break out of its libpq field.

## `attachPostgres` — credential redaction on failure
The function's comment promises that DuckDB's own `ATTACH` failure error (which embeds the full connection string, **password included**) never propagates. Test: a mocked `connection.run` rejects with an error whose message embeds the plaintext password; the re-thrown error is asserted to **not** contain the password and to carry the `credentials redacted` scrub + the `host:port/dbname` context. Plus a success-path test asserting the `ATTACH … (TYPE postgres, READ_ONLY)` statement passed to `connection.run` is built from `libpqConnString`.

Verified locally: 6/6 tests pass, prettier + eslint clean. `scripts/export-parquet.mjs` is not in vitest's `coverage.include`, so no codecov/patch gate applies; the tests are real and pass under the unit suite.