### PR TITLE
registry(sn103): add Djinn query-param odds/genius surfaces (#7115)

### DIFF
--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -292,6 +292,81 @@
       },
       "source_urls": ["https://github.com/Djinn-Inc/djinn"],
       "url": "https://www.djinn.gg/api/validators/discover"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-103-djinn-odds",
+      "kind": "subnet-api",
+      "name": "Djinn odds by sport",
+      "notes": "Public no-auth GET /api/odds on www.djinn.gg returning live odds for one sport. Requires query param `sport` (allowed keys listed in the 400 body when omitted). Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without sport returns HTTP 400. Live-verified 2026-07-21: no sport → 400; ?sport=basketball_nba → 200 JSON.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "djinn",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn",
+        "https://www.djinn.gg/api/sports"
+      ],
+      "url": "https://www.djinn.gg/api/odds"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-103-djinn-genius-signals",
+      "kind": "subnet-api",
+      "name": "Djinn genius signals by address",
+      "notes": "Public no-auth GET /api/genius/signals on www.djinn.gg returning Genius-track signals for one Ethereum address. Requires query param `address`. Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without address returns HTTP 400. Live-verified 2026-07-21: no address → 400 {\"error\":\"invalid_address\",...}.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "djinn",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn",
+        "https://www.djinn.gg/api/genius/leaderboard"
+      ],
+      "url": "https://www.djinn.gg/api/genius/signals"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-103-djinn-genius-earnings",
+      "kind": "subnet-api",
+      "name": "Djinn genius earnings by address",
+      "notes": "Public no-auth GET /api/genius/earnings on www.djinn.gg returning Genius-track earnings for one Ethereum address. Requires query param `address`. Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without address returns HTTP 400. Live-verified 2026-07-21: no address → 400 {\"error\":\"invalid_address\",...}.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "djinn",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn",
+        "https://www.djinn.gg/api/genius/leaderboard"
+      ],
+      "url": "https://www.djinn.gg/api/genius/earnings"
     }
   ],
   "website_url": "https://www.djinn.gg/"


### PR DESCRIPTION
## Summary

Registry-only append of three query-param Djinn surfaces to `registry/subnets/djinn.json` — resolves the additional-scope items from #7115 without bundling tests or editing top-level `curation` metadata.

Closes #7115

## Surfaces added

| id | URL | Required query |
|----|-----|----------------|
| `sn-103-djinn-odds` | `/api/odds` | `sport` |
| `sn-103-djinn-genius-signals` | `/api/genius/signals` | `address` |
| `sn-103-djinn-genius-earnings` | `/api/genius/earnings` | `address` |

All three: `kind: subnet-api`, `auth_required: false`, `probe.enabled: false` (bare GET returns 400).

## Live-verified 2026-07-21

- `GET /api/odds` → **400** (lists allowed sports)
- `GET /api/odds?sport=basketball_nba` → **200** JSON
- `GET /api/genius/signals` → **400** `invalid_address`
- `GET /api/genius/earnings` → **400** `invalid_address`

## Checklist

- [x] Changes exactly one `registry/subnets/djinn.json` file (append-only)
- [x] `authority: community`, `review.state: community-submitted`
- [x] Links open issue #7115 (`Closes #7115`)

## Validation

- [x] `npm run validate:surface -- registry/subnets/djinn.json`
- [x] `npx prettier --check registry/subnets/djinn.json`