### PR TITLE
feat(ui): domains capability-tag rollup page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -435,6 +435,7 @@ function SiteFooter() {
         </div>
         <FooterCol title="Registry">
           <FooterLink to="/subnets">Subnets</FooterLink>
+          <FooterLink to="/domains">Domains</FooterLink>
           <FooterLink to="/blocks">Blocks</FooterLink>
           <FooterLink to="/surfaces">Surfaces</FooterLink>
           <FooterLink to="/endpoints">Endpoints</FooterLink>

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -29,6 +29,7 @@ export const MEGA_PANELS: MegaPanel[] = [
     apiPath: "/api/v1/subnets",
     browse: [
       { to: "/subnets", label: "All subnets", hint: "Browse every active netuid" },
+      { to: "/domains", label: "By domain", hint: "Capability-tag rollup" },
       {
         to: "/subnets",
         search: { curation: "maintainer-reviewed" },

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -26,6 +26,16 @@ export function formatTao(v?: number | null): string {
 }
 
 /**
+ * Format a 0–1 ratio as a percentage string, e.g. 0.071288 → "7.1%". `digits`
+ * controls decimal places (default 1). Nullish / non-finite input renders the
+ * em-dash fallback. Used for domain emission-share and concentration ratios.
+ */
+export function formatPercent(v?: number | null, digits = 1): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${(v * 100).toFixed(digits)}%`;
+}
+
+/**
  * The upstream registry frequently emits "1970-01-01T00:00:00.000Z" as a
  * placeholder when an artifact hasn't been timestamped yet. Treat any
  * pre-2000 date as "unknown" so the UI doesn't claim freshness/staleness

--- a/apps/ui/src/lib/metagraphed/queries.domains.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.domains.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDomain } from "./queries";
+
+// #6996: normalizeDomain shapes one /api/v1/domains rollup entry (or a
+// /api/v1/domains/{tag}/summary object — same shape) into the Domain render
+// type, dropping malformed payloads and non-numeric netuids.
+describe("normalizeDomain (#6996)", () => {
+  const live = {
+    schema_version: 1,
+    domain: "agents",
+    subnet_count: 11,
+    netuids: [1, 6, 11, 15],
+    total_stake_tao: 30400330.8314,
+    total_emission_share: 0.071288,
+    emission_concentration: {
+      holders: 11,
+      gini: 0.338088,
+      hhi: 0.129248,
+      nakamoto_coefficient: 3,
+      top_1pct_share: 0.234275,
+      entropy: 3.191075,
+    },
+  };
+
+  it("maps a live rollup entry field-for-field", () => {
+    const d = normalizeDomain(live);
+    expect(d).not.toBeNull();
+    expect(d?.domain).toBe("agents");
+    expect(d?.subnet_count).toBe(11);
+    expect(d?.netuids).toEqual([1, 6, 11, 15]);
+    expect(d?.total_stake_tao).toBeCloseTo(30400330.8314);
+    expect(d?.total_emission_share).toBeCloseTo(0.071288);
+    expect(d?.emission_concentration?.gini).toBeCloseTo(0.338088);
+    expect(d?.emission_concentration?.nakamoto_coefficient).toBe(3);
+  });
+
+  it("returns null when the payload has no domain tag", () => {
+    expect(normalizeDomain({ subnet_count: 3 })).toBeNull();
+    expect(normalizeDomain(null)).toBeNull();
+    expect(normalizeDomain("agents")).toBeNull();
+  });
+
+  it("defaults netuids to an empty array and drops non-numeric entries", () => {
+    expect(normalizeDomain({ domain: "compute" })?.netuids).toEqual([]);
+    expect(normalizeDomain({ domain: "compute", netuids: [12, "x", null, 27] })?.netuids).toEqual([
+      12, 27,
+    ]);
+  });
+
+  it("tolerates a missing concentration block", () => {
+    const d = normalizeDomain({ domain: "data", netuids: [13] });
+    expect(d?.emission_concentration).toBeUndefined();
+  });
+
+  it("coerces absent numeric fields to undefined rather than 0", () => {
+    const d = normalizeDomain({ domain: "storage", netuids: [21] });
+    expect(d?.subnet_count).toBeUndefined();
+    expect(d?.total_stake_tao).toBeUndefined();
+    expect(d?.total_emission_share).toBeUndefined();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -258,6 +258,8 @@ import type {
   SurfaceUptime,
   SurfaceUptimeDay,
   Uptime,
+  Domain,
+  DomainConcentration,
 } from "./types";
 
 const STALE_SHORT = 30_000;
@@ -7812,6 +7814,72 @@ export const providersQuery = () =>
     queryFn: async ({ signal }) => {
       const res = await fetchList<unknown>("/api/v1/providers", "providers", undefined, signal);
       return { ...res, data: res.data.map(normalizeProviderListItem) } as ApiResult<Provider[]>;
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeDomainConcentration(value: unknown): DomainConcentration | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    holders: optionalNumber(value.holders),
+    gini: optionalNumber(value.gini),
+    hhi: optionalNumber(value.hhi),
+    hhi_normalized: optionalNumber(value.hhi_normalized),
+    nakamoto_coefficient: optionalNumber(value.nakamoto_coefficient),
+    top_1pct_share: optionalNumber(value.top_1pct_share),
+    top_5pct_share: optionalNumber(value.top_5pct_share),
+    top_10pct_share: optionalNumber(value.top_10pct_share),
+    top_20pct_share: optionalNumber(value.top_20pct_share),
+    entropy: optionalNumber(value.entropy),
+    entropy_normalized: optionalNumber(value.entropy_normalized),
+  };
+}
+
+/**
+ * Normalize one capability-domain rollup (a `/api/v1/domains` list entry or a
+ * `/api/v1/domains/{tag}/summary` object — same shape). Returns null when the
+ * payload has no `domain` tag so a malformed row is dropped rather than rendered.
+ */
+export function normalizeDomain(raw: unknown): Domain | null {
+  if (!isRecord(raw)) return null;
+  const domain = optionalString(raw.domain);
+  if (!domain) return null;
+  const netuids = Array.isArray(raw.netuids)
+    ? raw.netuids.filter((n): n is number => typeof n === "number" && Number.isFinite(n))
+    : [];
+  return {
+    domain,
+    subnet_count: optionalNumber(raw.subnet_count),
+    netuids,
+    total_stake_tao: optionalNumber(raw.total_stake_tao),
+    total_emission_share: optionalNumber(raw.total_emission_share),
+    emission_concentration: normalizeDomainConcentration(raw.emission_concentration),
+  };
+}
+
+/** The 14-tag capability-domain rollup: GET /api/v1/domains → data.domains[]. */
+export const domainsQuery = () =>
+  queryOptions({
+    queryKey: k("domains"),
+    queryFn: async ({ signal }) => {
+      const res = await fetchList<unknown>("/api/v1/domains", "domains", undefined, signal);
+      return {
+        ...res,
+        data: res.data.map(normalizeDomain).filter((d): d is Domain => d !== null),
+      } as ApiResult<Domain[]>;
+    },
+    staleTime: STALE_MED,
+  });
+
+/** Single-domain rollup: GET /api/v1/domains/{tag}/summary. */
+export const domainSummaryQuery = (tag: string) =>
+  queryOptions({
+    queryKey: k("domain-summary", tag),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/domains/${encodeURIComponent(tag)}/summary`, {
+        signal,
+      });
+      return { ...res, data: normalizeDomain(res.data) } as ApiResult<Domain | null>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -502,6 +502,40 @@ export interface ProviderEndpointSummary {
   by_publication_state?: Record<string, number>;
 }
 
+/**
+ * Within-domain emission concentration for a capability-domain rollup — how
+ * evenly emission is spread across the domain's member subnets. All fields are
+ * optional so an as-yet-unseen concentration payload still normalizes.
+ */
+export interface DomainConcentration {
+  holders?: number;
+  gini?: number;
+  hhi?: number;
+  hhi_normalized?: number;
+  nakamoto_coefficient?: number;
+  top_1pct_share?: number;
+  top_5pct_share?: number;
+  top_10pct_share?: number;
+  top_20pct_share?: number;
+  entropy?: number;
+  entropy_normalized?: number;
+}
+
+/**
+ * A capability-domain rollup from `GET /api/v1/domains` (and the single-domain
+ * `GET /api/v1/domains/{tag}/summary`, which returns the same shape): every
+ * subnet tagged with one of the taxonomy's domain tags, aggregated into member
+ * count, total stake + emission share, and within-domain emission concentration.
+ */
+export interface Domain {
+  domain: string;
+  subnet_count?: number;
+  netuids: number[];
+  total_stake_tao?: number;
+  total_emission_share?: number;
+  emission_concentration?: DomainConcentration;
+}
+
 export interface Provider {
   slug: string;
   name?: string;

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -19,6 +19,11 @@ export const tableSearchSchema = z.object({
   stale: fallback(z.string(), "").default(""),
   provider: fallback(z.string(), "").default(""),
   netuid: fallback(z.string(), "").default(""),
+  // Capability-domain filter, server-applied. GET /api/v1/subnets accepts
+  // `?domain=<tag>` (verified live), so the /domains rollup can link straight
+  // through to the subnets table pre-filtered to one domain's member subnets.
+  // Defaults to "" so an unfiltered /subnets URL is byte-identical to today's.
+  domain: fallback(z.string(), "").default(""),
   // #9: agent-catalog capability filters (applied client-side over joined rows).
   serviceKind: fallback(z.string(), "").default(""),
   readiness: fallback(z.string(), "").default(""),

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as RuntimeIndexRouteImport } from './routes/runtime.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
 import { Route as EventsIndexRouteImport } from './routes/events.index'
+import { Route as DomainsIndexRouteImport } from './routes/domains.index'
 import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
 import { Route as AdminChangesIndexRouteImport } from './routes/admin-changes.index'
 import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
@@ -38,6 +39,7 @@ import { Route as SubnetsNetuidRouteImport } from './routes/subnets.$netuid'
 import { Route as ProvidersSlugRouteImport } from './routes/providers.$slug'
 import { Route as GraphqlExplorerRouteImport } from './routes/graphql.explorer'
 import { Route as ExtrinsicsHashRouteImport } from './routes/extrinsics.$hash'
+import { Route as DomainsTagRouteImport } from './routes/domains.$tag'
 import { Route as DocsLlmsDottxtRouteImport } from './routes/docs.llms[.]txt'
 import { Route as DocsSplatRouteImport } from './routes/docs.$'
 import { Route as BlocksRefRouteImport } from './routes/blocks.$ref'
@@ -145,6 +147,11 @@ const EventsIndexRoute = EventsIndexRouteImport.update({
   path: '/events/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DomainsIndexRoute = DomainsIndexRouteImport.update({
+  id: '/domains/',
+  path: '/domains/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BlocksIndexRoute = BlocksIndexRouteImport.update({
   id: '/blocks/',
   path: '/blocks/',
@@ -188,6 +195,11 @@ const GraphqlExplorerRoute = GraphqlExplorerRouteImport.update({
 const ExtrinsicsHashRoute = ExtrinsicsHashRouteImport.update({
   id: '/extrinsics/$hash',
   path: '/extrinsics/$hash',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DomainsTagRoute = DomainsTagRouteImport.update({
+  id: '/domains/$tag',
+  path: '/domains/$tag',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DocsLlmsDottxtRoute = DocsLlmsDottxtRouteImport.update({
@@ -240,6 +252,7 @@ export interface FileRoutesByFullPath {
   '/blocks/$ref': typeof BlocksRefRoute
   '/docs/$': typeof DocsSplatRoute
   '/docs/llms.txt': typeof DocsLlmsDottxtRoute
+  '/domains/$tag': typeof DomainsTagRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
@@ -249,6 +262,7 @@ export interface FileRoutesByFullPath {
   '/accounts/': typeof AccountsIndexRoute
   '/admin-changes/': typeof AdminChangesIndexRoute
   '/blocks/': typeof BlocksIndexRoute
+  '/domains/': typeof DomainsIndexRoute
   '/events/': typeof EventsIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
@@ -277,6 +291,7 @@ export interface FileRoutesByTo {
   '/blocks/$ref': typeof BlocksRefRoute
   '/docs/$': typeof DocsSplatRoute
   '/docs/llms.txt': typeof DocsLlmsDottxtRoute
+  '/domains/$tag': typeof DomainsTagRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
@@ -286,6 +301,7 @@ export interface FileRoutesByTo {
   '/accounts': typeof AccountsIndexRoute
   '/admin-changes': typeof AdminChangesIndexRoute
   '/blocks': typeof BlocksIndexRoute
+  '/domains': typeof DomainsIndexRoute
   '/events': typeof EventsIndexRoute
   '/extrinsics': typeof ExtrinsicsIndexRoute
   '/providers': typeof ProvidersIndexRoute
@@ -315,6 +331,7 @@ export interface FileRoutesById {
   '/blocks/$ref': typeof BlocksRefRoute
   '/docs/$': typeof DocsSplatRoute
   '/docs/llms.txt': typeof DocsLlmsDottxtRoute
+  '/domains/$tag': typeof DomainsTagRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
@@ -324,6 +341,7 @@ export interface FileRoutesById {
   '/accounts/': typeof AccountsIndexRoute
   '/admin-changes/': typeof AdminChangesIndexRoute
   '/blocks/': typeof BlocksIndexRoute
+  '/domains/': typeof DomainsIndexRoute
   '/events/': typeof EventsIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
@@ -354,6 +372,7 @@ export interface FileRouteTypes {
     | '/blocks/$ref'
     | '/docs/$'
     | '/docs/llms.txt'
+    | '/domains/$tag'
     | '/extrinsics/$hash'
     | '/graphql/explorer'
     | '/providers/$slug'
@@ -363,6 +382,7 @@ export interface FileRouteTypes {
     | '/accounts/'
     | '/admin-changes/'
     | '/blocks/'
+    | '/domains/'
     | '/events/'
     | '/extrinsics/'
     | '/providers/'
@@ -391,6 +411,7 @@ export interface FileRouteTypes {
     | '/blocks/$ref'
     | '/docs/$'
     | '/docs/llms.txt'
+    | '/domains/$tag'
     | '/extrinsics/$hash'
     | '/graphql/explorer'
     | '/providers/$slug'
@@ -400,6 +421,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/admin-changes'
     | '/blocks'
+    | '/domains'
     | '/events'
     | '/extrinsics'
     | '/providers'
@@ -428,6 +450,7 @@ export interface FileRouteTypes {
     | '/blocks/$ref'
     | '/docs/$'
     | '/docs/llms.txt'
+    | '/domains/$tag'
     | '/extrinsics/$hash'
     | '/graphql/explorer'
     | '/providers/$slug'
@@ -437,6 +460,7 @@ export interface FileRouteTypes {
     | '/accounts/'
     | '/admin-changes/'
     | '/blocks/'
+    | '/domains/'
     | '/events/'
     | '/extrinsics/'
     | '/providers/'
@@ -466,6 +490,7 @@ export interface RootRouteChildren {
   BlocksRefRoute: typeof BlocksRefRoute
   DocsSplatRoute: typeof DocsSplatRoute
   DocsLlmsDottxtRoute: typeof DocsLlmsDottxtRoute
+  DomainsTagRoute: typeof DomainsTagRoute
   ExtrinsicsHashRoute: typeof ExtrinsicsHashRoute
   GraphqlExplorerRoute: typeof GraphqlExplorerRoute
   ProvidersSlugRoute: typeof ProvidersSlugRoute
@@ -475,6 +500,7 @@ export interface RootRouteChildren {
   AccountsIndexRoute: typeof AccountsIndexRoute
   AdminChangesIndexRoute: typeof AdminChangesIndexRoute
   BlocksIndexRoute: typeof BlocksIndexRoute
+  DomainsIndexRoute: typeof DomainsIndexRoute
   EventsIndexRoute: typeof EventsIndexRoute
   ExtrinsicsIndexRoute: typeof ExtrinsicsIndexRoute
   ProvidersIndexRoute: typeof ProvidersIndexRoute
@@ -627,6 +653,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/domains/': {
+      id: '/domains/'
+      path: '/domains'
+      fullPath: '/domains/'
+      preLoaderRoute: typeof DomainsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blocks/': {
       id: '/blocks/'
       path: '/blocks'
@@ -688,6 +721,13 @@ declare module '@tanstack/react-router' {
       path: '/extrinsics/$hash'
       fullPath: '/extrinsics/$hash'
       preLoaderRoute: typeof ExtrinsicsHashRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/domains/$tag': {
+      id: '/domains/$tag'
+      path: '/domains/$tag'
+      fullPath: '/domains/$tag'
+      preLoaderRoute: typeof DomainsTagRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/docs/llms.txt': {
@@ -754,6 +794,7 @@ const rootRouteChildren: RootRouteChildren = {
   BlocksRefRoute: BlocksRefRoute,
   DocsSplatRoute: DocsSplatRoute,
   DocsLlmsDottxtRoute: DocsLlmsDottxtRoute,
+  DomainsTagRoute: DomainsTagRoute,
   ExtrinsicsHashRoute: ExtrinsicsHashRoute,
   GraphqlExplorerRoute: GraphqlExplorerRoute,
   ProvidersSlugRoute: ProvidersSlugRoute,
@@ -763,6 +804,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccountsIndexRoute: AccountsIndexRoute,
   AdminChangesIndexRoute: AdminChangesIndexRoute,
   BlocksIndexRoute: BlocksIndexRoute,
+  DomainsIndexRoute: DomainsIndexRoute,
   EventsIndexRoute: EventsIndexRoute,
   ExtrinsicsIndexRoute: ExtrinsicsIndexRoute,
   ProvidersIndexRoute: ProvidersIndexRoute,

--- a/apps/ui/src/routes/domains.$tag.tsx
+++ b/apps/ui/src/routes/domains.$tag.tsx
@@ -1,0 +1,127 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { Skeleton } from "@/components/metagraphed/states";
+import { PageHero, SectionHeading, StatTile, TableState } from "@jsonbored/ui-kit";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { domainSummaryQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, formatTao, formatPercent } from "@/lib/metagraphed/format";
+
+export const Route = createFileRoute("/domains/$tag")({
+  head: ({ params }) => ({
+    meta: [
+      { title: `${params.tag} domain — Metagraphed` },
+      {
+        name: "description",
+        content: `Subnets in the ${params.tag} capability domain — member count, total stake, emission share, and within-domain emission concentration.`,
+      },
+    ],
+  }),
+  component: DomainDetailPage,
+});
+
+function DomainDetailPage() {
+  const { tag } = Route.useParams();
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Registry · Domain"
+        live
+        title={tag}
+        description={`Subnets tagged to the ${tag} capability domain, with combined stake, emission share, and how concentrated that emission is across the domain's members.`}
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
+          <DomainDetailContent tag={tag} />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter
+        paths={[`/api/v1/domains/${tag}/summary`]}
+        artifacts={[`/metagraph/domains/${tag}/summary.json`]}
+      />
+    </AppShell>
+  );
+}
+
+function DomainDetailContent({ tag }: { tag: string }) {
+  const { data: res } = useSuspenseQuery(domainSummaryQuery(tag));
+  const domain = res.data;
+
+  if (!domain) {
+    return (
+      <TableState
+        variant="empty"
+        title="Domain not found"
+        description={`No rollup exists for "${tag}". It may not be a recognized capability-domain tag.`}
+      />
+    );
+  }
+
+  const c = domain.emission_concentration;
+
+  return (
+    <>
+      <div className="mb-6 flex flex-wrap gap-3 [&>*]:grow [&>*]:basis-[160px]">
+        <StatTile eyebrow="Member subnets" value={formatNumber(domain.subnet_count)} />
+        <StatTile eyebrow="Total stake" value={formatTao(domain.total_stake_tao)} tone="accent" />
+        <StatTile eyebrow="Emission share" value={formatPercent(domain.total_emission_share)} />
+      </div>
+
+      <SectionHeading title="Emission concentration" />
+      <p className="mb-4 max-w-2xl text-sm text-ink-muted">
+        How evenly emission is spread across this domain&apos;s member subnets — a low Gini / high
+        Nakamoto coefficient means emission is broadly shared, a high Gini / low Nakamoto means it
+        clusters in a few subnets.
+      </p>
+      <div className="mb-8 flex flex-wrap gap-3 [&>*]:grow [&>*]:basis-[150px]">
+        <StatTile
+          eyebrow="Gini"
+          value={c?.gini != null ? c.gini.toFixed(3) : "—"}
+          hint="0 = even, 1 = concentrated"
+        />
+        <StatTile
+          eyebrow="Nakamoto"
+          value={formatNumber(c?.nakamoto_coefficient)}
+          hint="subnets holding >50%"
+        />
+        <StatTile eyebrow="HHI" value={c?.hhi != null ? c.hhi.toFixed(3) : "—"} />
+        <StatTile eyebrow="Top 1 share" value={formatPercent(c?.top_1pct_share)} />
+        <StatTile eyebrow="Top 5 share" value={formatPercent(c?.top_5pct_share)} />
+        <StatTile eyebrow="Top 10 share" value={formatPercent(c?.top_10pct_share)} />
+      </div>
+
+      <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
+        <SectionHeading title={`Member subnets (${formatNumber(domain.netuids.length)})`} />
+        <Link
+          to="/subnets"
+          search={{ domain: domain.domain }}
+          className="font-mono text-xs text-accent hover:underline"
+        >
+          View in subnets table →
+        </Link>
+      </div>
+      {domain.netuids.length === 0 ? (
+        <TableState
+          variant="empty"
+          title="No member subnets"
+          description="This domain currently has no subnets tagged to it."
+        />
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {domain.netuids.map((netuid) => (
+            <Link
+              key={netuid}
+              to="/subnets/$netuid"
+              params={{ netuid }}
+              className="rounded-md border border-border bg-card px-2.5 py-1 font-mono text-[12px] tabular-nums text-ink hover:border-accent/40 hover:text-ink-strong"
+            >
+              SN{netuid}
+            </Link>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/ui/src/routes/domains.index.tsx
+++ b/apps/ui/src/routes/domains.index.tsx
@@ -1,0 +1,214 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { Skeleton } from "@/components/metagraphed/states";
+import { PageHero, TableState } from "@jsonbored/ui-kit";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { domainsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, formatTao, formatPercent } from "@/lib/metagraphed/format";
+import type { Domain } from "@/lib/metagraphed/types";
+
+export const Route = createFileRoute("/domains/")({
+  head: () => ({
+    meta: [
+      { title: "Domains — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Browse Bittensor subnets by capability domain — member count, total stake, emission share, and within-domain emission concentration for every taxonomy tag.",
+      },
+      { property: "og:title", content: "Domains — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Browse Bittensor subnets by capability domain — member count, total stake, emission share, and emission concentration for every taxonomy tag.",
+      },
+    ],
+  }),
+  component: DomainsPage,
+});
+
+/** Emission share desc, then subnet count desc — biggest domains first. */
+function orderDomains(domains: Domain[]): Domain[] {
+  return [...domains].sort(
+    (a, b) =>
+      (b.total_emission_share ?? 0) - (a.total_emission_share ?? 0) ||
+      (b.subnet_count ?? 0) - (a.subnet_count ?? 0) ||
+      a.domain.localeCompare(b.domain),
+  );
+}
+
+function DomainsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Registry"
+        live
+        title="Domains"
+        description="Every capability domain in the taxonomy — the subnets tagged to it, their combined stake and emission share, and how concentrated that emission is within the domain. Pick one to drill into its members or filter the subnets table by it."
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
+          <DomainsContent />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter paths={["/api/v1/domains"]} artifacts={["/metagraph/domains/index.json"]} />
+    </AppShell>
+  );
+}
+
+function DomainsContent() {
+  const { data: res } = useSuspenseQuery(domainsQuery());
+  const rows = orderDomains(res.data);
+
+  if (rows.length === 0) {
+    return (
+      <TableState
+        variant="empty"
+        title="No domains available"
+        description="The domain rollup has no entries right now — this reflects the live /api/v1/domains response."
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
+        <KpiTile label="Domains" value={formatNumber(rows.length)} />
+        <KpiTile
+          label="Subnets tagged"
+          value={formatNumber(rows.reduce((n, d) => n + (d.subnet_count ?? 0), 0))}
+        />
+        <KpiTile
+          label="Total stake"
+          value={formatTao(rows.reduce((n, d) => n + (d.total_stake_tao ?? 0), 0))}
+        />
+        <KpiTile
+          label="Emission share"
+          value={formatPercent(rows.reduce((n, d) => n + (d.total_emission_share ?? 0), 0))}
+        />
+      </div>
+
+      <div className="hidden md:block rounded-xl border border-border bg-card overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+              <tr>
+                <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
+                  Domain
+                </th>
+                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                  Subnets
+                </th>
+                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                  Total Stake
+                </th>
+                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                  Emission Share
+                </th>
+                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                  Gini
+                </th>
+                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                  Nakamoto
+                </th>
+                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                  <span className="sr-only">Filter subnets</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((d) => (
+                <tr key={d.domain} className="mg-row-hover border-t border-border/60">
+                  <td className="px-3 py-2.5">
+                    <Link
+                      to="/domains/$tag"
+                      params={{ tag: d.domain }}
+                      className="font-medium text-ink-strong hover:underline"
+                    >
+                      {d.domain}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                    {formatNumber(d.subnet_count)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums">
+                    {formatTao(d.total_stake_tao)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums">
+                    {formatPercent(d.total_emission_share)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                    {d.emission_concentration?.gini != null
+                      ? d.emission_concentration.gini.toFixed(3)
+                      : "—"}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                    {formatNumber(d.emission_concentration?.nakamoto_coefficient)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right">
+                    <Link
+                      to="/subnets"
+                      search={{ domain: d.domain }}
+                      className="font-mono text-[11px] text-accent hover:underline"
+                    >
+                      Filter →
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 md:hidden">
+        {rows.map((d) => (
+          <div key={d.domain} className="rounded-xl border border-border bg-card px-4 py-3">
+            <div className="flex items-center justify-between">
+              <Link
+                to="/domains/$tag"
+                params={{ tag: d.domain }}
+                className="font-medium text-ink-strong hover:underline"
+              >
+                {d.domain}
+              </Link>
+              <span className="font-mono text-[11px] text-ink-muted">
+                {formatNumber(d.subnet_count)} subnets
+              </span>
+            </div>
+            <div className="mt-2 grid grid-cols-2 gap-2 font-mono text-[11px] tabular-nums text-ink-muted">
+              <span>Stake {formatTao(d.total_stake_tao)}</span>
+              <span>Emission {formatPercent(d.total_emission_share)}</span>
+              <span>
+                Gini{" "}
+                {d.emission_concentration?.gini != null
+                  ? d.emission_concentration.gini.toFixed(3)
+                  : "—"}
+              </span>
+              <span>Nakamoto {formatNumber(d.emission_concentration?.nakamoto_coefficient)}</span>
+            </div>
+            <Link
+              to="/subnets"
+              search={{ domain: d.domain }}
+              className="mt-2 inline-block font-mono text-[11px] text-accent hover:underline"
+            >
+              Filter subnets →
+            </Link>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function KpiTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card px-4 py-3">
+      <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">{label}</div>
+      <div className="mt-1 font-mono text-lg text-ink-strong tabular-nums">{value}</div>
+    </div>
+  );
+}

--- a/apps/ui/src/routes/domains.test.ts
+++ b/apps/ui/src/routes/domains.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6996: /domains capability-domain rollup. Both route files compose TanStack
+// Router/Query context a rendered test can't easily stand up, so this suite is
+// node-environment source assertions, mirroring the convention documented in
+// subnets-total-stake-tile.test.ts / leaderboards-csv-export-menu.test.ts. The
+// query-layer logic (normalizeDomain) is exercised directly in
+// ../lib/metagraphed/queries.domains.test.ts.
+const list = readFileSync(fileURLToPath(new URL("./domains.index.tsx", import.meta.url)), "utf8");
+const detail = readFileSync(fileURLToPath(new URL("./domains.$tag.tsx", import.meta.url)), "utf8");
+
+describe("domains.tsx (rollup list)", () => {
+  it("registers the /domains route", () => {
+    expect(list).toContain('createFileRoute("/domains/")');
+  });
+
+  it("fetches the live rollup from the domains query, not a hardcoded list", () => {
+    expect(list).toMatch(/import\s*\{[^}]*domainsQuery[^}]*\}/s);
+    expect(list).toContain("useSuspenseQuery(domainsQuery())");
+  });
+
+  it("links each domain through to its detail page", () => {
+    expect(list).toContain('to="/domains/$tag"');
+  });
+
+  it("links each domain through to the subnets table pre-filtered by domain", () => {
+    expect(list).toContain('to="/subnets"');
+    expect(list).toContain("search={{ domain: d.domain }}");
+  });
+
+  it("wraps the wide table in a horizontal-scroll container so it never overflows the page", () => {
+    expect(list).toContain("overflow-x-auto");
+  });
+
+  it("renders member count, stake, emission share, and concentration per domain", () => {
+    expect(list).toContain("formatTao(d.total_stake_tao)");
+    expect(list).toContain("formatPercent(d.total_emission_share)");
+    expect(list).toContain("nakamoto_coefficient");
+  });
+});
+
+describe("domains.$tag.tsx (per-domain summary)", () => {
+  it("registers the /domains/$tag route", () => {
+    expect(detail).toContain('createFileRoute("/domains/$tag")');
+  });
+
+  it("fetches the per-domain summary endpoint", () => {
+    expect(detail).toMatch(/import\s*\{[^}]*domainSummaryQuery[^}]*\}/s);
+    expect(detail).toContain("useSuspenseQuery(domainSummaryQuery(tag))");
+  });
+
+  it("surfaces the within-domain emission concentration", () => {
+    expect(detail).toContain("emission_concentration");
+    expect(detail).toContain('eyebrow="Gini"');
+    expect(detail).toContain('eyebrow="Nakamoto"');
+  });
+
+  it("links member subnets to their detail pages and back to the filtered table", () => {
+    expect(detail).toContain('to="/subnets/$netuid"');
+    expect(detail).toContain("search={{ domain: domain.domain }}");
+  });
+});

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -129,9 +129,17 @@ export const Route = createFileRoute("/subnets/")({
 type SubnetsSearch = z.infer<typeof tableSearchSchema>;
 
 /** Server-backed params only — sort/curation/health filters are client-side. */
-function subnetsQueryParams(search: SubnetsSearch): { q?: string; limit: number } {
+function subnetsQueryParams(search: SubnetsSearch): {
+  q?: string;
+  domain?: string;
+  limit: number;
+} {
   return {
     q: search.q || undefined,
+    // #6996: GET /api/v1/subnets applies `?domain=` server-side, so a domain
+    // link from the /domains rollup narrows the list (and its CSV export) to
+    // that domain's member subnets without a client-side join.
+    domain: search.domain || undefined,
     limit: search.limit,
   };
 }
@@ -141,6 +149,7 @@ function SubnetsPage() {
   const navigate = useNavigate({ from: Route.fullPath });
   const filtersActive =
     !!search.q ||
+    !!search.domain ||
     !!search.sort ||
     !!search.curation ||
     !!search.health ||


### PR DESCRIPTION
Closes #6996

Adds a **/domains** route surfacing the capability-domain rollup that was REST/MCP-only until now (`GET /api/v1/domains` + `GET /api/v1/domains/{tag}/summary`), so a visitor can browse subnets by capability domain instead of only filtering an already-loaded table by a domain they already know the name of.

### What's added
- **`/domains`** — the 14-tag rollup: per-domain member count, total stake, emission share, and within-domain emission concentration (Gini + Nakamoto inline), sorted by emission share. KPI strip totals the set. Desktop table + mobile card list.
- **`/domains/`** — per-domain detail over `/api/v1/domains/{tag}/summary`: member/stake/emission stat tiles, the full emission-concentration breakdown (Gini, Nakamoto, HHI, top-1/5/10 shares), and the member subnets as chips linking to each `/subnets/{netuid}`.
- Each domain links through to the **subnets table pre-filtered by that domain**. `GET /api/v1/subnets` already applies `?domain=` server-side (verified live), so this wires `domain` into the table's search schema and server params — the list (and its CSV export) narrow to the domain's members. Verified: `/subnets` → 25 rows, `/subnets?domain=agents` → 11 rows.
- Reachable from the Subnets mega-menu ("By domain") and the footer.
- New `domainsQuery`/`domainSummaryQuery` + `normalizeDomain` (unit-tested), a reusable `formatPercent`, and `Domain`/`DomainConcentration` types.

Uses the centralized design-system tokens (Tailwind v4) and the existing `PageHero`/`StatTile`/`TableState` primitives — no one-off values. Data layer is covered by `queries.domains.test.ts`; both routes have source-assertion tests mirroring the repo convention.

### Screenshots

**New `/domains` rollup page**

| Light | Dark |
|---|---|
| ![list light](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/screenshots-domains-6996/domains/list-light.png) | ![list dark](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/screenshots-domains-6996/domains/list-dark.png) |

**New `/domains/{tag}` detail (agents / compute)**

| Light | Dark |
|---|---|
| ![detail light](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/screenshots-domains-6996/domains/detail-light.png) | ![detail dark](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/screenshots-domains-6996/domains/detail-dark.png) |

**`/subnets` domain filter (companion change) — before → after**

| Before (`/subnets`, unfiltered) | After (`/subnets?domain=agents` — 11 members) |
|---|---|
| ![before](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/screenshots-domains-6996/domains/subnets-unfiltered.png) | ![after](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/screenshots-domains-6996/domains/subnets-filtered-agents.png) |

Local checks: `eslint` clean, `tsc --noEmit` clean (after the standard `packages/ui-kit` build), `vitest` 20/20 on the new + touched suites.
