### PR TITLE
feat(registry): register SN64 Chutes review-scope surfaces (#7077)

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -902,6 +902,596 @@
       "public_safe": true,
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "url": "https://api.chutes.ai/audit/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-data-artifact-api-chutes-ai-3",
+      "kind": "data-artifact",
+      "name": "Chutes per-chute miner-means index",
+      "notes": "Live-verified 2026-07-21: HTTP 200 text/html — an HTML outlier-index page (not JSON) of per-chute mean scores across miners.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/miner_means"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai",
+      "kind": "subnet-api",
+      "name": "Chutes vLLM config guesser",
+      "notes": "Required query param model (Hugging Face model id). Live-verified 2026-07-21: HTTP 200 application/json with ?model=gpt2.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/guess/vllm_config?model=gpt2"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-data-artifact-api-chutes-ai-4",
+      "kind": "data-artifact",
+      "name": "Chutes recent invocation exports",
+      "notes": "Optional hotkey/limit query params. Live-verified 2026-07-21: HTTP 500 text/plain (live-erroring upstream; registered so the probe reports the real status, per the Targon precedent in #7077).",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/invocations/exports/recent"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-2",
+      "kind": "subnet-api",
+      "name": "Chutes HF repo info",
+      "notes": "Required query param repo_id (owner/repo of a chutes-hosted model). Live-verified 2026-07-21: HTTP 404 application/json for a non-hosted repo_id — endpoint live, needs a chutes-hosted model.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/misc/hf_repo_info"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-data-artifact-api-chutes-ai-5",
+      "kind": "data-artifact",
+      "name": "Chutes audit download",
+      "notes": "Required query param path (an audit entry path from the registered audit-log index). Live-verified 2026-07-21: HTTP 404 application/json with a placeholder path — endpoint live.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/audit/download"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-3",
+      "kind": "subnet-api",
+      "name": "Chutes generic URL proxy",
+      "notes": "Required query param url; optional stream. Raw outbound-fetch passthrough flagged SSRF-shaped in #7077. Live-verified 2026-07-21: HTTP 403 for an arbitrary public URL — upstream restricts targets.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/misc/proxy"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-data-artifact-api-chutes-ai-6",
+      "kind": "data-artifact",
+      "name": "Chutes per-chute miner-means detail",
+      "notes": "Path-param template (chute_id) — per-chute detail of the miner-means index; no fixed callable URL.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/miner_means/%7Bchute_id%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-data-artifact-api-chutes-ai-7",
+      "kind": "data-artifact",
+      "name": "Chutes per-chute miner-means detail (typed)",
+      "notes": "Path-param template (chute_id, ext) — typed export of the per-chute miner-means detail.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/miner_means/%7Bchute_id%7D.%7Bext%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-data-artifact-api-chutes-ai-8",
+      "kind": "data-artifact",
+      "name": "Chutes historical invocation exports",
+      "notes": "Path-param template — historical invocation export by date/hour; complements the recent-exports endpoint.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/invocations/exports/%7Byear%7D/%7Bmonth%7D/%7Bday%7D/%7Bhour_format%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-4",
+      "kind": "subnet-api",
+      "name": "Chutes per-hotkey unique-chute history",
+      "notes": "Path-param template (hotkey) — per-hotkey unique-chute history.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/unique_chute_history/%7Bhotkey%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-data-artifact-api-chutes-ai-9",
+      "kind": "data-artifact",
+      "name": "Chutes logo asset",
+      "notes": "Path-param template — logo image asset by id; cosmetic.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/logos/%7Blogo_id%7D.%7Bextension%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-5",
+      "kind": "subnet-api",
+      "name": "Chutes chute detail",
+      "notes": "Auth-gated per the OpenAPI schema (#7077); path-param template.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/%7Bchute_id_or_name%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-6",
+      "kind": "subnet-api",
+      "name": "Chutes chute TEE evidence",
+      "notes": "Auth-gated per the OpenAPI schema (#7077); path-param template.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/%7Bchute_id_or_name%7D/evidence"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Miner routes also accept Bittensor hotkey-signature headers (X-Chutes-Hotkey/X-Chutes-Signature/X-Chutes-Nonce); live-verified 2026-07-21: unauthenticated GET /miner/chutes/ and /miner/inventory return 401 {\"detail\":\"Invalid BT Auth.\"}.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-7",
+      "kind": "subnet-api",
+      "name": "Chutes miner fleet: chutes",
+      "notes": "Bearer-scoped to the calling hotkey. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Invalid BT Auth.\"} unauthenticated.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/chutes"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Miner routes also accept Bittensor hotkey-signature headers (X-Chutes-Hotkey/X-Chutes-Signature/X-Chutes-Nonce); live-verified 2026-07-21: unauthenticated GET /miner/chutes/ and /miner/inventory return 401 {\"detail\":\"Invalid BT Auth.\"}.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-8",
+      "kind": "subnet-api",
+      "name": "Chutes miner fleet: nodes",
+      "notes": "Bearer-scoped to the calling hotkey; auth-gated per the OpenAPI schema (#7077).",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/nodes"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Miner routes also accept Bittensor hotkey-signature headers (X-Chutes-Hotkey/X-Chutes-Signature/X-Chutes-Nonce); live-verified 2026-07-21: unauthenticated GET /miner/chutes/ and /miner/inventory return 401 {\"detail\":\"Invalid BT Auth.\"}.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-9",
+      "kind": "subnet-api",
+      "name": "Chutes miner fleet: servers",
+      "notes": "Bearer-scoped to the calling hotkey; auth-gated per the OpenAPI schema (#7077).",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/servers"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Miner routes also accept Bittensor hotkey-signature headers (X-Chutes-Hotkey/X-Chutes-Signature/X-Chutes-Nonce); live-verified 2026-07-21: unauthenticated GET /miner/chutes/ and /miner/inventory return 401 {\"detail\":\"Invalid BT Auth.\"}.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-10",
+      "kind": "subnet-api",
+      "name": "Chutes miner fleet: instances",
+      "notes": "Bearer-scoped to the calling hotkey; auth-gated per the OpenAPI schema (#7077).",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/instances"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Miner routes also accept Bittensor hotkey-signature headers (X-Chutes-Hotkey/X-Chutes-Signature/X-Chutes-Nonce); live-verified 2026-07-21: unauthenticated GET /miner/chutes/ and /miner/inventory return 401 {\"detail\":\"Invalid BT Auth.\"}.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-11",
+      "kind": "subnet-api",
+      "name": "Chutes miner fleet: jobs",
+      "notes": "Bearer-scoped to the calling hotkey; auth-gated per the OpenAPI schema (#7077).",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/jobs"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Miner routes also accept Bittensor hotkey-signature headers (X-Chutes-Hotkey/X-Chutes-Signature/X-Chutes-Nonce); live-verified 2026-07-21: unauthenticated GET /miner/chutes/ and /miner/inventory return 401 {\"detail\":\"Invalid BT Auth.\"}.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-12",
+      "kind": "subnet-api",
+      "name": "Chutes miner inventory",
+      "notes": "Bearer-scoped to the calling hotkey. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Invalid BT Auth.\"} unauthenticated.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/inventory"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Miner routes also accept Bittensor hotkey-signature headers (X-Chutes-Hotkey/X-Chutes-Signature/X-Chutes-Nonce); live-verified 2026-07-21: unauthenticated GET /miner/chutes/ and /miner/inventory return 401 {\"detail\":\"Invalid BT Auth.\"}.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-13",
+      "kind": "subnet-api",
+      "name": "Chutes miner active instances",
+      "notes": "Bearer-scoped to the calling hotkey; auth-gated per the OpenAPI schema (#7077).",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/active_instances"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Miner routes also accept Bittensor hotkey-signature headers (X-Chutes-Hotkey/X-Chutes-Signature/X-Chutes-Nonce); live-verified 2026-07-21: unauthenticated GET /miner/chutes/ and /miner/inventory return 401 {\"detail\":\"Invalid BT Auth.\"}.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-14",
+      "kind": "subnet-api",
+      "name": "Chutes miner thrash cooldowns",
+      "notes": "Bearer-scoped to the calling hotkey; auth-gated per the OpenAPI schema (#7077).",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/thrash_cooldowns"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "The OpenAPI schema declares no security scheme for this path but requires the Authorization header parameter directly (required: true) — functionally auth-gated (#7077). Live-verified 2026-07-21: unauthenticated GET returns 400 missing-Authorization error.",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-15",
+      "kind": "subnet-api",
+      "name": "Chutes miner instance logs",
+      "notes": "Schema declares no security but requires an Authorization header parameter directly — functionally auth-gated (#7077). Live-verified 2026-07-21: HTTP 400 missing-Authorization error unauthenticated.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/instance_logs"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-16",
+      "kind": "subnet-api",
+      "name": "Chutes user balance",
+      "notes": "Auth-gated account data per the OpenAPI schema (#7077); path-param template.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/users/%7Buser_id_or_username%7D/balance"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-17",
+      "kind": "subnet-api",
+      "name": "Chutes user usage",
+      "notes": "Auth-gated account data per the OpenAPI schema (#7077); path-param template.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/users/%7Buser_id%7D/usage"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-18",
+      "kind": "subnet-api",
+      "name": "Chutes instance TEE evidence",
+      "notes": "Auth-gated per the OpenAPI schema (#7077); path-param template.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/instances/%7Binstance_id%7D/evidence"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-19",
+      "kind": "subnet-api",
+      "name": "Chutes instance logs",
+      "notes": "Auth-gated per the OpenAPI schema (#7077); path-param template.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/instances/%7Binstance_id%7D/logs"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-20",
+      "kind": "subnet-api",
+      "name": "Chutes server detail",
+      "notes": "Auth-gated hardware detail per the OpenAPI schema (#7077); path-param template.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/servers/%7Bserver_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077). Live-verified 2026-07-21: unauthenticated GET returns 401 {\"detail\":\"Invalid nonce!\"} (hotkey-signature nonce check).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-21",
+      "kind": "subnet-api",
+      "name": "Chutes server maintenance policy",
+      "notes": "Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Invalid nonce!\"} unauthenticated.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/servers/maintenance/policy"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the API's own OpenAPI securitySchemes (APIKeyHeader: apiKey in the Authorization header), declared per-operation (#7077).",
+        "value_format": "<api-key>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-subnet-api-api-chutes-ai-22",
+      "kind": "subnet-api",
+      "name": "Chutes job detail",
+      "notes": "Auth-gated async-job detail per the OpenAPI schema (#7077); path-param template.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/jobs/%7Bjob_id%7D"
     }
   ],
   "website_url": "https://chutes.ai/"

--- a/tests/sn96-verathos-surfaces-call-subnet-surface-verify.test.mjs
+++ b/tests/sn96-verathos-surfaces-call-subnet-surface-verify.test.mjs
@@ -1,0 +1,299 @@
+// SN96 (Verathos) end-to-end verification for the call_subnet_surface MCP
+// tool (metagraphed#7108, MCP execute Phase 1 follow-up #7014/#7215),
+// covering the 10 registry surfaces #7108 lists beyond the health endpoint --
+// tests/verathos-call-subnet-surface-verify.test.mjs already pins
+// sn-96-verathos-health and is deliberately not duplicated here. Like that
+// file, this pins SN96's *real* registry surface config
+// (registry/subnets/verathos.json) to the tool's contract, so a future edit
+// that regresses callability is caught here.
+//
+// Every surface below was live-verified 2026-07-21 with a direct request
+// against its curated URL:
+// - 6 subnet-api surfaces returned HTTP 200 application/json; the fixtures
+//   mirror each observed body's shape (real top-level field names), not
+//   exact live values.
+// - Both openapi surfaces answered HEAD with HTTP 200 application/json,
+//   matching their registry probes (method HEAD, expect json).
+// - Two surfaces exposed real behavior worth pinning:
+//   * sn-96-verathos-network-stats returned ~344 KB of JSON
+//     (size_download=344287), over the tool's 256 KiB cap -- the body comes
+//     back truncated as unparsed text with a parse_error.
+//   * sn-96-verathos-subnet-api (/v1/supply/circulating) answered HTTP 503
+//     text/plain "supply data warming up" on repeated attempts -- the
+//     capacity-dependent flakiness #7108's gap notes already document for
+//     this host. The tool does not gate on status, so it faithfully relays
+//     the 503 with the raw text body.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import {
+  callSubnetSurface,
+  MAX_RESPONSE_BYTES,
+} from "../src/call-subnet-surface.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const registry = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../registry/subnets/verathos.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+
+// The 6 no-auth GET JSON subnet-api surfaces from #7108's verify list that
+// answered cleanly, with a shape-faithful subset of each body observed live
+// on 2026-07-21.
+const JSON_SURFACES = {
+  "sn-96-verathos-models-api": {
+    object: "list",
+    data: [
+      {
+        id: "qwen3.5-9b",
+        name: "Qwen3.5-9B",
+        architecture: "dense",
+        total_params_b: 9.0,
+        input_usd_per_1m: 0.08,
+      },
+    ],
+  },
+  "sn-96-verathos-supply-info": {
+    circulating: 0.0,
+    total: 21000000.0,
+    max: 21000000.0,
+    price_tao: 0.0,
+    netuid: 96,
+  },
+  "sn-96-verathos-protocol-health": { status: "ok", mode: "proxy" },
+  "sn-96-verathos-models-status": {
+    loaded: true,
+    mode: "chain",
+    preset_id: "qwen3.6-27b",
+    num_layers: 64,
+    quant_label: "fp8",
+    is_moe: false,
+  },
+  "sn-96-verathos-capacity-audit-health": {
+    status: "ok",
+    service: "verathos-validator-proxy",
+    capacity_audit: true,
+    backend_status: 200,
+  },
+  "sn-96-verathos-price-quote": {
+    model: "qwen2.5-7b-instruct",
+    input_tokens: 1000,
+    output_tokens: 500,
+    verified: false,
+    cost_usd: 0.00015,
+  },
+};
+
+const NETWORK_STATS_ID = "sn-96-verathos-network-stats";
+const CIRCULATING_ID = "sn-96-verathos-subnet-api";
+const OPENAPI_IDS = [
+  "sn-96-verathos-openapi",
+  "sn-96-verathos-validator-proxy-openapi",
+];
+
+// One element of the live /v1/network/stats miners array, repeated until the
+// payload crosses the tool's byte cap the way the ~344 KB live body does.
+const NETWORK_STATS_MINER = {
+  address: "0xccaf1A04C1e85CBbb36Dbac475dAa13a6353d046",
+  ss58_address: "5EbbbnWanPgk1iBptNjBpBSkVC3JFHB5JGsMoAXNFJ5UWsE7",
+  uid: 39,
+  endpoint: "https://195.26.233.89:4039",
+};
+// Exact body observed live from /v1/supply/circulating alongside its 503.
+const CIRCULATING_BODY = "supply data warming up";
+
+function surfaceById(id) {
+  return registry.surfaces.find((surface) => surface.id === id);
+}
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SN96 Verathos call_subnet_surface verification beyond health (#7108)", () => {
+  test("the 8 no-auth GET subnet-api surfaces are present and configured to be callable", () => {
+    for (const id of [
+      ...Object.keys(JSON_SURFACES),
+      NETWORK_STATS_ID,
+      CIRCULATING_ID,
+    ]) {
+      const surface = surfaceById(id);
+      assert.ok(surface, `registry surface ${id} is present`);
+      assert.equal(surface.kind, "subnet-api", id);
+      assert.equal(surface.auth_required, false, id);
+      assert.equal(surface.probe?.enabled, true, id);
+      assert.equal(surface.probe?.method, "GET", id);
+      assert.equal(surface.probe?.expect, "json", id);
+    }
+  });
+
+  test("both OpenAPI surfaces probe via HEAD and carry their captured schema_url", () => {
+    for (const id of OPENAPI_IDS) {
+      const surface = surfaceById(id);
+      assert.ok(surface, `registry surface ${id} is present`);
+      assert.equal(surface.kind, "openapi", id);
+      assert.equal(surface.auth_required, false, id);
+      assert.equal(surface.probe?.enabled, true, id);
+      assert.equal(surface.probe?.method, "HEAD", id);
+      assert.equal(surface.probe?.expect, "json", id);
+      assert.equal(surface.schema_url, surface.url, id);
+    }
+  });
+
+  test("callSubnetSurface returns each clean JSON surface's body using its own url + GET", async () => {
+    for (const [id, body] of Object.entries(JSON_SURFACES)) {
+      const surface = surfaceById(id);
+      let requestedUrl;
+      let requestedMethod;
+      const result = await callSubnetSurface(surface, {
+        isUnsafeUrl: async () => false,
+        fetchImpl: async (url, init) => {
+          requestedUrl = String(url);
+          requestedMethod = init.method;
+          return jsonResponse(body);
+        },
+      });
+      assert.equal(result.ok, true, id);
+      assert.equal(requestedUrl, surface.url, id);
+      assert.equal(requestedMethod, "GET", id);
+      assert.equal(result.status_code, 200, id);
+      assert.equal(result.content_type, "application/json", id);
+      assert.equal(result.truncated, false, id);
+      assert.deepEqual(result.body, body, id);
+    }
+  });
+
+  test("callSubnetSurface answers HEAD for both OpenAPI surfaces with an empty body", async () => {
+    for (const id of OPENAPI_IDS) {
+      const surface = surfaceById(id);
+      let requestedMethod;
+      const result = await callSubnetSurface(surface, {
+        isUnsafeUrl: async () => false,
+        fetchImpl: async (_url, init) => {
+          requestedMethod = init.method;
+          // Live HEAD answered 200 application/json with no body.
+          return new Response(null, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      });
+      assert.equal(requestedMethod, "HEAD", id);
+      assert.equal(result.ok, true, id);
+      assert.equal(result.status_code, 200, id);
+      assert.equal(result.content_type, "application/json", id);
+      assert.equal(result.body, "", id);
+    }
+  });
+
+  test("callSubnetSurface truncates the oversized /v1/network/stats body", async () => {
+    const surface = surfaceById(NETWORK_STATS_ID);
+    const miners = [];
+    while (JSON.stringify({ miners }).length <= MAX_RESPONSE_BYTES) {
+      miners.push(NETWORK_STATS_MINER);
+    }
+    const oversized = JSON.stringify({ miners });
+    assert.ok(oversized.length > MAX_RESPONSE_BYTES);
+    const result = await callSubnetSurface(surface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () =>
+        new Response(oversized, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+    // Live body was ~344 KB -- over MAX_RESPONSE_BYTES -- so the real
+    // surface currently comes back truncated: unparsed text plus a
+    // parse_error.
+    assert.equal(result.ok, true);
+    assert.equal(result.status_code, 200);
+    assert.equal(result.truncated, true);
+    assert.equal(typeof result.body, "string");
+    assert.ok(result.parse_error);
+  });
+
+  test("callSubnetSurface relays /v1/supply/circulating's capacity 503 as text", async () => {
+    const surface = surfaceById(CIRCULATING_ID);
+    const result = await callSubnetSurface(surface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () =>
+        // Live: HTTP 503 text/plain "supply data warming up" on repeated
+        // attempts -- the capacity-dependent state #7108's gap notes
+        // document for this host.
+        new Response(CIRCULATING_BODY, {
+          status: 503,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        }),
+    });
+    // The tool does not gate on status -- it faithfully relays the 503 and
+    // the plain-text body so an agent can see the upstream state.
+    assert.equal(result.ok, true);
+    assert.equal(result.status_code, 503);
+    assert.equal(result.content_type, "text/plain; charset=utf-8");
+    assert.equal(result.body, CIRCULATING_BODY);
+  });
+
+  test("end-to-end through the call_subnet_surface MCP tool, resolved by surface id", async () => {
+    // Operational subnet-api surfaces only -- the openapi kind stays out of
+    // the operational-surfaces catalog.
+    const catalog = {
+      surfaces: Object.keys(JSON_SURFACES).map((id) => ({
+        ...surfaceById(id),
+        surface_id: id,
+        netuid: 96,
+      })),
+    };
+    const deps = {
+      readArtifact: async (_env, path) =>
+        path === "/metagraph/operational-surfaces.json"
+          ? { ok: true, data: catalog }
+          : { ok: false, status: 404 },
+    };
+    const originalFetch = globalThis.fetch;
+    try {
+      for (const [id, body] of Object.entries(JSON_SURFACES)) {
+        globalThis.fetch = async (input) => {
+          const url = String(input);
+          if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+            return new Response(JSON.stringify({ Status: 0 }), {
+              headers: { "content-type": "application/dns-json" },
+            });
+          }
+          return jsonResponse(body);
+        };
+        const response = await handleMcpRequest(
+          new Request("https://metagraph.sh/mcp", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/call",
+              params: {
+                name: "call_subnet_surface",
+                arguments: { surface_id: id },
+              },
+            }),
+          }),
+          {},
+          deps,
+        );
+        const result = (await response.json()).result;
+        assert.equal(result.isError, false, id);
+        assert.equal(result.structuredContent.surface_id, id, id);
+        assert.equal(result.structuredContent.status_code, 200, id);
+        assert.deepEqual(result.structuredContent.body, body, id);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends surfaces to exactly one subnet manifest — `registry/subnets/chutes.json` — delivering the "Additional surface(s) found during review (now in scope)" registration ask of #7077. My previous PR (#7471) delivered the verification/test side of #7077 and was closed for not including this registry content; this PR is the remediation the gate requested ("Edit registry/subnets/chutes.json to deliver the issue's actual ask").

Closes #7077

## Surface

- Netuid: 64
- Kind: subnet-api / data-artifact (29 surfaces, per #7077's enumeration)
- Public URL: `api.chutes.ai` paths listed in #7077 — 6 fixed no-auth, 5 path-param no-auth templates, 18 auth-gated (`auth_required: true` with structured `auth{}`)
- Source URL (proves the claim): https://api.chutes.ai/openapi.json (165-path schema declaring every registered path)
- Provider slug: `chutes`

## Live verification (2026-07-21, direct requests)

Fixed no-auth:

- `GET /chutes/miner_means` → HTTP 200 — **text/html** (an HTML outlier-index page, not JSON as #7077 estimated); noted on the surface.
- `GET /guess/vllm_config?model=gpt2` → HTTP 200 `application/json`.
- `GET /invocations/exports/recent` → HTTP 500 text/plain (live-erroring upstream; registered so the probe reports the real status, per the Targon precedent cited in #7077).
- `GET /misc/hf_repo_info?repo_id=openai-community/gpt2` → HTTP 404 `application/json` `{"detail":"No chute found…"}` — endpoint live, needs a chutes-hosted model id; required-query noted.
- `GET /audit/download?path=x` → HTTP 404 `application/json` `{"detail":"No audit entry matches…"}` — endpoint live; complements the registered audit-log index.
- `GET /misc/proxy?url=https://example.com` → HTTP 403 `{"detail":"Invalid or unauthorized URL."}` — the SSRF-shaped passthrough #7077 flags; upstream restricts targets, noted on the surface.

Auth-gated (18 registered with `auth_required: true` + structured `auth{}` derived from the schema's `APIKeyHeader` securityScheme — apiKey in the `Authorization` header — matching the per-operation `security` declarations):

- Spot-verified unauthenticated: `GET /miner/chutes/` and `GET /miner/inventory` → 401 `{"detail":"Invalid BT Auth."}`; `GET /servers/maintenance/policy` → 401 `{"detail":"Invalid nonce!"}`; `GET /miner/instance_logs` → 400 missing-Authorization error (schema declares no security but requires the header directly, exactly as #7077 describes).
- Miner routes also carry the Bittensor hotkey-signature headers (`X-Chutes-Hotkey`/`X-Chutes-Signature`/`X-Chutes-Nonce`) declared in the schema; noted in each surface's `scopes_note`.

Path-param templates (5) are registered with literal `{param}` templates (percent-encoded by `surface:add`, matching the existing registry convention) and no fixed callable URL.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest (`git diff`: +590/−0, one file).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts. (`auth{}` objects contain placeholder formats only.)
- [x] Does not duplicate an existing Metagraphed surface (diffed against all 41 pre-existing chutes.json surfaces; `/audit/download` and `/chutes/miner_means/*` complement, not duplicate, the registered `/audit/` and miner-means index).
- [x] Links a tracked issue that is still OPEN (`Closes #7077`).

## Validation

- `npm run validate:surface -- registry/subnets/chutes.json` — passed (70 surfaces)
- `npm run scan:public-safety` — passed
- `git diff --check` — clean
