### PR TITLE
fix(registry): wire SN85 Vidaio MCP execute probe config (#7098)

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -80,9 +80,10 @@
       "id": "sn-85-vidaio-openapi",
       "kind": "openapi",
       "name": "Vidaio API (OpenAPI)",
+      "notes": "Machine-readable OpenAPI schema for the Vidaio API on api.vidaio.io. Live-verified 2026-07-21: GET returns OpenAPI 3.1.0 JSON (title Vidaio API).",
       "probe": {
         "enabled": true,
-        "expect": "any",
+        "expect": "json",
         "method": "GET",
         "timeout_ms": 10000
       },
@@ -128,7 +129,13 @@
       "id": "sn-85-vidaio-health",
       "kind": "subnet-api",
       "name": "Vidaio API health",
-      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health).",
+      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health). Live-verified 2026-07-21: HTTP 200 JSON {\"status\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "vidaio",
       "public_safe": true,
       "review": {
@@ -147,7 +154,13 @@
       "id": "sn-85-vidaio-ready",
       "kind": "subnet-api",
       "name": "Vidaio API readiness health",
-      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint.",
+      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint. Live-verified 2026-07-21: HTTP 200 JSON {\"status\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "vidaio",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN85 (Vidaio) for MCP execute (`call_subnet_surface`) by adding missing probe config on health/ready and tightening the OpenAPI probe to `expect: json` after live verification.

Closes #7098

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-85-vidaio-openapi | 200 | OpenAPI 3.1.0 JSON (title Vidaio API) |
| sn-85-vidaio-health | 200 | JSON `{"status":"ok"}` |
| sn-85-vidaio-ready | 200 | JSON `{"status":"ok"}` |

## Registry changes

- **sn-85-vidaio-health**: add probe (GET, expect: json)
- **sn-85-vidaio-ready**: add probe (GET, expect: json)
- **sn-85-vidaio-openapi**: set probe expect to json (was any) + live-verified note

## Checklist

- [x] Changes exactly one `registry/subnets/vidaio.json` file
- [x] `npm run validate:surface` passed
- [x] `npm run scan:public-safety` passed
- [x] All three issue-scoped API surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Prefer /health or /ready for MCP smoke tests

Made with [Cursor](https://cursor.com)