### PR TITLE
registry(sn4): add Targon healthz surface (#7020)

### DIFF
--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -217,6 +217,28 @@
       },
       "source_urls": ["https://stats.targon.com/docs"],
       "url": "https://stats.targon.com/api/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-4-targon-healthz-api",
+      "kind": "subnet-api",
+      "name": "Targon Hub API healthz",
+      "notes": "Public no-auth GET /tha/v2/healthz on api.targon.com documented at docs.targon.com/api/health. Live-verified 2026-07-21: HTTP 500 application/json (INTERNAL_SERVER_ERROR) - registered so probe monitoring reflects current endpoint state.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": ["https://docs.targon.com/api/health"],
+      "url": "https://api.targon.com/tha/v2/healthz"
     }
   ],
   "website_url": "https://targon.com/"


### PR DESCRIPTION
## Summary

Registry-only append of `sn-4-targon-healthz-api` to `registry/subnets/targon.json` — closes the additional-scope item from #7020 (documented public `/tha/v2/healthz`).

Closes #7020

## Surface

- Netuid: 4
- Kind: subnet-api
- Public URL: `https://api.targon.com/tha/v2/healthz`
- Source URL: `https://docs.targon.com/api/health`
- Provider: targon
- `probe.enabled: true` (GET, expect: json)

## Live-verified 2026-07-21

| URL | status |
|-----|--------|
| `/tha/v2/inventory` | **200** |
| `/tha/v2/version` | **200** |
| `stats.targon.com/api/miners` | **200** |
| `/tha/v2/healthz` | **500** JSON `INTERNAL_SERVER_ERROR` |

Per issue: register healthz even while unhealthy so probes reflect reality.

## Checklist

- [x] Changes exactly one `registry/subnets/targon.json` file (append-only)
- [x] `authority: community`, `review.state: community-submitted`
- [x] No secrets / wallet / hotkey wording
- [x] `Closes #7020`
- [x] Single commit (one-shot; no follow-up pushes)

## Validation

- [x] `npm run validate:surface -- registry/subnets/targon.json`
- [x] `npx prettier --check registry/subnets/targon.json`