### PR TITLE
feat(ui): multi-subnet history overlay chart in the compare drawer

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/multi-series-line-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/multi-series-line-chart.tsx
@@ -1,0 +1,122 @@
+import { useId } from "react";
+import type { OverlaySeries } from "@/lib/metagraphed/compare-overlay-series";
+
+// #6885: a compact multi-series line chart — the one primitive the metagraphed
+// chart stack was missing (Sparkline is single-series and index-scaled). Draws N
+// pre-aligned series (see buildOverlaySeries) on one shared linear scale: one
+// <path> per subnet over a shared x (index into the shared date axis) and a
+// shared y (the [min,max] span across all series), breaking each line on null
+// gaps rather than interpolating across missing snapshots. Presentation only —
+// all alignment/scaling is done upstream in the pure helper.
+
+const PAD_X = 6;
+const PAD_Y = 8;
+
+function xAt(index: number, count: number, width: number): number {
+  const inner = width - PAD_X * 2;
+  if (count <= 1) return PAD_X + inner / 2;
+  return PAD_X + (index / (count - 1)) * inner;
+}
+
+function yAt(value: number, min: number, max: number, height: number): number {
+  const inner = height - PAD_Y * 2;
+  if (max <= min) return PAD_Y + inner / 2;
+  return PAD_Y + (1 - (value - min) / (max - min)) * inner;
+}
+
+// Build an SVG path, starting a fresh subpath (M) after every null gap so a
+// subnet missing a day's snapshot leaves a break instead of a straight jump.
+function linePath(
+  values: (number | null)[],
+  min: number,
+  max: number,
+  width: number,
+  height: number,
+): string {
+  const count = values.length;
+  let d = "";
+  let penDown = false;
+  for (let i = 0; i < count; i += 1) {
+    const value = values[i];
+    if (value == null) {
+      penDown = false;
+      continue;
+    }
+    const x = xAt(i, count, width).toFixed(2);
+    const y = yAt(value, min, max, height).toFixed(2);
+    d += `${penDown ? "L" : "M"}${x} ${y} `;
+    penDown = true;
+  }
+  return d.trim();
+}
+
+export function MultiSeriesLineChart({
+  series,
+  dateCount,
+  min,
+  max,
+  width = 640,
+  height = 200,
+  ariaLabel = "Multi-subnet history overlay",
+}: {
+  series: OverlaySeries[];
+  dateCount: number;
+  min: number;
+  max: number;
+  width?: number;
+  height?: number;
+  ariaLabel?: string;
+}) {
+  const titleId = useId();
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width="100%"
+      height={height}
+      role="img"
+      aria-labelledby={titleId}
+      preserveAspectRatio="none"
+      className="overflow-visible"
+    >
+      <title id={titleId}>{ariaLabel}</title>
+      {/* Baseline (min) + top (max) guide lines, hairline. */}
+      <line
+        x1={PAD_X}
+        y1={height - PAD_Y}
+        x2={width - PAD_X}
+        y2={height - PAD_Y}
+        stroke="var(--border)"
+        strokeWidth={1}
+      />
+      {series.map((line) =>
+        line.hasData ? (
+          <path
+            key={line.netuid}
+            d={linePath(line.values, min, max, width, height)}
+            fill="none"
+            stroke={line.color}
+            strokeWidth={1.75}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        ) : null,
+      )}
+      {/* Single-point subnets can't draw a line; mark them with a dot so a lone
+          snapshot still reads as present. */}
+      {dateCount === 1
+        ? series.map((line) =>
+            line.hasData && line.values[0] != null ? (
+              <circle
+                key={`dot-${line.netuid}`}
+                cx={xAt(0, 1, width)}
+                cy={yAt(line.values[0], min, max, height)}
+                r={2.5}
+                fill={line.color}
+              />
+            ) : null,
+          )
+        : null}
+    </svg>
+  );
+}

--- a/apps/ui/src/components/metagraphed/compare-overlay-chart.tsx
+++ b/apps/ui/src/components/metagraphed/compare-overlay-chart.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
+import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import {
+  buildOverlaySeries,
+  OVERLAY_METRICS,
+  type OverlayMetric,
+} from "@/lib/metagraphed/compare-overlay-series";
+import { MultiSeriesLineChart } from "@/components/metagraphed/charts/multi-series-line-chart";
+import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
+
+// Lowercase windows, mirroring subnet-history-chart.tsx / the /history API.
+type Win = "7d" | "30d" | "90d" | "1y" | "all";
+const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+
+// Categorical series palette (--chart-1..6, styles.css). The compare selection
+// caps at 4 (useCompareSelection MAX), so four colours suffice.
+const SERIES_COLORS = ["var(--chart-1)", "var(--chart-2)", "var(--chart-3)", "var(--chart-4)"];
+
+/**
+ * #6885: overlay every selected subnet's daily /history for one metric on a
+ * single shared-axis chart — the aggregate-comparison the metrics-grid tab
+ * (CompareGrid) can't show. Fans out one subnetHistoryQuery per selected netuid
+ * (the same per-subnet endpoint the detail page already uses), aligns them via
+ * buildOverlaySeries, and draws one line per subnet. A cold selection (no
+ * history yet) renders an empty state, never a broken chart.
+ */
+export function CompareOverlayChart({ netuids }: { netuids: number[] }) {
+  const [win, setWin] = useState<Win>("90d");
+  const [metric, setMetric] = useState<OverlayMetric>("stake");
+
+  const results = useQueries({
+    queries: netuids.map((netuid) => subnetHistoryQuery(netuid, win)),
+  });
+
+  const isLoading = results.some((result) => result.isLoading);
+  const allError = results.length > 0 && results.every((result) => result.isError);
+  const firstError = results.find((result) => result.isError)?.error;
+
+  const histories = netuids.map((netuid, index) => ({
+    netuid,
+    points: (results[index]?.data?.data?.points ?? []) as SubnetHistoryPoint[],
+  }));
+
+  const metricDef = OVERLAY_METRICS.find((m) => m.key === metric) ?? OVERLAY_METRICS[0];
+  const chart = buildOverlaySeries(histories, metric, SERIES_COLORS);
+  const fmt = metricDef.tao ? formatTao : formatNumber;
+
+  const metricSelector = (
+    <div
+      role="tablist"
+      aria-label="Overlay metric"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {OVERLAY_METRICS.map((m) => (
+        <button
+          key={m.key}
+          type="button"
+          role="tab"
+          aria-selected={m.key === metric}
+          onClick={() => setMetric(m.key)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            m.key === metric ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  );
+
+  const windowSelector = (
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          role="tab"
+          aria-selected={w === win}
+          onClick={() => setWin(w)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="space-y-3 border-t border-border px-3 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        {metricSelector}
+        {windowSelector}
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-48 w-full" />
+      ) : allError ? (
+        <ErrorState error={firstError} context="subnet history overlay" />
+      ) : chart.empty ? (
+        <EmptyState
+          title="No on-chain history"
+          description="Daily snapshots will appear here once enough chain history has accumulated for the selected subnets."
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card p-4">
+          {/* Legend: one swatch + subnet + latest value per line. */}
+          <div className="mb-3 flex flex-wrap gap-x-4 gap-y-1.5">
+            {chart.series.map((line) => (
+              <span
+                key={line.netuid}
+                className="inline-flex items-center gap-1.5 font-mono text-[11px]"
+              >
+                <span
+                  aria-hidden
+                  className="inline-block size-2.5 rounded-full"
+                  style={{ backgroundColor: line.color }}
+                />
+                <span className="text-ink-strong">SN{line.netuid}</span>
+                <span className="tabular-nums text-ink-muted">
+                  {line.lastValue != null ? fmt(line.lastValue) : "—"}
+                </span>
+              </span>
+            ))}
+          </div>
+
+          <div className="relative">
+            {/* Shared-axis max/min readouts (metric scale). */}
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex flex-col justify-between font-mono text-[10px] tabular-nums text-ink-muted">
+              <span>{fmt(chart.max)}</span>
+              <span>{fmt(chart.min)}</span>
+            </div>
+            <div className="pl-14">
+              <MultiSeriesLineChart
+                series={chart.series}
+                dateCount={chart.dates.length}
+                min={chart.min}
+                max={chart.max}
+                ariaLabel={`${metricDef.label} over the ${win} window for ${chart.series
+                  .map((s) => `SN${s.netuid}`)
+                  .join(", ")}`}
+              />
+            </div>
+          </div>
+
+          {chart.dates.length > 0 ? (
+            <div className="mt-1.5 flex justify-between pl-14 font-mono text-[10px] tabular-nums text-ink-muted">
+              <span>{chart.dates[0]}</span>
+              <span>{chart.dates[chart.dates.length - 1]}</span>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -7,6 +7,9 @@ import { compareQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { CompareSubnet, HealthState } from "@/lib/metagraphed/types";
 import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
+import { CompareOverlayChart } from "@/components/metagraphed/compare-overlay-chart";
+
+type CompareView = "grid" | "chart";
 
 /**
  * Floating bottom dock + expandable side-by-side compare drawer for selected
@@ -16,6 +19,7 @@ import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
 export function SubnetsCompareDrawer() {
   const { selected, max, remove, clear } = useCompareSelection();
   const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState<CompareView>("grid");
 
   if (selected.length === 0) return null;
 
@@ -80,8 +84,42 @@ export function SubnetsCompareDrawer() {
             </div>
           </div>
 
-          {/* Expanded side-by-side */}
-          {expanded && selected.length >= 2 ? <CompareGrid netuids={selected} /> : null}
+          {/* Expanded: a metrics grid (CompareGrid) and a multi-subnet history
+              overlay chart (#6885), toggled by a view tablist. */}
+          {expanded && selected.length >= 2 ? (
+            <div className="border-t border-border">
+              <div className="flex items-center px-3 py-2">
+                <div
+                  role="tablist"
+                  aria-label="Compare view"
+                  className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+                >
+                  {(["grid", "chart"] as const).map((v) => (
+                    <button
+                      key={v}
+                      type="button"
+                      role="tab"
+                      aria-selected={v === view}
+                      onClick={() => setView(v)}
+                      className={classNames(
+                        "px-3 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+                        v === view
+                          ? "bg-ink-strong text-paper"
+                          : "text-ink-muted hover:text-ink-strong",
+                      )}
+                    >
+                      {v}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {view === "grid" ? (
+                <CompareGrid netuids={selected} />
+              ) : (
+                <CompareOverlayChart netuids={selected} />
+              )}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/ui/src/lib/metagraphed/compare-overlay-series.test.ts
+++ b/apps/ui/src/lib/metagraphed/compare-overlay-series.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { buildOverlaySeries, OVERLAY_METRICS } from "./compare-overlay-series";
+import type { SubnetHistoryPoint } from "./types";
+
+const COLORS = ["c1", "c2", "c3", "c4"];
+
+function point(date: string, extra: Partial<SubnetHistoryPoint>): SubnetHistoryPoint {
+  return { snapshot_date: date, ...extra };
+}
+
+describe("buildOverlaySeries", () => {
+  it("aligns subnets onto the shared sorted union of dates, nulling missing days", () => {
+    const chart = buildOverlaySeries(
+      [
+        {
+          netuid: 7,
+          points: [
+            point("2026-01-01", { total_stake_tao: 100 }),
+            point("2026-01-03", { total_stake_tao: 120 }),
+          ],
+        },
+        {
+          netuid: 9,
+          points: [
+            point("2026-01-02", { total_stake_tao: 50 }),
+            point("2026-01-03", { total_stake_tao: 60 }),
+          ],
+        },
+      ],
+      "stake",
+      COLORS,
+    );
+    // Union of dates, ascending.
+    expect(chart.dates).toEqual(["2026-01-01", "2026-01-02", "2026-01-03"]);
+    // SN7 has no 2026-01-02 → null in the middle; SN9 has no 2026-01-01 → null first.
+    expect(chart.series[0]).toMatchObject({
+      netuid: 7,
+      color: "c1",
+      values: [100, null, 120],
+      hasData: true,
+      lastValue: 120,
+    });
+    expect(chart.series[1]).toMatchObject({
+      netuid: 9,
+      color: "c2",
+      values: [null, 50, 60],
+      hasData: true,
+      lastValue: 60,
+    });
+    // Shared min/max span every finite value across both subnets.
+    expect(chart.min).toBe(50);
+    expect(chart.max).toBe(120);
+    expect(chart.empty).toBe(false);
+  });
+
+  it("reads the field for the selected metric and ignores non-finite values", () => {
+    const histories = [
+      {
+        netuid: 1,
+        points: [
+          point("2026-02-01", {
+            total_stake_tao: 10,
+            total_emission_tao: 3,
+            neuron_count: 256,
+          }),
+          point("2026-02-02", {
+            total_stake_tao: Number.NaN,
+            total_emission_tao: 4,
+            neuron_count: 256,
+          }),
+        ],
+      },
+    ];
+    const stake = buildOverlaySeries(histories, "stake", COLORS);
+    // The NaN stake day is dropped (null), not coerced.
+    expect(stake.series[0].values).toEqual([10, null]);
+
+    const emission = buildOverlaySeries(histories, "emission", COLORS);
+    expect(emission.series[0].values).toEqual([3, 4]);
+
+    const neurons = buildOverlaySeries(histories, "neurons", COLORS);
+    expect(neurons.series[0].values).toEqual([256, 256]);
+  });
+
+  it("marks a cold selection with no finite values as empty and zeroes the scale", () => {
+    const chart = buildOverlaySeries(
+      [
+        { netuid: 3, points: [] },
+        { netuid: 4, points: [point("2026-03-01", { neuron_count: 5 })] },
+      ],
+      "stake", // neither subnet carries stake
+      COLORS,
+    );
+    expect(chart.empty).toBe(true);
+    expect(chart.min).toBe(0);
+    expect(chart.max).toBe(0);
+    expect(chart.series.every((s) => !s.hasData)).toBe(true);
+    expect(chart.series.every((s) => s.lastValue === null)).toBe(true);
+  });
+
+  it("cycles the colour palette by series index", () => {
+    const chart = buildOverlaySeries(
+      [1, 2, 3, 4, 5].map((netuid) => ({
+        netuid,
+        points: [point("2026-04-01", { total_stake_tao: netuid })],
+      })),
+      "stake",
+      COLORS,
+    );
+    expect(chart.series.map((s) => s.color)).toEqual([
+      "c1",
+      "c2",
+      "c3",
+      "c4",
+      "c1", // wraps
+    ]);
+  });
+
+  it("exposes the four subnet-history metrics", () => {
+    expect(OVERLAY_METRICS.map((m) => m.key)).toEqual([
+      "stake",
+      "emission",
+      "neurons",
+      "validators",
+    ]);
+    expect(OVERLAY_METRICS.find((m) => m.key === "stake")?.tao).toBe(true);
+    expect(OVERLAY_METRICS.find((m) => m.key === "neurons")?.tao).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/compare-overlay-series.ts
+++ b/apps/ui/src/lib/metagraphed/compare-overlay-series.ts
@@ -1,0 +1,121 @@
+// #6885: pure series-building for the compare drawer's multi-subnet history
+// overlay. Aligns N subnets' /subnets/{netuid}/history point arrays (which can
+// differ in length and date coverage) onto one shared, sorted date axis for a
+// single chosen metric, and computes the shared min/max so every line is drawn
+// to the same scale. Kept side-effect-free and separate from the SVG component
+// so this alignment logic is unit-testable without rendering (the repo's
+// convention for router/query-bound chart components — see
+// validator-dominance-ranking.ts).
+import type { SubnetHistoryPoint } from "./types";
+
+export type OverlayMetric = "neurons" | "validators" | "stake" | "emission";
+
+// The same four metrics subnet-history-chart.tsx already surfaces, mapped to
+// their SubnetHistoryPoint fields. `tao` marks a τ-denominated value so the UI
+// formats it with formatTao rather than formatNumber.
+export const OVERLAY_METRICS: {
+  key: OverlayMetric;
+  label: string;
+  field: keyof SubnetHistoryPoint;
+  tao: boolean;
+}[] = [
+  { key: "stake", label: "Total stake", field: "total_stake_tao", tao: true },
+  {
+    key: "emission",
+    label: "Total emission",
+    field: "total_emission_tao",
+    tao: true,
+  },
+  { key: "neurons", label: "Neurons", field: "neuron_count", tao: false },
+  { key: "validators", label: "Validators", field: "validator_count", tao: false },
+];
+
+export interface OverlaySeries {
+  netuid: number;
+  color: string;
+  // One entry per shared date (OverlayChartData.dates), null where this subnet
+  // has no snapshot on that date so the line can break rather than interpolate.
+  values: (number | null)[];
+  hasData: boolean;
+  // The subnet's most recent finite value for the metric (for the legend), or
+  // null when it has none.
+  lastValue: number | null;
+}
+
+export interface OverlayChartData {
+  dates: string[];
+  series: OverlaySeries[];
+  min: number;
+  max: number;
+  empty: boolean;
+}
+
+/**
+ * Align each subnet's history points onto a shared sorted date axis for one
+ * metric, colouring series by their position in `colors` (cycled). `min`/`max`
+ * span every finite value across all subnets; `empty` is true when no subnet
+ * has a single finite value for the metric (a cold overlay renders nothing).
+ */
+export function buildOverlaySeries(
+  histories: { netuid: number; points: SubnetHistoryPoint[] }[],
+  metric: OverlayMetric,
+  colors: string[],
+): OverlayChartData {
+  const def = OVERLAY_METRICS.find((m) => m.key === metric) ?? OVERLAY_METRICS[0];
+  const field = def.field;
+
+  const dateSet = new Set<string>();
+  for (const history of histories) {
+    for (const point of history.points) {
+      if (typeof point.snapshot_date === "string") {
+        dateSet.add(point.snapshot_date);
+      }
+    }
+  }
+  const dates = [...dateSet].sort();
+
+  let min = Infinity;
+  let max = -Infinity;
+
+  const series: OverlaySeries[] = histories.map((history, index) => {
+    const byDate = new Map<string, number>();
+    for (const point of history.points) {
+      const value = point[field];
+      if (
+        typeof point.snapshot_date === "string" &&
+        typeof value === "number" &&
+        Number.isFinite(value)
+      ) {
+        byDate.set(point.snapshot_date, value);
+      }
+    }
+
+    let hasData = false;
+    let lastValue: number | null = null;
+    const values = dates.map((date) => {
+      const value = byDate.get(date);
+      if (value === undefined) return null;
+      hasData = true;
+      lastValue = value;
+      if (value < min) min = value;
+      if (value > max) max = value;
+      return value;
+    });
+
+    return {
+      netuid: history.netuid,
+      color: colors[index % colors.length],
+      values,
+      hasData,
+      lastValue,
+    };
+  });
+
+  const empty = !series.some((s) => s.hasData);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    min = 0;
+    max = 0;
+  }
+
+  return { dates, series, min, max, empty };
+}


### PR DESCRIPTION
## Summary

Adds a **Chart** tab to the subnets compare drawer's expanded view (alongside the existing metrics grid), overlaying every selected subnet's daily `/subnets/{netuid}/history` on one shared-axis line chart — the aggregate view the metrics grid can't show (Tao Swap's "Multi-chart" is the precedent). #6885.

Closes #6885.

## What changed

- `apps/ui/src/lib/metagraphed/compare-overlay-series.ts` — `buildOverlaySeries`, a **pure, unit-tested** helper that aligns N subnets' history points onto a shared sorted date axis (nulling missing days so lines break rather than interpolate) and computes the shared min/max scale.
- `apps/ui/src/components/metagraphed/charts/multi-series-line-chart.tsx` — a new **multi-series SVG line primitive**. The stack had none (`Sparkline` is single-series + index-scaled), so this was the one genuinely-new piece; everything else composes existing parts.
- `apps/ui/src/components/metagraphed/compare-overlay-chart.tsx` — the tab: fans out one `subnetHistoryQuery` per selected netuid via `useQueries` (the established pattern), colours lines from `--chart-1..4`, and renders a legend + metric (stake/emission/neurons/validators) and window (7d–all) selectors, with cold/loading/error states.
- `apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx` — a **Grid ⇄ Chart** view tablist in the expanded region.
- Unit test: `compare-overlay-series.test.ts` (date alignment, metric field, shared scale, null gaps, cold-empty, colour cycling).

Reuses existing endpoint, query, selection state (`useCompareSelection`, cap 4), design tokens, and the window-selector pattern — no new data source. Respects the drawer's existing 4-subnet cap.

## Screenshots (before / after)

Before = compare drawer expanded on the metrics grid (no history overlay possible). After = the new **Chart** tab overlaying SN1 / SN64 / SN4 total-stake history. Fixed-viewport `page.screenshot` captures (Mobile 375×812 · Tablet 768×1024 · Desktop 1280×800), each theme forced via `mg-theme`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6885/after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- [x] `vitest run compare-overlay-series.test.ts` — 5 passing
- [x] `tsc --noEmit` (packages/ui-kit rebuilt) — no errors
- [x] `eslint` + `prettier --check` (apps/ui config) — clean
- [x] `vite build` — succeeds
- [x] Scoped to `apps/ui/**` (5 files); reuses existing tokens/queries/selection state
