### PR TITLE
fix(api): exclude zero-stake UIDs from the subnet_yield aggregate

### DIFF
--- a/src/subnet-yield.mjs
+++ b/src/subnet-yield.mjs
@@ -143,8 +143,17 @@ export function buildSubnetYield(rows, netuid) {
     totalStakeRao += toRaoBig(stake);
     if (emission != null) {
       totalEmissionRao += toRaoBig(emission);
-      yieldStakeRao += toRaoBig(stake);
-      yieldEmissionRao += toRaoBig(emission);
+      // subnet_yield is a stake-weighted return, so a UID with emission but no
+      // stake (a miner earning incentive with ~0 staked alpha) has an undefined
+      // per-stake return -- exclude it from the yield accumulators exactly as
+      // computeYieldValue (and thus the neurons[].yield distribution + median/
+      // mean/percentiles) already does, rather than letting its emission inflate
+      // the numerator over a 0-stake denominator contribution. Its emission is
+      // still counted toward total_emission_tao above.
+      if (stake > 0) {
+        yieldStakeRao += toRaoBig(stake);
+        yieldEmissionRao += toRaoBig(emission);
+      }
     }
     if (isValidator) validatorCount += 1;
     neurons.push({
@@ -205,8 +214,10 @@ export function buildSubnetYield(rows, netuid) {
     miner_count: neurons.length - validatorCount,
     total_stake_tao: round9(totalStake),
     total_emission_tao: round9(totalEmission),
-    // Subnet-wide return over UIDs with known stake + emission only — blank-emission
-    // rows stay in the neuron list but must not dilute the aggregate as if emission were 0.
+    // Subnet-wide return over UIDs with positive stake + known emission only —
+    // blank-emission and zero-stake rows stay in the neuron list but must not
+    // dilute the aggregate (as if emission were 0, or return were earned on no
+    // stake); mirrors the neurons[].yield / median / percentile distribution.
     subnet_yield: yieldStake > 0 ? round9(yieldEmission / yieldStake) : null,
     mean_yield: meanYield,
     median_yield: medianYield,
@@ -277,7 +288,9 @@ function yieldHistoryPoint(date, dayRows) {
     if (stake == null) continue;
     neuronCount += 1;
     const emission = nullableTao(row?.emission_tao);
-    if (emission != null) {
+    // Match buildSubnetYield: a zero-stake (or blank-emission) UID has no defined
+    // per-stake return, so it must not inflate the day's subnet_yield aggregate.
+    if (emission != null && stake > 0) {
       yieldStakeRao += toRaoBig(stake);
       yieldEmissionRao += toRaoBig(emission);
     }

--- a/tests/subnet-yield.test.mjs
+++ b/tests/subnet-yield.test.mjs
@@ -247,6 +247,22 @@ describe("buildSubnetYield", () => {
     assert.equal(d.subnet_yield, 0.1);
   });
 
+  test("subnet_yield excludes a zero-stake UID's emission from the aggregate (it has no stake to earn on)", () => {
+    const d = buildSubnetYield(
+      [
+        neuron(0, { validator: true, stake: 10, emission: 2 }), // yield 0.2
+        neuron(1, { stake: 0, emission: 5 }), // no stake -> undefined yield
+      ],
+      7,
+    );
+    // The zero-stake UID's emission still counts toward the subnet's total...
+    assert.equal(d.total_emission_tao, 7);
+    // ...but must NOT inflate subnet_yield (that would be 7/10=0.7); only the
+    // staked UID contributes, matching neurons[].yield / median_yield.
+    assert.equal(d.subnet_yield, 0.2);
+    assert.equal(d.median_yield, 0.2);
+  });
+
   test("a null D1 block_number stays null, not a fabricated genesis 0", () => {
     // block_number is a nullable INTEGER; Number(null) === 0 must not surface
     // as the real chain height 0 (the contract models it as ["integer","null"]).
@@ -481,6 +497,9 @@ describe("buildSubnetYieldHistory", () => {
     assert.equal(data.points[0].neuron_count, 2);
     assert.equal(data.points[0].yield_count, 1); // only the staked UID
     assert.equal(data.points[0].median_yield, 0.1);
+    // The zero-stake UID must not inflate the day's aggregate either (that
+    // would be 15/100=0.15); only the staked UID's 10/100 counts.
+    assert.equal(data.points[0].subnet_yield, 0.1);
   });
 
   test("drops the oldest (possibly partial) day when the read was capped", () => {


### PR DESCRIPTION
## Summary

Fixes an inflated `subnet_yield` aggregate in `src/subnet-yield.mjs`. The subnet-wide metric was counting a zero-stake UID's emission in its numerator while that UID contributes `0` to the denominator — even though those UIDs are already excluded from every *per-UID* distribution metric (`neurons[].yield`, `median_yield`, `mean_yield`, `p25/p75/p90`) via `computeYieldValue`'s `if (!(stake > 0)) return null`. The headline aggregate was internally inconsistent with the distribution it summarizes.

## Failing scenario (now pinned by a regression test)

Snapshot rows `uid0 {stake: 10, emission: 2}` + `uid1 {stake: 0, emission: 5}`:

- Before: `subnet_yield = (2 + 5) / (10 + 0)` = **0.7**
- After: `subnet_yield = 2 / 10` = **0.2**

`uid1` has an undefined per-stake return (no stake to earn on) and was already excluded from `median_yield`/percentiles/`neurons[].yield`. This is a real Bittensor case — miners earn incentive-based emission with ~0 staked alpha. The existing zero-stake tests asserted the per-UID exclusion but never `subnet_yield`, so the inflated aggregate was untested.

## Change

- `buildSubnetYield` and `yieldHistoryPoint`: gate the `yieldStakeRao`/`yieldEmissionRao` accumulators on `stake > 0`, mirroring `computeYieldValue` and the existing blank-emission exclusion. `total_emission_tao` continues to count all emission — only the stake-weighted `subnet_yield` changes.
- Regression tests asserting `subnet_yield` excludes zero-stake UIDs in both the snapshot and history paths (and that `total_emission_tao` still includes their emission).

## Verification

- `npx vitest run tests/subnet-yield.test.mjs` — 32 pass.
- Patch coverage 100% on every added line and branch.
- `prettier --check` clean; no schema/contract change (the `subnet_yield` field shape is unchanged).

Refs #2589
