### PR TITLE
fix(registry): add probe blocks to SN85 Vidaio health + ready surfaces

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -128,7 +128,13 @@
       "id": "sn-85-vidaio-health",
       "kind": "subnet-api",
       "name": "Vidaio API health",
-      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health).",
+      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health). Live-verified 2026-07-21: GET returns HTTP 200 application/json {\"status\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "vidaio",
       "public_safe": true,
       "review": {
@@ -147,7 +153,13 @@
       "id": "sn-85-vidaio-ready",
       "kind": "subnet-api",
       "name": "Vidaio API readiness health",
-      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint.",
+      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint. Live-verified 2026-07-21: GET returns HTTP 200 application/json {\"status\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "vidaio",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
Closes #7098

## Verification (real requests, 2026-07-21)

| Surface | Request | Result |
| --- | --- | --- |
| `sn-85-vidaio-health` | `GET https://api.vidaio.io/health` | **HTTP 200** `application/json` `{"status":"ok"}` |
| `sn-85-vidaio-ready` | `GET https://api.vidaio.io/ready` | **HTTP 200** `application/json` `{"status":"ok"}` |

Both are no-auth GET endpoints and work end-to-end.

## Problem

Both surfaces had **no `probe` block**. `scripts/build-artifacts.mjs` filters the prober's input (`operational-surfaces.json`) on `surface.probe?.enabled` — a missing `probe` is falsy, so both were **silently excluded from all health tracking**, indistinguishable from an intentionally-disabled probe (the class tracked in #5932).

## Fix

Added a `probe` block (`{enabled: true, expect: "json", method: "GET", timeout_ms: 10000}` — matching the sibling `openapi`/`subnet-api` surfaces' shape) to each, and appended a `Live-verified 2026-07-21: …` note documenting the observed response. **One file, no other surface or field changed.**

## Validation

- [x] `npm run validate:surface -- registry/subnets/vidaio.json` — passed (6 surfaces)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check` · `git diff --check` — clean
- [x] `operational-surfaces.json` is excluded from the derived-artifact freshness gate (validate.yml), so no artifact rebuild is required.
