### PR TITLE
test(sn118): verify Ditto call_subnet_surface

### DIFF
--- a/tests/sn118-call-subnet-surface-verify.test.mjs
+++ b/tests/sn118-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,126 @@
+// SN118 (Ditto) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7128, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN118's *real* no-auth GET JSON
+// registry surface (registry/subnets/ditto.json) to the tool's contract.
+//
+// Live-verified 2026-07-21:
+//   sn-118-taomarketcap-subnet-api  GET https://api.taomarketcap.com/public/v1/subnets/118/
+//     -> TaoMarketCap subnet snapshot JSON (netuid 118)
+// Website/docs/HTML surfaces and the OpenAPI swagger doc (kind "openapi",
+// not in OPERATIONAL_SURFACE_KINDS) are out of scope for this Path B verify.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-118-taomarketcap-subnet-api";
+const NETUID = 118;
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/ditto.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+const BODY = {
+  id: "118",
+  netuid: 118,
+  is_active: true,
+  latest_snapshot: { id: "8667000-118", netuid: 118 },
+};
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN118 Ditto call_subnet_surface verification (#7128)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(
+      SURFACE.url,
+      "https://api.taomarketcap.com/public/v1/subnets/118/",
+    );
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the TaoMarketCap JSON body via GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return jsonResponse(BODY);
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.truncated, false);
+    assert.equal(result.body.netuid, 118);
+    assert.equal(result.body.latest_snapshot.netuid, 118);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: NETUID }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return jsonResponse(BODY);
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.netuid, 118);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds hermetic Path B verify tests for SN118 Ditto `call_subnet_surface`.
- Covers `sn-118-taomarketcap-subnet-api` (live-probed 200 JSON, netuid 118).
- OpenAPI/HTML surfaces omitted (not operational MCP catalog kinds).
- Mirrors merged SN109 TMC verify pattern; no UI, no registry edits.

Closes #7128

## Test plan
- [x] `npx vitest run tests/sn118-call-subnet-surface-verify.test.mjs`
- [ ] CI green on this PR