### PR TITLE
fix(registry): wire SN9 iota MCP execute probe config (#7025)

### DIFF
--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -109,7 +109,7 @@
       "id": "sn-9-iota-openapi",
       "kind": "openapi",
       "name": "IOTA orchestrator API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo.",
+      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo. Live-verified 2026-07-21: GET returns OpenAPI 3.1 JSON.",
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -119,7 +119,13 @@
       "schema_status": "machine-readable",
       "schema_url": "https://iota.api.macrocosmos.ai/openapi.json",
       "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
-      "url": "https://iota.api.macrocosmos.ai/openapi.json"
+      "url": "https://iota.api.macrocosmos.ai/openapi.json",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      }
     },
     {
       "auth_required": false,
@@ -127,7 +133,7 @@
       "id": "sn-9-iota-healthcheck",
       "kind": "subnet-api",
       "name": "IOTA orchestrator healthcheck",
-      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec.",
+      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec. Live-verified 2026-07-21: GET returns healthy status JSON.",
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -135,7 +141,13 @@
         "submitted_by": "codevector96"
       },
       "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
-      "url": "https://iota.api.macrocosmos.ai/healthcheck"
+      "url": "https://iota.api.macrocosmos.ai/healthcheck",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary

Prepare SN9 (iota) for MCP execute (`call_subnet_surface`, #7014) by adding the missing `probe` blocks on the openapi and healthcheck surfaces — same minimal pattern as the merged Beam fix (#7143).

Closes #7025

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-9-iota-openapi | 200 | OpenAPI 3.1 JSON (~83 KB) |
| sn-9-iota-healthcheck | 200 | `{status:healthy}` |

Metrics and run-info already have correct probes; left untouched this round. Epistula-signed miner/validator reads remain out of scope.

## Registry changes

- **sn-9-iota-openapi**: add probe (GET, expect: json)
- **sn-9-iota-healthcheck**: add probe (GET, expect: json)

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7025`)
- [x] Changes exactly one `registry/subnets/iota.json` file
- [x] No secrets, PATs, wallet data, private URLs
- [x] No new surfaces; no generated artifacts touched

## Validation

- [x] `npm run validate:surface -- registry/subnets/iota.json`
- [x] `npx prettier --write registry/subnets/iota.json`
- [x] `npx vitest run tests/iota-call-subnet-surface-verify.test.mjs` (3 passed)
- [x] `git diff --check`
- [x] Live curl of openapi.json and /healthcheck

Made with [Cursor](https://cursor.com)