### PR TITLE
feat(graphql): add chain_events_stats parity for chain-events/stats

### DIFF
--- a/src/data-api-mcp.mjs
+++ b/src/data-api-mcp.mjs
@@ -180,3 +180,37 @@ export async function loadChainEventsFeed(
     events: Array.isArray(data?.events) ? data.events : [],
   };
 }
+
+// The optional `blocks` window for the chain-events/stats aggregate: a missing
+// value defaults to 1000; a provided value must be a positive integer and is
+// clamped to the data Worker's 1-5000 bound so a stray large value is silently
+// capped (the data Worker clamps too, but capping here keeps the request URL
+// honest). Shared by MCP's get_chain_activity and GraphQL's chain_events_stats.
+export function optionalBlocksWindow(args) {
+  const value = args?.blocks;
+  if (value === undefined || value === null) return 1000;
+  if (!Number.isInteger(value) || value < 1) {
+    throwToolError(
+      "invalid_params",
+      "Argument `blocks` must be a positive integer.",
+    );
+  }
+  return Math.min(value, 5000);
+}
+
+// Chain-activity aggregate (pallet.method event distribution) over the most
+// recent N blocks, from the Postgres-backed all-events tier via the DATA_API
+// binding — the same path REST's /api/v1/chain-events/stats proxy uses, and the
+// stats sibling of loadChainEventsFeed's raw feed above. Shared by MCP's
+// get_chain_activity and GraphQL's chain_events_stats.
+export async function loadChainActivity(ctx, blocks) {
+  const data = await dataApiFetchJson(
+    ctx,
+    `/api/v1/chain-events/stats?blocks=${blocks}`,
+  );
+  return {
+    window_blocks: data?.window_blocks ?? blocks,
+    groups: data?.groups ?? 0,
+    activity: Array.isArray(data?.activity) ? data.activity : [],
+  };
+}

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -19,7 +19,14 @@ import { loadEvidenceList } from "./evidence-mcp.mjs";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
-import { loadChainEventsFeed } from "./data-api-mcp.mjs";
+// #7432: GraphQL parity for GET /api/v1/chain-events/stats (the aggregate
+// sibling), reusing loadChainActivity + optionalBlocksWindow that MCP's
+// get_chain_activity already calls — both relocated here from mcp-server.mjs.
+import {
+  loadChainActivity,
+  loadChainEventsFeed,
+  optionalBlocksWindow,
+} from "./data-api-mcp.mjs";
 // #6992: GraphQL parity for profiles, reusing list_profiles' own loader
 // unchanged (same artifact read, filter, sort, and page logic REST and MCP
 // already use) -- not a reimplementation.
@@ -643,6 +650,8 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "Paginated all-events feed (newest first) from the Postgres-backed all-events tier: each event's block, event index, pallet, method, decoded args, phase, and emitting extrinsic index. Filter by pallet/method/block/extrinsic; page with limit (1-200, default 50) and the opaque keyset cursor (or legacy before=block_number). An invalid filter combo is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty feed, never a GraphQL error. Distinct from Subscription.chainEvents (live WebSocket firehose). Mirrors GET /api/v1/chain-events."
     chain_events(pallet: String, method: String, block: Int, extrinsic: Int, cursor: String, before: Int, limit: Int): ChainEventsFeed!
+    "Chain-activity aggregate over the most recent N blocks (the blocks arg, 1-5000, default 1000, a stray large value silently capped) from the Postgres-backed all-events tier: the pallet.method event distribution, each with its count, busiest first. A non-positive/non-integer blocks is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty aggregate, never a GraphQL error. The aggregate sibling of chain_events (the raw feed). Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity)."
+    chain_events_stats(blocks: Int): ChainEventsStats!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
     "Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes."
@@ -1972,6 +1981,20 @@ export const SDL = `
     phase: String
     extrinsic_index: Int
     observed_at: Float
+  }
+
+  "Chain-activity aggregate (pallet.method event distribution) over the most recent N blocks from the Postgres-backed all-events tier. The aggregate sibling of ChainEventsFeed. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity)."
+  type ChainEventsStats {
+    window_blocks: Int!
+    groups: Int!
+    activity: [ChainEventsStatsRow!]!
+  }
+
+  "One pallet.method group in the chain-activity aggregate, with its event count over the window."
+  type ChainEventsStatsRow {
+    pallet: String
+    method: String
+    count: Int
   }
 
   type ProfileList {
@@ -4188,6 +4211,7 @@ export const FIELD_COMPLEXITY = {
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_events: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_events_stats: RELATIONSHIP_FIELD_COMPLEXITY,
   sudo: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   governance_config_changes: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6909,6 +6933,32 @@ const rootValue = {
         next_cursor: null,
         events: [],
       };
+    }
+  },
+
+  // #7432: the aggregate sibling of chain_events. Reuses optionalBlocksWindow
+  // (the same 1000-default/positive-integer/1-5000-cap validation MCP's
+  // get_chain_activity applies) then loadChainActivity — both relocated to
+  // data-api-mcp.mjs beside loadChainEventsFeed.
+  async chain_events_stats({ blocks }, context) {
+    let window;
+    try {
+      window = optionalBlocksWindow({ blocks });
+    } catch (err) {
+      // optionalBlocksWindow's only failure is invalid_params (a non-positive
+      // or non-integer blocks) — surface it as BAD_USER_INPUT, mirroring how
+      // chain_events maps the sibling feed's invalid-filter error.
+      throw new GraphQLError(err.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    try {
+      return await loadChainActivity(context, window);
+    } catch {
+      // A cold/unbound/rate-limited tier degrades to a schema-stable empty
+      // aggregate (echoing the validated window), never a GraphQL error —
+      // matching chain_events' cold-empty convention.
+      return { window_blocks: window, groups: 0, activity: [] };
     }
   },
 

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -602,10 +602,11 @@ import {
   buildBlockExtrinsics,
 } from "./extrinsics.mjs";
 import {
-  dataApiFetchJson,
   loadBlockChainEvents,
+  loadChainActivity,
   loadChainEventsFeed,
   loadExtrinsicChainEvents,
+  optionalBlocksWindow,
 } from "./data-api-mcp.mjs";
 import {
   aiEnabled,
@@ -1296,21 +1297,9 @@ async function loadSubnetEconomics(ctx, netuid) {
 }
 
 // Chain-activity aggregate (pallet.method event distribution) over the most
-// recent N blocks, from the Postgres-backed all-events tier. That tier lives in
-// the dedicated data Worker (ADR 0013) so the postgres.js driver stays out of
-// this Worker's bundle; MCP handlers reach it through the DATA_API service
-// binding, the same binding the REST proxy uses for /api/v1/chain-events/stats.
-async function loadChainActivity(ctx, blocks) {
-  const data = await dataApiFetchJson(
-    ctx,
-    `/api/v1/chain-events/stats?blocks=${blocks}`,
-  );
-  return {
-    window_blocks: data?.window_blocks ?? blocks,
-    groups: data?.groups ?? 0,
-    activity: Array.isArray(data?.activity) ? data.activity : [],
-  };
-}
+// recent N blocks lives in src/data-api-mcp.mjs (exported loadChainActivity,
+// #7432) alongside its raw-feed sibling loadChainEventsFeed — same shared
+// DATA_API path, now reused by GraphQL's chain_events_stats field too.
 
 // One page of the raw recent chain-events feed (newest first) from the
 // Postgres-backed all-events tier via the DATA_API binding — the same path
@@ -1922,21 +1911,9 @@ function requireHotkey(args) {
 // parseCompareNetuidList/parseCompareNetuids are already shared for
 // compare_subnets/GET /api/v1/compare.
 
-// The optional `blocks` window for get_chain_activity: a missing value defaults
-// to 1000; a provided value must be a positive integer and is clamped to the
-// data Worker's 1-5000 bound so a stray large value is silently capped (the data
-// Worker clamps too, but capping here keeps the request URL honest).
-function optionalBlocksWindow(args) {
-  const value = args?.blocks;
-  if (value === undefined || value === null) return 1000;
-  if (!Number.isInteger(value) || value < 1) {
-    throw toolError(
-      "invalid_params",
-      "Argument `blocks` must be a positive integer.",
-    );
-  }
-  return Math.min(value, 5000);
-}
+// The optional `blocks` window for get_chain_activity lives in
+// src/data-api-mcp.mjs (exported optionalBlocksWindow, #7432) beside its
+// loadChainActivity loader — shared with GraphQL's chain_events_stats field.
 
 function clampLimit(value, fallback, max) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -19177,6 +19177,189 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
   });
 });
 
+// #7432: GraphQL parity for GET /api/v1/chain-events/stats (the aggregate
+// sibling of chain_events), reusing the loadChainActivity + optionalBlocksWindow
+// that MCP get_chain_activity already calls, both relocated to data-api-mcp.mjs.
+describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold/unbound tier returns a schema-stable empty aggregate, never an error", async () => {
+    const { status, body } = await gql(
+      "{ chain_events_stats { window_blocks groups activity { pallet method count } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    // Loader throws (no DATA_API); resolver degrades to an empty aggregate that
+    // echoes the validated default window.
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 1000,
+      groups: 0,
+      activity: [],
+    });
+  });
+
+  test("resolves the pallet.method aggregate from DATA_API", async () => {
+    let capturedUrl;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            window_blocks: 1000,
+            groups: 2,
+            activity: [
+              { pallet: "SubtensorModule", method: "WeightsSet", count: 42 },
+              { pallet: "System", method: "ExtrinsicSuccess", count: 7 },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats { window_blocks groups activity { pallet method count } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    // Same DATA_API path REST's /chain-events/stats proxy uses; omitted blocks
+    // defaults to 1000.
+    assert.equal(capturedUrl.pathname, "/api/v1/chain-events/stats");
+    assert.equal(capturedUrl.searchParams.get("blocks"), "1000");
+    assert.equal(body.data.chain_events_stats.window_blocks, 1000);
+    assert.equal(body.data.chain_events_stats.groups, 2);
+    assert.equal(body.data.chain_events_stats.activity.length, 2);
+    assert.deepEqual(body.data.chain_events_stats.activity[0], {
+      pallet: "SubtensorModule",
+      method: "WeightsSet",
+      count: 42,
+    });
+  });
+
+  test("forwards an explicit blocks window as a query param", async () => {
+    let capturedUrl;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ window_blocks: 250, groups: 0, activity: [] });
+        },
+      },
+    };
+    const { body } = await gql(
+      "{ chain_events_stats(blocks: 250) { window_blocks } }",
+      env,
+    );
+    assert.equal(capturedUrl.searchParams.get("blocks"), "250");
+    assert.equal(body.data.chain_events_stats.window_blocks, 250);
+  });
+
+  test("clamps an over-cap blocks window to 5000", async () => {
+    let capturedUrl;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            window_blocks: 5000,
+            groups: 0,
+            activity: [],
+          });
+        },
+      },
+    };
+    await gql("{ chain_events_stats(blocks: 99999) { window_blocks } }", env);
+    assert.equal(capturedUrl.searchParams.get("blocks"), "5000");
+  });
+
+  test("treats an explicit null blocks as the default window", async () => {
+    let capturedUrl;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            window_blocks: 1000,
+            groups: 0,
+            activity: [],
+          });
+        },
+      },
+    };
+    await gql("{ chain_events_stats(blocks: null) { window_blocks } }", env);
+    assert.equal(capturedUrl.searchParams.get("blocks"), "1000");
+  });
+
+  test("a non-positive / non-integer blocks is BAD_USER_INPUT, not an aggregate", async () => {
+    for (const blocks of [0, -5]) {
+      const { status, body } = await gql(
+        `{ chain_events_stats(blocks: ${blocks}) { window_blocks } }`,
+        { DATA_API: dataApi(Response.json({})) },
+      );
+      assert.equal(status, 200);
+      assert.ok(
+        body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+        `blocks=${blocks} should be BAD_USER_INPUT`,
+      );
+      assert.match(body.errors[0].message, /blocks/);
+      assert.equal(body.data?.chain_events_stats ?? null, null);
+    }
+  });
+
+  test("a partial DATA_API body degrades to resolver defaults", async () => {
+    const env = { DATA_API: dataApi(Response.json({})) };
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 500) { window_blocks groups activity { pallet } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    // window_blocks falls back to the requested window; groups/activity to their
+    // schema-stable defaults.
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 500,
+      groups: 0,
+      activity: [],
+    });
+  });
+
+  test("a data_rate_limited loader failure degrades to an empty aggregate", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({
+          window_blocks: 1000,
+          groups: 1,
+          activity: [{ pallet: "X", method: "Y", count: 1 }],
+        }),
+      ),
+      DATA_RATE_LIMITER: {
+        async limit() {
+          return { success: false };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats { window_blocks groups activity { pallet } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 1000,
+      groups: 0,
+      activity: [],
+    });
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_events_stats,
+      FIELD_COMPLEXITY.chain_events,
+    );
+  });
+});
+
 // --- curation parity (#6982) ---
 describe("graphql — curation parity (#6982)", () => {
   test("curation resolves the baked curation-states artifact", async () => {


### PR DESCRIPTION
feat(graphql): add chain_events_stats parity for chain-events/stats

Relocate loadChainActivity and its optionalBlocksWindow validator out of
src/mcp-server.mjs into src/data-api-mcp.mjs (exported), beside the sibling
loadChainEventsFeed they share the DATA_API /api/v1/chain-events path with.
The get_chain_activity MCP tool now imports the relocated loader with no
behavior change.

Add a chain_events_stats(blocks: Int): ChainEventsStats! Query field backed by
the same loader, reusing optionalBlocksWindow for the identical
1000-default/positive-integer/1-5000-cap bounds MCP applies. A bad blocks value
is BAD_USER_INPUT; a cold/unbound/rate-limited tier degrades to a schema-stable
empty aggregate, matching the sibling chain_events field. Named to avoid the
unrelated existing chain_activity field (a different REST route).

Closes #7432

