### PR TITLE
fix(registry): wire SN1 Apex MCP execute probe config (#7017)

### DIFF
--- a/registry/subnets/apex.json
+++ b/registry/subnets/apex.json
@@ -174,7 +174,7 @@
       "id": "sn-1-apex-orchestrator-openapi",
       "kind": "openapi",
       "name": "Apex orchestrator API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST).",
+      "notes": "Machine-readable OpenAPI 3.x schema for the Apex SN1 orchestrator (title: FastAPI). Served publicly at apex.api.macrocosmos.ai; documents miner submission, competition, validator scoring, and /healthcheck routes. Mainnet default host in the official apex shared settings (ORCHESTRATOR_HOST). Live-verified 2026-07-22: GET returns OpenAPI 3.1.0 JSON (title FastAPI).",
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -187,7 +187,13 @@
         "https://github.com/macrocosm-os/apex/blob/main/shared/common/src/common/settings.py",
         "https://apex.api.macrocosmos.ai/openapi.json"
       ],
-      "url": "https://apex.api.macrocosmos.ai/openapi.json"
+      "url": "https://apex.api.macrocosmos.ai/openapi.json",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     },
     {
       "auth_required": false,
@@ -195,7 +201,7 @@
       "id": "sn-1-apex-healthcheck",
       "kind": "subnet-api",
       "name": "Apex orchestrator healthcheck API",
-      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings.",
+      "notes": "Public no-auth GET /healthcheck on apex.api.macrocosmos.ai returning liveness JSON (observed: {\"status\":\"healthy\"}). Documented as GET /healthcheck in the subnet OpenAPI spec; apex.api.macrocosmos.ai is the mainnet ORCHESTRATOR_HOST (https) in the official apex shared settings. Live-verified 2026-07-22: HTTP 200 JSON {\"status\":\"healthy\"}.",
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {
@@ -206,7 +212,13 @@
         "https://apex.api.macrocosmos.ai/openapi.json",
         "https://github.com/macrocosm-os/apex/blob/main/shared/common/src/common/settings.py"
       ],
-      "url": "https://apex.api.macrocosmos.ai/healthcheck"
+      "url": "https://apex.api.macrocosmos.ai/healthcheck",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     },
     {
       "auth_required": false,
@@ -214,7 +226,7 @@
       "id": "sn-1-apex-healthcheck-ready",
       "kind": "subnet-api",
       "name": "Apex orchestrator readiness check",
-      "notes": "Public no-auth GET returning readiness status (observed: {\"status\":\"ready\"}), distinct from the already-tracked liveness /healthcheck. Documented in the subnet's own OpenAPI schema (path /healthcheck/ready); same host as the existing healthcheck surface.",
+      "notes": "Public no-auth GET returning readiness status (observed: {\"status\":\"ready\"}), distinct from the already-tracked liveness /healthcheck. Documented in the subnet's own OpenAPI schema (path /healthcheck/ready); same host as the existing healthcheck surface. Live-verified 2026-07-22: HTTP 200 JSON {\"status\":\"ready\"}.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -236,7 +248,7 @@
       "id": "sn-1-apex-metrics",
       "kind": "subnet-api",
       "name": "Apex orchestrator Prometheus metrics",
-      "notes": "Public no-auth GET returning Prometheus text-exposition-format process/runtime metrics (python_gc_objects_collected_total and similar). Documented in the subnet's own OpenAPI schema (path /metrics); plain-text response, not JSON, so tracked with expect: any.",
+      "notes": "Public no-auth GET returning Prometheus text-exposition-format process/runtime metrics (python_gc_objects_collected_total and similar). Documented in the subnet's own OpenAPI schema (path /metrics); plain-text response, not JSON, so tracked with expect: any. Live-verified 2026-07-22: HTTP 200 Prometheus text exposition.",
       "probe": {
         "enabled": true,
         "expect": "any",


### PR DESCRIPTION
## Summary

Prepare SN1 (Apex) for MCP execute by adding missing probe config on openapi and healthcheck, and live-verifying all four issue-scoped surfaces — same minimal pattern as SN9 iota / SN105 Beam.

Closes #7017

## Surfaces verified (live 2026-07-22)

| surface_id | status | response |
|---|---|---|
| sn-1-apex-orchestrator-openapi | 200 | OpenAPI 3.1.0 JSON (title FastAPI) |
| sn-1-apex-healthcheck | 200 | JSON `{"status":"healthy"}` |
| sn-1-apex-healthcheck-ready | 200 | JSON `{"status":"ready"}` (probe already present) |
| sn-1-apex-metrics | 200 | Prometheus text (probe already present, expect: any) |

## Registry changes

- **sn-1-apex-orchestrator-openapi**: add probe (GET, expect: json) + Live-verified note
- **sn-1-apex-healthcheck**: add probe (GET, expect: json) + Live-verified note
- **sn-1-apex-healthcheck-ready** / **sn-1-apex-metrics**: append Live-verified notes

Auth-gated OpenAPI paths from the issue addendum stay out of scope (separate enrichment).

## Checklist

- [x] Changes exactly one `registry/subnets/apex.json` file
- [x] `npm run validate:surface -- registry/subnets/apex.json`
- [x] `npx vitest run tests/apex-call-subnet-surface-verify.test.mjs` (3 passed)
- [x] All four issue-scoped surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green

Made with [Cursor](https://cursor.com)