### PR TITLE
fix(registry): wire SN1 Apex MCP execute probe config (#7017)

### DIFF
--- a/registry/subnets/apex.json
+++ b/registry/subnets/apex.json
@@ -174,15 +174,19 @@
       "id": "sn-1-apex-orchestrator-openapi",
       "kind": "openapi",
       "name": "Apex orchestrator API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST).",
+      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST). Live-verified 2026-07-21: GET https://apex.api.macrocosmos.ai/openapi.json -> HTTP 200 application/json (OpenAPI schema).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "bohdansolovie"
       },
-      "schema_status": "machine-readable",
-      "schema_url": "https://apex.api.macrocosmos.ai/openapi.json",
       "source_urls": [
         "https://github.com/macrocosm-os/apex/blob/main/shared/common/src/common/settings.py",
         "https://apex.api.macrocosmos.ai/openapi.json"
@@ -195,7 +199,13 @@
       "id": "sn-1-apex-healthcheck",
       "kind": "subnet-api",
       "name": "Apex orchestrator healthcheck API",
-      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings.",
+      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings. Live-verified 2026-07-21: GET https://apex.api.macrocosmos.ai/healthcheck -> HTTP 200 application/json.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {

--- a/registry/subnets/apex.json
+++ b/registry/subnets/apex.json
@@ -187,6 +187,8 @@
         "state": "community-submitted",
         "submitted_by": "bohdansolovie"
       },
+      "schema_status": "machine-readable",
+      "schema_url": "https://apex.api.macrocosmos.ai/openapi.json",
       "source_urls": [
         "https://github.com/macrocosm-os/apex/blob/main/shared/common/src/common/settings.py",
         "https://apex.api.macrocosmos.ai/openapi.json"


### PR DESCRIPTION
## Summary

Prepare SN1 (Apex) for MCP execute (`call_subnet_surface`, #7014) by adding the missing probe config on the two issue-scoped surfaces that lacked it, and live-verifying the endpoints — same minimal pattern as SN9 iota (#7463), SN43 Graphite (#7476), and SN3 Templar (#7485).

Closes #7017

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-1-apex-orchestrator-openapi | 200 | OpenAPI JSON (~71KB) |
| sn-1-apex-healthcheck | 200 | JSON |
| sn-1-apex-healthcheck-ready | 200 | JSON |
| sn-1-apex-metrics | 200 | Prometheus text |

## Registry changes

- **sn-1-apex-orchestrator-openapi**: add probe (GET, expect: json) + Live-verified note
- **sn-1-apex-healthcheck**: add probe (GET, expect: json) + Live-verified note

The ready + metrics surfaces already had correct probe config.

## Checklist

- [x] Changes exactly one `registry/subnets/apex.json` file
- [x] `npm run validate:surface -- registry/subnets/apex.json` passed
- [x] No `apex.json` findings from `npm run scan:public-safety`
- [x] All four issue-scoped primary surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green