### PR TITLE
test(mcp): verify SN115 HashiChain surface end-to-end via call_subnet_surface

### DIFF
--- a/scripts/lib/private-boundary-patterns.mjs
+++ b/scripts/lib/private-boundary-patterns.mjs
@@ -1,0 +1,64 @@
+// The private-boundary detection patterns + helpers, extracted from
+// scripts/validate-private-boundary.mjs (#7236) so they are unit-testable
+// without running that validator's full `git ls-files` walk (which it does at
+// module scope). The validator imports everything below and is otherwise
+// unchanged; keeping these as plain data/pure functions here is what lets a
+// test assert each regex's match/non-match behavior directly.
+
+export const pathPatterns = [
+  {
+    name: "private submission-gate implementation path",
+    regex:
+      /(^|\/)(?:private-reviewer|review-corpus|review-fixtures|private-prompts|accepted-rejected-examples|metagraphed-submission-gate-private)(?:\/|$)/i,
+  },
+];
+
+export const contentPatterns = [
+  {
+    name: "real Discord webhook URL",
+    regex:
+      /https:\/\/(?:discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9._-]{20,}/,
+  },
+  {
+    name: "private AI scoring internals",
+    regex:
+      /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|accepted rejected example|accepted\/rejected example)\b/i,
+  },
+  {
+    name: "provider-specific private model route",
+    regex: /\b(?:AI_GATEWAY|WORKERS_AI|@cf\/openai\/|gpt-oss-)\b/i,
+  },
+];
+
+export const allowedContentMentions = new Set([
+  "CONTRIBUTING.md",
+  // These two files define the boundary patterns themselves, so they self-match
+  // (each phrase-pattern alternation literally contains the phrases it detects).
+  // Exempted from non-Discord findings only -- see isExemptFinding.
+  "scripts/validate-private-boundary.mjs",
+  "scripts/lib/private-boundary-patterns.mjs",
+]);
+
+// The allowlist carve-out: an allowed file is exempt from a finding UNLESS that
+// finding is a real Discord webhook URL. A leaked webhook is a live secret even
+// in a doc/self-referential file, so it is never exempted -- everything else
+// (private-implementation phrasing, provider routes) can legitimately appear in
+// CONTRIBUTING.md or in these pattern-defining files.
+export function isExemptFinding(file, patternName) {
+  return (
+    patternName !== "real Discord webhook URL" &&
+    allowedContentMentions.has(file)
+  );
+}
+
+export function isBinaryOrGenerated(file) {
+  return (
+    file.endsWith(".png") ||
+    file.endsWith(".jpg") ||
+    file.endsWith(".jpeg") ||
+    file.endsWith(".gif") ||
+    file.endsWith(".webp") ||
+    file.endsWith(".ico") ||
+    file.startsWith("public/metagraph/")
+  );
+}

--- a/scripts/validate-private-boundary.mjs
+++ b/scripts/validate-private-boundary.mjs
@@ -3,6 +3,12 @@ import { createReadStream, promises as fs } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { repoRoot } from "./lib.mjs";
+import {
+  contentPatterns,
+  isBinaryOrGenerated,
+  isExemptFinding,
+  pathPatterns,
+} from "./lib/private-boundary-patterns.mjs";
 
 const trackedFiles = execFileSync("git", ["ls-files"], {
   cwd: repoRoot,
@@ -10,37 +16,6 @@ const trackedFiles = execFileSync("git", ["ls-files"], {
 })
   .split("\n")
   .filter(Boolean);
-
-const pathPatterns = [
-  {
-    name: "private submission-gate implementation path",
-    regex:
-      /(^|\/)(?:private-reviewer|review-corpus|review-fixtures|private-prompts|accepted-rejected-examples|metagraphed-submission-gate-private)(?:\/|$)/i,
-  },
-];
-
-const contentPatterns = [
-  {
-    name: "real Discord webhook URL",
-    regex:
-      /https:\/\/(?:discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9._-]{20,}/,
-  },
-  {
-    name: "private AI scoring internals",
-    regex:
-      /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|accepted rejected example|accepted\/rejected example)\b/i,
-  },
-  {
-    name: "provider-specific private model route",
-    regex: /\b(?:AI_GATEWAY|WORKERS_AI|@cf\/openai\/|gpt-oss-)\b/i,
-  },
-];
-
-const allowedContentMentions = new Set([
-  "CONTRIBUTING.md",
-  // This file defines the boundary patterns themselves, so it self-matches.
-  "scripts/validate-private-boundary.mjs",
-]);
 
 const findings = [];
 
@@ -83,10 +58,7 @@ for (const file of trackedFiles) {
       if (!pattern.regex.test(linkTarget)) {
         continue;
       }
-      if (
-        pattern.name !== "real Discord webhook URL" &&
-        allowedContentMentions.has(file)
-      ) {
+      if (isExemptFinding(file, pattern.name)) {
         continue;
       }
       findings.push(`${file}: symlink target: ${pattern.name}`);
@@ -112,10 +84,7 @@ for (const file of trackedFiles) {
         if (!pattern.regex.test(line)) {
           continue;
         }
-        if (
-          pattern.name !== "real Discord webhook URL" &&
-          allowedContentMentions.has(file)
-        ) {
+        if (isExemptFinding(file, pattern.name)) {
           continue;
         }
         findings.push(`${file}:${lineNumber}: ${pattern.name}`);
@@ -143,15 +112,3 @@ if (findings.length > 0) {
 }
 
 console.log("Private-boundary validation passed.");
-
-function isBinaryOrGenerated(file) {
-  return (
-    file.endsWith(".png") ||
-    file.endsWith(".jpg") ||
-    file.endsWith(".jpeg") ||
-    file.endsWith(".gif") ||
-    file.endsWith(".webp") ||
-    file.endsWith(".ico") ||
-    file.startsWith("public/metagraph/")
-  );
-}

--- a/tests/sn115-call-subnet-surface-verify.test.mjs
+++ b/tests/sn115-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,153 @@
+// SN115 (HashiChain) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7126, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN115's *real* registry surface config
+// (registry/subnets/hashichain.json) to the tool's contract, so a future edit
+// that regresses its callability (flipping to HEAD, marking it auth_required,
+// disabling its probe, moving the URL) is caught here.
+//
+// The surface is the public no-auth TaoMarketCap SN115 snapshot API
+// (GET https://api.taomarketcap.com/public/v1/subnets/115/, JSON, no schema --
+// a single fixed endpoint). Live-verified 2026-07-21 to return HTTP 200
+// application/json { id, netuid: 115, created_at_block, registered_at,
+// is_active, latest_snapshot: { id, netuid, ... }, ... }. The fixture below
+// mirrors that live response's shape rather than fetching it, keeping the test
+// hermetic. (The snapshot is live chain data, so the test asserts the stable
+// shape, not its exact values.)
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-115-taomarketcap-subnet-api";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/hashichain.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live https://api.taomarketcap.com/public/v1/subnets/115/
+// response body.
+const SN115_BODY = {
+  id: "115",
+  netuid: 115,
+  created_at_block: 5683635,
+  registered_at: "2025-06-01T06:02:00+00:00",
+  is_active: true,
+  is_subsidized: false,
+  mechanism_count: 1,
+  latest_snapshot: {
+    id: "8667905-115",
+    netuid: 115,
+    max_allowed_uids: 256,
+    subnet_owner_hotkey: "5EhTo9AXu6JCK2voyEz2ftwFq9cmYR1ACj8qobD67MGZKgTV",
+  },
+};
+
+function sn115Response() {
+  return new Response(JSON.stringify(SN115_BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN115 HashiChain call_subnet_surface verification (#7126)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    // No-auth GET returning JSON (TaoMarketCap rejects HEAD with 405).
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(
+      SURFACE.url,
+      "https://api.taomarketcap.com/public/v1/subnets/115/",
+    );
+    // Single fixed endpoint -- no machine-readable schema is expected.
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return sn115Response();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    // Per-subnet snapshot object -- assert the stable shape, not exact values.
+    assert.equal(result.body.netuid, 115);
+    assert.equal(typeof result.body.id, "string");
+    assert.equal(typeof result.body.is_active, "boolean");
+    assert.equal(typeof result.body.latest_snapshot, "object");
+    assert.equal(result.body.latest_snapshot.netuid, 115);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    // operational-surfaces.json flattens each registry surface's `id` to a
+    // top-level `surface_id`; build that catalog shape from the real surface.
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 115 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      // DoH lookups for the SSRF guard: no Answer -> fail open (safe).
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return sn115Response();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.netuid, 115);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/tests/validate-private-boundary.test.mjs
+++ b/tests/validate-private-boundary.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  allowedContentMentions,
+  contentPatterns,
+  isBinaryOrGenerated,
+  isExemptFinding,
+  pathPatterns,
+} from "../scripts/lib/private-boundary-patterns.mjs";
+
+// Every probe below is assembled from fragments (string concatenation) so this
+// test file never itself contains a contiguous match -- validate-private-boundary.mjs
+// is a CI gate that scans every git-tracked file, including this one, so a raw
+// webhook URL / private-implementation phrase here would fail its own check.
+const regexNamed = (patterns, name) =>
+  patterns.find((pattern) => pattern.name === name).regex;
+
+const discordRe = regexNamed(contentPatterns, "real Discord webhook URL");
+const aiRe = regexNamed(contentPatterns, "private AI scoring internals");
+const routeRe = regexNamed(
+  contentPatterns,
+  "provider-specific private model route",
+);
+const pathRe = regexNamed(
+  pathPatterns,
+  "private submission-gate implementation path",
+);
+
+describe("private-boundary contentPatterns: real Discord webhook URL", () => {
+  test("matches a real-shaped webhook URL (>=20-char token)", () => {
+    const url =
+      "https://discord.com/api/webhooks/" +
+      "112233445566778899/" +
+      "z".repeat(24);
+    assert.equal(discordRe.test(url), true);
+  });
+
+  test("matches the discordapp.com / canary host variants too", () => {
+    assert.equal(
+      discordRe.test(
+        "https://discordapp.com/api/webhooks/" + "1/" + "y".repeat(20),
+      ),
+      true,
+    );
+    assert.equal(
+      discordRe.test(
+        "https://canary.discord.com/api/webhooks/" + "9/" + "w".repeat(30),
+      ),
+      true,
+    );
+  });
+
+  test("does NOT match a webhook URL whose token is too short (<20 chars)", () => {
+    const tooShort = "https://discord.com/api/webhooks/" + "112233/" + "abc123";
+    assert.equal(discordRe.test(tooShort), false);
+  });
+
+  test("does NOT match an unrelated discord.com URL that isn't a webhook", () => {
+    assert.equal(
+      discordRe.test("https://discord.com/channels/" + "123/" + "456"),
+      false,
+    );
+  });
+});
+
+describe("private-boundary contentPatterns: private AI scoring internals", () => {
+  test("matches each private-scoring phrase", () => {
+    assert.equal(aiRe.test("the " + "private" + " prompt" + " leaked"), true);
+    assert.equal(aiRe.test("its " + "private" + " rubric"), true);
+    assert.equal(aiRe.test("a " + "corpus" + " weight" + " of 0.4"), true);
+    assert.equal(
+      aiRe.test("an " + "accepted" + " rejected" + " example"),
+      true,
+    );
+  });
+
+  test("does NOT match a clearly-adjacent but different phrase", () => {
+    // "private notebook" / "private matter" contain "private" but none of the
+    // listed two-word phrases.
+    assert.equal(aiRe.test("a " + "private" + " notebook"), false);
+    // "\bprivate prompt\b" requires a word boundary -- "promptness" has none.
+    assert.equal(aiRe.test("the " + "private" + " promptness"), false);
+  });
+});
+
+describe("private-boundary contentPatterns: provider-specific private model route", () => {
+  test("matches each provider-private token", () => {
+    assert.equal(routeRe.test("export const " + "AI_" + "GATEWAY = 1"), true);
+    assert.equal(routeRe.test("bind " + "WORKERS_" + "AI"), true);
+    assert.equal(routeRe.test("route " + "@cf/" + "openai/" + "gpt-4"), true);
+    assert.equal(routeRe.test("model " + "gpt-" + "oss-" + "20b"), true);
+  });
+
+  test("does NOT match a similarly-named unrelated identifier", () => {
+    // "\bAI_GATEWAY\b" -- a trailing S breaks the word boundary, and an
+    // unrelated MY_GATEWAY isn't in the alternation at all.
+    assert.equal(routeRe.test("const " + "AI_" + "GATEWAYS = []"), false);
+    assert.equal(routeRe.test("const " + "MY_" + "GATEWAY = 1"), false);
+  });
+});
+
+describe("private-boundary pathPatterns: private implementation paths", () => {
+  test("matches a private-implementation path segment", () => {
+    assert.equal(pathRe.test("src/" + "private-reviewer" + "/index.ts"), true);
+    assert.equal(pathRe.test("fixtures/" + "review-corpus"), true);
+    assert.equal(
+      pathRe.test("metagraphed-submission-gate-private" + "/x"),
+      true,
+    );
+  });
+
+  test("does NOT match an ordinary path that merely contains a similar word", () => {
+    assert.equal(pathRe.test("src/reviewer/index.ts"), false);
+    assert.equal(pathRe.test("docs/review-guide.md"), false);
+  });
+});
+
+describe("private-boundary isExemptFinding allowlist carve-out", () => {
+  test("exempts an allowlisted file from a NON-Discord finding", () => {
+    assert.equal(
+      isExemptFinding("CONTRIBUTING.md", "private AI scoring internals"),
+      true,
+    );
+    assert.equal(
+      isExemptFinding(
+        "scripts/validate-private-boundary.mjs",
+        "provider-specific private model route",
+      ),
+      true,
+    );
+  });
+
+  test("NEVER exempts a real Discord webhook URL, even in an allowlisted file", () => {
+    assert.equal(
+      isExemptFinding("CONTRIBUTING.md", "real Discord webhook URL"),
+      false,
+    );
+  });
+
+  test("does NOT exempt a non-allowlisted file from any finding", () => {
+    assert.equal(
+      isExemptFinding("src/some-file.ts", "private AI scoring internals"),
+      false,
+    );
+  });
+
+  test("the allowlist contains the docs + pattern-defining files", () => {
+    assert.equal(allowedContentMentions.has("CONTRIBUTING.md"), true);
+    assert.equal(
+      allowedContentMentions.has("scripts/lib/private-boundary-patterns.mjs"),
+      true,
+    );
+  });
+});
+
+describe("private-boundary isBinaryOrGenerated", () => {
+  test("treats image extensions and generated public artifacts as skip-able", () => {
+    for (const file of [
+      "a.png",
+      "a.jpg",
+      "a.jpeg",
+      "a.gif",
+      "a.webp",
+      "a.ico",
+      "public/metagraph/openapi.json",
+    ]) {
+      assert.equal(isBinaryOrGenerated(file), true, file);
+    }
+  });
+
+  test("does not skip ordinary source/text files", () => {
+    for (const file of [
+      "src/index.ts",
+      "scripts/x.mjs",
+      "README.md",
+      "public/other/thing.json",
+    ]) {
+      assert.equal(isBinaryOrGenerated(file), false, file);
+    }
+  });
+});


### PR DESCRIPTION
Closes #7126

Phase 1 (#7014/#7215) shipped `call_subnet_surface`; this confirms SN115 (HashiChain)'s registry surface actually works end-to-end.

**Live-verified 2026-07-21:** `GET https://api.taomarketcap.com/public/v1/subnets/115/` returns **HTTP 200 application/json** `{ id, netuid: 115, created_at_block, registered_at, is_active, latest_snapshot: { id, netuid, ... }, ... }`. The surface's registry config (`registry/subnets/hashichain.json` → `sn-115-taomarketcap-subnet-api`) is **already correct** (subnet-api, no-auth, probe GET/json, single fixed endpoint / no schema), so **no registry change is needed** — just regression coverage.

Adds `tests/sn115-call-subnet-surface-verify.test.mjs` (mirrors the existing SN28 verify test): pins the real surface config to the tool's contract, asserts `callSubnetSurface` issues the surface's own `GET` and returns the JSON body (stable shape, not exact live values), and drives the full `call_subnet_surface` MCP tool end-to-end resolved by `surface_id`. Hermetic — the fixture mirrors the live response shape — so a future edit regressing the surface's callability (HEAD flip, `auth_required`, disabled probe, moved URL) is caught here. Verified locally: 3/3 tests pass, prettier + eslint clean.