### PR TITLE
test(mcp): verify SN81 Grail OpenAPI surface via call_subnet_surface

### DIFF
--- a/tests/grail-call-subnet-surface-verify.test.mjs
+++ b/tests/grail-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,127 @@
+// SN81 (Grail) end-to-end verification for the call_subnet_surface MCP tool
+// (metagraphed#7094, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN81's real registry surface config
+// (registry/subnets/grail.json) to the tool's contract, so a future edit that
+// regresses its callability (flipping to HEAD, marking it auth_required,
+// disabling its probe) is caught here.
+//
+// The surface is the public no-auth GET JSON OpenAPI document served by
+// Grail's official Grafana instance (sn-81-grail-grafana-openapi, GET
+// https://grail-grafana.tplr.ai/public/openapi3.json). Live-verified
+// 2026-07-21 to return HTTP 200 application/json -- an OpenAPI 3.0.3 document
+// (info.title "Grafana HTTP API.", version "0.0.1", 207 documented paths). The
+// fixture below mirrors that live response's top-level shape rather than
+// fetching it, keeping the test hermetic while still exercising the JSON
+// parse-and-return path.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-81-grail-grafana-openapi";
+const OPENAPI_URL = "https://grail-grafana.tplr.ai/public/openapi3.json";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/grail.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+const BODY = {
+  openapi: "3.0.3",
+  info: { title: "Grafana HTTP API.", version: "0.0.1" },
+};
+
+function upstreamResponse() {
+  return new Response(JSON.stringify(BODY), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN81 Grail call_subnet_surface verification (#7094)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "openapi");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(SURFACE.url, OPENAPI_URL);
+    // An OpenAPI surface carries its own machine-readable schema at the URL.
+    assert.equal(SURFACE.schema_url, OPENAPI_URL);
+  });
+
+  test("callSubnetSurface returns the real JSON body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json");
+    assert.equal(result.truncated, false);
+    assert.deepEqual(result.body, BODY);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 81 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.deepEqual(result.structuredContent.body, BODY);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Pins SN81's public no-auth GET JSON OpenAPI surface (`sn-81-grail-grafana-openapi`) to the `call_subnet_surface` MCP tool contract, so a future edit that regresses its callability (flipping to HEAD, marking it `auth_required`, disabling its probe) is caught by CI.

**Surface:** GET https://grail-grafana.tplr.ai/public/openapi3.json — Grail's official Grafana OpenAPI document.
**Live-verified 2026-07-21:** HTTP 200 `application/json`, OpenAPI 3.0.3 (`info.title` "Grafana HTTP API.", version 0.0.1, 207 documented paths).

The test exercises three things against a hermetic fixture mirroring the live top-level shape:
1. the registry surface config (kind `openapi`, no-auth, probe GET/json, url + schema_url);
2. `callSubnetSurface` returning the parsed JSON body via GET on the surface's own url;
3. the end-to-end `call_subnet_surface` MCP tool path resolved by surface id.

Tests-only, no registry or schema changes.

Closes #7094