### PR TITLE
test(mcp): verify SN29 Coldint surface end-to-end via call_subnet_surface

### DIFF
--- a/tests/coldint-call-subnet-surface-verify.test.mjs
+++ b/tests/coldint-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,134 @@
+// SN29 (Coldint) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7045, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring
+// with synthetic surfaces -- this file pins SN29's registry surface
+// (registry/subnets/coldint.json) to the tool's contract, so a future edit
+// that regresses its callability (flipping to HEAD, marking it
+// auth_required, disabling its probe) is caught here.
+//
+// The surface is the public no-auth competitions-config API
+// (sn-29-coldint-competitions-api, GET
+// https://github.com/coldint/sn29/raw/main/competitions.json, JSON, single
+// fixed endpoint -- no schema). Live-verified 2026-07-21: the `raw` URL
+// 302-redirects to raw.githubusercontent.com (which fetch() follows
+// transparently, same as callSubnetSurface's own manual redirect handling),
+// resolving to HTTP 200 application/json. Cross-checked directly against
+// the GitHub contents API (a separate, authoritative source): the file is
+// genuinely only 3 bytes right now -- `{}` -- not a fetch or caching
+// artifact. That's live upstream data (no active competitions configured
+// at verification time), not a probe-config defect; the surface's kind,
+// auth, and probe shape all correctly match how it actually behaves. The
+// fixture below mirrors that live (redirect-resolved) response rather than
+// fetching it, keeping the test hermetic while still exercising the JSON
+// parse-and-return path.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-29-coldint-competitions-api";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/coldint.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// The live (redirect-resolved) response body: no active competitions
+// configured at verification time.
+const BODY = {};
+
+function upstreamResponse() {
+  return new Response(JSON.stringify(BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN29 Coldint call_subnet_surface verification (#7045)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(
+      SURFACE.url,
+      "https://github.com/coldint/sn29/raw/main/competitions.json",
+    );
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    assert.deepEqual(result.body, BODY);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 29 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.deepEqual(result.structuredContent.body, BODY);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #7045

Part of #7013. Phase 1 (#7014) shipped (#7215) — `call_subnet_surface` is live.

## Scope

Confirm SN29 (Coldint)'s callable surface(s) actually work end-to-end — an actual request against the live URL, not an assumption.

## Verification (real request, 2026-07-21)

| Surface | Request | Result |
| --- | --- | --- |
| `sn-29-coldint-competitions-api` | `GET https://github.com/coldint/sn29/raw/main/competitions.json` | **HTTP 302 → 200** `application/json` — `{}` |

The `raw` URL 302-redirects to `raw.githubusercontent.com`, which `fetch()` follows transparently (same redirect handling `callSubnetSurface` implements manually). Cross-checked the body against the GitHub contents API directly (a separate, authoritative source): the file is genuinely 3 bytes — `{}` — right now, not a fetch/caching artifact. That's live upstream data (no active competitions configured at verification time), not a probe-config defect.

No-auth GET, single fixed endpoint, works end-to-end as configured. The surface's registry config (`subnet-api`, `auth_required: false`, probe `enabled`+`GET`+`json`) already matches reality, so this pins it with a regression test (the "welcome" deliverable in #7045), mirroring the merged SN37/SN12/SN11/SN25… verify tests.

## What the test does

- Asserts the real `registry/subnets/coldint.json` surface is configured callable (kind, no-auth, probe enabled + `GET` + `json`, canonical url, no schema).
- `callSubnetSurface` issues the exact `GET` and returns the parsed JSON body.
- End-to-end through the `call_subnet_surface` MCP tool resolved by `surface_id`.
- Hermetic fixture mirroring the live (redirect-resolved) response — no network in CI.

## Validation

- [x] `npx vitest run tests/coldint-call-subnet-surface-verify.test.mjs` — 3 passed
- [x] eslint on the file · `npx prettier --check` — clean
- [x] One new file only: `tests/coldint-call-subnet-surface-verify.test.mjs`
