### PR TITLE
fix(registry): wire SN3 Templar MCP execute probe config (#7019)

### DIFF
--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -151,7 +151,13 @@
       "id": "sn-3-templar-health",
       "kind": "subnet-api",
       "name": "Templar Grafana health",
-      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README.",
+      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README. Live-verified 2026-07-21: HTTP 200 JSON {\"database\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "one-covenant",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN3 (Templar) for MCP execute by adding the missing probe on the Grafana health surface after live verification.

Closes #7019

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-3-templar-health | 200 | JSON `{"database":"ok"}` |

## Registry changes

- **sn-3-templar-health**: add probe (GET, expect: json) + live-verified note

## Checklist

- [x] Exactly one `registry/subnets/templar.json`
- [x] validate:surface + scan:public-safety passed
- [x] Live-probed

## Test plan

- [ ] Gittensory Gate + CI green

Made with [Cursor](https://cursor.com)