### PR TITLE
fix(registry): SN14 Cacheon — add missing probe config for MCP execute (#7030)

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -194,7 +194,13 @@
       "id": "sn-14-cacheon-leader-api",
       "kind": "subnet-api",
       "name": "Cacheon current leader API",
-      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data.",
+      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data. Live-verified 2026-07-21: GET returns 200 application/json (~840 B leader record).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -213,7 +219,13 @@
       "id": "sn-14-cacheon-health",
       "kind": "subnet-api",
       "name": "Cacheon API health",
-      "notes": "Public no-auth GET /api/health on api.cacheon.ai returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /api/health in the subnet OpenAPI spec on the same host as the existing /api/status and /api/leader subnet-api surfaces.",
+      "notes": "Public no-auth GET /api/health on api.cacheon.ai returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /api/health in the subnet OpenAPI spec on the same host as the existing /api/status and /api/leader subnet-api surfaces. Live-verified 2026-07-21: GET returns 200 {\"status\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -232,7 +244,13 @@
       "id": "sn-14-cacheon-rounds-api",
       "kind": "subnet-api",
       "name": "Cacheon evaluation rounds API",
-      "notes": "Public no-auth GET returning evaluation round history with challenger counts, scores, speed improvement, and per-round evaluation metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/rounds); same host as the existing /api/status and /api/leader subnet-api surfaces.",
+      "notes": "Public no-auth GET returning evaluation round history with challenger counts, scores, speed improvement, and per-round evaluation metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/rounds); same host as the existing /api/status and /api/leader subnet-api surfaces. Live-verified 2026-07-21: GET returns 200 application/json (~95 KB round history).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -251,7 +269,13 @@
       "id": "sn-14-cacheon-leader-history-api",
       "kind": "subnet-api",
       "name": "Cacheon leader overtake history API",
-      "notes": "Public no-auth GET returning leader overtake history with timestamps, blocks, leader UID, scores, and image metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader/history); same host as the existing /api/status, /api/leader, and /api/rounds subnet-api surfaces.",
+      "notes": "Public no-auth GET returning leader overtake history with timestamps, blocks, leader UID, scores, and image metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader/history); same host as the existing /api/status, /api/leader, and /api/rounds subnet-api surfaces. Live-verified 2026-07-21: GET returns 200 application/json (~24 KB history).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
Closes #7030

Part of #7013. Phase 1 (#7014) shipped (#7215) — `call_subnet_surface` is live.

## Scope

Confirm SN14 (Cacheon)'s callable surface(s) actually work end-to-end — an actual request against the live URL, not an assumption.

## Surfaces verified (live 2026-07-21)

| surface_id | method | status | response |
|---|---|---|---|
| sn-14-cacheon-leader-api | GET | 200 | `application/json`, ~840 B leader record (uid, hotkey, image, score, ...) |
| sn-14-cacheon-health | GET | 200 | `application/json`, `{"status":"ok"}` |
| sn-14-cacheon-rounds-api | GET | 200 | `application/json`, ~95 KB round-history array |
| sn-14-cacheon-leader-history-api | GET | 200 | `application/json`, ~24 KB overtake history |
| sn-14-cacheon-openapi | GET | 200 | already had a correct probe, no edit needed |
| sn-14-cacheon-subnet-api | GET | 200 | already had a correct probe, no edit needed |
| sn-14-cacheon-evaluations | GET | 200 | already had a correct probe, no edit needed |
| sn-14-cacheon-eval-progress | GET | 200 | already had a correct probe, no edit needed |
| sn-14-cacheon-validator-logs | GET | 200 | already had a correct probe, no edit needed |
| sn-14-cacheon-eval-job | GET | 200 | already had a correct probe, no edit needed |

## Registry changes

Four SN14 surfaces (`leader-api`, `health`, `rounds-api`, `leader-history-api`) had **no `probe` block at all**, despite their `notes` already documenting expected behavior — meaning `call_subnet_surface` had nothing to resolve against for any of the four. Added a probe to each:

- All four: `{enabled: true, expect: "json", method: "GET", timeout_ms: 10000}` — matches the sibling `sn-14-cacheon-evaluations`/`eval-progress`/`validator-logs`/`eval-job` surfaces' existing probe shape exactly (same host, same JSON-API pattern).

Each notes field got a trailing `Live-verified 2026-07-21: ...` line documenting the actual request made, per precedent metagraphed#7143 (which this PR matches exactly in scope — registry file only, no derived-artifact companion diff).

The remaining six issue-scoped surfaces already had correct probe config and required no edits — confirmed by re-requesting each live.

## Checklist

- [x] Changes exactly one file: registry/subnets/cacheon.json
- [x] `npm run validate:surface -- registry/subnets/cacheon.json` passed
- [x] All ten issue-scoped surfaces live-probed for real responses (not assumed)

## Test plan

- [x] `npm run validate:surface` — clean
- [ ] Gittensory Gate + CI green
