### PR TITLE
fix(registry): live-verify SN21 AdTAO MCP execute surfaces (#7037)

### DIFF
--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -72,7 +72,7 @@
       "id": "sn-21-adtao-validator-openapi",
       "kind": "openapi",
       "name": "AdTAO SN21 Validator OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.1.0 schema (title \"SN21 Validator\", version 0.1.0) served by the official AdTAO validator API on the operator's validator.adtao.io host. Documents the public epoch/episode, prediction, commitment, verification, scores, and training routes plus /health. Unauthenticated GET returns the full paths object.",
+      "notes": "Machine-readable OpenAPI 3.1.0 schema (title \"SN21 Validator\", version 0.1.0) served by the official AdTAO validator API on the operator's validator.adtao.io host. Documents the public epoch/episode, prediction, commitment, verification, scores, and training routes plus /health. Unauthenticated GET returns the full paths object. Live-verified 2026-07-22: GET returns OpenAPI 3.1.0 JSON (title SN21 Validator).",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -99,7 +99,7 @@
       "id": "sn-21-adtao-validator-api",
       "kind": "subnet-api",
       "name": "AdTAO SN21 Validator API",
-      "notes": "Official public AdTAO (SN21) validator API on the operator's validator.adtao.io host. An unauthenticated GET on /health returns live JSON service status (service, current epoch label, episodes loaded, submission window, deadline). The /v1/epochs routes are described in the linked OpenAPI schema.",
+      "notes": "Official public AdTAO (SN21) validator API on the operator's validator.adtao.io host. An unauthenticated GET on /health returns live JSON service status (service, current epoch label, episodes loaded, submission window, deadline). The /v1/epochs routes are described in the linked OpenAPI schema. Live-verified 2026-07-22: HTTP 200 JSON status=ok for sn21-validator health.",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
## Summary

Live-verify SN21 (AdTAO) callable surfaces for MCP execute. Probes already match reality; this appends `Live-verified` notes on the two issue-scoped surfaces.

Closes #7037

## Surfaces verified (live 2026-07-22)

| surface_id | status | response |
|---|---|---|
| sn-21-adtao-validator-openapi | 200 | OpenAPI 3.1.0 JSON (title SN21 Validator) |
| sn-21-adtao-validator-api | 200 | JSON `status=ok` (sn21-validator health) |

Additional epoch/miner-header routes from the issue addendum stay out of scope (issue marks new-surface discovery as a separate enrichment process).

## Registry changes

- Append Live-verified notes on the two surfaces above (no probe/method changes)

## Checklist

- [x] Changes exactly one `registry/subnets/adtao.json` file
- [x] `npm run validate:surface -- registry/subnets/adtao.json`
- [x] `npx vitest run tests/adtao-call-subnet-surface-verify.test.mjs`
- [x] Both issue-scoped surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green

Made with [Cursor](https://cursor.com)