### PR TITLE
fix(registry): SN28 gm Gateway API parity (4 missing surfaces) (#7044)

### DIFF
--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -160,6 +160,122 @@
         "https://github.com/taostat/gm-miner/blob/main/image/envoy.yaml"
       ],
       "url": "https://raw.githubusercontent.com/taostat/gm-miner/refs/heads/main/image/envoy.yaml"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (bearerAuth), declared as a top-level requirement every operation inherits.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-28-gm-chat-completions",
+      "kind": "subnet-api",
+      "name": "gm Gateway chat completions (OpenAI-compatible)",
+      "notes": "Create a chat completion operation on the gm Gateway API (POST /chat/completions), declared in the subnet's own OpenAPI 3.1.0 spec at https://saygm.com/openapi.json (server https://api.saygm.com/v1). The spec sets a top-level bearerAuth requirement that every operation inherits, so it is registered auth_required:true with the probe disabled (Phase 3). Live-verified 2026-07-21: an unauthenticated POST to https://api.saygm.com/v1/chat/completions returns HTTP 401 (authentication required), confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1/chat/completions"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (bearerAuth), declared as a top-level requirement every operation inherits.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-28-gm-gemini-generate-content",
+      "kind": "subnet-api",
+      "name": "gm Gateway Gemini generateContent",
+      "notes": "Gemini generateContent / streamGenerateContent operation on the gm Gateway API (POST /v1beta/models/{modelAndAction}), declared in the subnet's own OpenAPI 3.1.0 spec at https://saygm.com/openapi.json (server https://api.saygm.com/v1). The spec sets a top-level bearerAuth requirement that every operation inherits, so it is registered auth_required:true with the probe disabled (Phase 3). Path-parameterized on {modelAndAction}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1/v1beta/models/%7BmodelAndAction%7D"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (bearerAuth), declared as a top-level requirement every operation inherits.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-28-gm-messages",
+      "kind": "subnet-api",
+      "name": "gm Gateway messages (Anthropic Messages API)",
+      "notes": "Create a message (Anthropic Messages API) operation on the gm Gateway API (POST /messages), declared in the subnet's own OpenAPI 3.1.0 spec at https://saygm.com/openapi.json (server https://api.saygm.com/v1). The spec sets a top-level bearerAuth requirement that every operation inherits, so it is registered auth_required:true with the probe disabled (Phase 3). Live-verified 2026-07-21: an unauthenticated POST to https://api.saygm.com/v1/messages returns HTTP 401 (authentication required), confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1/messages"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (bearerAuth), declared as a top-level requirement every operation inherits.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-28-gm-responses",
+      "kind": "subnet-api",
+      "name": "gm Gateway responses (OpenAI Responses API)",
+      "notes": "Create a response (OpenAI Responses API) operation on the gm Gateway API (POST /responses), declared in the subnet's own OpenAPI 3.1.0 spec at https://saygm.com/openapi.json (server https://api.saygm.com/v1). The spec sets a top-level bearerAuth requirement that every operation inherits, so it is registered auth_required:true with the probe disabled (Phase 3). Live-verified 2026-07-21: an unauthenticated POST to https://api.saygm.com/v1/responses returns HTTP 401 (authentication required), confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1/responses"
     }
   ],
   "website_url": "https://saygm.com/"


### PR DESCRIPTION
## Summary

Closes #7044.

Brings SN28 (gm) up to **full subnet API parity** — the completeness bar in `.claude/skills/contributor-pipeline-gardening/SKILL.md`'s "MCP execute verify + wire SN*" special-sweep section: *"the registry is meant to catalog everything a subnet's real API exposes, not just what's currently callable by the anonymous Phase-1 tool."* Same approach as SN37 Aurelius (#7466) and SN36 Eirel (#7465).

The already-registered `sn-28-gm-openapi` surface points at the gm Gateway API's OpenAPI 3.1.0 spec (`servers: https://api.saygm.com/v1`, 4 operations) — but only the spec *document* was registered, **none of its operations**. The registered `sn-28-gm-subnet-api` covers `/v1/models`, which is not one of the spec's paths, so all 4 were genuinely missing.

## What this adds

| surface | path | method |
|---|---|---|
| `sn-28-gm-chat-completions` | `/chat/completions` | POST |
| `sn-28-gm-responses` | `/responses` | POST |
| `sn-28-gm-messages` | `/messages` | POST |
| `sn-28-gm-gemini-generate-content` | `/v1beta/models/{modelAndAction}` | POST |

All 4 are `auth_required: true`, `probe.enabled: false` (Phase 3), and each carries a structured **`auth{}`** object (`bearer` / `header` / `Authorization`) derived from the spec's top-level `bearerAuth` requirement that every operation inherits. Placeholder value format only — no credential material.

**Live-verified 2026-07-21** that the gate is real, not schema-only:

| request | result |
|---|---|
| unauthenticated `POST /v1/chat/completions` | **401** authentication required |
| unauthenticated `POST /v1/responses` | **401** authentication required |
| unauthenticated `POST /v1/messages` | **401** authentication required |

The Gemini route is path-parameterized and registered with its percent-encoded `{modelAndAction}` template (`…/v1beta/models/%7BmodelAndAction%7D`) — no single fixed callable URL, Phase 2 — matching SN37 Aurelius's encoding.

## Checklist

- [x] Changes exactly one `registry/subnets/gm.json` file (+116/−0, clean append)
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed, **no `auth_required` advisories**
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` (6 passed)
- [x] `npm run scan:public-safety` passed (no gm findings)
- [x] `provider` uses the already-registered `gm` slug
- [x] Rebased on latest `main`

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Callable once Phase 3 credential passthrough (#7016) lands
