### PR TITLE
fix(registry): wire SN1 Apex MCP execute probe config (#7017)

### DIFF
--- a/registry/subnets/apex.json
+++ b/registry/subnets/apex.json
@@ -174,7 +174,13 @@
       "id": "sn-1-apex-orchestrator-openapi",
       "kind": "openapi",
       "name": "Apex orchestrator API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST).",
+      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST). Live-verified 2026-07-21: GET returns OpenAPI 3.1.0 JSON (title FastAPI, 32 paths).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -195,7 +201,13 @@
       "id": "sn-1-apex-healthcheck",
       "kind": "subnet-api",
       "name": "Apex orchestrator healthcheck API",
-      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings.",
+      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings. Live-verified 2026-07-21: HTTP 200 JSON {\"status\":\"healthy\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN1 (Apex) for MCP execute (`call_subnet_surface`, #7014) by adding missing probe config on the two surfaces that lacked it and live-verifying all four issue-scoped endpoints.

Closes #7017

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-1-apex-orchestrator-openapi | 200 | OpenAPI 3.1.0 JSON (title FastAPI, 32 paths) |
| sn-1-apex-healthcheck | 200 | JSON `{"status":"healthy"}` |
| sn-1-apex-healthcheck-ready | 200 | JSON `{"status":"ready"}` (probe already present) |
| sn-1-apex-metrics | 200 | Prometheus text (~54 KB; probe already present, expect: any) |

## Registry changes

- **sn-1-apex-orchestrator-openapi**: add probe (GET, expect: json) — was missing despite captured schema
- **sn-1-apex-healthcheck**: add probe (GET, expect: json) — enables operational monitoring + execute resolution

The readiness and metrics subnet-api surfaces already had correct probe config and required no edits.

## Checklist

- [x] Changes exactly one `registry/subnets/apex.json` file
- [x] `npm run validate:surface -- --file registry/subnets/apex.json` passed
- [x] `npm run scan:public-safety` passed
- [x] All four issue-scoped surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Prefer healthcheck/ready for MCP smoke tests (metrics is large Prometheus text)

Made with [Cursor](https://cursor.com)