### PR TITLE
fix(registry): SN118 Ditto Admin API parity (13 missing surfaces) (#7128)

### DIFF
--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -324,6 +324,292 @@
         "https://api.heyditto.ai/api/admin/v1/swagger/doc.json"
       ],
       "url": "https://api.heyditto.ai/api/admin/v1/swagger/doc.json"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-agent-account-by-id",
+      "kind": "subnet-api",
+      "name": "Ditto admin agent-account by id",
+      "notes": "Admin API operation on the Ditto Admin API (GET, PATCH /agent-accounts/{account_id}), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. Get a single agent account created by this app. Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {account_id} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/agent-accounts/%7Baccount_id%7D"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-agent-account-link",
+      "kind": "subnet-api",
+      "name": "Ditto admin agent-account link",
+      "notes": "Admin API operation on the Ditto Admin API (POST /agent-accounts/{account_id}/link), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. Link an agent account to a user. Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {account_id} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/agent-accounts/%7Baccount_id%7D/link"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-agent-account-readable-threads",
+      "kind": "subnet-api",
+      "name": "Ditto admin agent-account readable threads",
+      "notes": "Admin API operation on the Ditto Admin API (GET, PUT /agent-accounts/{account_id}/readable-threads), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. List an agent account's readable threads. Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {account_id} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/agent-accounts/%7Baccount_id%7D/readable-threads"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-agent-account-unlink",
+      "kind": "subnet-api",
+      "name": "Ditto admin agent-account unlink",
+      "notes": "Admin API operation on the Ditto Admin API (POST /agent-accounts/{account_id}/unlink), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. Unlink an agent account from its user. Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {account_id} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/agent-accounts/%7Baccount_id%7D/unlink"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-agent-accounts",
+      "kind": "subnet-api",
+      "name": "Ditto admin agent-accounts collection",
+      "notes": "Admin API operation on the Ditto Admin API (GET, POST /agent-accounts), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. List all agent accounts created by this app (paginated). Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Live-verified 2026-07-21: GET https://api.heyditto.ai/api/admin/v1/agent-accounts without credentials -> HTTP 401 {\"message\":\"unauthorized\",\"status\":401}, confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/agent-accounts"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-consent-requests",
+      "kind": "subnet-api",
+      "name": "Ditto admin consent requests",
+      "notes": "Admin API operation on the Ditto Admin API (POST /consent-requests), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. Create an OAuth consent request (returnable consent URL). Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/consent-requests"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-graphs",
+      "kind": "subnet-api",
+      "name": "Ditto admin graphs collection",
+      "notes": "Admin API operation on the Ditto Admin API (GET, POST /graphs), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. List graphs provisioned by this app. Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Live-verified 2026-07-21: GET https://api.heyditto.ai/api/admin/v1/graphs without credentials -> HTTP 401 {\"message\":\"unauthorized\",\"status\":401}, confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/graphs"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-user-agent-accounts",
+      "kind": "subnet-api",
+      "name": "Ditto admin user agent-accounts",
+      "notes": "Admin API operation on the Ditto Admin API (GET /users/{user_id}/agent-accounts), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. List a user's agent accounts (paginated). Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {user_id} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/users/%7Buser_id%7D/agent-accounts"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-user-by-id",
+      "kind": "subnet-api",
+      "name": "Ditto admin user by id",
+      "notes": "Admin API operation on the Ditto Admin API (GET, PATCH /users/{user_id}), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. Get a provisioned user's state. Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {user_id} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/users/%7Buser_id%7D"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-user-grant-requests",
+      "kind": "subnet-api",
+      "name": "Ditto admin user grant requests",
+      "notes": "Admin API operation on the Ditto Admin API (POST /users/{user_id}/grant-requests), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. Request data-sharing scopes from a user. Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {user_id} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/users/%7Buser_id%7D/grant-requests"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-user-provider-credential-by-provider",
+      "kind": "subnet-api",
+      "name": "Ditto admin user provider credential by provider",
+      "notes": "Admin API operation on the Ditto Admin API (PUT /users/{user_id}/keys/{provider}), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. Set one provider key (BYOK). Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {user_id}, {provider} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/users/%7Buser_id%7D/keys/%7Bprovider%7D"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-user-provider-credentials",
+      "kind": "subnet-api",
+      "name": "Ditto admin user provider credentials",
+      "notes": "Admin API operation on the Ditto Admin API (GET, POST /users/{user_id}/keys), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. List a user's provider keys (status only). Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Path-parameterized, so it has no single fixed callable URL; the {user_id} template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/users/%7Buser_id%7D/keys"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-118-ditto-admin-users",
+      "kind": "subnet-api",
+      "name": "Ditto admin users collection",
+      "notes": "Admin API operation on the Ditto Admin API (GET, POST /users), declared in the subnet's own Swagger 2.0 spec at /api/admin/v1/swagger/doc.json. List users provisioned by this admin (paginated). Every operation in this spec declares the AdminKey security scheme (an admin token supplied in the Authorization header), so it is registered auth_required:true with the probe disabled. Live-verified 2026-07-21: GET https://api.heyditto.ai/api/admin/v1/users without credentials -> HTTP 401 {\"message\":\"unauthorized\",\"status\":401}, confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.heyditto.ai/api/admin/v1/swagger/doc.json"],
+      "url": "https://api.heyditto.ai/api/admin/v1/users"
     }
   ],
   "website_url": "https://heyditto.ai/"


### PR DESCRIPTION
## Summary

Closes #7128.

Brings SN118 (Ditto) up to **full subnet API parity** — the completeness bar documented in `.claude/skills/contributor-pipeline-gardening/SKILL.md`'s "MCP execute verify + wire SN*" special-sweep section: *"the registry is meant to catalog everything a subnet's real API exposes, not just what's currently callable by the anonymous Phase-1 tool."* Same approach as SN37 Aurelius (#7466) and SN36 Eirel (#7465).

The already-registered `sn-118-ditto-admin-openapi` surface points at the Ditto Admin API's Swagger 2.0 spec (`basePath /api/admin/v1`, **13 paths / 21 operations**) — but only the spec *document* was registered; **none of its operations were**. This adds all 13.

## What this adds

One entry per path (same-path multi-method pairs collapse under the registry's `netuid|kind|url` dedup key, with the other methods recorded in `notes`):

| surface | path | methods |
|---|---|---|
| `…-admin-agent-accounts` | `/agent-accounts` | GET, POST |
| `…-admin-agent-account-by-id` | `/agent-accounts/{account_id}` | GET, PATCH |
| `…-admin-agent-account-link` | `/agent-accounts/{account_id}/link` | POST |
| `…-admin-agent-account-readable-threads` | `/agent-accounts/{account_id}/readable-threads` | GET, PUT |
| `…-admin-agent-account-unlink` | `/agent-accounts/{account_id}/unlink` | POST |
| `…-admin-consent-requests` | `/consent-requests` | POST |
| `…-admin-graphs` | `/graphs` | GET, POST |
| `…-admin-users` | `/users` | GET, POST |
| `…-admin-user-by-id` | `/users/{user_id}` | GET, PATCH |
| `…-admin-user-agent-accounts` | `/users/{user_id}/agent-accounts` | GET |
| `…-admin-user-grant-requests` | `/users/{user_id}/grant-requests` | POST |
| `…-admin-user-provider-credentials` | `/users/{user_id}/keys` | GET, POST |
| `…-admin-user-provider-credential-by-provider` | `/users/{user_id}/keys/{provider}` | PUT |

**All 13 are `auth_required: true`, `probe.enabled: false`** — every operation in the spec declares the `AdminKey` security scheme (Phase 3 territory).

**Live-verified 2026-07-21** that the gate is real rather than schema-only:

| request | result |
|---|---|
| `GET /api/admin/v1/users` | **401** `{"message":"unauthorized","status":401}` |
| `GET /api/admin/v1/graphs` | **401** `{"message":"unauthorized","status":401}` |
| `GET /api/admin/v1/agent-accounts` | **401** `{"message":"unauthorized","status":401}` |

The **7 path-parameterized routes** are registered with percent-encoded `{param}` templates (e.g. `…/users/%7Buser_id%7D/keys/%7Bprovider%7D`) — no single fixed callable URL, Phase 2 — matching the encoding already used in SN37 Aurelius. No credential material or key formats are reproduced in any note.

## Checklist

- [x] Changes exactly one `registry/subnets/ditto.json` file (+286/−0)
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed (1292 surfaces / 129 files)
- [x] `npm run scan:public-safety` passed (no ditto findings)
- [x] README catalog up to date (unchanged — subnet count is the same)
- [x] `npx vitest run tests/sn118-call-subnet-surface-verify.test.mjs` (3 passed — unaffected)
- [x] `provider` uses the registered `ditto-assistant` slug
- [x] Rebased on latest `main`

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] These become callable once Phase 3 credential passthrough (#7016) lands
