### PR TITLE
fix(registry): SN2 DSperse — add missing probe config for MCP execute (#7018)

### DIFF
--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -167,7 +167,13 @@
       "id": "sn-2-inference-labs-subnet-api",
       "kind": "subnet-api",
       "name": "DSperse network stats API",
-      "notes": "Public no-auth GET /stats on sn2-api.inferencelabs.com returning JSON network counters (observed: total_proofs, unique_miners, unique_validators). The official subnet-2 validator client sets DEFAULT_API_URL to https://sn2-api.inferencelabs.com on the same host.",
+      "notes": "Public no-auth GET /stats on sn2-api.inferencelabs.com returning JSON network counters (observed: total_proofs, unique_miners, unique_validators). The official subnet-2 validator client sets DEFAULT_API_URL to https://sn2-api.inferencelabs.com on the same host. Live-verified 2026-07-21: GET returns 200 {\"total_proofs\":2588511354,\"unique_miners\":1703,\"unique_validators\":26}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "inference-labs",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
Closes #7018

Part of #7013. Phase 1 (#7014) shipped (#7215) — `call_subnet_surface` is live.

## Scope

Confirm SN2 (DSperse)'s callable surface(s) actually work end-to-end — an actual request against the live URL, not an assumption.

## Surfaces verified (live 2026-07-21)

| surface_id | method | status | response |
|---|---|---|---|
| `sn-2-inference-labs-subnet-api` | GET | 200 | `application/json` — `{"total_proofs":2588511354,"unique_miners":1703,"unique_validators":26}` |
| `sn-2-dsperse-circuit-repository-openapi` | GET | 200 | already had a correct probe, no edit needed |
| `sn-2-dsperse-circuit-list` | GET | 200 | already had a correct probe, no edit needed |
| `sn-2-dsperse-component-list` | GET | 200 | already had a correct probe, no edit needed |
| `sn-2-dsperse-model-list` | GET | 200 | already had a correct probe, no edit needed |

## Registry changes

`sn-2-inference-labs-subnet-api` had **no `probe` block at all**, despite its `notes` already describing observed live behavior — meaning `call_subnet_surface` had nothing to resolve against. Added `{enabled: true, expect: "json", method: "GET", timeout_ms: 10000}`, matching the sibling `sn-2-dsperse-*` surfaces' existing probe shape. Appended a `Live-verified 2026-07-21: ...` note documenting the actual request made, per precedent metagraphed#7143.

The other four issue-scoped surfaces already had correct probe config and required no edits — confirmed by re-requesting each live.

## Checklist

- [x] Changes exactly one file: registry/subnets/dsperse.json
- [x] `npm run validate:surface -- registry/subnets/dsperse.json` passed
- [x] All five issue-scoped surfaces live-probed for real responses (not assumed)

## Test plan

- [x] `npm run validate:surface` — clean
- [ ] Gittensory Gate + CI green
