### PR TITLE
fix(registry): live-verify SN75 Hippius MCP execute surfaces (#7088)

### DIFF
--- a/registry/subnets/hippius.json
+++ b/registry/subnets/hippius.json
@@ -146,7 +146,8 @@
       "schema_status": "machine-readable",
       "schema_url": "https://api.hippius.com/swagger.json",
       "source_urls": ["https://api.hippius.com/swagger"],
-      "url": "https://api.hippius.com/swagger.json"
+      "url": "https://api.hippius.com/swagger.json",
+      "notes": ". Live-verified 2026-07-22: GET returns Swagger 2.0 JSON (title Hippius API)."
     },
     {
       "auth_required": false,
@@ -154,7 +155,7 @@
       "id": "sn-75-hippius-models-subnet-api",
       "kind": "subnet-api",
       "name": "Hippius model registry API",
-      "notes": "Public no-auth endpoint returning the paginated Hippius model registry (project/repo/digest/format for ~1300 hosted models); documented in the official Hippius OpenAPI spec. Verified publicly readable with no Authorization header, though the spec declares a global bearer scheme.",
+      "notes": "Public no-auth endpoint returning the paginated Hippius model registry (project/repo/digest/format for ~1300 hosted models); documented in the official Hippius OpenAPI spec. Verified publicly readable with no Authorization header, though the spec declares a global bearer scheme. Live-verified 2026-07-22: HTTP 200 JSON paginated models list.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -204,7 +205,7 @@
       "id": "sn-75-hippius-health",
       "kind": "subnet-api",
       "name": "Hippius registry health",
-      "notes": "Public no-auth GET /api/registry/health/ returning Hippius registry reachability JSON (observed: {\"ok\":true,\"latency_ms\":133}). Documented in the subnet swagger.json as a lightweight Harbor reachability check on the same api.hippius.com host as the existing models subnet-api surface.",
+      "notes": "Public no-auth GET /api/registry/health/ returning Hippius registry reachability JSON (observed: {\"ok\":true,\"latency_ms\":133}). Documented in the subnet swagger.json as a lightweight Harbor reachability check on the same api.hippius.com host as the existing models subnet-api surface. Live-verified 2026-07-22: HTTP 200 JSON with ok=true and latency_ms.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -295,7 +296,7 @@
       "id": "sn-75-hippius-storage-control-health",
       "kind": "subnet-api",
       "name": "Hippius storage-control health",
-      "notes": "Public no-auth GET /api/storage-control/health/ on api.hippius.com returning storage-control liveness JSON (observed: {\"status\":\"ok\"}). Documented in the subnet swagger.json OpenAPI spec on the same host as the existing registry health surface, a distinct service.",
+      "notes": "Public no-auth GET /api/storage-control/health/ on api.hippius.com returning storage-control liveness JSON (observed: {\"status\":\"ok\"}). Documented in the subnet swagger.json OpenAPI spec on the same host as the existing registry health surface, a distinct service. Live-verified 2026-07-22: HTTP 200 JSON {\"status\":\"ok\"}.",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
## Summary

Live-verify SN75 (Hippius) callable surfaces for MCP execute. Probes already match reality; this appends `Live-verified` notes on the four issue-scoped surfaces.

Closes #7088

## Surfaces verified (live 2026-07-22)

| surface_id | status | response |
|---|---|---|
| sn-75-hippius-openapi | 200 | Swagger 2.0 JSON (title Hippius API) |
| sn-75-hippius-models-subnet-api | 200 | JSON paginated models list |
| sn-75-hippius-health | 200 | JSON `ok=true` + `latency_ms` |
| sn-75-hippius-storage-control-health | 200 | JSON `{"status":"ok"}` |

Account/workspace API paths from the issue addendum stay out of scope (separate enrichment; issue marks new-surface discovery as out of scope).

## Registry changes

- Append Live-verified notes on the four surfaces above (no probe/method changes)

## Checklist

- [x] Changes exactly one `registry/subnets/hippius.json` file
- [x] `npm run validate:surface -- registry/subnets/hippius.json`
- [x] `npx vitest run tests/sn75-call-subnet-surface-verify.test.mjs` (12 passed)
- [x] All four issue-scoped surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green

Made with [Cursor](https://cursor.com)