### PR TITLE
test(mcp): verify SN126 Poker44 health surface via call_subnet_surface (#7134)

### DIFF
--- a/tests/sn126-call-subnet-surface-verify.test.mjs
+++ b/tests/sn126-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,136 @@
+// SN126 (Poker44) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7134, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN126's *real* registry surface config
+// (registry/subnets/poker44.json) to the tool's contract, so a future edit
+// that regresses its callability (flipping method, marking it auth_required,
+// disabling its probe, changing the path) is caught here.
+//
+// The surface is the public no-auth platform health feed
+// (GET https://api.poker44.net/health, JSON, no schema -- a single fixed
+// endpoint). Verified live to return HTTP 200 application/json; charset=utf-8
+// with `{success:true, data:{status:"healthy", services:{...}}}`. The fixture
+// below mirrors that live response's top-level shape rather than fetching it,
+// keeping the test hermetic while still exercising charset-suffixed JSON
+// parsing against the upstream's actual field set.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-126-poker44-health";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/poker44.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live https://api.poker44.net/health response.
+const SN126_BODY = {
+  success: true,
+  data: {
+    status: "healthy",
+    timestamp: "2026-07-21T03:15:12.539Z",
+    uptime: 479367.478391343,
+    services: {
+      database: { status: "connected", latency: 1 },
+      redis: { status: "connected", latency: 0 },
+    },
+  },
+};
+
+function sn126Response() {
+  return new Response(JSON.stringify(SN126_BODY), {
+    status: 200,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+describe("SN126 Poker44 call_subnet_surface verification (#7134)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(SURFACE.url, "https://api.poker44.net/health");
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return sn126Response();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.truncated, false);
+    assert.equal(result.body.success, true);
+    assert.equal(result.body.data.status, "healthy");
+    assert.equal(result.body.data.services.database.status, "connected");
+    assert.equal(result.body.data.services.redis.status, "connected");
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 126 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return sn126Response();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.success, true);
+      assert.equal(result.structuredContent.body.data.status, "healthy");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #7134

## Summary

Pins SN126 Poker44's real registry surface (`sn-126-poker44-health` in `registry/subnets/poker44.json`) to the `call_subnet_surface` MCP tool contract now that Phase 1 (#7014 / #7215) has shipped.

Live-verified: `GET https://api.poker44.net/health` returns HTTP 200 `application/json; charset=utf-8` with `{success:true, data:{status:healthy, services:{database, redis}}}`. No registry config changes required.

## What changed

- **One file only:** `tests/sn126-call-subnet-surface-verify.test.mjs` (same pattern as merged SN128 / SN127 / SN92).
- Asserts registry callability (GET/json, no-auth).
- Asserts `callSubnetSurface` against the faithful health body shape (charset-suffixed JSON).
- Asserts end-to-end MCP `tools/call` resolution by `surface_id`.

## Validation

- [x] `npm test -- tests/sn126-call-subnet-surface-verify.test.mjs` (3 passed)
- [x] Prettier clean
- [x] No UI / no `apps/ui/**`
- [x] No open PR overlap on #7134 at submission time

## Risk / tradeoffs

Hermetic mocked fetch — guards registry + tool contract regressions without live network in CI.