### PR TITLE
fix(registry): add missing probe block to SN87 Luminar health surface

### DIFF
--- a/registry/subnets/luminar-network.json
+++ b/registry/subnets/luminar-network.json
@@ -220,7 +220,13 @@
       "id": "sn-87-luminar-health",
       "kind": "subnet-api",
       "name": "Luminar Network health",
-      "notes": "Public no-auth GET /healthz on luminar.network returning gateway liveness (observed plain-text response: ok). Served on the official SN87 website host registered in this manifest and linked from the Luminar source repository README.",
+      "notes": "Public no-auth GET /healthz on luminar.network returning gateway liveness (observed plain-text response: ok). Served on the official SN87 website host registered in this manifest and linked from the Luminar source repository README. Live-verified 2026-07-21: GET https://luminar.network/healthz returned HTTP 200 text/plain body \"ok\" (no auth, no redirect); added the previously missing probe block (GET, expect any for the plain-text body) so the surface is emitted into operational-surfaces.json and callable via call_subnet_surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "luminar-network",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
The sn-87-luminar-health surface had no probe block, so it was never emitted into operational-surfaces.json and was not reachable through call_subnet_surface. Live-verified 2026-07-21: GET https://luminar.network/healthz returns HTTP 200 text/plain "ok" (no auth, no redirect). Add the probe (GET, expect any for the plain-text liveness body) so the surface is now callable, and note the verification.

Closes #7099.

## Pick The Right Template

Use the matching PR template so the submission gate can classify your PR
correctly:

- [Subnet surface](?template=surface.md): one `registry/subnets/<slug>.json`
  file — a community surface added with `npm run surface:add`; for a missing
  subnet manifest, scaffold it first with `npm run subnet:new` in the same file
  (optionally plus one `registry/providers/*.json` for a debut provider).
- [Provider/operator profile](?template=provider-profile.md): one
  `registry/providers/*.json` file only.
- [Backend/code change](?template=backend-code.md): scripts, schemas,
  contracts, workflows, or registry generator logic.
- [Docs-only change](?template=docs-only.md): README or docs edits only.

For data submissions, do not edit generated `public/metagraph/**` artifacts,
native snapshots, scripts, workflows, or package files.
