### PR TITLE
fix(registry): wire SN85 Vidaio MCP execute probe config (#7098)

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -128,7 +128,13 @@
       "id": "sn-85-vidaio-health",
       "kind": "subnet-api",
       "name": "Vidaio API health",
-      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health).",
+      "notes": "Public no-auth GET /health returning {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing openapi surface (api.vidaio.io/openapi.json, path /health). Live-verified 2026-07-21: GET https://api.vidaio.io/health -> HTTP 200 application/json (status ok).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "vidaio",
       "public_safe": true,
       "review": {
@@ -147,7 +153,13 @@
       "id": "sn-85-vidaio-ready",
       "kind": "subnet-api",
       "name": "Vidaio API readiness health",
-      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint.",
+      "notes": "Public no-auth GET /ready returning {\"status\":\"ok\"} when the API can reach its backing database. Documented in the machine-readable OpenAPI spec on the same host as the existing openapi and /health subnet-api surfaces (api.vidaio.io/openapi.json, path /ready). Distinct from the /health liveness endpoint. Live-verified 2026-07-21: GET https://api.vidaio.io/ready -> HTTP 200 application/json (status ok).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "vidaio",
       "public_safe": true,
       "review": {

--- a/tests/sn85-call-subnet-surface-verify.test.mjs
+++ b/tests/sn85-call-subnet-surface-verify.test.mjs
@@ -14,9 +14,8 @@
 // (src/health-probe-core.mjs), so that surface is absent from the real
 // public/metagraph/operational-surfaces.json and cannot be resolved by
 // surface_id through the MCP tool -- it is verified direct-call only (matching
-// the SN74 precedent). health/ready are subnet-api (operational) and carry no
-// probe block; call_subnet_surface defaults to GET when a surface has no
-// probe.method, so they are callable as-is. Fixtures below mirror the live
+// the SN74 precedent). health/ready are subnet-api (operational) and carry an
+// enabled GET probe (wired for MCP execute). Fixtures below mirror the live
 // shapes, keeping the test hermetic (bodies are live data -> assert stable shape).
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -112,7 +111,7 @@ const SURFACES = [
     kind: "subnet-api",
     operational: true,
     url: "https://api.vidaio.io/health",
-    hasProbe: false,
+    hasProbe: true,
     hasSchema: false,
     body: { status: "ok" },
     assertShape: (body) => {
@@ -124,7 +123,7 @@ const SURFACES = [
     kind: "subnet-api",
     operational: true,
     url: "https://api.vidaio.io/ready",
-    hasProbe: false,
+    hasProbe: true,
     hasSchema: false,
     body: { status: "ok" },
     assertShape: (body) => {


### PR DESCRIPTION
## Summary

Prepare SN85 (Vidaio) for MCP execute by adding missing probe config on health/ready and updating the existing verify suite to expect those probes — same registry+test pairing that merged for SN36 Eirel (#7465).

Closes #7098

## Surfaces verified (live 2026-07-21)

| surface_id | status | response |
|---|---|---|
| sn-85-vidaio-health | 200 | `{"status":"ok"}` |
| sn-85-vidaio-ready | 200 | `{"status":"ok"}` |
| sn-85-vidaio-openapi | (unchanged) | already probed |

## Registry changes

- **sn-85-vidaio-health**: add probe (GET, expect: json) + Live-verified note
- **sn-85-vidaio-ready**: add probe (GET, expect: json) + Live-verified note

## Test changes

- Set `hasProbe: true` for health/ready in `tests/sn85-call-subnet-surface-verify.test.mjs` (previously asserted probe absence, which blocked registry-only wires)

## Checklist

- [x] `npm run validate:surface -- registry/subnets/vidaio.json`
- [x] `npx vitest run tests/sn85-call-subnet-surface-verify.test.mjs` (9 passed)
- [x] `npx prettier --check` on both files
- [x] No follow-up commits planned (one-shot)

## Test plan

- [ ] Gittensory Gate + CI green