### PR TITLE
fix(registry): wire SN1 Apex MCP execute probe config (#7017)

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 556,
+  "surface_count": 557,
   "surfaces": [
     {
       "auth_required": false,
@@ -191,6 +191,24 @@
       "surface_id": "opentensor-lite-wss",
       "surface_key": "srf-dcf48d017826dc4b",
       "url": "wss://lite.chain.opentensor.ai:443"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 1,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "subnet_name": "Apex",
+      "subnet_slug": "sn-1",
+      "surface_id": "sn-1-apex-healthcheck",
+      "surface_key": "srf-07941863062c55b5",
+      "url": "https://apex.api.macrocosmos.ai/healthcheck"
     },
     {
       "auth_required": false,

--- a/registry/subnets/apex.json
+++ b/registry/subnets/apex.json
@@ -174,7 +174,13 @@
       "id": "sn-1-apex-orchestrator-openapi",
       "kind": "openapi",
       "name": "Apex orchestrator API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST).",
+      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST). Live-verified 2026-07-21: GET returns 200 application/json (~70 KB OpenAPI 3.1 document, title \"FastAPI\").",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -195,7 +201,13 @@
       "id": "sn-1-apex-healthcheck",
       "kind": "subnet-api",
       "name": "Apex orchestrator healthcheck API",
-      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings.",
+      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings. Live-verified 2026-07-21: GET returns 200 {\"status\":\"healthy\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
Closes #7017

Part of #7013. Phase 1 (#7014) shipped (#7215) — `call_subnet_surface` is live.

## Scope

Confirm SN1 (Apex)'s callable surface(s) actually work end-to-end — an actual request against the live URL, not an assumption.

## Surfaces verified (live 2026-07-21)

| surface_id | method | status | response |
|---|---|---|---|
| sn-1-apex-orchestrator-openapi | GET | 200 | `application/json`, ~70 KB OpenAPI 3.1 document (title "FastAPI") |
| sn-1-apex-healthcheck | GET | 200 | `application/json`, `{"status":"healthy"}` |
| sn-1-apex-healthcheck-ready | GET | 200 | already had a correct probe, no edit needed |
| sn-1-apex-metrics | GET | 200 | already had a correct probe, no edit needed |

## Registry changes

Both `sn-1-apex-orchestrator-openapi` and `sn-1-apex-healthcheck` had **no `probe` block at all** despite their `notes` already describing observed live behavior — meaning `call_subnet_surface` had nothing to resolve against for either surface. Added:

- `sn-1-apex-orchestrator-openapi`: `{enabled: true, expect: "json", method: "GET", timeout_ms: 10000}` — matches this repo's dominant convention for `openapi`-kind surfaces (30/59 existing entries use exactly this shape).
- `sn-1-apex-healthcheck`: same shape, matching the sibling `sn-1-apex-healthcheck-ready` surface's existing probe exactly.

Both notes fields got a trailing `Live-verified 2026-07-21: ...` line documenting the actual request made, per the issue's own precedent (metagraphed#7143).

The other two issue-scoped surfaces (`healthcheck-ready`, `metrics`) already had correct probe config and required no edits — confirmed by re-requesting both live.

## Checklist

- [x] Changes exactly one registry/subnets/apex.json file (+ the derived `public/metagraph/operational-surfaces.json` artifact, regenerated via `npm run build`)
- [x] `npm run validate:surface -- registry/subnets/apex.json` passed
- [x] `npm run validate` (full gate) passed
- [x] All four issue-scoped surfaces live-probed for real responses (not assumed)

## Test plan

- [x] `npm run validate` — clean
- [ ] Gittensory Gate + CI green