### PR TITLE
feat(ui): add domains capability-tag rollup overview and detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -30,6 +30,11 @@ export const MEGA_PANELS: MegaPanel[] = [
     browse: [
       { to: "/subnets", label: "All subnets", hint: "Browse every active netuid" },
       {
+        to: "/domains",
+        label: "Domains",
+        hint: "Capability-tag rollups",
+      },
+      {
         to: "/subnets",
         search: { curation: "maintainer-reviewed" },
         label: "Curated",
@@ -50,6 +55,8 @@ export const MEGA_PANELS: MegaPanel[] = [
       { to: "/subnets", search: { kind: "docs" }, label: "Has docs" },
       { to: "/subnets", search: { kind: "sse" }, label: "Has SSE" },
       { to: "/subnets", search: { stale: "1" }, label: "Stale > 24h" },
+      { to: "/subnets", search: { domain: "inference" }, label: "Inference" },
+      { to: "/subnets", search: { domain: "storage" }, label: "Storage" },
     ],
   },
   {

--- a/apps/ui/src/lib/metagraphed/queries.domains.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.domains.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDomainSummary, normalizeDomainsOverview } from "./queries";
+
+describe("normalizeDomainSummary (#6996)", () => {
+  it("normalizes a live-shaped domain rollup", () => {
+    const row = normalizeDomainSummary({
+      schema_version: 1,
+      domain: "Inference",
+      subnet_count: 2,
+      netuids: [2, "6", 14.0],
+      total_stake_tao: 42663451.4604,
+      total_emission_share: 0.163342,
+      emission_concentration: {
+        holders: 15,
+        total: 0.1633,
+        gini: 0.531804,
+        hhi: 0.173868,
+        hhi_normalized: 0.114858,
+        nakamoto_coefficient: 2,
+        top_1pct_share: 0.335223,
+        top_10pct_share: 0.535337,
+      },
+    });
+    expect(row).toEqual({
+      domain: "inference",
+      subnet_count: 2,
+      netuids: [2, 6, 14],
+      total_stake_tao: 42663451.4604,
+      total_emission_share: 0.163342,
+      emission_concentration: expect.objectContaining({
+        holders: 15,
+        gini: 0.531804,
+        nakamoto_coefficient: 2,
+      }),
+      schema_version: 1,
+    });
+  });
+
+  it("returns null for malformed rows and nulls empty concentration", () => {
+    expect(normalizeDomainSummary(null)).toBeNull();
+    expect(normalizeDomainSummary({ subnet_count: 1 })).toBeNull();
+    const emptyConc = normalizeDomainSummary({
+      domain: "agents",
+      subnet_count: 0,
+      netuids: [],
+      emission_concentration: { holders: 0, gini: null },
+    });
+    expect(emptyConc?.emission_concentration).toBeNull();
+  });
+});
+
+describe("normalizeDomainsOverview (#6996)", () => {
+  it("drops malformed members and backfills domain_count", () => {
+    const overview = normalizeDomainsOverview({
+      schema_version: 1,
+      domains: [
+        { domain: "agents", subnet_count: 1, netuids: [74] },
+        { subnet_count: 9 },
+        { domain: "storage", subnet_count: 3, netuids: [1, 2, 3], total_emission_share: 0.01 },
+      ],
+    });
+    expect(overview.domain_count).toBe(2);
+    expect(overview.domains.map((d) => d.domain)).toEqual(["agents", "storage"]);
+    expect(overview.schema_version).toBe(1);
+  });
+
+  it("degrades a junk payload to an empty overview", () => {
+    expect(normalizeDomainsOverview(null)).toEqual({
+      domain_count: 0,
+      domains: [],
+      schema_version: 1,
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -157,6 +157,8 @@ import type {
   LeaderboardBoardKey,
   LeaderboardRow,
   Leaderboards,
+  DomainSummary,
+  DomainsOverview,
   Lineage,
   LineageLink,
   PrimaryAppSurface,
@@ -888,6 +890,72 @@ export const leaderboardsQuery = () =>
         signal,
       });
       return { data: normalizeLeaderboards(res.data?.boards), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #6996: per-domain capability-tag rollups from GET /api/v1/domains (+ /{tag}/summary).
+// Pure composition over the subnets index + economics — no separate capture tier.
+export function normalizeDomainSummary(raw: unknown): DomainSummary | null {
+  if (!isRecord(raw)) return null;
+  const domain = coerceString(raw.domain)?.trim().toLowerCase();
+  if (!domain) return null;
+  const netuids = Array.isArray(raw.netuids)
+    ? raw.netuids
+        .map((n) => coerceFiniteNumber(n))
+        .filter((n): n is number => n != null && Number.isInteger(n) && n >= 0)
+    : [];
+  return {
+    domain,
+    subnet_count: coerceFiniteNumber(raw.subnet_count) ?? netuids.length,
+    netuids,
+    total_stake_tao: coerceFiniteNumber(raw.total_stake_tao) ?? null,
+    total_emission_share: coerceFiniteNumber(raw.total_emission_share) ?? null,
+    emission_concentration: normalizeConcentrationMetricsOrNull(raw.emission_concentration),
+    schema_version: coerceFiniteNumber(raw.schema_version) ?? 1,
+  };
+}
+
+export function normalizeDomainsOverview(raw: unknown): DomainsOverview {
+  const d = isRecord(raw) ? raw : {};
+  const domains = Array.isArray(d.domains)
+    ? d.domains.flatMap((row) => {
+        const normalized = normalizeDomainSummary(row);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    domain_count: coerceFiniteNumber(d.domain_count) ?? domains.length,
+    domains,
+    schema_version: coerceFiniteNumber(d.schema_version) ?? 1,
+  };
+}
+
+export const domainsQuery = () =>
+  queryOptions({
+    queryKey: k("domains"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/domains", { signal });
+      return {
+        ...res,
+        data: normalizeDomainsOverview(res.data),
+      } as ApiResult<DomainsOverview>;
+    },
+    staleTime: STALE_MED,
+  });
+
+export const domainSummaryQuery = (tag: string) =>
+  queryOptions({
+    queryKey: k("domain-summary", tag),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/domains/${encodeURIComponent(tag)}/summary`, {
+        signal,
+      });
+      const normalized = normalizeDomainSummary(res.data);
+      if (!normalized) {
+        throw new Error(`Invalid domain summary payload for tag "${tag}"`);
+      }
+      return { ...res, data: normalized } as ApiResult<DomainSummary>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -3644,3 +3644,46 @@ export interface AlertTriggerCreated {
   match_count: number;
   owner_token: string;
 }
+
+/* ===================== Domain / capability-tag rollups (#6996) ===================== */
+
+/**
+ * Fixed 14-tag capability taxonomy shared with the Worker (`src/domain-tags.mjs`)
+ * and validated by `?domain=` on `/api/v1/subnets` plus `/api/v1/domains/{tag}/summary`.
+ */
+export const DOMAIN_TAGS = [
+  "agents",
+  "compute",
+  "data",
+  "finance",
+  "inference",
+  "media",
+  "prediction",
+  "privacy",
+  "robotics",
+  "science",
+  "search",
+  "security",
+  "storage",
+  "training",
+] as const;
+
+export type DomainTag = (typeof DOMAIN_TAGS)[number];
+
+/** One domain rollup from GET /api/v1/domains or /api/v1/domains/{tag}/summary. */
+export interface DomainSummary {
+  domain: DomainTag | string;
+  subnet_count: number;
+  netuids: number[];
+  total_stake_tao: number | null;
+  total_emission_share: number | null;
+  emission_concentration: ConcentrationMetrics | null;
+  schema_version: number;
+}
+
+/** Overview envelope from GET /api/v1/domains. */
+export interface DomainsOverview {
+  domain_count: number;
+  domains: DomainSummary[];
+  schema_version: number;
+}

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -19,6 +19,10 @@ export const tableSearchSchema = z.object({
   stale: fallback(z.string(), "").default(""),
   provider: fallback(z.string(), "").default(""),
   netuid: fallback(z.string(), "").default(""),
+  // #6996: server-backed domain/capability-tag filter (`?domain=` on
+  // /api/v1/subnets). Empty string = no filter. Valid values are the fixed
+  // 14-tag taxonomy in DOMAIN_TAGS; the Worker rejects unknown tags with 400.
+  domain: fallback(z.string(), "").default(""),
   // #9: agent-catalog capability filters (applied client-side over joined rows).
   serviceKind: fallback(z.string(), "").default(""),
   readiness: fallback(z.string(), "").default(""),

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as SudoIndexRouteImport } from './routes/sudo.index'
 import { Route as SubnetsIndexRouteImport } from './routes/subnets.index'
 import { Route as RuntimeIndexRouteImport } from './routes/runtime.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
+import { Route as DomainsIndexRouteImport } from './routes/domains.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
 import { Route as EventsIndexRouteImport } from './routes/events.index'
 import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
@@ -36,6 +37,7 @@ import { Route as ValidatorsHotkeyRouteImport } from './routes/validators.$hotke
 import { Route as ToolsSs58RouteImport } from './routes/tools.ss58'
 import { Route as SubnetsNetuidRouteImport } from './routes/subnets.$netuid'
 import { Route as ProvidersSlugRouteImport } from './routes/providers.$slug'
+import { Route as DomainsTagRouteImport } from './routes/domains.$tag'
 import { Route as GraphqlExplorerRouteImport } from './routes/graphql.explorer'
 import { Route as ExtrinsicsHashRouteImport } from './routes/extrinsics.$hash'
 import { Route as DocsLlmsDottxtRouteImport } from './routes/docs.llms[.]txt'
@@ -135,6 +137,11 @@ const ProvidersIndexRoute = ProvidersIndexRouteImport.update({
   path: '/providers/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DomainsIndexRoute = DomainsIndexRouteImport.update({
+  id: '/domains/',
+  path: '/domains/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ExtrinsicsIndexRoute = ExtrinsicsIndexRouteImport.update({
   id: '/extrinsics/',
   path: '/extrinsics/',
@@ -178,6 +185,11 @@ const SubnetsNetuidRoute = SubnetsNetuidRouteImport.update({
 const ProvidersSlugRoute = ProvidersSlugRouteImport.update({
   id: '/providers/$slug',
   path: '/providers/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DomainsTagRoute = DomainsTagRouteImport.update({
+  id: '/domains/$tag',
+  path: '/domains/$tag',
   getParentRoute: () => rootRouteImport,
 } as any)
 const GraphqlExplorerRoute = GraphqlExplorerRouteImport.update({
@@ -243,6 +255,7 @@ export interface FileRoutesByFullPath {
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
+  '/domains/$tag': typeof DomainsTagRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
@@ -252,6 +265,7 @@ export interface FileRoutesByFullPath {
   '/events/': typeof EventsIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
+  '/domains/': typeof DomainsIndexRoute
   '/runtime/': typeof RuntimeIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
   '/sudo/': typeof SudoIndexRoute
@@ -280,6 +294,7 @@ export interface FileRoutesByTo {
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
+  '/domains/$tag': typeof DomainsTagRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
@@ -289,6 +304,7 @@ export interface FileRoutesByTo {
   '/events': typeof EventsIndexRoute
   '/extrinsics': typeof ExtrinsicsIndexRoute
   '/providers': typeof ProvidersIndexRoute
+  '/domains': typeof DomainsIndexRoute
   '/runtime': typeof RuntimeIndexRoute
   '/subnets': typeof SubnetsIndexRoute
   '/sudo': typeof SudoIndexRoute
@@ -318,6 +334,7 @@ export interface FileRoutesById {
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
+  '/domains/$tag': typeof DomainsTagRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
@@ -327,6 +344,7 @@ export interface FileRoutesById {
   '/events/': typeof EventsIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
+  '/domains/': typeof DomainsIndexRoute
   '/runtime/': typeof RuntimeIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
   '/sudo/': typeof SudoIndexRoute
@@ -357,6 +375,7 @@ export interface FileRouteTypes {
     | '/extrinsics/$hash'
     | '/graphql/explorer'
     | '/providers/$slug'
+    | '/domains/$tag'
     | '/subnets/$netuid'
     | '/tools/ss58'
     | '/validators/$hotkey'
@@ -366,6 +385,7 @@ export interface FileRouteTypes {
     | '/events/'
     | '/extrinsics/'
     | '/providers/'
+    | '/domains/'
     | '/runtime/'
     | '/subnets/'
     | '/sudo/'
@@ -394,6 +414,7 @@ export interface FileRouteTypes {
     | '/extrinsics/$hash'
     | '/graphql/explorer'
     | '/providers/$slug'
+    | '/domains/$tag'
     | '/subnets/$netuid'
     | '/tools/ss58'
     | '/validators/$hotkey'
@@ -403,6 +424,7 @@ export interface FileRouteTypes {
     | '/events'
     | '/extrinsics'
     | '/providers'
+    | '/domains'
     | '/runtime'
     | '/subnets'
     | '/sudo'
@@ -431,6 +453,7 @@ export interface FileRouteTypes {
     | '/extrinsics/$hash'
     | '/graphql/explorer'
     | '/providers/$slug'
+    | '/domains/$tag'
     | '/subnets/$netuid'
     | '/tools/ss58'
     | '/validators/$hotkey'
@@ -440,6 +463,7 @@ export interface FileRouteTypes {
     | '/events/'
     | '/extrinsics/'
     | '/providers/'
+    | '/domains/'
     | '/runtime/'
     | '/subnets/'
     | '/sudo/'
@@ -469,6 +493,7 @@ export interface RootRouteChildren {
   ExtrinsicsHashRoute: typeof ExtrinsicsHashRoute
   GraphqlExplorerRoute: typeof GraphqlExplorerRoute
   ProvidersSlugRoute: typeof ProvidersSlugRoute
+  DomainsTagRoute: typeof DomainsTagRoute
   SubnetsNetuidRoute: typeof SubnetsNetuidRoute
   ToolsSs58Route: typeof ToolsSs58Route
   ValidatorsHotkeyRoute: typeof ValidatorsHotkeyRoute
@@ -478,6 +503,7 @@ export interface RootRouteChildren {
   EventsIndexRoute: typeof EventsIndexRoute
   ExtrinsicsIndexRoute: typeof ExtrinsicsIndexRoute
   ProvidersIndexRoute: typeof ProvidersIndexRoute
+  DomainsIndexRoute: typeof DomainsIndexRoute
   RuntimeIndexRoute: typeof RuntimeIndexRoute
   SubnetsIndexRoute: typeof SubnetsIndexRoute
   SudoIndexRoute: typeof SudoIndexRoute
@@ -613,6 +639,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProvidersIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/domains/': {
+      id: '/domains/'
+      path: '/domains'
+      fullPath: '/domains/'
+      preLoaderRoute: typeof DomainsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/extrinsics/': {
       id: '/extrinsics/'
       path: '/extrinsics'
@@ -674,6 +707,13 @@ declare module '@tanstack/react-router' {
       path: '/providers/$slug'
       fullPath: '/providers/$slug'
       preLoaderRoute: typeof ProvidersSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/domains/$tag': {
+      id: '/domains/$tag'
+      path: '/domains/$tag'
+      fullPath: '/domains/$tag'
+      preLoaderRoute: typeof DomainsTagRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/graphql/explorer': {
@@ -757,6 +797,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExtrinsicsHashRoute: ExtrinsicsHashRoute,
   GraphqlExplorerRoute: GraphqlExplorerRoute,
   ProvidersSlugRoute: ProvidersSlugRoute,
+  DomainsTagRoute: DomainsTagRoute,
   SubnetsNetuidRoute: SubnetsNetuidRoute,
   ToolsSs58Route: ToolsSs58Route,
   ValidatorsHotkeyRoute: ValidatorsHotkeyRoute,
@@ -766,6 +807,7 @@ const rootRouteChildren: RootRouteChildren = {
   EventsIndexRoute: EventsIndexRoute,
   ExtrinsicsIndexRoute: ExtrinsicsIndexRoute,
   ProvidersIndexRoute: ProvidersIndexRoute,
+  DomainsIndexRoute: DomainsIndexRoute,
   RuntimeIndexRoute: RuntimeIndexRoute,
   SubnetsIndexRoute: SubnetsIndexRoute,
   SudoIndexRoute: SudoIndexRoute,

--- a/apps/ui/src/routes/domains.$tag.tsx
+++ b/apps/ui/src/routes/domains.$tag.tsx
@@ -1,0 +1,277 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { ArrowLeft, Coins, Layers, Percent, Scale, Users, BarChart3 } from "lucide-react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { PageHero, ShareButton, ActionBar, StatTile, BarMini } from "@jsonbored/ui-kit";
+import { domainSummaryQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { DOMAIN_TAGS, type ConcentrationMetrics, type DomainTag } from "@/lib/metagraphed/types";
+
+const DOMAIN_TAG_SET = new Set<string>(DOMAIN_TAGS);
+
+function isDomainTag(tag: string): tag is DomainTag {
+  return DOMAIN_TAG_SET.has(tag);
+}
+
+export const Route = createFileRoute("/domains/$tag")({
+  parseParams: ({ tag }) => {
+    const normalized = decodeURIComponent(tag).trim().toLowerCase();
+    if (!isDomainTag(normalized)) throw notFound();
+    return { tag: normalized };
+  },
+  head: ({ params }) => {
+    const title = `${params.tag} — Domains — Metagraphed`;
+    const description = `Capability-domain rollup for ${params.tag}: member subnets, total stake, emission share, and within-domain concentration.`;
+    return {
+      meta: [
+        { title },
+        { name: "description", content: description },
+        { property: "og:title", content: title },
+        { property: "og:description", content: description },
+      ],
+    };
+  },
+  component: DomainDetailPage,
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading title="Domain not found" />
+      <EmptyState
+        title="Unknown domain tag"
+        description={`Valid tags: ${DOMAIN_TAGS.join(", ")}.`}
+        action={{ label: "Back to domains", href: "/domains" }}
+      />
+    </AppShell>
+  ),
+});
+
+function DomainDetailPage() {
+  const { tag } = Route.useParams();
+  return (
+    <AppShell>
+      <QueryErrorBoundary>
+        <Suspense fallback={<DomainDetailSkeleton />}>
+          <DomainDetail tag={tag} />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter
+        paths={[`/api/v1/domains/${tag}/summary`, "/api/v1/domains"]}
+        artifacts={[`/metagraph/domains/${tag}/summary.json`]}
+      />
+    </AppShell>
+  );
+}
+
+function DomainDetailSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-24 w-full" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+      </div>
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}
+
+function pctShare(v: number | null | undefined, digits = 2): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${(v * 100).toFixed(digits)}%`;
+}
+
+function giniTone(g?: number | null): "ok" | "warn" | "down" | "default" {
+  if (g == null) return "default";
+  if (g >= 0.85) return "down";
+  if (g >= 0.6) return "warn";
+  return "ok";
+}
+
+function nakamotoTone(n?: number | null): "ok" | "warn" | "down" | "default" {
+  if (n == null) return "default";
+  if (n <= 1) return "down";
+  if (n <= 3) return "warn";
+  return "ok";
+}
+
+function DomainDetail({ tag }: { tag: DomainTag }) {
+  const { data: res } = useSuspenseQuery(domainSummaryQuery(tag));
+  const d = res.data;
+  const conc = d.emission_concentration;
+
+  return (
+    <div className="space-y-8" id="domain-detail">
+      <PageHero
+        eyebrow="Domain"
+        live
+        title={d.domain}
+        description="Live rollup over member subnets in this capability tag — stake, emission share, and emission concentration within the domain."
+        actions={
+          <ActionBar>
+            <Link
+              to="/domains"
+              className="inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+            >
+              <ArrowLeft className="size-3" aria-hidden />
+              All domains
+            </Link>
+            <Link
+              to="/subnets"
+              search={{ domain: d.domain }}
+              className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-accent/10 px-3 py-1 min-h-8 font-mono text-[11px] uppercase tracking-widest text-accent-text hover:border-accent/60 transition-colors"
+            >
+              Browse subnets
+            </Link>
+            <ShareButton bare />
+          </ActionBar>
+        }
+      />
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatTile icon={Layers} eyebrow="Member subnets" value={formatNumber(d.subnet_count)} />
+        <StatTile icon={Coins} eyebrow="Total stake" value={formatTao(d.total_stake_tao)} />
+        <StatTile
+          icon={Percent}
+          eyebrow="Emission share"
+          value={pctShare(d.total_emission_share)}
+        />
+        <StatTile
+          icon={Scale}
+          eyebrow="Emission Gini"
+          value={conc?.gini != null ? conc.gini.toFixed(3) : "—"}
+          tone={giniTone(conc?.gini)}
+          hint={
+            conc?.nakamoto_coefficient != null
+              ? `Nakamoto ${conc.nakamoto_coefficient}`
+              : "within-domain"
+          }
+        />
+      </div>
+
+      {conc ? <ConcentrationStrip metrics={conc} /> : null}
+
+      <MemberSubnets netuids={d.netuids} tag={tag} />
+    </div>
+  );
+}
+
+function ConcentrationStrip({ metrics }: { metrics: ConcentrationMetrics }) {
+  const bars = [
+    { label: "Top 1%", value: pctToBar(metrics.top_1pct_share) },
+    { label: "Top 5%", value: pctToBar(metrics.top_5pct_share) },
+    { label: "Top 10%", value: pctToBar(metrics.top_10pct_share) },
+    { label: "Top 20%", value: pctToBar(metrics.top_20pct_share) },
+  ];
+  const allEmpty = bars.every((b) => b.value === 0);
+  return (
+    <div
+      className="rounded-xl border border-border bg-card p-4 space-y-4"
+      id="domain-concentration"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Emission concentration
+        </h2>
+        <p className="text-[12px] text-ink-muted">
+          Across {formatNumber(metrics.holders)} emitting members in this domain
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={Users}
+          eyebrow="Nakamoto"
+          value={metrics.nakamoto_coefficient ?? "—"}
+          hint="members to 51%"
+          tone={nakamotoTone(metrics.nakamoto_coefficient)}
+        />
+        <StatTile
+          icon={BarChart3}
+          eyebrow="HHI"
+          value={metrics.hhi != null ? metrics.hhi.toFixed(3) : "—"}
+          hint={
+            metrics.hhi_normalized != null ? `norm ${metrics.hhi_normalized.toFixed(3)}` : undefined
+          }
+          tone={giniTone(metrics.hhi)}
+        />
+        <StatTile
+          icon={Percent}
+          eyebrow="Top 10% share"
+          value={pctShare(metrics.top_10pct_share)}
+        />
+      </div>
+      {allEmpty ? (
+        <p className="font-mono text-[11px] text-ink-muted">Not enough share data yet.</p>
+      ) : (
+        <BarMini data={bars} max={100} />
+      )}
+    </div>
+  );
+}
+
+function pctToBar(v?: number | null): number {
+  if (v == null || !Number.isFinite(v)) return 0;
+  return Math.round(v * 100);
+}
+
+function MemberSubnets({ netuids, tag }: { netuids: number[]; tag: DomainTag }) {
+  const { data: subnetsRes } = useSuspenseQuery(subnetsQuery({ limit: 200 }));
+  const byId = new Map((subnetsRes.data ?? []).map((s) => [s.netuid, s]));
+  const ordered = netuids.slice().sort((a, b) => a - b);
+
+  if (ordered.length === 0) {
+    return (
+      <EmptyState
+        title="No member subnets"
+        description="No active Finney subnets currently carry this capability tag."
+        action={{ label: "Back to domains", href: "/domains" }}
+      />
+    );
+  }
+
+  return (
+    <section className="space-y-3" id="domain-members">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Member subnets
+        </h2>
+        <Link
+          to="/subnets"
+          search={{ domain: tag }}
+          className="font-mono text-[11px] uppercase tracking-widest text-accent-text hover:underline"
+        >
+          Open filtered table →
+        </Link>
+      </div>
+      <ul className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {ordered.map((netuid) => {
+          const s = byId.get(netuid);
+          return (
+            <li key={netuid}>
+              <Link
+                to="/subnets/$netuid"
+                params={{ netuid }}
+                className="flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-3 py-2.5 hover:border-ink/30 hover:bg-surface transition-colors"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate font-medium text-ink-strong">
+                    {s?.name ?? `Subnet ${netuid}`}
+                  </span>
+                  <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    SN{netuid}
+                    {s?.symbol ? ` · ${s.symbol}` : ""}
+                  </span>
+                </span>
+                <span className="shrink-0 font-mono text-[11px] text-ink-muted">→</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/ui/src/routes/domains.index.tsx
+++ b/apps/ui/src/routes/domains.index.tsx
@@ -1,0 +1,204 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, useMemo } from "react";
+import { Layers, Coins, Percent } from "lucide-react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { PageHero, ShareButton, ActionBar, StatTile } from "@jsonbored/ui-kit";
+import { domainsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import type { DomainSummary, DomainTag } from "@/lib/metagraphed/types";
+import { DOMAIN_TAGS } from "@/lib/metagraphed/types";
+
+const DOMAIN_TAG_SET = new Set<string>(DOMAIN_TAGS);
+
+function asDomainTag(tag: string): DomainTag {
+  if (!DOMAIN_TAG_SET.has(tag)) {
+    // Overview rows always come from the fixed taxonomy; fall back defensively
+    // so a stale/unknown tag still links rather than failing the render.
+    return tag as DomainTag;
+  }
+  return tag as DomainTag;
+}
+
+export const Route = createFileRoute("/domains/")({
+  head: () => ({
+    meta: [
+      { title: "Domains — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Browse Bittensor subnets by capability domain — stake, emission share, and within-domain concentration for each of the 14 taxonomy tags.",
+      },
+      { property: "og:title", content: "Domains — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Browse Bittensor subnets by capability domain — stake, emission share, and within-domain concentration for each of the 14 taxonomy tags.",
+      },
+    ],
+  }),
+  component: DomainsPage,
+});
+
+const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+
+function DomainsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Registry"
+        live
+        title="Domains"
+        description="Capability-tag rollups across the fixed 14-tag taxonomy — member count, stake, emission share, and within-domain concentration."
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<DomainsSkeleton />}>
+          <DomainsOverview />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter
+        paths={["/api/v1/domains", "/api/v1/domains/{tag}/summary"]}
+        artifacts={["/metagraph/domains.json"]}
+      />
+    </AppShell>
+  );
+}
+
+function DomainsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+      </div>
+      <Skeleton className="h-96 w-full" />
+    </div>
+  );
+}
+
+function pctShare(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${(v * 100).toFixed(2)}%`;
+}
+
+function DomainsOverview() {
+  const { data: res } = useSuspenseQuery(domainsQuery());
+  const overview = res.data;
+  const ranked = useMemo(
+    () =>
+      [...overview.domains].sort(
+        (a, b) => (b.total_emission_share ?? -1) - (a.total_emission_share ?? -1),
+      ),
+    [overview.domains],
+  );
+
+  const taggedSubnets = useMemo(
+    () => ranked.reduce((sum, d) => sum + (d.subnet_count ?? 0), 0),
+    [ranked],
+  );
+  const totalEmission = useMemo(
+    () => ranked.reduce((sum, d) => sum + (d.total_emission_share ?? 0), 0),
+    [ranked],
+  );
+
+  if (ranked.length === 0) {
+    return (
+      <EmptyState
+        title="No domain rollups"
+        description="Domain aggregation will appear here once the subnets index and economics tier are available."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6" id="domains-overview">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatTile icon={Layers} eyebrow="Domains" value={formatNumber(overview.domain_count)} />
+        <StatTile
+          icon={Coins}
+          eyebrow="Tagged memberships"
+          value={formatNumber(taggedSubnets)}
+          hint="a subnet may appear in several domains"
+        />
+        <StatTile
+          icon={Percent}
+          eyebrow="Emission covered"
+          value={pctShare(totalEmission)}
+          hint="sum of per-domain shares (overlap possible)"
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-border bg-card">
+        <table className="w-full min-w-[720px] text-left text-[13px]">
+          <thead className="border-b border-border bg-surface/60">
+            <tr>
+              <th className={TH}>Domain</th>
+              <th className={`${TH} text-right`}>Subnets</th>
+              <th className={`${TH} text-right`}>Stake</th>
+              <th className={`${TH} text-right`}>Emission</th>
+              <th className={`${TH} text-right`}>Gini</th>
+              <th className={`${TH} text-right`}>Nakamoto</th>
+              <th className={`${TH} text-right`}>Browse</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ranked.map((d) => (
+              <DomainRow key={d.domain} domain={d} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function DomainRow({ domain: d }: { domain: DomainSummary }) {
+  const gini = d.emission_concentration?.gini;
+  const nakamoto = d.emission_concentration?.nakamoto_coefficient;
+  return (
+    <tr className="border-b border-border/70 last:border-0 hover:bg-surface/40">
+      <td className="px-4 py-3">
+        <Link
+          to="/domains/$tag"
+          params={{ tag: asDomainTag(d.domain) }}
+          className="font-medium text-ink-strong hover:text-accent-text"
+        >
+          {d.domain}
+        </Link>
+      </td>
+      <td className="px-4 py-3 text-right font-mono tabular-nums text-ink">
+        {formatNumber(d.subnet_count)}
+      </td>
+      <td className="px-4 py-3 text-right font-mono tabular-nums text-ink">
+        {formatTao(d.total_stake_tao)}
+      </td>
+      <td className="px-4 py-3 text-right font-mono tabular-nums text-ink">
+        {pctShare(d.total_emission_share)}
+      </td>
+      <td className="px-4 py-3 text-right font-mono tabular-nums text-ink-muted">
+        {gini != null && Number.isFinite(gini) ? gini.toFixed(3) : "—"}
+      </td>
+      <td className="px-4 py-3 text-right font-mono tabular-nums text-ink-muted">
+        {nakamoto != null ? formatNumber(nakamoto) : "—"}
+      </td>
+      <td className="px-4 py-3 text-right">
+        <Link
+          to="/subnets"
+          search={{ domain: d.domain }}
+          className="font-mono text-[11px] uppercase tracking-widest text-accent-text hover:underline"
+        >
+          Subnets
+        </Link>
+      </td>
+    </tr>
+  );
+}

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -70,6 +70,7 @@ import {
 } from "@/lib/metagraphed/url-state";
 import { API_BASE } from "@/lib/metagraphed/config";
 import type { AgentCatalogSummary, Subnet, SubnetEconomics } from "@/lib/metagraphed/types";
+import { DOMAIN_TAGS } from "@/lib/metagraphed/types";
 
 // #9: a list row enriched with its agent-catalog capability fields (flattened
 // from the netuid-keyed catalog map so client-side sort/filter can read them).
@@ -128,11 +129,16 @@ export const Route = createFileRoute("/subnets/")({
 
 type SubnetsSearch = z.infer<typeof tableSearchSchema>;
 
-/** Server-backed params only — sort/curation/health filters are client-side. */
-function subnetsQueryParams(search: SubnetsSearch): { q?: string; limit: number } {
+/** Server-backed params — q, limit, and domain. Sort/curation/health are client-side. */
+function subnetsQueryParams(search: SubnetsSearch): {
+  q?: string;
+  limit: number;
+  domain?: string;
+} {
   return {
     q: search.q || undefined,
     limit: search.limit,
+    domain: search.domain || undefined,
   };
 }
 
@@ -144,6 +150,7 @@ function SubnetsPage() {
     !!search.sort ||
     !!search.curation ||
     !!search.health ||
+    !!search.domain ||
     !!search.serviceKind ||
     !!search.readiness ||
     !!search.kind ||
@@ -350,9 +357,10 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
 
-  // /api/v1/subnets supports only q + cursor/limit. `sort` returns HTTP 400, and
-  // `curation`/`health` are ignored server-side — so those are applied
-  // client-side (filtered/sorted over the fetched pages) and must NOT be sent.
+  // /api/v1/subnets supports q + cursor/limit + domain (#6996). `sort` returns
+  // HTTP 400, and `curation`/`health` are ignored server-side — so those are
+  // applied client-side (filtered/sorted over the fetched pages) and must NOT
+  // be sent.
   const baseParams = subnetsQueryParams(search);
 
   const {
@@ -451,6 +459,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     search.q ||
     search.curation ||
     search.health ||
+    search.domain ||
     search.serviceKind ||
     search.readiness ||
     search.kind ||
@@ -461,7 +470,8 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     !search.includeRoot
   );
 
-  // Client-side filter + sort (the list API only honors q + cursor/limit).
+  // Client-side filter + sort (domain is server-backed via baseParams; the rest
+  // of these are applied over the fetched pages).
   // Both are memoized on the joined rows and the exact search params they read,
   // so they only recompute when one of those actually changes — not on every
   // keystroke-driven re-render.
@@ -572,6 +582,12 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           { value: "down", label: "down" },
           { value: "unknown", label: "unknown" },
         ]}
+      />
+      <SelectFilter
+        label="domain"
+        value={search.domain}
+        onChange={(v) => setSearch({ domain: v })}
+        options={DOMAIN_TAGS.map((tag) => ({ value: tag, label: tag }))}
       />
       <SelectFilter
         label="service"


### PR DESCRIPTION
## Summary

Surfaces the live **domain/capability-tag rollup** APIs in the UI. `GET /api/v1/domains` and `GET /api/v1/domains/{tag}/summary` (plus MCP `get_domain_summary`) already shipped; there was no UI for either — visitors could only filter the subnets table by a domain they already knew. This adds a `/domains` registry overview of all 14 tags and a per-tag detail page, each linking through to `/subnets?domain=…`.

Closes #6996

## What it adds

- **`/domains`** — PageHero + rollup StatTiles + table (member-subnet count, total stake, emission share, Gini, Nakamoto) for every taxonomy tag; domain name → `/domains/{tag}`, Browse → `/subnets?domain=`
- **`/domains/$tag`** — validates against the fixed 14-tag taxonomy; KPIs, emission-concentration (BarMini), member-subnet list; “Browse subnets” reuses the existing filter
- **Subnets `?domain=` wiring** — `domain` in `tableSearchSchema` + SelectFilter over `DOMAIN_TAGS` (API already supported; UI previously did not)
- **Client** — `DOMAIN_TAGS` / `DomainSummary` / `DomainsOverview`, `normalizeDomainSummary` / `normalizeDomainsOverview`, `domainsQuery` / `domainSummaryQuery` + unit tests
- **Nav** — Domains browse entry + inference/storage shortcuts in the mega menu

## Notes

- Design-system tokens + shared primitives only (`PageHero`, `StatTile`, `BarMini`, `ApiSourceFooter`); no one-off colors/shadows/gradients
- Confined to `apps/ui/` (Path C)
- Visual change — held for manual review per contribution rules

## Verification

- `tsc --noEmit` (apps/ui) — pass
- `vitest run queries.domains` — 4 pass
- `prettier --check` — clean
- Screenshots below (fixed viewport × theme matrix; before = `main` 404, after = this branch; scrolled to `#domains-overview` / `#domain-detail`)

## Changed (9 files)

- `apps/ui/src/routes/domains.index.tsx` — overview
- `apps/ui/src/routes/domains.$tag.tsx` — detail
- `apps/ui/src/lib/metagraphed/{types,queries,url-state}.ts` + `queries.domains.test.ts`
- `apps/ui/src/routes/subnets.index.tsx` — `?domain=` filter UI
- `apps/ui/src/components/metagraphed/nav-mega-menu-data.ts`
- `apps/ui/src/routeTree.gen.ts` — register `/domains` + `/domains/$tag`

## Screenshots

### Domains overview (`/domains`)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domains-after-mobile-dark.png)<br><sub>after</sub> |

### Domain detail (`/domains/inference`)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6996-domain-detail-after-mobile-dark.png)<br><sub>after</sub> |
