### PR TITLE
docs(gardening-skill): mandate explicit reuse-existing-pattern callouts

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -81,6 +81,32 @@ doesn't require access a contributor can't have). metagraphed-specific instances
   maintainer-vs-contributor gating a code change does, since the gate's own AI-reviewer +
   ownership-proof verification is the real safety net there, not issue labeling.
 
+## Reuse-existing-pattern is mandatory, not implied, whenever a real precedent exists
+
+Maintainer's own words, 2026-07-21: "gittensor miners are lazy and don't care, so we need to be
+extremely clear about what's wanted/needed." Applies here exactly as it does on gittensory/loopover's
+own copy of this skill (see that repo's `reference.md` for the full incident writeup) — a contributor's
+AI-harness agent reads only the issue text, not this skill file, not either repo's CLAUDE.md, and not
+"the obviously right way to do it."
+
+**What this broke on the sibling repo already:** a batch of issues had their labels flipped to
+contributor-eligible, but the body text was left saying `maintainer-only` verbatim in the footer, and
+one issue's Deliverables left the actual artifact ambiguous between three different plausible shapes
+with no pick. Caught only because the maintainer asked for the whole body to be reread end-to-end
+rather than trusting each edit in isolation.
+
+**How to apply here:** whenever an issue's fix has a real existing precedent to follow — an existing
+route/endpoint's shape, an existing schema pattern, an existing Worker handler, a comparable already-
+merged PR — name the *exact* file/PR to mirror as a leading, standalone callout (not buried in prose
+Context), and state explicitly what does **not** satisfy the issue (a differently-shaped
+implementation, an unspecified choice among multiple plausible artifacts, a new parallel mechanism
+instead of extending the cited one). Applies to code issues under the template below; for
+registry/surface-data issues, the equivalent is naming the exact sibling subnet file whose surface
+shape/format should be mirrored, per `.claude/skills/metagraphed/reference.md`'s own conventions.
+
+Before publishing any batch, reread each finished issue body end-to-end — not just the diff of what
+changed — to catch exactly this class of self-contradiction.
+
 ## Issue body template
 
 ```md


### PR DESCRIPTION
## Summary
- Mirrors the reuse-existing-pattern rule just added to loopover's own gardening skill (JSONbored/loopover#7684).
- A label flip to contributor-eligible isn't enough on its own — the body text has to actually name the exact file/PR/schema to mirror as a leading callout, and state what does *not* satisfy the issue.
- Documents the incident that motivated this: a batch of flipped issues still said `maintainer-only` in the footer, and one issue's deliverable was ambiguous between three plausible artifact shapes.
- Adds a "reread the whole body before publishing, not just the diff" check to the existing native-relationship-linking workflow.

## Test plan
- Docs-only change to `.claude/skills/contributor-pipeline-gardening/reference.md` — no code affected.
- Verified the new section renders correctly and sits above the existing `## Issue body template` heading.