### PR TITLE
fix(registry): SN65 TPN API parity (11 missing surfaces) (#7078)

### DIFF
--- a/registry/subnets/tao-private-network.json
+++ b/registry/subnets/tao-private-network.json
@@ -163,6 +163,306 @@
         "https://api.taoprivatenetwork.com/api-docs/openapi.json"
       ],
       "url": "https://api.taoprivatenetwork.com/api/v1/version"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "x-api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (apiKeyAuth), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-65-tpn-failover-config-new",
+      "kind": "subnet-api",
+      "name": "TPN failover config issuance",
+      "notes": "Generate Failover VPN Configuration operation on the TPN API (POST /failover/config/new), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares the apiKeyAuth security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/failover/config/new"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "x-api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (apiKeyAuth), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-65-tpn-failover-countries",
+      "kind": "subnet-api",
+      "name": "TPN failover country availability",
+      "notes": "Get Available Firehose Countries operation on the TPN API (GET /failover/countries), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares the apiKeyAuth security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET /failover/countries returns HTTP 401 'Unauthorized: API Key missing', confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/failover/countries"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "x-api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (apiKeyAuth), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-65-tpn-failover-health",
+      "kind": "subnet-api",
+      "name": "TPN failover health",
+      "notes": "Get Firehose Pool Health operation on the TPN API (GET /failover/health), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares the apiKeyAuth security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET /failover/health returns HTTP 401 'Unauthorized: API Key missing', confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/failover/health"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "x-api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (apiKeyAuth), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-65-tpn-proxy-generate",
+      "kind": "subnet-api",
+      "name": "TPN proxy config generation",
+      "notes": "Generate SOCKS5 Proxy Configuration operation on the TPN API (POST /proxy/generate), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares the apiKeyAuth security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/proxy/generate"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "x-api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (apiKeyAuth), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-65-tpn-user-balance",
+      "kind": "subnet-api",
+      "name": "TPN account balance",
+      "notes": "Get API Key Balance operation on the TPN API (GET /user/balance), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares the apiKeyAuth security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET /user/balance returns HTTP 401 'Unauthorized: API Key missing', confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/user/balance"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-tpn-vpn-cost",
+      "kind": "subnet-api",
+      "name": "TPN VPN cost quote",
+      "notes": "Calculate VPN Credit Cost operation on the TPN API (POST /vpn/cost), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares no security on it, but it is a state-changing POST and not probe-safe, so the probe is disabled.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/vpn/cost"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-tpn-vpn-countries",
+      "kind": "subnet-api",
+      "name": "TPN VPN country availability",
+      "notes": "Get Available VPN Countries operation on the TPN API (GET /vpn/countries), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares no security on it. Live-checked 2026-07-21: GET /vpn/countries returned HTTP 500 after roughly 50s (reproduced for both no-auth GET reporting routes), so the endpoint is documented but not currently serving; the probe is left disabled rather than asserting a working surface.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/vpn/countries"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "x-api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (apiKeyAuth), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-65-tpn-vpn-generate",
+      "kind": "subnet-api",
+      "name": "TPN VPN config generation",
+      "notes": "Generate WireGuard VPN Configuration operation on the TPN API (POST /vpn/generate), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares the apiKeyAuth security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/vpn/generate"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-tpn-vpn-stats",
+      "kind": "subnet-api",
+      "name": "TPN VPN network statistics",
+      "notes": "Get VPN Validator Statistics operation on the TPN API (GET /vpn/stats), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares no security on it. Live-checked 2026-07-21: GET /vpn/stats returned HTTP 500 after roughly 50s (reproduced for both no-auth GET reporting routes), so the endpoint is documented but not currently serving; the probe is left disabled rather than asserting a working surface.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/vpn/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-tpn-x402-proxy-generate",
+      "kind": "subnet-api",
+      "name": "TPN x402 proxy config generation",
+      "notes": "Generate SOCKS5 Proxy Configuration (x402) operation on the TPN API (POST /x402/proxy/generate), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares no security on it, but it is a state-changing POST and not probe-safe, so the probe is disabled.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/x402/proxy/generate"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-65-tpn-x402-vpn-generate",
+      "kind": "subnet-api",
+      "name": "TPN x402 VPN config generation",
+      "notes": "Generate WireGuard VPN Configuration (x402) operation on the TPN API (POST /x402/vpn/generate), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares no security on it, but it is a state-changing POST and not probe-safe, so the probe is disabled.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofu-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.taoprivatenetwork.com/api-docs/openapi.json"
+      ],
+      "url": "https://api.taoprivatenetwork.com/api/v1/x402/vpn/generate"
     }
   ],
   "website_url": "https://tpn.taofu.xyz/"


### PR DESCRIPTION
## Summary

Closes #7078.

Brings SN65 (TAO Private Network) up to **full subnet API parity** — the completeness bar in `.claude/skills/contributor-pipeline-gardening/SKILL.md`'s "MCP execute verify + wire SN*" special-sweep section. Same approach as SN37 Aurelius (#7466) and SN36 Eirel (#7465).

The already-registered `sn-65-taofu-labs-openapi` surface points at the TPN API's OpenAPI spec (13 paths, `servers: /api/v1`). Only `/health` and `/version` had registry entries; the other **11 had none**.

## What this adds

**6 auth-gated** (`apiKeyAuth` in the spec) → `auth_required: true`, `probe.enabled: false`, each with an `auth{}` object (`api-key` / `header` / `x-api-key`):
`/vpn/generate`, `/proxy/generate`, `/user/balance`, `/failover/countries`, `/failover/health`, `/failover/config/new`

Live-verified 2026-07-21 the gate is real, not schema-only:

| request | result |
|---|---|
| `GET /api/v1/user/balance` | **401** `Unauthorized: API Key missing` |
| `GET /api/v1/failover/countries` | **401** `Unauthorized: API Key missing` |
| `GET /api/v1/failover/health` | **401** `Unauthorized: API Key missing` |

**3 no-auth state-changing POSTs** → `auth_required: false`, probe disabled (not probe-safe):
`/x402/vpn/generate`, `/x402/proxy/generate`, `/vpn/cost`

**2 no-auth reporting GETs that are currently broken upstream** — worth flagging:

| request | result |
|---|---|
| `GET /api/v1/vpn/stats` | **500** after ~50s |
| `GET /api/v1/vpn/countries` | **500** after ~50s |

Both are documented in the spec but not currently serving (reproduced for both). They're registered with the probe **disabled** and the observation recorded in `notes`, rather than asserting a working surface or silently omitting them. `GET /api/v1/health` (already registered) still returns 200 `{"message":"OK!"}`, so this is specific to those two routes, not the host.

## Checklist

- [x] Changes exactly one `registry/subnets/tao-private-network.json` file (+300/−0, clean append)
- [x] Every added surface: `authority: community`, `review.state: community-submitted`, `public_safe: true`; no health/`verification` set by hand
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed, **no `auth_required` advisories**
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` (6 passed)
- [x] `npx vitest run tests/sn65-call-subnet-surface-verify.test.mjs` (9 passed — unaffected)
- [x] `npm run scan:public-safety` passed (no findings)
- [x] `provider` uses the already-registered `taofu-labs` slug
- [x] No other open PR references #7078
- [x] Rebased on latest `main`

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Gated ops become callable once Phase 3 credential passthrough (#7016) lands
- [ ] `/vpn/stats` + `/vpn/countries` worth re-probing later — if the upstream 500 clears, their probes can be enabled
