### PR TITLE
fix(registry): SN87 Luminar Network — add missing probe config for MCP execute (#7099)

### DIFF
--- a/registry/subnets/luminar-network.json
+++ b/registry/subnets/luminar-network.json
@@ -220,7 +220,13 @@
       "id": "sn-87-luminar-health",
       "kind": "subnet-api",
       "name": "Luminar Network health",
-      "notes": "Public no-auth GET /healthz on luminar.network returning gateway liveness (observed plain-text response: ok). Served on the official SN87 website host registered in this manifest and linked from the Luminar source repository README.",
+      "notes": "Public no-auth GET /healthz on luminar.network returning gateway liveness (observed plain-text response: ok). Served on the official SN87 website host registered in this manifest and linked from the Luminar source repository README. Live-verified 2026-07-21: GET returns 200 \"ok\".",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "luminar-network",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
Closes #7099

Part of #7013. Phase 1 (#7014) shipped (#7215) — `call_subnet_surface` is live.

## Scope

Confirm SN87 (Luminar Network)'s callable surface actually works end-to-end — an actual request against the live URL, not an assumption.

## Surface verified (live 2026-07-21)

| surface_id | method | status | response |
|---|---|---|---|
| `sn-87-luminar-health` | GET | 200 | `text/plain` — `ok` |

## Registry changes

`sn-87-luminar-health` had **no `probe` block at all**, despite its `notes` already describing observed live behavior — meaning `call_subnet_surface` had nothing to resolve against. Added `{enabled: true, expect: "any", method: "GET", timeout_ms: 10000}` (`"any"` since the response is plain text, not JSON). Appended a `Live-verified 2026-07-21: ...` note documenting the actual request made, per precedent metagraphed#7143.

## Checklist

- [x] Changes exactly one file: registry/subnets/luminar-network.json
- [x] `npm run validate:surface -- registry/subnets/luminar-network.json` passed
- [x] Issue-scoped surface live-probed for a real response (not assumed)

## Test plan

- [x] `npm run validate:surface` — clean
- [ ] Gittensory Gate + CI green
