### PR TITLE
feat(ui): subnet detail — Activity tab event-summary + axon-removals rollup

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -15,6 +15,9 @@ import {
   Activity,
   ChevronDown,
   Filter,
+  Layers,
+  Coins,
+  UserMinus,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton, RECOVERY } from "@/components/metagraphed/states";
@@ -78,6 +81,8 @@ import {
   subnetHyperparamsHistoryQuery,
   subnetAlphaVolumeQuery,
   subnetStakeQuoteQuery,
+  subnetEventSummaryQuery,
+  subnetAxonRemovalsQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { rovingTabIndex, useRovingTablist } from "@/hooks/use-roving-tablist";
@@ -1036,6 +1041,7 @@ function ActivityPanel({ netuid }: { netuid: number }) {
         />
       }
     >
+      <ActivityEventRollup netuid={netuid} />
       <StakeFlowScorecard netuid={netuid} />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-32 w-full" />}>
@@ -1043,6 +1049,64 @@ function ActivityPanel({ netuid }: { netuid: number }) {
         </Suspense>
       </QueryErrorBoundary>
     </SectionAnchor>
+  );
+}
+
+// #7000: windowed rollup complementing the raw per-event Activity table below —
+// total events / distinct kinds & categories / TAO+alpha moved (from
+// subnetEventSummaryQuery's per-category breakdown) plus an axon-removals
+// glance (from subnetAxonRemovalsQuery), so a visitor doesn't have to tally the
+// raw event log by hand. Both queries already exist for other surfaces; this is
+// the first place either is actually rendered.
+const TOP_CATEGORY_COUNT = 3;
+
+function ActivityEventRollup({ netuid }: { netuid: number }) {
+  const { data: summaryRes } = useQuery(subnetEventSummaryQuery(netuid));
+  const { data: axonRes } = useQuery(subnetAxonRemovalsQuery(netuid));
+  const summary = summaryRes?.data;
+  const axon = axonRes?.data;
+  if (!summary && !axon) return null;
+
+  const categories = summary?.categories ?? [];
+  const topCategories = [...categories]
+    .sort((a, b) => b.event_count - a.event_count)
+    .slice(0, TOP_CATEGORY_COUNT)
+    .map((c) => c.category)
+    .join(", ");
+  const totalTao = categories.reduce((sum, c) => sum + c.amount_tao, 0);
+  const totalAlpha = categories.reduce((sum, c) => sum + c.alpha_amount, 0);
+
+  return (
+    <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatTile
+        icon={Activity}
+        eyebrow="Events"
+        value={formatNumber(summary?.total_events ?? 0)}
+        hint={summary ? `over ${summary.window}` : "—"}
+        tooltip="Total decoded chain events for this subnet in the window."
+      />
+      <StatTile
+        icon={Layers}
+        eyebrow="Kinds / categories"
+        value={`${formatNumber(summary?.kind_count ?? 0)} / ${formatNumber(summary?.category_count ?? 0)}`}
+        hint={topCategories || "—"}
+        tooltip="Distinct event kinds and categories seen, with the top categories by volume."
+      />
+      <StatTile
+        icon={Coins}
+        eyebrow="TAO / alpha moved"
+        value={`${taoCompact(totalTao)} τ`}
+        hint={`${taoCompact(totalAlpha)} α`}
+        tooltip="Summed TAO and alpha amounts across all categorized events in the window."
+      />
+      <StatTile
+        icon={UserMinus}
+        eyebrow="Axon removals"
+        value={formatNumber(axon?.removals ?? 0)}
+        hint={axon ? `${formatNumber(axon.distinct_removers)} removers · ${axon.window}` : "—"}
+        tooltip="AxonInfoRemoved events and distinct removing hotkeys over the window."
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #7000

## Summary

`subnets.$netuid.tsx`'s Activity tab has always shown the raw per-event log with no rollup —
you had to tally kinds/categories/TAO by hand. Adds an `ActivityEventRollup` scorecard above
the raw event table (and above the existing stake-flow scorecard) with:

- **Events** — total decoded chain events over the window.
- **Kinds / categories** — distinct counts, plus the top 3 categories by event volume.
- **TAO / alpha moved** — summed across all categorized events in the window.
- **Axon removals** — `AxonInfoRemoved` count and distinct removing hotkeys.

## Re: the other two #7000 deliverables

Verified against current `main` before starting: latency percentiles (p50/p95/p99 per surface)
are already rendered in `ReliabilityPanel`, and cumulative TAO-recycled is already rendered in
`EconomicsPanel` — both landed since the issue was filed. This PR completes the remaining gap:
`subnetEventSummaryQuery` and `subnetAxonRemovalsQuery` already existed in `queries.ts` (with
their own normalizers + tests), but neither was consumed anywhere in the UI until now.

Note: the live `/event-summary` response shape (`total_events`, `kind_count`, `category_count`,
`categories[]` with `event_count`/`amount_tao`/`alpha_amount`) doesn't include the distinct
hotkey/coldkey counts the issue text mentions — built the card around what the endpoint actually
returns.

## Validation

- [x] `cd apps/ui && npx eslint src/routes/subnets.$netuid.tsx` — 0 errors (pre-existing
      `react-refresh/only-export-components` warnings only, same as every other export in this
      file; unrelated to this diff).
- [x] `npx prettier --check src/routes/subnets.$netuid.tsx` — clean.
- [x] `node scripts/scan-public-safety.mjs` — clean.
- [x] Full `apps/ui` suite: `npx vitest run` — 174 files / 1331 tests passed, no regressions.
- [x] Rebased onto current `upstream/main`; no conflicts.
- [x] Diff confined to one file, 64 lines added, no new dependencies.

## Screenshots

Captured on `/subnets/1?tab=activity` (real live data — 11,503 events / 12 kinds / 5 categories
/ 2.2k τ + 236.4k α moved / 0 axon removals in the current window for subnet 1).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/7000-activity-rollup-after-mobile-dark.png)<br><sub>after</sub> |

## Risk / tradeoffs

- Pure `apps/ui` presentational addition — no new dependencies, no query-shape changes, no
  schema/contract/OpenAPI surface touched.
- Matches this repo's `StatTile` design-system convention (`@jsonbored/ui-kit`) throughout — no
  one-off Tailwind values.
- No tests added, matching this repo's convention for pure UI-wiring PRs (the 15 prior
  external-contributor merges in this file's history took the same approach); both consumed
  query hooks already have their own unit tests in `queries.subnet-event-summary.test.ts` /
  `queries.subnet-axon-removals.test.ts`.
- `apps/ui/**` is a guardrail-protected path — expect this to be held for manual review
  regardless of automated-check outcome.
