### PR TITLE
fix(registry): wire SN3 Templar MCP execute probe + live-verify (#7019)

### DIFF
--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -151,7 +151,13 @@
       "id": "sn-3-templar-health",
       "kind": "subnet-api",
       "name": "Templar Grafana health",
-      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README.",
+      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README. Live-verified 2026-07-21: HTTP 200 application/json body {\"database\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "one-covenant",
       "public_safe": true,
       "review": {
@@ -170,7 +176,7 @@
       "id": "sn-3-templar-grafana-openapi",
       "kind": "openapi",
       "name": "Templar Grafana HTTP API OpenAPI",
-      "notes": "Public no-auth OpenAPI 3.0.3 schema (title \"Grafana HTTP API.\", 208 paths) on grafana.tplr.ai/public/openapi3.json. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README; the built-in Swagger UI at grafana.tplr.ai/swagger loads this spec alongside the legacy v2 merge at public/api-merged.json.",
+      "notes": "Public no-auth OpenAPI 3.0.3 schema (title \"Grafana HTTP API.\", 208 paths) on grafana.tplr.ai/public/openapi3.json. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README; the built-in Swagger UI at grafana.tplr.ai/swagger loads this spec alongside the legacy v2 merge at public/api-merged.json. Live-verified 2026-07-21: HTTP 200 application/json OpenAPI 3.0.3, title \"Grafana HTTP API.\", 208 paths (~728 KB).",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends or updates surface(s) on exactly one subnet manifest —
`registry/subnets/templar.json`.

Closes #7019

## Surface

- Netuid: 3 (Templar)
- Kind: `subnet-api` (`sn-3-templar-health`) + `openapi` (`sn-3-templar-grafana-openapi`)
- Public URL: `https://grafana.tplr.ai/api/health` and `https://grafana.tplr.ai/public/openapi3.json`
- Source URL (proves the claim): existing `source_urls` unchanged (Templar repo + Grafana host / swagger)
- Provider slug: `one-covenant`

## What changed

Live-verified both issue-scoped surfaces (2026-07-21):

| surface_id | status | observed |
|---|---|---|
| `sn-3-templar-health` | 200 `application/json` | `{"database":"ok"}` |
| `sn-3-templar-grafana-openapi` | 200 `application/json` | OpenAPI 3.0.3, title `Grafana HTTP API.`, 208 paths (~728 KB) |

Registry edits (mirrors the SN105 Beam #7143 pattern):

- **sn-3-templar-health**: add missing `probe` (GET, expect json) so MCP execute / ops probes resolve method + expectation; append Live-verified note with the exact body observed.
- **sn-3-templar-grafana-openapi**: probe/auth/schema already matched reality; append Live-verified note confirming openapi/title/path count.

No new surfaces added. No `call_subnet_surface` tool changes.

## Checklist

- [x] Changes exactly one `registry/subnets/templar.json` file
- [x] `authority: community` / `review.state: community-submitted` preserved (probe + notes only)
- [x] URLs public and safe; `source_urls` unchanged
- [x] Public-safe: no secrets / private URLs
- [x] Does not duplicate an existing surface
- [x] Links open issue `Closes #7019`

## Validation

- [x] Live GET both URLs (results above)
- [x] `npm run validate:surface -- registry/subnets/templar.json`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)