### PR TITLE
feat(ui): registry leaderboards on /leaderboards

### DIFF
--- a/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
@@ -1,0 +1,215 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { leaderboardsQuery } from "@/lib/metagraphed/queries";
+import { BrandIcon } from "@jsonbored/ui-kit";
+import type { LeaderboardBoardKey, LeaderboardRow } from "@/lib/metagraphed/types";
+
+// #6995: surface the registry's own D1-computed leaderboards on /leaderboards.
+// Ten boards, split into economic-opportunity boards (open-slots,
+// cheapest-registration, highest-emission, validator-headroom) — the
+// "where should I register / validate" boards, placed first per the issue — and
+// operational boards (healthiest, fastest-rpc, most-complete, most-enriched,
+// fastest-growing, most-reliable). Each board is a config entry mapping its key
+// to a label, a one-line blurb, and the formatter for its own metric column
+// (each board carries different metric fields — see LeaderboardRow). All boards
+// render even when currently empty, so every board stays reachable from the UI.
+
+const ROWS_PER_BOARD = 10;
+
+interface BoardSpec {
+  key: LeaderboardBoardKey;
+  label: string;
+  blurb: string;
+  metric: (row: LeaderboardRow) => string | null;
+}
+
+const round = (v: number) => Math.round(v);
+// TAO amounts span from ~0.0001 (cheap registration) to millions (total stake),
+// so cap fraction digits rather than pinning a fixed precision.
+const tao = (v: number) =>
+  `${v.toLocaleString("en-US", { maximumFractionDigits: v >= 1 ? 2 : 4 })} τ`;
+
+const ECONOMIC_BOARDS: BoardSpec[] = [
+  {
+    key: "open-slots",
+    label: "Open slots",
+    blurb: "Most room to register a new neuron.",
+    metric: (r) => (r.open_slots != null ? `${r.open_slots.toLocaleString("en-US")} open` : null),
+  },
+  {
+    key: "cheapest-registration",
+    label: "Cheapest registration",
+    blurb: "Lowest registration cost among subnets currently open.",
+    metric: (r) => (r.registration_cost_tao != null ? tao(r.registration_cost_tao) : null),
+  },
+  {
+    key: "highest-emission",
+    label: "Highest emission",
+    blurb: "Where network emission is concentrated.",
+    metric: (r) => (r.emission_share != null ? `${(r.emission_share * 100).toFixed(2)}%` : null),
+  },
+  {
+    key: "validator-headroom",
+    label: "Validator headroom",
+    blurb: "Open validator permits still attainable.",
+    metric: (r) =>
+      r.validator_headroom != null
+        ? `${r.validator_headroom} permit${r.validator_headroom === 1 ? "" : "s"}`
+        : null,
+  },
+];
+
+const OPERATIONAL_BOARDS: BoardSpec[] = [
+  {
+    key: "healthiest",
+    label: "Healthiest",
+    blurb: "Highest live operational-surface uptime.",
+    metric: (r) => (r.uptime_ratio != null ? `${round(r.uptime_ratio * 100)}% up` : null),
+  },
+  {
+    key: "fastest-rpc",
+    label: "Fastest RPC",
+    blurb: "Lowest RPC latency.",
+    metric: (r) => (r.latency_ms != null ? `${round(r.latency_ms)}ms` : null),
+  },
+  {
+    key: "most-complete",
+    label: "Most complete",
+    blurb: "Most complete profiles by completeness score.",
+    metric: (r) => (r.completeness_score != null ? `${round(r.completeness_score)}%` : null),
+  },
+  {
+    key: "most-enriched",
+    label: "Most enriched",
+    blurb: "Most registered surfaces.",
+    metric: (r) =>
+      r.surface_count != null
+        ? `${r.surface_count} surface${r.surface_count === 1 ? "" : "s"}`
+        : null,
+  },
+  {
+    key: "fastest-growing",
+    label: "Fastest growing",
+    blurb: "Biggest recent completeness gain.",
+    metric: (r) => (r.completeness_delta != null ? `+${round(r.completeness_delta)} pts` : null),
+  },
+  {
+    key: "most-reliable",
+    label: "Most reliable",
+    blurb: "Best windowed reliability score (uptime minus latency penalty).",
+    metric: (r) => (r.score != null ? `${round(r.score)}${r.grade ? ` · ${r.grade}` : ""}` : null),
+  },
+];
+
+export function RegistryLeaderboards() {
+  const { data: res } = useSuspenseQuery(leaderboardsQuery());
+  const boards = res.data;
+
+  return (
+    <section id="registry-leaderboards" className="scroll-mt-24 space-y-8">
+      <div className="max-w-2xl">
+        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted inline-flex items-center gap-2">
+          <span className="mg-live-dot" />
+          Registry
+        </div>
+        <h2 className="mt-2 font-display text-2xl md:text-3xl font-semibold tracking-tight text-ink-strong">
+          Registry leaderboards
+        </h2>
+        <p className="mt-2 text-sm text-ink-muted leading-relaxed">
+          Ten boards computed live from registry data — economic-opportunity boards for miners and
+          validators deciding where to register or validate, plus operational boards ranking health,
+          latency, completeness, and reliability.
+        </p>
+      </div>
+
+      <BoardGroup title="Economic opportunity" boards={ECONOMIC_BOARDS} data={boards} />
+      <BoardGroup title="Operational" boards={OPERATIONAL_BOARDS} data={boards} />
+    </section>
+  );
+}
+
+function BoardGroup({
+  title,
+  boards,
+  data,
+}: {
+  title: string;
+  boards: BoardSpec[];
+  data: Record<LeaderboardBoardKey, LeaderboardRow[]>;
+}) {
+  return (
+    <div className="space-y-4">
+      <h3 className="mg-section-rule font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+        {title}
+      </h3>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {boards.map((board) => (
+          <BoardCard
+            key={board.key}
+            label={board.label}
+            blurb={board.blurb}
+            rows={(data[board.key] ?? []).slice(0, ROWS_PER_BOARD)}
+            metric={board.metric}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BoardCard({
+  label,
+  blurb,
+  rows,
+  metric,
+}: {
+  label: string;
+  blurb: string;
+  rows: LeaderboardRow[];
+  metric: (row: LeaderboardRow) => string | null;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        {label}
+      </div>
+      <p className="mb-3 text-xs text-ink-subtle leading-relaxed">{blurb}</p>
+      {rows.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border px-2 py-3 text-center text-xs text-ink-subtle">
+          No ranked subnets yet.
+        </p>
+      ) : (
+        <ol className="space-y-0.5">
+          {rows.map((row, i) => (
+            <li key={row.netuid}>
+              <Link
+                to="/subnets/$netuid"
+                params={{ netuid: row.netuid }}
+                className="mg-row-hover flex items-center justify-between gap-2 rounded-md px-2 py-1.5"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <span className="w-4 shrink-0 text-right font-mono text-[10px] text-ink-muted tabular-nums">
+                    {i + 1}
+                  </span>
+                  <BrandIcon
+                    size={18}
+                    name={row.name ?? `Subnet ${row.netuid}`}
+                    fallback={row.netuid}
+                    netuid={row.netuid}
+                    subnetSlug={row.slug}
+                  />
+                  <span className="truncate text-sm text-ink-strong">
+                    {row.name ?? `Subnet ${row.netuid}`}
+                  </span>
+                </span>
+                <span className="shrink-0 font-mono text-[12px] tabular-nums text-ink-muted">
+                  {metric(row) ?? "—"}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.registry-leaderboards.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.registry-leaderboards.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { leaderboardsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Boards shaped exactly as GET /api/v1/registry/leaderboards returns them
+// (live-verified 2026-07-21): each board carries only its own metric columns.
+function resolveWith(boards: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data: { boards },
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/registry/leaderboards",
+  });
+}
+
+async function runQuery() {
+  const opts = leaderboardsQuery();
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+beforeEach(() => {
+  mockedApiFetch.mockReset();
+});
+
+describe("leaderboardsQuery normalizer — registry boards (#6995)", () => {
+  it("exposes all ten operational + economic boards, defaulting missing ones to []", async () => {
+    resolveWith({});
+    const res = await runQuery();
+    expect(Object.keys(res.data).sort()).toEqual(
+      [
+        "cheapest-registration",
+        "fastest-growing",
+        "fastest-rpc",
+        "healthiest",
+        "highest-emission",
+        "most-complete",
+        "most-enriched",
+        "most-reliable",
+        "open-slots",
+        "validator-headroom",
+      ].sort(),
+    );
+    expect(res.data["open-slots"]).toEqual([]);
+  });
+
+  it("extracts the economic-board metric columns", async () => {
+    resolveWith({
+      "open-slots": [
+        {
+          netuid: 122,
+          slug: "sn-122",
+          name: "Bitrecs",
+          open_slots: 252,
+          max_uids: 256,
+          registration_cost_tao: 0.999999999,
+          registration_allowed: true,
+        },
+      ],
+      "highest-emission": [
+        {
+          netuid: 64,
+          slug: "sn-64",
+          name: "Chutes",
+          emission_share: 0.054756,
+          total_stake_tao: 3674872.73,
+          validator_count: 18,
+          miner_count: 238,
+        },
+      ],
+      "validator-headroom": [
+        {
+          netuid: 1,
+          slug: "sn-1",
+          name: "Apex",
+          validator_headroom: 119,
+          validator_count: 9,
+          max_validators: 128,
+          emission_share: 0.00641,
+        },
+      ],
+    });
+    const res = await runQuery();
+    expect(res.data["open-slots"][0]).toMatchObject({
+      netuid: 122,
+      name: "Bitrecs",
+      open_slots: 252,
+      max_uids: 256,
+      registration_cost_tao: 0.999999999,
+      registration_allowed: true,
+    });
+    expect(res.data["highest-emission"][0]).toMatchObject({
+      emission_share: 0.054756,
+      total_stake_tao: 3674872.73,
+      validator_count: 18,
+      miner_count: 238,
+    });
+    expect(res.data["validator-headroom"][0]).toMatchObject({
+      validator_headroom: 119,
+      max_validators: 128,
+    });
+  });
+
+  it("extracts the most-reliable score + letter grade", async () => {
+    resolveWith({
+      "most-reliable": [
+        {
+          netuid: 5,
+          slug: "sn-5",
+          name: "Openkaito",
+          score: 98,
+          grade: "A",
+          uptime_ratio: 0.99,
+          avg_latency_ms: 120,
+          sample_count: 288,
+        },
+      ],
+    });
+    const res = await runQuery();
+    expect(res.data["most-reliable"][0]).toMatchObject({
+      netuid: 5,
+      score: 98,
+      grade: "A",
+    });
+  });
+
+  it("drops rows without a numeric netuid and ignores boards outside the surfaced set", async () => {
+    resolveWith({
+      "open-slots": [{ slug: "sn-x", open_slots: 5 }],
+      "biggest-alpha-gain-1d": [{ netuid: 7, alpha_price_change_1d: 0.5 }],
+    });
+    const res = await runQuery();
+    expect(res.data["open-slots"]).toEqual([]);
+    expect(res.data).not.toHaveProperty("biggest-alpha-gain-1d");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -774,6 +774,11 @@ const LEADERBOARD_BOARD_KEYS: LeaderboardBoardKey[] = [
   "most-complete",
   "most-enriched",
   "fastest-growing",
+  "most-reliable",
+  "open-slots",
+  "cheapest-registration",
+  "highest-emission",
+  "validator-headroom",
 ];
 
 function normalizeLeaderboardRow(raw: unknown): LeaderboardRow | null {
@@ -782,6 +787,7 @@ function normalizeLeaderboardRow(raw: unknown): LeaderboardRow | null {
   if (typeof r.netuid !== "number") return null;
   const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
   const str = (v: unknown) => (typeof v === "string" ? v : undefined);
+  const bool = (v: unknown) => (typeof v === "boolean" ? v : undefined);
   return {
     netuid: r.netuid,
     slug: str(r.slug),
@@ -795,6 +801,19 @@ function normalizeLeaderboardRow(raw: unknown): LeaderboardRow | null {
     surface_count: num(r.surface_count),
     operational_interface_count: num(r.operational_interface_count),
     completeness_delta: num(r.completeness_delta),
+    score: num(r.score),
+    grade: str(r.grade),
+    sample_count: num(r.sample_count),
+    open_slots: num(r.open_slots),
+    max_uids: num(r.max_uids),
+    registration_cost_tao: num(r.registration_cost_tao),
+    registration_allowed: bool(r.registration_allowed),
+    emission_share: num(r.emission_share),
+    total_stake_tao: num(r.total_stake_tao),
+    validator_count: num(r.validator_count),
+    miner_count: num(r.miner_count),
+    validator_headroom: num(r.validator_headroom),
+    max_validators: num(r.max_validators),
   };
 }
 
@@ -810,9 +829,12 @@ function normalizeLeaderboards(raw: unknown): Leaderboards {
   return out;
 }
 
-// #1111: registry leaderboards — five live, D1-computed boards (healthiest,
-// fastest-rpc, most-complete, most-enriched, fastest-growing). One artifact carries
-// all boards; the homepage discovery module renders the top rows of each.
+// #1111: registry leaderboards — live, D1-computed boards. Six operational
+// (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing,
+// most-reliable) and four economic-opportunity (open-slots,
+// cheapest-registration, highest-emission, validator-headroom). One artifact
+// carries all boards; the homepage discovery module renders the top rows of a
+// subset, and /leaderboards surfaces them all (#6995).
 function normalizeSubnetMover(raw: unknown): SubnetMover | null {
   if (!isRecord(raw)) return null;
   const netuid = coerceFiniteNumber(raw.netuid);

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -670,14 +670,30 @@ export interface Lineage {
   links: LineageLink[];
 }
 
-/** The five D1-computed registry leaderboards from /api/v1/registry/leaderboards. */
+/**
+ * Registry leaderboards from /api/v1/registry/leaderboards. Six operational
+ * boards (`healthiest`, `fastest-rpc`, `most-complete`, `most-enriched`,
+ * `fastest-growing`, `most-reliable`) and four economic-opportunity boards
+ * (`open-slots`, `cheapest-registration`, `highest-emission`,
+ * `validator-headroom`). (The endpoint also returns two `biggest-alpha-gain-*`
+ * boards not surfaced here.)
+ */
 export type LeaderboardBoardKey =
-  "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing";
+  | "healthiest"
+  | "fastest-rpc"
+  | "most-complete"
+  | "most-enriched"
+  | "fastest-growing"
+  | "most-reliable"
+  | "open-slots"
+  | "cheapest-registration"
+  | "highest-emission"
+  | "validator-headroom";
 
 /**
  * One ranked subnet in a leaderboard. Every row carries netuid/slug/name; only
- * the metric field relevant to its board is populated (e.g. `uptime_ratio` for
- * `healthiest`, `latency_ms` for `fastest-rpc`).
+ * the metric fields relevant to its board are populated (e.g. `uptime_ratio` for
+ * `healthiest`, `latency_ms` for `fastest-rpc`, `open_slots` for `open-slots`).
  */
 export interface LeaderboardRow {
   netuid: number;
@@ -686,12 +702,25 @@ export interface LeaderboardRow {
   uptime_ratio?: number; // healthiest (0–1)
   surfaces_ok?: number; // healthiest
   surfaces_total?: number; // healthiest
-  avg_latency_ms?: number; // healthiest
+  avg_latency_ms?: number; // healthiest / most-reliable
   latency_ms?: number; // fastest-rpc
   completeness_score?: number; // most-complete (0–100)
   surface_count?: number; // most-enriched
   operational_interface_count?: number; // most-enriched
   completeness_delta?: number; // fastest-growing (points)
+  score?: number; // most-reliable (0–100)
+  grade?: string; // most-reliable (A–F)
+  sample_count?: number; // most-reliable
+  open_slots?: number; // open-slots / cheapest-registration
+  max_uids?: number; // open-slots
+  registration_cost_tao?: number; // open-slots / cheapest-registration
+  registration_allowed?: boolean; // open-slots / cheapest-registration
+  emission_share?: number; // highest-emission / validator-headroom (0–1)
+  total_stake_tao?: number; // highest-emission
+  validator_count?: number; // highest-emission / validator-headroom
+  miner_count?: number; // highest-emission
+  validator_headroom?: number; // validator-headroom
+  max_validators?: number; // validator-headroom
 }
 
 export type Leaderboards = Record<LeaderboardBoardKey, LeaderboardRow[]>;

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -8,6 +8,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { RegistryLeaderboards } from "@/components/metagraphed/registry-leaderboards";
 import {
   PageHero,
   BrandIcon,
@@ -44,13 +45,13 @@ export const Route = createFileRoute("/leaderboards")({
       {
         name: "description",
         content:
-          "Network-wide Bittensor leaderboards — validator weight-setting activity and neuron deregistrations ranked by subnet over 7d and 30d windows.",
+          "Network-wide Bittensor leaderboards — registry health, RPC latency, completeness and economic-opportunity boards, plus validator weight-setting activity and neuron deregistrations ranked by subnet.",
       },
       { property: "og:title", content: "Leaderboards — Metagraphed" },
       {
         property: "og:description",
         content:
-          "Network-wide Bittensor leaderboards — validator weight-setting activity and neuron deregistrations ranked by subnet over 7d and 30d windows.",
+          "Network-wide Bittensor leaderboards — registry health, RPC latency, completeness and economic-opportunity boards, plus validator weight-setting activity and neuron deregistrations ranked by subnet.",
       },
     ],
   }),
@@ -85,8 +86,29 @@ function LeaderboardSkeleton() {
   );
 }
 
-// Every board on this route ranks the same 7d/30d window, so the window control lives at the page
-// level and governs both sections rather than each board owning a duplicate toggle.
+// The registry-leaderboards section is a card grid (two groups of boards), a
+// different shape from the StatTile+table chain boards, so it gets its own
+// matching skeleton rather than borrowing LeaderboardSkeleton.
+function RegistryLeaderboardsSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <Skeleton className="h-3 w-24 mb-2" />
+        <Skeleton className="h-7 w-72 mb-2" />
+        <Skeleton className="h-4 w-full max-w-lg" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton key={i} className="h-56" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Every chain board on this route ranks the same 7d/30d window, so the window control lives at the
+// page level and governs those sections rather than each board owning a duplicate toggle. The
+// registry-leaderboards section is not windowed and renders independently of it.
 function LeaderboardsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -98,7 +120,7 @@ function LeaderboardsPage() {
         eyebrow="Explorer"
         live
         title="Leaderboards"
-        description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
+        description="Registry and chain-activity boards — ranked by subnet from live registry data and chain-direct analytics."
         actions={
           <ActionBar>
             <CsvExportMenu win={win} />
@@ -123,6 +145,11 @@ function LeaderboardsPage() {
       </div>
       <div className="space-y-12">
         <QueryErrorBoundary>
+          <Suspense fallback={<RegistryLeaderboardsSkeleton />}>
+            <RegistryLeaderboards />
+          </Suspense>
+        </QueryErrorBoundary>
+        <QueryErrorBoundary>
           <Suspense fallback={<LeaderboardSkeleton />}>
             <WeightSettingLeaderboard win={win} />
           </Suspense>
@@ -139,7 +166,12 @@ function LeaderboardsPage() {
         </QueryErrorBoundary>
       </div>
       <ApiSourceFooter
-        paths={["/api/v1/chain/weights", "/api/v1/chain/deregistrations", "/api/v1/economics"]}
+        paths={[
+          "/api/v1/registry/leaderboards",
+          "/api/v1/chain/weights",
+          "/api/v1/chain/deregistrations",
+          "/api/v1/economics",
+        ]}
       />
     </AppShell>
   );


### PR DESCRIPTION
## Summary

Surfaces the registry's own D1-computed leaderboards on the existing `/leaderboards` page — the ten boards `GET /api/v1/registry/leaderboards` serves, none of which appeared anywhere in the UI before. Four **economic-opportunity** boards (placed first, since they answer "where should I register / validate"):

- `open-slots` — most room to register a new neuron
- `cheapest-registration` — lowest registration cost among subnets currently open
- `highest-emission` — where network emission is concentrated
- `validator-headroom` — open validator permits still attainable

…and six **operational** boards: `healthiest`, `fastest-rpc`, `most-complete`, `most-enriched`, `fastest-growing`, `most-reliable`.

## Approach

- Extends the already-shipped `leaderboardsQuery` normalizer + `LeaderboardRow`/`LeaderboardBoardKey` types (`apps/ui/src/lib/metagraphed/`) to carry each board's own metric columns. Every field name is traced to the board projection in `src/health-serving.mjs` (`ECONOMIC_BOARD_SPECS` + `formatLeaderboards`), not guessed.
- New config-driven `RegistryLeaderboards` section component reuses the existing homepage board-card pattern (`components/metagraphed/leaderboards.tsx`), grouped Economic / Operational, each board linking through to `/subnets/{netuid}`. Currently-empty boards render a compact placeholder so all ten stay reachable.
- Mounted as the first section on `/leaderboards` (not windowed, so independent of the 7d/30d toggle); `/api/v1/registry/leaderboards` added to the page's `ApiSourceFooter`.
- The two `biggest-alpha-gain-*` boards the endpoint also returns are intentionally out of scope (the issue names ten).

## Tests / gates

- New `queries.registry-leaderboards.test.ts` covering the extended normalizer (board set, economic-column extraction, most-reliable score+grade, netuid/unknown-board guards).
- `lint` (0 errors), `typecheck` (0), full unit suite (1335 pass incl. the new test), and `build` all green locally. Scope: 5 files, +459/−14, `apps/ui/**` only.

## Screenshots

Route `/leaderboards`, scrolled to the new section (before = same route on `main`). Fixed viewports, both themes.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6995/6995-registry-leaderboards-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6995
