### PR TITLE
fix(registry): SN114 SOMA full API parity for auth-gated platform routes (#7125)

### DIFF
--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -75,10 +75,7 @@
       },
       "provider": "soma",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/dashboard",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/dashboard", "https://thesoma.ai/"],
       "url": "https://thesoma.ai/dashboard"
     },
     {
@@ -96,10 +93,7 @@
       },
       "provider": "soma",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/mcp",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/mcp", "https://thesoma.ai/"],
       "url": "https://thesoma.ai/mcp"
     },
     {
@@ -117,10 +111,7 @@
       },
       "provider": "soma",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/soma-access",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/soma-access", "https://thesoma.ai/"],
       "url": "https://thesoma.ai/soma-access"
     },
     {
@@ -243,9 +234,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/competition/timeframe/current"
     },
     {
@@ -271,9 +260,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/competition/%7Bcompetition_id%7D/aggregate"
     },
     {
@@ -299,9 +286,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/competitions-list"
     },
     {
@@ -327,9 +312,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D"
     },
     {
@@ -355,9 +338,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
     },
     {
@@ -383,9 +364,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition"
     },
     {
@@ -411,9 +390,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition/challenges"
     },
     {
@@ -439,9 +416,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener"
     },
     {
@@ -467,9 +442,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener/challenges"
     },
     {
@@ -495,9 +468,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bhotkey%7D/competition/challenges/%7Bbatch_challenge_id%7D"
     },
     {
@@ -523,9 +494,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/summary"
     },
     {
@@ -551,9 +520,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D"
     },
     {
@@ -579,9 +546,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
     },
     {
@@ -607,9 +572,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/penalties"
     },
     {
@@ -635,9 +598,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks"
     },
     {
@@ -663,9 +624,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D"
     },
     {
@@ -691,9 +650,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D/runs"
     },
     {
@@ -719,9 +676,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/validators"
     },
     {
@@ -747,9 +702,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/incentives/competitions/%7Bcompetition_id%7D/candidates"
     },
     {
@@ -775,9 +728,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/incentives/top-miners/%7Btop_miner_id%7D/approval"
     },
     {
@@ -803,9 +754,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/sandbox/compact-bench/report"
     },
     {
@@ -831,9 +780,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/competition/timeframe/current"
     },
     {
@@ -859,9 +806,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/competitions-list"
     },
     {
@@ -887,9 +832,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D"
     },
     {
@@ -915,9 +858,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
     },
     {
@@ -943,9 +884,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition"
     },
     {
@@ -971,9 +910,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition/challenges"
     },
     {
@@ -999,9 +936,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener"
     },
     {
@@ -1027,9 +962,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener/challenges"
     },
     {
@@ -1055,9 +988,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bhotkey%7D/competition/challenges/%7Bbatch_challenge_id%7D"
     },
     {
@@ -1083,9 +1014,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/summary"
     },
     {
@@ -1111,9 +1040,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D"
     },
     {
@@ -1139,9 +1066,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
     },
     {
@@ -1167,9 +1092,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/penalties"
     },
     {
@@ -1195,9 +1118,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks"
     },
     {
@@ -1223,9 +1144,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D"
     },
     {
@@ -1251,9 +1170,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D/runs"
     },
     {
@@ -1279,9 +1196,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/validators"
     },
     {
@@ -1307,9 +1222,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/miner/openrouter-key/add"
     },
     {
@@ -1335,9 +1248,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/miner/openrouter-key/delete"
     },
     {
@@ -1363,9 +1274,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/miner/openrouter-key/update"
     },
     {
@@ -1391,9 +1300,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/miner/upload"
     },
     {
@@ -1419,9 +1326,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/validator/get_best_miners"
     },
     {
@@ -1447,9 +1352,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/validator/get_swebench_validation"
     },
     {
@@ -1475,9 +1378,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/validator/register"
     },
     {
@@ -1503,9 +1404,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/validator/submit_swebench_validation_score"
     }
   ],

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -75,7 +75,10 @@
       },
       "provider": "soma",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/dashboard", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/dashboard",
+        "https://thesoma.ai/"
+      ],
       "url": "https://thesoma.ai/dashboard"
     },
     {
@@ -93,7 +96,10 @@
       },
       "provider": "soma",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/mcp", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/mcp",
+        "https://thesoma.ai/"
+      ],
       "url": "https://thesoma.ai/mcp"
     },
     {
@@ -111,7 +117,10 @@
       },
       "provider": "soma",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/soma-access", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/soma-access",
+        "https://thesoma.ai/"
+      ],
       "url": "https://thesoma.ai/soma-access"
     },
     {
@@ -165,7 +174,7 @@
       "id": "sn-114-soma-health",
       "kind": "subnet-api",
       "name": "SOMA API health",
-      "notes": "Public no-auth GET /api/health on thesoma.ai returning application liveness JSON. Served on the official SN114 website host registered in this manifest and linked from the DendriteHQ/SOMA source repository.",
+      "notes": "Public no-auth GET /api/health on thesoma.ai returning application liveness JSON. Served on the official SN114 website host registered in this manifest and linked from the DendriteHQ/SOMA source repository. Live-verified 2026-07-21: GET https://thesoma.ai/api/health -> HTTP 200 application/json {\"status\":\"ok\",\"ts\":\"...\"} (callable via call_subnet_surface).",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -190,7 +199,7 @@
       "id": "sn-114-soma-openapi",
       "kind": "openapi",
       "name": "SOMA platform OpenAPI schema",
-      "notes": "Public no-auth OpenAPI 3.1 schema (title \"MCP-subnet\", 46 paths) for the SN114 SOMA platform API on platform.thesoma.ai. The official DendriteHQ/SOMA validator/.env.example sets NETUID=114 and PLATFORM_URL=https://platform.thesoma.ai, tying this host to the subnet; Swagger UI is served at /docs on the same host. Distinct from thesoma.ai website and /api/health surfaces.",
+      "notes": "Public no-auth OpenAPI 3.1 schema (title \"MCP-subnet\", 46 paths) for the SN114 SOMA platform API on platform.thesoma.ai. The official DendriteHQ/SOMA validator/.env.example sets NETUID=114 and PLATFORM_URL=https://platform.thesoma.ai, tying this host to the subnet; Swagger UI is served at /docs on the same host. Distinct from thesoma.ai website and /api/health surfaces. Live-verified 2026-07-21: GET https://platform.thesoma.ai/openapi.json -> HTTP 200 application/json OpenAPI 3.1 schema (46 paths, title MCP-subnet).",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -210,6 +219,1294 @@
         "https://platform.thesoma.ai/openapi.json"
       ],
       "url": "https://platform.thesoma.ai/openapi.json"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-competition-timeframe-current",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend competition timeframe current",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/competition/timeframe/current on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/competition/timeframe/current"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-competition-competition-id-aggregate",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend competition competition_id aggregate",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/competition/{competition_id}/aggregate on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/competition/%7Bcompetition_id%7D/aggregate"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-competitions-list",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend competitions-list",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/competitions-list on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Live-verified 2026-07-21: HTTP 403 for anonymous GET. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/competitions-list"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend miners comp_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend miners comp_id hotkey",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey-competition",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend miners comp_id hotkey competition",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey}/competition on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey-competition-challenges",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend miners comp_id hotkey competition challenges",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey}/competition/challenges on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition/challenges"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey-screener",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend miners comp_id hotkey screener",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey}/screener on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey-screener-challenges",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend miners comp_id hotkey screener challenges",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey}/screener/challenges on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener/challenges"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-hotkey-competition-challenges-batch-challenge-id",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend miners hotkey competition challenges batch_challenge_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{hotkey}/competition/challenges/{batch_challenge_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bhotkey%7D/competition/challenges/%7Bbatch_challenge_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-summary",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend summary",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/summary on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Live-verified 2026-07-21: HTTP 403 for anonymous GET. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/summary"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend swe miners comp_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend swe miners comp_id hotkey",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey-penalties",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend swe miners comp_id hotkey penalties",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey}/penalties on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/penalties"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey-tasks",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend swe miners comp_id hotkey tasks",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey}/tasks on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey-tasks-task-name",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend swe miners comp_id hotkey tasks task_name",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey}/tasks/{task_name} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey-tasks-task-name-runs",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend swe miners comp_id hotkey tasks task_name runs",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey}/tasks/{task_name}/runs on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D/runs"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-validators",
+      "kind": "subnet-api",
+      "name": "SOMA GET api private frontend validators",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/validators on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/validators"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-incentives-competitions-competition-id-candidates",
+      "kind": "subnet-api",
+      "name": "SOMA POST api private incentives competitions competition_id candidates",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /api/private/incentives/competitions/{competition_id}/candidates on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/incentives/competitions/%7Bcompetition_id%7D/candidates"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-incentives-top-miners-top-miner-id-approval",
+      "kind": "subnet-api",
+      "name": "SOMA PATCH api private incentives top-miners top_miner_id approval",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) PATCH /api/private/incentives/top-miners/{top_miner_id}/approval on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/incentives/top-miners/%7Btop_miner_id%7D/approval"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-sandbox-compact-bench-report",
+      "kind": "subnet-api",
+      "name": "SOMA POST api private sandbox compact-bench report",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /api/private/sandbox/compact-bench/report on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/sandbox/compact-bench/report"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-competition-timeframe-current",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key competition timeframe current",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/competition/timeframe/current on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/competition/timeframe/current"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-competitions-list",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key competitions-list",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/competitions-list on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Live-verified 2026-07-21: HTTP 401 for anonymous GET. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/competitions-list"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key miners comp_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key miners comp_id hotkey",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey-competition",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key miners comp_id hotkey competition",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey}/competition on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey-competition-challenges",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key miners comp_id hotkey competition challenges",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey}/competition/challenges on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition/challenges"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey-screener",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key miners comp_id hotkey screener",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey}/screener on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey-screener-challenges",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key miners comp_id hotkey screener challenges",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey}/screener/challenges on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener/challenges"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-hotkey-competition-challenges-batch-challenge-id",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key miners hotkey competition challenges batch_challenge_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{hotkey}/competition/challenges/{batch_challenge_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bhotkey%7D/competition/challenges/%7Bbatch_challenge_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-summary",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key summary",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/summary on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Live-verified 2026-07-21: HTTP 401 for anonymous GET. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/summary"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key swe miners comp_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key swe miners comp_id hotkey",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey-penalties",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key swe miners comp_id hotkey penalties",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey}/penalties on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/penalties"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey-tasks",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key swe miners comp_id hotkey tasks",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey}/tasks on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey-tasks-task-name",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key swe miners comp_id hotkey tasks task_name",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey}/tasks/{task_name} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey-tasks-task-name-runs",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key swe miners comp_id hotkey tasks task_name runs",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey}/tasks/{task_name}/runs on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D/runs"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-validators",
+      "kind": "subnet-api",
+      "name": "SOMA GET api public frontend-key validators",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/validators on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/validators"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-miner-openrouter-key-add",
+      "kind": "subnet-api",
+      "name": "SOMA POST miner openrouter-key add",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /miner/openrouter-key/add on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/miner/openrouter-key/add"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-miner-openrouter-key-delete",
+      "kind": "subnet-api",
+      "name": "SOMA POST miner openrouter-key delete",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /miner/openrouter-key/delete on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/miner/openrouter-key/delete"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-miner-openrouter-key-update",
+      "kind": "subnet-api",
+      "name": "SOMA POST miner openrouter-key update",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /miner/openrouter-key/update on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/miner/openrouter-key/update"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-miner-upload",
+      "kind": "subnet-api",
+      "name": "SOMA POST miner upload",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /miner/upload on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/miner/upload"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-validator-get-best-miners",
+      "kind": "subnet-api",
+      "name": "SOMA POST validator get_best_miners",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /validator/get_best_miners on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/validator/get_best_miners"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-validator-get-swebench-validation",
+      "kind": "subnet-api",
+      "name": "SOMA POST validator get_swebench_validation",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /validator/get_swebench_validation on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/validator/get_swebench_validation"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-validator-register",
+      "kind": "subnet-api",
+      "name": "SOMA POST validator register",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /validator/register on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/validator/register"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-validator-submit-swebench-validation-score",
+      "kind": "subnet-api",
+      "name": "SOMA POST validator submit_swebench_validation_score",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /validator/submit_swebench_validation_score on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/validator/submit_swebench_validation_score"
     }
   ],
   "website_url": "https://thesoma.ai/"


### PR DESCRIPTION
## Summary

Addresses the [#7125](https://github.com/JSONbored/metagraphed/issues/7125) reopen: registers all 46 auth-gated platform API operations from `sn-114-soma-openapi` that JSONbored flagged in the **"Additional surface(s) found during review"** section, following the same full-API-parity pattern as SN36 (#7465) and SN37 (#7466).

Closes #7125

## Original checklist (still good)

Live-verified 2026-07-21:
- `sn-114-soma-health` — `GET https://thesoma.ai/api/health` → **200** `application/json` `{"status":"ok","ts":"..."}` (callable via `call_subnet_surface`; covered by existing `tests/sn114-call-subnet-surface-verify.test.mjs` from #7311)
- `sn-114-soma-openapi` — `GET https://platform.thesoma.ai/openapi.json` → **200** OpenAPI 3.1 schema (46 paths; kind `openapi` is not in `OPERATIONAL_SURFACE_KINDS`, so out of scope for Phase-1 tool-path verification)

## New auth-gated surfaces (46)

All appended to `registry/subnets/soma.json` with `auth_required:true`, `probe.enabled:false`, `public_safe:true`, and path templates URI-encoded (`%7Bparam%7D`):

| Group | Count | Live spot-check |
|---|---|---|
| `/api/private/frontend/*` (no-param + path-param + incentives/sandbox writes) | 21 | `summary` + `competitions-list` → **403** |
| `/api/public/frontend-key/*` (no-param + path-param mirror) | 17 | `summary` + `competitions-list` → **401** |
| `/miner/*` + `/validator/*` protocol writes | 8 | Not individually curled; flagged per issue for maintainer hotkey-signature confirmation |

No top-level `curation` metadata edits (append-only surfaces).

## Validation

- [x] `npm run validate:surface -- registry/subnets/soma.json`
- [x] `npx vitest run tests/sn114-call-subnet-surface-verify.test.mjs`


Made with [Cursor](https://cursor.com)