### PR TITLE
fix(registry): add probe block to SN43 Graphite subnet-stats surface

### DIFF
--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -127,7 +127,13 @@
       "id": "sn-43-graphite-ai-subnet-api",
       "kind": "subnet-api",
       "name": "Graphite SN43 subnet stats API",
-      "notes": "Public, unauthenticated JSON endpoint on Graphite's official SN43 API (api.graphite-ai.net) returning the live subnet-43 metagraph aggregate: netuid, total registered neurons, validator/miner counts, total alpha stake, and an availability flag. Documented in the subnet's OpenAPI spec as GET /api/v1/stats/subnet.",
+      "notes": "Public, unauthenticated JSON endpoint on Graphite's official SN43 API (api.graphite-ai.net) returning the live subnet-43 metagraph aggregate: netuid, total registered neurons, validator/miner counts, total alpha stake, and an availability flag. Documented in the subnet's OpenAPI spec as GET /api/v1/stats/subnet. Live-verified 2026-07-21: GET returns HTTP 200 application/json with {netuid: 43, total_registered, validators, miners, total_alpha_stake, updated_at}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "graphite-ai",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
Closes #7057

## Verification (real request, 2026-07-21)

| Surface | Request | Result |
| --- | --- | --- |
| `sn-43-graphite-ai-subnet-api` | `GET https://api.graphite-ai.net/api/v1/stats/subnet` | **HTTP 200** `application/json` — `{"netuid":43,"total_registered":256,"validators":8,"miners":248,"total_alpha_stake":…,"updated_at":…}` |

No-auth GET, works end-to-end and returns the live subnet-43 aggregate exactly as its `notes` describe.

## Problem

`sn-43-graphite-ai-subnet-api` had **no `probe` block**, so `scripts/build-artifacts.mjs` (which filters the prober's `operational-surfaces.json` on `surface.probe?.enabled`) **silently excluded it from health tracking** — the class tracked in #5932. Its sibling Graphite subnet-api surfaces (`health`, `miners-stats`, `coverage-stats`, `graph-data`) all already carry a `probe`.

## Fix

Added a `probe` block (`{enabled: true, expect: "json", method: "GET", timeout_ms: 10000}` — matching the siblings) and appended a `Live-verified 2026-07-21: …` note. **One file, no other surface or field changed.**

## Validation

- [x] `npm run validate:surface -- registry/subnets/graphite.json` — passed (10 surfaces)
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check` · `git diff --check` — clean
- [x] `operational-surfaces.json` is excluded from the derived-artifact freshness gate (validate.yml) — no artifact rebuild required.
