### PR TITLE
fix(registry): SN46 Zipcode full API parity (35 missing surfaces)

### DIFF
--- a/registry/subnets/zipcode.json
+++ b/registry/subnets/zipcode.json
@@ -190,7 +190,7 @@
       "id": "sn-46-zipcode-real-estate-validation-set",
       "kind": "data-artifact",
       "name": "Zipcode real estate validation dataset",
-      "notes": "Public no-auth GET returning the SN46 real-estate validation dataset (price, living_area_sqft, lot_size_sqft, bedrooms, bathrooms, lat/long, year_built, and other property features), the miner-model evaluation ground truth. Documented in the RESI Dashboard API docs (path /api/dashboard/validation-set/real_estate/download).",
+      "notes": "Public no-auth GET returning the SN46 real-estate validation dataset (price, living_area_sqft, lot_size_sqft, bedrooms, bathrooms, lat/long, year_built, and other property features), the miner-model evaluation ground truth. Documented in the RESI Dashboard API docs (path /api/dashboard/validation-set/real_estate/download). Live-verified 2026-07-21: currently returns HTTP 404 {\"error\":\"No validation set found for 2026-07-21.\",\"code\":\"NO_VALIDATION_SET\"} -- the endpoint is still documented in the live OpenAPI schema (not moved/removed), this is a legitimate empty-state response for a date-scoped daily resource, not a config defect. url/method/auth unchanged.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -205,6 +205,956 @@
       },
       "source_urls": ["https://zipcode.ai/api/dashboard/docs"],
       "url": "https://zipcode.ai/api/dashboard/validation-set/real_estate/download"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-billing-checkout",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api billing checkout",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/billing/checkout on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/billing/checkout"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-billing-portal",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api billing portal",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/billing/portal on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/billing/portal"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-billing-summary",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api billing summary",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/billing/summary on zipcode.ai. Live-verified 2026-07-21: HTTP 401 {\"ok\":false,\"error\":\"Unauthorized\",\"message\":\"Valid PortalUser authentication required. Please log in.\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/billing/summary"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-dashboard-auth-validation-set",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api dashboard auth validation set",
+      "notes": "GET /api/dashboard/auth/validation-set on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide) — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21. Registered per the registry's full-API-parity policy (metagraphed#7060) even though it now is.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/dashboard/auth/validation-set"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-dashboard-models-uid",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api dashboard models by uid",
+      "notes": "GET /api/dashboard/models/{uid} on zipcode.ai — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/dashboard/models/%7Buid%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-dashboard-models-uid-validations-date",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api dashboard models by uid validations by date",
+      "notes": "GET /api/dashboard/models/{uid}/validations/{date} on zipcode.ai — public, no auth declared in the OpenAPI schema. Not individually curled — no `security` declared in the OpenAPI schema, same as the verified public endpoints above. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/dashboard/models/%7Buid%7D/validations/%7Bdate%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-dashboard-models-uid-validations",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api dashboard models by uid validations",
+      "notes": "GET /api/dashboard/models/{uid}/validations on zipcode.ai — public, no auth declared in the OpenAPI schema. Not individually curled — no `security` declared in the OpenAPI schema, same as the verified public endpoints above. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/dashboard/models/%7Buid%7D/validations"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-geocode",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api geocode",
+      "notes": "GET /api/geocode on zipcode.ai — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21. Registered per the registry's full-API-parity policy (metagraphed#7060) even though it now is.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/geocode"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-acs-zipcode",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api portal acs by zipCode",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/portal/acs/{zipCode} on zipcode.ai. Live-verified 2026-07-21: HTTP 401 {\"ok\":false,\"error\":\"Unauthorized\",\"message\":\"Valid PortalUser authentication required. Please log in.\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/acs/%7BzipCode%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-api-keys-keyid-reveal",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api portal projects by projectId api keys by keyId reveal",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/portal/projects/{projectId}/api-keys/{keyId}/reveal on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/api-keys/%7BkeyId%7D/reveal"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-api-keys-keyid-revoke",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api portal projects by projectId api keys by keyId revoke",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/portal/projects/{projectId}/api-keys/{keyId}/revoke on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/api-keys/%7BkeyId%7D/revoke"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid-assets-assetid",
+      "kind": "subnet-api",
+      "name": "Zipcode DELETE api portal projects by projectId chats by chatId assets by assetId",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) DELETE /api/portal/projects/{projectId}/chats/{chatId}/assets/{assetId} on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D/assets/%7BassetId%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid-assets-bulk-upload",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api portal projects by projectId chats by chatId assets bulk upload",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/portal/projects/{projectId}/chats/{chatId}/assets/bulk-upload on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D/assets/bulk-upload"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid-assets-features",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api portal projects by projectId chats by chatId assets features",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/portal/projects/{projectId}/chats/{chatId}/assets/features on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D/assets/features"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid-assets-from-address",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api portal projects by projectId chats by chatId assets from address",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/portal/projects/{projectId}/chats/{chatId}/assets/from-address on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D/assets/from-address"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid-assets",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api portal projects by projectId chats by chatId assets",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/portal/projects/{projectId}/chats/{chatId}/assets on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D/assets"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid-assets-stats",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api portal projects by projectId chats by chatId assets stats",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/portal/projects/{projectId}/chats/{chatId}/assets/stats on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D/assets/stats"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid",
+      "kind": "subnet-api",
+      "name": "Zipcode PATCH api portal projects by projectId chats by chatId",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) PATCH /api/portal/projects/{projectId}/chats/{chatId} on zipcode.ai (this path also supports DELETE — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid-scrape-batch-jobid",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api portal projects by projectId chats by chatId scrape batch by jobId",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/portal/projects/{projectId}/chats/{chatId}/scrape-batch/{jobId} on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D/scrape-batch/%7BjobId%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats-chatid-scrape-batch",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api portal projects by projectId chats by chatId scrape batch",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/portal/projects/{projectId}/chats/{chatId}/scrape-batch on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats/%7BchatId%7D/scrape-batch"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid-chats",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api portal projects by projectId chats",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/portal/projects/{projectId}/chats on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D/chats"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects-projectid",
+      "kind": "subnet-api",
+      "name": "Zipcode PATCH api portal projects by projectId",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) PATCH /api/portal/projects/{projectId} on zipcode.ai (this path also supports DELETE — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects/%7BprojectId%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-portal-projects",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api portal projects",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/portal/projects on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Live-verified 2026-07-21: HTTP 401 {\"ok\":false,\"error\":\"Unauthorized\",\"message\":\"Valid PortalUser authentication required. Please log in.\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/portal/projects"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid-bathrooms-id",
+      "kind": "subnet-api",
+      "name": "Zipcode PUT api v1 real estate asset by assetId bathrooms by id",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) PUT /api/v1/real_estate/asset/{assetId}/bathrooms/{id} on zipcode.ai (this path also supports DELETE — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D/bathrooms/%7Bid%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid-bathrooms",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api v1 real estate asset by assetId bathrooms",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/v1/real_estate/asset/{assetId}/bathrooms on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D/bathrooms"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid-bedrooms-id",
+      "kind": "subnet-api",
+      "name": "Zipcode PUT api v1 real estate asset by assetId bedrooms by id",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) PUT /api/v1/real_estate/asset/{assetId}/bedrooms/{id} on zipcode.ai (this path also supports DELETE — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D/bedrooms/%7Bid%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid-bedrooms",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api v1 real estate asset by assetId bedrooms",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/v1/real_estate/asset/{assetId}/bedrooms on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D/bedrooms"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid-kitchens-id",
+      "kind": "subnet-api",
+      "name": "Zipcode PUT api v1 real estate asset by assetId kitchens by id",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) PUT /api/v1/real_estate/asset/{assetId}/kitchens/{id} on zipcode.ai (this path also supports DELETE — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D/kitchens/%7Bid%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid-kitchens",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api v1 real estate asset by assetId kitchens",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/v1/real_estate/asset/{assetId}/kitchens on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D/kitchens"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid-living-rooms-id",
+      "kind": "subnet-api",
+      "name": "Zipcode PUT api v1 real estate asset by assetId living rooms by id",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) PUT /api/v1/real_estate/asset/{assetId}/living-rooms/{id} on zipcode.ai (this path also supports DELETE — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D/living-rooms/%7Bid%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid-living-rooms",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api v1 real estate asset by assetId living rooms",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/v1/real_estate/asset/{assetId}/living-rooms on zipcode.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D/living-rooms"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset-assetid",
+      "kind": "subnet-api",
+      "name": "Zipcode PUT api v1 real estate asset by assetId",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) PUT /api/v1/real_estate/asset/{assetId} on zipcode.ai (this path also supports DELETE — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset/%7BassetId%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-asset",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api v1 real estate asset",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/v1/real_estate/asset on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/asset"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-evaluate-features",
+      "kind": "subnet-api",
+      "name": "Zipcode POST api v1 real estate evaluate features",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) POST /api/v1/real_estate/evaluate/features on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/evaluate/features"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: PortalJWT (`Authorization: JWT <token>`, or cookie `payload-token` for browser sessions) or PortalApiKey (`Authorization: Bearer <token>`, or `x-api-key`/`x-resi-key` headers) — either is accepted per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-v1-real-estate-evaluate-results-id",
+      "kind": "subnet-api",
+      "name": "Zipcode GET api v1 real estate evaluate results by id",
+      "notes": "Auth-gated (PortalUser session auth, Phase 3 credential passthrough, not built yet) GET /api/v1/real_estate/evaluate/results/{id} on zipcode.ai. Not individually curled at this volume — same declared `PortalJWT`/`PortalApiKey` security scheme as the verified `sn-46-zipcode-api-billing-summary` (401, same message), and the OpenAPI schema's own `security` field names the scheme explicitly. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7060) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://zipcode.ai/openapi.json"],
+      "url": "https://zipcode.ai/api/v1/real_estate/evaluate/results/%7Bid%7D"
     }
   ],
   "website_url": "https://zipcode.ai/"


### PR DESCRIPTION
## Summary

Closes #7060. Same pattern as #7465 (SN36) and #7466 (SN37): PR #7359 (already merged) closed this issue by verifying the 4 originally-listed surfaces (still accurate) but added zero registry changes, leaving the 52 additional operations the issue's own OpenAPI sweep found unregistered.

## A finding on an already-registered surface

While re-verifying the existing (not just the 4 newly-listed) surfaces, `sn-46-zipcode-real-estate-validation-set` (`GET /api/dashboard/validation-set/real_estate/download`) returned `HTTP 404 {"error":"No validation set found for 2026-07-21.","code":"NO_VALIDATION_SET"}`. The path is still documented in the live OpenAPI schema (not moved/removed) — this is a legitimate empty-state response for a date-scoped daily resource (no fresh dataset published today), not a config defect. No `url`/`probe`/`auth` change; appended a `Live-verified` note explaining the 404 so a future reader isn't confused by it.

## What this adds (35 new surfaces)

Diffed the live OpenAPI spec (`https://zipcode.ai/openapi.json`, 57 operations) against the registry (7 already covered, including one now-annotated as above) → 36 unique missing paths, minus 1 correction (below) → **35 new surfaces**.

**One correction to the issue's characterization**: the issue listed `GET /api/docs` under "Combined OpenAPI spec" as a distinct surface to add. Live-checked: it's a `302` redirect, and following it lands on byte-identical content to the already-registered `sn-46-zipcode-openapi` (`/openapi.json`) — confirmed with a direct diff of both responses. Not a distinct resource; not registered as a separate surface.

**4 public, no-auth** (schema declares no `security`):
- `POST`/`GET /api/dashboard/auth/validation-set` — live-verified GET returns a self-describing info response about the POST auth handshake (presigned URLs for validators, `Hotkey`/`Nonce`/`Signature` headers).
- `GET /api/dashboard/models/{uid}` (+ 2 sibling nested lookups: `/validations`, `/validations/{date}`) — live-verified with a real `uid` (241, pulled from the already-registered models list): `200` with the full model detail.
- `GET /api/geocode` — live-verified with `q=10001`: `200` with real geocoding results, already callable today via `call_subnet_surface`'s own `query` arg.

**30 auth-gated, schema-declared `PortalJWT`/`PortalApiKey`** (`auth_required:true`, `auth:{scheme:"api-key",...}`, `probe.enabled:false`): the schema's `components.securitySchemes` explicitly documents both mechanisms (`Authorization: JWT <token>` or cookie `payload-token` for PortalJWT; `Authorization: Bearer <token>` or `x-api-key`/`x-resi-key` for PortalApiKey) — a genuinely known, documented scheme, unlike SN36's undocumented case. I independently spot-checked 3 across different functional areas (billing, portal projects, portal ACS) rather than trusting the schema's `security` field alone; all 3 returned a uniform `401 {"ok":false,"error":"Unauthorized","message":"Valid PortalUser authentication required. Please log in."}`, matching the schema's claim.

Covers: billing (3 ops), portal API-key management (2), portal project/chat/asset CRUD (~19), and RealEstateV1 asset + per-room-type CRUD (~20, collapsed from the schema's per-method listing to per-path per the registry's `netuid|kind|url` dedup key — e.g. `PUT`/`DELETE /api/v1/real_estate/asset/{assetId}/bathrooms/{id}` registers once, both methods noted).

## Schema/tooling notes (same as #7465/#7466)
- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC` — non-probable surfaces here use `probe.enabled:false` + `probe.method:"GET"` as a schema-satisfying placeholder; the real method is in `name`/`notes`.
- Path-param URLs use the percent-encoded brace form (`%7Buid%7D` etc.) — a literal unencoded `{`/`}` fails this repo's `url` `format:"uri"` schema check.
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`, served fresh on deploy.

## Validation
- [x] `npm run validate:surface -- registry/subnets/zipcode.json` — 43 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2016 total surfaces, clean
- [x] `npx vitest run tests/sn46-call-subnet-surface-verify.test.mjs` — 11 passed (unchanged — already accurate)
- [x] `npm test` — full suite, clean
- [x] `npx prettier --check` — clean

Closes #7060
