### PR TITLE
fix(api): split hotkey/coldkey OR into two indexed branches (METAGRAPHED-6)

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1426,15 +1426,93 @@ test("GET /api/v1/accounts/:ss58/events returns a feed shaped like the D1 route"
   expect(ev.amount_tao).toBe(1.5);
 });
 
-test("GET /api/v1/accounts/:ss58/events matches hotkey OR coldkey in one flat WHERE, no INDEXED BY / dedup guard", async () => {
+test("GET /api/v1/accounts/:ss58/events queries hotkey and coldkey as two separate indexed branches (Sentry METAGRAPHED-6)", async () => {
+  // Matches the sibling /api/v1/accounts/:ss58 route's own #6878 fix: a flat
+  // `WHERE (hotkey = $1 OR coldkey = $1)` defeats index-ordered scanning on
+  // account_events (confirmed live via EXPLAIN against a TimescaleDB
+  // compressed chunk -- see the route's own comment), so this queries each
+  // column separately and merges client-side instead.
   mockRows.current = [ACCOUNT_EVENT_ROW];
   await req(`/api/v1/accounts/${SS58}/events`);
   const text = queryText();
-  expect(text).toContain("WHERE (hotkey =");
-  expect(text).toContain("OR coldkey =");
+  expect(text).toContain("WHERE hotkey =");
+  expect(text).toContain("WHERE coldkey =");
+  expect(text).toContain("hotkey IS NULL OR hotkey <>");
+  expect(text).not.toContain("WHERE (hotkey =");
+  expect(text).not.toContain("OR coldkey =");
   expect(text).not.toContain("INDEXED BY");
-  expect(text).not.toContain("UNION");
-  expect(text).not.toContain("hotkey <>");
+});
+
+test("GET /api/v1/accounts/:ss58/events merges, re-sorts, and re-caps rows from BOTH branches without double-counting a self-referential row", async () => {
+  // Same scenario the sibling /api/v1/accounts/:ss58 route's own merge test
+  // covers: an address with activity under both hotkey and coldkey, PLUS one
+  // row where hotkey and coldkey are the SAME address -- the coldkey
+  // branch's `hotkey IS NULL OR hotkey <> ss58` guard must exclude that row
+  // (already returned by the hotkey branch) rather than double-counting it.
+  // hotkeyRow and selfRow also share the same observed_at, exercising the
+  // sort's block_number tie-break (real chain data can't tie there, but the
+  // tie-break exists for defense-in-depth and needs its own branch coverage).
+  const hotkeyRow = {
+    ...ACCOUNT_EVENT_ROW,
+    observed_at: "100",
+    block_number: "100",
+    event_index: 0,
+    event_kind: "StakeAdded",
+    hotkey: SS58,
+    coldkey: "5ColdOther",
+  };
+  const selfRow = {
+    ...ACCOUNT_EVENT_ROW,
+    observed_at: "100",
+    block_number: "150",
+    event_index: 0,
+    event_kind: "StakeRemoved",
+    hotkey: SS58,
+    coldkey: SS58,
+  };
+  const coldkeyRowNewer = {
+    ...ACCOUNT_EVENT_ROW,
+    observed_at: "200",
+    block_number: "200",
+    event_index: 1,
+    event_kind: "WeightsSet",
+    hotkey: "5HotOther",
+    coldkey: SS58,
+  };
+  // Every one of the 5 optional filter ternaries in EACH branch (kind,
+  // netuid, block_start, block_end, cursor) is itself a nested sql`` call
+  // under this mock, consuming its own queue slot even on its falsy/empty
+  // branch -- so the two real per-branch results sit 6 slots apart from
+  // each other (1 outer call + 5 filter ternaries), after the global
+  // dispatchReadRoutes SET and this route's own SET LOCAL.
+  mockQueue.current = [
+    [], // SET statement_timeout = 3000ms (dispatchReadRoutes' own default)
+    [], // SET LOCAL statement_timeout = 10000ms (this route's own override)
+    [],
+    [],
+    [],
+    [],
+    [], // hotkeyRows' 5 filter ternaries (kind/netuid/block_start/block_end/cursor), all empty here
+    [selfRow, hotkeyRow], // hotkeyRows itself (hotkey = ss58)
+    [],
+    [],
+    [],
+    [],
+    [], // coldkeyRows' 5 filter ternaries, same as above
+    [coldkeyRowNewer], // coldkeyRows itself (coldkey = ss58 AND hotkey <> ss58 -- selfRow correctly excluded here)
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}/events?limit=10`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // 3 distinct rows, not 4 -- selfRow only ever counted once even though it
+  // would satisfy both branches' raw predicates.
+  expect(body.event_count).toBe(3);
+  expect(body.events.map((e) => e.block_number)).toEqual([200, 150, 100]);
+  expect(body.events.map((e) => e.event_kind)).toEqual([
+    "WeightsSet",
+    "StakeRemoved",
+    "StakeAdded",
+  ]);
 });
 
 test("GET /api/v1/accounts/:ss58/events applies the same filter set as the former account event-feed D1 loader", async () => {
@@ -1457,7 +1535,10 @@ test("GET /api/v1/accounts/:ss58/events caps oversized offsets before Postgres",
   );
   expect(accountEventsCall).toBeTruthy();
   const boundValues = sqlCalls.flatMap((call) => call.values);
-  expect(boundValues).toContain(1_000_000);
+  // offset is no longer bound directly (it's applied client-side after the
+  // two branches are merged) -- each branch's own LIMIT is limit+offset, so
+  // the capped offset shows up folded into that derived bound value instead.
+  expect(boundValues).toContain(1 + MAX_OFFSET);
   expect(boundValues).not.toContain(999999999999);
 });
 
@@ -1473,8 +1554,13 @@ test("GET /api/v1/accounts/:ss58/events ignores an old 2-part cursor (pre-METAGR
   mockRows.current = [ACCOUNT_EVENT_ROW];
   await req(`/api/v1/accounts/${SS58}/events?cursor=8586300.0`);
   const text = queryText();
+  // Never emits SQL OFFSET at all -- both branches are always capped by
+  // LIMIT and the offset window is applied client-side after the merge (see
+  // the route's own comment), so an invalid cursor falling back to "page
+  // from the start" shows up as the absence of the cursor's WHERE clause,
+  // not the presence of OFFSET.
   expect(text).not.toContain("AND (observed_at, block_number, event_index) <");
-  expect(text).toContain("OFFSET");
+  expect(text).not.toContain("OFFSET");
 });
 
 test("GET /api/v1/accounts/:ss58/events with no matching rows returns a schema-stable empty feed", async () => {
@@ -4338,6 +4424,82 @@ test("GET /api/v1/accounts/:ss58/transfers?direction=received narrows to the col
   expect(text).not.toContain("OR coldkey");
 });
 
+test("GET /api/v1/accounts/:ss58/transfers?direction=sent also applies block_start/block_end/cursor on the single-branch path", async () => {
+  mockRows.current = [];
+  await req(
+    `/api/v1/accounts/${SS58}/transfers?direction=sent&block_start=1&block_end=2&cursor=1783600000000.8586300.0`,
+  );
+  const text = queryText();
+  expect(text).toContain("AND block_number >=");
+  expect(text).toContain("AND block_number <=");
+  expect(text).toContain("AND (observed_at, block_number, event_index) <");
+  expect(text).not.toContain("OFFSET");
+});
+
+test("GET /api/v1/accounts/:ss58/transfers (no direction) queries hotkey and coldkey as two separate indexed branches (Sentry METAGRAPHED-6)", async () => {
+  // Same METAGRAPHED-6 class of bug as /api/v1/accounts/:ss58/events: a flat
+  // `WHERE ... AND (hotkey = $1 OR coldkey = $1)` defeats index-ordered
+  // scanning on account_events' TimescaleDB-compressed chunks -- only the
+  // "all directions" (no ?direction=) path hits this, since sent/received
+  // already query a single indexed column.
+  mockRows.current = [ACCOUNT_EVENT_ROW];
+  await req(`/api/v1/accounts/${SS58}/transfers`);
+  const text = queryText();
+  expect(text).toContain("AND hotkey =");
+  expect(text).toContain("AND coldkey =");
+  expect(text).toContain("hotkey IS NULL OR hotkey <>");
+  expect(text).not.toContain("OR coldkey =");
+});
+
+test("GET /api/v1/accounts/:ss58/transfers (no direction) merges both branches without double-counting a self-transfer row", async () => {
+  // hotkeyRow and selfRow share the same observed_at, exercising the sort's
+  // block_number tie-break branch (see the /events route's own merge test).
+  const hotkeyRow = {
+    ...ACCOUNT_EVENT_ROW,
+    observed_at: "100",
+    block_number: "100",
+    event_index: 0,
+    hotkey: SS58,
+    coldkey: "5ColdOther",
+  };
+  const selfRow = {
+    ...ACCOUNT_EVENT_ROW,
+    observed_at: "100",
+    block_number: "150",
+    event_index: 0,
+    hotkey: SS58,
+    coldkey: SS58,
+  };
+  const coldkeyRowNewer = {
+    ...ACCOUNT_EVENT_ROW,
+    observed_at: "200",
+    block_number: "200",
+    event_index: 1,
+    hotkey: "5HotOther",
+    coldkey: SS58,
+  };
+  // 1 SET (global) + 1 SET LOCAL + 3 filter ternaries (block_start,
+  // block_end, cursor) + hotkeyRows itself, then the same 3 ternaries +
+  // coldkeyRows itself -- see the /events route's own merge test for why
+  // each falsy ternary branch still consumes its own queue slot.
+  mockQueue.current = [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [selfRow, hotkeyRow],
+    [],
+    [],
+    [],
+    [coldkeyRowNewer],
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}/transfers?limit=10`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.transfers.map((e) => e.block_number)).toEqual([200, 150, 100]);
+});
+
 test("GET /api/v1/accounts/:ss58/transfers applies block_start/block_end bounds", async () => {
   mockRows.current = [];
   await req(`/api/v1/accounts/${SS58}/transfers?block_start=1&block_end=2`);
@@ -4360,8 +4522,13 @@ test("GET /api/v1/accounts/:ss58/transfers ignores an old 2-part cursor (pre-MET
   mockRows.current = [];
   await req(`/api/v1/accounts/${SS58}/transfers?cursor=8586300.0`);
   const text = queryText();
+  // The default (all-directions) path never emits SQL OFFSET at all -- both
+  // branches are always capped by LIMIT and the offset window is applied
+  // client-side after the merge (see the route's own comment) -- so an
+  // invalid cursor falling back to "page from the start" shows up as the
+  // absence of the cursor's WHERE clause, not the presence of OFFSET.
   expect(text).not.toContain("AND (observed_at, block_number, event_index) <");
-  expect(text).toContain("OFFSET");
+  expect(text).not.toContain("OFFSET");
 });
 
 test("GET /api/v1/accounts/:ss58/transfers returns a next_cursor when the page is full", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -5245,11 +5245,25 @@ export default {
         // D1's hotkey/coldkey union is two INDEXED BY branches combined with
         // UNION ALL (each SQLite index can only ever seek ONE column), with a
         // second-branch guard to stop UNION ALL from double-counting a row
-        // where both columns equal the same ss58. Postgres has no INDEXED BY
-        // equivalent and evaluates a flat `WHERE (hotkey = $1 OR coldkey = $1)`
-        // as one plan, so a matching row is naturally visited exactly once --
-        // the double-count guard has nothing to do here and is deliberately
-        // omitted, not an oversight.
+        // where both columns equal the same ss58. This route's own prior fix
+        // (the observed_at-leading ORDER BY/3-part cursor above) addressed
+        // chunk exclusion but kept the flat `WHERE (hotkey = $1 OR
+        // coldkey = $1)` -- confirmed live via EXPLAIN that this STILL
+        // trips the same statement-timeout (Sentry METAGRAPHED-6, regressed,
+        // still firing after that fix): on TimescaleDB-compressed chunks
+        // hotkey has no compression segment/order-by metadata at all (unlike
+        // coldkey, which does), so an OR pulls every compressed chunk into a
+        // full DecompressChunk + seq scan just to test the hotkey side, an
+        // estimated 45M+ rows before LIMIT even applies -- the exact same
+        // class of bug the sibling /api/v1/accounts/:ss58 route hit as
+        // METAGRAPHED-5/#6878, just never ported to this route. Restored
+        // that same two-branch shape: one capped ORDER BY/LIMIT scan on
+        // hotkey = $1 (lets the planner use idx_ae_hotkey + ordered chunk-
+        // append), a second on coldkey = $1 excluding rows the hotkey branch
+        // already matched (so a self-referential hotkey/coldkey account
+        // isn't double-counted), then merged + re-sorted client-side -- an
+        // active account's matches are almost always satisfied from recent,
+        // uncompressed chunks without ever touching the compressed tail.
         const acctEvents = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)\/events$/,
         );
@@ -5273,23 +5287,57 @@ export default {
             url.searchParams,
             "block_end",
           );
-          // ORDER BY must lead with observed_at (the hypertable's partition
-          // column), same fix as the /api/v1/extrinsics list route above --
-          // block_number DESC alone forces a scan/sort across every chunk
-          // (no chunk exclusion), which is what tripped this route's
-          // statement_timeout in production (METAGRAPHED-6).
-          const rows = await sql`
+          // Each branch needs up to limit+offset rows, not just limit: in
+          // the worst case every one of the final `limit` (post-offset)
+          // rows comes from a single branch, and offset is only applied
+          // once, after the two branches are merged below. Cursor-based
+          // pages never carry an offset (the cursor itself already narrows
+          // past prior pages), so they only need `limit` per branch.
+          const perBranchLimit = limit + (cursor ? 0 : offset);
+          // Same reasoning as /api/v1/chain/transfers above: this route
+          // alone widens its budget for the (now rarer, but not impossible)
+          // case of a sparse/nonexistent account whose branches still have
+          // to walk back through the compressed chunk tail to prove there's
+          // nothing more to find, rather than raising the global 3s default
+          // for every other (much lighter) route in this dispatcher.
+          await sql`SET LOCAL statement_timeout = '10000ms'`;
+          const hotkeyRows = await sql`
           SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
           FROM account_events
-          WHERE (hotkey = ${ss58} OR coldkey = ${ss58})
+          WHERE hotkey = ${ss58}
             ${kind ? sql`AND event_kind = ${kind}` : sql``}
             ${netuid != null ? sql`AND netuid = ${netuid}` : sql``}
             ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
             ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
             ${cursor ? sql`AND (observed_at, block_number, event_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})` : sql``}
           ORDER BY observed_at DESC, block_number DESC, event_index DESC
-          LIMIT ${limit}
-          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          LIMIT ${perBranchLimit}`;
+          const coldkeyRows = await sql`
+          SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+          FROM account_events
+          WHERE coldkey = ${ss58} AND (hotkey IS NULL OR hotkey <> ${ss58})
+            ${kind ? sql`AND event_kind = ${kind}` : sql``}
+            ${netuid != null ? sql`AND netuid = ${netuid}` : sql``}
+            ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+            ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+            ${cursor ? sql`AND (observed_at, block_number, event_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})` : sql``}
+          ORDER BY observed_at DESC, block_number DESC, event_index DESC
+          LIMIT ${perBranchLimit}`;
+          // Each branch is already this account's own newest perBranchLimit
+          // rows on its key, so the true newest (limit+offset) rows across
+          // both are guaranteed to be present in this merged set -- re-sort
+          // by the same feed order, then apply the offset/limit window the
+          // single-scan query used to apply in SQL (cursor pages skip the
+          // offset slice, matching the cursor's own WHERE-side narrowing).
+          const merged = hotkeyRows.concat(coldkeyRows).sort((a, b) => {
+            const observedDelta = Number(b.observed_at) - Number(a.observed_at);
+            if (observedDelta !== 0) return observedDelta;
+            const blockDelta = Number(b.block_number) - Number(a.block_number);
+            if (blockDelta !== 0) return blockDelta;
+            return Number(b.event_index) - Number(a.event_index);
+          });
+          const windowStart = cursor ? 0 : offset;
+          const rows = merged.slice(windowStart, windowStart + limit);
           const last = rows.length === limit ? rows[rows.length - 1] : null;
           const nextCursor = last
             ? encodeCursor([
@@ -7572,17 +7620,61 @@ export default {
             url.searchParams,
             "block_end",
           );
-          const rows = await sql`
-          SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
-          FROM account_events
-          WHERE event_kind = 'Transfer'
-            ${direction === "sent" ? sql`AND hotkey = ${ss58}` : direction === "received" ? sql`AND coldkey = ${ss58}` : sql`AND (hotkey = ${ss58} OR coldkey = ${ss58})`}
-            ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
-            ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
-            ${cursor ? sql`AND (observed_at, block_number, event_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})` : sql``}
-          ORDER BY observed_at DESC, block_number DESC, event_index DESC
-          LIMIT ${limit}
-          ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          let rows;
+          if (direction === "sent" || direction === "received") {
+            // A single indexed column -- idx_ae_hotkey/idx_ae_coldkey already
+            // handle this efficiently, same as before; only the "all
+            // directions" case below hits METAGRAPHED-6's OR-defeats-index
+            // problem.
+            rows = await sql`
+            SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+            FROM account_events
+            WHERE event_kind = 'Transfer'
+              ${direction === "sent" ? sql`AND hotkey = ${ss58}` : sql`AND coldkey = ${ss58}`}
+              ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+              ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+              ${cursor ? sql`AND (observed_at, block_number, event_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})` : sql``}
+            ORDER BY observed_at DESC, block_number DESC, event_index DESC
+            LIMIT ${limit}
+            ${!cursor ? sql`OFFSET ${offset}` : sql``}`;
+          } else {
+            // Same METAGRAPHED-6 fix as /api/v1/accounts/:ss58/events above:
+            // a flat `WHERE (hotkey = $1 OR coldkey = $1)` defeats index
+            // usage on account_events' TimescaleDB-compressed chunks (hotkey
+            // has no compression segment/order-by metadata, unlike coldkey),
+            // so split into two indexed branches and merge client-side.
+            const perBranchLimit = limit + (cursor ? 0 : offset);
+            await sql`SET LOCAL statement_timeout = '10000ms'`;
+            const hotkeyRows = await sql`
+            SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+            FROM account_events
+            WHERE event_kind = 'Transfer' AND hotkey = ${ss58}
+              ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+              ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+              ${cursor ? sql`AND (observed_at, block_number, event_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})` : sql``}
+            ORDER BY observed_at DESC, block_number DESC, event_index DESC
+            LIMIT ${perBranchLimit}`;
+            const coldkeyRows = await sql`
+            SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
+            FROM account_events
+            WHERE event_kind = 'Transfer' AND coldkey = ${ss58} AND (hotkey IS NULL OR hotkey <> ${ss58})
+              ${blockStart != null ? sql`AND block_number >= ${blockStart}` : sql``}
+              ${blockEnd != null ? sql`AND block_number <= ${blockEnd}` : sql``}
+              ${cursor ? sql`AND (observed_at, block_number, event_index) < (${cursor[0]}, ${cursor[1]}, ${cursor[2]})` : sql``}
+            ORDER BY observed_at DESC, block_number DESC, event_index DESC
+            LIMIT ${perBranchLimit}`;
+            const merged = hotkeyRows.concat(coldkeyRows).sort((a, b) => {
+              const observedDelta =
+                Number(b.observed_at) - Number(a.observed_at);
+              if (observedDelta !== 0) return observedDelta;
+              const blockDelta =
+                Number(b.block_number) - Number(a.block_number);
+              if (blockDelta !== 0) return blockDelta;
+              return Number(b.event_index) - Number(a.event_index);
+            });
+            const windowStart = cursor ? 0 : offset;
+            rows = merged.slice(windowStart, windowStart + limit);
+          }
           const last = rows.length === limit ? rows[rows.length - 1] : null;
           const nextCursor = last
             ? encodeCursor([


### PR DESCRIPTION
## Summary
- Fixes Sentry [METAGRAPHED-6](https://jsonbored.sentry.io/issues/METAGRAPHED-6) (`PostgresError: canceling statement due to statement timeout`, 248 occurrences, regressed) on `GET /api/v1/accounts/:ss58/events` and the default (no `?direction=`) branch of `GET /api/v1/accounts/:ss58/transfers`.
- Root cause confirmed live via `EXPLAIN` against production: `WHERE (hotkey = $1 OR coldkey = $1)` defeats index-ordered scanning on `account_events`' TimescaleDB-compressed chunks -- `hotkey` carries no compression segment/order-by metadata (unlike `coldkey`), so the OR forces a full decompress+scan of every compressed chunk (~45M+ rows) just to test the hotkey side, before `LIMIT` even applies.
- This is the same bug class the sibling `/api/v1/accounts/:ss58` route hit as METAGRAPHED-5/#6878, just never ported to these two routes. Both now split into two separately-indexed branches (`hotkey = $1`, `coldkey = $1 AND (hotkey IS NULL OR hotkey <> $1)`) and merge/re-sort client-side, matching #6878's already-proven shape.
- Sentry's Seer auto-analysis blamed a "GROUP BY mismatch" for this issue -- verified against the actual code that this is incorrect (that bug class was already fixed once, in #6877); the real cause is the compressed-chunk index gap above.
- Integrated on top of #7255's already-shipped `observed_at`-leading `ORDER BY` + 3-part cursor fix (a different, complementary half of the same METAGRAPHED-6 problem) -- this PR doesn't touch that part, just adds the missing branch-split on top of it.

## Test plan
- [x] New tests covering the two-branch query shape, merge/dedup correctness (including a self-referential hotkey==coldkey row and a same-`observed_at` block_number tie-break), and the single-branch `?direction=sent/received` path's filter/cursor combos, for both routes
- [x] `tests/data-api.test.mjs` full file: 528/528 passing
- [x] 100% statement/branch coverage on every changed line (verified via targeted coverage report, not just the flaky-under-load full suite)
- [x] Full repo test suite run twice; the only failures were `tests/lib-helpers.test.mjs` and `tests/public-safety.test.mjs` timeouts, both confirmed as pre-existing environmental flakes under heavy parallel load (pass cleanly in isolation, untouched by this diff)
- [x] `prettier --check` / `eslint` clean on both changed files