### PR TITLE
test(mcp): verify SN85 Vidaio surfaces end-to-end via call_subnet_surface

### DIFF
--- a/tests/sn85-call-subnet-surface-verify.test.mjs
+++ b/tests/sn85-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,178 @@
+// SN85 (Vidaio) end-to-end verification for the call_subnet_surface MCP tool
+// (metagraphed#7098, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN85's three *real* registry surfaces
+// (registry/subnets/vidaio.json) to the tool's contract, so a future edit that
+// regresses their callability (marking one auth_required, moving a URL, or --
+// for the two probe-less health endpoints -- adding a HEAD probe that would
+// change how call_subnet_surface calls them) is caught here.
+//
+// All three live-verified 2026-07-21 to return HTTP 200 application/json:
+//   - sn-85-vidaio-openapi GET https://api.vidaio.io/openapi.json -> OpenAPI 3.1 doc
+//   - sn-85-vidaio-health  GET https://api.vidaio.io/health       -> { status: "ok" }
+//   - sn-85-vidaio-ready   GET https://api.vidaio.io/ready        -> { status: "ok" }
+// health/ready carry no `probe` block; call_subnet_surface defaults to GET when
+// a surface has no probe.method (src/call-subnet-surface.mjs), so they are
+// callable as-is. Fixtures below mirror the live shapes, keeping the test
+// hermetic (bodies are live data, so the test asserts the stable shape only).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const NETUID = 85;
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/vidaio.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const surfaceById = (id) => registry.surfaces.find((s) => s.id === id);
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function callThroughMcpTool(surface, body) {
+  const catalog = {
+    surfaces: [{ ...surface, surface_id: surface.id, netuid: NETUID }],
+  };
+  const deps = {
+    readArtifact: async (_env, path) =>
+      path === "/metagraph/operational-surfaces.json"
+        ? { ok: true, data: catalog }
+        : { ok: false, status: 404 },
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+      return new Response(JSON.stringify({ Status: 0 }), {
+        headers: { "content-type": "application/dns-json" },
+      });
+    }
+    return jsonResponse(body);
+  };
+  try {
+    const httpResponse = await handleMcpRequest(
+      new Request("https://metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "call_subnet_surface",
+            arguments: { surface_id: surface.id },
+          },
+        }),
+      }),
+      {},
+      deps,
+    );
+    return (await httpResponse.json()).result;
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+const SURFACES = [
+  {
+    id: "sn-85-vidaio-openapi",
+    kind: "openapi",
+    url: "https://api.vidaio.io/openapi.json",
+    hasProbe: true,
+    hasSchema: true,
+    body: {
+      openapi: "3.1.0",
+      info: { title: "Vidaio API", version: "1.0.0" },
+      paths: {},
+    },
+    assertShape: (body) => {
+      assert.equal(typeof body.openapi, "string");
+      assert.equal(typeof body.info, "object");
+    },
+  },
+  {
+    id: "sn-85-vidaio-health",
+    kind: "subnet-api",
+    url: "https://api.vidaio.io/health",
+    hasProbe: false,
+    hasSchema: false,
+    body: { status: "ok" },
+    assertShape: (body) => {
+      assert.equal(body.status, "ok");
+    },
+  },
+  {
+    id: "sn-85-vidaio-ready",
+    kind: "subnet-api",
+    url: "https://api.vidaio.io/ready",
+    hasProbe: false,
+    hasSchema: false,
+    body: { status: "ok" },
+    assertShape: (body) => {
+      assert.equal(body.status, "ok");
+    },
+  },
+];
+
+for (const spec of SURFACES) {
+  describe(`SN85 Vidaio ${spec.id} call_subnet_surface verification (#7098)`, () => {
+    const SURFACE = surfaceById(spec.id);
+
+    test("the registry surface exists and is configured to be callable", () => {
+      assert.ok(SURFACE, `registry surface ${spec.id} is present`);
+      assert.equal(SURFACE.kind, spec.kind);
+      assert.equal(SURFACE.auth_required, false);
+      assert.equal(SURFACE.url, spec.url);
+      if (spec.hasProbe) {
+        assert.equal(SURFACE.probe?.enabled, true);
+        // A non-HEAD probe -> call_subnet_surface issues a GET.
+        assert.notEqual(SURFACE.probe?.method, "HEAD");
+      } else {
+        // No probe block: call_subnet_surface defaults to GET (see below).
+        assert.ok(!SURFACE.probe);
+      }
+      if (spec.hasSchema) {
+        assert.equal(typeof SURFACE.schema_url, "string");
+      } else {
+        assert.equal(SURFACE.schema_url, undefined);
+      }
+    });
+
+    test("callSubnetSurface issues a GET to the surface's own url and returns the JSON body", async () => {
+      let requestedUrl;
+      let requestedMethod;
+      const result = await callSubnetSurface(SURFACE, {
+        isUnsafeUrl: async () => false,
+        fetchImpl: async (url, init) => {
+          requestedUrl = String(url);
+          requestedMethod = init.method;
+          return jsonResponse(spec.body);
+        },
+      });
+      assert.equal(result.ok, true);
+      assert.equal(requestedUrl, SURFACE.url);
+      assert.equal(requestedMethod, "GET");
+      assert.equal(result.status_code, 200);
+      assert.equal(result.content_type, "application/json");
+      spec.assertShape(result.body);
+    });
+
+    test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+      const result = await callThroughMcpTool(SURFACE, spec.body);
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, spec.id);
+      assert.equal(result.structuredContent.status_code, 200);
+      spec.assertShape(result.structuredContent.body);
+    });
+  });
+}


### PR DESCRIPTION
Closes #7098

Phase 1 (#7014/#7215) shipped `call_subnet_surface`; this confirms SN85 (Vidaio)'s three callable surfaces work end-to-end.

**All three live-verified 2026-07-21** to return **HTTP 200 application/json**:
- `sn-85-vidaio-openapi` — OpenAPI 3.1 document
- `sn-85-vidaio-health` — `{ status: "ok" }`
- `sn-85-vidaio-ready` — `{ status: "ok" }`

Registry config (`registry/subnets/vidaio.json`) is **already correct**, so **no registry change is needed**: `openapi` carries its `schema_url` + GET probe; `health`/`ready` have no `probe` block, and `call_subnet_surface` defaults to `GET` when a surface has no `probe.method` (`src/call-subnet-surface.mjs`), so they are callable as-is.

Adds `tests/sn85-call-subnet-surface-verify.test.mjs` (mirrors the merged SN28/SN115/SN120 verify tests, data-driven over the three surfaces): pins each surface's config to the tool's contract (including the probe-less GET default), asserts `callSubnetSurface` issues a `GET` to the surface's own url and returns the JSON body (stable shape, not exact live values), and drives the full `call_subnet_surface` MCP tool end-to-end resolved by `surface_id`. Hermetic — fixtures mirror the live shapes. Verified locally: 9/9 tests pass, prettier + eslint clean.