### PR TITLE
feat(graphql): add build query parity for GET /api/v1/build

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -53,6 +53,9 @@ import { loadAdapter } from "./adapters-mcp.mjs";
 // already call -- not a reimplementation.
 import { loadChangelog } from "./changelog-mcp.mjs";
 import { loadContracts } from "./contracts-mcp.mjs";
+// #7431: GraphQL parity for GET /api/v1/build, reusing loadBuildSummary that
+// MCP get_build already calls -- not a reimplementation.
+import { loadBuildSummary } from "./build-mcp.mjs";
 import { loadHealthHistory } from "./health-history-mcp.mjs";
 import {
   buildChainAxonRemovals,
@@ -624,6 +627,8 @@ export const SDL = `
     changelog: Changelog
     "The registry's public artifact contract metadata: every baked artifact path, storage tier, schema reference, and consumer notes. Resolves to a GraphQL error (not null) when the contracts artifact has not been baked in this environment, matching the REST route's 404 and the get_contracts MCP tool. Mirrors GET /api/v1/contracts."
     contracts: Contracts
+    "The generated build summary: artifact inventory counts and sizes, subnet/provider/surface totals, coverage rollup, and publish metadata. Resolves to a GraphQL error (not null) when the build-summary artifact has not been baked in this environment, matching the REST route's 404 and the get_build MCP tool. Mirrors GET /api/v1/build."
+    build: BuildSummary!
     "A compact daily operational health snapshot for one UTC date (YYYY-MM-DD): per-surface status/latency plus summary incident counts from the archived health/history tier. Filter by netuid/kind/provider/status/classification, sort with sort/order, and page with limit (1-1000)/cursor. An invalid date/filter/sort/limit/cursor or a missing snapshot is a GraphQL error, not a silently substituted default. Distinct from the live health rollup and health_trends. Mirrors GET /api/v1/health/history/{date}."
     health_history(date: String!, netuid: Int, kind: String, provider: String, status: String, classification: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): HealthHistory!
     "Global operational health rollup with per-subnet summaries."
@@ -2002,6 +2007,22 @@ export const SDL = `
     type_definitions_url: String
     notes: JSON
     artifacts: [JSON!]!
+  }
+
+  type BuildSummary {
+    schema_version: Int!
+    contract_version: String
+    generated_at: String
+    published_at: String
+    adapter_count: Int
+    artifact_count: Int!
+    artifact_size_bytes: Int
+    subnet_count: Int
+    surface_count: Int
+    provider_count: Int
+    artifacts: JSON
+    coverage: JSON
+    artifact_budget_summary: JSON
   }
 
   type HealthHistory {
@@ -4160,6 +4181,7 @@ export const FIELD_COMPLEXITY = {
   rpc_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   changelog: RELATIONSHIP_FIELD_COMPLEXITY,
   contracts: RELATIONSHIP_FIELD_COMPLEXITY,
+  build: RELATIONSHIP_FIELD_COMPLEXITY,
   health_history: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6197,6 +6219,13 @@ const rootValue = {
 
   contracts(_args, context) {
     return loadContracts(context, { readArtifact });
+  },
+
+  // #7431: reuse get_build's own loader unchanged (the same baked artifact read
+  // REST and MCP already use). A cold/absent artifact makes the loader throw,
+  // which the graphql executor surfaces as a normal GraphQL error.
+  build(_args, context) {
+    return loadBuildSummary(context, { readArtifact });
   },
 
   // #7170: reuse get_health_history's own loader unchanged. It takes deps as

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1714,6 +1714,54 @@ describe("graphql — contracts", () => {
   });
 });
 
+// #7431: GraphQL parity for GET /api/v1/build, reusing loadBuildSummary that MCP
+// get_build already calls (same artifact read + error behavior as REST and MCP).
+describe("graphql — build", () => {
+  const BUILD_BLOB = {
+    schema_version: 1,
+    contract_version: "2026-06-29.1",
+    generated_at: "2026-07-01T00:00:00.000Z",
+    published_at: "2026-07-01T00:00:00.000Z",
+    artifact_count: 99,
+    artifact_size_bytes: 1_000_000,
+    subnet_count: 129,
+    surface_count: 400,
+    provider_count: 50,
+    artifacts: [{ path: "/metagraph/subnets.json", size_bytes: 1000 }],
+    coverage: { surfaces: 10 },
+    artifact_budget_summary: { ok: 1, warn: 0, fail: 0 },
+  };
+
+  test("serves the baked build-summary artifact verbatim", async () => {
+    const env = fixtureEnv({ "/metagraph/build-summary.json": BUILD_BLOB });
+    const { status, body } = await gql(
+      "{ build { schema_version contract_version generated_at published_at artifact_count artifact_size_bytes subnet_count surface_count provider_count artifacts coverage artifact_budget_summary } }",
+      env,
+    );
+    assert.equal(status, 200);
+    const build = body.data.build;
+    assert.equal(build.schema_version, 1);
+    assert.equal(build.contract_version, "2026-06-29.1");
+    assert.equal(build.generated_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(build.published_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(build.artifact_count, 99);
+    assert.equal(build.subnet_count, 129);
+    assert.deepEqual(build.artifacts[0].path, "/metagraph/subnets.json");
+    assert.equal(build.coverage.surfaces, 10);
+    assert.equal(build.artifact_budget_summary.ok, 1);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ build { schema_version } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.build, 5);
+  });
+});
+
 describe("graphql — health_history", () => {
   const SURFACE_ROW = {
     netuid: 7,


### PR DESCRIPTION
## Summary
- Adds GraphQL `build` query field backed by `loadBuildSummary` from `build-mcp.mjs` (same loader as REST `GET /api/v1/build` and MCP `get_build`).
- Mirrors the #7170 changelog/contracts parity pattern: SDL type, resolver, and hermetic tests.

Closes #7431

## Test plan
- [x] `npx vitest run tests/graphql.test.mjs -t "graphql — build"` (3 tests green)
- [x] `npx prettier --check src/graphql.mjs tests/graphql.test.mjs`
