### PR TITLE
test(mcp): verify SN8 Vanta model-parameters surface via call_subnet_surface

### DIFF
--- a/tests/vanta-call-subnet-surface-verify.test.mjs
+++ b/tests/vanta-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,132 @@
+// SN8 (Vanta) end-to-end verification for the call_subnet_surface MCP tool
+// (metagraphed#7024, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN8's real registry surface config
+// (registry/subnets/vanta.json) to the tool's contract, so a future edit that
+// regresses its callability (flipping to HEAD, marking it auth_required,
+// disabling its probe) is caught here.
+//
+// The surface is the public no-auth GET SN8 model-parameters artifact served
+// from Vanta's official source repo (sn-8-vanta-model-parameters, GET
+// https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/all_model_parameters.json).
+// Live-verified 2026-07-21: after GitHub's raw redirect it returns HTTP 200
+// with content-type text/plain (GitHub serves raw .json blobs as text/plain),
+// so although the payload is JSON-shaped, call_subnet_surface returns it as an
+// unparsed capped string rather than a parsed object -- the surface's probe
+// declares expect "json" but the tool classifies by the response's actual
+// content-type. The fixture below mirrors that live text/plain response,
+// keeping the test hermetic while exercising the text (non-JSON) return path.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-8-vanta-model-parameters";
+const SURFACE_URL =
+  "https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/all_model_parameters.json";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../registry/subnets/vanta.json", import.meta.url)),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// GitHub raw serves this JSON-shaped blob as text/plain, so the tool returns
+// it verbatim as a string. Mirror that (a representative slice, not the full
+// live file).
+const BODY = '{\n    "equity": {\n        "AAPL": {}\n    }\n}';
+
+function upstreamResponse() {
+  return new Response(BODY, {
+    status: 200,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}
+
+describe("SN8 Vanta call_subnet_surface verification (#7024)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    assert.equal(SURFACE.probe?.enabled, true);
+    assert.equal(SURFACE.probe?.method, "GET");
+    assert.equal(SURFACE.probe?.expect, "json");
+    assert.equal(SURFACE.url, SURFACE_URL);
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the raw text body using the surface's own url + GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "text/plain; charset=utf-8");
+    assert.equal(result.truncated, false);
+    // text/plain -> returned as an unparsed string, not a parsed object.
+    assert.equal(typeof result.body, "string");
+    assert.equal(result.body, BODY);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 8 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(typeof result.structuredContent.body, "string");
+      assert.equal(result.structuredContent.body, BODY);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Pins SN8's public no-auth GET model-parameters artifact (`sn-8-vanta-model-parameters`) to the `call_subnet_surface` MCP tool contract, so a future edit that regresses its callability (flipping to HEAD, marking it `auth_required`, disabling its probe) is caught by CI.

**Surface:** GET https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/all_model_parameters.json — Vanta's official per-asset model parameters, served from the subnet source repo.
**Live-verified 2026-07-21:** HTTP 200 `text/plain; charset=utf-8` (GitHub serves raw `.json` blobs as text/plain), so although the payload is JSON-shaped the tool returns it as an unparsed capped **string**, classified by the response's actual content-type rather than the probe's declared `expect: json`.

The test exercises the registry surface config, `callSubnetSurface` returning the raw text body via GET on the surface's own url, and the end-to-end `call_subnet_surface` MCP tool path resolved by surface id — all against a hermetic fixture mirroring the live text/plain response.

Tests-only, no registry or schema changes.

Closes #7024