### PR TITLE
test(mcp): verify SN128 ByteLeap surface via call_subnet_surface (#7136)

### DIFF
--- a/tests/sn128-call-subnet-surface-verify.test.mjs
+++ b/tests/sn128-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,168 @@
+// SN128 (ByteLeap) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7136, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN128's *real* registry surface config
+// (registry/subnets/byteleap.json) to the tool's contract, so a future edit
+// that regresses its callability (flipping to HEAD, marking it auth_required,
+// disabling its probe, dropping the trailing slash) is caught here.
+//
+// The surface is the public no-auth TaoMarketCap subnet snapshot feed
+// (GET https://api.taomarketcap.com/public/v1/subnets/128/, JSON, no schema --
+// a single fixed endpoint). Verified live to return HTTP 200 application/json
+// with ByteLeap SubnetIdentitiesV3 metadata; HEAD 405 (so the probe correctly
+// declares GET) and the non-slash path 301s to the tracked trailing-slash URL.
+// The fixture below mirrors that live response's top-level shape rather than
+// fetching it, keeping the test hermetic while still exercising the JSON
+// parse-and-return path against the upstream's actual field set.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-128-taomarketcap-subnet-api";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/byteleap.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live https://api.taomarketcap.com/public/v1/subnets/128/
+// response body (top-level fields + nested latest_snapshot identity).
+const SN128_BODY = {
+  id: "128",
+  netuid: 128,
+  created_at_block: 5856038,
+  registered_at: "2025-06-25T04:45:00+00:00",
+  latest_snapshot_id: "8666726-128",
+  is_active: true,
+  is_subsidized: false,
+  mechanism_count: 1,
+  latest_snapshot: {
+    id: "8666726-128",
+    netuid: 128,
+    subtoken_enabled: true,
+    subnet_identities_v3: {
+      subnetName: "ByteLeap",
+      githubRepo: "https://github.com/byteleapai/byteleap-Miner",
+      subnetUrl: "ByteLeap.ai",
+    },
+  },
+};
+
+function sn128Response() {
+  return new Response(JSON.stringify(SN128_BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN128 ByteLeap call_subnet_surface verification (#7136)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    // HEAD 405 upstream -> the probe must call GET.
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    // Canonical non-redirecting form (non-slash path 301s).
+    assert.equal(
+      SURFACE.url,
+      "https://api.taomarketcap.com/public/v1/subnets/128/",
+    );
+    assert.ok(SURFACE.url.endsWith("/"));
+    // Single fixed endpoint -- no machine-readable schema is expected.
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return sn128Response();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    assert.equal(result.body.id, "128");
+    assert.equal(result.body.netuid, 128);
+    assert.equal(result.body.is_active, true);
+    assert.equal(result.body.latest_snapshot.netuid, 128);
+    assert.equal(
+      result.body.latest_snapshot.subnet_identities_v3.subnetName,
+      "ByteLeap",
+    );
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    // operational-surfaces.json flattens each registry surface's `id` to a
+    // top-level `surface_id`; build that catalog shape from the real surface.
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 128 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      // DoH lookups for the SSRF guard: no Answer -> fail open (safe).
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return sn128Response();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.netuid, 128);
+      assert.equal(result.structuredContent.body.is_active, true);
+      assert.equal(
+        result.structuredContent.body.latest_snapshot.subnet_identities_v3
+          .subnetName,
+        "ByteLeap",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #7136

## Summary

Pins SN128 ByteLeap's real registry surface (`sn-128-taomarketcap-subnet-api` in `registry/subnets/byteleap.json`) to the `call_subnet_surface` MCP tool contract now that Phase 1 (#7014 / #7215) has shipped.

Live-verified: `GET https://api.taomarketcap.com/public/v1/subnets/128/` returns HTTP 200 `application/json` with ByteLeap identity metadata. HEAD is 405 (probe correctly uses GET). No registry config changes were required.

## What changed

- **One file only:** `tests/sn128-call-subnet-surface-verify.test.mjs` (mirrors the merged SN92 Tensorclaw pattern on `main`).
- Asserts registry callability (GET/json, no-auth, trailing-slash URL).
- Asserts `callSubnetSurface` returns the faithful JSON body shape.
- Asserts end-to-end MCP `tools/call` resolution by `surface_id`.

## Validation

- [x] `npm test -- tests/sn128-call-subnet-surface-verify.test.mjs` (3 passed)
- [x] Prettier clean on the new file
- [x] No UI / no `apps/ui/**` (avoids Path C screenshot gate)
- [x] No open PR overlap on #7136 at submission time

## Risk / tradeoffs

Hermetic mocked fetch (same as SN92) — guards registry + tool contract regressions without depending on live network in CI.