### PR TITLE
fix(registry): SN82 Compelle — add missing probe config for MCP execute (#7095)

### DIFF
--- a/registry/subnets/compelle.json
+++ b/registry/subnets/compelle.json
@@ -68,7 +68,13 @@
       "id": "sn-82-compelle-health",
       "kind": "subnet-api",
       "name": "Compelle aggregation health",
-      "notes": "Public no-auth GET /api/health on compelle.com returning aggregation-service liveness JSON (observed: {\"ok\":true,\"db_size_bytes\":...,\"games\":...,\"miners\":...}). Served on the official Compelle SN82 debate arena host linked from the validator repository.",
+      "notes": "Public no-auth GET /api/health on compelle.com returning aggregation-service liveness JSON (observed: {\"ok\":true,\"db_size_bytes\":...,\"games\":...,\"miners\":...}). Served on the official Compelle SN82 debate arena host linked from the validator repository. Live-verified 2026-07-21: GET returns 200 application/json {\"ok\":true,\"db_size_bytes\":6893121536,\"last_epoch_block\":8668714,\"games\":238628,\"miners\":858}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "compelle",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
Closes #7095

Part of #7013. Phase 1 (#7014) shipped (#7215) — `call_subnet_surface` is live.

## Scope

Confirm SN82 (Compelle)'s callable surface actually works end-to-end — an actual request against the live URL, not an assumption.

## Surface verified (live 2026-07-21)

| surface_id | method | status | response |
|---|---|---|---|
| `sn-82-compelle-health` | GET | 200 | `application/json` — `{"ok":true,"db_size_bytes":6893121536,"last_epoch_block":8668714,"games":238628,"miners":858}` |

## Registry changes

`sn-82-compelle-health` had **no `probe` block at all**, despite its `notes` already describing observed live behavior — meaning `call_subnet_surface` had nothing to resolve against. Added `{enabled: true, expect: "json", method: "GET", timeout_ms: 10000}`, matching the sibling surfaces' probe shape. Appended a `Live-verified 2026-07-21: ...` note documenting the actual request made, per precedent metagraphed#7143.

## Checklist

- [x] Changes exactly one file: registry/subnets/compelle.json
- [x] `npm run validate:surface -- registry/subnets/compelle.json` passed
- [x] Issue-scoped surface live-probed for a real response (not assumed)

## Test plan

- [x] `npm run validate:surface` — clean
- [ ] Gittensory Gate + CI green
