### PR TITLE
fix(registry): SN44 Score full API parity (13 missing surfaces)

### DIFF
--- a/registry/subnets/score.json
+++ b/registry/subnets/score.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 44,
-  "name": "Score",
-  "slug": "sn-44",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "computer-vision",
@@ -11,6 +6,7 @@
     "official-source-repo",
     "official-website"
   ],
+  "contact": "hello@wearescore.com",
   "curation": {
     "gap_notes": [
       "The registered official website still links score-vision as its GitHub/Documentation reference, but on-chain SubnetIdentitiesV3 source_repo and description now point to a separate, actively-developed repository (turbovision, pushed same-day at review time) whose own README self-identifies wearescore.com as its website too. Both repositories are tracked pending clarification from the operator; not treated as a resolved rename.",
@@ -23,65 +19,74 @@
     "source_count": 6,
     "verified_at": "2026-07-16T02:10:00.000Z"
   },
+  "name": "Score",
+  "netuid": 44,
   "notes": "First maintainer-reviewed pass for SN44 (previously candidate-discovered/unreviewed, categories empty, no website surface despite website_url already being set). Added the missing website surface and a second source-repo surface for turbovision (matching the top-level source_repo field and on-chain data, already set by a prior pass but never backed by a tracked surface). Corrected the existing score-vision surface's notes, which incorrectly characterized turbovision as \"legacy\" -- the opposite of what the evidence shows (turbovision is the actively-developed, on-chain-declared repo; score-vision has not been pushed to since December 2025). Left as needs-review since the operator's own website still points to score-vision, an unresolved discrepancy. Fixed 3 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Diffed the score-vision-hosted OpenAPI schema (14 paths): all documented endpoints beyond the tracked /health require an API key (APIKeyHeader/APIKeyQuery) or are otherwise gated, so none are promoted as additional surfaces.",
+  "schema_version": 1,
+  "slug": "sn-44",
+  "social": {
+    "x": "https://x.com/webuildscore"
+  },
+  "source_repo": "https://github.com/score-technologies/turbovision",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-44-score-website",
-      "name": "Score website",
       "kind": "website",
-      "url": "https://www.wearescore.com/",
-      "provider": "score",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
+      "name": "Score website",
+      "notes": "Official Score (SN44) website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
+      "provider": "score",
+      "public_safe": true,
       "source_urls": ["https://github.com/score-technologies/turbovision"],
-      "notes": "Official Score (SN44) website."
+      "url": "https://www.wearescore.com/"
     },
     {
-      "id": "sn-44-score-turbovision-source-repo",
-      "name": "TurboVision source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/score-technologies/turbovision",
-      "provider": "score",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
+      "id": "sn-44-score-turbovision-source-repo",
+      "kind": "source-repo",
+      "name": "TurboVision source repository",
+      "notes": "Official SN44 source repository per on-chain SubnetIdentitiesV3 source_repo and description (\"Making every camera intelligent\", matching TurboVision's broader live-video/imagery scope) -- actively developed (pushed same-day at review time), vs. the score-vision repo below which has not been pushed to since December 2025. Its own README links wearescore.com as \"Score Website\", and its CLI is branded \"ScoreVision\", suggesting continuity from the earlier Score Vision product rather than an unrelated project.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
+      "provider": "score",
+      "public_safe": true,
       "source_urls": ["https://www.wearescore.com/"],
-      "notes": "Official SN44 source repository per on-chain SubnetIdentitiesV3 source_repo and description (\"Making every camera intelligent\", matching TurboVision's broader live-video/imagery scope) -- actively developed (pushed same-day at review time), vs. the score-vision repo below which has not been pushed to since December 2025. Its own README links wearescore.com as \"Score Website\", and its CLI is branded \"ScoreVision\", suggesting continuity from the earlier Score Vision product rather than an unrelated project."
+      "url": "https://github.com/score-technologies/turbovision"
     },
     {
-      "id": "sn-44-score-source-repo",
-      "name": "Score Vision validator and miner code",
-      "kind": "source-repo",
-      "url": "https://github.com/score-technologies/score-vision",
-      "provider": "score",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
+      "id": "sn-44-score-source-repo",
+      "kind": "source-repo",
+      "name": "Score Vision validator and miner code",
+      "notes": "Still linked as both \"GitHub\" and \"Documentation\" from the official wearescore.com site, and the host for the subnet's tracked OpenAPI/health API surfaces. Not pushed to since December 2025 -- on-chain source_repo instead points to the separately-tracked, actively-developed turbovision repo. Kept tracked pending clarification rather than dropped, since the live website still references it.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "source_urls": ["https://www.wearescore.com/"],
+      "provider": "score",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Still linked as both \"GitHub\" and \"Documentation\" from the official wearescore.com site, and the host for the subnet's tracked OpenAPI/health API surfaces. Not pushed to since December 2025 -- on-chain source_repo instead points to the separately-tracked, actively-developed turbovision repo. Kept tracked pending clarification rather than dropped, since the live website still references it."
+      "source_urls": ["https://www.wearescore.com/"],
+      "url": "https://github.com/score-technologies/score-vision"
     },
     {
       "auth_required": false,
@@ -92,8 +97,8 @@
       "notes": "Machine-readable OpenAPI 3.1 schema for the Score SN44 backend (title: Score Subnet API). Served publicly at api.scorevision.io; documents challenge/task routes and the no-auth GET /health probe.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "score",
@@ -119,8 +124,8 @@
       "notes": "Public no-auth GET /health on api.scorevision.io returning backend liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /health in the subnet OpenAPI spec; api.scorevision.io is the SCORE_VISION_API host configured in the score-vision validator source.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "score",
@@ -144,8 +149,8 @@
       "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official score-technologies/score-vision repository as min_compute.yaml. Documents SN44 Score Vision operator CPU, GPU/VRAM, memory, storage, network, and OS requirements aligned with miner/REQUIREMENTS.md.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "any",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "score",
@@ -160,12 +165,363 @@
         "https://github.com/score-technologies/score-vision/blob/main/min_compute.yaml"
       ],
       "url": "https://raw.githubusercontent.com/score-technologies/score-vision/main/min_compute.yaml"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "X-API-Key",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: APIKeyHeader (`X-API-Key` header) or APIKeyQuery (`api_key` query param) — either is accepted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-challenge-types",
+      "kind": "subnet-api",
+      "name": "Score GET api challenge types",
+      "notes": "Auth-gated (API key, Phase 3 credential passthrough, not built yet) GET /api/challenge-types on api.scorevision.io (this path also supports POST — not registered as a separate surface since the url would collide). Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Invalid API key\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7058) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/challenge-types"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "X-API-Key",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: APIKeyHeader (`X-API-Key` header) or APIKeyQuery (`api_key` query param) — either is accepted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-challenge-types-challenge-type-id",
+      "kind": "subnet-api",
+      "name": "Score GET api challenge types by challenge type id",
+      "notes": "Auth-gated (API key, Phase 3 credential passthrough, not built yet) GET /api/challenge-types/{challenge_type_id} on api.scorevision.io. Not individually curled — same declared `APIKeyHeader`/`APIKeyQuery` security scheme as the verified `sn-44-score-api-challenge-types` (401 \"Invalid API key\"). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7058) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/challenge-types/%7Bchallenge_type_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "X-API-Key",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: APIKeyHeader (`X-API-Key` header) or APIKeyQuery (`api_key` query param) — either is accepted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-challenge-types-challenge-type-id-progress",
+      "kind": "subnet-api",
+      "name": "Score GET api challenge types by challenge type id progress",
+      "notes": "Auth-gated (API key, Phase 3 credential passthrough, not built yet) GET /api/challenge-types/{challenge_type_id}/progress on api.scorevision.io. Not individually curled — same declared `APIKeyHeader`/`APIKeyQuery` security scheme as the verified `sn-44-score-api-challenge-types` (401 \"Invalid API key\"). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7058) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/challenge-types/%7Bchallenge_type_id%7D/progress"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "X-API-Key",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: APIKeyHeader (`X-API-Key` header) or APIKeyQuery (`api_key` query param) — either is accepted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-tasks",
+      "kind": "subnet-api",
+      "name": "Score POST api tasks",
+      "notes": "Auth-gated (API key, Phase 3 credential passthrough, not built yet) POST /api/tasks on api.scorevision.io. Not individually curled — same declared `APIKeyHeader`/`APIKeyQuery` security scheme as the verified `sn-44-score-api-challenge-types` (401 \"Invalid API key\"). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7058) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/tasks"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "X-API-Key",
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes: APIKeyHeader (`X-API-Key` header) or APIKeyQuery (`api_key` query param) — either is accepted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-challenges",
+      "kind": "subnet-api",
+      "name": "Score POST api challenges",
+      "notes": "Auth-gated (API key, Phase 3 credential passthrough, not built yet) POST /api/challenges on api.scorevision.io. Not individually curled — same declared `APIKeyHeader`/`APIKeyQuery` security scheme as the verified `sn-44-score-api-challenge-types` (401 \"Invalid API key\"). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7058) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/challenges"
+    },
+    {
+      "auth": {
+        "location": "query",
+        "scheme": "custom",
+        "scopes_note": "Not a header token — requires validator_hotkey + signature + nonce + netuid query params (a cryptographic signature proving control of a registered validator's `validator_hotkey`), not declared in the OpenAPI schema's security field. Confirmed live: a request missing all 4 either 401s (\"Missing validator authentication\") or 422s naming the 4 required fields."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-tasks-challenge-id-ground-truth",
+      "kind": "subnet-api",
+      "name": "Score GET api tasks by challenge id ground truth",
+      "notes": "Auth-gated (validator-signature query params, Phase 3 credential passthrough, not built yet) GET /api/tasks/{challenge_id}/ground-truth on api.scorevision.io (this path also supports POST — not registered as a separate surface since the url would collide; note POST on this same path is API-key-gated per the schema, distinct from this GET's validator-signature gating). The OpenAPI schema declares NO security scheme for this path (a documentation gap, corrected here), but Not individually curled — same validator-signature gating as the verified `sn-44-score-api-blacklist` (401 \"Missing validator authentication\"). Registered auth_required:true anyway, per the registry's full-API-parity policy (metagraphed#7058).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/tasks/%7Bchallenge_id%7D/ground-truth"
+    },
+    {
+      "auth": {
+        "location": "query",
+        "scheme": "custom",
+        "scopes_note": "Not a header token — requires validator_hotkey + signature + nonce + netuid query params (a cryptographic signature proving control of a registered validator's `validator_hotkey`), not declared in the OpenAPI schema's security field. Confirmed live: a request missing all 4 either 401s (\"Missing validator authentication\") or 422s naming the 4 required fields."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-blacklist",
+      "kind": "subnet-api",
+      "name": "Score GET api blacklist",
+      "notes": "Auth-gated (validator-signature query params, Phase 3 credential passthrough, not built yet) GET /api/blacklist on api.scorevision.io (this path also supports POST — not registered as a separate surface since the url would collide). The OpenAPI schema declares NO security scheme for this path (a documentation gap, corrected here), but Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Missing validator authentication\"} or (for endpoints validating query shape first) HTTP 422 listing the 4 required fields. Registered auth_required:true anyway, per the registry's full-API-parity policy (metagraphed#7058).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/blacklist"
+    },
+    {
+      "auth": {
+        "location": "query",
+        "scheme": "custom",
+        "scopes_note": "Not a header token — requires validator_hotkey + signature + nonce + netuid query params (a cryptographic signature proving control of a registered validator's `validator_hotkey`), not declared in the OpenAPI schema's security field. Confirmed live: a request missing all 4 either 401s (\"Missing validator authentication\") or 422s naming the 4 required fields."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-blacklist-hotkey",
+      "kind": "subnet-api",
+      "name": "Score DELETE api blacklist by hotkey",
+      "notes": "Auth-gated (validator-signature query params, Phase 3 credential passthrough, not built yet) DELETE /api/blacklist/{hotkey} on api.scorevision.io. The OpenAPI schema declares NO security scheme for this path (a documentation gap, corrected here), but Not individually curled — same validator-signature gating as the verified `sn-44-score-api-blacklist` (401 \"Missing validator authentication\"). Registered auth_required:true anyway, per the registry's full-API-parity policy (metagraphed#7058).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/blacklist/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "location": "query",
+        "scheme": "custom",
+        "scopes_note": "Not a header token — requires validator_hotkey + signature + nonce + netuid query params (a cryptographic signature proving control of a registered validator's `validator_hotkey`), not declared in the OpenAPI schema's security field. Confirmed live: a request missing all 4 either 401s (\"Missing validator authentication\") or 422s naming the 4 required fields."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-spotchecks-pending",
+      "kind": "subnet-api",
+      "name": "Score GET api spotchecks pending",
+      "notes": "Auth-gated (validator-signature query params, Phase 3 credential passthrough, not built yet) GET /api/spotchecks/pending on api.scorevision.io (this path also supports POST — not registered as a separate surface since the url would collide). The OpenAPI schema declares NO security scheme for this path (a documentation gap, corrected here), but Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Missing validator authentication\"} or (for endpoints validating query shape first) HTTP 422 listing the 4 required fields. Registered auth_required:true anyway, per the registry's full-API-parity policy (metagraphed#7058).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/spotchecks/pending"
+    },
+    {
+      "auth": {
+        "location": "query",
+        "scheme": "custom",
+        "scopes_note": "Not a header token — requires validator_hotkey + signature + nonce + netuid query params (a cryptographic signature proving control of a registered validator's `validator_hotkey`), not declared in the OpenAPI schema's security field. Confirmed live: a request missing all 4 either 401s (\"Missing validator authentication\") or 422s naming the 4 required fields."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-spotchecks-pending-challenge-id",
+      "kind": "subnet-api",
+      "name": "Score DELETE api spotchecks pending by challenge id",
+      "notes": "Auth-gated (validator-signature query params, Phase 3 credential passthrough, not built yet) DELETE /api/spotchecks/pending/{challenge_id} on api.scorevision.io. The OpenAPI schema declares NO security scheme for this path (a documentation gap, corrected here), but Not individually curled — same validator-signature gating as the verified `sn-44-score-api-blacklist` (401 \"Missing validator authentication\"). Registered auth_required:true anyway, per the registry's full-API-parity policy (metagraphed#7058).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/spotchecks/pending/%7Bchallenge_id%7D"
+    },
+    {
+      "auth": {
+        "location": "query",
+        "scheme": "custom",
+        "scopes_note": "Not a header token — requires validator_hotkey + signature + nonce + netuid query params (a cryptographic signature proving control of a registered validator's `validator_hotkey`), not declared in the OpenAPI schema's security field. Confirmed live: a request missing all 4 either 401s (\"Missing validator authentication\") or 422s naming the 4 required fields."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-tasks-next",
+      "kind": "subnet-api",
+      "name": "Score GET api tasks next",
+      "notes": "Auth-gated (validator-signature query params, Phase 3 credential passthrough, not built yet) GET /api/tasks/next on api.scorevision.io. The OpenAPI schema declares NO security scheme for this path (a documentation gap, corrected here), but Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Missing validator authentication\"} or (for endpoints validating query shape first) HTTP 422 listing the 4 required fields. Registered auth_required:true anyway, per the registry's full-API-parity policy (metagraphed#7058).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/tasks/next"
+    },
+    {
+      "auth": {
+        "location": "query",
+        "scheme": "custom",
+        "scopes_note": "Not a header token — requires validator_hotkey + signature + nonce + netuid query params (a cryptographic signature proving control of a registered validator's `validator_hotkey`), not declared in the OpenAPI schema's security field. Confirmed live: a request missing all 4 either 401s (\"Missing validator authentication\") or 422s naming the 4 required fields."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-tasks-complete",
+      "kind": "subnet-api",
+      "name": "Score POST api tasks complete",
+      "notes": "Auth-gated (validator-signature query params, Phase 3 credential passthrough, not built yet) POST /api/tasks/complete on api.scorevision.io. The OpenAPI schema declares NO security scheme for this path (a documentation gap, corrected here), but Not individually curled — same validator-signature gating as the verified `sn-44-score-api-blacklist` (401 \"Missing validator authentication\"). Registered auth_required:true anyway, per the registry's full-API-parity policy (metagraphed#7058).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/tasks/complete"
+    },
+    {
+      "auth": {
+        "location": "query",
+        "scheme": "custom",
+        "scopes_note": "Not a header token — requires validator_hotkey + signature + nonce + netuid query params (a cryptographic signature proving control of a registered validator's `validator_hotkey`), not declared in the OpenAPI schema's security field. Confirmed live: a request missing all 4 either 401s (\"Missing validator authentication\") or 422s naming the 4 required fields."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-44-score-api-tasks-score",
+      "kind": "subnet-api",
+      "name": "Score POST api tasks score",
+      "notes": "Auth-gated (validator-signature query params, Phase 3 credential passthrough, not built yet) POST /api/tasks/score on api.scorevision.io. The OpenAPI schema declares NO security scheme for this path (a documentation gap, corrected here), but Not individually curled — same validator-signature gating as the verified `sn-44-score-api-blacklist` (401 \"Missing validator authentication\"). Registered auth_required:true anyway, per the registry's full-API-parity policy (metagraphed#7058).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "score",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.scorevision.io/openapi.json"],
+      "url": "https://api.scorevision.io/api/tasks/score"
     }
   ],
-  "social": {
-    "x": "https://x.com/webuildscore"
-  },
-  "contact": "hello@wearescore.com",
-  "source_repo": "https://github.com/score-technologies/turbovision",
   "website_url": "https://www.wearescore.com/"
 }


### PR DESCRIPTION
## Summary

Closes #7058. Same pattern as #7465/#7466/#7481: PR #7289 (already merged) closed this issue by verifying the 2 originally-listed surfaces (still accurate) but added zero registry changes, leaving the 17 additional operations the issue's own OpenAPI sweep found unregistered.

## What this adds (13 new surfaces)

Diffed the live OpenAPI spec (`https://api.scorevision.io/openapi.json`, 18 operations) against the registry (1 already covered — `/health`) → **13 unique missing paths**, split across two genuinely distinct auth mechanisms — a good contrast with the last three (SN36's undocumented custom scheme, SN37's HTTPBearer, SN46's PortalJWT/PortalApiKey):

**7 API-key gated** (`auth:{scheme:"api-key",...}`) — the schema's `components.securitySchemes` declares two accepted mechanisms: `APIKeyHeader` (`X-API-Key` header) or `APIKeyQuery` (`api_key` query param). Live-verified `GET /api/challenge-types`: `401 {"detail":"Invalid API key"}`, matching the schema's claim.

**6 validator-signature gated** (`auth:{scheme:"custom",location:"query",...}`) — a genuinely different mechanism the schema doesn't declare at all: `validator_hotkey` + `signature` + `nonce` + `netuid` query params (a cryptographic signature proving control of a registered validator's hotkey), not a header token. Independently spot-checked 3 of the 6: `GET /api/blacklist` and `GET /api/spotchecks/pending` both `401 {"detail":"Missing validator authentication"}`; `GET /api/tasks/next` `422`s naming all 4 required fields (schema validation runs before the auth check on this one). One path, `/api/tasks/{challenge_id}/ground-truth`, is a genuine two-tier case: its `GET` is validator-signature-gated (undeclared) while its `POST` is API-key-gated (declared) — registered once under the primary `GET` method per the registry's `netuid|kind|url` dedup key, with the differing `POST` auth noted explicitly rather than silently dropped.

## A public-safety scanner note

My first draft's `scopes_note` prose ("proving control of a registered validator hotkey") tripped `scan:public-safety`'s "sensitive hotkey wording" rule — it flags `validator[\s-]+hotkey` in free text (space/hyphen-joined) while explicitly allowing the underscore-joined `validator_hotkey` field-name form (per the rule's own comment, tuned after an earlier over-broad version false-positived on `registry/subnets/ridges.json`'s legitimate `miner_hotkey` field name). Rephrased to reference the literal `validator_hotkey` field name instead of the prose phrase — scan passes clean.

## Schema/tooling notes (same as #7465/#7466/#7481)
- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC` — every new surface here has `probe.enabled:false` (all 13 are auth-gated) and `probe.method:"GET"` as a schema-satisfying placeholder; the real method is in `name`/`notes`.
- Path-param URLs use the percent-encoded brace form (`%7Bhotkey%7D` etc.).
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`.

## Validation
- [x] `npm run validate:surface -- registry/subnets/score.json` — 19 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2029 total surfaces, clean
- [x] `npx vitest run tests/score-call-subnet-surface-verify.test.mjs` — 3 passed (unchanged — already accurate)
- [x] `npm test` — full suite, clean
- [x] `npx prettier --check` — clean

Closes #7058
