### PR TITLE
fix(registry): SN114 SOMA auth-gated API parity append-only (#7125)

### DIFF
--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -210,6 +210,1294 @@
         "https://platform.thesoma.ai/openapi.json"
       ],
       "url": "https://platform.thesoma.ai/openapi.json"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-competition-timeframe-current",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend competition timeframe current",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/competition/timeframe/current on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/competition/timeframe/current"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-competition-competition-id-aggregate",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend competition competition id aggregate",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/competition/{competition_id}/aggregate on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/competition/%7Bcompetition_id%7D/aggregate"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-competitions-list",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend competitions-list",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/competitions-list on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Live-verified 2026-07-21: HTTP 403 for anonymous GET. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/competitions-list"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend miners comp id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend miners comp id hotkey",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey-competition",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend miners comp id hotkey competition",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey}/competition on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey-competition-challenges",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend miners comp id hotkey competition challenges",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey}/competition/challenges on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition/challenges"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey-screener",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend miners comp id hotkey screener",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey}/screener on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-comp-id-hotkey-screener-challenges",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend miners comp id hotkey screener challenges",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{comp_id}/{hotkey}/screener/challenges on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener/challenges"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-miners-hotkey-competition-challenges-batch-challenge-id",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend miners hotkey competition challenges batch challenge id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/miners/{hotkey}/competition/challenges/{batch_challenge_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bhotkey%7D/competition/challenges/%7Bbatch_challenge_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-summary",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend summary",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/summary on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Live-verified 2026-07-21: HTTP 403 for anonymous GET. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/summary"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend swe miners comp id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend swe miners comp id hotkey",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey-penalties",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend swe miners comp id hotkey penalties",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey}/penalties on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/penalties"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey-tasks",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend swe miners comp id hotkey tasks",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey}/tasks on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey-tasks-task-name",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend swe miners comp id hotkey tasks task name",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey}/tasks/{task_name} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-swe-miners-comp-id-hotkey-tasks-task-name-runs",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend swe miners comp id hotkey tasks task name runs",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/swe/miners/{comp_id}/{hotkey}/tasks/{task_name}/runs on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D/runs"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-frontend-validators",
+      "kind": "subnet-api",
+      "name": "SOMA api private frontend validators",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/private/frontend/validators on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/frontend/validators"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-incentives-competitions-competition-id-candidates",
+      "kind": "subnet-api",
+      "name": "SOMA api private incentives competitions competition id candidates",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /api/private/incentives/competitions/{competition_id}/candidates on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/incentives/competitions/%7Bcompetition_id%7D/candidates"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-incentives-top-miners-top-miner-id-approval",
+      "kind": "subnet-api",
+      "name": "SOMA api private incentives top-miners top miner id approval",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) PATCH /api/private/incentives/top-miners/{top_miner_id}/approval on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/incentives/top-miners/%7Btop_miner_id%7D/approval"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 403 (live-verified 2026-07-21 on sibling routes /api/private/frontend/summary and /api/private/frontend/competitions-list)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-private-sandbox-compact-bench-report",
+      "kind": "subnet-api",
+      "name": "SOMA api private sandbox compact-bench report",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /api/private/sandbox/compact-bench/report on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/private/* router/auth boundary as the verified sn-114-soma-api-private-frontend-summary (403). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/private/sandbox/compact-bench/report"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-competition-timeframe-current",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key competition timeframe current",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/competition/timeframe/current on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/competition/timeframe/current"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-competitions-list",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key competitions-list",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/competitions-list on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Live-verified 2026-07-21: HTTP 401 for anonymous GET. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/competitions-list"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key miners comp id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key miners comp id hotkey",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey-competition",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key miners comp id hotkey competition",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey}/competition on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey-competition-challenges",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key miners comp id hotkey competition challenges",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey}/competition/challenges on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition/challenges"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey-screener",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key miners comp id hotkey screener",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey}/screener on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-comp-id-hotkey-screener-challenges",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key miners comp id hotkey screener challenges",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{comp_id}/{hotkey}/screener/challenges on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener/challenges"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-miners-hotkey-competition-challenges-batch-challenge-id",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key miners hotkey competition challenges batch challenge id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/miners/{hotkey}/competition/challenges/{batch_challenge_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bhotkey%7D/competition/challenges/%7Bbatch_challenge_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-summary",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key summary",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/summary on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Live-verified 2026-07-21: HTTP 401 for anonymous GET. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/summary"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key swe miners comp id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key swe miners comp id hotkey",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey-penalties",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key swe miners comp id hotkey penalties",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey}/penalties on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/penalties"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey-tasks",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key swe miners comp id hotkey tasks",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey}/tasks on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey-tasks-task-name",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key swe miners comp id hotkey tasks task name",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey}/tasks/{task_name} on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-swe-miners-comp-id-hotkey-tasks-task-name-runs",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key swe miners comp id hotkey tasks task name runs",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/swe/miners/{comp_id}/{hotkey}/tasks/{task_name}/runs on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D/runs"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented -- the OpenAPI schema declares no security scheme for this path (a documentation gap on SOMA's side), but anonymous callers receive HTTP 401 despite the 'public/frontend-key' path prefix (live-verified 2026-07-21 on sibling routes /api/public/frontend-key/summary and /api/public/frontend-key/competitions-list). Requires a frontend-key credential."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-api-public-frontend-key-validators",
+      "kind": "subnet-api",
+      "name": "SOMA api public frontend-key validators",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /api/public/frontend-key/validators on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not individually curled at this volume (46 auth-gated operations) -- same /api/public/frontend-key/* router/auth boundary as the verified sn-114-soma-api-public-frontend-key-summary (401). Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/api/public/frontend-key/validators"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-miner-openrouter-key-add",
+      "kind": "subnet-api",
+      "name": "SOMA miner openrouter-key add",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /miner/openrouter-key/add on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/miner/openrouter-key/add"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-miner-openrouter-key-delete",
+      "kind": "subnet-api",
+      "name": "SOMA miner openrouter-key delete",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /miner/openrouter-key/delete on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/miner/openrouter-key/delete"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-miner-openrouter-key-update",
+      "kind": "subnet-api",
+      "name": "SOMA miner openrouter-key update",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /miner/openrouter-key/update on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/miner/openrouter-key/update"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-miner-upload",
+      "kind": "subnet-api",
+      "name": "SOMA miner upload",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /miner/upload on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/miner/upload"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-validator-get-best-miners",
+      "kind": "subnet-api",
+      "name": "SOMA validator get best miners",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /validator/get_best_miners on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/validator/get_best_miners"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-validator-get-swebench-validation",
+      "kind": "subnet-api",
+      "name": "SOMA validator get swebench validation",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /validator/get_swebench_validation on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/validator/get_swebench_validation"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-validator-register",
+      "kind": "subnet-api",
+      "name": "SOMA validator register",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /validator/register on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/validator/register"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Bittensor miner/validator protocol action -- the OpenAPI schema declares no security scheme, but these routes almost certainly require hotkey-signature or subnet credentials not expressed in OpenAPI security (not spot-verified individually; flagged in metagraphed#7125 for maintainer confirmation before Phase 3 credential passthrough)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-114-soma-validator-submit-swebench-validation-score",
+      "kind": "subnet-api",
+      "name": "SOMA validator submit swebench validation score",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) POST /validator/submit_swebench_validation_score on platform.thesoma.ai -- from the SN114 SOMA platform OpenAPI schema (sn-114-soma-openapi, 46 paths). Not spot-verified individually -- Bittensor miner/validator protocol writes flagged in metagraphed#7125 for maintainer confirmation of the actual hotkey-signature gate. Registered per the registry full-API-parity policy (metagraphed#7125 reopen) even though it is not callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://platform.thesoma.ai/openapi.json"
+      ],
+      "url": "https://platform.thesoma.ai/validator/submit_swebench_validation_score"
     }
   ],
   "website_url": "https://thesoma.ai/"

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -234,9 +234,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/competition/timeframe/current"
     },
     {
@@ -262,9 +260,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/competition/%7Bcompetition_id%7D/aggregate"
     },
     {
@@ -290,9 +286,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/competitions-list"
     },
     {
@@ -318,9 +312,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D"
     },
     {
@@ -346,9 +338,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
     },
     {
@@ -374,9 +364,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition"
     },
     {
@@ -402,9 +390,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition/challenges"
     },
     {
@@ -430,9 +416,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener"
     },
     {
@@ -458,9 +442,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener/challenges"
     },
     {
@@ -486,9 +468,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/miners/%7Bhotkey%7D/competition/challenges/%7Bbatch_challenge_id%7D"
     },
     {
@@ -514,9 +494,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/summary"
     },
     {
@@ -542,9 +520,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D"
     },
     {
@@ -570,9 +546,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
     },
     {
@@ -598,9 +572,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/penalties"
     },
     {
@@ -626,9 +598,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks"
     },
     {
@@ -654,9 +624,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D"
     },
     {
@@ -682,9 +650,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D/runs"
     },
     {
@@ -710,9 +676,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/frontend/validators"
     },
     {
@@ -738,9 +702,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/incentives/competitions/%7Bcompetition_id%7D/candidates"
     },
     {
@@ -766,9 +728,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/incentives/top-miners/%7Btop_miner_id%7D/approval"
     },
     {
@@ -794,9 +754,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/private/sandbox/compact-bench/report"
     },
     {
@@ -822,9 +780,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/competition/timeframe/current"
     },
     {
@@ -850,9 +806,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/competitions-list"
     },
     {
@@ -878,9 +832,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D"
     },
     {
@@ -906,9 +858,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
     },
     {
@@ -934,9 +884,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition"
     },
     {
@@ -962,9 +910,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/competition/challenges"
     },
     {
@@ -990,9 +936,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener"
     },
     {
@@ -1018,9 +962,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bcomp_id%7D/%7Bhotkey%7D/screener/challenges"
     },
     {
@@ -1046,9 +988,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/miners/%7Bhotkey%7D/competition/challenges/%7Bbatch_challenge_id%7D"
     },
     {
@@ -1074,9 +1014,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/summary"
     },
     {
@@ -1102,9 +1040,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D"
     },
     {
@@ -1130,9 +1066,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D"
     },
     {
@@ -1158,9 +1092,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/penalties"
     },
     {
@@ -1186,9 +1118,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks"
     },
     {
@@ -1214,9 +1144,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D"
     },
     {
@@ -1242,9 +1170,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/swe/miners/%7Bcomp_id%7D/%7Bhotkey%7D/tasks/%7Btask_name%7D/runs"
     },
     {
@@ -1270,9 +1196,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/api/public/frontend-key/validators"
     },
     {
@@ -1298,9 +1222,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/miner/openrouter-key/add"
     },
     {
@@ -1326,9 +1248,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/miner/openrouter-key/delete"
     },
     {
@@ -1354,9 +1274,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/miner/openrouter-key/update"
     },
     {
@@ -1382,9 +1300,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/miner/upload"
     },
     {
@@ -1410,9 +1326,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/validator/get_best_miners"
     },
     {
@@ -1438,9 +1352,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/validator/get_swebench_validation"
     },
     {
@@ -1466,9 +1378,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/validator/register"
     },
     {
@@ -1494,9 +1404,7 @@
         "state": "community-submitted",
         "submitted_by": "andriypolanski"
       },
-      "source_urls": [
-        "https://platform.thesoma.ai/openapi.json"
-      ],
+      "source_urls": ["https://platform.thesoma.ai/openapi.json"],
       "url": "https://platform.thesoma.ai/validator/submit_swebench_validation_score"
     }
   ],


### PR DESCRIPTION
## Summary

Resubmit for [#7125](https://github.com/JSONbored/metagraphed/issues/7125) after [#7475](https://github.com/JSONbored/metagraphed/pull/7475) closed. Registers all 46 auth-gated platform OpenAPI operations flagged in JSONbored's reopen comment.

Closes #7125

| Blocker | #7475 | This PR |
|---|---|---|
| `probe.method: GET` vs `name` stating POST/PATCH | Names included HTTP verbs | Names are path-only (e.g. `SOMA api private incentives competitions competition id candidates`); actual verb (GET/POST/PATCH) is in `notes` only; `probe.method` stays schema-valid `GET` with `probe.enabled: false` |
| Not a clean append | Edited `sn-114-soma-health` / `sn-114-soma-openapi` notes + reformatted existing arrays | **Pure append-only**: +1288 lines, 0 deletions on existing surfaces |

## Surfaces added (46)

All from `https://platform.thesoma.ai/openapi.json` with `auth_required:true`, `probe.enabled:false`, `public_safe:true`:

- 21 `/api/private/frontend/*` (+ incentives/sandbox writes) — 403 spot-checked on `summary` + `competitions-list`
- 17 `/api/public/frontend-key/*` — 401 spot-checked on `summary` + `competitions-list`
- 8 `/miner/*` + `/validator/*` protocol writes — registered per issue; hotkey-signature gate not individually spot-verified

Original callable surfaces unchanged; MCP verify test from #7311 still passes.

## Validation

- [x] `npm run validate:surface -- registry/subnets/soma.json`
- [x] `npx vitest run tests/sn114-call-subnet-surface-verify.test.mjs`
