### PR TITLE
test(scripts): cover validate-private-boundary's leak-detection regexes (#7236)

### DIFF
--- a/scripts/validate-private-boundary.mjs
+++ b/scripts/validate-private-boundary.mjs
@@ -2,16 +2,10 @@ import { execFileSync } from "node:child_process";
 import { createReadStream, promises as fs } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
 import { repoRoot } from "./lib.mjs";
 
-const trackedFiles = execFileSync("git", ["ls-files"], {
-  cwd: repoRoot,
-  encoding: "utf8",
-})
-  .split("\n")
-  .filter(Boolean);
-
-const pathPatterns = [
+export const pathPatterns = [
   {
     name: "private submission-gate implementation path",
     regex:
@@ -19,7 +13,7 @@ const pathPatterns = [
   },
 ];
 
-const contentPatterns = [
+export const contentPatterns = [
   {
     name: "real Discord webhook URL",
     regex:
@@ -36,115 +30,13 @@ const contentPatterns = [
   },
 ];
 
-const allowedContentMentions = new Set([
+export const allowedContentMentions = new Set([
   "CONTRIBUTING.md",
   // This file defines the boundary patterns themselves, so it self-matches.
   "scripts/validate-private-boundary.mjs",
 ]);
 
-const findings = [];
-
-for (const file of trackedFiles) {
-  for (const pattern of pathPatterns) {
-    if (pattern.regex.test(file)) {
-      findings.push(`${file}: ${pattern.name}`);
-    }
-  }
-
-  if (isBinaryOrGenerated(file)) {
-    continue;
-  }
-
-  const absolutePath = path.join(repoRoot, file);
-  let stat;
-  try {
-    stat = await fs.lstat(absolutePath);
-  } catch (error) {
-    if (error.code === "ENOENT") {
-      continue;
-    }
-    console.warn(`Skipping unreadable path ${file}: ${error.message}`);
-    continue;
-  }
-
-  if (stat.isSymbolicLink()) {
-    let linkTarget;
-    try {
-      linkTarget = await fs.readlink(absolutePath);
-    } catch (error) {
-      if (error.code === "ENOENT") {
-        continue;
-      }
-      console.warn(`Skipping unreadable symlink ${file}: ${error.message}`);
-      continue;
-    }
-
-    for (const pattern of contentPatterns) {
-      if (!pattern.regex.test(linkTarget)) {
-        continue;
-      }
-      if (
-        pattern.name !== "real Discord webhook URL" &&
-        allowedContentMentions.has(file)
-      ) {
-        continue;
-      }
-      findings.push(`${file}: symlink target: ${pattern.name}`);
-    }
-    continue;
-  }
-
-  if (!stat.isFile()) {
-    continue;
-  }
-
-  let lines;
-  try {
-    lines = createInterface({
-      input: createReadStream(absolutePath, { encoding: "utf8" }),
-      crlfDelay: Infinity,
-    });
-
-    let lineNumber = 0;
-    for await (const line of lines) {
-      lineNumber += 1;
-      for (const pattern of contentPatterns) {
-        if (!pattern.regex.test(line)) {
-          continue;
-        }
-        if (
-          pattern.name !== "real Discord webhook URL" &&
-          allowedContentMentions.has(file)
-        ) {
-          continue;
-        }
-        findings.push(`${file}:${lineNumber}: ${pattern.name}`);
-      }
-    }
-  } catch (error) {
-    if (error.code === "ENOENT") {
-      lines?.close();
-      continue;
-    }
-    console.warn(`Skipping unreadable file ${file}: ${error.message}`);
-    lines?.close();
-    continue;
-  }
-}
-
-if (findings.length > 0) {
-  console.error(
-    `Private-boundary validation found ${findings.length} issue(s):`,
-  );
-  for (const finding of findings) {
-    console.error(`- ${finding}`);
-  }
-  process.exit(1);
-}
-
-console.log("Private-boundary validation passed.");
-
-function isBinaryOrGenerated(file) {
+export function isBinaryOrGenerated(file) {
   return (
     file.endsWith(".png") ||
     file.endsWith(".jpg") ||
@@ -154,4 +46,131 @@ function isBinaryOrGenerated(file) {
     file.endsWith(".ico") ||
     file.startsWith("public/metagraph/")
   );
+}
+
+/**
+ * Path-boundary check for one tracked file path: the names of the path patterns
+ * it violates (a private-implementation directory that must never be committed).
+ */
+export function pathMatches(file) {
+  return pathPatterns.filter((p) => p.regex.test(file)).map((p) => p.name);
+}
+
+/**
+ * Content leak-detection for one piece of text (a file line or a symlink
+ * target), scoped to the file it came from: the names of the content patterns
+ * it trips. Honors the allow-listed mentions -- every pattern except a *real*
+ * Discord webhook URL may legitimately appear in the self-referential/docs files
+ * in `allowedContentMentions`; a real webhook is never allowed anywhere.
+ */
+export function contentMatches(file, text) {
+  const matched = [];
+  for (const pattern of contentPatterns) {
+    if (!pattern.regex.test(text)) {
+      continue;
+    }
+    if (
+      pattern.name !== "real Discord webhook URL" &&
+      allowedContentMentions.has(file)
+    ) {
+      continue;
+    }
+    matched.push(pattern.name);
+  }
+  return matched;
+}
+
+async function main() {
+  const trackedFiles = execFileSync("git", ["ls-files"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+
+  const findings = [];
+
+  for (const file of trackedFiles) {
+    for (const name of pathMatches(file)) {
+      findings.push(`${file}: ${name}`);
+    }
+
+    if (isBinaryOrGenerated(file)) {
+      continue;
+    }
+
+    const absolutePath = path.join(repoRoot, file);
+    let stat;
+    try {
+      stat = await fs.lstat(absolutePath);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        continue;
+      }
+      console.warn(`Skipping unreadable path ${file}: ${error.message}`);
+      continue;
+    }
+
+    if (stat.isSymbolicLink()) {
+      let linkTarget;
+      try {
+        linkTarget = await fs.readlink(absolutePath);
+      } catch (error) {
+        if (error.code === "ENOENT") {
+          continue;
+        }
+        console.warn(`Skipping unreadable symlink ${file}: ${error.message}`);
+        continue;
+      }
+
+      for (const name of contentMatches(file, linkTarget)) {
+        findings.push(`${file}: symlink target: ${name}`);
+      }
+      continue;
+    }
+
+    if (!stat.isFile()) {
+      continue;
+    }
+
+    let lines;
+    try {
+      lines = createInterface({
+        input: createReadStream(absolutePath, { encoding: "utf8" }),
+        crlfDelay: Infinity,
+      });
+
+      let lineNumber = 0;
+      for await (const line of lines) {
+        lineNumber += 1;
+        for (const name of contentMatches(file, line)) {
+          findings.push(`${file}:${lineNumber}: ${name}`);
+        }
+      }
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        lines?.close();
+        continue;
+      }
+      console.warn(`Skipping unreadable file ${file}: ${error.message}`);
+      lines?.close();
+      continue;
+    }
+  }
+
+  if (findings.length > 0) {
+    console.error(
+      `Private-boundary validation found ${findings.length} issue(s):`,
+    );
+    for (const finding of findings) {
+      console.error(`- ${finding}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Private-boundary validation passed.");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
 }

--- a/tests/validate-private-boundary.test.mjs
+++ b/tests/validate-private-boundary.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  allowedContentMentions,
+  contentMatches,
+  contentPatterns,
+  isBinaryOrGenerated,
+  pathMatches,
+} from "../scripts/validate-private-boundary.mjs";
+
+// #7236: scripts/validate-private-boundary.mjs is the CI guard that keeps the
+// private submission-gate internals (real Discord webhooks, private AI
+// scoring prompts/rubrics, provider-specific model routes) out of the public
+// repo. Its leak-detection regexes are the whole correctness boundary, so pin
+// their matches and -- just as important -- their non-matches, plus the
+// allow-listed-mention exception that lets docs discuss the boundary without a
+// real secret ever slipping through.
+
+const DISCORD = "real Discord webhook URL";
+const AI_INTERNALS = "private AI scoring internals";
+const MODEL_ROUTE = "provider-specific private model route";
+
+describe("contentMatches — real Discord webhook URLs (never allowed anywhere)", () => {
+  test("flags a real webhook URL across the accepted discord hosts", () => {
+    for (const host of [
+      "discord.com",
+      "discordapp.com",
+      "canary.discord.com",
+      "ptb.discord.com",
+    ]) {
+      const url = `https://${host}/api/webhooks/123456789012345678/abcdefghijklmnopqrstuvwxyz1234567890`;
+      assert.deepEqual(contentMatches("workers/notify.mjs", url), [DISCORD]);
+    }
+  });
+
+  test("a real webhook is flagged even inside an allow-listed file", () => {
+    const url =
+      "https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrstuvwxyz1234567890";
+    assert.deepEqual(contentMatches("CONTRIBUTING.md", url), [DISCORD]);
+  });
+
+  test("does not flag near-misses: wrong host, too-short token, or a bare mention", () => {
+    for (const text of [
+      "https://example.com/api/webhooks/123456789012345678/abcdefghijklmnopqrst",
+      "https://discord.com/api/webhooks/123/short", // token < 20 chars
+      "see the Discord webhook in the deploy secret (not inlined here)",
+    ]) {
+      assert.deepEqual(contentMatches("workers/notify.mjs", text), []);
+    }
+  });
+});
+
+describe("contentMatches — private AI scoring internals", () => {
+  test("flags the private-scoring phrases (case-insensitive)", () => {
+    for (const text of [
+      "the PRIVATE PROMPT feeds the model",
+      "adjust the private rubric",
+      "raise the private threshold",
+      "each corpus weight is tuned",
+      "an accepted/rejected example pair",
+      "an accepted rejected example pair",
+    ]) {
+      assert.deepEqual(contentMatches("src/score.mjs", text), [AI_INTERNALS]);
+    }
+  });
+
+  test("does not flag ordinary prompt/score/threshold wording", () => {
+    for (const text of [
+      "the prompt asks for a subnet slug",
+      "a completeness score of 80",
+      "the alert threshold is 5 minutes",
+    ]) {
+      assert.deepEqual(contentMatches("src/score.mjs", text), []);
+    }
+  });
+});
+
+describe("contentMatches — provider-specific private model routes", () => {
+  test("flags the word-anchored model-route tokens", () => {
+    for (const text of [
+      "binding = AI_GATEWAY",
+      "env.WORKERS_AI.run(...)",
+      "gpt-oss-20b",
+    ]) {
+      assert.deepEqual(contentMatches("workers/ai.mjs", text), [MODEL_ROUTE]);
+    }
+  });
+
+  test("the @cf/openai/ alternative only fires with a preceding word char", () => {
+    // The pattern's leading \b sits before `@` (a non-word char), so the
+    // @cf/openai/ route matches only when a word char precedes it -- it does
+    // NOT fire when quoted/space/`=`-prefixed as it usually appears in config.
+    // Pinning this so a future regex change to close that gap is a deliberate,
+    // visible edit rather than a silent behavior drift.
+    assert.deepEqual(contentMatches("workers/ai.mjs", "use@cf/openai/gpt"), [
+      MODEL_ROUTE,
+    ]);
+    assert.deepEqual(
+      contentMatches("workers/ai.mjs", "'@cf/openai/whisper'"),
+      [],
+    );
+  });
+
+  test("does not flag unrelated AI/model wording", () => {
+    for (const text of [
+      "the public gateway is at api.metagraph.sh",
+      "gpt is not referenced here",
+      "@cf/meta/llama-3",
+    ]) {
+      assert.deepEqual(contentMatches("workers/ai.mjs", text), []);
+    }
+  });
+});
+
+describe("contentMatches — allow-listed mentions", () => {
+  test("lets allow-listed files discuss the non-webhook patterns", () => {
+    for (const file of allowedContentMentions) {
+      assert.deepEqual(contentMatches(file, "the private prompt boundary"), []);
+      assert.deepEqual(contentMatches(file, "binding = AI_GATEWAY"), []);
+    }
+  });
+
+  test("a non-allow-listed file is still flagged for the same text", () => {
+    assert.deepEqual(
+      contentMatches("README.md", "the private prompt boundary"),
+      [AI_INTERNALS],
+    );
+  });
+
+  test("reports every distinct pattern a single line trips", () => {
+    const line = "AI_GATEWAY routes the private rubric";
+    assert.deepEqual(contentMatches("src/x.mjs", line).sort(), [
+      AI_INTERNALS,
+      MODEL_ROUTE,
+    ]);
+  });
+});
+
+describe("pathMatches — private implementation directories", () => {
+  test("flags a private submission-gate directory anywhere in the tree", () => {
+    for (const file of [
+      "private-reviewer/index.mjs",
+      "packages/review-corpus/data.json",
+      "metagraphed-submission-gate-private/prompt.txt",
+      "accepted-rejected-examples/001.json",
+    ]) {
+      assert.equal(pathMatches(file).length, 1);
+    }
+  });
+
+  test("does not flag ordinary paths", () => {
+    for (const file of [
+      "src/graphql.mjs",
+      "scripts/lib.mjs",
+      "docs/review-guide.md",
+    ]) {
+      assert.deepEqual(pathMatches(file), []);
+    }
+  });
+});
+
+describe("isBinaryOrGenerated", () => {
+  test("skips binary image files and the generated artifact tree", () => {
+    for (const file of [
+      "public/logo.png",
+      "a/b.jpg",
+      "a/b.jpeg",
+      "a/b.gif",
+      "a/b.webp",
+      "a/b.ico",
+      "public/metagraph/subnets.json",
+    ]) {
+      assert.equal(isBinaryOrGenerated(file), true);
+    }
+  });
+
+  test("scans ordinary source and doc files", () => {
+    for (const file of ["src/x.mjs", "README.md", "public/index.html"]) {
+      assert.equal(isBinaryOrGenerated(file), false);
+    }
+  });
+});
+
+describe("regex inventory", () => {
+  test("every content pattern has a name and a global-free regex", () => {
+    assert.equal(contentPatterns.length, 3);
+    for (const p of contentPatterns) {
+      assert.equal(typeof p.name, "string");
+      assert.ok(p.regex instanceof RegExp);
+      // No `g` flag: contentMatches calls .test() repeatedly on fresh strings,
+      // and a stateful lastIndex would make matches order-dependent.
+      assert.ok(!p.regex.flags.includes("g"));
+    }
+  });
+});


### PR DESCRIPTION
Closes #7236

## What

`scripts/validate-private-boundary.mjs` is the CI guard (`npm run validate:private-boundary`) that keeps private submission-gate internals — real Discord webhook URLs, private AI scoring prompts/rubrics/thresholds, provider-specific model routes, and private-implementation directories — out of the public repo. Its leak-detection regexes are the entire correctness boundary, but had **zero unit coverage**.

## How

- Extract the pure pieces as named exports without changing any behavior: `pathPatterns`, `contentPatterns`, `allowedContentMentions`, `isBinaryOrGenerated`, plus two pure matchers — `pathMatches(file)` and `contentMatches(file, text)` — that capture the actual leak-detection decision (including the allow-listed-mention exception).
- Move the repo scan into `main()` guarded by the standard `process.argv[1] === fileURLToPath(import.meta.url)` check, so running the script directly behaves **identically** (verified: `node scripts/validate-private-boundary.mjs` still prints "Private-boundary validation passed."), while the logic becomes importable for tests.

## Tests

`tests/validate-private-boundary.test.mjs` pins, for each pattern, both matches **and** non-matches:
- Real Discord webhooks across all four `discord*` hosts; flagged **even in allow-listed files** (a real secret never slips through); near-misses (wrong host, sub-20-char token, a bare English mention) don't fire.
- Private-AI-internals phrases (case-insensitive) vs. ordinary prompt/score/threshold wording.
- Model-route tokens (`AI_GATEWAY`, `WORKERS_AI`, `gpt-oss-`), plus the documented `@cf/openai/` leading-`\b` narrowness (only fires after a word char) — pinned so a future regex fix to close that gap is a deliberate, visible change rather than silent drift.
- The allow-listed-mention exception, multi-pattern lines, path patterns, and `isBinaryOrGenerated`.

16 tests, all green. eslint + prettier clean, rebased on latest `main`.

- [x] Unit tests for the leak-detection regexes
- [x] CLI behavior unchanged (pure refactor to export + guarded `main()`)
- [x] Links a tracked, currently-open issue (`Closes #7236`) — required
