### PR TITLE
registry(sn126): add Poker44 benchmark-chunks surface (#7134)

### DIFF
--- a/registry/subnets/poker44.json
+++ b/registry/subnets/poker44.json
@@ -10,7 +10,7 @@
     "gap_notes": [
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
-      "The /api/v1/benchmark/chunks route requires a sourceDate/chunkId parameter and is not promotable."
+      "The /api/v1/benchmark/chunks route needs a sourceDate query parameter (now registered as sn-126-poker44-benchmark-chunks, callable via the tool's query argument); its /api/v1/benchmark/chunks/{chunkId} path-parameterized variant has no fixed URL and remains unregistrable."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -183,6 +183,30 @@
         "https://poker44.net/"
       ],
       "url": "https://poker44.net/Poker44_Whitepaper.pdf"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-benchmark-chunks",
+      "kind": "data-artifact",
+      "name": "Poker44 benchmark chunks for a source date",
+      "notes": "Public no-auth GET /api/v1/benchmark/chunks on api.poker44.net listing the published shadow-training chunks for one release date (chunkId, chunkHash, chunkIndex, releasedAt, plus a nextCursor for pagination). Documented in docs/training-benchmark.md alongside the already-tracked /api/v1/benchmark status and /api/v1/benchmark/releases surfaces. Takes a required sourceDate query parameter (plus optional limit/cursor) rather than a path parameter, so the base URL is fixed and the route is callable today via call_subnet_surface's query argument; probe.enabled is false because the bare URL (no sourceDate) returns HTTP 422. Live-verified 2026-07-21: GET /api/v1/benchmark/chunks?sourceDate=2026-07-21&limit=1 -> HTTP 200 application/json. No wallet/hotkey data.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md"
+      ],
+      "url": "https://api.poker44.net/api/v1/benchmark/chunks"
     }
   ],
   "website_url": "https://poker44.net/"


### PR DESCRIPTION
Registers the additional surface #7134 flagged as newly in scope, as a **registry-only** change (this resubmits it standalone after #7447 was closed for bundling a test with the registry entry — "A registry submission must not bundle other file changes"). Part of #7134.

**New surface — `sn-126-poker44-benchmark-chunks`** (`data-artifact`, no-auth):
- `GET https://api.poker44.net/api/v1/benchmark/chunks` — lists the published shadow-training chunks for a release date (`chunkId`, `chunkHash`, `chunkIndex`, `releasedAt`, + `nextCursor`).
- Takes a required `sourceDate` **query** param (optional `limit`/`cursor`), not a path param, so the base URL is fixed and it's callable today via `call_subnet_surface`'s `query` argument. `probe.enabled:false` because the bare URL (no `sourceDate`) is HTTP 422.
- **Live-verified 2026-07-21:** bare URL → **422**; `?sourceDate=2026-07-21&limit=1` → **200** `application/json`.

Also updates the one contradicting `curation.gap_notes` entry (it previously called this route "not promotable") in the same file. The sibling `/api/v1/benchmark/chunks/{chunkId}` path-param route has no fixed callable URL and stays unregistrable.

Registry-only: `registry/subnets/poker44.json` is the sole changed file. Schema + surface + readme-catalog validators all green.
