### PR TITLE
fix(registry): wire SN43 Graphite MCP execute probe config (#7057)

### DIFF
--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -127,7 +127,13 @@
       "id": "sn-43-graphite-ai-subnet-api",
       "kind": "subnet-api",
       "name": "Graphite SN43 subnet stats API",
-      "notes": "Public, unauthenticated JSON endpoint on Graphite's official SN43 API (api.graphite-ai.net) returning the live subnet-43 metagraph aggregate: netuid, total registered neurons, validator/miner counts, total alpha stake, and an availability flag. Documented in the subnet's OpenAPI spec as GET /api/v1/stats/subnet.",
+      "notes": "Public, unauthenticated JSON endpoint on Graphite's official SN43 API (api.graphite-ai.net) returning the live subnet-43 metagraph aggregate: netuid, total registered neurons, validator/miner counts, total alpha stake, and an availability flag. Documented in the subnet's OpenAPI spec as GET /api/v1/stats/subnet. Live-verified 2026-07-21: GET https://api.graphite-ai.net/api/v1/stats/subnet -> HTTP 200 application/json (netuid 43, total_registered/validators/miners counts, total_alpha_stake, updated_at).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "graphite-ai",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN43 (Graphite) for MCP execute (`call_subnet_surface`, #7014) by adding the missing probe config on the one issue-scoped surface that lacked it, and live-verifying the endpoints — same minimal pattern as SN9 iota (#7463) and SN105 Beam (#7143).

Closes #7057

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-43-graphite-ai-subnet-api | 200 | JSON — `netuid: 43`, `total_registered: 256`, `validators: 8`, `miners: 248`, `total_alpha_stake`, `updated_at` |
| sn-43-graphite-ai-openapi | 200 | OpenAPI 3.1.0 JSON (title "SN43 Knowledge Graph API") |
| sn-43-graphite-health | 200 | JSON `{"status":"ok","entities":195790,...}` |
| sn-43-graphite-miners-stats-api | 200 | JSON — per-miner contribution stats |

## Registry changes

- **sn-43-graphite-ai-subnet-api**: add probe (GET, expect: json) + a `Live-verified 2026-07-21: …` note recording what was observed

Uses `{enabled: true, method: GET, expect: json, timeout_ms: 10000}`, matching the sibling `sn-43-graphite-health` and `sn-43-graphite-miners-stats-api` surfaces already configured this way. The other three issue-scoped surfaces already had correct probe config and required no edits — all re-probed 200 above.

## Checklist

- [x] Changes exactly one `registry/subnets/graphite.json` file
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed (1279 surfaces / 129 files)
- [x] `npm run scan:public-safety` passed (no graphite findings)
- [x] `npx vitest run tests/sn43-call-subnet-surface-verify.test.mjs` (3 passed — unaffected, it pins `sn-43-graphite-health`)
- [x] All four issue-scoped surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Prefer `/health` for MCP smoke tests
