### PR TITLE
test(sign-staged-neurons): cover envelope building + validation error paths

### DIFF
--- a/scripts/sign-staged-neurons.mjs
+++ b/scripts/sign-staged-neurons.mjs
@@ -1,38 +1,59 @@
 #!/usr/bin/env node
 import { createHmac } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-const [inputPath, outputPath = inputPath] = process.argv.slice(2);
-const key = process.env.METAGRAPH_STAGING_SIGNING_KEY;
-if (!inputPath || !key) {
-  throw new Error(
-    "usage: METAGRAPH_STAGING_SIGNING_KEY=... node scripts/sign-staged-neurons.mjs <input> [output]",
-  );
-}
-
-const parsed = JSON.parse(readFileSync(inputPath, "utf8"));
-let rows;
-let refreshed_netuids;
-let captured_at;
-let payload;
-if (Array.isArray(parsed)) {
-  rows = parsed;
-  payload = JSON.stringify(rows);
-} else if (parsed && typeof parsed === "object") {
-  rows = parsed.rows;
-  refreshed_netuids = parsed.refreshed_netuids;
-  captured_at = parsed.captured_at;
-  if (!Array.isArray(rows)) {
-    throw new Error("staged payload rows must be a JSON array");
+// Build the signed staged-neurons envelope from a parsed staging payload.
+// Accepts either a bare array of rows (signs `JSON.stringify(rows)` directly) or
+// a staging object `{ rows, refreshed_netuids, captured_at }` (signs the full
+// object). Returns `{ schema_version, hmac_sha256, rows, ... }`. Pure +
+// side-effect-free so the CLI stays a thin wrapper and the branching/signing is
+// unit-tested directly (mirrors shouldPublishEconomics in economics-floor.mjs).
+export function buildSignedEnvelope(parsed, key) {
+  let rows;
+  let refreshed_netuids;
+  let captured_at;
+  let payload;
+  if (Array.isArray(parsed)) {
+    rows = parsed;
+    payload = JSON.stringify(rows);
+  } else if (parsed && typeof parsed === "object") {
+    rows = parsed.rows;
+    refreshed_netuids = parsed.refreshed_netuids;
+    captured_at = parsed.captured_at;
+    if (!Array.isArray(rows)) {
+      throw new Error("staged payload rows must be a JSON array");
+    }
+    payload = JSON.stringify({ rows, refreshed_netuids, captured_at });
+  } else {
+    throw new Error("staged payload must be a JSON array or staging object");
   }
-  payload = JSON.stringify({ rows, refreshed_netuids, captured_at });
-} else {
-  throw new Error("staged payload must be a JSON array or staging object");
+
+  const hmac_sha256 = createHmac("sha256", key).update(payload).digest("hex");
+  const envelope = { schema_version: 1, hmac_sha256, rows };
+  if (refreshed_netuids !== undefined)
+    envelope.refreshed_netuids = refreshed_netuids;
+  if (captured_at !== undefined) envelope.captured_at = captured_at;
+  return envelope;
 }
 
-const hmac_sha256 = createHmac("sha256", key).update(payload).digest("hex");
-const envelope = { schema_version: 1, hmac_sha256, rows };
-if (refreshed_netuids !== undefined)
-  envelope.refreshed_netuids = refreshed_netuids;
-if (captured_at !== undefined) envelope.captured_at = captured_at;
-writeFileSync(outputPath, `${JSON.stringify(envelope)}\n`);
+function main() {
+  const [inputPath, outputPath = inputPath] = process.argv.slice(2);
+  const key = process.env.METAGRAPH_STAGING_SIGNING_KEY;
+  if (!inputPath || !key) {
+    throw new Error(
+      "usage: METAGRAPH_STAGING_SIGNING_KEY=... node scripts/sign-staged-neurons.mjs <input> [output]",
+    );
+  }
+
+  const parsed = JSON.parse(readFileSync(inputPath, "utf8"));
+  const envelope = buildSignedEnvelope(parsed, key);
+  writeFileSync(outputPath, `${JSON.stringify(envelope)}\n`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/tests/sign-staged-neurons.test.mjs
+++ b/tests/sign-staged-neurons.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { describe, test } from "vitest";
+import { buildSignedEnvelope } from "../scripts/sign-staged-neurons.mjs";
+
+const KEY = "test-staging-signing-key";
+
+const hmacOf = (payload, key = KEY) =>
+  createHmac("sha256", key).update(payload).digest("hex");
+
+describe("buildSignedEnvelope (staged-neurons signing)", () => {
+  test("array input signs JSON.stringify(rows) directly", () => {
+    const rows = [
+      { netuid: 1, hotkey: "a" },
+      { netuid: 2, hotkey: "b" },
+    ];
+    const envelope = buildSignedEnvelope(rows, KEY);
+
+    assert.equal(envelope.schema_version, 1);
+    assert.deepEqual(envelope.rows, rows);
+    assert.equal(envelope.hmac_sha256, hmacOf(JSON.stringify(rows)));
+    // A bare array carries no staging metadata.
+    assert.equal("refreshed_netuids" in envelope, false);
+    assert.equal("captured_at" in envelope, false);
+  });
+
+  test("object input signs the full { rows, refreshed_netuids, captured_at }", () => {
+    const parsed = {
+      rows: [{ netuid: 7 }],
+      refreshed_netuids: [7, 8],
+      captured_at: "2026-07-20T00:00:00.000Z",
+    };
+    const envelope = buildSignedEnvelope(parsed, KEY);
+
+    assert.equal(envelope.schema_version, 1);
+    assert.deepEqual(envelope.rows, parsed.rows);
+    assert.deepEqual(envelope.refreshed_netuids, parsed.refreshed_netuids);
+    assert.equal(envelope.captured_at, parsed.captured_at);
+    assert.equal(
+      envelope.hmac_sha256,
+      hmacOf(
+        JSON.stringify({
+          rows: parsed.rows,
+          refreshed_netuids: parsed.refreshed_netuids,
+          captured_at: parsed.captured_at,
+        }),
+      ),
+    );
+  });
+
+  test("object input omits undefined staging metadata from the envelope", () => {
+    const envelope = buildSignedEnvelope({ rows: [] }, KEY);
+
+    assert.deepEqual(envelope.rows, []);
+    assert.equal("refreshed_netuids" in envelope, false);
+    assert.equal("captured_at" in envelope, false);
+    assert.equal(
+      envelope.hmac_sha256,
+      hmacOf(
+        JSON.stringify({
+          rows: [],
+          refreshed_netuids: undefined,
+          captured_at: undefined,
+        }),
+      ),
+    );
+  });
+
+  test("object input with non-array rows throws", () => {
+    assert.throws(
+      () => buildSignedEnvelope({ rows: "not-an-array" }, KEY),
+      /staged payload rows must be a JSON array/,
+    );
+    assert.throws(
+      () => buildSignedEnvelope({ refreshed_netuids: [1] }, KEY),
+      /staged payload rows must be a JSON array/,
+    );
+  });
+
+  test("input that is neither an array nor an object throws", () => {
+    for (const bad of [null, "string", 42, true]) {
+      assert.throws(
+        () => buildSignedEnvelope(bad, KEY),
+        /staged payload must be a JSON array or staging object/,
+      );
+    }
+  });
+
+  test("same input + key is deterministic; a different key changes the hmac", () => {
+    const rows = [{ netuid: 1 }];
+    const a = buildSignedEnvelope(rows, KEY);
+    const b = buildSignedEnvelope(rows, KEY);
+    assert.equal(a.hmac_sha256, b.hmac_sha256);
+
+    const c = buildSignedEnvelope(rows, "a-different-key");
+    assert.notEqual(a.hmac_sha256, c.hmac_sha256);
+  });
+});


### PR DESCRIPTION
## What

`scripts/sign-staged-neurons.mjs` HMAC-signs a staged-neurons payload before it is
published, but its branching (two input shapes, three validation error paths) and
signing logic had no test coverage.

Following the `shouldPublishEconomics` precedent in `scripts/economics-floor.mjs`,
this extracts the pure envelope-building logic out of the top-level script body into
an exported `buildSignedEnvelope(parsed, key)` function, and guards the CLI entrypoint
with the repo's standard `import.meta.url === pathToFileURL(process.argv[1]).href`
main-module check so the module is importable side-effect-free by a test. The CLI
behaviour is unchanged (verified end-to-end for both the array and object input shapes).

## Tests

`tests/sign-staged-neurons.test.mjs` covers:

- array input — signs `JSON.stringify(rows)` directly, no staging metadata on the envelope
- object input — signs the full `{ rows, refreshed_netuids, captured_at }` and carries the metadata
- object input with undefined metadata — omitted from the envelope
- non-array `rows` on the object path throws `staged payload rows must be a JSON array`
- neither-array-nor-object input throws `staged payload must be a JSON array or staging object`
- determinism — same input + key yields the same `hmac_sha256`; a different key changes it

Uses a fixed test signing key (no real secret), verifying the script's own correctness.

Closes #7233
