### PR TITLE
test(sn55): verify NIOME call_subnet_surface

### DIFF
--- a/tests/sn55-call-subnet-surface-verify.test.mjs
+++ b/tests/sn55-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,129 @@
+// SN55 (NIOME) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7068, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN55's *real* no-auth GET JSON registry
+// surface (registry/subnets/niome.json) to the tool's contract.
+//
+// Live-verified 2026-07-21:
+//   sn-55-niome-tasks-api  GET https://niome-api.genomes.io/api/tasks
+//     -> {"items":[{content:{genome_context:{gene:"CFTR",...},...}},...]}
+// Issue #7068 lists this single surface only.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-55-niome-tasks-api";
+const NETUID = 55;
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/niome.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+const BODY = {
+  items: [
+    {
+      content: {
+        expected_variant_count: 0,
+        genome_context: { chromosome: "chr7", gene: "CFTR", region: "7q31.2" },
+      },
+    },
+  ],
+};
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN55 NIOME call_subnet_surface verification (#7068)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(SURFACE.url, "https://niome-api.genomes.io/api/tasks");
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the tasks JSON body via GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return jsonResponse(BODY);
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.truncated, false);
+    assert.ok(Array.isArray(result.body.items));
+    assert.equal(result.body.items[0].content.genome_context.gene, "CFTR");
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: NETUID }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return jsonResponse(BODY);
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(
+        result.structuredContent.body.items[0].content.genome_context.gene,
+        "CFTR",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds hermetic Path B verify tests for SN55 NIOME `call_subnet_surface`.
- Covers the sole issue-listed surface `sn-55-niome-tasks-api` (live-probed 200 JSON).
- Mirrors merged SN80 TMC verify pattern; no UI, no registry edits.

Closes #7068

## Test plan
- [x] `npx vitest run tests/sn55-call-subnet-surface-verify.test.mjs`
- [x] `npx prettier --check tests/sn55-call-subnet-surface-verify.test.mjs`
- [ ] CI green on this PR