### PR TITLE
fix(api): lead event-summary recent-slice ORDER BY with observed_at (#7000)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1024,12 +1024,16 @@ function StakeFlowScorecard({ netuid }: { netuid: number }) {
  * Economics; this fills the Activity-tab gap the issue called out.
  */
 function ActivityEventRollup({ netuid }: { netuid: number }) {
-  const { data: summaryRes, isPending: summaryPending, isError: summaryError } = useQuery(
-    subnetEventSummaryQuery(netuid),
-  );
-  const { data: axonRes, isPending: axonPending, isError: axonError } = useQuery(
-    subnetAxonRemovalsQuery(netuid),
-  );
+  const {
+    data: summaryRes,
+    isPending: summaryPending,
+    isError: summaryError,
+  } = useQuery(subnetEventSummaryQuery(netuid));
+  const {
+    data: axonRes,
+    isPending: axonPending,
+    isError: axonError,
+  } = useQuery(subnetAxonRemovalsQuery(netuid));
   const summary = summaryRes?.data;
   const axon = axonRes?.data;
   const topCategories = [...(summary?.categories ?? [])]
@@ -1039,18 +1043,22 @@ function ActivityEventRollup({ netuid }: { netuid: number }) {
     ? topCategories.map((c) => `${formatNumber(c.event_count)} ${c.category}`).join(" · ")
     : "by category";
   const windowLabel = summary?.window ?? axon?.window ?? "7d";
-  const totalEvents =
-    summaryError ? "—" : summaryPending && !summary ? "…" : formatNumber(summary?.total_events ?? 0);
-  const kindCount =
-    summaryError ? "—" : summaryPending && !summary ? "…" : formatNumber(summary?.kind_count ?? 0);
-  const categoryCount =
-    summaryError
-      ? "—"
-      : summaryPending && !summary
-        ? "…"
-        : formatNumber(summary?.category_count ?? 0);
-  const removals =
-    axonError ? "—" : axonPending && !axon ? "…" : formatNumber(axon?.removals ?? 0);
+  const totalEvents = summaryError
+    ? "—"
+    : summaryPending && !summary
+      ? "…"
+      : formatNumber(summary?.total_events ?? 0);
+  const kindCount = summaryError
+    ? "—"
+    : summaryPending && !summary
+      ? "…"
+      : formatNumber(summary?.kind_count ?? 0);
+  const categoryCount = summaryError
+    ? "—"
+    : summaryPending && !summary
+      ? "…"
+      : formatNumber(summary?.category_count ?? 0);
+  const removals = axonError ? "—" : axonPending && !axon ? "…" : formatNumber(axon?.removals ?? 0);
   const removers = axon?.distinct_removers ?? 0;
 
   return (

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -74,6 +74,8 @@ import {
   subnetWeightsQuery,
   subnetIdentityHistoryQuery,
   subnetStakeFlowQuery,
+  subnetEventSummaryQuery,
+  subnetAxonRemovalsQuery,
   subnetHyperparametersQuery,
   subnetHyperparamsHistoryQuery,
   subnetAlphaVolumeQuery,
@@ -1015,6 +1017,84 @@ function StakeFlowScorecard({ netuid }: { netuid: number }) {
   );
 }
 
+/**
+ * #7000: windowed event-summary + axon-removals rollup above the raw Activity
+ * table — a quick-glance complement to StakeFlowScorecard / ActivityTableLoader,
+ * not a replacement. Percentiles and recycled TAO already live on Reliability /
+ * Economics; this fills the Activity-tab gap the issue called out.
+ */
+function ActivityEventRollup({ netuid }: { netuid: number }) {
+  const { data: summaryRes, isPending: summaryPending, isError: summaryError } = useQuery(
+    subnetEventSummaryQuery(netuid),
+  );
+  const { data: axonRes, isPending: axonPending, isError: axonError } = useQuery(
+    subnetAxonRemovalsQuery(netuid),
+  );
+  const summary = summaryRes?.data;
+  const axon = axonRes?.data;
+  const topCategories = [...(summary?.categories ?? [])]
+    .sort((a, b) => b.event_count - a.event_count)
+    .slice(0, 3);
+  const categoryHint = topCategories.length
+    ? topCategories.map((c) => `${formatNumber(c.event_count)} ${c.category}`).join(" · ")
+    : "by category";
+  const windowLabel = summary?.window ?? axon?.window ?? "7d";
+  const totalEvents =
+    summaryError ? "—" : summaryPending && !summary ? "…" : formatNumber(summary?.total_events ?? 0);
+  const kindCount =
+    summaryError ? "—" : summaryPending && !summary ? "…" : formatNumber(summary?.kind_count ?? 0);
+  const categoryCount =
+    summaryError
+      ? "—"
+      : summaryPending && !summary
+        ? "…"
+        : formatNumber(summary?.category_count ?? 0);
+  const removals =
+    axonError ? "—" : axonPending && !axon ? "…" : formatNumber(axon?.removals ?? 0);
+  const removers = axon?.distinct_removers ?? 0;
+
+  return (
+    <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatTile
+        icon={Activity}
+        eyebrow={`Events · ${windowLabel}`}
+        value={totalEvents}
+        hint={categoryHint}
+      />
+      <StatTile
+        icon={Filter}
+        eyebrow="Event kinds"
+        value={kindCount}
+        hint={`${categoryCount} categories`}
+      />
+      <StatTile
+        icon={AlertTriangle}
+        eyebrow={`Axon removals · ${axon?.window ?? "30d"}`}
+        value={removals}
+        hint={
+          axonError
+            ? "axon-removals unavailable"
+            : `${formatNumber(removers)} distinct ${removers === 1 ? "remover" : "removers"}`
+        }
+      />
+      <StatTile
+        icon={Waves}
+        eyebrow="Avg removals / remover"
+        value={
+          axonError
+            ? "—"
+            : axonPending && !axon
+              ? "…"
+              : axon?.removals_per_remover == null
+                ? "—"
+                : axon.removals_per_remover.toFixed(2)
+        }
+        hint="AxonInfoRemoved window average"
+      />
+    </div>
+  );
+}
+
 function ActivityPanel({ netuid }: { netuid: number }) {
   const { ev_kind } = Route.useSearch();
   const navigate = Route.useNavigate();
@@ -1037,6 +1117,7 @@ function ActivityPanel({ netuid }: { netuid: number }) {
       }
     >
       <StakeFlowScorecard netuid={netuid} />
+      <ActivityEventRollup netuid={netuid} />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-32 w-full" />}>
           <ActivityTableLoader netuid={netuid} kind={ev_kind} />

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4040,6 +4040,11 @@ test("GET /api/v1/subnets/:netuid/event-summary shapes kind/category aggregates 
     "GROUP BY event_kind ORDER BY event_count DESC",
   );
   expect(queryText()).toContain("AND coldkey IS NOT NULL");
+  // METAGRAPHED-6 leftover: recent-slice must lead ORDER BY with observed_at
+  // so Timescale can chunk-prune under LIMIT (#7255 missed this site).
+  expect(queryText()).toContain(
+    "ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT",
+  );
 });
 
 test("GET /api/v1/subnets/:netuid/event-summary defaults the window when absent", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -5410,10 +5410,16 @@ export default {
             ...row,
             coldkey_count: coldkeyCountByKind.get(row.event_kind) ?? 0,
           }));
+          // METAGRAPHED-6 leftover from #7255: account_events is a Timescale
+          // hypertable on observed_at. Leading ORDER BY with observed_at lets
+          // ChunkAppend prune to the live chunk under LIMIT — the same pattern
+          // /subnets/:netuid/events already uses. Ordering by block_number alone
+          // still statement-timeouts under load; tryPostgresTier then returns an
+          // empty summary (200) and the Activity rollup dashes out.
           const recentRows = await sql`
           SELECT block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at
           FROM account_events WHERE netuid = ${netuid} AND observed_at >= ${cutoff}
-          ORDER BY block_number DESC, event_index DESC LIMIT ${limit}`;
+          ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT ${limit}`;
           return json(
             buildSubnetEventSummary(
               kindRowsWithColdkeyCount,


### PR DESCRIPTION
Closes #7000

## Summary

**Root cause:** `#7255` fixed 13 hypertable `ORDER BY` sites that statement-timeout under load (METAGRAPHED-5/6), but missed the `/api/v1/subnets/{netuid}/event-summary` recent-evidence slice. That query still ordered by `block_number DESC, event_index DESC` on the `account_events` Timescale hypertable. Under load it times out; `tryPostgresTier` then returns an empty-but-200 summary, so the Activity rollup (and masthead activity tile) silently dash out.

**Fix approach:**
1. Lead that recent-slice `ORDER BY` with `observed_at DESC` — same ChunkAppend-prune pattern `/subnets/:netuid/events` already uses.
2. Complete the remaining #7000 Activity-tab gap: add an event-summary + axon-removals rollup card above the raw Activity table (percentiles / recycled TAO / axon already live on Reliability / Economics / Operational).

## Impact

- Event-summary stays populated under production load instead of degrading to empty.
- Activity tab visitors get a windowed category/kind + axon-removals glance without scanning the raw event table.

## Validation

- [x] `npm test -- tests/data-api.test.mjs` (524 passed; assertion covers the new `ORDER BY observed_at DESC, block_number DESC, event_index DESC` clause)
- [x] `npm run test --workspace=apps/ui -- src/lib/metagraphed/queries.subnet-event-summary.test.ts src/lib/metagraphed/queries.subnet-axon-removals.test.ts` (10 passed)
- [x] Prettier on touched files

## Screenshots

Visual UI change is confined to the Activity tab scorecard strip. LoopOver's automated before/after capture on `/subnets/{netuid}?tab=activity` should supply the screenshot evidence for manual review.

## Risk / tradeoffs

- Sort key change is equivalent for rows within the same `observed_at` millisecond (still tie-breaks on `block_number`, `event_index`).
- Worker API + `apps/ui/**` are guarded paths — expect manual review (not auto-merge).
- No open-PR overlap on #7000 at open time.
