### PR TITLE
fix(registry): wire SN2 DSperse MCP execute probe config (#7018)

### DIFF
--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -148,7 +148,7 @@
       "id": "sn-2-truthtensor-benchmark-dataset",
       "kind": "data-artifact",
       "name": "Inference Labs TruthTensor benchmark dataset",
-      "notes": "Public Inference Labs HuggingFace TruthTensor benchmark — ~88k text/parquet rows of per-run LLM decision-execution logs (model, latency/duration, token counts, action, reasoning columns) measuring instruction divergence; not gated. Published by inferencelabs, the HF-verified org of Inference Labs, the DSperse (SN2) operator (its site subnet2.inferencelabs.com and X @inference_labs are the subnet's registered surfaces).",
+      "notes": "Public Inference Labs HuggingFace TruthTensor benchmark \u2014 ~88k text/parquet rows of per-run LLM decision-execution logs (model, latency/duration, token counts, action, reasoning columns) measuring instruction divergence; not gated. Published by inferencelabs, the HF-verified org of Inference Labs, the DSperse (SN2) operator (its site subnet2.inferencelabs.com and X @inference_labs are the subnet's registered surfaces).",
       "provider": "inference-labs",
       "public_safe": true,
       "review": {
@@ -167,7 +167,13 @@
       "id": "sn-2-inference-labs-subnet-api",
       "kind": "subnet-api",
       "name": "DSperse network stats API",
-      "notes": "Public no-auth GET /stats on sn2-api.inferencelabs.com returning JSON network counters (observed: total_proofs, unique_miners, unique_validators). The official subnet-2 validator client sets DEFAULT_API_URL to https://sn2-api.inferencelabs.com on the same host.",
+      "notes": "Public no-auth GET /stats on sn2-api.inferencelabs.com returning JSON network counters (observed: total_proofs, unique_miners, unique_validators). The official subnet-2 validator client sets DEFAULT_API_URL to https://sn2-api.inferencelabs.com on the same host. Live-verified 2026-07-21: GET https://sn2-api.inferencelabs.com/stats -> HTTP 200 application/json (total_proofs, unique_miners, unique_validators).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "inference-labs",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN2 (DSperse) for MCP execute (`call_subnet_surface`, #7014) by adding the missing probe config on the one issue-scoped surface that lacked it, and live-verifying the endpoints — same minimal pattern as SN9 iota (#7463), SN43 Graphite (#7476), and SN3 Templar (#7485).

Closes #7018

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-2-inference-labs-subnet-api | 200 | JSON (`total_proofs`, `unique_miners`, `unique_validators`) |
| sn-2-dsperse-circuit-repository-openapi | 200 | OpenAPI JSON |
| sn-2-dsperse-circuit-list | 200 | JSON |
| sn-2-dsperse-component-list | 200 | JSON |
| sn-2-dsperse-model-list | 200 | JSON |

## Registry changes

- **sn-2-inference-labs-subnet-api**: add probe (GET, expect: json) + Live-verified note

The other four issue-scoped surfaces already had correct probe config.

## Checklist

- [x] Changes exactly one `registry/subnets/dsperse.json` file
- [x] `npm run validate:surface -- registry/subnets/dsperse.json` passed
- [x] No `dsperse` findings from `npm run scan:public-safety`
- [x] All five issue-scoped primary surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green