### PR TITLE
registry(sn123): add MANTIS dashboard snap surfaces (#7131)

### DIFF
--- a/registry/subnets/mantis.json
+++ b/registry/subnets/mantis.json
@@ -213,6 +213,131 @@
         "https://mantis123.com/dashboard/static/app.js"
       ],
       "url": "https://mantis123.com/dashboard/api/history/incentive"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-123-mantis-dashboard-snap-breakouts",
+      "kind": "subnet-api",
+      "name": "MANTIS dashboard breakout events",
+      "notes": "Public no-auth GET /dashboard/api/snap/breakouts on mantis123.com returning per-ticker breakout event history (trigger/resolution blocks, direction, labels, predictor counts). Sibling of the already-registered snap/meta surface — same host/pattern, discovered via the console app.js snap(\"breakouts\") call site. Live-verified 2026-07-21: HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mantis",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": [
+        "https://mantis123.com/",
+        "https://mantis123.com/dashboard/static/app.js"
+      ],
+      "url": "https://mantis123.com/dashboard/api/snap/breakouts"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-123-mantis-dashboard-snap-clusters",
+      "kind": "subnet-api",
+      "name": "MANTIS dashboard miner clusters",
+      "notes": "Public no-auth GET /dashboard/api/snap/clusters on mantis123.com returning per-ticker miner clustering data as public SS58 address groups (no coldkeys or wallet secrets). Sibling of snap/meta — app.js snap(\"clusters\"). Live-verified 2026-07-21: HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mantis",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": [
+        "https://mantis123.com/",
+        "https://mantis123.com/dashboard/static/app.js"
+      ],
+      "url": "https://mantis123.com/dashboard/api/snap/clusters"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-123-mantis-dashboard-snap-metagraph",
+      "kind": "subnet-api",
+      "name": "MANTIS dashboard metagraph snapshot",
+      "notes": "Public no-auth GET /dashboard/api/snap/metagraph on mantis123.com returning a per-UID metagraph snapshot (hotkey, incentive, emission, stake, trust) at the latest synced block. Same public-hotkey-only shape as history/incentive. Sibling of snap/meta — app.js snap(\"metagraph\"). Live-verified 2026-07-21: HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mantis",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": [
+        "https://mantis123.com/",
+        "https://mantis123.com/dashboard/static/app.js"
+      ],
+      "url": "https://mantis123.com/dashboard/api/snap/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-123-mantis-dashboard-snap-miners",
+      "kind": "subnet-api",
+      "name": "MANTIS dashboard miner totals",
+      "notes": "Public no-auth GET /dashboard/api/snap/miners on mantis123.com returning per-ticker miner participation totals (ch_totals). Sibling of snap/meta — app.js snap(\"miners\"). Live-verified 2026-07-21: HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mantis",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": [
+        "https://mantis123.com/",
+        "https://mantis123.com/dashboard/static/app.js"
+      ],
+      "url": "https://mantis123.com/dashboard/api/snap/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-123-mantis-dashboard-snap-participation",
+      "kind": "subnet-api",
+      "name": "MANTIS dashboard participation history",
+      "notes": "Public no-auth GET /dashboard/api/snap/participation on mantis123.com returning per-ticker time series of participation counts. Sibling of snap/meta — app.js snap(\"participation\"). Live-verified 2026-07-21: HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mantis",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": [
+        "https://mantis123.com/",
+        "https://mantis123.com/dashboard/static/app.js"
+      ],
+      "url": "https://mantis123.com/dashboard/api/snap/participation"
     }
   ],
   "website_url": "https://mantis123.com/"


### PR DESCRIPTION
## Summary

Registry-only append of five additional MANTIS dashboard `snap/*` surfaces to `registry/subnets/mantis.json` — resolves the additional-scope items from #7131 without bundling tests or editing top-level `curation` metadata.

Closes #7131

## Surfaces added

| id | URL |
|----|-----|
| `sn-123-mantis-dashboard-snap-breakouts` | `/dashboard/api/snap/breakouts` |
| `sn-123-mantis-dashboard-snap-clusters` | `/dashboard/api/snap/clusters` |
| `sn-123-mantis-dashboard-snap-metagraph` | `/dashboard/api/snap/metagraph` |
| `sn-123-mantis-dashboard-snap-miners` | `/dashboard/api/snap/miners` |
| `sn-123-mantis-dashboard-snap-participation` | `/dashboard/api/snap/participation` |

All five: `kind: subnet-api`, `auth_required: false`, `probe.enabled: true`, `expect: json`.

## Live-verified 2026-07-21

- `GET .../snap/breakouts` → **200** JSON (~418KB)
- `GET .../snap/clusters` → **200** JSON (~160KB, public SS58 address groups only)
- `GET .../snap/metagraph` → **200** JSON (~56KB)
- `GET .../snap/miners` → **200** JSON (~91KB)
- `GET .../snap/participation` → **200** JSON (~662KB)

`snap/salience` still 404 (`unknown snapshot`) — left unregistered per issue.

## Checklist

- [x] Changes exactly one `registry/subnets/mantis.json` file (append-only)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public-safe wording (no sensitive key phrases)
- [x] Links open issue #7131 (`Closes #7131`)

## Validation

- [x] `npm run validate:surface -- registry/subnets/mantis.json`
- [x] `npx prettier --check registry/subnets/mantis.json`