### PR TITLE
fix(registry): wire SN14 cacheon MCP execute probe config (#7030)

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -194,7 +194,13 @@
       "id": "sn-14-cacheon-leader-api",
       "kind": "subnet-api",
       "name": "Cacheon current leader API",
-      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data.",
+      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data. Live-verified 2026-07-21: GET https://api.cacheon.ai/api/leader -> HTTP 200 application/json (current leader record: uid, commit block, container image reference).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -213,7 +219,13 @@
       "id": "sn-14-cacheon-health",
       "kind": "subnet-api",
       "name": "Cacheon API health",
-      "notes": "Public no-auth GET /api/health on api.cacheon.ai returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /api/health in the subnet OpenAPI spec on the same host as the existing /api/status and /api/leader subnet-api surfaces.",
+      "notes": "Public no-auth GET /api/health on api.cacheon.ai returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /api/health in the subnet OpenAPI spec on the same host as the existing /api/status and /api/leader subnet-api surfaces. Live-verified 2026-07-21: GET https://api.cacheon.ai/api/health -> HTTP 200 application/json {\"status\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -232,7 +244,13 @@
       "id": "sn-14-cacheon-rounds-api",
       "kind": "subnet-api",
       "name": "Cacheon evaluation rounds API",
-      "notes": "Public no-auth GET returning evaluation round history with challenger counts, scores, speed improvement, and per-round evaluation metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/rounds); same host as the existing /api/status and /api/leader subnet-api surfaces.",
+      "notes": "Public no-auth GET returning evaluation round history with challenger counts, scores, speed improvement, and per-round evaluation metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/rounds); same host as the existing /api/status and /api/leader subnet-api surfaces. Live-verified 2026-07-21: GET https://api.cacheon.ai/api/rounds -> HTTP 200 application/json (evaluation rounds with per-round challenger uid lists).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -251,7 +269,13 @@
       "id": "sn-14-cacheon-leader-history-api",
       "kind": "subnet-api",
       "name": "Cacheon leader overtake history API",
-      "notes": "Public no-auth GET returning leader overtake history with timestamps, blocks, leader UID, scores, and image metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader/history); same host as the existing /api/status, /api/leader, and /api/rounds subnet-api surfaces.",
+      "notes": "Public no-auth GET returning leader overtake history with timestamps, blocks, leader UID, scores, and image metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader/history); same host as the existing /api/status, /api/leader, and /api/rounds subnet-api surfaces. Live-verified 2026-07-21: GET https://api.cacheon.ai/api/leader/history -> HTTP 200 application/json (leader-change history entries with timestamps and blocks).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN14 (Cacheon) for MCP execute (`call_subnet_surface`, #7014) by adding the missing probe config on the four issue-scoped surfaces that lacked it, and live-verifying those endpoints — same minimal pattern as SN9 iota (#7463) and SN105 Beam (#7143).

Closes #7030

> Resubmits #7474 (closed on a secret-scan finding). That PR's `Live-verified` note for the leader surface described the payload using the words "hotkey" and "digest", which the scanner read as key material. The notes here describe the observed responses in neutral terms and name no key material — matching #7463, which called this out explicitly. No other change.

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-14-cacheon-health | 200 | JSON `{"status":"ok"}` |
| sn-14-cacheon-leader-api | 200 | JSON — current leader record (uid, commit block, container image reference) |
| sn-14-cacheon-rounds-api | 200 | JSON — evaluation rounds with per-round challenger uid lists |
| sn-14-cacheon-leader-history-api | 200 | JSON — leader-change history entries with timestamps and blocks |

## Registry changes

- **sn-14-cacheon-health**: add probe (GET, expect: json)
- **sn-14-cacheon-leader-api**: add probe (GET, expect: json)
- **sn-14-cacheon-rounds-api**: add probe (GET, expect: json)
- **sn-14-cacheon-leader-history-api**: add probe (GET, expect: json)
- Each gets a `Live-verified 2026-07-21: …` note recording what was actually observed

All four use `{enabled: true, method: GET, expect: json, timeout_ms: 10000}`, matching the sibling surfaces already configured in this manifest. The remaining surfaces already had correct probe config and required no edits.

## Checklist

- [x] Changes exactly one `registry/subnets/cacheon.json` file
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed (1279 surfaces / 129 files)
- [x] `npm run scan:public-safety` passed (no cacheon findings)
- [x] `npx vitest run tests/cacheon-call-subnet-surface-verify.test.mjs` (3 passed — unaffected, it pins `sn-14-cacheon-evaluations`)
- [x] No credential-ish terms introduced in any added note
- [x] All four issue-scoped surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Prefer `/api/health` for MCP smoke tests
