### PR TITLE
fix(registry): wire SN3 Templar MCP execute probe config (#7019)

### DIFF
--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -151,7 +151,13 @@
       "id": "sn-3-templar-health",
       "kind": "subnet-api",
       "name": "Templar Grafana health",
-      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README.",
+      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README. Live-verified 2026-07-21: GET https://grafana.tplr.ai/api/health -> HTTP 200 application/json {\"database\": \"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
       "provider": "one-covenant",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN3 (Templar) for MCP execute (`call_subnet_surface`, #7014) by adding the missing probe config on the one issue-scoped surface that lacked it, and live-verifying it — same minimal pattern as SN43 Graphite (#7476), SN9 iota (#7463) and SN105 Beam (#7143).

Closes #7019

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-3-templar-health | 200 | `application/json` — `{"database": "ok"}` |

## Registry changes

- **sn-3-templar-health**: add probe (GET, expect: json, timeout_ms: 15000) + a `Live-verified 2026-07-21: …` note recording what was observed

The 15s timeout matches the sibling `sn-3-templar-grafana-openapi` surface, which is on this same `grafana.tplr.ai` host (the other surfaces in the manifest use the 10s default on different hosts). Every other surface already had correct probe config and required no edits.

## Checklist

- [x] Changes exactly one `registry/subnets/templar.json` file
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed (1279 surfaces / 129 files)
- [x] `npm run scan:public-safety` passed (no templar findings)
- [x] `npx vitest run tests/templar-call-subnet-surface-verify.test.mjs` (3 passed — unaffected, it does not pin this surface)
- [x] No credential-ish terms in any added note
- [x] Issue-scoped surface live-probed

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Prefer `/api/health` for MCP smoke tests
