### PR TITLE
feat(graphql): add chain_events_stats parity for chain-events/stats

### DIFF
--- a/src/data-api-mcp.mjs
+++ b/src/data-api-mcp.mjs
@@ -180,3 +180,37 @@ export async function loadChainEventsFeed(
     events: Array.isArray(data?.events) ? data.events : [],
   };
 }
+
+const CHAIN_ACTIVITY_BLOCKS_DEFAULT = 1000;
+const CHAIN_ACTIVITY_BLOCKS_MAX = 5000;
+
+// The optional `blocks` window for get_chain_activity / chain_events_stats: a
+// missing value defaults to 1000; a provided value must be a positive integer
+// and is clamped to the data Worker's 1-5000 bound.
+export function optionalBlocksWindow(args) {
+  const value = args?.blocks;
+  if (value === undefined || value === null)
+    return CHAIN_ACTIVITY_BLOCKS_DEFAULT;
+  if (!Number.isInteger(value) || value < 1) {
+    throwToolError(
+      "invalid_params",
+      "Argument `blocks` must be a positive integer.",
+    );
+  }
+  return Math.min(value, CHAIN_ACTIVITY_BLOCKS_MAX);
+}
+
+// Chain-activity aggregate (pallet.method event distribution) over the most
+// recent N blocks, from the Postgres-backed all-events tier — same DATA_API path
+// REST's /api/v1/chain-events/stats proxy and MCP get_chain_activity use.
+export async function loadChainActivity(ctx, blocks) {
+  const data = await dataApiFetchJson(
+    ctx,
+    `/api/v1/chain-events/stats?blocks=${blocks}`,
+  );
+  return {
+    window_blocks: data?.window_blocks ?? blocks,
+    groups: data?.groups ?? 0,
+    activity: Array.isArray(data?.activity) ? data.activity : [],
+  };
+}

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -19,7 +19,11 @@ import { loadEvidenceList } from "./evidence-mcp.mjs";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
-import { loadChainEventsFeed } from "./data-api-mcp.mjs";
+import {
+  loadChainActivity,
+  loadChainEventsFeed,
+  optionalBlocksWindow,
+} from "./data-api-mcp.mjs";
 // #6992: GraphQL parity for profiles, reusing list_profiles' own loader
 // unchanged (same artifact read, filter, sort, and page logic REST and MCP
 // already use) -- not a reimplementation.
@@ -643,6 +647,8 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "Paginated all-events feed (newest first) from the Postgres-backed all-events tier: each event's block, event index, pallet, method, decoded args, phase, and emitting extrinsic index. Filter by pallet/method/block/extrinsic; page with limit (1-200, default 50) and the opaque keyset cursor (or legacy before=block_number). An invalid filter combo is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty feed, never a GraphQL error. Distinct from Subscription.chainEvents (live WebSocket firehose). Mirrors GET /api/v1/chain-events."
     chain_events(pallet: String, method: String, block: Int, extrinsic: Int, cursor: String, before: Int, limit: Int): ChainEventsFeed!
+    "Pallet.method event-distribution aggregate over the most recent N blocks from the Postgres-backed all-events tier (default 1000, max 5000). An invalid blocks argument is a GraphQL BAD_USER_INPUT error; an unavailable tier is a GraphQL error. Distinct from chain_activity (daily block/extrinsic series from GET /api/v1/chain/activity). Mirrors GET /api/v1/chain-events/stats."
+    chain_events_stats(blocks: Int): ChainEventsStats!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
     "Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes."
@@ -1972,6 +1978,13 @@ export const SDL = `
     phase: String
     extrinsic_index: Int
     observed_at: Float
+  }
+
+  "Pallet.method event-distribution aggregate from the all-events tier. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity)."
+  type ChainEventsStats {
+    window_blocks: Int!
+    groups: Int!
+    activity: [JSON!]!
   }
 
   type ProfileList {
@@ -4188,6 +4201,7 @@ export const FIELD_COMPLEXITY = {
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_events: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_events_stats: RELATIONSHIP_FIELD_COMPLEXITY,
   sudo: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   governance_config_changes: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6909,6 +6923,23 @@ const rootValue = {
         next_cursor: null,
         events: [],
       };
+    }
+  },
+
+  // #7432: reuse loadChainActivity (the same DATA_API path MCP get_chain_activity
+  // already calls). invalid_params (bad blocks window) is BAD_USER_INPUT; a cold
+  // or unavailable tier surfaces as a GraphQL error, matching MCP/REST.
+  async chain_events_stats({ blocks }, context) {
+    try {
+      const window = optionalBlocksWindow({ blocks });
+      return await loadChainActivity(context, window);
+    } catch (err) {
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      throw err;
     }
   },
 

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -604,8 +604,10 @@ import {
 import {
   dataApiFetchJson,
   loadBlockChainEvents,
+  loadChainActivity,
   loadChainEventsFeed,
   loadExtrinsicChainEvents,
+  optionalBlocksWindow,
 } from "./data-api-mcp.mjs";
 import {
   aiEnabled,
@@ -1295,29 +1297,9 @@ async function loadSubnetEconomics(ctx, netuid) {
   };
 }
 
-// Chain-activity aggregate (pallet.method event distribution) over the most
-// recent N blocks, from the Postgres-backed all-events tier. That tier lives in
-// the dedicated data Worker (ADR 0013) so the postgres.js driver stays out of
-// this Worker's bundle; MCP handlers reach it through the DATA_API service
-// binding, the same binding the REST proxy uses for /api/v1/chain-events/stats.
-async function loadChainActivity(ctx, blocks) {
-  const data = await dataApiFetchJson(
-    ctx,
-    `/api/v1/chain-events/stats?blocks=${blocks}`,
-  );
-  return {
-    window_blocks: data?.window_blocks ?? blocks,
-    groups: data?.groups ?? 0,
-    activity: Array.isArray(data?.activity) ? data.activity : [],
-  };
-}
-
 // One page of the raw recent chain-events feed (newest first) from the
-// Postgres-backed all-events tier via the DATA_API binding — the same path
-// loadChainActivity uses for the stats aggregate. Optional pallet/method/block/
-// extrinsic filters + an opaque keyset cursor; the data Worker validates the
-// filter combo and returns 400, surfaced here as a clean invalid_params error.
-// Implemented in src/data-api-mcp.mjs (shared with GraphQL Query.chain_events).
+// Postgres-backed all-events tier via the DATA_API binding — implemented in
+// src/data-api-mcp.mjs (shared with GraphQL Query.chain_events).
 
 // Mirrors loadChainEventsFeed's own DATA_API-direct call (#6637): the
 // all-events tier has no per-table tryPostgresTier flag (unlike
@@ -1921,22 +1903,6 @@ function requireHotkey(args) {
 // one hotkey-list contract for both surfaces, mirroring how
 // parseCompareNetuidList/parseCompareNetuids are already shared for
 // compare_subnets/GET /api/v1/compare.
-
-// The optional `blocks` window for get_chain_activity: a missing value defaults
-// to 1000; a provided value must be a positive integer and is clamped to the
-// data Worker's 1-5000 bound so a stray large value is silently capped (the data
-// Worker clamps too, but capping here keeps the request URL honest).
-function optionalBlocksWindow(args) {
-  const value = args?.blocks;
-  if (value === undefined || value === null) return 1000;
-  if (!Number.isInteger(value) || value < 1) {
-    throw toolError(
-      "invalid_params",
-      "Argument `blocks` must be a positive integer.",
-    );
-  }
-  return Math.min(value, 5000);
-}
 
 function clampLimit(value, fallback, max) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -602,7 +602,6 @@ import {
   buildBlockExtrinsics,
 } from "./extrinsics.mjs";
 import {
-  dataApiFetchJson,
   loadBlockChainEvents,
   loadChainActivity,
   loadChainEventsFeed,

--- a/tests/extrinsic-detail.test.mjs
+++ b/tests/extrinsic-detail.test.mjs
@@ -3,8 +3,10 @@ import { describe, test } from "vitest";
 import {
   dataApiFetchJson,
   loadBlockChainEvents,
+  loadChainActivity,
   loadChainEventsFeed,
   loadExtrinsicChainEvents,
+  optionalBlocksWindow,
 } from "../src/data-api-mcp.mjs";
 
 function dataApiCtx({ fetchImpl, rateLimit = null } = {}) {
@@ -444,5 +446,57 @@ describe("data-api-mcp", () => {
     assert.deepEqual(out.events, []);
     assert.equal(out.next_before, null);
     assert.equal(out.next_cursor, null);
+  });
+
+  test("optionalBlocksWindow defaults omitted or null blocks to 1000", () => {
+    assert.equal(optionalBlocksWindow({}), 1000);
+    assert.equal(optionalBlocksWindow({ blocks: null }), 1000);
+    assert.equal(optionalBlocksWindow({ blocks: undefined }), 1000);
+  });
+
+  test("optionalBlocksWindow clamps an over-cap blocks window to 5000", () => {
+    assert.equal(optionalBlocksWindow({ blocks: 99999 }), 5000);
+  });
+
+  test("optionalBlocksWindow rejects a non-positive / non-integer blocks argument", () => {
+    for (const blocks of [0, -5, 1.5]) {
+      assert.throws(
+        () => optionalBlocksWindow({ blocks }),
+        (err) =>
+          err.code === "invalid_params" &&
+          /blocks.*positive integer/.test(err.message),
+      );
+    }
+  });
+
+  test("loadChainActivity shapes the stats aggregate and forwards the window", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async (request) => {
+        const url = new URL(request.url);
+        assert.equal(url.pathname, "/api/v1/chain-events/stats");
+        assert.equal(url.searchParams.get("blocks"), "250");
+        return Response.json({
+          window_blocks: 250,
+          groups: 2,
+          activity: [
+            { pallet: "SubtensorModule", method: "set_weights", count: 42 },
+          ],
+        });
+      },
+    });
+    const out = await loadChainActivity(ctx, 250);
+    assert.equal(out.window_blocks, 250);
+    assert.equal(out.groups, 2);
+    assert.equal(out.activity[0].method, "set_weights");
+  });
+
+  test("loadChainActivity falls back when the upstream body omits optional fields", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () => Response.json({}),
+    });
+    const out = await loadChainActivity(ctx, 1000);
+    assert.equal(out.window_blocks, 1000);
+    assert.equal(out.groups, 0);
+    assert.deepEqual(out.activity, []);
   });
 });

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -19177,6 +19177,90 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
   });
 });
 
+// #7432: GraphQL parity for GET /api/v1/chain-events/stats, reusing
+// loadChainActivity that MCP get_chain_activity already calls.
+describe("graphql — chain_events_stats (#7432, DATA_API stats aggregate)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("unbound DATA_API tier is a GraphQL error, matching MCP/REST", async () => {
+    const { body } = await gql("{ chain_events_stats { window_blocks } }");
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("resolves the pallet.method aggregate from DATA_API", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({
+          window_blocks: 250,
+          groups: 2,
+          activity: [
+            { pallet: "SubtensorModule", method: "set_weights", count: 42 },
+            { pallet: "System", method: "ExtrinsicSuccess", count: 7 },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 250) { window_blocks groups activity } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.chain_events_stats.window_blocks, 250);
+    assert.equal(body.data.chain_events_stats.groups, 2);
+    assert.deepEqual(body.data.chain_events_stats.activity[0], {
+      pallet: "SubtensorModule",
+      method: "set_weights",
+      count: 42,
+    });
+  });
+
+  test("defaults blocks to 1000 when omitted", async () => {
+    let capturedUrl;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            window_blocks: 1000,
+            groups: 0,
+            activity: [],
+          });
+        },
+      },
+    };
+    await gql("{ chain_events_stats { window_blocks } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain-events/stats");
+    assert.equal(capturedUrl.searchParams.get("blocks"), "1000");
+  });
+
+  test("rejects a non-positive / non-integer blocks argument", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({ window_blocks: 1, groups: 0, activity: [] }),
+      ),
+    };
+    for (const blocks of [0, -5, 1.5]) {
+      const { body } = await gql(
+        `{ chain_events_stats(blocks: ${blocks}) { window_blocks } }`,
+        env,
+      );
+      assert.ok(body.errors?.length, `blocks=${blocks}`);
+      assert.ok(body.data == null);
+    }
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_events_stats,
+      FIELD_COMPLEXITY.chain_events,
+    );
+  });
+});
+
 // --- curation parity (#6982) ---
 describe("graphql — curation parity (#6982)", () => {
   test("curation resolves the baked curation-states artifact", async () => {


### PR DESCRIPTION
## Summary
- Add `Query.chain_events_stats(blocks: Int)` GraphQL field with the same `loadChainActivity` / `optionalBlocksWindow` loaders MCP and REST use.
- Move shared loaders into `data-api-mcp.mjs` so MCP and GraphQL share one implementation.
- Add direct unit tests for `optionalBlocksWindow` and `loadChainActivity` so codecov/patch covers the relocated lines.

Closes #7432

## Test plan
- [x] `npx vitest run tests/extrinsic-detail.test.mjs tests/graphql.test.mjs -t chain_events_stats|optionalBlocksWindow|loadChainActivity`
- [x] `npx prettier --check tests/extrinsic-detail.test.mjs`
- [ ] CI green including codecov/patch