### PR TITLE
fix(registry): wire SN85 Vidaio MCP execute probe config (#7098)

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -128,7 +128,7 @@
       "id": "sn-85-vidaio-health",
       "kind": "subnet-api",
       "name": "Vidaio API health",
-      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health).",
+      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, route /health). Live-verified 2026-07-21: HTTP 200 JSON {\"status\":\"ok\"}.",
       "provider": "vidaio",
       "public_safe": true,
       "review": {
@@ -139,7 +139,13 @@
         "https://api.vidaio.io/openapi.json",
         "https://vidaio.io/"
       ],
-      "url": "https://api.vidaio.io/health"
+      "url": "https://api.vidaio.io/health",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     },
     {
       "auth_required": false,
@@ -147,7 +153,7 @@
       "id": "sn-85-vidaio-ready",
       "kind": "subnet-api",
       "name": "Vidaio API readiness health",
-      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint.",
+      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, route /ready). Distinct from the /health liveness endpoint. Live-verified 2026-07-21: HTTP 200 JSON {\"status\":\"ok\"}.",
       "provider": "vidaio",
       "public_safe": true,
       "review": {
@@ -158,7 +164,13 @@
         "https://api.vidaio.io/openapi.json",
         "https://vidaio.io/"
       ],
-      "url": "https://api.vidaio.io/ready"
+      "url": "https://api.vidaio.io/ready",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     }
   ],
   "website_url": "https://vidaio.io/"

--- a/tests/sn85-call-subnet-surface-verify.test.mjs
+++ b/tests/sn85-call-subnet-surface-verify.test.mjs
@@ -14,10 +14,9 @@
 // (src/health-probe-core.mjs), so that surface is absent from the real
 // public/metagraph/operational-surfaces.json and cannot be resolved by
 // surface_id through the MCP tool -- it is verified direct-call only (matching
-// the SN74 precedent). health/ready are subnet-api (operational) and carry no
-// probe block; call_subnet_surface defaults to GET when a surface has no
-// probe.method, so they are callable as-is. Fixtures below mirror the live
-// shapes, keeping the test hermetic (bodies are live data -> assert stable shape).
+// the SN74 precedent). health/ready are subnet-api (operational) with GET/json
+// probes so call_subnet_surface resolves method from probe.method. Fixtures
+// below mirror the live shapes, keeping the test hermetic.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -112,7 +111,7 @@ const SURFACES = [
     kind: "subnet-api",
     operational: true,
     url: "https://api.vidaio.io/health",
-    hasProbe: false,
+    hasProbe: true,
     hasSchema: false,
     body: { status: "ok" },
     assertShape: (body) => {
@@ -124,7 +123,7 @@ const SURFACES = [
     kind: "subnet-api",
     operational: true,
     url: "https://api.vidaio.io/ready",
-    hasProbe: false,
+    hasProbe: true,
     hasSchema: false,
     body: { status: "ok" },
     assertShape: (body) => {


### PR DESCRIPTION
## Summary

Prepare SN85 (Vidaio) for MCP execute by adding missing probe config on health/ready and updating the existing verify test (`tests/sn85-call-subnet-surface-verify.test.mjs`) which previously asserted those surfaces had no probe block — that assertion is what failed CI on #7470.

Closes #7098

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-85-vidaio-health | 200 | JSON `{"status":"ok"}` |
| sn-85-vidaio-ready | 200 | JSON `{"status":"ok"}` |

`sn-85-vidaio-openapi` already had probe config. Auth-required routes from the issue addendum stay out of scope (401 without credentials).

## Registry / test changes

- **sn-85-vidaio-health**: add probe (GET, expect: json)
- **sn-85-vidaio-ready**: add probe (GET, expect: json)
- **tests/sn85-call-subnet-surface-verify.test.mjs**: set `hasProbe: true` for health/ready

## Checklist

- [x] Links open issue `Closes #7098`
- [x] `npm run validate:surface -- registry/subnets/vidaio.json`
- [x] `npx vitest run tests/sn85-call-subnet-surface-verify.test.mjs` (9 passed)
- [x] `npm run scan:public-safety` (no vidaio findings)

## Test plan

- [ ] Gittensory Gate + CI green (especially the `test` job)

Made with [Cursor](https://cursor.com)