### PR TITLE
registry(sn71): add Leadpoet contact API surface (#7084)

### DIFF
--- a/registry/subnets/leadpoet.json
+++ b/registry/subnets/leadpoet.json
@@ -181,6 +181,28 @@
       },
       "source_urls": ["https://leadpoet.com/api/geo/cities"],
       "url": "https://leadpoet.com/api/geo/cities"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-71-leadpoet-contact-api",
+      "kind": "subnet-api",
+      "name": "Leadpoet contact form API",
+      "notes": "Public no-auth POST /api/contact on leadpoet.com documented in the subnet OpenAPI schema (path /api/contact). Marketing contact-form submit with a JSON body; probe.enabled:false because it is a write endpoint and not safe to auto-probe. Live-verified 2026-07-21: GET returns HTTP 200 (endpoint reachable); POST left unfired.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leadpoet",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kai392"
+      },
+      "source_urls": ["https://leadpoet.com/api/openapi.json"],
+      "url": "https://leadpoet.com/api/contact"
     }
   ],
   "website_url": "https://leadpoet.com/"


### PR DESCRIPTION
## Summary

Registry-only append of `sn-71-leadpoet-contact-api` to `registry/subnets/leadpoet.json` — closes the additional-scope item from #7084.

Closes #7084

## Surface

- Netuid: 71
- Kind: subnet-api
- Public URL: `https://leadpoet.com/api/contact`
- Source URL: `https://leadpoet.com/api/openapi.json`
- Provider: leadpoet
- `probe.enabled: false` (write/contact-form endpoint)

## Live-verified 2026-07-21

- OpenAPI schema → **200**
- `GET /api/contact` → **200** (reachable; POST body left unfired)

## Checklist

- [x] Changes exactly one file (append-only, +22 lines)
- [x] `authority: community`, `review.state: community-submitted`
- [x] `Closes #7084`
- [x] Single commit (one-shot)

## Validation

- [x] `npm run validate:surface -- registry/subnets/leadpoet.json`
- [x] `npx prettier --check registry/subnets/leadpoet.json`