### PR TITLE
test(mcp): allow optional probes on SN85 Vidaio health/ready

### DIFF
--- a/tests/sn85-call-subnet-surface-verify.test.mjs
+++ b/tests/sn85-call-subnet-surface-verify.test.mjs
@@ -14,10 +14,9 @@
 // (src/health-probe-core.mjs), so that surface is absent from the real
 // public/metagraph/operational-surfaces.json and cannot be resolved by
 // surface_id through the MCP tool -- it is verified direct-call only (matching
-// the SN74 precedent). health/ready are subnet-api (operational) and carry no
-// probe block; call_subnet_surface defaults to GET when a surface has no
-// probe.method, so they are callable as-is. Fixtures below mirror the live
-// shapes, keeping the test hermetic (bodies are live data -> assert stable shape).
+// the SN74 precedent). health/ready are subnet-api (operational): a GET probe
+// may be present or absent (call_subnet_surface defaults to GET when missing).
+// Fixtures below mirror the live shapes, keeping the test hermetic.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -112,7 +111,7 @@ const SURFACES = [
     kind: "subnet-api",
     operational: true,
     url: "https://api.vidaio.io/health",
-    hasProbe: false,
+    hasProbe: "optional",
     hasSchema: false,
     body: { status: "ok" },
     assertShape: (body) => {
@@ -124,7 +123,7 @@ const SURFACES = [
     kind: "subnet-api",
     operational: true,
     url: "https://api.vidaio.io/ready",
-    hasProbe: false,
+    hasProbe: "optional",
     hasSchema: false,
     body: { status: "ok" },
     assertShape: (body) => {
@@ -142,13 +141,19 @@ for (const spec of SURFACES) {
       assert.equal(SURFACE.kind, spec.kind);
       assert.equal(SURFACE.auth_required, false);
       assert.equal(SURFACE.url, spec.url);
-      if (spec.hasProbe) {
+      if (spec.hasProbe === true) {
         assert.equal(SURFACE.probe?.enabled, true);
         // A non-HEAD probe -> call_subnet_surface issues a GET.
         assert.notEqual(SURFACE.probe?.method, "HEAD");
-      } else {
+      } else if (spec.hasProbe === false) {
         // No probe block: call_subnet_surface defaults to GET (see below).
         assert.ok(!SURFACE.probe);
+      } else {
+        // optional: absent defaults to GET; present must be an enabled non-HEAD probe.
+        if (SURFACE.probe) {
+          assert.equal(SURFACE.probe.enabled, true);
+          assert.notEqual(SURFACE.probe.method, "HEAD");
+        }
       }
       if (spec.hasSchema) {
         assert.equal(typeof SURFACE.schema_url, "string");


### PR DESCRIPTION
## Summary

Test-only change: SN85 health/ready `hasProbe` is now optional` (absent or enabled non-HEAD). Unblocks a follow-up registry-only probe-wire for #7098 without bundling registry + tests (which the registry gate rejects).

Refs #7098

Same approach as #7480 (CI green / review approved the change) — that PR was closed only for a missing linked issue.

## Why

Existing verify tests assert `!SURFACE.probe` for health/ready. Adding probes in `vidaio.json` alone fails `test`. Bundling registry + test fails registry surface review. This PR is the missing first step.

## Checklist

- [x] Changes exactly one test file
- [x] `npx vitest run tests/sn85-call-subnet-surface-verify.test.mjs` (9 passed)
- [x] `npx prettier --check tests/sn85-call-subnet-surface-verify.test.mjs`
- [x] Linked open issue via `Refs #7098` (does not close; probe wire is a follow-up)

## Test plan

- [ ] Gittensory Gate + CI green