### PR TITLE
fix(registry): wire SN3 Templar MCP execute probe config (#7019)

### DIFF
--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -151,7 +151,13 @@
       "id": "sn-3-templar-health",
       "kind": "subnet-api",
       "name": "Templar Grafana health",
-      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README.",
+      "notes": "Public no-auth GET /api/health on grafana.tplr.ai returning application liveness JSON. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README. Live-verified 2026-07-21: GET https://grafana.tplr.ai/api/health -> HTTP 200 application/json (database ok).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "one-covenant",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN3 (Templar) for MCP execute (`call_subnet_surface`, #7014) by adding the missing probe config on the one issue-scoped surface that lacked it, and live-verifying the endpoints — same minimal pattern as SN9 iota (#7463) and SN43 Graphite (#7476).

Closes #7019

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-3-templar-health | 200 | JSON `{"database":"ok"}` |
| sn-3-templar-grafana-openapi | 200 | OpenAPI 3 JSON (Grafana HTTP API) |

## Registry changes

- **sn-3-templar-health**: add probe (GET, expect: json) + a `Live-verified 2026-07-21: …` note recording what was observed

Uses `{enabled: true, method: GET, expect: json, timeout_ms: 10000}`, matching sibling surfaces already configured this way. The openapi surface already had correct probe config and required no edits.

## Checklist

- [x] Changes exactly one `registry/subnets/templar.json` file
- [x] `npm run validate:surface -- registry/subnets/templar.json` passed
- [x] No `templar` findings from `npm run scan:public-safety`
- [x] Both issue-scoped primary surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green