### PR TITLE
feat(ui): add validator-comparison drawer mirroring the subnets compare drawer

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -3,6 +3,7 @@ import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { AccountAddress } from "@/components/metagraphed/account-address";
+import { ValidatorCompareToggle } from "@/components/metagraphed/validators-compare-drawer";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
@@ -40,6 +41,10 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
                 {f.hotkeyShort}
               </Link>
               <CopyButton value={v.hotkey} label="hotkey" compact />
+              {/* Same add-to-compare affordance as the desktop table's first column (#6998). */}
+              <span className="ml-auto shrink-0">
+                <ValidatorCompareToggle hotkey={v.hotkey} />
+              </span>
             </div>
             {/* Mirrors the hotkey row above: a flex row so the copy button's 44px
                 touch target centers against the value. `compact` folds that height

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -1,0 +1,291 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { X, BarChart3, ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { useValidatorsCompareSelection } from "@/lib/metagraphed/validators-compare-selection";
+import { compareValidatorsQuery } from "@/lib/metagraphed/queries";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { taoCompact, scoreStr } from "@/components/metagraphed/neuron-format";
+import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
+import type { CompareValidator } from "@/lib/metagraphed/types";
+
+/**
+ * Floating bottom dock + expandable side-by-side compare drawer for selected
+ * validators (#6998) — the validator counterpart of SubnetsCompareDrawer, same
+ * dock/expand interaction and the same localStorage-backed selection contract
+ * (useValidatorsCompareSelection). Pure presentation — does not mutate URL.
+ */
+export function ValidatorsCompareDrawer() {
+  const { selected, max, remove, clear } = useValidatorsCompareSelection();
+  const [expanded, setExpanded] = useState(false);
+
+  if (selected.length === 0) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
+      <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
+        <div
+          className={classNames(
+            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
+            "mg-fade-in",
+          )}
+        >
+          {/* Dock */}
+          <div className="flex flex-wrap items-center gap-2 px-3 py-2">
+            <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <BarChart3 className="size-3 text-accent" />
+              Compare
+              <span className="text-ink-strong tabular-nums">
+                {selected.length}/{max}
+              </span>
+            </span>
+            <span aria-hidden className="h-4 w-px bg-border" />
+            <div className="flex flex-wrap gap-1.5 min-w-0">
+              {selected.map((hotkey) => {
+                const short = shortHash(hotkey) ?? hotkey;
+                return (
+                  <span
+                    key={hotkey}
+                    title={hotkey}
+                    className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-paper pl-2.5 pr-1 font-mono text-[10px] text-ink-strong"
+                  >
+                    {short}
+                    <button
+                      type="button"
+                      onClick={() => remove(hotkey)}
+                      aria-label={`Remove ${short}`}
+                      className="ml-0.5 inline-flex size-4 items-center justify-center rounded-full text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+                    >
+                      <X className="size-2.5" />
+                    </button>
+                  </span>
+                );
+              })}
+            </div>
+            <div className="ml-auto flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                disabled={selected.length < 2}
+                className={classNames(
+                  "inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                  selected.length < 2
+                    ? "opacity-50 cursor-not-allowed"
+                    : "hover:border-accent/60 hover:text-accent text-ink-strong",
+                )}
+              >
+                {expanded ? "Hide" : "Compare"}
+              </button>
+              <button
+                type="button"
+                onClick={clear}
+                className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-paper px-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong transition-colors"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+
+          {/* Expanded side-by-side */}
+          {expanded && selected.length >= 2 ? <CompareValidatorsGrid hotkeys={selected} /> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
+  const { data, isPending, isError, refetch } = useQuery({
+    ...compareValidatorsQuery(hotkeys),
+    retry: 0,
+  });
+
+  const byHotkey = new Map<string, CompareValidator>();
+  for (const v of data?.data?.validators ?? []) byHotkey.set(v.hotkey, v);
+
+  const rows: Array<{ label: string; render: (hotkey: string) => React.ReactNode }> = [
+    {
+      label: "Operator",
+      render: (hotkey) => (
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey }}
+          className="inline-flex items-center gap-1 hover:text-accent"
+        >
+          <ValidatorIdentityChip
+            hotkey={hotkey}
+            identity={byHotkey.get(hotkey)?.coldkey_identity}
+            size={20}
+          />
+          <ExternalLink className="size-3 opacity-60" />
+        </Link>
+      ),
+    },
+    {
+      label: "Take",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {formatTakePct(byHotkey.get(hotkey)?.take)}
+        </span>
+      ),
+    },
+    {
+      label: "Est. APY",
+      render: (hotkey) => {
+        // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
+        const apy = byHotkey.get(hotkey)?.apy_estimate;
+        return (
+          <span className="font-mono tabular-nums text-ink-strong">
+            {formatApyPct(apy != null ? apy * 100 : null)}
+          </span>
+        );
+      },
+    },
+    {
+      label: "Nominators",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {formatNumber(byHotkey.get(hotkey)?.nominator_count)}
+        </span>
+      ),
+    },
+    {
+      label: "Total stake",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {taoCompact(byHotkey.get(hotkey)?.total_stake_tao)}
+        </span>
+      ),
+    },
+    {
+      label: "Total emission",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {taoCompact(byHotkey.get(hotkey)?.total_emission_tao)}
+        </span>
+      ),
+    },
+    {
+      label: "Avg trust",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {scoreStr(byHotkey.get(hotkey)?.avg_validator_trust)}
+        </span>
+      ),
+    },
+    {
+      label: "Max trust",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {scoreStr(byHotkey.get(hotkey)?.max_validator_trust)}
+        </span>
+      ),
+    },
+    {
+      label: "Active subnets",
+      render: (hotkey) => (
+        <span className="font-mono tabular-nums text-ink-strong">
+          {formatNumber(byHotkey.get(hotkey)?.subnet_count)}
+        </span>
+      ),
+    },
+  ];
+
+  if (isError) {
+    return (
+      <div className="border-t border-border px-3 py-6 text-center">
+        <p className="font-mono text-[11px] text-ink-muted">Could not load comparison.</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest text-ink-strong hover:border-accent/60 hover:text-accent transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-border max-h-[55vh] overflow-auto">
+      <table className="min-w-full text-[12px]">
+        <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
+          <tr>
+            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted backdrop-blur">
+              Metric
+            </th>
+            {hotkeys.map((hotkey) => (
+              <th
+                key={hotkey}
+                title={hotkey}
+                className="min-w-[8rem] whitespace-nowrap px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-strong"
+              >
+                {shortHash(hotkey) ?? hotkey}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td className="sticky left-0 z-[1] bg-card px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                {row.label}
+              </td>
+              {hotkeys.map((hotkey) => (
+                <td key={hotkey} className="px-3 py-2">
+                  {isPending ? (
+                    <span className="inline-block h-3 w-12 animate-pulse rounded bg-border/60" />
+                  ) : (
+                    row.render(hotkey)
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Inline checkbox-style toggle for table/card rows. */
+export function ValidatorCompareToggle({ hotkey }: { hotkey: string }) {
+  const { has, toggle, selected, max } = useValidatorsCompareSelection();
+  const on = has(hotkey);
+  const disabled = !on && selected.length >= max;
+  const short = shortHash(hotkey) ?? hotkey;
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={on}
+      aria-label={on ? `Remove ${short} from compare` : `Add ${short} to compare`}
+      disabled={disabled}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!disabled) toggle(hotkey);
+      }}
+      title={disabled ? `Compare is full (${max})` : on ? "Remove from compare" : "Add to compare"}
+      className={classNames(
+        "inline-flex size-4 shrink-0 items-center justify-center rounded border transition-colors",
+        on ? "bg-accent border-accent text-paper" : "border-border bg-paper hover:border-accent/60",
+        disabled && "opacity-40 cursor-not-allowed",
+      )}
+    >
+      {on ? (
+        <svg viewBox="0 0 12 12" fill="none" className="size-2.5" aria-hidden>
+          <path
+            d="M2 6.5l2.5 2.5L10 3.5"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.compare-validators.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.compare-validators.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { compareValidatorsQuery, normalizeCompareValidators } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 addresses.
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/compare/validators",
+  });
+}
+
+// The queryFn is defined on the queryOptions returned by the factory.
+async function runQuery(hotkeys: string[], netuid?: number) {
+  const opts = compareValidatorsQuery(hotkeys, netuid);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeCompareValidators", () => {
+  it("coerces a well-formed comparison, keeping caller order", () => {
+    const result = normalizeCompareValidators({
+      schema_version: 1,
+      netuid: null,
+      validator_count: 2,
+      validators: [
+        {
+          hotkey: ALICE,
+          coldkey: BOB,
+          coldkey_identity: { has_identity: true, name: "Alice Ops" },
+          take: 0.09,
+          apy_estimate: 0.123,
+          apy_estimate_eligible_subnet_count: 3,
+          nominator_count: 41,
+          total_stake_tao: 1200.5,
+          total_emission_tao: 4.2,
+          avg_validator_trust: 0.91,
+          max_validator_trust: 0.99,
+          subnet_count: 5,
+          subnet_context: null,
+        },
+        {
+          hotkey: BOB,
+          coldkey: null,
+          coldkey_identity: null,
+          take: null,
+          apy_estimate: null,
+          apy_estimate_eligible_subnet_count: null,
+          nominator_count: null,
+          total_stake_tao: null,
+          total_emission_tao: null,
+          avg_validator_trust: null,
+          max_validator_trust: null,
+          subnet_count: null,
+          subnet_context: null,
+        },
+      ],
+    });
+    expect(result.netuid).toBeNull();
+    expect(result.validator_count).toBe(2);
+    expect(result.validators.map((v) => v.hotkey)).toEqual([ALICE, BOB]);
+    expect(result.validators[0]).toMatchObject({
+      coldkey: BOB,
+      take: 0.09,
+      apy_estimate: 0.123,
+      nominator_count: 41,
+      total_stake_tao: 1200.5,
+      subnet_count: 5,
+      subnet_context: null,
+    });
+    expect(result.validators[0].coldkey_identity).toMatchObject({
+      has_identity: true,
+      name: "Alice Ops",
+    });
+    // A tier-empty row keeps its hotkey and stays all-null (buildValidatorDetail([], hotkey)).
+    expect(result.validators[1]).toMatchObject({
+      hotkey: BOB,
+      coldkey: null,
+      coldkey_identity: null,
+      take: null,
+      total_stake_tao: null,
+    });
+  });
+
+  it("carries the netuid context and its subnet_context membership row", () => {
+    const result = normalizeCompareValidators({
+      netuid: 8,
+      validator_count: 1,
+      validators: [
+        {
+          hotkey: ALICE,
+          subnet_context: {
+            netuid: 8,
+            uid: 12,
+            stake_tao: 100.25,
+            emission_tao: 0.5,
+            validator_trust: 0.87,
+          },
+        },
+      ],
+    });
+    expect(result.netuid).toBe(8);
+    expect(result.validators[0].subnet_context).toEqual({
+      netuid: 8,
+      uid: 12,
+      stake_tao: 100.25,
+      emission_tao: 0.5,
+      validator_trust: 0.87,
+    });
+  });
+
+  it("drops rows without a hotkey and non-record rows, then recounts", () => {
+    const result = normalizeCompareValidators({
+      // validator_count deliberately absent — falls back to the surviving row count.
+      validators: [{ hotkey: ALICE }, { take: 0.1 }, "junk", null, 7],
+    });
+    expect(result.validators.map((v) => v.hotkey)).toEqual([ALICE]);
+    expect(result.validator_count).toBe(1);
+  });
+
+  it("returns a schema-stable empty shape for malformed input", () => {
+    for (const raw of [null, undefined, "x", 4, [], { validators: "nope" }]) {
+      const result = normalizeCompareValidators(raw);
+      expect(result.netuid).toBeNull();
+      expect(result.validator_count).toBe(0);
+      expect(result.validators).toEqual([]);
+    }
+  });
+
+  it("coerces numeric strings and nulls non-finite metrics", () => {
+    const result = normalizeCompareValidators({
+      validators: [
+        {
+          hotkey: ALICE,
+          take: "0.18",
+          nominator_count: "12",
+          total_stake_tao: Number.NaN,
+          avg_validator_trust: "not-a-number",
+        },
+      ],
+    });
+    expect(result.validators[0].take).toBe(0.18);
+    expect(result.validators[0].nominator_count).toBe(12);
+    expect(result.validators[0].total_stake_tao).toBeNull();
+    expect(result.validators[0].avg_validator_trust).toBeNull();
+  });
+});
+
+describe("compareValidatorsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("requests the joined hotkey list and normalizes the response", async () => {
+    resolveWith({ netuid: null, validator_count: 1, validators: [{ hotkey: ALICE }] });
+    const res = await runQuery([ALICE, BOB]);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/compare/validators",
+      expect.objectContaining({
+        params: { hotkeys: `${ALICE},${BOB}`, netuid: undefined },
+      }),
+    );
+    expect(res.data.validators.map((v) => v.hotkey)).toEqual([ALICE]);
+  });
+
+  it("passes the optional netuid context through to the request", async () => {
+    resolveWith({ netuid: 8, validator_count: 0, validators: [] });
+    await runQuery([ALICE], 8);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/compare/validators",
+      expect.objectContaining({ params: { hotkeys: ALICE, netuid: 8 } }),
+    );
+  });
+
+  it("keys the cache on the sorted hotkey set plus the netuid context", () => {
+    const a = compareValidatorsQuery([BOB, ALICE], 8);
+    const b = compareValidatorsQuery([ALICE, BOB], 8);
+    expect(a.queryKey).toEqual(b.queryKey);
+    const noContext = compareValidatorsQuery([ALICE, BOB]);
+    expect(noContext.queryKey).not.toEqual(a.queryKey);
+  });
+
+  it("is disabled with an empty selection", () => {
+    expect(compareValidatorsQuery([]).enabled).toBe(false);
+    expect(compareValidatorsQuery([ALICE]).enabled).toBe(true);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -123,6 +123,8 @@ import type {
   Candidate,
   Compare,
   CompareSubnet,
+  CompareValidator,
+  CompareValidators,
   BlockEvent,
   BlockEvents,
   BlockChainEvents,
@@ -6972,6 +6974,68 @@ export const compareQuery = (netuids: number[]) =>
       return { data: normalizeCompare(res.data), meta: res.meta, url: res.url };
     },
     enabled: netuids.length > 0,
+    staleTime: STALE_SHORT,
+  });
+
+function normalizeCompareValidator(raw: unknown): CompareValidator | null {
+  if (!isRecord(raw)) return null;
+  const hotkey = coerceString(raw.hotkey);
+  if (!hotkey) return null;
+  const nullableNum = (value: unknown): number | null =>
+    value == null ? null : (coerceFiniteNumber(value) ?? null);
+  return {
+    hotkey,
+    coldkey: coerceString(raw.coldkey) ?? null,
+    coldkey_identity: normalizeColdkeyIdentity(raw.coldkey_identity),
+    take: nullableNum(raw.take),
+    apy_estimate: nullableNum(raw.apy_estimate),
+    apy_estimate_eligible_subnet_count: nullableNum(raw.apy_estimate_eligible_subnet_count),
+    nominator_count: nullableNum(raw.nominator_count),
+    total_stake_tao: nullableNum(raw.total_stake_tao),
+    total_emission_tao: nullableNum(raw.total_emission_tao),
+    avg_validator_trust: nullableNum(raw.avg_validator_trust),
+    max_validator_trust: nullableNum(raw.max_validator_trust),
+    subnet_count: nullableNum(raw.subnet_count),
+    subnet_context: normalizeGlobalValidatorSubnet(raw.subnet_context),
+  };
+}
+
+export function normalizeCompareValidators(raw: unknown): CompareValidators {
+  const d = isRecord(raw) ? raw : {};
+  const validators = Array.isArray(d.validators)
+    ? d.validators.flatMap((validator) => {
+        const normalized = normalizeCompareValidator(validator);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  return {
+    netuid: d.netuid == null ? null : (coerceFiniteNumber(d.netuid) ?? null),
+    validator_count: coerceFiniteNumber(d.validator_count) ?? validators.length,
+    validators,
+  };
+}
+
+/**
+ * Validator-side comparison (#6325/#6998): each selected hotkey's take rate,
+ * estimated APY, nominator count, identity, and cross-subnet aggregates in one
+ * request — the validator equivalent of compareQuery above, so the validators
+ * compare drawer renders its grid from a single call instead of a
+ * validator-detail request per selected hotkey. `netuid` is the route's
+ * optional subnet-context parameter: when set, each row also carries that
+ * validator's membership in that one subnet (subnet_context).
+ */
+export const compareValidatorsQuery = (hotkeys: string[], netuid?: number) =>
+  queryOptions({
+    queryKey: k("compare-validators", [...hotkeys].sort(), netuid ?? null),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>("/api/v1/compare/validators", {
+        // buildUrl drops undefined params, so netuid only reaches the URL when set.
+        params: { hotkeys: hotkeys.join(","), netuid },
+        signal,
+      });
+      return { data: normalizeCompareValidators(res.data), meta: res.meta, url: res.url };
+    },
+    enabled: hotkeys.length > 0,
     staleTime: STALE_SHORT,
   });
 

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2382,6 +2382,37 @@ export interface GlobalValidators {
   validators: GlobalValidator[];
 }
 
+/**
+ * One validator projected to the stake-decision fields by
+ * /api/v1/compare/validators (#6325/#6998) — take rate, estimated APY,
+ * nominator count, identity, plus the cross-subnet aggregates that give those
+ * numbers context. Every field except hotkey is null when the neurons tier has
+ * no row for that hotkey.
+ */
+export interface CompareValidator {
+  hotkey: string;
+  coldkey: string | null;
+  coldkey_identity: ColdkeyIdentity | null;
+  take: number | null;
+  apy_estimate: number | null;
+  apy_estimate_eligible_subnet_count: number | null;
+  nominator_count: number | null;
+  total_stake_tao: number | null;
+  total_emission_tao: number | null;
+  avg_validator_trust: number | null;
+  max_validator_trust: number | null;
+  subnet_count: number | null;
+  /** Membership row in the optional netuid context, null without one (or no permit there). */
+  subnet_context: GlobalValidatorSubnet | null;
+}
+
+/** Validator-side comparison from GET /api/v1/compare/validators (#6325). */
+export interface CompareValidators {
+  netuid: number | null;
+  validator_count: number;
+  validators: CompareValidator[];
+}
+
 /** One per-subnet membership row from /api/v1/validators/{hotkey} (#4335, 7.1). */
 export interface ValidatorDetailSubnet {
   netuid: number;

--- a/apps/ui/src/lib/metagraphed/validators-compare-selection.test.ts
+++ b/apps/ui/src/lib/metagraphed/validators-compare-selection.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const KEY = "metagraphed:compare-validators";
+
+const HK_A = "5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjQX";
+const HK_B = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";
+const HK_C = "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw";
+const HK_D = "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL";
+const HK_E = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+// An EventTarget-based fake `window` (so subscribe's add/remove/dispatch of the "storage" event work)
+// plus a Map-backed localStorage. Node provides EventTarget globally.
+function makeWindow(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  const win = new EventTarget() as EventTarget & {
+    localStorage: Pick<Storage, "getItem" | "setItem" | "removeItem">;
+    store: Map<string, string>;
+    throwOnRead?: boolean;
+  };
+  win.store = store;
+  win.localStorage = {
+    getItem: (k: string) => {
+      if (win.throwOnRead) throw new Error("blocked");
+      return store.has(k) ? store.get(k)! : null;
+    },
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  return win;
+}
+
+// validators-compare-selection caches raw/value + listeners at module scope, so a fresh module per
+// case is the only way to observe first-read/cache behaviour deterministically. Stub `window`
+// before importing.
+async function freshStore(win?: ReturnType<typeof makeWindow>) {
+  vi.resetModules();
+  if (win) vi.stubGlobal("window", win);
+  return import("./validators-compare-selection");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("parseRaw", () => {
+  it("returns [] for null/empty/non-array/malformed input", async () => {
+    const { parseRaw } = await freshStore(makeWindow());
+    expect(parseRaw(null)).toEqual([]);
+    expect(parseRaw("")).toEqual([]);
+    expect(parseRaw("{not json")).toEqual([]);
+    expect(parseRaw(JSON.stringify({ a: HK_A }))).toEqual([]);
+  });
+
+  it("keeps only non-empty strings and caps at 4", async () => {
+    const { parseRaw } = await freshStore(makeWindow());
+    expect(parseRaw(JSON.stringify([HK_A, 7, null, HK_B, "", HK_C]))).toEqual([HK_A, HK_B, HK_C]);
+    expect(parseRaw(JSON.stringify([HK_A, HK_B, HK_C, HK_D, HK_E]))).toEqual([
+      HK_A,
+      HK_B,
+      HK_C,
+      HK_D,
+    ]);
+  });
+});
+
+describe("readSnapshot", () => {
+  it("returns [] during SSR (no window)", async () => {
+    const { readSnapshot } = await freshStore(); // no window stubbed
+    expect(readSnapshot()).toEqual([]);
+  });
+
+  it("reads + parses the persisted selection", async () => {
+    const { readSnapshot } = await freshStore(makeWindow({ [KEY]: JSON.stringify([HK_A, HK_B]) }));
+    expect(readSnapshot()).toEqual([HK_A, HK_B]);
+  });
+
+  it("serves an unchanged snapshot from cache (same reference)", async () => {
+    const { readSnapshot } = await freshStore(makeWindow({ [KEY]: JSON.stringify([HK_A, HK_B]) }));
+    const a = readSnapshot();
+    const b = readSnapshot();
+    expect(a).toBe(b); // second read short-circuits on the identical raw string
+  });
+
+  it("degrades to [] when localStorage access throws", async () => {
+    const win = makeWindow();
+    win.throwOnRead = true;
+    const { readSnapshot } = await freshStore(win);
+    expect(readSnapshot()).toEqual([]);
+  });
+});
+
+describe("writeRaw", () => {
+  it("is a no-op during SSR (no window)", async () => {
+    const { writeRaw, readSnapshot } = await freshStore(); // no window
+    expect(() => writeRaw([HK_A, HK_B])).not.toThrow();
+    expect(readSnapshot()).toEqual([]);
+  });
+
+  it("cleans (non-empty strings only), caps at 4, and persists", async () => {
+    const win = makeWindow();
+    const { writeRaw, readSnapshot } = await freshStore(win);
+    writeRaw([HK_A, "", HK_B, HK_C, HK_D, HK_E]);
+    expect(win.store.get(KEY)).toBe(JSON.stringify([HK_A, HK_B, HK_C, HK_D]));
+    expect(readSnapshot()).toEqual([HK_A, HK_B, HK_C, HK_D]);
+  });
+
+  it("notifies registered subscribers", async () => {
+    const { writeRaw, subscribe } = await freshStore(makeWindow());
+    const calls: number[] = [];
+    subscribe(() => calls.push(1));
+    writeRaw([HK_A]);
+    expect(calls).toEqual([1]);
+  });
+});
+
+describe("subscribe", () => {
+  it("stops notifying after the returned unsubscribe runs", async () => {
+    const { writeRaw, subscribe } = await freshStore(makeWindow());
+    let count = 0;
+    const off = subscribe(() => (count += 1));
+    writeRaw([HK_A]);
+    off();
+    writeRaw([HK_B]);
+    expect(count).toBe(1);
+  });
+
+  it("re-notifies on a cross-tab 'storage' event for this key, and ignores other keys", async () => {
+    const win = makeWindow({ [KEY]: JSON.stringify([HK_A]) });
+    const { subscribe, readSnapshot } = await freshStore(win);
+    let count = 0;
+    subscribe(() => (count += 1));
+    readSnapshot(); // prime the cache
+
+    const other = new Event("storage") as Event & { key: string };
+    other.key = "some-other-key";
+    win.dispatchEvent(other);
+    expect(count).toBe(0); // unrelated key: ignored
+
+    win.store.set(KEY, JSON.stringify([HK_A, HK_B]));
+    const ours = new Event("storage") as Event & { key: string };
+    ours.key = KEY;
+    win.dispatchEvent(ours);
+    expect(count).toBe(1); // our key: listener fired
+    expect(readSnapshot()).toEqual([HK_A, HK_B]); // cache was invalidated + re-read
+  });
+
+  it("returns a no-op unsubscribe during SSR without throwing", async () => {
+    const { subscribe } = await freshStore(); // no window
+    const off = subscribe(() => {});
+    expect(typeof off).toBe("function");
+    expect(() => off()).not.toThrow();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/validators-compare-selection.ts
+++ b/apps/ui/src/lib/metagraphed/validators-compare-selection.ts
@@ -1,0 +1,106 @@
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+/**
+ * Tiny localStorage-backed selection store for validator comparison (#6998) —
+ * the hotkey (SS58 string) counterpart of compare-selection.ts, same store
+ * shape and the same cross-component notification contract.
+ * Holds up to MAX hotkeys and notifies subscribers across components.
+ */
+const KEY = "metagraphed:compare-validators";
+const MAX = 4;
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+let cachedRaw: string | null = null;
+let cachedValue: string[] = [];
+
+// parseRaw / readSnapshot / writeRaw / subscribe are the store primitives the hook composes; they
+// are exported for unit testing (same contract as compare-selection.ts, #3414). The public
+// component API stays `useValidatorsCompareSelection`.
+export function parseRaw(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string" && v.length > 0).slice(0, MAX);
+  } catch {
+    return [];
+  }
+}
+
+export function readSnapshot(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (raw === cachedRaw) return cachedValue;
+    cachedRaw = raw;
+    cachedValue = parseRaw(raw);
+    return cachedValue;
+  } catch {
+    if (cachedRaw === null) return cachedValue;
+    cachedRaw = null;
+    cachedValue = [];
+    return cachedValue;
+  }
+}
+
+export function writeRaw(next: string[]) {
+  if (typeof window === "undefined") return;
+  const clean = next
+    .filter((v): v is string => typeof v === "string" && v.length > 0)
+    .slice(0, MAX);
+  const raw = JSON.stringify(clean);
+  try {
+    window.localStorage.setItem(KEY, raw);
+  } catch {
+    /* ignore quota errors */
+  }
+  cachedRaw = raw;
+  cachedValue = clean;
+  for (const l of listeners) l();
+}
+
+export function subscribe(l: Listener) {
+  listeners.add(l);
+  if (typeof window !== "undefined") {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === KEY) {
+        cachedRaw = null;
+        cachedValue = [];
+        l();
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      listeners.delete(l);
+      window.removeEventListener("storage", onStorage);
+    };
+  }
+  return () => listeners.delete(l);
+}
+
+const EMPTY: string[] = [];
+
+export function useValidatorsCompareSelection() {
+  // Avoid SSR/CSR snapshot mismatch — start empty on the server, hydrate on mount.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  const value = useSyncExternalStore(
+    subscribe,
+    () => (hydrated ? readSnapshot() : EMPTY),
+    () => EMPTY,
+  );
+
+  return {
+    selected: value,
+    max: MAX,
+    has: (hotkey: string) => value.includes(hotkey),
+    toggle: (hotkey: string) => {
+      const cur = readSnapshot();
+      if (cur.includes(hotkey)) writeRaw(cur.filter((h) => h !== hotkey));
+      else if (cur.length < MAX) writeRaw([...cur, hotkey]);
+    },
+    remove: (hotkey: string) => writeRaw(readSnapshot().filter((h) => h !== hotkey)),
+    clear: () => writeRaw([]),
+  };
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -26,6 +26,10 @@ import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-form
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";
+import {
+  ValidatorsCompareDrawer,
+  ValidatorCompareToggle,
+} from "@/components/metagraphed/validators-compare-drawer";
 import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
@@ -154,6 +158,7 @@ function ValidatorsPage() {
         </QueryErrorBoundary>
       </div>
       <ApiSourceFooter paths={["/api/v1/validators"]} />
+      <ValidatorsCompareDrawer />
     </AppShell>
   );
 }
@@ -204,6 +209,7 @@ function ValidatorsTable({
           >
             <thead className="bg-surface/50">
               <tr>
+                <th className="w-6 px-3 py-2" aria-label="Compare" />
                 {VALIDATOR_COLUMNS.map((col) => (
                   <th
                     key={col.header}
@@ -229,6 +235,9 @@ function ValidatorsTable({
             <tbody className="divide-y divide-border">
               {validators.map((v) => (
                 <tr key={v.hotkey} className="hover:bg-surface/40">
+                  <td className="px-3 py-2 align-middle">
+                    <ValidatorCompareToggle hotkey={v.hotkey} />
+                  </td>
                   {VALIDATOR_COLUMNS.map((col) => (
                     <td key={col.header} className={col.tdClassName}>
                       {col.cell(v)}


### PR DESCRIPTION
## What

`/api/v1/compare/validators` (#6325) has had REST and MCP (`compare_validators`) exposure but no UI — a delegator weighing validators today has to open N detail tabs. This adds the validator-side equivalent of the existing subnets compare drawer: pick up to 4 validators on `/validators`, then compare take rate, estimated APY, nominator count, on-chain identity, total stake/emission, avg/max trust, and active-subnet count side by side.

Closes #6998

## What changed

- `validators-compare-selection.ts` — localStorage-backed selection store (`metagraphed:compare-validators`), the hotkey-keyed counterpart of `compare-selection.ts` with the same store primitives and the same cross-tab notification contract.
- `compareValidatorsQuery` + `normalizeCompareValidators` (`queries.ts` / `types.ts`) — one request for the whole grid via `/api/v1/compare/validators`, network-scoped query key on the sorted hotkey set, optional netuid context passed through to the route's `subnet_context`.
- `ValidatorsCompareDrawer` — same dock + expandable grid interaction as `SubnetsCompareDrawer`, reusing `ValidatorIdentityChip`, `formatTakePct`/`formatApyPct`, `taoCompact`, and `scoreStr` for cells.
- Entry points: a leading compare column on the `/validators` desktop table and the same toggle on the mobile card list; drawer mounted on the `/validators` route.

Scoped to the one drawer + its `/validators` entry points the issue names — no `packages/ui-kit` change, no other route touched.

## Screenshots

Full viewport at the required sizes (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), each theme forced via `mg-theme`, scrolled to the validators table where the new compare column lives.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-after-mobile-dark.png)<br><sub>after</sub> |

### New drawer states (after only)

The compare dock and expanded grid did not exist before this change, so these states have no "before" equivalent — captured after selecting two validators via the new compare toggles, same fixed viewports and `mg-theme` forcing.

| State · Viewport | Light | Dark |
| --- | --- | --- |
| Dock · Desktop | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-dock-desktop-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-dock-desktop-light.png)<br><sub>dock</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-dock-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-dock-desktop-dark.png)<br><sub>dock</sub> |
| Dock · Mobile | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-dock-mobile-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-dock-mobile-light.png)<br><sub>dock</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-dock-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-dock-mobile-dark.png)<br><sub>dock</sub> |
| Expanded grid · Desktop | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-grid-desktop-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-grid-desktop-light.png)<br><sub>expanded</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-grid-desktop-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-grid-desktop-dark.png)<br><sub>expanded</sub> |
| Expanded grid · Mobile | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-grid-mobile-light.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-grid-mobile-light.png)<br><sub>expanded</sub> | [<img src="https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-grid-mobile-dark.png" width="260">](https://raw.githubusercontent.com/bidobird/metagraphed/screenshots/6998-validators-compare-drawer-grid-mobile-dark.png)<br><sub>expanded</sub> |

## Validation

- `npm run lint --workspace=apps/ui` — 0 errors
- `npm run format:check --workspace=apps/ui` — clean on changed files
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 174 files / 1331 tests pass, including full store-primitive coverage for the new selection store (mirroring `compare-selection.test.ts`) plus normalizer/query-factory coverage (caller order, null-safe empty shapes, netuid context, sorted cache key, disabled-when-empty)
- `npm run test:e2e --workspace=apps/ui` — responsive-overflow baseline unchanged across all checked routes and viewports; one unrelated spec (`multisig-related-error.spec.ts`, #6426) flakes locally under parallel load — it fails identically on the parent commit and passes in isolation on this branch
- `npm run build --workspace=apps/ui` — clean

Note on prior attempts: #7205 and #7238 targeted this issue and were closed in manual review with clean CI and no gate findings. This implementation additionally covers the query/normalizer layer with tests (not only the selection store), keys the compare query on the sorted hotkey set so cache identity is stable across selection order, and threads the optional `subnet_context` netuid through to the route.

## Registry Safety

- [x] Links a tracked open issue (#6998)
- [x] No secrets, PATs, wallet data, or private URLs
- [x] No hand-edited generated artifacts
- [x] No R2-only / high-churn artifacts committed
- [x] No public API/OpenAPI/schema changes
