### PR TITLE
test(mcp): verify SN82 Compelle surface via call_subnet_surface (#7095)

### DIFF
--- a/tests/compelle-call-subnet-surface-verify.test.mjs
+++ b/tests/compelle-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,149 @@
+// SN82 (Compelle) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7095, MCP execute Phase 1 follow-up #7014/#7215). Unlike
+// tests/call-subnet-surface-mcp.test.mjs -- which proves the tool wiring with
+// synthetic surfaces -- this file pins SN82's *real* registry surface config
+// (registry/subnets/compelle.json) to the tool's contract, so a future edit
+// that regresses its callability (marking it auth_required, flipping its probe
+// to HEAD, or disabling its probe) is caught here.
+//
+// The surface is the public no-auth Compelle aggregation health endpoint
+// (sn-82-compelle-health, GET https://compelle.com/api/health, JSON, single
+// fixed endpoint -- no schema). Live-verified 2026-07-21 to return HTTP 200
+// application/json; charset=utf-8 with body
+// {"ok":true,"db_size_bytes":...,"last_epoch_block":...,"last_indexed_at":...,
+// "games":...,"miners":...}. The surface declares no `probe` block at all --
+// which is not a defect: call_subnet_surface resolves an absent probe method to
+// its default GET (src/call-subnet-surface.mjs) and classifies the body by the
+// live content-type (probe.expect is never read by the tool), and the MCP
+// handler only rejects a surface when auth_required is true or probe.enabled is
+// explicitly false (src/mcp-server.mjs). The fixture below mirrors that live
+// response rather than fetching it, keeping the test hermetic while still
+// exercising the charset-suffixed JSON parse-and-return path.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { callSubnetSurface } from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const SURFACE_ID = "sn-82-compelle-health";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/compelle.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+const SURFACE = registry.surfaces.find((surface) => surface.id === SURFACE_ID);
+
+// A faithful subset of the live https://compelle.com/api/health response body.
+const BODY = {
+  ok: true,
+  db_size_bytes: 6933532672,
+  last_epoch_block: 8670255,
+  last_indexed_at: 1784643996,
+  games: 239828,
+  miners: 861,
+};
+
+function upstreamResponse() {
+  return new Response(JSON.stringify(BODY), {
+    status: 200,
+    // Live upstream returns charset-suffixed JSON; the tool must still parse it.
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+describe("SN82 Compelle call_subnet_surface verification (#7095)", () => {
+  test("the registry surface exists and is configured to be callable", () => {
+    assert.ok(SURFACE, `registry surface ${SURFACE_ID} is present`);
+    assert.equal(SURFACE.kind, "subnet-api");
+    assert.equal(SURFACE.auth_required, false);
+    // No-auth GET returning JSON. The surface declares no probe block, so the
+    // tool uses its default GET and the handler does not reject it -- the only
+    // callability regressions are an auth flip, a probe disable, or a HEAD flip
+    // (which would drop the body), all guarded below.
+    assert.notEqual(SURFACE.probe?.enabled, false);
+    assert.notEqual(SURFACE.probe?.method, "HEAD");
+    assert.equal(SURFACE.url, "https://compelle.com/api/health");
+    // Single fixed endpoint -- no machine-readable schema is expected.
+    assert.equal(SURFACE.schema_url, undefined);
+  });
+
+  test("callSubnetSurface returns the real JSON body via the surface's own url + default GET", async () => {
+    let requestedUrl;
+    let requestedMethod;
+    const result = await callSubnetSurface(SURFACE, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url, init) => {
+        requestedUrl = String(url);
+        requestedMethod = init.method;
+        return upstreamResponse();
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, SURFACE.url);
+    // The surface has no probe.method; the tool resolves that to GET.
+    assert.equal(requestedMethod, "GET");
+    assert.equal(result.status_code, 200);
+    assert.equal(result.content_type, "application/json; charset=utf-8");
+    assert.equal(result.truncated, false);
+    assert.equal(result.body.ok, true);
+    assert.equal(typeof result.body.db_size_bytes, "number");
+    assert.equal(typeof result.body.games, "number");
+    assert.equal(typeof result.body.miners, "number");
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    // operational-surfaces.json flattens each registry surface's `id` to a
+    // top-level `surface_id`; build that catalog shape from the real surface.
+    const catalog = {
+      surfaces: [{ ...SURFACE, surface_id: SURFACE.id, netuid: 82 }],
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      // DoH lookups for the SSRF guard: no Answer -> fail open (safe).
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(JSON.stringify({ Status: 0 }), {
+          headers: { "content-type": "application/dns-json" },
+        });
+      }
+      return upstreamResponse();
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: { surface_id: SURFACE_ID },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.surface_id, SURFACE_ID);
+      assert.equal(result.structuredContent.status_code, 200);
+      assert.equal(result.structuredContent.body.ok, true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #7095

Part of #7013. Phase 1 (#7014) shipped (#7215) — `call_subnet_surface` is live.

## Scope

Confirm SN82 (Compelle)'s callable surface `sn-82-compelle-health` actually works end-to-end — an actual request against the live URL, not an assumption.

## Surface verified (live 2026-07-21)

| surface_id | method | status | response |
|---|---|---|---|
| `sn-82-compelle-health` | GET | 200 | `application/json; charset=utf-8` — `{"ok":true,"db_size_bytes":6933532672,"last_epoch_block":8670255,"last_indexed_at":1784643996,"games":239828,"miners":861}` |

Fetched directly (`curl -i https://compelle.com/api/health`): `HTTP/2 200`, `content-type: application/json; charset=utf-8`, `access-control-allow-origin: *`. `call_subnet_surface` is a passthrough of the exact same request, so the direct fetch is equivalent verification for this no-auth GET surface.

## Everything already matches reality — no registry change

`sn-82-compelle-health` declares **no `probe` block**, and that is **not** a defect for `call_subnet_surface`:

- The tool resolves an absent probe method to its default **GET** and never reads `probe.expect` — it classifies the body by the live `content-type` (`src/call-subnet-surface.mjs`: `const method = surface?.probe?.method === "HEAD" ? "HEAD" : "GET"`).
- The MCP handler only refuses a surface when `auth_required` is `true` or `probe.enabled` is **explicitly** `false` (`src/mcp-server.mjs`). This surface is `auth_required: false` with no probe, so it is fully callable as-is.

So the surface resolves correctly today and needs no edit to its registry entry. This PR therefore only adds the regression test the issue calls "welcome" — pinning the current-good behavior so a future edit that regresses callability (an auth flip, a probe disable, or a HEAD flip that would drop the body) is caught in CI.

## Registry changes

**None.** One new test file only: `tests/compelle-call-subnet-surface-verify.test.mjs`, mirroring the existing `tests/sn127-call-subnet-surface-verify.test.mjs` / `tests/leadpoet-call-subnet-surface-verify.test.mjs` pattern (real registry config pinned to the tool contract + a hermetic fixture of the live response).

## Validation

- [x] `npx vitest run tests/compelle-call-subnet-surface-verify.test.mjs` — 3 passed
- [x] `prettier --check` + `eslint` clean on the new file
- [ ] Gittensory Gate + CI green

Made with [Cursor](https://cursor.com)