### PR TITLE
test(mcp): verify SN92 Tensorclaw surface end-to-end via call_subnet_surface

### DIFF
--- a/tests/sn92-call-subnet-surface-verify.test.mjs
+++ b/tests/sn92-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,155 @@
+// SN92 (Tensorclaw) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7104, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN92's *real* registry surface config
+// (registry/subnets/tensorclaw.json) to the tool's contract, so a future edit
+// that regresses its callability (flipping to HEAD, marking it auth_required,
+// disabling its probe, dropping the trailing slash) is caught here.
+//
+// The surface is the public no-auth TaoMarketCap subnet snapshot feed
+// (GET https://api.taomarketcap.com/public/v1/subnets/92/, JSON, no schema --
+// a single fixed endpoint). Verified live to return HTTP 200 application/json;
+// HEAD 405 (so the probe correctly declares GET) and the non-slash path 301s
+// to the tracked trailing-slash URL. The fixture below mirrors that live
+// response's top-level shape rather than fetching it, keeping the test
+// hermetic while still exercising the JSON parse-and-return path against the
+// upstream's actual field set.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-92-taomarketcap-subnet-api";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/tensorclaw.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live https://api.taomarketcap.com/public/v1/subnets/92/
+// response body (top-level fields + the nested latest_snapshot object).
+const SN92_BODY = {
+  id: "92",
+  netuid: 92,
+  created_at_block: 5356404,
+  registered_at: "2025-04-15T11:14:24+00:00",
+  latest_snapshot_id: "8666677-92",
+  is_active: true,
+  is_subsidized: false,
+  mechanism_count: 1,
+  latest_snapshot: {
+    id: "8666677-92",
+    netuid: 92,
+    subtoken_enabled: true,
+    subnet_owner_hotkey: "5FeHbWK12HHMLY4AtnWkKk8jtQajhQZMLCenGd96Hhs4UJGc",
+  },
+};
+
+function sn92Response() {
+  return new Response(JSON.stringify(SN92_BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN92 Tensorclaw call_subnet_surface verification (#7104)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    // HEAD 405 upstream -> the probe must call GET.
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    // Canonical non-redirecting form (non-slash path 301s).
+    assert.equal(
+      SURFACE.url,
+      "https://api.taomarketcap.com/public/v1/subnets/92/",
+    );
+    assert.ok(SURFACE.url.endsWith("/"));
+    // Single fixed endpoint -- no machine-readable schema is expected.
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return sn92Response();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    assert.equal(result.body.id, "92");
+    assert.equal(result.body.netuid, 92);
+    assert.equal(result.body.is_active, true);
+    assert.equal(result.body.latest_snapshot.netuid, 92);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    // operational-surfaces.json flattens each registry surface's `id` to a
+    // top-level `surface_id`; build that catalog shape from the real surface.
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 92 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      // DoH lookups for the SSRF guard: no Answer -> fail open (safe).
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return sn92Response();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.netuid, 92);
+      assert.equal(result.structuredContent.body.is_active, true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds an end-to-end verification test that pins SN92 (Tensorclaw)'s real
registry surface — `sn-92-taomarketcap-subnet-api` — to the
`call_subnet_surface` MCP tool's contract, now that MCP execute Phase 1
(#7014) has shipped (#7215).

## Why

Per the issue, once Phase 1's generic `call_subnet_surface` tool is live, each
subnet's callable surface(s) need to be confirmed to actually work end-to-end
through it and any tool-exposed breakage fixed. SN92's only callable surface is
the public no-auth TaoMarketCap subnet snapshot feed.

I verified it live:

- `GET https://api.taomarketcap.com/public/v1/subnets/92/` → **HTTP 200
  `application/json`**, a real machine-readable SN92 snapshot body (~4 KiB).
- `HEAD` → **405** — so the registry's `probe.method: "GET"` is correct.
- The non-slash path `…/subnets/92` → **301** to the tracked trailing-slash URL,
  which is already the canonical form in the registry.

The surface config (`auth_required: false`, `probe.enabled: true`,
`probe.method: "GET"`, `expect: "json"`, canonical URL) is already correct — it
was curated in earlier registry passes (#4757/#6102). Nothing is broken, so
there is no registry/source change to make; the deliverable is the durable
verification itself.

## Change

`tests/sn92-call-subnet-surface-verify.test.mjs` (test-only):

1. Asserts SN92's real registry surface is present and configured to be callable
   (kind, no-auth, probe enabled, GET, `expect: json`, canonical trailing-slash
   URL, no schema — a single fixed endpoint).
2. Drives `callSubnetSurface` with the surface's own url + probe against a
   faithful subset of the live response, asserting it fetches with GET and
   returns the parsed JSON body (not just health metadata).
3. Drives the full `call_subnet_surface` MCP tool via `handleMcpRequest`,
   resolving the surface by id, and asserts the real parsed body flows back
   through the JSON-RPC path.

This locks the verified-good config against a future edit that would regress its
callability (flipping to HEAD, marking it `auth_required`, disabling the probe,
or dropping the trailing slash) — exactly the kinds of breakage the generic tool
exposes.

## Out of scope

Building the execute tool (maintainer-only, Phase 1/2/3) and adding new surfaces
for SN92 (normal registry enrichment) — untouched.

Closes #7104
