### PR TITLE
fix(indexer-rs): reconnect to Postgres on any poller job tick failure

### DIFF
--- a/apps/indexer-rs/src/bin/poller/jobs/account_balances.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/account_balances.rs
@@ -93,6 +93,13 @@ pub async fn run_loop(rpc_url: String, db_url: String, interval: Duration) {
         ticker.tick().await;
         let t0 = std::time::Instant::now();
         let result = run(&chain, &mut pg).await;
+        if result.is_err() {
+            // See subnet_ownership::run_loop's own comment on this exact
+            // pattern -- a dead single-lifetime connection (e.g. after a
+            // Postgres restart) fails every query forever with no
+            // self-healing otherwise.
+            pg = backfill_rs::connect_pg_retrying("account-balances", &db_url).await;
+        }
         crate::log_job_outcome("account-balances", &result, t0.elapsed(), interval);
     }
 }

--- a/apps/indexer-rs/src/bin/poller/jobs/self_stake.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/self_stake.rs
@@ -82,6 +82,13 @@ pub async fn run_loop(rpc_url: String, db_url: String, interval: Duration) {
         ticker.tick().await;
         let t0 = std::time::Instant::now();
         let result = run(&chain, &mut pg).await;
+        if result.is_err() {
+            // See subnet_ownership::run_loop's own comment on this exact
+            // pattern -- a dead single-lifetime connection (e.g. after a
+            // Postgres restart) fails every query forever with no
+            // self-healing otherwise.
+            pg = backfill_rs::connect_pg_retrying("self-stake", &db_url).await;
+        }
         crate::log_job_outcome("self-stake", &result, t0.elapsed(), interval);
     }
 }

--- a/apps/indexer-rs/src/bin/poller/jobs/subnet_ownership.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/subnet_ownership.rs
@@ -94,6 +94,21 @@ pub async fn run_loop(rpc_url: String, db_url: String, interval: Duration) {
         ticker.tick().await;
         let t0 = std::time::Instant::now();
         let result = run(&chain, &mut pg).await;
+        if result.is_err() {
+            // This loop holds ONE Postgres connection for its entire
+            // lifetime (see this function's own doc comment) -- if it dies
+            // (e.g. a Postgres restart, confirmed live 2026-07-20 via
+            // metagraphed-infra's own schema-ref-bump-triggered restarts:
+            // every subsequent tick failed forever with "connection
+            // closed", caught only once indexer-rs-poller-health-poll.sh's
+            // per-job freshness metric existed to notice the silence), every
+            // query on it fails forever with no self-healing. Reconnect on
+            // ANY tick failure, not just ones that look connection-related
+            // -- a fresh connect is cheap and harmless even when the error
+            // was unrelated to connectivity, and distinguishing error kinds
+            // here isn't worth the complexity for a 30s-backoff reconnect.
+            pg = backfill_rs::connect_pg_retrying("subnet-ownership", &db_url).await;
+        }
         crate::log_job_outcome("subnet-ownership", &result, t0.elapsed(), interval);
     }
 }

--- a/apps/indexer-rs/src/bin/poller/jobs/validator_nominators.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/validator_nominators.rs
@@ -88,6 +88,13 @@ pub async fn run_loop(rpc_url: String, db_url: String, interval: Duration) {
         ticker.tick().await;
         let t0 = std::time::Instant::now();
         let result = run(&chain, &mut pg).await;
+        if result.is_err() {
+            // See subnet_ownership::run_loop's own comment on this exact
+            // pattern -- a dead single-lifetime connection (e.g. after a
+            // Postgres restart) fails every query forever with no
+            // self-healing otherwise.
+            pg = backfill_rs::connect_pg_retrying("validator-nominators", &db_url).await;
+        }
         crate::log_job_outcome("validator-nominators", &result, t0.elapsed(), interval);
     }
 }


### PR DESCRIPTION
## Summary

Every direct-Postgres-write poller job (subnet-ownership, account-balances, validator-nominators, self-stake) connects once at `run_loop` startup and holds that single `tokio_postgres::Client` for its entire lifetime, with no reconnection logic in the tick loop itself. If the underlying connection dies (e.g. a Postgres restart -- which metagraphed-infra's schema-ref-bump workflow triggers routinely), every subsequent tick fails forever with "connection closed", with no self-healing.

**Confirmed live 2026-07-20**: caught by `indexer-rs-poller-health-poll.sh`'s new per-job freshness metric (metagraphed-infra#142) within minutes of it first running -- `subnet-ownership` had been failing every 300s tick for hours, resolving all 129 netuids successfully each time and then failing on the Postgres read step, forever, since an earlier Postgres restart in this same session.

## Fix

Reconnect on ANY tick failure, not just ones that look connection-related -- a fresh connect is cheap and harmless even when the error was unrelated to connectivity, and distinguishing error kinds isn't worth the complexity for a 30s-backoff reconnect (`connect_pg_retrying` already exists and is what every job already uses for its initial connection). Applied identically to all 4 affected jobs.

## Validation

- `cargo check --bin poller`: clean
- `cargo clippy --bin poller`: clean
- `cargo test --bin poller`: 27/27 existing tests pass (none exercise `run_loop` itself -- infinite loop over real network I/O, not unit-testable; the pure logic functions this change didn't touch are what's covered)
- Not subject to codecov's patch-coverage gate: that's scoped to `src/**`/`workers/**` JS runtime code via vitest, not `apps/indexer-rs`'s Rust

## Deploy note

This is a source fix only -- taking effect in production requires rebuilding the `metagraphed-indexer-rs` Docker image and redeploying the `indexer-rs-poller` container on the indexer box, same as the original poller rollout. Not done as part of this PR; flagging for the maintainer to decide when to do that rebuild+redeploy.