### PR TITLE
registry(sn90): add DegenBrain test next-chunk surface (#7102)

### DIFF
--- a/registry/subnets/degenbrain.json
+++ b/registry/subnets/degenbrain.json
@@ -212,6 +212,31 @@
         "https://subnet90.com/"
       ],
       "url": "https://api.subnet90.com/api/markets/btc-100k-2024/breakdown"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-90-degenbrain-test-next-chunk",
+      "kind": "subnet-api",
+      "name": "DegenBrain test next-chunk API",
+      "notes": "Public, unauthenticated GET /api/test/next-chunk on the SN90 DegenBrain Brain-API returning a batch of prediction statements for a validator to test (chunk_id, validator_id, chunk_size, statements[]). Declared with no security in the API's OpenAPI spec at /openapi.json. Takes a required validator_id query parameter (plus optional chunk_size) rather than a path parameter, so the base URL is fixed and the route is callable today via call_subnet_surface's query argument; probe.enabled is false because the bare URL (no validator_id) returns HTTP 422. Live-verified 2026-07-21: GET /api/test/next-chunk?validator_id=test&chunk_size=1 -> HTTP 200 application/json with a real chunk_id and statement list. No wallet/hotkey data.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "degenbrain",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://subnet90.com/",
+        "https://api.subnet90.com/openapi.json"
+      ],
+      "url": "https://api.subnet90.com/api/test/next-chunk"
     }
   ],
   "website_url": "https://subnet90.com/"


### PR DESCRIPTION
Closes #7102

Registers one of the additional no-auth surfaces #7102 flagged as newly in scope, as a **registry-only** change (single file, no bundled test). Resubmits with the issue linked from creation.

**New surface — `sn-90-degenbrain-test-next-chunk`** (`subnet-api`, no-auth):
- `GET https://api.subnet90.com/api/test/next-chunk` — returns a batch of prediction statements for a validator to test (`chunk_id`, `validator_id`, `chunk_size`, `statements[]`). Declared with no `security` in the API's OpenAPI spec.
- Required `validator_id` **query** param (optional `chunk_size`), not a path param, so the base URL is fixed and it's callable today via `call_subnet_surface`'s `query` argument. `probe.enabled:false` because the bare URL (no `validator_id`) is HTTP 422.
- **Live-verified 2026-07-21:** bare URL → **422** (`{"detail":[{"type":"missing","loc":["query","validator_id"]...}]}`); `?validator_id=test&chunk_size=1` → **200** `application/json` with a real `chunk_id` and statement list.

**Scope note:** the issue's other additional paths are intentionally not in this entry — `/api/resolutions/{statement_id}` and the three POST routes are either path-parameterized (no fixed callable URL → unregistrable) or state-changing POSTs that aren't probe-safe to verify.

Registry-only: `registry/subnets/degenbrain.json` is the sole changed file. Schema + surface validators green.
