### PR TITLE
feat(ui): domains/capability-tag rollup overview page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -435,6 +435,7 @@ function SiteFooter() {
         </div>
         <FooterCol title="Registry">
           <FooterLink to="/subnets">Subnets</FooterLink>
+          <FooterLink to="/domains">Domains</FooterLink>
           <FooterLink to="/blocks">Blocks</FooterLink>
           <FooterLink to="/surfaces">Surfaces</FooterLink>
           <FooterLink to="/endpoints">Endpoints</FooterLink>

--- a/apps/ui/src/components/metagraphed/domains-rollup.tsx
+++ b/apps/ui/src/components/metagraphed/domains-rollup.tsx
@@ -1,0 +1,168 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { domainsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { BrandIcon } from "@jsonbored/ui-kit";
+import type { Domain, Subnet } from "@/lib/metagraphed/types";
+
+// #6996: the per-domain rollup over the 14-tag capability taxonomy
+// (/api/v1/domains). Each domain is an expandable row — the collapsed row
+// carries the headline rollup (member count, total stake, emission share,
+// concentration), and expanding it reveals the full within-domain concentration
+// breakdown plus every member subnet, each linking through to its detail page.
+
+const pct = (v: number | undefined) => (v != null ? `${(v * 100).toFixed(2)}%` : "—");
+const ratio = (v: number | undefined) => (v != null ? v.toFixed(3) : "—");
+
+export function DomainsRollup() {
+  const { data: domRes } = useSuspenseQuery(domainsQuery());
+  const { data: snRes } = useSuspenseQuery(subnetsQuery());
+
+  const subnetById = useMemo(() => {
+    const m = new Map<number, Subnet>();
+    for (const s of (snRes.data ?? []) as Subnet[]) m.set(s.netuid, s);
+    return m;
+  }, [snRes]);
+
+  // Rank by emission share (the "where is the weight" signal), then by member
+  // count, so the most significant domains lead.
+  const domains = useMemo(
+    () =>
+      [...(domRes.data ?? [])].sort(
+        (a, b) =>
+          (b.total_emission_share ?? -1) - (a.total_emission_share ?? -1) ||
+          b.subnet_count - a.subnet_count ||
+          a.domain.localeCompare(b.domain),
+      ),
+    [domRes],
+  );
+
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  return (
+    <section id="domains-rollup" className="scroll-mt-24">
+      <div className="hidden grid-cols-[1.4fr_0.7fr_1fr_0.9fr_1fr] gap-2 border-b border-border px-4 pb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted md:grid">
+        <span>Domain</span>
+        <span className="text-right">Subnets</span>
+        <span className="text-right">Total stake</span>
+        <span className="text-right">Emission</span>
+        <span className="text-right">Nakamoto · Gini</span>
+      </div>
+      <ul className="divide-y divide-border">
+        {domains.map((domain) => (
+          <DomainRow
+            key={domain.domain}
+            domain={domain}
+            subnetById={subnetById}
+            open={expanded === domain.domain}
+            onToggle={() => setExpanded((cur) => (cur === domain.domain ? null : domain.domain))}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function DomainRow({
+  domain,
+  subnetById,
+  open,
+  onToggle,
+}: {
+  domain: Domain;
+  subnetById: Map<number, Subnet>;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const c = domain.emission_concentration;
+  const panelId = `domain-detail-${domain.domain}`;
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className="mg-row-hover grid w-full grid-cols-[1fr_auto] items-center gap-2 px-4 py-3 text-left md:grid-cols-[1.4fr_0.7fr_1fr_0.9fr_1fr]"
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          <ChevronDown
+            className={`size-4 shrink-0 text-ink-muted transition-transform ${open ? "rotate-180" : ""}`}
+          />
+          <span className="truncate font-medium capitalize text-ink-strong">{domain.domain}</span>
+        </span>
+        <span className="font-mono text-xs tabular-nums text-ink-muted md:hidden">
+          {domain.subnet_count} · {pct(domain.total_emission_share)}
+        </span>
+        <span className="hidden text-right font-mono text-sm tabular-nums text-ink-strong md:block">
+          {domain.subnet_count}
+        </span>
+        <span className="hidden text-right font-mono text-sm tabular-nums text-ink-strong md:block">
+          {formatTao(domain.total_stake_tao)}
+        </span>
+        <span className="hidden text-right font-mono text-sm tabular-nums text-ink-strong md:block">
+          {pct(domain.total_emission_share)}
+        </span>
+        <span className="hidden text-right font-mono text-sm tabular-nums text-ink-muted md:block">
+          {formatNumber(c?.nakamoto_coefficient)} · {ratio(c?.gini)}
+        </span>
+      </button>
+
+      {open ? (
+        <div id={panelId} className="space-y-4 px-4 pb-5 pt-1">
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+            <Metric label="Total stake" value={formatTao(domain.total_stake_tao)} />
+            <Metric label="Emission share" value={pct(domain.total_emission_share)} />
+            <Metric label="Nakamoto coeff." value={formatNumber(c?.nakamoto_coefficient)} />
+            <Metric label="Gini" value={ratio(c?.gini)} />
+            <Metric label="HHI (normalized)" value={ratio(c?.hhi_normalized)} />
+            <Metric label="Top-10% share" value={pct(c?.top_10pct_share)} />
+            <Metric label="Top-20% share" value={pct(c?.top_20pct_share)} />
+            <Metric label="Entropy (normalized)" value={ratio(c?.entropy_normalized)} />
+          </dl>
+          <div>
+            <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              {domain.subnet_count} member subnet{domain.subnet_count === 1 ? "" : "s"}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {domain.netuids.map((netuid) => {
+                const sn = subnetById.get(netuid);
+                const name = sn?.name ?? `Subnet ${netuid}`;
+                return (
+                  <Link
+                    key={netuid}
+                    to="/subnets/$netuid"
+                    params={{ netuid }}
+                    className="mg-chip inline-flex items-center gap-1.5"
+                  >
+                    <BrandIcon
+                      size={16}
+                      name={name}
+                      fallback={netuid}
+                      netuid={netuid}
+                      subnetSlug={sn?.slug}
+                    />
+                    <span className="truncate text-xs text-ink-strong">{name}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-ink-muted">
+        {label}
+      </div>
+      <div className="mt-0.5 font-mono text-sm tabular-nums text-ink-strong">{value}</div>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.domains.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.domains.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDomains } from "./queries";
+
+// Shape mirrors GET /api/v1/domains (live-verified 2026-07-21).
+const AGENTS = {
+  schema_version: 1,
+  domain: "agents",
+  subnet_count: 11,
+  netuids: [1, 6, 11, 15, 62, 66, 74, 98, 115, 118, 121],
+  total_stake_tao: 30400330.8314,
+  total_emission_share: 0.071288,
+  emission_concentration: {
+    holders: 11,
+    gini: 0.338088,
+    hhi: 0.129248,
+    hhi_normalized: 0.042172,
+    nakamoto_coefficient: 3,
+    top_1pct_share: 0.234275,
+    top_10pct_share: 0.398272,
+    top_20pct_share: 0.523244,
+    entropy: 3.191075,
+    entropy_normalized: 0.922427,
+  },
+};
+
+describe("normalizeDomains (#6996)", () => {
+  it("passes a well-formed domain through, including nested concentration", () => {
+    const [d] = normalizeDomains([AGENTS]);
+    expect(d).toMatchObject({
+      domain: "agents",
+      subnet_count: 11,
+      netuids: [1, 6, 11, 15, 62, 66, 74, 98, 115, 118, 121],
+      total_stake_tao: 30400330.8314,
+      total_emission_share: 0.071288,
+    });
+    expect(d.emission_concentration).toMatchObject({
+      gini: 0.338088,
+      nakamoto_coefficient: 3,
+      top_10pct_share: 0.398272,
+      entropy_normalized: 0.922427,
+    });
+  });
+
+  it("accepts both a bare array and a { domains: [...] } envelope", () => {
+    expect(normalizeDomains([AGENTS])).toHaveLength(1);
+    expect(normalizeDomains({ domains: [AGENTS] })).toHaveLength(1);
+    expect(normalizeDomains(null)).toEqual([]);
+  });
+
+  it("falls back subnet_count to netuids length and filters non-numeric netuids", () => {
+    const [d] = normalizeDomains([{ domain: "storage", netuids: [3, "x", 9, null] }]);
+    expect(d.netuids).toEqual([3, 9]);
+    expect(d.subnet_count).toBe(2);
+  });
+
+  it("drops rows without a string domain and coerces junk numbers to undefined", () => {
+    const out = normalizeDomains([
+      { subnet_count: 5 },
+      { domain: "compute", total_stake_tao: "nope", netuids: [1] },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].domain).toBe("compute");
+    expect(out[0].total_stake_tao).toBeUndefined();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -156,6 +156,8 @@ import type {
   HealthTrends,
   HealthTrendSurface,
   HealthTrendWindow,
+  Domain,
+  DomainConcentration,
   LeaderboardBoardKey,
   LeaderboardRow,
   Leaderboards,
@@ -890,6 +892,62 @@ export const leaderboardsQuery = () =>
         signal,
       });
       return { data: normalizeLeaderboards(res.data?.boards), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #6996: per-domain rollup over the 14-tag capability taxonomy from
+// /api/v1/domains — member subnets, total stake/emission, and within-domain
+// emission concentration. Every numeric cell coerces defensively so a cold
+// store never produces NaN in the UI.
+function normalizeDomainConcentration(raw: unknown): DomainConcentration | undefined {
+  if (!isRecord(raw)) return undefined;
+  const num = (v: unknown) => coerceFiniteNumber(v) ?? undefined;
+  return {
+    holders: num(raw.holders),
+    gini: num(raw.gini),
+    hhi: num(raw.hhi),
+    hhi_normalized: num(raw.hhi_normalized),
+    nakamoto_coefficient: num(raw.nakamoto_coefficient),
+    top_1pct_share: num(raw.top_1pct_share),
+    top_5pct_share: num(raw.top_5pct_share),
+    top_10pct_share: num(raw.top_10pct_share),
+    top_20pct_share: num(raw.top_20pct_share),
+    entropy: num(raw.entropy),
+    entropy_normalized: num(raw.entropy_normalized),
+  };
+}
+
+export function normalizeDomains(raw: unknown): Domain[] {
+  const list = Array.isArray(raw)
+    ? raw
+    : isRecord(raw) && Array.isArray(raw.domains)
+      ? raw.domains
+      : [];
+  return list.flatMap((row) => {
+    if (!isRecord(row) || typeof row.domain !== "string") return [];
+    const netuids = Array.isArray(row.netuids)
+      ? row.netuids.filter((n): n is number => typeof n === "number" && Number.isFinite(n))
+      : [];
+    return [
+      {
+        domain: row.domain,
+        subnet_count: coerceFiniteNumber(row.subnet_count) ?? netuids.length,
+        netuids,
+        total_stake_tao: coerceFiniteNumber(row.total_stake_tao) ?? undefined,
+        total_emission_share: coerceFiniteNumber(row.total_emission_share) ?? undefined,
+        emission_concentration: normalizeDomainConcentration(row.emission_concentration),
+      },
+    ];
+  });
+}
+
+export const domainsQuery = () =>
+  queryOptions({
+    queryKey: k("domains"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<{ domains?: unknown }>("/api/v1/domains", { signal });
+      return { data: normalizeDomains(res.data?.domains), meta: res.meta, url: res.url };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -696,6 +696,38 @@ export interface LeaderboardRow {
 
 export type Leaderboards = Record<LeaderboardBoardKey, LeaderboardRow[]>;
 
+/**
+ * Within-domain emission-concentration metrics from /api/v1/domains — how
+ * concentrated a domain's emission is across its member subnets.
+ */
+export interface DomainConcentration {
+  holders?: number;
+  gini?: number;
+  hhi?: number;
+  hhi_normalized?: number;
+  nakamoto_coefficient?: number;
+  top_1pct_share?: number;
+  top_5pct_share?: number;
+  top_10pct_share?: number;
+  top_20pct_share?: number;
+  entropy?: number;
+  entropy_normalized?: number;
+}
+
+/**
+ * One capability-domain rollup from /api/v1/domains: a domain/capability tag in
+ * the 14-tag taxonomy with its member subnets, total stake, emission share, and
+ * within-domain emission concentration.
+ */
+export interface Domain {
+  domain: string;
+  subnet_count: number;
+  netuids: number[];
+  total_stake_tao?: number;
+  total_emission_share?: number;
+  emission_concentration?: DomainConcentration;
+}
+
 /** Result of an on-demand re-probe via /api/v1/surfaces/{id}/verify. */
 export interface VerifyResult {
   status?: HealthState | string;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as HealthRouteImport } from './routes/health'
 import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as ExplorerRouteImport } from './routes/explorer'
 import { Route as EndpointsRouteImport } from './routes/endpoints'
+import { Route as DomainsRouteImport } from './routes/domains'
 import { Route as AgentsRouteImport } from './routes/agents'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
@@ -93,6 +94,11 @@ const ExplorerRoute = ExplorerRouteImport.update({
 const EndpointsRoute = EndpointsRouteImport.update({
   id: '/endpoints',
   path: '/endpoints',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DomainsRoute = DomainsRouteImport.update({
+  id: '/domains',
+  path: '/domains',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsRoute = AgentsRouteImport.update({
@@ -225,6 +231,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
+  '/domains': typeof DomainsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
@@ -262,6 +269,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
+  '/domains': typeof DomainsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
@@ -300,6 +308,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
+  '/domains': typeof DomainsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
@@ -339,6 +348,7 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/agents'
+    | '/domains'
     | '/endpoints'
     | '/explorer'
     | '/gaps'
@@ -376,6 +386,7 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/agents'
+    | '/domains'
     | '/endpoints'
     | '/explorer'
     | '/gaps'
@@ -413,6 +424,7 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/agents'
+    | '/domains'
     | '/endpoints'
     | '/explorer'
     | '/gaps'
@@ -451,6 +463,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
   AgentsRoute: typeof AgentsRoute
+  DomainsRoute: typeof DomainsRoute
   EndpointsRoute: typeof EndpointsRoute
   ExplorerRoute: typeof ExplorerRoute
   GapsRoute: typeof GapsRoute
@@ -555,6 +568,13 @@ declare module '@tanstack/react-router' {
       path: '/endpoints'
       fullPath: '/endpoints'
       preLoaderRoute: typeof EndpointsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/domains': {
+      id: '/domains'
+      path: '/domains'
+      fullPath: '/domains'
+      preLoaderRoute: typeof DomainsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents': {
@@ -739,6 +759,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
   AgentsRoute: AgentsRoute,
+  DomainsRoute: DomainsRoute,
   EndpointsRoute: EndpointsRoute,
   ExplorerRoute: ExplorerRoute,
   GapsRoute: GapsRoute,

--- a/apps/ui/src/routes/domains.tsx
+++ b/apps/ui/src/routes/domains.tsx
@@ -1,0 +1,62 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Suspense } from "react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { Skeleton } from "@/components/metagraphed/states";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { DomainsRollup } from "@/components/metagraphed/domains-rollup";
+import { PageHero, ActionBar, ShareButton } from "@jsonbored/ui-kit";
+
+export const Route = createFileRoute("/domains")({
+  head: () => ({
+    meta: [
+      { title: "Domains — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Browse Bittensor subnets by capability domain — inference, storage, compute, finance, and more — with member count, total stake, emission share, and within-domain emission concentration per domain.",
+      },
+      { property: "og:title", content: "Domains — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Browse Bittensor subnets by capability domain with real stake and emission context per domain.",
+      },
+    ],
+  }),
+  component: DomainsPage,
+});
+
+function DomainsRollupSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 8 }, (_, i) => (
+        <Skeleton key={i} className="h-12 w-full" />
+      ))}
+    </div>
+  );
+}
+
+function DomainsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Explorer"
+        live
+        title="Domains"
+        description="The 14-tag capability taxonomy — every domain with its member subnets, total stake, emission share, and within-domain emission concentration. Expand a domain to see its full concentration breakdown and jump to any member subnet."
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<DomainsRollupSkeleton />}>
+          <DomainsRollup />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter paths={["/api/v1/domains", "/api/v1/subnets"]} />
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a `/domains` route rendering the 14-tag capability taxonomy from `GET /api/v1/domains` — a rollup that had no UI at all. Each domain shows its member-subnet count, total stake, emission share, and within-domain emission concentration; rows **expand in place** to reveal the full concentration breakdown (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) and every member subnet, each linking through to its `/subnets/{netuid}` detail page. A "Domains" link is added to the footer Registry nav for discoverability.

Closes #6996

## Approach

- New `domainsQuery` + `normalizeDomains` normalizer (defensive numeric coercion) and `Domain`/`DomainConcentration` types, following the existing `leaderboardsQuery` shape.
- Config-driven `DomainsRollup` section reusing the app's table/row + `BrandIcon` conventions and design tokens; domains ranked by emission share.
- Member-subnet chips resolve names via the shared `subnetsQuery` cache and link to subnet detail (the issue's "link through to subnets"). Note: `/subnets` has no `?domain=` UI filter today, so link-through is per-member-subnet rather than a pre-filtered table — a dedicated table filter is a natural follow-up.

## Tests / gates

- `queries.domains.test.ts` covers the normalizer (envelope/array shapes, subnet_count fallback, non-numeric filtering, nested concentration, junk coercion).
- `lint` 0 errors, `typecheck` 0, full unit suite (1335 pass incl. the new test), `build` green. Scope: 7 files, +407/−0, `apps/ui/**` only.

## Screenshots

Route `/domains`, scrolled to the rollup. **This is a brand-new route** — it did not exist on `main`, so navigating there returned a 404 with no page; the `before` column reflects that (blank), and the `after` column shows the new page. Fixed viewports, both themes.

| Viewport · Theme | Before (route absent) | After |
| ---------------- | --------------------- | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-desktop-light.png)<br><sub>route absent on main (404)</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-desktop-dark.png)<br><sub>route absent on main (404)</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-tablet-light.png)<br><sub>route absent on main (404)</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-tablet-dark.png)<br><sub>route absent on main (404)</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-mobile-light.png)<br><sub>route absent on main (404)</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-before-mobile-dark.png)<br><sub>route absent on main (404)</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/6996/6996-domains-after-mobile-dark.png)<br><sub>after</sub> |
