### PR TITLE
fix(registry): wire SN85 Vidaio MCP execute probe config (#7098)

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -128,7 +128,7 @@
       "id": "sn-85-vidaio-health",
       "kind": "subnet-api",
       "name": "Vidaio API health",
-      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health).",
+      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, route /health). Live-verified 2026-07-21: HTTP 200 JSON {\"status\":\"ok\"}.",
       "provider": "vidaio",
       "public_safe": true,
       "review": {
@@ -139,7 +139,13 @@
         "https://api.vidaio.io/openapi.json",
         "https://vidaio.io/"
       ],
-      "url": "https://api.vidaio.io/health"
+      "url": "https://api.vidaio.io/health",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     },
     {
       "auth_required": false,
@@ -147,7 +153,7 @@
       "id": "sn-85-vidaio-ready",
       "kind": "subnet-api",
       "name": "Vidaio API readiness health",
-      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint.",
+      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, route /ready). Distinct from the /health liveness endpoint. Live-verified 2026-07-21: HTTP 200 JSON {\"status\":\"ok\"}.",
       "provider": "vidaio",
       "public_safe": true,
       "review": {
@@ -158,7 +164,13 @@
         "https://api.vidaio.io/openapi.json",
         "https://vidaio.io/"
       ],
-      "url": "https://api.vidaio.io/ready"
+      "url": "https://api.vidaio.io/ready",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     }
   ],
   "website_url": "https://vidaio.io/"


### PR DESCRIPTION
## Summary

Prepare SN85 (Vidaio) for MCP execute (`call_subnet_surface`, #7014) by adding missing probe config on the two subnet-api surfaces that lacked it — same minimal pattern as SN1 Apex / SN9 iota / SN105 Beam.

Closes #7098

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-85-vidaio-health | 200 | JSON `{"status":"ok"}` |
| sn-85-vidaio-ready | 200 | JSON `{"status":"ok"}` |

`sn-85-vidaio-openapi` already had probe config; left untouched. Auth-required routes from the issue addendum (rate_limits, credits, compression, upscaling) stay out of scope.

## Registry changes

- **sn-85-vidaio-health**: add probe (GET, expect: json)
- **sn-85-vidaio-ready**: add probe (GET, expect: json)

## Checklist

- [x] Changes exactly one `registry/subnets/vidaio.json` file
- [x] `npm run validate:surface -- registry/subnets/vidaio.json` passed
- [x] `npm run scan:public-safety` passed (no vidaio findings)
- [x] Both issue-scoped subnet-api surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Prefer health/ready for MCP smoke tests

Made with [Cursor](https://cursor.com)