### PR TITLE
test(mcp): verify SN12 Compute Horde surface end-to-end via call_subnet_surface

### DIFF
--- a/tests/compute-horde-call-subnet-surface-verify.test.mjs
+++ b/tests/compute-horde-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,142 @@
+// SN12 (Compute Horde) end-to-end verification for the call_subnet_surface
+// MCP tool (metagraphed#7028, MCP execute Phase 1 follow-up #7014/#7215).
+// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool
+// wiring with synthetic surfaces -- this file pins SN12's registry surface
+// (registry/subnets/compute-horde.json) to the tool's contract, so a future
+// edit that regresses its callability (flipping to HEAD, marking it
+// auth_required, disabling its probe) is caught here.
+//
+// The surface is the public no-auth Grafana OpenAPI schema
+// (sn-12-compute-horde-grafana-openapi, GET
+// https://grafana.bittensor.church/public/openapi3.json, JSON, has captured
+// schema). Live-verified 2026-07-21 to return HTTP 200 application/json (a
+// ~735 KB OpenAPI 3 document). The fixture below mirrors the shape of that
+// live response with a minimal document rather than fetching it, keeping
+// the test hermetic while still exercising the JSON parse-and-return path.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-12-compute-horde-grafana-openapi";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/compute-horde.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live Grafana OpenAPI document's shape.
+const BODY = {
+  components: {
+    responses: {
+      GetAllIntervalsResponse: {
+        content: {
+          "application/json": {
+            schema: {
+              type: "array",
+              items: { $ref: "#/components/schemas/GettableTimeIntervals" },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+function upstreamResponse() {
+  return new Response(JSON.stringify(BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN12 Compute Horde call_subnet_surface verification (#7028)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "openapi");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(
+      SURFACE.url,
+      "https://grafana.bittensor.church/public/openapi3.json",
+    );
+    assert.equal(SURFACE.schema_url, SURFACE.url);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    assert.deepEqual(result.body, BODY);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 12 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.deepEqual(result.structuredContent.body, BODY);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #7028

Part of #7013. Phase 1 (#7014) shipped (#7215) — `call_subnet_surface` is live.

## Scope

Confirm SN12 (Compute Horde)'s callable surface(s) actually work end-to-end — an actual request against the live URL, not an assumption.

## Verification (real request, 2026-07-21)

| Surface | Request | Result |
| --- | --- | --- |
| `sn-12-compute-horde-grafana-openapi` | `GET https://grafana.bittensor.church/public/openapi3.json` | **HTTP 200** `application/json` — ~735 KB OpenAPI 3 document |

No-auth GET, has a captured schema, works end-to-end. The surface's registry config (`openapi`, `auth_required: false`, probe `enabled`+`GET`+`json`, `schema_url` matching `url`) already matches reality, so this pins it with a regression test (the "welcome" deliverable in #7028), mirroring the merged SN37/SN43/SN90… verify tests.

## What the test does

- Asserts the real `registry/subnets/compute-horde.json` surface is configured callable (kind, no-auth, probe enabled + `GET` + `json`, canonical url, schema_url matches url).
- `callSubnetSurface` issues the exact `GET` and returns the parsed JSON body.
- End-to-end through the `call_subnet_surface` MCP tool resolved by `surface_id`.
- Hermetic fixture mirroring the live document's shape — no network in CI.

## Validation

- [x] `npx vitest run tests/compute-horde-call-subnet-surface-verify.test.mjs` — 3 passed
- [x] eslint on the file · `npx prettier --check` — clean
- [x] One new file only: `tests/compute-horde-call-subnet-surface-verify.test.mjs`
