### PR TITLE
fix(registry): wire SN9 iota MCP execute probe config (#7025)

### DIFF
--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -90,7 +90,13 @@
       "id": "sn-9-iota-codeparrot-dataset",
       "kind": "data-artifact",
       "name": "IOTA code pretraining dataset",
-      "notes": "Public Macrocosmos HuggingFace GitHub-code corpus (repo_name/path/size/content/license columns; 32 languages) in the macrocosm-os org, a pretraining-data source fit for the IOTA (SN9) LLM-pretraining subnet; not gated. The IOTA repo README (source) declares Macrocosmos operates subnet 9 and links docs.macrocosmos.ai/subnets/subnet-9-pre-training.",
+      "notes": "Public Macrocosmos HuggingFace GitHub-code corpus (repo_name/path/size/content/license columns; 32 languages) in the macrocosm-os org, a pretraining-data source fit for the IOTA (SN9) LLM-pretraining subnet; not gated. The IOTA repo README (source) declares Macrocosmos operates subnet 9 and links docs.macrocosmos.ai/subnets/subnet-9-pre-training. Live-verified 2026-07-21: GET returns HTTP 200.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 15000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -109,7 +115,13 @@
       "id": "sn-9-iota-openapi",
       "kind": "openapi",
       "name": "IOTA orchestrator API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo.",
+      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo. Live-verified 2026-07-21: GET returns OpenAPI 3.1 JSON (~83 KB).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -127,7 +139,13 @@
       "id": "sn-9-iota-healthcheck",
       "kind": "subnet-api",
       "name": "IOTA orchestrator healthcheck",
-      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec.",
+      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec. Live-verified 2026-07-21: HTTP 200 application/json {\"status\":\"healthy\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -143,7 +161,7 @@
       "id": "sn-9-iota-metrics",
       "kind": "subnet-api",
       "name": "IOTA orchestrator Prometheus metrics",
-      "notes": "Public no-auth GET returning Prometheus text-exposition-format process/runtime metrics (python_gc_objects_collected_total and similar). Documented in the subnet's own OpenAPI schema (path /metrics); plain-text response, not JSON, so tracked with expect: any. Same pattern as the SN1 Apex orchestrator's own /metrics surface (same macrocosm-os org).",
+      "notes": "Public no-auth GET returning Prometheus text-exposition-format process/runtime metrics (python_gc_objects_collected_total and similar). Documented in the subnet's own OpenAPI schema (path /metrics); plain-text response, not JSON, so tracked with expect: any. Same pattern as the SN1 Apex orchestrator's own /metrics surface (same macrocosm-os org). Live-verified 2026-07-21: HTTP 200 text/plain Prometheus exposition.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -161,7 +179,7 @@
       "id": "sn-9-iota-run-info",
       "kind": "subnet-api",
       "name": "IOTA training run info",
-      "notes": "Public no-auth GET /common/get_run_info on the IOTA orchestrator, returning the current decentralized pre-training run's configuration (run_id, num_miners, incentive_perc, run_flags) with no parameters required. Distinct from /common/get_run_epoch, which needs a specific run_id and is not tracked here since the current run_id changes over time (this endpoint is how a client discovers it).",
+      "notes": "Public no-auth GET /common/get_run_info on the IOTA orchestrator, returning the current decentralized pre-training run's configuration (run_id, num_miners, incentive_perc, run_flags) with no parameters required. Distinct from /common/get_run_epoch, which needs a specific run_id and is not tracked here since the current run_id changes over time (this endpoint is how a client discovers it). Live-verified 2026-07-21: HTTP 200 application/json array of RunInfo objects.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -172,6 +190,31 @@
       "public_safe": true,
       "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
       "url": "https://iota.api.macrocosmos.ai/common/get_run_info"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-9-iota-profiler-status",
+      "kind": "subnet-api",
+      "name": "IOTA profiler status",
+      "notes": "Public no-auth GET /profiler/status on the IOTA SN9 orchestrator returning profiler liveness JSON (running, profiler_exists). Documented in the subnet OpenAPI schema with no auth required (unlike /profiler/start and /profiler/stop). Live-verified 2026-07-21: HTTP 200 application/json {\"running\":false,\"profiler_exists\":false}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "RealDiligent"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://iota.api.macrocosmos.ai/profiler/status"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/profiler/status"
     }
   ],
   "website_url": "https://iota.macrocosmos.ai/"


### PR DESCRIPTION
## Summary

Prepare SN9 (iota) for MCP execute (`call_subnet_surface`, #7014) by adding missing probe config on surfaces that lacked it, registering the public profiler-status read called out in #7025, and live-verifying the issue-scoped endpoints.

Closes #7025

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-9-iota-openapi | 200 | OpenAPI 3.1 JSON (~83 KB) |
| sn-9-iota-healthcheck | 200 | `{status:healthy}` |
| sn-9-iota-metrics | 200 | Prometheus text exposition |
| sn-9-iota-run-info | 200 | JSON array of RunInfo |
| sn-9-iota-profiler-status | 200 | `{running:false,profiler_exists:false}` |
| sn-9-iota-codeparrot-dataset | 200 | HuggingFace dataset page |

## Registry changes

- **sn-9-iota-openapi**: add probe (GET, expect: json) — was missing despite captured schema
- **sn-9-iota-healthcheck**: add probe (GET, expect: json) — enables operational monitoring + execute resolution
- **sn-9-iota-codeparrot-dataset**: add probe (HEAD, expect: html) — was missing
- **sn-9-iota-metrics** / **sn-9-iota-run-info**: append Live-verified notes (probes already correct)
- **sn-9-iota-profiler-status**: new community subnet-api for the public no-auth profiler status read (#7025 in-scope addition)

Epistula-signed miner/validator reads from the issue note are left for a follow-up (auth_required surfaces).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7025`)
- [x] Changes exactly one `registry/subnets/iota.json` file
- [x] No secrets, PATs, wallet data, private URLs
- [x] No generated artifacts touched

## Validation

- [x] `npm run validate:surface -- registry/subnets/iota.json`
- [x] `npx prettier --write registry/subnets/iota.json`
- [x] `npx vitest run tests/iota-call-subnet-surface-verify.test.mjs` (3 passed)
- [x] `git diff --check`
- [x] Live curl of all issue-scoped URLs above