### PR TITLE
test(mcp): verify SN108 TalkHead health surface via call_subnet_surface (#7119)

### DIFF
--- a/tests/sn108-call-subnet-surface-verify.test.mjs
+++ b/tests/sn108-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,122 @@
+// SN108 (TalkHead) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7119, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN108's *real* registry surface config
+// (registry/subnets/talkhead.json) to the tool's contract, so a future edit
+// that regresses its callability (flipping method, marking it auth_required,
+// disabling its probe, changing expect away from `any`) is caught here.
+//
+// The surface is the public no-auth health feed
+// (GET https://api.talkhead.ai/health, no schema -- a single fixed endpoint).
+// Verified live to return HTTP 200 `text/html; charset=utf-8` with plain-text
+// body `Healthy` (not JSON) -- which is why the registry correctly sets
+// `probe.expect: "any"`. The fixture below mirrors that live response rather
+// than fetching it, keeping the test hermetic while still exercising the
+// non-JSON body path through the tool.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-108-talkhead-health";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/talkhead.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+function sn108Response() {
+  return new Response("Healthy", {
+    status: 200,
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+
+describe("SN108 TalkHead call_subnet_surface verification (#7119)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    // Live body is plain text under a text/html content-type -- not JSON.
+    assert.equal(SURFACE.probe?.expect, "any");
+    assert.equal(SURFACE.url, "https://api.talkhead.ai/health");
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the plain-text Healthy body via GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return sn108Response();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.truncated, false);
+    assert.equal(result.body, "Healthy");
+    assert.match(result.content_type, /^text\/html/i);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 108 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return sn108Response();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body, "Healthy");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #7119

## Summary

Pins SN108 TalkHead's real registry surface (`sn-108-talkhead-health` in `registry/subnets/talkhead.json`) to the `call_subnet_surface` MCP tool contract now that Phase 1 (#7014 / #7215) has shipped.

Live-verified: `GET https://api.talkhead.ai/health` returns HTTP 200 `text/html; charset=utf-8` with plain-text body `Healthy` (not JSON). Registry already has `probe.expect: any` — correct; no config change needed.

## What changed

- **One file only:** `tests/sn108-call-subnet-surface-verify.test.mjs` (same pattern as merged SN126/127/128).
- Asserts registry callability (GET + `expect: any`, no-auth).
- Asserts `callSubnetSurface` returns the plain-text `Healthy` body.
- Asserts end-to-end MCP `tools/call` resolution by `surface_id`.

## Validation

- [x] `npm test -- tests/sn108-call-subnet-surface-verify.test.mjs` (3 passed)
- [x] Prettier clean
- [x] No UI / no `apps/ui/**`
- [x] No open PR overlap on #7119 at submission time

## Risk / tradeoffs

Hermetic mocked fetch — exercises the non-JSON body path the tool must keep supporting for this surface.