### PR TITLE
fix(registry): SN34 BitMind Detection API parity + correct auth_required (#7049)

### DIFF
--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -218,6 +218,236 @@
         "https://bitmind.ai/"
       ],
       "url": "https://huggingface.co/datasets/bitmind/bm-real"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes and no per-operation security, but every one of these endpoints empirically rejects an unauthenticated request with HTTP 401 \"API key is required\" (live-checked 2026-07-21). The header/parameter the credential is passed in is not documented in the spec, so only the scheme is recorded here."
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-34-bitmind-detect",
+      "kind": "subnet-api",
+      "name": "BitMind unified detection",
+      "notes": "Detect operation on the BitMind Detection API (POST /v1/detect), declared in the subnet's own OpenAPI spec at https://api.bitmind.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated POST returns HTTP 401 {\"detail\":\"API key is required\"} -- so it is registered auth_required:true (correcting what the schema implies) with probe.enabled:false, since it is a state-changing POST and not probe-safe (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/v1/detect"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes and no per-operation security, but every one of these endpoints empirically rejects an unauthenticated request with HTTP 401 \"API key is required\" (live-checked 2026-07-21). The header/parameter the credential is passed in is not documented in the spec, so only the scheme is recorded here."
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-34-bitmind-detect-document",
+      "kind": "subnet-api",
+      "name": "BitMind document detection",
+      "notes": "Detect Document operation on the BitMind Detection API (POST /detect-document), declared in the subnet's own OpenAPI spec at https://api.bitmind.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated POST returns HTTP 401 {\"detail\":\"API key is required\"} -- so it is registered auth_required:true (correcting what the schema implies) with probe.enabled:false, since it is a state-changing POST and not probe-safe (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/detect-document"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes and no per-operation security, but every one of these endpoints empirically rejects an unauthenticated request with HTTP 401 \"API key is required\" (live-checked 2026-07-21). The header/parameter the credential is passed in is not documented in the spec, so only the scheme is recorded here."
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-34-bitmind-detect-image",
+      "kind": "subnet-api",
+      "name": "BitMind image detection",
+      "notes": "Detect Image operation on the BitMind Detection API (POST /detect-image), declared in the subnet's own OpenAPI spec at https://api.bitmind.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated POST returns HTTP 401 {\"detail\":\"API key is required\"} -- so it is registered auth_required:true (correcting what the schema implies) with probe.enabled:false, since it is a state-changing POST and not probe-safe (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/detect-image"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes and no per-operation security, but every one of these endpoints empirically rejects an unauthenticated request with HTTP 401 \"API key is required\" (live-checked 2026-07-21). The header/parameter the credential is passed in is not documented in the spec, so only the scheme is recorded here."
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-34-bitmind-detect-text",
+      "kind": "subnet-api",
+      "name": "BitMind text detection",
+      "notes": "Detect Text operation on the BitMind Detection API (POST /detect-text), declared in the subnet's own OpenAPI spec at https://api.bitmind.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated POST returns HTTP 401 {\"detail\":\"API key is required\"} -- so it is registered auth_required:true (correcting what the schema implies) with probe.enabled:false, since it is a state-changing POST and not probe-safe (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/detect-text"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes and no per-operation security, but every one of these endpoints empirically rejects an unauthenticated request with HTTP 401 \"API key is required\" (live-checked 2026-07-21). The header/parameter the credential is passed in is not documented in the spec, so only the scheme is recorded here."
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-34-bitmind-detect-video",
+      "kind": "subnet-api",
+      "name": "BitMind video detection",
+      "notes": "Detect Video operation on the BitMind Detection API (POST /detect-video), declared in the subnet's own OpenAPI spec at https://api.bitmind.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated POST returns HTTP 401 {\"detail\":\"API key is required\"} -- so it is registered auth_required:true (correcting what the schema implies) with probe.enabled:false, since it is a state-changing POST and not probe-safe (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/detect-video"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes and no per-operation security, but every one of these endpoints empirically rejects an unauthenticated request with HTTP 401 \"API key is required\" (live-checked 2026-07-21). The header/parameter the credential is passed in is not documented in the spec, so only the scheme is recorded here."
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-34-bitmind-liveness-verify",
+      "kind": "subnet-api",
+      "name": "BitMind liveness verification",
+      "notes": "Liveness Verify operation on the BitMind Detection API (POST /liveness/verify), declared in the subnet's own OpenAPI spec at https://api.bitmind.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated POST returns HTTP 401 {\"detail\":\"API key is required\"} -- so it is registered auth_required:true (correcting what the schema implies) with probe.enabled:false, since it is a state-changing POST and not probe-safe (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/liveness/verify"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes and no per-operation security, but every one of these endpoints empirically rejects an unauthenticated request with HTTP 401 \"API key is required\" (live-checked 2026-07-21). The header/parameter the credential is passed in is not documented in the spec, so only the scheme is recorded here."
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-34-bitmind-preprocess-video",
+      "kind": "subnet-api",
+      "name": "BitMind video preprocessing",
+      "notes": "Preprocess Video operation on the BitMind Detection API (POST /preprocess-video), declared in the subnet's own OpenAPI spec at https://api.bitmind.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated POST returns HTTP 401 {\"detail\":\"API key is required\"} -- so it is registered auth_required:true (correcting what the schema implies) with probe.enabled:false, since it is a state-changing POST and not probe-safe (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/preprocess-video"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-34-bitmind-service-root",
+      "kind": "subnet-api",
+      "name": "BitMind Detection API service root",
+      "notes": "Public no-auth GET / on api.bitmind.ai returning the service banner (service name, version, region, docs path), declared in the subnet's own OpenAPI spec. Live-verified 2026-07-21: HTTP 200 application/json {\"service\":\"BitMind Detection API\",\"version\":\"1.0.0\",...}. Unlike the detection operations on this host it needs no credential, so its probe stays enabled.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes and no per-operation security, but every one of these endpoints empirically rejects an unauthenticated request with HTTP 401 \"API key is required\" (live-checked 2026-07-21). The header/parameter the credential is passed in is not documented in the spec, so only the scheme is recorded here."
+      },
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-34-bitmind-video-upload-url",
+      "kind": "subnet-api",
+      "name": "BitMind video upload URL issuance",
+      "notes": "Get Video Upload Url operation on the BitMind Detection API (POST /get-video-upload-url), declared in the subnet's own OpenAPI spec at https://api.bitmind.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated POST returns HTTP 401 {\"detail\":\"API key is required\"} -- so it is registered auth_required:true (correcting what the schema implies) with probe.enabled:false, since it is a state-changing POST and not probe-safe (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "url": "https://api.bitmind.ai/get-video-upload-url"
     }
   ],
   "website_url": "https://bitmind.ai/"


### PR DESCRIPTION
## Summary

Closes #7049.

Brings SN34 (BitMind) up to **full subnet API parity** — the completeness bar in `.claude/skills/contributor-pipeline-gardening/SKILL.md`'s "MCP execute verify + wire SN*" special-sweep section — **and corrects what the schema implies about auth**.

The already-registered `sn-34-bitmind-openapi` surface points at the BitMind Detection API's OpenAPI spec (10 paths). Only `/health` had a registry entry; the other **9 paths had none**.

## The correction (the interesting part)

The spec declares **no `securitySchemes` and no per-operation `security`** — which reads as "these are open endpoints." **They are not.** Live-verified 2026-07-21, every detection/liveness/video POST rejects an unauthenticated request:

| request | result |
|---|---|
| `POST /v1/detect` | **401** `{"detail":"API key is required"}` |
| `POST /detect-image` | **401** `{"detail":"API key is required"}` |
| `POST /detect-video` | **401** `{"detail":"API key is required"}` |
| `POST /detect-text` | **401** `{"detail":"API key is required"}` |
| `POST /detect-document` | **401** `{"detail":"API key is required"}` |
| `POST /liveness/verify` | **401** `{"detail":"API key is required"}` |
| `POST /preprocess-video` | **401** `{"detail":"API key is required"}` |
| `POST /get-video-upload-url` | **401** `{"detail":"API key is required"}` |

So those 8 are registered `auth_required: true` (correcting the schema's implication), `probe.enabled: false` — they're state-changing POSTs and not probe-safe — each with an `auth{}` object recording the `api-key` scheme. The spec doesn't document *which* header carries the credential, so **only the scheme is asserted**, not a header name I couldn't verify.

`GET /` genuinely needs no credential — live-verified **200** `{"service":"BitMind Detection API","version":"1.0.0","region":...}` — so it's registered `auth_required: false` with its **probe enabled**.

## Checklist

- [x] Changes exactly one `registry/subnets/bitmind.json` file (+230/−0, clean append)
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed, **no `auth_required` advisories**
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` (6 passed)
- [x] `npx vitest run tests/sn34-call-subnet-surface-verify.test.mjs` (6 passed — unaffected)
- [x] `npm run scan:public-safety` passed (no bitmind findings)
- [x] `provider` uses the already-registered `bitmind` slug
- [x] Rebased on latest `main`

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] `GET /` is a good no-auth MCP smoke target; the 8 gated ops become callable once Phase 3 (#7016) lands
