### PR TITLE
fix(registry): live-verify SN78 Vocence MCP execute surfaces (#7091)

### DIFF
--- a/registry/subnets/vocence.json
+++ b/registry/subnets/vocence.json
@@ -64,7 +64,7 @@
       "id": "sn-78-vocence-subnet-api",
       "kind": "subnet-api",
       "name": "Vocence developer API health endpoint",
-      "notes": "Public health endpoint for the official Vocence developer API.",
+      "notes": "Public health endpoint for the official Vocence developer API. Live-verified 2026-07-21: HTTP 200 JSON {\"status\":\"ok\",\"service\":\"vocence-developer-api\"}.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -89,7 +89,7 @@
       "id": "sn-78-vocence-openapi",
       "kind": "openapi",
       "name": "Vocence Developer API OpenAPI",
-      "notes": "Official machine-readable OpenAPI spec for the Vocence developer API.",
+      "notes": "Official machine-readable OpenAPI spec for the Vocence developer API. Live-verified 2026-07-21: GET returns OpenAPI 3.1.0 JSON (title Vocence Developer API).",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
## Summary

Live-verify SN78 (Vocence) callable surfaces for MCP execute. Probes already match reality; this appends `Live-verified` notes on the two issue-scoped surfaces.

Closes #7091

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-78-vocence-subnet-api | 200 | JSON `{"status":"ok","service":"vocence-developer-api"}` |
| sn-78-vocence-openapi | 200 | OpenAPI 3.1.0 (title: Vocence Developer API) |

Auth-gated developer-API routes from the issue addendum remain out of scope (`auth_required` enrichment is a separate registry process; unauthenticated calls return 401).

## Registry changes

- **sn-78-vocence-subnet-api**: append Live-verified note
- **sn-78-vocence-openapi**: append Live-verified note

## Checklist

- [x] Changes exactly one `registry/subnets/vocence.json` file
- [x] `npm run validate:surface -- registry/subnets/vocence.json`
- [x] `npm run scan:public-safety` (no vocence findings)
- [x] Both issue-scoped surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green

Made with [Cursor](https://cursor.com)