### PR TITLE
test(mcp): verify SN113 TensorUSD health surfaces via call_subnet_surface (#7124)

### DIFF
--- a/tests/sn113-call-subnet-surface-verify.test.mjs
+++ b/tests/sn113-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,150 @@
+// SN113 (TensorUSD) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7124, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN113's *real* registry surface configs
+// (registry/subnets/tensorusd.json) to the tool's contract, so a future edit
+// that regresses their callability is caught here.
+//
+// Both surfaces are public no-auth GET JSON health feeds (single fixed
+// endpoints, no schema). Live-verified 2026-07-21:
+//   sn-113-tensorusd-subnet-api       GET https://api.tensorusd.com/health
+//     -> {"status":"healthy","components":{...}}
+//   sn-113-tensorusd-agent-api-health GET https://agent-api.tensorusd.com/health
+//     -> {"success":true,"data":{"status":"ok","env":"prod"}}
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const NETUID = 113;
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/tensorusd.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+
+const SURFACES = [
+  {
+    id: "sn-113-tensorusd-subnet-api",
+    url: "https://api.tensorusd.com/health",
+    body: {
+      status: "healthy",
+      components: { database: { connected: true, state: "connected" } },
+    },
+    assertBody: (b) => {
+      assert.equal(b.status, "healthy");
+      assert.equal(b.components.database.connected, true);
+    },
+  },
+  {
+    id: "sn-113-tensorusd-agent-api-health",
+    url: "https://agent-api.tensorusd.com/health",
+    body: { success: true, data: { status: "ok", env: "prod" } },
+    assertBody: (b) => {
+      assert.equal(b.success, true);
+      assert.equal(b.data.status, "ok");
+    },
+  },
+];
+
+function surfaceOf(id) {
+  return registry.surfaces.find((surface) => surface.id === id);
+}
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN113 TensorUSD call_subnet_surface verification (#7124)", () => {
+  for (const fixture of SURFACES) {
+    test(`${fixture.id}: registry surface is callable`, () => {
+      const surface = surfaceOf(fixture.id);
+      assert.ok(surface, `registry surface ${fixture.id} is present`);
+      assert.equal(surface.kind, "subnet-api");
+      assert.equal(surface.auth_required, false);
+      assert.equal(surface.probe?.enabled, true);
+      assert.equal(surface.probe?.method, "GET");
+      assert.equal(surface.probe?.expect, "json");
+      assert.equal(surface.url, fixture.url);
+      assert.equal(surface.schema_url, undefined);
+    });
+
+    test(`${fixture.id}: callSubnetSurface returns the real JSON body`, async () => {
+      const surface = surfaceOf(fixture.id);
+      let requestedUrl;
+      let requestedMethod;
+      const result = await callSubnetSurface(surface, {
+        isUnsafeUrl: async () => false,
+        fetchImpl: async (url, init) => {
+          requestedUrl = String(url);
+          requestedMethod = init.method;
+          return jsonResponse(fixture.body);
+        },
+      });
+      assert.equal(result.ok, true);
+      assert.equal(requestedUrl, surface.url);
+      assert.equal(requestedMethod, "GET");
+      assert.equal(result.status_code, 200);
+      assert.equal(result.truncated, false);
+      fixture.assertBody(result.body);
+    });
+
+    test(`${fixture.id}: end-to-end MCP tools/call by surface id`, async () => {
+      const surface = surfaceOf(fixture.id);
+      const catalog = {
+        surfaces: [{ ...surface, surface_id: surface.id, netuid: NETUID }],
+      };
+      const deps = {
+        readArtifact: async (_env, path) =>
+          path === "/metagraph/operational-surfaces.json"
+            ? { ok: true, data: catalog }
+            : { ok: false, status: 404 },
+      };
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = async (input) => {
+        const url = String(input);
+        if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+          return new Response(JSON.stringify({ Status: 0 }), {
+            headers: { "content-type": "application/dns-json" },
+          });
+        }
+        return jsonResponse(fixture.body);
+      };
+      try {
+        const response = await handleMcpRequest(
+          new Request("https://metagraph.sh/mcp", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/call",
+              params: {
+                name: "call_subnet_surface",
+                arguments: { surface_id: fixture.id },
+              },
+            }),
+          }),
+          {},
+          deps,
+        );
+        const result = (await response.json()).result;
+        assert.equal(result.isError, false);
+        assert.equal(result.structuredContent.surface_id, fixture.id);
+        assert.equal(result.structuredContent.status_code, 200);
+        fixture.assertBody(result.structuredContent.body);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #7124

## Summary

Pins SN113 TensorUSD's two real registry health surfaces (`sn-113-tensorusd-subnet-api`, `sn-113-tensorusd-agent-api-health` in `registry/subnets/tensorusd.json`) to the `call_subnet_surface` MCP tool contract now that Phase 1 (#7014 / #7215) has shipped.

Live-verified 2026-07-21:
- `GET https://api.tensorusd.com/health` → 200 JSON `{status:healthy,...}`
- `GET https://agent-api.tensorusd.com/health` → 200 JSON `{success:true,data:{status:ok}}`

No registry config changes required.

## What changed

- **One file only:** `tests/sn113-call-subnet-surface-verify.test.mjs`
- Per-surface registry callability + `callSubnetSurface` + MCP `tools/call` coverage

## Validation

- [x] `npm test -- tests/sn113-call-subnet-surface-verify.test.mjs` (6 passed)
- [x] Prettier clean · no UI · no open PR overlap on #7124