### PR TITLE
test(mcp): verify SN19 health surface via call_subnet_surface

### DIFF
--- a/tests/blockmachine-call-subnet-surface-verify.test.mjs
+++ b/tests/blockmachine-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,124 @@
+// SN19 (SN19) end-to-end verification for the call_subnet_surface MCP tool
+// (metagraphed#7035, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN19's *real* registry surface config
+// (registry/subnets/blockmachine.json) to the tool's contract, so a future edit that
+// regresses its callability (flipping to HEAD, marking it auth_required,
+// disabling its probe) is caught here.
+//
+// The surface is the public no-auth SN19 API health endpoint
+// (sn-19-blockmachine-health, GET https://api.blockmachine.io/health, JSON, single fixed endpoint -- no schema). Live-verified
+// 2026-07-21 to return HTTP 200 application/json {"status":"ok"}. The
+// fixture below mirrors that live response rather than fetching it, keeping the
+// test hermetic while still exercising the JSON parse-and-return path.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-19-blockmachine-health";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/blockmachine.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live https://api.blockmachine.io/health response body.
+const BODY = { status: "ok" };
+
+function upstreamResponse() {
+  return new Response(JSON.stringify(BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN19 SN19 call_subnet_surface verification (#7035)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    // No-auth GET returning JSON.
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(SURFACE.url, "https://api.blockmachine.io/health");
+    // Single fixed endpoint -- no machine-readable schema is expected.
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    assert.equal(result.body.status, "ok");
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 19 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.status, "ok");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #7035

## Verification (real request, 2026-07-21)
| Surface | Request | Result |
| --- | --- | --- |
| `sn-19-blockmachine-health` | `GET https://api.blockmachine.io/health` | **HTTP 200** `application/json` — `{"status":"ok"}` |

No-auth GET, single fixed endpoint, works end-to-end; the registry config (subnet-api, no-auth, probe enabled+GET+json) already matches reality, so this pins it with a regression test (the "welcome" deliverable in #7035), mirroring the merged SN43…SN45 verify tests.

## Validation
- [x] `npx vitest run tests/blockmachine-call-subnet-surface-verify.test.mjs` — 3 passed
- [x] eslint · prettier · scan:public-safety — clean; one new test file, no source/registry changes.