### PR TITLE
fix(registry): live-verify SN68 NOVA MCP execute surfaces (#7081)

### DIFF
--- a/registry/subnets/nova.json
+++ b/registry/subnets/nova.json
@@ -163,7 +163,7 @@
       "id": "sn-68-nova-score-share-openapi",
       "kind": "openapi",
       "name": "NOVA Boltz score sharing API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.x schema for the NOVA SN68 validator score-sharing service (title: Boltz score sharing API). Served publicly at vali-score-share-api.metanova-labs.ai; documents molecule and nanobody score-share routes used by validators to average non-deterministic model results.",
+      "notes": "Machine-readable OpenAPI 3.x schema for the NOVA SN68 validator score-sharing service (title: Boltz score sharing API). Served publicly at vali-score-share-api.metanova-labs.ai; documents molecule and nanobody score-share routes used by validators to average non-deterministic model results. Live-verified 2026-07-22: GET returns OpenAPI 3.1.0 JSON (title Boltz score sharing API).",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -191,7 +191,7 @@
       "id": "sn-68-nova-score-share-molecules",
       "kind": "subnet-api",
       "name": "NOVA score-share molecules catalog API",
-      "notes": "Public no-auth GET /api/v1/molecules on vali-score-share-api.metanova-labs.ai returning paginated molecule score-share records (items with name, epoch, target_averages). Documented as GET /api/v1/molecules in the subnet OpenAPI spec; same host as SCORE_SHARE_API_URL in the official nova validator docs and validator.py.",
+      "notes": "Public no-auth GET /api/v1/molecules on vali-score-share-api.metanova-labs.ai returning paginated molecule score-share records (items with name, epoch, target_averages). Documented as GET /api/v1/molecules in the subnet OpenAPI spec; same host as SCORE_SHARE_API_URL in the official nova validator docs and validator.py. Live-verified 2026-07-22: HTTP 200 JSON paginated molecules list (items/total/page).",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
## Summary

Live-verify SN68 (NOVA) callable surfaces for MCP execute. Probes already match reality; this appends `Live-verified` notes on the two issue-scoped surfaces.

Closes #7081

## Surfaces verified (live 2026-07-22)

| surface_id | status | response |
|---|---|---|
| sn-68-nova-score-share-openapi | 200 | OpenAPI 3.1.0 JSON (title Boltz score sharing API) |
| sn-68-nova-score-share-molecules | 200 | JSON paginated molecules list (items/total/page) |

Additional template/path endpoints from the issue addendum stay out of scope (issue marks new-surface discovery as a separate enrichment process).

## Registry changes

- Append Live-verified notes on the two surfaces above (no probe/method changes)

## Checklist

- [x] Changes exactly one `registry/subnets/nova.json` file
- [x] `npm run validate:surface -- registry/subnets/nova.json`
- [x] Both issue-scoped surfaces live-probed

## Test plan

- [ ] Gittensory Gate + CI green

Made with [Cursor](https://cursor.com)