### PR TITLE
fix(registry): wire SN9 iota MCP execute probe config (#7025)

### DIFF
--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -109,7 +109,13 @@
       "id": "sn-9-iota-openapi",
       "kind": "openapi",
       "name": "IOTA orchestrator API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo.",
+      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo. Live-verified 2026-07-21: HTTP 200 application/json (~83 KB), OpenAPI 3.1 document (FastAPI).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -127,7 +133,13 @@
       "id": "sn-9-iota-healthcheck",
       "kind": "subnet-api",
       "name": "IOTA orchestrator healthcheck",
-      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec.",
+      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec. Live-verified 2026-07-21: HTTP 200 application/json, body {\"status\":\"healthy\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN9 (iota) for MCP execute (`call_subnet_surface`, #7013) by adding the missing `probe` config on the two surfaces that lacked it, and live-verifying all four issue-scoped endpoints.

Closes #7025

## Surfaces verified (live 2026-07-21, direct GET against each URL)

| surface_id | status | response |
|---|---|---|
| sn-9-iota-openapi | 200 | OpenAPI 3.1 JSON, FastAPI schema (~83 KB) |
| sn-9-iota-healthcheck | 200 | JSON `{"status":"healthy"}` |
| sn-9-iota-metrics | 200 | Prometheus text exposition, text/plain (~67 KB) — matches its existing `expect: any` probe |
| sn-9-iota-run-info | 200 | JSON array of run records: run_id, num_miners, whitelisted (~2.5 KB) |

## Registry changes

- **sn-9-iota-openapi**: add probe (GET, expect: json) — was missing despite captured schema
- **sn-9-iota-healthcheck**: add probe (GET, expect: json) — was missing

Both wired surfaces gain a dated `Live-verified 2026-07-21: …` note recording the observed status, content type, and response shape. The metrics and run-info surfaces already had correct probe config (including metrics' `expect: any`, correct for its Prometheus text/plain output) and required no edits.

## Checklist

- [x] Changes exactly one `registry/subnets/iota.json` file
- [x] `npm run validate:surface -- registry/subnets/iota.json` passed (8 surfaces)
- [x] All four issue-scoped surfaces live-probed with direct GETs; every claim above traces to a request actually made
- [x] No health/`verification` fields touched (probe config + notes only)

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Post-merge: wired surfaces resolvable through `call_subnet_surface` (healthcheck is the natural smoke test)