### PR TITLE
feat(api): GraphQL parity for chain-events/stats aggregate

### DIFF
--- a/src/data-api-mcp.mjs
+++ b/src/data-api-mcp.mjs
@@ -180,3 +180,38 @@ export async function loadChainEventsFeed(
     events: Array.isArray(data?.events) ? data.events : [],
   };
 }
+
+// The optional `blocks` window for get_chain_activity / Query.chain_events_stats:
+// a missing value defaults to 1000; a provided value must be a positive integer
+// and is clamped to the data Worker's 1-5000 bound so a stray large value is
+// silently capped (the data Worker clamps too, but capping here keeps the
+// request URL honest). Shared so MCP and GraphQL apply the same contract.
+export function optionalBlocksWindow(args) {
+  const value = args?.blocks;
+  if (value === undefined || value === null) return 1000;
+  if (!Number.isInteger(value) || value < 1) {
+    throwToolError(
+      "invalid_params",
+      "Argument `blocks` must be a positive integer.",
+    );
+  }
+  return Math.min(value, 5000);
+}
+
+// Chain-activity aggregate (pallet.method event distribution) over the most
+// recent N blocks, from the Postgres-backed all-events tier. That tier lives in
+// the dedicated data Worker (ADR 0013) so the postgres.js driver stays out of
+// the main Worker bundle; callers reach it through the DATA_API service
+// binding, the same binding the REST proxy uses for /api/v1/chain-events/stats.
+// Shared by MCP get_chain_activity and GraphQL Query.chain_events_stats (#7432).
+export async function loadChainActivity(ctx, blocks) {
+  const data = await dataApiFetchJson(
+    ctx,
+    `/api/v1/chain-events/stats?blocks=${blocks}`,
+  );
+  return {
+    window_blocks: data?.window_blocks ?? blocks,
+    groups: data?.groups ?? 0,
+    activity: Array.isArray(data?.activity) ? data.activity : [],
+  };
+}

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -6938,21 +6938,22 @@ const rootValue = {
   },
 
   // #7432: reuse loadChainActivity + optionalBlocksWindow (the same DATA_API
-  // path MCP get_chain_activity already calls). invalid_params (bad blocks) is
-  // BAD_USER_INPUT; a cold/unbound/rate-limited tier degrades to a
-  // schema-stable empty aggregate, never a GraphQL error — matching
-  // chain_events' cold-empty convention. Distinct from Query.chain_activity.
+  // path MCP get_chain_activity already calls). invalid_params (bad blocks or
+  // a data-Worker 400) is BAD_USER_INPUT; a cold/unbound/rate-limited tier
+  // degrades to a schema-stable empty aggregate, never a GraphQL error —
+  // matching chain_events' cold-empty convention. Distinct from
+  // Query.chain_activity.
   async chain_events_stats({ blocks }, context) {
     let windowBlocks;
     try {
       windowBlocks = optionalBlocksWindow({ blocks });
     } catch (err) {
-      if (err?.toolError && err.code === "invalid_params") {
-        throw new GraphQLError(err.message, {
-          extensions: { code: "BAD_USER_INPUT" },
-        });
-      }
-      throw err;
+      // optionalBlocksWindow only throws toolError invalid_params; map it
+      // straight to BAD_USER_INPUT (same contract as MCP get_chain_activity).
+      throw new GraphQLError(
+        err?.message || "Argument `blocks` must be a positive integer.",
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
     }
     try {
       const data = await loadChainActivity(context, windowBlocks);

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -19,7 +19,15 @@ import { loadEvidenceList } from "./evidence-mcp.mjs";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
-import { loadChainEventsFeed } from "./data-api-mcp.mjs";
+// #7432: GraphQL parity for GET /api/v1/chain-events/stats (pallet.method
+// aggregate), reusing loadChainActivity + optionalBlocksWindow that MCP
+// get_chain_activity already calls. Named chain_events_stats so it does not
+// collide with the unrelated Query.chain_activity (daily series).
+import {
+  loadChainActivity,
+  loadChainEventsFeed,
+  optionalBlocksWindow,
+} from "./data-api-mcp.mjs";
 // #6992: GraphQL parity for profiles, reusing list_profiles' own loader
 // unchanged (same artifact read, filter, sort, and page logic REST and MCP
 // already use) -- not a reimplementation.
@@ -638,6 +646,8 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "Paginated all-events feed (newest first) from the Postgres-backed all-events tier: each event's block, event index, pallet, method, decoded args, phase, and emitting extrinsic index. Filter by pallet/method/block/extrinsic; page with limit (1-200, default 50) and the opaque keyset cursor (or legacy before=block_number). An invalid filter combo is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty feed, never a GraphQL error. Distinct from Subscription.chainEvents (live WebSocket firehose). Mirrors GET /api/v1/chain-events."
     chain_events(pallet: String, method: String, block: Int, extrinsic: Int, cursor: String, before: Int, limit: Int): ChainEventsFeed!
+    "Pallet.method event-distribution aggregate over the most recent N blocks from the Postgres-backed all-events tier (each row's count, busiest first). Distinct from chain_activity (daily block/extrinsic/event-count series). blocks defaults to 1000 and is clamped to 1-5000; a non-positive value is BAD_USER_INPUT. A cold/unbound tier resolves to a schema-stable empty aggregate, never a GraphQL error. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity)."
+    chain_events_stats(blocks: Int): ChainEventsStats!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
     "Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes."
@@ -1967,6 +1977,20 @@ export const SDL = `
     phase: String
     extrinsic_index: Int
     observed_at: Float
+  }
+
+  "One pallet.method pair's event count in the recent-blocks window. Mirrors one row of GET /api/v1/chain-events/stats activity[]."
+  type ChainEventsStatsActivity {
+    pallet: String
+    method: String
+    count: Int
+  }
+
+  "Pallet.method event-distribution aggregate over the most recent N blocks from the all-events tier. Distinct from ChainActivity (daily series). Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity)."
+  type ChainEventsStats {
+    window_blocks: Int!
+    groups: Int!
+    activity: [ChainEventsStatsActivity!]!
   }
 
   type ProfileList {
@@ -4166,6 +4190,7 @@ export const FIELD_COMPLEXITY = {
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_events: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_events_stats: RELATIONSHIP_FIELD_COMPLEXITY,
   sudo: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   governance_config_changes: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6879,6 +6904,48 @@ const rootValue = {
         next_before: null,
         next_cursor: null,
         events: [],
+      };
+    }
+  },
+
+  // #7432: reuse loadChainActivity + optionalBlocksWindow (the same DATA_API
+  // path MCP get_chain_activity already calls). invalid_params (bad blocks) is
+  // BAD_USER_INPUT; a cold/unbound/rate-limited tier degrades to a
+  // schema-stable empty aggregate, never a GraphQL error — matching
+  // chain_events' cold-empty convention. Distinct from Query.chain_activity.
+  async chain_events_stats({ blocks }, context) {
+    let windowBlocks;
+    try {
+      windowBlocks = optionalBlocksWindow({ blocks });
+    } catch (err) {
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      throw err;
+    }
+    try {
+      const data = await loadChainActivity(context, windowBlocks);
+      return {
+        window_blocks: data.window_blocks,
+        groups: data.groups,
+        activity: data.activity.map((row) => ({
+          pallet: row.pallet ?? null,
+          method: row.method ?? null,
+          count: row.count ?? null,
+        })),
+      };
+    } catch (err) {
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      return {
+        window_blocks: windowBlocks,
+        groups: 0,
+        activity: [],
       };
     }
   },

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -602,10 +602,11 @@ import {
   buildBlockExtrinsics,
 } from "./extrinsics.mjs";
 import {
-  dataApiFetchJson,
   loadBlockChainEvents,
+  loadChainActivity,
   loadChainEventsFeed,
   loadExtrinsicChainEvents,
+  optionalBlocksWindow,
 } from "./data-api-mcp.mjs";
 import {
   aiEnabled,
@@ -1295,29 +1296,9 @@ async function loadSubnetEconomics(ctx, netuid) {
   };
 }
 
-// Chain-activity aggregate (pallet.method event distribution) over the most
-// recent N blocks, from the Postgres-backed all-events tier. That tier lives in
-// the dedicated data Worker (ADR 0013) so the postgres.js driver stays out of
-// this Worker's bundle; MCP handlers reach it through the DATA_API service
-// binding, the same binding the REST proxy uses for /api/v1/chain-events/stats.
-async function loadChainActivity(ctx, blocks) {
-  const data = await dataApiFetchJson(
-    ctx,
-    `/api/v1/chain-events/stats?blocks=${blocks}`,
-  );
-  return {
-    window_blocks: data?.window_blocks ?? blocks,
-    groups: data?.groups ?? 0,
-    activity: Array.isArray(data?.activity) ? data.activity : [],
-  };
-}
-
-// One page of the raw recent chain-events feed (newest first) from the
-// Postgres-backed all-events tier via the DATA_API binding — the same path
-// loadChainActivity uses for the stats aggregate. Optional pallet/method/block/
-// extrinsic filters + an opaque keyset cursor; the data Worker validates the
-// filter combo and returns 400, surfaced here as a clean invalid_params error.
-// Implemented in src/data-api-mcp.mjs (shared with GraphQL Query.chain_events).
+// loadChainActivity / optionalBlocksWindow live in src/data-api-mcp.mjs
+// (shared with GraphQL Query.chain_events_stats, #7432). list_chain_events
+// uses loadChainEventsFeed from the same module.
 
 // Mirrors loadChainEventsFeed's own DATA_API-direct call (#6637): the
 // all-events tier has no per-table tryPostgresTier flag (unlike
@@ -1921,22 +1902,6 @@ function requireHotkey(args) {
 // one hotkey-list contract for both surfaces, mirroring how
 // parseCompareNetuidList/parseCompareNetuids are already shared for
 // compare_subnets/GET /api/v1/compare.
-
-// The optional `blocks` window for get_chain_activity: a missing value defaults
-// to 1000; a provided value must be a positive integer and is clamped to the
-// data Worker's 1-5000 bound so a stray large value is silently capped (the data
-// Worker clamps too, but capping here keeps the request URL honest).
-function optionalBlocksWindow(args) {
-  const value = args?.blocks;
-  if (value === undefined || value === null) return 1000;
-  if (!Number.isInteger(value) || value < 1) {
-    throw toolError(
-      "invalid_params",
-      "Argument `blocks` must be a positive integer.",
-    );
-  }
-  return Math.min(value, 5000);
-}
 
 function clampLimit(value, fallback, max) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to

--- a/tests/extrinsic-detail.test.mjs
+++ b/tests/extrinsic-detail.test.mjs
@@ -3,8 +3,10 @@ import { describe, test } from "vitest";
 import {
   dataApiFetchJson,
   loadBlockChainEvents,
+  loadChainActivity,
   loadChainEventsFeed,
   loadExtrinsicChainEvents,
+  optionalBlocksWindow,
 } from "../src/data-api-mcp.mjs";
 
 function dataApiCtx({ fetchImpl, rateLimit = null } = {}) {
@@ -444,5 +446,56 @@ describe("data-api-mcp", () => {
     assert.deepEqual(out.events, []);
     assert.equal(out.next_before, null);
     assert.equal(out.next_cursor, null);
+  });
+
+  test("optionalBlocksWindow defaults to 1000 and clamps to 5000", () => {
+    assert.equal(optionalBlocksWindow({}), 1000);
+    assert.equal(optionalBlocksWindow({ blocks: null }), 1000);
+    assert.equal(optionalBlocksWindow({ blocks: 250 }), 250);
+    assert.equal(optionalBlocksWindow({ blocks: 9000 }), 5000);
+  });
+
+  test("optionalBlocksWindow rejects a non-positive blocks value", () => {
+    assert.throws(
+      () => optionalBlocksWindow({ blocks: 0 }),
+      (err) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => optionalBlocksWindow({ blocks: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadChainActivity fetches /chain-events/stats and shapes the aggregate", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async (request) => {
+        const url = new URL(request.url);
+        assert.equal(url.pathname, "/api/v1/chain-events/stats");
+        assert.equal(url.searchParams.get("blocks"), "250");
+        return Response.json({
+          window_blocks: 250,
+          groups: 2,
+          activity: [
+            { pallet: "SubtensorModule", method: "set_weights", count: 42 },
+            { pallet: "System", method: "ExtrinsicSuccess", count: 7 },
+          ],
+        });
+      },
+    });
+    const out = await loadChainActivity(ctx, 250);
+    assert.equal(out.window_blocks, 250);
+    assert.equal(out.groups, 2);
+    assert.equal(out.activity.length, 2);
+    assert.equal(out.activity[0].method, "set_weights");
+  });
+
+  test("loadChainActivity degrades a partial DATA_API body to defaults", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () => Response.json({}),
+    });
+    const out = await loadChainActivity(ctx, 1000);
+    assert.equal(out.window_blocks, 1000);
+    assert.equal(out.groups, 0);
+    assert.deepEqual(out.activity, []);
   });
 });

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -19277,6 +19277,65 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
     assert.equal(body.data?.chain_events_stats ?? null, null);
   });
 
+  test("a DATA_API 400 is BAD_USER_INPUT, not an empty aggregate", async () => {
+    const env = {
+      DATA_API: dataApi(
+        new Response(JSON.stringify({ error: "blocks out of range" }), {
+          status: 400,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 100) { window_blocks } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.match(body.errors[0].message, /blocks out of range/);
+    assert.equal(body.data?.chain_events_stats ?? null, null);
+  });
+
+  test("a non-OK DATA_API response degrades to an empty aggregate", async () => {
+    const env = {
+      DATA_API: dataApi(new Response("err", { status: 503 })),
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 100) { window_blocks groups activity { pallet } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 100,
+      groups: 0,
+      activity: [],
+    });
+  });
+
+  test("a rate-limited DATA_API call degrades to an empty aggregate", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({ window_blocks: 1000, groups: 1, activity: [{}] }),
+      ),
+      DATA_RATE_LIMITER: {
+        async limit() {
+          return { success: false };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats { window_blocks groups activity { pallet } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 1000,
+      groups: 0,
+      activity: [],
+    });
+  });
+
   test("sparse activity rows fill null defaults", async () => {
     const env = {
       DATA_API: dataApi(

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -19129,6 +19129,136 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
   });
 });
 
+// #7432: GraphQL parity for GET /api/v1/chain-events/stats.
+describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold/unbound tier returns a schema-stable empty aggregate, never an error", async () => {
+    const { status, body } = await gql(
+      "{ chain_events_stats { window_blocks groups activity { pallet } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 1000,
+      groups: 0,
+      activity: [],
+    });
+  });
+
+  test("resolves DATA_API activity rows matching GET /api/v1/chain-events/stats", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({
+          window_blocks: 250,
+          groups: 2,
+          activity: [
+            { pallet: "SubtensorModule", method: "set_weights", count: 42 },
+            { pallet: "System", method: "ExtrinsicSuccess", count: 7 },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ chain_events_stats(blocks: 250) {
+          window_blocks groups
+          activity { pallet method count }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 250,
+      groups: 2,
+      activity: [
+        { pallet: "SubtensorModule", method: "set_weights", count: 42 },
+        { pallet: "System", method: "ExtrinsicSuccess", count: 7 },
+      ],
+    });
+  });
+
+  test("defaults blocks to 1000 and forwards an explicit window", async () => {
+    let capturedUrl;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            window_blocks: 1000,
+            groups: 0,
+            activity: [],
+          });
+        },
+      },
+    };
+    await gql("{ chain_events_stats { window_blocks } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain-events/stats");
+    assert.equal(capturedUrl.searchParams.get("blocks"), "1000");
+
+    await gql("{ chain_events_stats(blocks: 250) { window_blocks } }", env);
+    assert.equal(capturedUrl.searchParams.get("blocks"), "250");
+  });
+
+  test("clamps blocks above 5000 and rejects a non-positive value", async () => {
+    let capturedUrl;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            window_blocks: 5000,
+            groups: 0,
+            activity: [],
+          });
+        },
+      },
+    };
+    await gql("{ chain_events_stats(blocks: 9000) { window_blocks } }", env);
+    assert.equal(capturedUrl.searchParams.get("blocks"), "5000");
+
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 0) { window_blocks } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.match(body.errors[0].message, /positive integer/);
+    assert.equal(body.data?.chain_events_stats ?? null, null);
+  });
+
+  test("sparse activity rows fill null defaults", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({
+          window_blocks: 1000,
+          groups: 1,
+          activity: [{}],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats { activity { pallet method count } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_events_stats.activity[0], {
+      pallet: null,
+      method: null,
+      count: null,
+    });
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_events_stats,
+      FIELD_COMPLEXITY.chain_events,
+    );
+  });
+});
+
 // --- curation parity (#6982) ---
 describe("graphql — curation parity (#6982)", () => {
   test("curation resolves the baked curation-states artifact", async () => {


### PR DESCRIPTION
## Summary
- Relocates `loadChainActivity` and `optionalBlocksWindow` from `src/mcp-server.mjs` into `src/data-api-mcp.mjs` (exported), alongside the sibling `loadChainEventsFeed`.
- MCP `get_chain_activity` now imports the shared loader/validator — no behavior change.
- Adds GraphQL `Query.chain_events_stats(blocks: Int): ChainEventsStats!` (not `chain_activity`, which already mirrors a different REST route) with the same blocks bounds and DATA_API path as MCP/REST.

Closes #7432

## Test plan
- [x] `npx vitest run tests/graphql.test.mjs -t chain_events_stats`
- [x] `npx vitest run tests/extrinsic-detail.test.mjs -t "loadChainActivity|optionalBlocksWindow"`
- [x] `npx vitest run tests/mcp-server.test.mjs -t get_chain_activity`
- [x] eslint on touched files
- [ ] CI Validate green
