### PR TITLE
test(private-boundary): extract + cover the leak-detection patterns (#7236)

### DIFF
--- a/scripts/private-boundary-patterns.mjs
+++ b/scripts/private-boundary-patterns.mjs
@@ -1,0 +1,66 @@
+// The leak-detection patterns, allowlist carve-out, and binary/generated skip
+// behind scripts/validate-private-boundary.mjs's CI gate (#7236). Extracted into
+// this side-effect-free module so the regexes and the allowlist decision are
+// unit-testable directly, without running the validator's full git-ls-files
+// walk (which executes at its import time). validate-private-boundary.mjs
+// imports these — the walk logic stays there; only the patterns/decision live
+// here, so the gate's behavior is unchanged.
+
+export const pathPatterns = [
+  {
+    name: "private submission-gate implementation path",
+    regex:
+      /(^|\/)(?:private-reviewer|review-corpus|review-fixtures|private-prompts|accepted-rejected-examples|metagraphed-submission-gate-private)(?:\/|$)/i,
+  },
+];
+
+export const contentPatterns = [
+  {
+    name: "real Discord webhook URL",
+    regex:
+      /https:\/\/(?:discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9._-]{20,}/,
+  },
+  {
+    name: "private AI scoring internals",
+    regex:
+      /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|accepted rejected example|accepted\/rejected example)\b/i,
+  },
+  {
+    name: "provider-specific private model route",
+    regex: /\b(?:AI_GATEWAY|WORKERS_AI|@cf\/openai\/|gpt-oss-)\b/i,
+  },
+];
+
+export const allowedContentMentions = new Set([
+  "CONTRIBUTING.md",
+  // These three define/exercise the boundary patterns themselves, so they
+  // self-match on the non-Discord patterns (a real Discord webhook URL is still
+  // never exempted, per isAllowedContentMention).
+  "scripts/validate-private-boundary.mjs",
+  "scripts/private-boundary-patterns.mjs",
+  "tests/private-boundary-patterns.test.mjs",
+]);
+
+// A content-pattern finding on `file` for `patternName` is suppressed only when
+// it is a NON-Discord-URL pattern AND `file` is on the content-mentions
+// allowlist (CONTRIBUTING.md, the validator itself — files that legitimately
+// describe the boundary). A real Discord webhook URL is NEVER exempted: that's a
+// live secret regardless of which file it appears in.
+export function isAllowedContentMention(file, patternName) {
+  return (
+    patternName !== "real Discord webhook URL" &&
+    allowedContentMentions.has(file)
+  );
+}
+
+export function isBinaryOrGenerated(file) {
+  return (
+    file.endsWith(".png") ||
+    file.endsWith(".jpg") ||
+    file.endsWith(".jpeg") ||
+    file.endsWith(".gif") ||
+    file.endsWith(".webp") ||
+    file.endsWith(".ico") ||
+    file.startsWith("public/metagraph/")
+  );
+}

--- a/scripts/validate-private-boundary.mjs
+++ b/scripts/validate-private-boundary.mjs
@@ -3,6 +3,12 @@ import { createReadStream, promises as fs } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { repoRoot } from "./lib.mjs";
+import {
+  pathPatterns,
+  contentPatterns,
+  isAllowedContentMention,
+  isBinaryOrGenerated,
+} from "./private-boundary-patterns.mjs";
 
 const trackedFiles = execFileSync("git", ["ls-files"], {
   cwd: repoRoot,
@@ -10,37 +16,6 @@ const trackedFiles = execFileSync("git", ["ls-files"], {
 })
   .split("\n")
   .filter(Boolean);
-
-const pathPatterns = [
-  {
-    name: "private submission-gate implementation path",
-    regex:
-      /(^|\/)(?:private-reviewer|review-corpus|review-fixtures|private-prompts|accepted-rejected-examples|metagraphed-submission-gate-private)(?:\/|$)/i,
-  },
-];
-
-const contentPatterns = [
-  {
-    name: "real Discord webhook URL",
-    regex:
-      /https:\/\/(?:discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9._-]{20,}/,
-  },
-  {
-    name: "private AI scoring internals",
-    regex:
-      /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|accepted rejected example|accepted\/rejected example)\b/i,
-  },
-  {
-    name: "provider-specific private model route",
-    regex: /\b(?:AI_GATEWAY|WORKERS_AI|@cf\/openai\/|gpt-oss-)\b/i,
-  },
-];
-
-const allowedContentMentions = new Set([
-  "CONTRIBUTING.md",
-  // This file defines the boundary patterns themselves, so it self-matches.
-  "scripts/validate-private-boundary.mjs",
-]);
 
 const findings = [];
 
@@ -83,10 +58,7 @@ for (const file of trackedFiles) {
       if (!pattern.regex.test(linkTarget)) {
         continue;
       }
-      if (
-        pattern.name !== "real Discord webhook URL" &&
-        allowedContentMentions.has(file)
-      ) {
+      if (isAllowedContentMention(file, pattern.name)) {
         continue;
       }
       findings.push(`${file}: symlink target: ${pattern.name}`);
@@ -112,10 +84,7 @@ for (const file of trackedFiles) {
         if (!pattern.regex.test(line)) {
           continue;
         }
-        if (
-          pattern.name !== "real Discord webhook URL" &&
-          allowedContentMentions.has(file)
-        ) {
+        if (isAllowedContentMention(file, pattern.name)) {
           continue;
         }
         findings.push(`${file}:${lineNumber}: ${pattern.name}`);
@@ -143,15 +112,3 @@ if (findings.length > 0) {
 }
 
 console.log("Private-boundary validation passed.");
-
-function isBinaryOrGenerated(file) {
-  return (
-    file.endsWith(".png") ||
-    file.endsWith(".jpg") ||
-    file.endsWith(".jpeg") ||
-    file.endsWith(".gif") ||
-    file.endsWith(".webp") ||
-    file.endsWith(".ico") ||
-    file.startsWith("public/metagraph/")
-  );
-}

--- a/tests/private-boundary-patterns.test.mjs
+++ b/tests/private-boundary-patterns.test.mjs
@@ -1,0 +1,216 @@
+// Unit tests for the leak-detection patterns behind the private-boundary CI
+// gate (#7236) — extracted from scripts/validate-private-boundary.mjs into
+// scripts/private-boundary-patterns.mjs so the regexes, the allowlist carve-out,
+// and the binary/generated skip are verified directly rather than exercised for
+// the first time against whatever a future PR happens to contain. Each content
+// regex gets a matching case AND a clearly-adjacent non-matching case, since a
+// too-narrow regex silently lets a real leak through and a too-broad one breaks
+// legitimate PRs.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  contentPatterns,
+  isAllowedContentMention,
+  isBinaryOrGenerated,
+  pathPatterns,
+} from "../scripts/private-boundary-patterns.mjs";
+
+const byName = (patterns, name) => {
+  const found = patterns.find((p) => p.name === name);
+  assert.ok(found, `expected a pattern named "${name}"`);
+  return found.regex;
+};
+
+describe("contentPatterns — real Discord webhook URL", () => {
+  const regex = byName(contentPatterns, "real Discord webhook URL");
+  const TOKEN = "a".repeat(30); // well over the {20,} minimum
+
+  test("matches a real-shaped webhook URL on each accepted host", () => {
+    for (const host of [
+      "discord.com",
+      "discordapp.com",
+      "canary.discord.com",
+      "ptb.discord.com",
+    ]) {
+      assert.ok(
+        regex.test(`https://${host}/api/webhooks/123456789012345678/${TOKEN}`),
+        host,
+      );
+    }
+  });
+
+  test("does NOT match a token shorter than the {20,} requirement", () => {
+    assert.equal(
+      regex.test("https://discord.com/api/webhooks/123456789/short"),
+      false,
+    );
+  });
+
+  test("does NOT match a non-Discord host or a plain webhooks mention", () => {
+    assert.equal(
+      regex.test(`https://evil.example.com/api/webhooks/123/${TOKEN}`),
+      false,
+    );
+    assert.equal(regex.test("see the discord webhooks docs"), false);
+  });
+});
+
+describe("contentPatterns — private AI scoring internals", () => {
+  const regex = byName(contentPatterns, "private AI scoring internals");
+
+  test("matches each private-scoring phrase (case-insensitively)", () => {
+    for (const phrase of [
+      "private prompt",
+      "private rubric",
+      "private score",
+      "private threshold",
+      "corpus weight",
+      "accepted rejected example",
+      "accepted/rejected example",
+      "Private Rubric", // case-insensitive
+    ]) {
+      assert.ok(regex.test(`the ${phrase} is secret`), phrase);
+    }
+  });
+
+  test("does NOT match adjacent-but-innocent phrasing", () => {
+    for (const phrase of [
+      "public prompt",
+      "private garden",
+      "score threshold", // neither "private score" nor "private threshold"
+      "corpus of weights",
+    ]) {
+      assert.equal(regex.test(`the ${phrase} here`), false, phrase);
+    }
+  });
+});
+
+describe("contentPatterns — provider-specific private model route", () => {
+  const regex = byName(
+    contentPatterns,
+    "provider-specific private model route",
+  );
+
+  test("matches each private-route token", () => {
+    // These three start with a word char, so a normal separator prefix works.
+    for (const token of ["AI_GATEWAY", "WORKERS_AI", "gpt-oss-20b"]) {
+      assert.ok(regex.test(`route: ${token}`), token);
+    }
+    // @cf/openai/ starts with a non-word char, so the pattern's leading \b needs
+    // a word char immediately before it to fire (documents the shipped regex's
+    // boundary behavior).
+    assert.ok(
+      regex.test("x@cf/openai/gpt-4"),
+      "@cf/openai/ with a word-char prefix",
+    );
+  });
+
+  test("does NOT match adjacent-but-unrelated identifiers", () => {
+    for (const token of [
+      "AIGATEWAY", // no underscore — a different identifier
+      "MY_AI_GATEWAY_VALUE", // AI_GATEWAY embedded, no word boundary either side
+      "gpt-oss", // missing the trailing dash the token requires
+      "@cf/other/model", // not the openai route
+    ]) {
+      assert.equal(regex.test(`route: ${token}`), false, token);
+    }
+  });
+});
+
+describe("pathPatterns — private submission-gate implementation path", () => {
+  const regex = byName(
+    pathPatterns,
+    "private submission-gate implementation path",
+  );
+
+  test("matches a private-implementation path segment", () => {
+    for (const p of [
+      "private-reviewer/index.mjs",
+      "src/review-corpus/data.json",
+      "metagraphed-submission-gate-private/x",
+      "a/accepted-rejected-examples/b",
+    ]) {
+      assert.ok(regex.test(p), p);
+    }
+  });
+
+  test("does NOT match an ordinary repo path", () => {
+    for (const p of [
+      "src/graphql.mjs",
+      "scripts/lib.mjs",
+      "docs/review-process.md", // "review" alone, not a private segment
+    ]) {
+      assert.equal(regex.test(p), false, p);
+    }
+  });
+});
+
+describe("isAllowedContentMention (allowlist carve-out)", () => {
+  test("exempts allowlisted files from a NON-Discord finding", () => {
+    assert.equal(
+      isAllowedContentMention(
+        "CONTRIBUTING.md",
+        "private AI scoring internals",
+      ),
+      true,
+    );
+    assert.equal(
+      isAllowedContentMention(
+        "scripts/validate-private-boundary.mjs",
+        "provider-specific private model route",
+      ),
+      true,
+    );
+  });
+
+  test("NEVER exempts a real Discord webhook URL, even in an allowlisted file", () => {
+    assert.equal(
+      isAllowedContentMention("CONTRIBUTING.md", "real Discord webhook URL"),
+      false,
+    );
+    assert.equal(
+      isAllowedContentMention(
+        "scripts/validate-private-boundary.mjs",
+        "real Discord webhook URL",
+      ),
+      false,
+    );
+  });
+
+  test("does not exempt a file that is not on the allowlist", () => {
+    assert.equal(
+      isAllowedContentMention(
+        "src/whatever.mjs",
+        "private AI scoring internals",
+      ),
+      false,
+    );
+  });
+});
+
+describe("isBinaryOrGenerated", () => {
+  test("skips binary image extensions and the generated public/metagraph tree", () => {
+    for (const f of [
+      "a.png",
+      "b.jpg",
+      "c.jpeg",
+      "d.gif",
+      "e.webp",
+      "f.ico",
+      "public/metagraph/subnets.json",
+    ]) {
+      assert.equal(isBinaryOrGenerated(f), true, f);
+    }
+  });
+
+  test("does not skip ordinary source/text files", () => {
+    for (const f of [
+      "src/graphql.mjs",
+      "README.md",
+      "public/other/thing.json", // not under public/metagraph/
+      "notes.png.txt", // .png not at the end
+    ]) {
+      assert.equal(isBinaryOrGenerated(f), false, f);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #7236. `scripts/validate-private-boundary.mjs` — the CI gate keeping private submission-gate details out of this public repo — had **no test coverage** for its leak-detection regexes (they were only ever run against whatever a PR happened to contain), and it runs its full `git ls-files` walk at import time, so the patterns weren't importable in isolation.

## Changes

- New side-effect-free `scripts/private-boundary-patterns.mjs` exporting `pathPatterns`, `contentPatterns`, `allowedContentMentions`, `isBinaryOrGenerated`, and the pure `isAllowedContentMention(file, patternName)` (the allowlist carve-out, extracted from the walk).
- `validate-private-boundary.mjs` imports them and uses `isAllowedContentMention` in place of the two inline `pattern.name !== "real Discord webhook URL" && allowedContentMentions.has(file)` checks. **Gate behavior is unchanged** — `npm run validate:private-boundary` still passes.
- `tests/private-boundary-patterns.test.mjs` (14 tests).

## Coverage

- **Each content regex — match + adjacent non-match:** a real-shaped Discord webhook URL on every accepted host vs. one under the `{20,}` token minimum / a non-Discord host; each private-AI-scoring phrase vs. innocent phrasing; each provider-route token (`AI_GATEWAY`/`WORKERS_AI`/`gpt-oss-`/`@cf/openai/`) vs. adjacent identifiers — including documenting `@cf/openai/`'s leading-`\b` word-boundary behavior.
- **Path pattern:** private segments match; ordinary paths don't.
- **Allowlist carve-out:** `CONTRIBUTING.md` / the validator itself are exempt from non-Discord findings, but a **real Discord webhook URL is never exempt** (the security-relevant carve-out).
- **`isBinaryOrGenerated`:** the exact extension/prefix list.

## Risk

`scripts/**` is outside the `codecov/patch` gate. The only runtime change is a pure extraction of patterns/decision into a new module the validator imports — no change to what the gate flags (verified: still passes). Isolated new module + test file.