### PR TITLE
registry(sn126): add Poker44 benchmark-chunks surface (#7134)

### DIFF
--- a/registry/subnets/poker44.json
+++ b/registry/subnets/poker44.json
@@ -165,6 +165,30 @@
     },
     {
       "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-benchmark-chunks",
+      "kind": "data-artifact",
+      "name": "Poker44 benchmark chunk payloads (by source date)",
+      "notes": "Public no-auth GET /api/v1/benchmark/chunks on api.poker44.net returning shadow-training benchmark chunk payloads for one release date — the miner-visible model input. Query params: sourceDate (required, YYYY-MM-DD, taken from the /api/v1/benchmark status endpoint's latestSourceDate) plus optional limit/cursor/split. Each chunk carries chunkId, chunkHash, chunkIndex, the chunks model-input groups, and groundTruth/groundTruthLabels. Documented as a standalone route in docs/training-benchmark.md alongside the already-tracked /api/v1/benchmark and /releases endpoints. The same doc lists a sibling per-chunk route, GET /api/v1/benchmark/chunks/{chunkId}, that returns a single chunk by id (live-verified 2026-07-21: chunkId 069386f8-998f-4437-9402-2a4ea6e520a0 -> HTTP 200 JSON); it is folded into this surface rather than registered separately because a {chunkId} path template is not a valid url format and path-param calling is Phase 2 of #7013. probe.enabled:false because a bare GET without the required sourceDate query param is not a stable liveness probe (query-param calling is Phase 2 of #7013). Live-verified 2026-07-21: GET /api/v1/benchmark/chunks?sourceDate=2026-07-21&limit=1 -> HTTP 200 application/json; charset=utf-8, body {success:true, data:{sourceDate, releaseVersion, schemaVersion, chunks:[{chunkId, chunkHash, ...}]}}. No wallet/hotkey data.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md"
+      ],
+      "url": "https://api.poker44.net/api/v1/benchmark/chunks"
+    },
+    {
+      "auth_required": false,
       "authority": "official",
       "id": "sn-126-poker44-whitepaper",
       "kind": "docs",


### PR DESCRIPTION
## Summary

Registry-only append of `sn-126-poker44-benchmark-chunks` to `registry/subnets/poker44.json` — resolves the additional-scope item from #7134 without bundling tests or editing top-level `curation` metadata.

Closes #7134

## Surface

- Netuid: 126
- Kind: data-artifact
- Public URL: `https://api.poker44.net/api/v1/benchmark/chunks`
- Source URL: `https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md`
- Provider slug: poker44

## New surface — `sn-126-poker44-benchmark-chunks`

Public no-auth GET listing shadow-training benchmark chunks for one release date (`chunkId`, `chunkHash`, `chunkIndex`, + pagination cursor). Requires a `sourceDate` query param (optional `limit`/`cursor`), so the base URL is fixed and callable via `call_subnet_surface`'s `query` argument. `probe.enabled: false` because bare GET without `sourceDate` returns HTTP 422.

Live-verified 2026-07-21:
- `GET /api/v1/benchmark/chunks` → **422**
- `GET /api/v1/benchmark/chunks?sourceDate=2026-07-21&limit=1` → **200** `application/json`

The sibling `/api/v1/benchmark/chunks/{chunkId}` path-param route has no fixed callable URL and remains unregistrable (Phase 2 of #7013).

## Checklist

- [x] Changes exactly one `registry/subnets/poker44.json` file (append-only; no `curation.gap_notes` edit)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public-safe: no secrets, wallet/PAT data, or private URLs
- [x] Links open issue #7134 (`Closes #7134`)

## Validation

- [x] `npm run validate:surface -- registry/subnets/poker44.json`
- [x] `npm run scan:public-safety`


Made with [Cursor](https://cursor.com)