### PR TITLE
test(sn72): verify StreetVision call_subnet_surface

### DIFF
--- a/tests/sn72-call-subnet-surface-verify.test.mjs
+++ b/tests/sn72-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,131 @@
+// SN72 (StreetVision by NATIX) end-to-end verification for the
+// call_subnet_surface MCP tool (metagraphed#7085, MCP execute Phase 1
+// follow-up #7014/#7215). Unlike tests/call-subnet-surface-mcp.test.mjs --
+// which proves the tool wiring with synthetic surfaces -- this file pins
+// SN72's *real* no-auth GET JSON registry surface
+// (registry/subnets/streetvision-by-natix.json) to the tool's contract.
+//
+// Live-verified 2026-07-21:
+//   sn-72-taomarketcap-subnet-api  GET https://api.taomarketcap.com/public/v1/subnets/72/
+//     -> TaoMarketCap subnet snapshot JSON (netuid 72)
+// Issue #7085 lists this single surface only.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-72-taomarketcap-subnet-api";
+const NETUID = 72;
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL(
+        "../registry/subnets/streetvision-by-natix.json",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+const BODY = {
+  id: "72",
+  netuid: 72,
+  is_active: true,
+  latest_snapshot: { id: "8668427-72", netuid: 72 },
+};
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN72 StreetVision call_subnet_surface verification (#7085)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(
+      SURFACE.url,
+      "https://api.taomarketcap.com/public/v1/subnets/72/",
+    );
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the TaoMarketCap JSON body via GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return jsonResponse(BODY);
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.truncated, false);
+    assert.equal(result.body.netuid, 72);
+    assert.equal(result.body.latest_snapshot.netuid, 72);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: NETUID }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return jsonResponse(BODY);
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.netuid, 72);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds hermetic Path B verify tests for SN72 StreetVision `call_subnet_surface`.
- Covers the sole issue-listed surface `sn-72-taomarketcap-subnet-api` (live-probed 200 JSON, netuid 72).
- Mirrors merged SN80/SN73 TMC verify pattern; no UI, no registry edits.

Closes #7085

## Test plan
- [x] `npx vitest run tests/sn72-call-subnet-surface-verify.test.mjs`
- [x] `npx prettier --check tests/sn72-call-subnet-surface-verify.test.mjs`
- [ ] CI green on this PR