### PR TITLE
feat(ui): surface the delegation graph and entity labels on the account page

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-delegation.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-delegation.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountChildrenQuery, accountParentsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 addresses (ss58PathSegment rejects malformed input).
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+function resolveWith(data: unknown, url: string): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url,
+  });
+}
+
+async function runChildren(ss58: string) {
+  const opts = accountChildrenQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+async function runParents(ss58: string) {
+  const opts = accountParentsQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountChildrenQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the children route and reads the per-entry `child` counterpart field", async () => {
+    resolveWith(
+      {
+        schema_version: 1,
+        account: ALICE,
+        subnets: [
+          {
+            netuid: 3,
+            entries: [
+              { child: BOB, proportion: "9223372036854775808", proportion_fraction: 0.5 },
+            ],
+          },
+        ],
+        queried_at: "2026-07-21T00:00:00.000Z",
+      },
+      `/api/v1/accounts/${ALICE}/children`,
+    );
+    const res = await runChildren(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/children`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data.account).toBe(ALICE);
+    expect(res.data.queried_at).toBe("2026-07-21T00:00:00.000Z");
+    expect(res.data.subnets).toEqual([
+      {
+        netuid: 3,
+        entries: [
+          { counterpart: BOB, proportion: "9223372036854775808", proportion_fraction: 0.5 },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves `subnets: null` (live RPC failed) as a distinct tri-state, not []", async () => {
+    resolveWith(
+      { schema_version: 1, account: ALICE, subnets: null, queried_at: null },
+      `/api/v1/accounts/${ALICE}/children`,
+    );
+    const res = await runChildren(ALICE);
+    expect(res.data.subnets).toBeNull();
+  });
+
+  it("drops subnets with no netuid, entries with no counterpart, and coerces junk fractions to null", async () => {
+    resolveWith(
+      {
+        account: ALICE,
+        subnets: [
+          { netuid: "nope", entries: [{ child: BOB, proportion_fraction: 1 }] }, // no numeric netuid → dropped
+          {
+            netuid: 7,
+            entries: [
+              { proportion_fraction: 1 }, // no child → dropped
+              { child: BOB, proportion: 123, proportion_fraction: "junk" },
+            ],
+          },
+        ],
+      },
+      `/api/v1/accounts/${ALICE}/children`,
+    );
+    const res = await runChildren(ALICE);
+    expect(res.data.subnets).toEqual([
+      {
+        netuid: 7,
+        entries: [{ counterpart: BOB, proportion: null, proportion_fraction: null }],
+      },
+    ]);
+  });
+
+  it("degrades a cold / unknown account to an empty subnet list (never throws)", async () => {
+    for (const raw of [{}, null, { subnets: "not-an-array" }]) {
+      resolveWith(raw, `/api/v1/accounts/${ALICE}/children`);
+      const res = await runChildren(ALICE);
+      expect(res.data.account).toBe(ALICE);
+      expect(res.data.subnets).toEqual([]);
+    }
+  });
+});
+
+describe("accountParentsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the parents route and reads the per-entry `parent` counterpart field", async () => {
+    resolveWith(
+      {
+        account: ALICE,
+        subnets: [{ netuid: 1, entries: [{ parent: BOB, proportion_fraction: 0.25 }] }],
+      },
+      `/api/v1/accounts/${ALICE}/parents`,
+    );
+    const res = await runParents(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/parents`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data.subnets).toEqual([
+      { netuid: 1, entries: [{ counterpart: BOB, proportion: null, proportion_fraction: 0.25 }] },
+    ]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountEntitiesQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 address (ss58PathSegment rejects malformed input).
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${ALICE}/entities`,
+  });
+}
+
+async function runQuery(ss58: string) {
+  const opts = accountEntitiesQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountEntitiesQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the entities route and passes through labels + ownership ties", async () => {
+    resolveWith({
+      ss58: ALICE,
+      labels: [
+        {
+          name: "Foundation",
+          category: "team",
+          notes: "core dev",
+          source_urls: ["https://example.com/a", "https://example.com/b"],
+        },
+      ],
+      ownership_tie_count: 2,
+      ownership_ties: [
+        { netuid: 5, role: "gained_ownership", block_number: 1000, observed_at: "2026-07-20T00:00:00.000Z" },
+        { netuid: 6, role: "lost_ownership", block_number: 900, observed_at: null },
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/entities`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data.ss58).toBe(ALICE);
+    expect(res.data.labels).toEqual([
+      {
+        name: "Foundation",
+        category: "team",
+        notes: "core dev",
+        source_urls: ["https://example.com/a", "https://example.com/b"],
+      },
+    ]);
+    expect(res.data.ownership_tie_count).toBe(2);
+    expect(res.data.ownership_ties).toEqual([
+      { netuid: 5, role: "gained_ownership", block_number: 1000, observed_at: "2026-07-20T00:00:00.000Z" },
+      { netuid: 6, role: "lost_ownership", block_number: 900, observed_at: null },
+    ]);
+  });
+
+  it("nulls missing label/tie fields, drops non-string source URLs and empty ties, and never NaNs", async () => {
+    resolveWith({
+      ss58: ALICE,
+      labels: [{ source_urls: ["https://ok", 42, null] }],
+      ownership_ties: [
+        { netuid: "junk", role: "gained_ownership", block_number: "junk" },
+        {}, // no role/netuid/block → dropped
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(res.data.labels).toEqual([
+      { name: null, category: null, notes: null, source_urls: ["https://ok"] },
+    ]);
+    expect(res.data.ownership_ties).toEqual([
+      { netuid: null, role: "gained_ownership", block_number: null, observed_at: null },
+    ]);
+    // ownership_tie_count falls back to the surviving-row count when absent.
+    expect(res.data.ownership_tie_count).toBe(1);
+  });
+
+  it("degrades a cold / unknown account to empty labels + ties (never throws)", async () => {
+    for (const raw of [{}, null, { labels: "x", ownership_ties: 3 }]) {
+      resolveWith(raw);
+      const res = await runQuery(ALICE);
+      expect(res.data.ss58).toBe(ALICE);
+      expect(res.data.labels).toEqual([]);
+      expect(res.data.ownership_ties).toEqual([]);
+      expect(res.data.ownership_tie_count).toBe(0);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -48,6 +48,11 @@ import type {
   AccountEventsPage,
   AccountCounterparties,
   AccountCounterparty,
+  AccountDelegationGraph,
+  AccountDelegationSubnet,
+  AccountEntities,
+  AccountEntityLabel,
+  AccountOwnershipTie,
   AccountStakeFlow,
   AccountStakeFlowSubnet,
   AccountHistory,
@@ -2706,6 +2711,142 @@ export const accountCounterpartiesQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountCounterparties>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #6723: live child/parent-hotkey delegation graph — the counterpart hotkeys
+// this account delegates stake-weight to (children) or receives it from
+// (parents), per subnet. Shared normalizer for both /accounts/{ss58}/children
+// and /parents, which differ only in the per-entry counterpart field name
+// ("child" vs "parent"). Preserves the backend's `subnets: null` tri-state (live
+// RPC failed) distinctly from `subnets: []` (genuinely no delegations) so the UI
+// can render "temporarily unavailable" separately from a cold wallet.
+function normalizeDelegationSubnets(
+  raw: unknown,
+  counterpartKey: "child" | "parent",
+): AccountDelegationSubnet[] | null {
+  if (raw === null) return null;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((subnet) => {
+    if (!isRecord(subnet)) return [];
+    const netuid = firstFiniteNumber(subnet.netuid);
+    if (netuid == null) return [];
+    const entries = Array.isArray(subnet.entries)
+      ? subnet.entries.flatMap((entry) => {
+          if (!isRecord(entry)) return [];
+          const counterpart = firstString(entry[counterpartKey]);
+          if (!counterpart) return [];
+          return [
+            {
+              counterpart,
+              proportion: firstString(entry.proportion) ?? null,
+              proportion_fraction: firstFiniteNumber(entry.proportion_fraction) ?? null,
+            },
+          ];
+        })
+      : [];
+    return [{ netuid, entries }];
+  });
+}
+
+function delegationGraphQuery(
+  ss58: string,
+  route: "children" | "parents",
+  counterpartKey: "child" | "parent",
+) {
+  return queryOptions({
+    queryKey: k(`account-${route}`, ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/${route}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          account: firstString(d.account) ?? ss58,
+          subnets: normalizeDelegationSubnets(d.subnets, counterpartKey),
+          queried_at: firstString(d.queried_at) ?? null,
+        } as AccountDelegationGraph,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountDelegationGraph>;
+    },
+    staleTime: STALE_MED,
+  });
+}
+
+export const accountChildrenQuery = (ss58: string) =>
+  delegationGraphQuery(ss58, "children", "child");
+
+export const accountParentsQuery = (ss58: string) =>
+  delegationGraphQuery(ss58, "parents", "parent");
+
+// #6740: community entity labels + subnet-ownership ties for one address, from
+// /api/v1/accounts/{ss58}/entities. Structured-object response with two arrays;
+// both degrade to [] on a cold/unknown address (never throws).
+function normalizeEntityLabel(raw: unknown): AccountEntityLabel | null {
+  if (!isRecord(raw)) return null;
+  return {
+    name: firstString(raw.name) ?? null,
+    category: firstString(raw.category) ?? null,
+    notes: firstString(raw.notes) ?? null,
+    source_urls: Array.isArray(raw.source_urls)
+      ? raw.source_urls.flatMap((u) => {
+          const s = firstString(u);
+          return s ? [s] : [];
+        })
+      : [],
+  };
+}
+
+function normalizeOwnershipTie(raw: unknown): AccountOwnershipTie | null {
+  if (!isRecord(raw)) return null;
+  const role = firstString(raw.role);
+  const netuid = firstFiniteNumber(raw.netuid);
+  const block = firstFiniteNumber(raw.block_number);
+  if (role == null && netuid == null && block == null) return null;
+  return {
+    netuid: netuid ?? null,
+    role: role ?? null,
+    block_number: block ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+  };
+}
+
+export const accountEntitiesQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-entities", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/entities`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const labels = Array.isArray(d.labels)
+        ? d.labels.flatMap((row) => {
+            const l = normalizeEntityLabel(row);
+            return l ? [l] : [];
+          })
+        : [];
+      const ownershipTies = Array.isArray(d.ownership_ties)
+        ? d.ownership_ties.flatMap((row) => {
+            const t = normalizeOwnershipTie(row);
+            return t ? [t] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          labels,
+          ownership_tie_count:
+            firstFiniteNumber(d.ownership_tie_count) ?? ownershipTies.length,
+          ownership_ties: ownershipTies,
+        } as AccountEntities,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountEntities>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1320,6 +1320,65 @@ export interface AccountCounterparties {
   counterparties: AccountCounterparty[];
   [key: string]: unknown;
 }
+/**
+ * One edge in the live child/parent-hotkey delegation graph
+ * (/accounts/{ss58}/children | /parents, #6723) — the counterpart hotkey and
+ * the proportion of stake-weight this edge carries on a given subnet.
+ */
+export interface AccountDelegationEdge {
+  /** The child (children route) or parent (parents route) hotkey ss58. */
+  counterpart: string;
+  /** Raw u64 proportion as a decimal string (0..u64::MAX ≙ 0..100%). */
+  proportion: string | null;
+  /** The same proportion as a 0..1 fraction. */
+  proportion_fraction: number | null;
+}
+/** One subnet's delegation edges in the child/parent-hotkey graph. */
+export interface AccountDelegationSubnet {
+  netuid: number;
+  entries: AccountDelegationEdge[];
+}
+/**
+ * #6723: /accounts/{ss58}/children | /parents — this account's live stake-weight
+ * delegation graph, per subnet. `subnets` is `null` (not `[]`) when the live RPC
+ * failed, so callers can distinguish "temporarily unavailable" from "genuinely
+ * none" — matching src/child-hotkey-delegation.mjs's tri-state contract.
+ */
+export interface AccountDelegationGraph {
+  account: string;
+  subnets: AccountDelegationSubnet[] | null;
+  queried_at: string | null;
+  [key: string]: unknown;
+}
+/** One community-contributed entity label in /accounts/{ss58}/entities (#6740). */
+export interface AccountEntityLabel {
+  name: string | null;
+  category: string | null;
+  notes: string | null;
+  source_urls: string[];
+}
+/**
+ * One subnet-ownership tie in /accounts/{ss58}/entities — a SubnetOwnerChanged
+ * transfer this address was on either side of.
+ */
+export interface AccountOwnershipTie {
+  netuid: number | null;
+  /** "gained_ownership" when this address became owner, else "lost_ownership". */
+  role: string | null;
+  block_number: number | null;
+  observed_at: string | null;
+}
+/**
+ * #6740: /accounts/{ss58}/entities — this address's community labels plus every
+ * subnet-ownership tie via the SubnetOwnerChanged chain-events stream.
+ */
+export interface AccountEntities {
+  ss58: string;
+  labels: AccountEntityLabel[];
+  ownership_tie_count: number;
+  ownership_ties: AccountOwnershipTie[];
+  [key: string]: unknown;
+}
 /** One per-subnet stake/unstake flow row in /accounts/{ss58}/stake-flow. */
 export interface AccountStakeFlowSubnet {
   netuid: number;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -17,10 +17,12 @@ import {
   Github,
   Globe,
   MessageCircle,
+  Network,
   Radar,
   RefreshCw,
   Rows3,
   Scale,
+  Tag,
   Unplug,
   UserMinus,
   UserPlus,
@@ -50,6 +52,9 @@ import { AccountPositionHistoryChart } from "@/components/metagraphed/account-po
 import {
   accountAxonRemovalsQuery,
   accountCounterpartiesQuery,
+  accountChildrenQuery,
+  accountParentsQuery,
+  accountEntitiesQuery,
   accountStakeFlowQuery,
   accountPortfolioQuery,
   accountStakeMovesQuery,
@@ -77,6 +82,10 @@ import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
 import { entityNotFoundMeta } from "@/lib/metagraphed/entity-not-found-meta";
 import type {
   AccountCounterparty,
+  AccountDelegationGraph,
+  AccountDelegationSubnet,
+  AccountEntityLabel,
+  AccountOwnershipTie,
   AccountStakeFlowSubnet,
   AccountRegistration,
   AccountSummary,
@@ -399,6 +408,12 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       {/* #3340: the aggregated fund-flow view over the same transfer data. */}
       <AccountCounterpartiesSection ss58={ss58} />
 
+      {/* #6723: live child/parent-hotkey stake-weight delegation graph. */}
+      <AccountDelegationSection ss58={ss58} />
+
+      {/* #6740: community entity labels + subnet-ownership ties. */}
+      <AccountEntitiesSection ss58={ss58} />
+
       {/* #6432: deliberately NOT "← All accounts" like the other detail pages'
           back-links. /accounts is a lookup form, not an index -- there is no
           list of every chain account to go back to -- so the label names what
@@ -427,6 +442,9 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
             { label: "counterparties", path: `/api/v1/accounts/${sourceRef}/counterparties` },
+            { label: "children", path: `/api/v1/accounts/${sourceRef}/children` },
+            { label: "parents", path: `/api/v1/accounts/${sourceRef}/parents` },
+            { label: "entities", path: `/api/v1/accounts/${sourceRef}/entities` },
             { label: "stake-flow", path: `/api/v1/accounts/${sourceRef}/stake-flow` },
             { label: "serving", path: `/api/v1/accounts/${sourceRef}/serving` },
             { label: "prometheus", path: `/api/v1/accounts/${sourceRef}/prometheus` },
@@ -442,6 +460,9 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
           `/api/v1/accounts/${sourceRef}/counterparties`,
+          `/api/v1/accounts/${sourceRef}/children`,
+          `/api/v1/accounts/${sourceRef}/parents`,
+          `/api/v1/accounts/${sourceRef}/entities`,
           `/api/v1/accounts/${sourceRef}/stake-flow`,
           `/api/v1/accounts/${sourceRef}/serving`,
           `/api/v1/accounts/${sourceRef}/prometheus`,
@@ -1061,6 +1082,389 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
         <p className="mt-3 font-mono text-[10px] text-ink-muted">
           Showing the {rows.length} highest-volume of {formatNumber(parties.length)} counterparties.
         </p>
+      ) : null}
+    </SectionAnchor>
+  );
+}
+
+// A u64 proportion is delivered as a 0..1 fraction; show it as a percent of the
+// account's stake-weight on that subnet.
+function fmtProportionPct(f: number | null): string {
+  if (f == null || !Number.isFinite(f)) return "—";
+  return `${(f * 100).toFixed(2)}%`;
+}
+
+type DelegationRow = {
+  netuid: number;
+  counterpart: string;
+  proportion_fraction: number | null;
+};
+
+// Flatten the per-subnet delegation payload into a flat, subnet-ordered row list.
+// `subnets === null` (live RPC failure) and `[]` (genuinely none) both yield an
+// empty list here; the caller distinguishes them via the query's own state.
+function flattenDelegation(subnets: AccountDelegationSubnet[] | null): DelegationRow[] {
+  if (!Array.isArray(subnets)) return [];
+  const rows: DelegationRow[] = [];
+  for (const subnet of subnets) {
+    for (const entry of subnet.entries) {
+      rows.push({
+        netuid: subnet.netuid,
+        counterpart: entry.counterpart,
+        proportion_fraction: entry.proportion_fraction,
+      });
+    }
+  }
+  return rows.sort((a, b) => a.netuid - b.netuid);
+}
+
+function DelegationTable({
+  ss58,
+  rows,
+  counterpartHeader,
+}: {
+  ss58: string;
+  rows: DelegationRow[];
+  counterpartHeader: string;
+}) {
+  return (
+    <DataPanel>
+      <table className="w-full text-left text-sm">
+        <thead className="bg-surface/50">
+          <tr>
+            <th className={TH}>Subnet</th>
+            <th className={TH}>{counterpartHeader}</th>
+            <th className={`${TH} text-right`}>Stake-weight share</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((r, i) => (
+            <tr key={`${r.netuid}-${r.counterpart}-${i}`} className="hover:bg-surface/30">
+              <td className="px-5 py-4 font-mono text-[12px]">
+                <Link
+                  to="/subnets/$netuid"
+                  params={{ netuid: r.netuid }}
+                  className="text-ink hover:text-accent hover:underline"
+                >
+                  SN{r.netuid}
+                </Link>
+              </td>
+              <td className="px-5 py-4 font-mono text-[11px] text-ink-muted" title={r.counterpart}>
+                {r.counterpart !== ss58 ? (
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: r.counterpart }}
+                    className="hover:text-accent hover:underline"
+                  >
+                    {shortHash(r.counterpart)}
+                  </Link>
+                ) : (
+                  (shortHash(r.counterpart) ?? "—")
+                )}
+              </td>
+              <td className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                {fmtProportionPct(r.proportion_fraction)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </DataPanel>
+  );
+}
+
+// #6723 (child-hotkey delegation epic #6721): this account's live stake-weight
+// delegation graph — child hotkeys it delegates to and parent hotkeys that
+// delegate to it — from the already-shipped /accounts/{ss58}/children and
+// /parents live-RPC routes. Two independent queries; each side surfaces its own
+// "temporarily unavailable" (RPC failed) vs "none" state inline, and the whole
+// section stays out of the way (renders nothing) for a cold wallet with neither.
+function AccountDelegationSection({ ss58 }: { ss58: string }) {
+  const childrenResult = useQuery(accountChildrenQuery(ss58));
+  const parentsResult = useQuery(accountParentsQuery(ss58));
+  const childrenData: AccountDelegationGraph | undefined = childrenResult.data?.data;
+  const parentsData: AccountDelegationGraph | undefined = parentsResult.data?.data;
+  const SUBTITLE =
+    "Live stake-weight delegation graph — the child hotkeys this account delegates to, and the parent hotkeys delegating to it, per subnet with each edge's share.";
+
+  if (
+    (childrenResult.isPending && !childrenData) ||
+    (parentsResult.isPending && !parentsData)
+  ) {
+    return (
+      <AccountFeedSectionSkeleton id="delegation" title="Delegation graph" subtitle={SUBTITLE} />
+    );
+  }
+
+  const childRows = flattenDelegation(childrenData?.subnets ?? null);
+  const parentRows = flattenDelegation(parentsData?.subnets ?? null);
+  // An HTTP error OR a `subnets: null` payload both mean the live RPC didn't
+  // answer for that side — a distinct state from "genuinely no edges".
+  const childUnavailable = childrenResult.isError || childrenData?.subnets === null;
+  const parentUnavailable = parentsResult.isError || parentsData?.subnets === null;
+
+  // Cold wallet: both sides resolved with genuinely-empty data — render nothing,
+  // exactly like AccountCounterpartiesSection, so the page stays uncluttered.
+  if (
+    !childUnavailable &&
+    !parentUnavailable &&
+    childRows.length === 0 &&
+    parentRows.length === 0
+  ) {
+    return null;
+  }
+
+  const subnetsSpanned = new Set(
+    [...childRows, ...parentRows].map((r) => r.netuid),
+  ).size;
+
+  return (
+    <SectionAnchor
+      id="delegation"
+      title="Delegation graph"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="Live child/parent-hotkey delegation from /api/v1/accounts/{ss58}/children and /parents — read at request time from the chain's ChildKeys/ParentKeys storage and cached briefly. Each row is one delegation edge and its share of stake-weight on that subnet."
+      right={
+        <SectionBadge tone="accent">
+          {formatNumber(childRows.length + parentRows.length)} edges
+        </SectionBadge>
+      }
+    >
+      <div className="mb-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <StatTile
+          icon={Network}
+          eyebrow="Child hotkeys"
+          tone="accent"
+          value={childUnavailable ? "—" : formatNumber(childRows.length)}
+          hint="delegated to"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Parent hotkeys"
+          value={parentUnavailable ? "—" : formatNumber(parentRows.length)}
+          hint="delegating in"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Subnets spanned"
+          value={formatNumber(subnetsSpanned)}
+          hint="with an edge"
+          className={KPI_TILE}
+        />
+      </div>
+
+      <div className="space-y-6">
+        <div>
+          <h3 className="mb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Child hotkeys — delegated to
+          </h3>
+          {childUnavailable ? (
+            <TableState
+              variant="error"
+              title="Child hotkeys temporarily unavailable"
+              description="The live delegation-graph RPC didn't respond — the rest of the account page is unaffected."
+              error={childrenResult.error}
+              onRetry={() => void childrenResult.refetch()}
+            />
+          ) : childRows.length === 0 ? (
+            <TableState
+              variant="empty"
+              title="No child hotkeys"
+              description="This account delegates stake-weight to no child hotkeys on any subnet."
+            />
+          ) : (
+            <DelegationTable ss58={ss58} rows={childRows} counterpartHeader="Child hotkey" />
+          )}
+        </div>
+
+        <div>
+          <h3 className="mb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Parent hotkeys — delegating in
+          </h3>
+          {parentUnavailable ? (
+            <TableState
+              variant="error"
+              title="Parent hotkeys temporarily unavailable"
+              description="The live delegation-graph RPC didn't respond — the rest of the account page is unaffected."
+              error={parentsResult.error}
+              onRetry={() => void parentsResult.refetch()}
+            />
+          ) : parentRows.length === 0 ? (
+            <TableState
+              variant="empty"
+              title="No parent hotkeys"
+              description="No parent hotkeys delegate stake-weight to this account on any subnet."
+            />
+          ) : (
+            <DelegationTable ss58={ss58} rows={parentRows} counterpartHeader="Parent hotkey" />
+          )}
+        </div>
+      </div>
+    </SectionAnchor>
+  );
+}
+
+function ownershipRoleLabel(role: string | null): string {
+  if (role === "gained_ownership") return "Gained";
+  if (role === "lost_ownership") return "Lost";
+  return "—";
+}
+
+function EntityLabelCard({ label }: { label: AccountEntityLabel }) {
+  return (
+    <div className={KPI_TILE}>
+      <div className="flex flex-wrap items-center gap-2">
+        <Tag className="h-4 w-4 text-accent" />
+        <span className="font-semibold text-ink">{label.name ?? "Unnamed entity"}</span>
+        {label.category ? (
+          <span className="rounded border border-border/70 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-ink-muted">
+            {label.category}
+          </span>
+        ) : null}
+      </div>
+      {label.notes ? <p className="mt-2 text-[12px] text-ink-muted">{label.notes}</p> : null}
+      {label.source_urls.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-3">
+          {label.source_urls.map((url, i) => (
+            <ExternalLink
+              key={`${url}-${i}`}
+              href={url}
+              className="font-mono text-[10px] text-accent-text hover:underline"
+            >
+              source{label.source_urls.length > 1 ? ` ${i + 1}` : ""}
+            </ExternalLink>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// #6740 (entity-labels epic #6737–#6740): community-contributed identity labels
+// plus every subnet this address gained or lost ownership of via the
+// SubnetOwnerChanged chain-events stream, from /api/v1/accounts/{ss58}/entities.
+// Renders nothing for an address with neither a label nor an ownership tie.
+function AccountEntitiesSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountEntitiesQuery(ss58));
+  const e = result.data?.data;
+  const SUBTITLE =
+    "Any community-contributed identity label for this address, plus every subnet it gained or lost ownership of via the SubnetOwnerChanged stream.";
+
+  if (result.isPending && !e) {
+    return (
+      <AccountFeedSectionSkeleton id="entities" title="Entity & ownership" subtitle={SUBTITLE} />
+    );
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor id="entities" title="Entity & ownership" subtitle={SUBTITLE} tone="accent">
+        <TableState
+          variant="error"
+          title="Couldn't load entity labels"
+          description="The entity-labels tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+  const labels: AccountEntityLabel[] = e?.labels ?? [];
+  const ties: AccountOwnershipTie[] = e?.ownership_ties ?? [];
+  if (!e || (labels.length === 0 && ties.length === 0)) return null;
+
+  return (
+    <SectionAnchor
+      id="entities"
+      title="Entity & ownership"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="Community entity labels and subnet-ownership ties from /api/v1/accounts/{ss58}/entities. Ownership ties come from the SubnetOwnerChanged chain-events stream (automatic transfers only, not genesis ownership)."
+      right={
+        <SectionBadge tone="accent">
+          {formatNumber(labels.length)} {labels.length === 1 ? "label" : "labels"}
+        </SectionBadge>
+      }
+    >
+      {labels.length > 0 ? (
+        <div className="mb-6 grid gap-4 sm:grid-cols-2">
+          {labels.map((label, i) => (
+            <EntityLabelCard key={`${label.name ?? "label"}-${i}`} label={label} />
+          ))}
+        </div>
+      ) : null}
+
+      {ties.length > 0 ? (
+        <>
+          <h3 className="mb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Subnet-ownership ties
+          </h3>
+          <DataPanel>
+            <table className="w-full text-left text-sm">
+              <thead className="bg-surface/50">
+                <tr>
+                  <th className={TH}>Subnet</th>
+                  <th className={TH}>Change</th>
+                  <th className={`${TH} text-right`}>Block</th>
+                  <th className={`${TH} text-right`}>Observed</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {ties.map((tie, i) => (
+                  <tr
+                    key={`${tie.netuid}-${tie.block_number}-${i}`}
+                    className="hover:bg-surface/30"
+                  >
+                    <td className="px-5 py-4 font-mono text-[12px]">
+                      {tie.netuid != null ? (
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: tie.netuid }}
+                          className="text-ink hover:text-accent hover:underline"
+                        >
+                          SN{tie.netuid}
+                        </Link>
+                      ) : (
+                        <span className="text-ink-muted">—</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-[11px]">
+                      <span
+                        className={
+                          tie.role === "gained_ownership"
+                            ? "text-health-ok"
+                            : tie.role === "lost_ownership"
+                              ? "text-health-warn-text"
+                              : "text-ink-muted"
+                        }
+                      >
+                        {ownershipRoleLabel(tie.role)}
+                      </span>
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[12px]">
+                      {tie.block_number != null ? (
+                        <Link
+                          to="/blocks/$ref"
+                          params={{ ref: String(tie.block_number) }}
+                          className="text-ink hover:text-accent hover:underline"
+                        >
+                          #{formatNumber(tie.block_number)}
+                        </Link>
+                      ) : (
+                        <span className="text-ink-muted">—</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] text-ink-muted">
+                      {tie.observed_at ? <TimeAgo at={tie.observed_at} /> : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </DataPanel>
+        </>
       ) : null}
     </SectionAnchor>
   );


### PR DESCRIPTION
## Summary

Two shipped, named-epic account sub-resources had no UI on the account detail page. This wires both onto `apps/ui/src/routes/accounts.$ss58.tsx`, following the existing `AccountCounterpartiesSection` pattern:

- **Delegation graph** (#6723, child-hotkey epic #6721) — the live child hotkeys this account delegates stake-weight to and the parent hotkeys delegating to it, per subnet with each edge's stake-weight share, from `GET /api/v1/accounts/{ss58}/children` + `/parents`.
- **Entity & ownership** (#6737–#6740) — community-contributed entity labels plus every `SubnetOwnerChanged` subnet-ownership tie, from `GET /api/v1/accounts/{ss58}/entities`.

Closes #6999.

## What changed

- `apps/ui/src/lib/metagraphed/queries.ts` — `accountChildrenQuery`, `accountParentsQuery` (shared normalizer), and `accountEntitiesQuery`, plus matching types in `types.ts`.
- `apps/ui/src/routes/accounts.$ss58.tsx` — `AccountDelegationSection` + `AccountEntitiesSection`, rendered after the counterparties section, and `children`/`parents`/`entities` added to the "Call this endpoint" list + API footer.
- Unit tests: `queries.account-delegation.test.ts`, `queries.account-entities.test.ts`.

## Design notes

- **Tri-state preserved.** The children/parents loader returns `subnets: null` on a live-RPC failure (distinct from `[]` = genuinely none). The query keeps that distinction, and each side renders a "temporarily unavailable" state on `null` separately from an empty side — a cold wallet with neither children nor parents renders **nothing**, exactly like `AccountCounterpartiesSection`.
- Design-system tokens only (`KPI_TILE`/`TH`/`StatTile`/`DataPanel`/`SectionAnchor`), no one-off values.

## Screenshots (before / after)

Captured against a local dev server (data from production `api.metagraph.sh`) on account `5Fh1YD…KMEyh9`, which has a live delegation graph.

**New — Delegation graph** (net-new section; absent before)

| Viewport | Light | Dark |
| --- | --- | --- |
| Desktop | ![](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6999/after-delegation-desktop-light.png) | ![](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6999/after-delegation-desktop-dark.png) |
| Mobile | ![](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6999/after-delegation-mobile-light.png) | ![](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6999/after-delegation-mobile-dark.png) |

**"Call this endpoint" list — before vs after** (gains `children` / `parents` / `entities` rows)

| | Before | After |
| --- | --- | --- |
| Desktop | ![](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6999/before-call-desktop-light.png) | ![](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6999/after-call-desktop-light.png) |
| Mobile | ![](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6999/before-call-mobile-light.png) | ![](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6999/after-call-mobile-light.png) |

> The **Entity & ownership** section renders only for addresses with a label or an ownership tie; the delegation-rich account above has neither, so it isn't shown here. Its states (labels grid + ownership-ties table) are covered by `queries.account-entities.test.ts`.

## Validation

- [x] `npx vitest run` on the two new test files — 8 passing
- [x] `tsc --noEmit` — no new type errors from the changed files
- [x] `vite build` — succeeds
- [x] `prettier --check` — clean on all changed files
- [x] UI-only change; `src/**`/`workers/**` codecov scope untouched
