### PR TITLE
feat(api): add chain_events_stats GraphQL field for chain-events/stats parity

### DIFF
--- a/src/data-api-mcp.mjs
+++ b/src/data-api-mcp.mjs
@@ -180,3 +180,40 @@ export async function loadChainEventsFeed(
     events: Array.isArray(data?.events) ? data.events : [],
   };
 }
+
+// The optional `blocks` window for the chain-activity aggregate (MCP's
+// get_chain_activity tool + GraphQL's chain_events_stats): a missing value
+// defaults to 1000; a provided value must be a positive integer and is clamped to
+// the data Worker's 1-5000 bound so a stray large value is silently capped (the
+// data Worker clamps too, but capping here keeps the request URL honest). Lives
+// beside its loader here so both the MCP tool and the GraphQL resolver reuse one
+// validator rather than reimplementing the bound.
+export function optionalBlocksWindow(args) {
+  const value = args?.blocks;
+  if (value === undefined || value === null) return 1000;
+  if (!Number.isInteger(value) || value < 1) {
+    throwToolError(
+      "invalid_params",
+      "Argument `blocks` must be a positive integer.",
+    );
+  }
+  return Math.min(value, 5000);
+}
+
+// Chain-activity aggregate (pallet.method event distribution, busiest first) over
+// the most recent N blocks — same DATA_API path REST's /api/v1/chain-events/stats
+// proxy, MCP's get_chain_activity tool, and GraphQL's chain_events_stats field all
+// use. Shared here beside its raw-feed sibling loadChainEventsFeed rather than
+// duplicated in the MCP server (#7432). Cold/unbound tier surfaces as a thrown
+// tool error from dataApiFetchJson, which each caller degrades in its own idiom.
+export async function loadChainActivity(ctx, blocks) {
+  const data = await dataApiFetchJson(
+    ctx,
+    `/api/v1/chain-events/stats?blocks=${blocks}`,
+  );
+  return {
+    window_blocks: data?.window_blocks ?? blocks,
+    groups: data?.groups ?? 0,
+    activity: Array.isArray(data?.activity) ? data.activity : [],
+  };
+}

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -19,7 +19,13 @@ import { loadEvidenceList } from "./evidence-mcp.mjs";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
-import { loadChainEventsFeed } from "./data-api-mcp.mjs";
+// #7432: chain_events_stats parity reuses the relocated loadChainActivity +
+// optionalBlocksWindow (same shared module as their raw-feed sibling).
+import {
+  loadChainEventsFeed,
+  loadChainActivity,
+  optionalBlocksWindow,
+} from "./data-api-mcp.mjs";
 // #6992: GraphQL parity for profiles, reusing list_profiles' own loader
 // unchanged (same artifact read, filter, sort, and page logic REST and MCP
 // already use) -- not a reimplementation.
@@ -643,6 +649,8 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "Paginated all-events feed (newest first) from the Postgres-backed all-events tier: each event's block, event index, pallet, method, decoded args, phase, and emitting extrinsic index. Filter by pallet/method/block/extrinsic; page with limit (1-200, default 50) and the opaque keyset cursor (or legacy before=block_number). An invalid filter combo is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty feed, never a GraphQL error. Distinct from Subscription.chainEvents (live WebSocket firehose). Mirrors GET /api/v1/chain-events."
     chain_events(pallet: String, method: String, block: Int, extrinsic: Int, cursor: String, before: Int, limit: Int): ChainEventsFeed!
+    "The chain-activity aggregate: the pallet.method event distribution (each with its count, busiest first) over the most recent N blocks from the Postgres-backed all-events tier. blocks defaults to 1000 and is capped at 5000; a non-positive-integer blocks is a GraphQL BAD_USER_INPUT error, while a cold/unbound tier resolves to a schema-stable empty aggregate (groups:0, activity:[]), never a GraphQL error. The aggregate sibling of chain_events. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity)."
+    chain_events_stats(blocks: Int): ChainEventsStats!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
     "Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes."
@@ -1972,6 +1980,20 @@ export const SDL = `
     phase: String
     extrinsic_index: Int
     observed_at: Float
+  }
+
+  "The pallet.method event-distribution aggregate over a recent block window from the Postgres-backed all-events tier. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity). The aggregate sibling of ChainEventsFeed."
+  type ChainEventsStats {
+    window_blocks: Int!
+    groups: Int!
+    activity: [ChainEventStat!]!
+  }
+
+  "One pallet.method group in the chain-activity aggregate: how many events that pallet+method emitted over the window (groups ordered by count descending, top 100)."
+  type ChainEventStat {
+    pallet: String
+    method: String
+    count: Int
   }
 
   type ProfileList {
@@ -4188,6 +4210,7 @@ export const FIELD_COMPLEXITY = {
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_events: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_events_stats: RELATIONSHIP_FIELD_COMPLEXITY,
   sudo: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   governance_config_changes: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6909,6 +6932,40 @@ const rootValue = {
         next_cursor: null,
         events: [],
       };
+    }
+  },
+
+  // #7432: reuse the relocated loadChainActivity + optionalBlocksWindow (the same
+  // DATA_API path + blocks-window bound MCP's get_chain_activity applies). A
+  // non-positive-integer `blocks` is invalid_params -> BAD_USER_INPUT; a
+  // cold/unbound/rate-limited tier degrades to a schema-stable empty aggregate,
+  // never a GraphQL error -- matching chain_events' cold-empty convention.
+  async chain_events_stats({ blocks }, context) {
+    let window;
+    try {
+      window = optionalBlocksWindow({ blocks });
+    } catch (err) {
+      // optionalBlocksWindow's only throw is invalid_params (a non-positive-integer
+      // blocks) -- surface it as GraphQL BAD_USER_INPUT.
+      throw new GraphQLError(err.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    try {
+      const data = await loadChainActivity(context, window);
+      return {
+        window_blocks: data.window_blocks,
+        groups: data.groups,
+        activity: data.activity.map((row) => ({
+          pallet: row.pallet ?? null,
+          method: row.method ?? null,
+          count: row.count ?? null,
+        })),
+      };
+    } catch {
+      // cold/unbound/rate-limited tier (or any loader failure): a schema-stable
+      // empty aggregate over the requested window, never a GraphQL error.
+      return { window_blocks: window, groups: 0, activity: [] };
     }
   },
 

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -602,10 +602,11 @@ import {
   buildBlockExtrinsics,
 } from "./extrinsics.mjs";
 import {
-  dataApiFetchJson,
   loadBlockChainEvents,
+  loadChainActivity,
   loadChainEventsFeed,
   loadExtrinsicChainEvents,
+  optionalBlocksWindow,
 } from "./data-api-mcp.mjs";
 import {
   aiEnabled,
@@ -1295,29 +1296,18 @@ async function loadSubnetEconomics(ctx, netuid) {
   };
 }
 
-// Chain-activity aggregate (pallet.method event distribution) over the most
-// recent N blocks, from the Postgres-backed all-events tier. That tier lives in
-// the dedicated data Worker (ADR 0013) so the postgres.js driver stays out of
-// this Worker's bundle; MCP handlers reach it through the DATA_API service
-// binding, the same binding the REST proxy uses for /api/v1/chain-events/stats.
-async function loadChainActivity(ctx, blocks) {
-  const data = await dataApiFetchJson(
-    ctx,
-    `/api/v1/chain-events/stats?blocks=${blocks}`,
-  );
-  return {
-    window_blocks: data?.window_blocks ?? blocks,
-    groups: data?.groups ?? 0,
-    activity: Array.isArray(data?.activity) ? data.activity : [],
-  };
-}
+// The chain-activity aggregate loader (loadChainActivity) + its blocks-window
+// validator (optionalBlocksWindow) were relocated to src/data-api-mcp.mjs in
+// #7432, beside their raw-feed sibling loadChainEventsFeed, so the get_chain_activity
+// tool below and GraphQL's chain_events_stats field share one implementation.
 
 // One page of the raw recent chain-events feed (newest first) from the
-// Postgres-backed all-events tier via the DATA_API binding — the same path
-// loadChainActivity uses for the stats aggregate. Optional pallet/method/block/
-// extrinsic filters + an opaque keyset cursor; the data Worker validates the
-// filter combo and returns 400, surfaced here as a clean invalid_params error.
-// Implemented in src/data-api-mcp.mjs (shared with GraphQL Query.chain_events).
+// Postgres-backed all-events tier via the DATA_API binding — the same
+// /api/v1/chain-events/stats sibling path the relocated loadChainActivity uses.
+// Optional pallet/method/block/extrinsic filters + an opaque keyset cursor; the
+// data Worker validates the filter combo and returns 400, surfaced here as a
+// clean invalid_params error. Implemented in src/data-api-mcp.mjs (shared with
+// GraphQL Query.chain_events).
 
 // Mirrors loadChainEventsFeed's own DATA_API-direct call (#6637): the
 // all-events tier has no per-table tryPostgresTier flag (unlike
@@ -1921,22 +1911,6 @@ function requireHotkey(args) {
 // one hotkey-list contract for both surfaces, mirroring how
 // parseCompareNetuidList/parseCompareNetuids are already shared for
 // compare_subnets/GET /api/v1/compare.
-
-// The optional `blocks` window for get_chain_activity: a missing value defaults
-// to 1000; a provided value must be a positive integer and is clamped to the
-// data Worker's 1-5000 bound so a stray large value is silently capped (the data
-// Worker clamps too, but capping here keeps the request URL honest).
-function optionalBlocksWindow(args) {
-  const value = args?.blocks;
-  if (value === undefined || value === null) return 1000;
-  if (!Number.isInteger(value) || value < 1) {
-    throw toolError(
-      "invalid_params",
-      "Argument `blocks` must be a positive integer.",
-    );
-  }
-  return Math.min(value, 5000);
-}
 
 function clampLimit(value, fallback, max) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -19177,6 +19177,108 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
   });
 });
 
+// --- chain_events_stats parity (#7432) ---
+describe("graphql — chain_events_stats (#7432, DATA_API chain-activity aggregate)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold/unbound tier returns a schema-stable empty aggregate, never an error", async () => {
+    const { status, body } = await gql(
+      "{ chain_events_stats { window_blocks groups activity { pallet } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 1000,
+      groups: 0,
+      activity: [],
+    });
+  });
+
+  test("resolves DATA_API rows and maps activity fields, nulling sparse groups", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({
+          window_blocks: 500,
+          groups: 2,
+          activity: [
+            { pallet: "SubtensorModule", method: "WeightsSet", count: 9 },
+            {},
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 500) { window_blocks groups activity { pallet method count } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 500,
+      groups: 2,
+      activity: [
+        { pallet: "SubtensorModule", method: "WeightsSet", count: 9 },
+        { pallet: null, method: null, count: null },
+      ],
+    });
+  });
+
+  test("defaults blocks to 1000 and clamps a large window to 5000 in the request URL", async () => {
+    const urls = [];
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          urls.push(new URL(req.url));
+          return Response.json({
+            window_blocks: 5000,
+            groups: 0,
+            activity: [],
+          });
+        },
+      },
+    };
+    await gql("{ chain_events_stats { window_blocks } }", env);
+    await gql("{ chain_events_stats(blocks: 6000) { window_blocks } }", env);
+    assert.equal(urls[0].pathname, "/api/v1/chain-events/stats");
+    assert.equal(urls[0].searchParams.get("blocks"), "1000");
+    assert.equal(urls[1].searchParams.get("blocks"), "5000");
+  });
+
+  test("a partial DATA_API body degrades to loader defaults over the requested window", async () => {
+    const env = { DATA_API: dataApi(Response.json({})) };
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 250) { window_blocks groups activity { pallet } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_events_stats, {
+      window_blocks: 250,
+      groups: 0,
+      activity: [],
+    });
+  });
+
+  test("a non-positive-integer blocks is BAD_USER_INPUT, not an empty aggregate", async () => {
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 0) { window_blocks } }",
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.match(body.errors[0].message, /positive integer/);
+    assert.equal(body.data?.chain_events_stats ?? null, null);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_events_stats,
+      FIELD_COMPLEXITY.extrinsics,
+    );
+  });
+});
+
 // --- curation parity (#6982) ---
 describe("graphql — curation parity (#6982)", () => {
   test("curation resolves the baked curation-states artifact", async () => {


### PR DESCRIPTION
Closes #7432.

Adds `chain_events_stats(blocks: Int): ChainEventsStats!` to the GraphQL API, the aggregate sibling of `chain_events`, giving `GET /api/v1/chain-events/stats` full three-way REST/MCP/GraphQL parity.

## Changes
- Relocated `loadChainActivity` and its `optionalBlocksWindow` blocks-window validator out of `src/mcp-server.mjs` into `src/data-api-mcp.mjs` (exported), beside their raw-feed sibling `loadChainEventsFeed` and the shared `dataApiFetchJson` helper. Behavior/return shape unchanged. The validator moved too because `mcp-server.mjs` imports `graphql.mjs`, so importing the validator the other way would be a cycle; the shared leaf module lets both the MCP tool and the GraphQL resolver reuse one implementation.
- `get_chain_activity` MCP tool now imports the relocated loader/validator (no behavior change).
- Added the `chain_events_stats` field to the SDL with `ChainEventsStats` + `ChainEventStat` types, and wired the resolver in `rootValue` reusing the relocated loader + validator. A non-positive-integer `blocks` is a GraphQL `BAD_USER_INPUT` error; a cold/unbound tier resolves to a schema-stable empty aggregate, matching `chain_events`' convention. Priced at the relationship-field complexity weight.

## Validation
- `npm run lint`, `npm run format:check`, `npm run validate`, `npm run validate:contract-drift`, `npm run validate:openapi` all clean.
- `npm run build` regenerates no artifacts (GraphQL SDL + internal relocation touch no committed contract).
- New tests exercise `query { chain_events_stats(blocks: ...) { ... } }` (rows/mapping, default + clamped window in the request URL, partial-body defaults, cold-tier empty, non-positive-integer BAD_USER_INPUT). Patch coverage on the changed lines is 100%; the existing `get_chain_activity` MCP tests still pass against the relocated code (16 pass), and the graphql/mcp-server/data-api suites pass (2600).
- Worker bundle budget passes.
