### PR TITLE
fix(registry): wire SN79 MVTRX MCP execute probe config (#7092)

### DIFF
--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -91,7 +91,13 @@
       "id": "sn-79-taos-im-subnet-api",
       "kind": "subnet-api",
       "name": "MVTRX exchange health API",
-      "notes": "Public no-auth GET /health on mvtrx.exchange returning JSON liveness for the TAOS IM trading host (observed: {\"status\":\"ok\",\"mode\":\"host\",\"network\":\"mainnet\"}). The official SN79 README links mvtrx.exchange as the project exchange.",
+      "notes": "Public no-auth GET /health on mvtrx.exchange returning JSON liveness for the TAOS IM trading host (observed: {\"status\":\"ok\",\"mode\":\"host\",\"network\":\"mainnet\"}). The official SN79 README links mvtrx.exchange as the project exchange. Live-verified 2026-07-21: GET returned HTTP 200 application/json with that body; HEAD returned HTTP 405, so probe.method must stay GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taos-im",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary
- Live-verified `sn-79-taos-im-subnet-api`: `GET https://mvtrx.exchange/health` → HTTP 200 `application/json` `{"status":"ok","mode":"host","network":"mainnet"}`. `HEAD` → HTTP 405 (so method must be GET, matching the issue's `?`).
- Added the missing `probe` block (`enabled`, `GET`, `expect: json`) so the surface can enter the operational catalog for `call_subnet_surface`.
- Appended a short factual Live-verified note documenting the GET/HEAD finding.

Closes #7092

## Test plan
- [x] Live GET `/health` → 200 JSON; HEAD → 405
- [x] `npm run validate:surface -- registry/subnets/mvtrx.json`
- [ ] CI green on this PR
