### PR TITLE
fix(registry): wire SN81 Grail health probe for MCP execute

### DIFF
--- a/registry/subnets/grail.json
+++ b/registry/subnets/grail.json
@@ -96,7 +96,13 @@
       "id": "sn-81-grail-health",
       "kind": "subnet-api",
       "name": "Grail Grafana health",
-      "notes": "Public no-auth GET /api/health on grail-grafana.tplr.ai returning application liveness JSON. Served on the Grail Grafana host registered as a dashboard surface and linked from the Grail source repository README.",
+      "notes": "Public no-auth GET /api/health on grail-grafana.tplr.ai returning application liveness JSON. Served on the Grail Grafana host registered as a dashboard surface and linked from the Grail source repository README. Live-verified 2026-07-21: GET https://grail-grafana.tplr.ai/api/health returned HTTP 200 application/json {\"database\":\"ok\"}. Added missing probe (GET, expect: json) for MCP execute / health monitoring (#7094).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "one-covenant",
       "public_safe": true,
       "review": {
@@ -152,7 +158,7 @@
       "id": "sn-81-grail-grafana-openapi",
       "kind": "openapi",
       "name": "Grail Grafana HTTP API OpenAPI",
-      "notes": "Public no-auth OpenAPI 3 schema (title \"Grafana HTTP API.\") served at grail-grafana.tplr.ai/public/openapi3.json — the same host already registered as this file's dashboard and subnet-api (health) surfaces. Same operator (one-covenant / tplr.ai) and identical publish convention already accepted for the sibling Templar (SN3) subnet's Grafana OpenAPI surface (grafana.tplr.ai/public/openapi3.json).",
+      "notes": "Public no-auth OpenAPI 3 schema (title \"Grafana HTTP API.\") served at grail-grafana.tplr.ai/public/openapi3.json — the same host already registered as this file's dashboard and subnet-api (health) surfaces. Same operator (one-covenant / tplr.ai) and identical publish convention already accepted for the sibling Templar (SN3) subnet's Grafana OpenAPI surface (grafana.tplr.ai/public/openapi3.json). Live-verified 2026-07-21: GET https://grail-grafana.tplr.ai/public/openapi3.json returned HTTP 200 application/json OpenAPI 3.0.3 (~733 KB; exceeds call_subnet_surface MAX_RESPONSE_BYTES 256 KiB, so a live tool call truncates), info.title \"Grafana HTTP API.\", version 0.0.1.",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
## Add or update a subnet surface

This PR updates surface(s) on exactly one subnet manifest — `registry/subnets/grail.json`.

## Surface

- Netuid: 81 (Grail)
- Kind: subnet-api (`sn-81-grail-health`) + openapi (`sn-81-grail-grafana-openapi`)
- Public URL: https://grail-grafana.tplr.ai/api/health ; https://grail-grafana.tplr.ai/public/openapi3.json
- Source URL: https://github.com/one-covenant/grail ; https://grail-grafana.tplr.ai/
- Provider slug: one-covenant

## Summary
- live-verified both #7094 catalogued URLs
- **sn-81-grail-health** was missing a `probe` block (issue listed method as `?`) — added `probe.enabled: true`, `method: GET`, `expect: json`, and a Live-verified note (same class of fix as SN105 Beam #7143)
- **sn-81-grail-grafana-openapi** already matched (GET/json, captured schema) — appended Live-verified note including the large-body truncation quirk (~733 KB > MAX_RESPONSE_BYTES)

## Live verification (2026-07-21)
- `sn-81-grail-health`: GET https://grail-grafana.tplr.ai/api/health → HTTP 200 `{"database":"ok"}`
- `sn-81-grail-grafana-openapi`: GET https://grail-grafana.tplr.ai/public/openapi3.json → HTTP 200 OpenAPI 3.0.3, info.title "Grafana HTTP API.", version 0.0.1 (~733 KB)

## Checklist
- [x] Changes exactly one `registry/subnets/grail.json` file
- [x] Public-safe; no secrets
- [x] Does not duplicate an existing surface
- [x] Links open issue (`Closes #7094`)

## Validation
- [x] `npm run validate:surface -- registry/subnets/grail.json`
- [x] `npm run validate:private-boundary`

## Template Used
surface

Closes #7094
