### PR TITLE
test(mcp): verify SN69 ain TaoMarketCap surface via call_subnet_surface

### DIFF
--- a/tests/sn69-call-subnet-surface-verify.test.mjs
+++ b/tests/sn69-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,142 @@
+// SN69 (ain) end-to-end verification for the call_subnet_surface MCP tool
+// (metagraphed#7082, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN69's *real* registry surface config
+// (registry/subnets/ain.json) to the tool's contract, so a future edit that
+// regresses its callability (flipping to HEAD, marking it auth_required,
+// disabling its probe) is caught here.
+//
+// The surface is the public no-auth TaoMarketCap SN69 subnet snapshot API
+// (sn-69-taomarketcap-subnet-api,
+// GET https://api.taomarketcap.com/public/v1/subnets/69/, JSON, single fixed
+// endpoint -- no schema). Live-verified 2026-07-21 to return HTTP 200
+// application/json with {id:"69", netuid:69, is_active, latest_snapshot, ...}.
+// The fixture below mirrors that live response's stable shape rather than
+// fetching it, keeping the test hermetic while still exercising the JSON
+// parse-and-return path. (Snapshot/emission fields are live data, so the
+// test asserts the stable identity fields, not exact economics values.)
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-69-taomarketcap-subnet-api";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/ain.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live /public/v1/subnets/69/ response body.
+const BODY = {
+  id: "69",
+  netuid: 69,
+  is_active: true,
+  latest_snapshot: { id: "8668171-69", netuid: 69 },
+};
+
+function upstreamResponse() {
+  return new Response(JSON.stringify(BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN69 ain call_subnet_surface verification (#7082)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    // No-auth GET returning JSON. Notes document that HEAD returns 405.
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(
+      SURFACE.url,
+      "https://api.taomarketcap.com/public/v1/subnets/69/",
+    );
+    // Single fixed endpoint -- no machine-readable schema is expected.
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    // Live subnet snapshot -- assert the stable identity fields.
+    assert.equal(result.body.id, "69");
+    assert.equal(result.body.netuid, 69);
+    assert.equal(typeof result.body.is_active, "boolean");
+    assert.equal(typeof result.body.latest_snapshot, "object");
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    // operational-surfaces.json flattens each registry surface's `id` to a
+    // top-level `surface_id`; build that catalog shape from the real surface.
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 69 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      // DoH lookups for the SSRF guard: no Answer -> fail open (safe).
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.netuid, 69);
+      assert.equal(result.structuredContent.body.id, "69");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- live-verified SN69's `sn-69-taomarketcap-subnet-api` surface from #7082 against its exact catalogued URL and confirmed the registry already matches reality (no registry change needed)
- adds `tests/sn69-call-subnet-surface-verify.test.mjs` following the established `tests/*-call-subnet-surface-verify.test.mjs` pattern (SN63/SN68/SN75), pinning the real registry config to the tool's contract so a future edit that regresses callability is caught

## Live verification (2026-07-21, direct request to the catalogued URL)
- `sn-69-taomarketcap-subnet-api`: GET `https://api.taomarketcap.com/public/v1/subnets/69/` returned HTTP 200 `application/json` (3,857 bytes) with `{id:"69", netuid:69, is_active, latest_snapshot, ...}`
- Registry already correct: `kind: subnet-api`, `auth_required: false`, `probe.enabled: true`, `probe.method: GET`, `probe.expect: json`, no schema (single fixed endpoint)

## Validation
- `npx vitest run tests/sn69-call-subnet-surface-verify.test.mjs` — 3 tests pass
- `npx eslint` + `npx prettier --check` — clean
- `npm run validate:private-boundary` — passed

Closes #7082