### PR TITLE
fix(registry): SN28 gm Gateway API parity (4 missing surfaces)

### DIFF
--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -25,7 +25,7 @@
   "docs_url": null,
   "name": "gm",
   "netuid": 28,
-  "notes": "Reviewed overlay for SN28 gm. Public news/directory sources describe a TEE-enabled LLM inference marketplace. This pass added the missing website and source-repo surfaces (both already set as top-level website_url/source_repo fields, live-verified, but previously untracked as surfaces) and fixed all 4 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. The 4 documented gm Gateway API paths (chat/completions, responses, messages, v1beta model actions) all require bearer auth per the OpenAPI schema's global security requirement and are write/inference-call endpoints, so none are promoted as additional surfaces. No dedicated docs subdomain found (docs.saygm.com unresolvable, saygm.com/docs 404s).",
+  "notes": "Reviewed overlay for SN28 gm. Public news/directory sources describe a TEE-enabled LLM inference marketplace. Website and source-repo surfaces are tracked; probe configs cover the public no-auth surfaces (openapi / models / healthz / envoy config). The four Gateway API operations from saygm.com/openapi.json (chat/completions, responses, messages, and v1beta generateContent) are registered as auth-gated subnet-api surfaces (auth_required:true, probe.enabled:false) for full API parity \u2014 Phase 3 credential passthrough is not built yet. Live-verified 2026-07-21: openapi.json 200, /v1/models 200, /healthz 200 \"ok\"; the four write endpoints return 401 without a key (Gemini base is https://api.saygm.com with no /v1 prefix). No dedicated docs subdomain found (docs.saygm.com unresolvable, saygm.com/docs 404s).",
   "schema_version": 1,
   "slug": "gm",
   "social": {
@@ -49,7 +49,9 @@
       },
       "provider": "gm",
       "public_safe": true,
-      "source_urls": ["https://github.com/taostat/gm-miner"],
+      "source_urls": [
+        "https://github.com/taostat/gm-miner"
+      ],
       "url": "https://saygm.com/"
     },
     {
@@ -67,7 +69,9 @@
       },
       "provider": "gm",
       "public_safe": true,
-      "source_urls": ["https://saygm.com/"],
+      "source_urls": [
+        "https://saygm.com/"
+      ],
       "url": "https://github.com/taostat/gm-miner"
     },
     {
@@ -90,7 +94,10 @@
       },
       "schema_status": "machine-readable",
       "schema_url": "https://saygm.com/openapi.json",
-      "source_urls": ["https://saygm.com/", "https://saygm.com/openapi.json"],
+      "source_urls": [
+        "https://saygm.com/",
+        "https://saygm.com/openapi.json"
+      ],
       "url": "https://saygm.com/openapi.json"
     },
     {
@@ -111,7 +118,10 @@
         "state": "community-submitted",
         "submitted_by": "dhgoal"
       },
-      "source_urls": ["https://saygm.com/", "https://saygm.com/openapi.json"],
+      "source_urls": [
+        "https://saygm.com/",
+        "https://saygm.com/openapi.json"
+      ],
       "url": "https://api.saygm.com/v1/models"
     },
     {
@@ -133,7 +143,10 @@
         "state": "community-submitted",
         "submitted_by": "jimcody1995"
       },
-      "source_urls": ["https://saygm.com/", "https://saygm.com/openapi.json"],
+      "source_urls": [
+        "https://saygm.com/",
+        "https://saygm.com/openapi.json"
+      ],
       "url": "https://saygm.com/healthz"
     },
     {
@@ -160,6 +173,134 @@
         "https://github.com/taostat/gm-miner/blob/main/image/envoy.yaml"
       ],
       "url": "https://raw.githubusercontent.com/taostat/gm-miner/refs/heads/main/image/envoy.yaml"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <gm-api-key>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (bearerAuth): a gm API key minted in the dashboard, sent as Authorization: Bearer <gm-api-key>. Declared as the document-level security requirement inherited by every Gateway API operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-28-gm-chat-completions",
+      "kind": "subnet-api",
+      "name": "gm Gateway API POST chat completions",
+      "notes": "Auth-gated (Bearer gm API key, Phase 3 credential passthrough, not built yet) POST /v1/chat/completions on api.saygm.com \u2014 OpenAI-compatible Chat Completions from the already-registered sn-28-gm-openapi schema (servers: https://api.saygm.com/v1). Live-verified 2026-07-21: unauthenticated POST returned HTTP 401 {\"error\":{\"message\":\"Invalid Authentication\",\"type\":\"invalid_request_error\",\"code\":\"invalid_api_key\"}}. probe.enabled:false \u2014 POST-only write/inference endpoint (a GET probe would 405). Registered per the registry's full-API-parity policy (metagraphed#7044); not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://saygm.com/openapi.json",
+        "https://api.saygm.com/v1/chat/completions"
+      ],
+      "url": "https://api.saygm.com/v1/chat/completions"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <gm-api-key>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (bearerAuth): a gm API key minted in the dashboard, sent as Authorization: Bearer <gm-api-key>. Declared as the document-level security requirement inherited by every Gateway API operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-28-gm-responses",
+      "kind": "subnet-api",
+      "name": "gm Gateway API POST responses",
+      "notes": "Auth-gated (Bearer gm API key, Phase 3 credential passthrough, not built yet) POST /v1/responses on api.saygm.com \u2014 OpenAI-compatible Responses API from the already-registered sn-28-gm-openapi schema. Live-verified 2026-07-21: unauthenticated POST returned HTTP 401 {\"error\":{\"message\":\"Invalid Authentication\",\"type\":\"invalid_request_error\",\"code\":\"invalid_api_key\"}}. probe.enabled:false \u2014 POST-only. Registered per metagraphed#7044.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://saygm.com/openapi.json",
+        "https://api.saygm.com/v1/responses"
+      ],
+      "url": "https://api.saygm.com/v1/responses"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <gm-api-key>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (bearerAuth): a gm API key minted in the dashboard, sent as Authorization: Bearer <gm-api-key>. Declared as the document-level security requirement inherited by every Gateway API operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-28-gm-messages",
+      "kind": "subnet-api",
+      "name": "gm Gateway API POST messages",
+      "notes": "Auth-gated (Bearer gm API key, Phase 3 credential passthrough, not built yet) POST /v1/messages on api.saygm.com \u2014 Anthropic-compatible Messages API from the already-registered sn-28-gm-openapi schema (OpenAPI text: auth is still the gm API key as a bearer token). Live-verified 2026-07-21: unauthenticated POST returned HTTP 401 {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key\"}} (Anthropic-shaped error body; document-level securitySchemes still name bearerAuth). probe.enabled:false \u2014 POST-only. Registered per metagraphed#7044.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://saygm.com/openapi.json",
+        "https://api.saygm.com/v1/messages"
+      ],
+      "url": "https://api.saygm.com/v1/messages"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <gm-api-key>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (bearerAuth): a gm API key minted in the dashboard, sent as Authorization: Bearer <gm-api-key>. Declared as the document-level security requirement inherited by every Gateway API operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-28-gm-gemini-generate-content",
+      "kind": "subnet-api",
+      "name": "gm Gateway API POST Gemini generateContent",
+      "notes": "Auth-gated (Bearer gm API key, Phase 3 credential passthrough, not built yet) POST /v1beta/models/{modelAndAction} on api.saygm.com \u2014 Gemini-compatible generateContent / streamGenerateContent. The operation overrides the document servers entry: base is https://api.saygm.com (no /v1 prefix); a naively-prefixed /v1/v1beta/... URL 404s. Live-verified 2026-07-21: unauthenticated POST to https://api.saygm.com/v1beta/models/gemini-2.5-pro:generateContent returned HTTP 401 {\"error\":{\"code\":401,\"message\":\"API key not valid...\",\"status\":\"UNAUTHENTICATED\"}}; the /v1-prefixed twin returned 404. URL uses percent-encoded {%7BmodelAndAction%7D} template (raw braces fail format:uri). probe.enabled:false \u2014 POST-only path-param surface (Phase 2). Registered per metagraphed#7044.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://saygm.com/openapi.json",
+        "https://api.saygm.com/v1beta/models/%7BmodelAndAction%7D"
+      ],
+      "url": "https://api.saygm.com/v1beta/models/%7BmodelAndAction%7D"
     }
   ],
   "website_url": "https://saygm.com/"


### PR DESCRIPTION
## Summary

Closes #7044.

Brings SN28 (gm) up to **full Gateway API parity** for the four operations documented in the issue's **Additional surface(s) found during review** section — the reopen pass after the original verify PR merged. Same approach as SN37 Aurelius (#7466) / SN36 Eirel (#7465).

The already-registered `sn-28-gm-openapi` surface points at the gm Gateway API OpenAPI 3.1.0 spec (`servers: https://api.saygm.com/v1`, plus an operation-level server override for Gemini), but only the spec *document* was registered — **none of its operations**. `sn-28-gm-subnet-api` covers `GET /v1/models`, which is not one of the spec's paths, so all four ops were genuinely missing.

## What this adds

| surface | path | method | notes |
| --- | --- | --- | --- |
| `sn-28-gm-chat-completions` | `/v1/chat/completions` | POST | OpenAI Chat Completions |
| `sn-28-gm-responses` | `/v1/responses` | POST | OpenAI Responses API |
| `sn-28-gm-messages` | `/v1/messages` | POST | Anthropic Messages API |
| `sn-28-gm-gemini-generate-content` | `/v1beta/models/{modelAndAction}` | POST | Gemini generateContent (base `https://api.saygm.com`, **no `/v1` prefix**) |

All four are `auth_required: true`, `probe.enabled: false`, `authority: "community"` (matching the existing gm community-submitted Gateway surfaces), with a structured `auth{}` object derived from the schema's `bearerAuth` security scheme:

```json
{ "scheme": "bearer", "location": "header", "name": "Authorization", "value_format": "Bearer <gm-api-key>" }
```

That is the exact gap that caused #7489 to fail CI (`auth_required` advisory with no `auth{}`).

## Live verification (2026-07-21)

| request | result |
| --- | --- |
| `GET https://saygm.com/openapi.json` | **200** OpenAPI 3.1.0 |
| `GET https://api.saygm.com/v1/models` | **200** model catalog |
| `GET https://saygm.com/healthz` | **200** `ok` |
| unauthenticated `POST /v1/chat/completions` | **401** `invalid_api_key` |
| unauthenticated `POST /v1/responses` | **401** `invalid_api_key` |
| unauthenticated `POST /v1/messages` | **401** Anthropic-shaped `invalid x-api-key` (schema still declares bearerAuth) |
| unauthenticated `POST https://api.saygm.com/v1beta/models/gemini-2.5-pro:generateContent` | **401** `UNAUTHENTICATED` |
| `POST https://api.saygm.com/v1/v1beta/models/...` (wrong `/v1` prefix) | **404** |

Gemini URL registered as `https://api.saygm.com/v1beta/models/%7BmodelAndAction%7D` (percent-encoded braces for `format:uri`).

No credential material is reproduced in any note.

## Validation

- [x] `npm run validate:surface -- registry/subnets/gm.json` — 10 surfaces, passed
- [x] `npm run validate:surface` — 1326 surfaces / 129 files, passed (no auth_required advisories)
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` — 6/6 passed
- [x] `npm run scan:public-safety` — passed
- [x] Single-file change: `registry/subnets/gm.json` only
- [x] Rebased on latest `main`

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Confirm the four surfaces appear after deploy / registry sync
- [ ] Callable once Phase 3 credential passthrough (#7016) lands
