### PR TITLE
fix(registry): live-verify SN107 Minos MCP execute surfaces (#7118)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -35,7 +35,7 @@
       "id": "sn-107-minos-subnet-api",
       "kind": "subnet-api",
       "name": "Minos Platform API",
-      "notes": "Public health/status endpoint of the Minos Platform (api.theminos.ai), the hosted round-coordination service documented in the official minos_subnet README. Unauthenticated GET returns JSON service status; the /v2/* task endpoints require hotkey auth.",
+      "notes": "Public health/status endpoint of the Minos Platform (api.theminos.ai), the hosted round-coordination service documented in the official minos_subnet README. Unauthenticated GET returns JSON service status; the /v2/* task endpoints require hotkey auth. Live-verified 2026-07-21: HTTP 200 application/json {\"status\":\"healthy\",\"version\":\"2.0.0\",\"mode\":\"active\"}.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -59,7 +59,7 @@
       "id": "sn-107-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Minos TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/107/ on api.taomarketcap.com returning machine-readable JSON for SN107 Minos on-chain subnet state, economics, registration/burn parameters, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API and provides the standalone public JSON data for netuid 107 alongside the subnet's first-party /health endpoint. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "notes": "Public no-auth GET /public/v1/subnets/107/ on api.taomarketcap.com returning machine-readable JSON for SN107 Minos on-chain subnet state, economics, registration/burn parameters, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API and provides the standalone public JSON data for netuid 107 alongside the subnet's first-party /health endpoint. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET. Live-verified 2026-07-21: HTTP 200 application/json (~4 KB) with netuid 107, is_active true, and a latest_snapshot object.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -120,7 +120,7 @@
       "id": "sn-107-minos-mcp",
       "kind": "subnet-api",
       "name": "Minos MCP (live subnet data)",
-      "notes": "Streamable-HTTP MCP server described in the official README as providing \"current round/leaderboard/miner-history data\" for the `@minos` graph and Minos MCP tooling. JSON-RPC 2.0 over SSE; a plain GET returns a protocol-negotiation error (\"Client must accept text/event-stream\") rather than 401/403, so recurring simple probes are intentionally disabled.",
+      "notes": "Streamable-HTTP MCP server described in the official README as providing \"current round/leaderboard/miner-history data\" for the `@minos` graph and Minos MCP tooling. JSON-RPC 2.0 over SSE; a plain GET returns a protocol-negotiation error (\"Client must accept text/event-stream\") rather than 401/403, so recurring simple probes are intentionally disabled. Live-verified 2026-07-21: plain GET → HTTP 406 application/json Not Acceptable (must accept text/event-stream); POST initialize with Accept text/event-stream → HTTP 200 text/event-stream, serverInfo name \"minos\" version \"1.27.2\".",
       "probe": {
         "enabled": false,
         "expect": "json",


### PR DESCRIPTION
## Add or update a subnet surface

Updates notes on exactly one subnet manifest — `registry/subnets/minos.json`.

Closes #7118

## Surface

- Netuid: 107 (Minos)
- Kind: `subnet-api` ×3 (health, TaoMarketCap snapshot, MCP)
- Public URLs:
  - `https://api.theminos.ai/health`
  - `https://api.taomarketcap.com/public/v1/subnets/107/`
  - `https://mcp.theminos.ai/`
- Source URLs: unchanged
- Provider slug: `minos` / `taomarketcap`

## Live verification (2026-07-21)

| surface_id | observed |
|---|---|
| `sn-107-minos-subnet-api` | GET → HTTP 200 `application/json` `{"status":"healthy","version":"2.0.0","mode":"active"}` |
| `sn-107-taomarketcap-subnet-api` | GET → HTTP 200 `application/json` (~4 KB) `netuid` 107, `is_active` true, `latest_snapshot` present |
| `sn-107-minos-mcp` | plain GET → HTTP 406 JSON Not Acceptable (must accept `text/event-stream`); POST `initialize` with Accept `text/event-stream` → HTTP 200 SSE, `serverInfo.name` `minos` `version` `1.27.2` |

Probe/auth/URL config already matched reality (GET/json on the two simple APIs; MCP probe intentionally `enabled: false` / `JSON-RPC`). No probe or URL edits — Live-verified notes only.

## Checklist

- [x] Changes exactly one `registry/subnets/minos.json` file
- [x] Public-safe; no secrets / private URLs
- [x] Does not duplicate an existing surface
- [x] `Closes #7118`

## Validation

- [x] Live requests for all three issue-scoped URLs (results above)
- [x] `npm run validate:surface -- registry/subnets/minos.json`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)