### PR TITLE
fix(registry): wire SN2 DSperse MCP execute probe config (#7018)

### DIFF
--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -148,7 +148,7 @@
       "id": "sn-2-truthtensor-benchmark-dataset",
       "kind": "data-artifact",
       "name": "Inference Labs TruthTensor benchmark dataset",
-      "notes": "Public Inference Labs HuggingFace TruthTensor benchmark — ~88k text/parquet rows of per-run LLM decision-execution logs (model, latency/duration, token counts, action, reasoning columns) measuring instruction divergence; not gated. Published by inferencelabs, the HF-verified org of Inference Labs, the DSperse (SN2) operator (its site subnet2.inferencelabs.com and X @inference_labs are the subnet's registered surfaces).",
+      "notes": "Public Inference Labs HuggingFace TruthTensor benchmark \u2014 ~88k text/parquet rows of per-run LLM decision-execution logs (model, latency/duration, token counts, action, reasoning columns) measuring instruction divergence; not gated. Published by inferencelabs, the HF-verified org of Inference Labs, the DSperse (SN2) operator (its site subnet2.inferencelabs.com and X @inference_labs are the subnet's registered surfaces).",
       "provider": "inference-labs",
       "public_safe": true,
       "review": {
@@ -167,7 +167,13 @@
       "id": "sn-2-inference-labs-subnet-api",
       "kind": "subnet-api",
       "name": "DSperse network stats API",
-      "notes": "Public no-auth GET /stats on sn2-api.inferencelabs.com returning JSON network counters (observed: total_proofs, unique_miners, unique_validators). The official subnet-2 validator client sets DEFAULT_API_URL to https://sn2-api.inferencelabs.com on the same host.",
+      "notes": "Public no-auth GET /stats on sn2-api.inferencelabs.com returning JSON network counters (observed: total_proofs, unique_miners, unique_validators). The official subnet-2 validator client sets DEFAULT_API_URL to https://sn2-api.inferencelabs.com on the same host. Live-verified 2026-07-21: HTTP 200 JSON with total_proofs/unique_miners/unique_validators.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "inference-labs",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN2 (DSperse) for MCP execute by adding the missing probe on the Inference Labs stats subnet-api after live verification.

Closes #7018

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-2-inference-labs-subnet-api | 200 | JSON `total_proofs` / `unique_miners` / `unique_validators` |

## Registry changes

- **sn-2-inference-labs-subnet-api**: add probe (GET, expect: json) + live-verified note

## Checklist

- [x] Exactly one `registry/subnets/dsperse.json`
- [x] validate:surface + scan:public-safety passed
- [x] Live-probed

## Test plan

- [ ] Gittensory Gate + CI green

Made with [Cursor](https://cursor.com)