### PR TITLE
test(mcp): verify SN96 Verathos models-api surface via call_subnet_surface (#7108)

### DIFF
--- a/tests/sn96-call-subnet-surface-verify.test.mjs
+++ b/tests/sn96-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,139 @@
+// SN96 (Verathos) end-to-end verification for the call_subnet_surface MCP tool
+// (metagraphed#7108, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN96's *real* registry surface config
+// (registry/subnets/verathos.json) to the tool's contract, so a future edit that
+// regresses its callability (flipping to HEAD, marking it auth_required,
+// disabling its probe) is caught here.
+//
+// The surface is the public no-auth Verathos model list API
+// (sn-96-verathos-models-api, GET https://api.verathos.ai/v1/models, JSON).
+// Live-verified 2026-07-21 to return HTTP 200 application/json
+// { object: "list", data: [ { id, architecture, ... } ] }.
+// The fixture below mirrors that live response's shape rather than fetching it,
+// keeping the test hermetic. (The model list is live data, so the test asserts
+// the stable list shape, not its exact contents.)
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-96-verathos-models-api";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/verathos.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live https://api.verathos.ai/v1/models response body.
+const BODY = {
+  object: "list",
+  data: [
+    {
+      id: "qwen3.5-9b",
+      architecture: "dense",
+    },
+  ],
+};
+
+function upstreamResponse() {
+  return new Response(JSON.stringify(BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN96 Verathos call_subnet_surface verification (#7108)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    // No-auth GET returning JSON.
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(SURFACE.url, "https://api.verathos.ai/v1/models");
+    // Machine-readable schema is linked via the OpenAPI surface.
+    assert.equal(SURFACE.schema_url, "https://verathos.ai/openapi.json");
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    // OpenAI-compatible model list -- assert the stable shape, not exact models.
+    assert.equal(result.body.object, "list");
+    assert.ok(Array.isArray(result.body.data));
+    assert.equal(typeof result.body.data[0].id, "string");
+    assert.equal(typeof result.body.data[0].architecture, "string");
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 96 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      // DoH lookups for the SSRF guard: no Answer -> fail open (safe).
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.object, "list");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #7108

## Verification (real request, 2026-07-21)

| Surface | Request | Result |
| --- | --- | --- |
| `sn-96-verathos-models-api` | `GET https://api.verathos.ai/v1/models` | **HTTP 200** `application/json` — `{"object":"list","data":[{"id":"qwen3.5-9b","architecture":"dense",...}]}` |

No-auth GET, JSON model list, works end-to-end. The surface's registry config (subnet-api, `auth_required: false`, probe `enabled`+`GET`+`json`, `schema_url` pointing to the linked OpenAPI) already matches reality, so this pins it with a regression test (the "welcome" deliverable in #7108), mirroring the merged SN44/SN28/SN43/SN33 verify tests.

## What the test does

`tests/sn96-call-subnet-surface-verify.test.mjs` (3 tests):

1. **Config pin** — reads `registry/subnets/verathos.json` and asserts the surface has `kind: subnet-api`, `auth_required: false`, probe enabled with `GET`+`json`, the correct URL, and the linked `schema_url`.
2. **callSubnetSurface unit** — calls `callSubnetSurface(SURFACE, { fetchImpl })` with a hermetic fixture (faithful subset of the live response shape) and asserts `ok: true`, correct URL/method forwarding, `status_code: 200`, `content_type: application/json`, the list `object` field, and that `data` is an array with string `id` and `architecture` fields.
3. **MCP end-to-end** — drives the full `call_subnet_surface` MCP tool path via `handleMcpRequest`, asserts `isError: false`, correct `surface_id` and `status_code` in `structuredContent`, and the list `object` field.

## Validation

- [x] `GET https://api.verathos.ai/v1/models` → HTTP 200 `application/json` (live-verified 2026-07-21)
- [x] Surface registry config matches reality (probe enabled, GET, json, schema_url set)
- [x] Hermetic fixture mirrors the stable live response shape
- [x] All 3 tests pass locally: `npx vitest run tests/sn96-call-subnet-surface-verify.test.mjs`
- [x] `npx prettier --check tests/sn96-call-subnet-surface-verify.test.mjs` — clean