### PR TITLE
test(mcp): verify SN24 Quasar subnet feed via call_subnet_surface (#7040)

### DIFF
--- a/tests/quasar-call-subnet-surface-verify.test.mjs
+++ b/tests/quasar-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,136 @@
+// SN24 (Quasar) end-to-end verification for the call_subnet_surface MCP tool
+// (metagraphed#7058, MCP execute Phase 1 follow-up #7014/#7215; issue #7040).
+// Unlike tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// with synthetic surfaces -- this file pins SN24's *real* registry surface
+// config (registry/subnets/quasar.json) to the tool's contract, so a future
+// edit that regresses its callability (flipping to HEAD, marking it
+// auth_required, disabling its probe, moving the url) is caught here.
+//
+// The surface is the public no-auth SN24 indexed subnet feed on TaoMarketCap
+// (sn-24-taomarketcap-subnet-api, GET
+// https://api.taomarketcap.com/public/v1/subnets/24/, JSON, single fixed
+// endpoint -- no schema). Live-verified 2026-07-21 to return HTTP 200
+// application/json -- an object self-reporting netuid 24 (id, is_active,
+// mechanism_count, latest_snapshot). The fixture below mirrors that live
+// response rather than fetching it, keeping the test hermetic while still
+// exercising the tool's JSON parse-and-return path.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-24-taomarketcap-subnet-api";
+const NETUID = 24;
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/quasar.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live SN24 TaoMarketCap subnet feed.
+const BODY = {
+  id: "24",
+  netuid: 24,
+  is_active: true,
+  mechanism_count: 1,
+  latest_snapshot_id: "8667931-24",
+};
+
+function upstreamResponse() {
+  return new Response(JSON.stringify(BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN24 Quasar call_subnet_surface verification (#7058)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    // No-auth GET returning JSON.
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(
+      SURFACE.url,
+      "https://api.taomarketcap.com/public/v1/subnets/24/",
+    );
+    // Single fixed endpoint -- no machine-readable schema is expected.
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    assert.equal(result.body.netuid, NETUID);
+    assert.equal(typeof result.body.is_active, "boolean");
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: NETUID }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.netuid, NETUID);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

End-to-end verification for the `call_subnet_surface` MCP tool against SN24 (Quasar), the follow-up to Phase 1 (#7014/#7215) tracked in #7040. Adds `tests/quasar-call-subnet-surface-verify.test.mjs`, mirroring the SN20 GroundLayer (#7351) and SN44 Score (#7289) verifications: it pins SN24's real registry surface to the tool contract so a future edit that regresses its callability is caught.

Closes #7040.

## Surface verified (1)

The public no-auth `GET` SN24 indexed subnet feed, already correctly wired in `registry/subnets/quasar.json` (`probe.enabled: true`, `method: GET`, `expect: json`):

- `sn-24-taomarketcap-subnet-api` — `https://api.taomarketcap.com/public/v1/subnets/24/`

**Live-verified 2026-07-21:** returns HTTP 200 `application/json` — an object self-reporting `netuid: 24` (`id`, `is_active`, `mechanism_count`, `latest_snapshot`). The fixture mirrors a faithful subset, keeping the test hermetic.

## What the test asserts

1. The registry surface exists and is a callable no-auth `GET`/`json` surface with `probe.enabled: true` and no `schema_url`.
2. `callSubnetSurface` requests the surface's own `url` with `GET` and returns its parsed JSON body (status 200, `application/json`, not truncated, `netuid: 24`).
3. The `call_subnet_surface` MCP tool resolves the surface by `surface_id` end-to-end and returns the same body.

## Validation

- [x] `npx vitest run tests/quasar-call-subnet-surface-verify.test.mjs` — 3 passing
- [x] `prettier --check` (repo-pinned) + `eslint` — clean
- [x] `git diff --check` — clean
- [x] Test-only addition; no `src/**`/`workers/**`/registry changes (codecov patch scope untouched)
