### PR TITLE
fix(registry): SN74 Gittensor full API parity (20 missing surfaces)

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -662,6 +662,446 @@
       },
       "source_urls": ["https://api.gittensor.io/swagger-json"],
       "url": "https://api.gittensor.io/configurations/general"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-dash-lines-hotkey",
+      "kind": "subnet-api",
+      "name": "Gittensor GET dash lines hotkey",
+      "notes": "GET /dash/lines/hotkey on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Required query params: hotkey. Live-verified 2026-07-21 with a real, valid value: HTTP 200. probe.enabled:false is the safer default here: an auto-probe with no query params would just error, misreporting the surface as down. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/lines/hotkey"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-miners-githubid",
+      "kind": "subnet-api",
+      "name": "Gittensor GET miners by githubId",
+      "notes": "GET /miners/{githubId} on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Live-verified 2026-07-21 with a real, valid value: HTTP 200. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/miners/%7BgithubId%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-miners-githubid-prs",
+      "kind": "subnet-api",
+      "name": "Gittensor GET miners by githubId prs",
+      "notes": "GET /miners/{githubId}/prs on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Live-verified 2026-07-21 with a real, valid value: HTTP 200. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/miners/%7BgithubId%7D/prs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-miners-githubid-github",
+      "kind": "subnet-api",
+      "name": "Gittensor GET miners by githubId github",
+      "notes": "GET /miners/{githubId}/github on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-repos-repo` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/miners/%7BgithubId%7D/github"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-miners-by-hotkey-hotkey-github",
+      "kind": "subnet-api",
+      "name": "Gittensor GET miners by hotkey by hotkey github",
+      "notes": "GET /miners/by-hotkey/{hotkey}/github on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-repos-repo` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/miners/by-hotkey/%7Bhotkey%7D/github"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-miners-by-github-id-githubid-hotkey",
+      "kind": "subnet-api",
+      "name": "Gittensor GET miners by github id by githubId hotkey",
+      "notes": "GET /miners/by-github-id/{githubId}/hotkey on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-repos-repo` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/miners/by-github-id/%7BgithubId%7D/hotkey"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-prs-details",
+      "kind": "subnet-api",
+      "name": "Gittensor GET prs details",
+      "notes": "GET /prs/details on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Required query params: repo, number. Live-verified 2026-07-21 with a real, valid value: HTTP 200. probe.enabled:false is the safer default here: an auto-probe with no query params would just error, misreporting the surface as down. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/prs/details"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-prs-comments",
+      "kind": "subnet-api",
+      "name": "Gittensor GET prs comments",
+      "notes": "GET /prs/comments on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Required query params: repo, number. Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-dash-lines-hotkey` sibling. probe.enabled:false is the safer default here: an auto-probe with no query params would just error, misreporting the surface as down. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/prs/comments"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-repo-impact",
+      "kind": "subnet-api",
+      "name": "Gittensor GET repos by repo impact",
+      "notes": "GET /repos/{repo}/impact on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Live-verified 2026-07-21 with a real, valid value: HTTP 200. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/%7Brepo%7D/impact"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-repo-prs",
+      "kind": "subnet-api",
+      "name": "Gittensor GET repos by repo prs",
+      "notes": "GET /repos/{repo}/prs on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-repos-repo` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/%7Brepo%7D/prs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-repo-badge-svg",
+      "kind": "subnet-api",
+      "name": "Gittensor GET repos by repo badge svg",
+      "notes": "GET /repos/{repo}/badge.svg on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Live-verified 2026-07-21 with a real, valid value: HTTP 200. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/%7Brepo%7D/badge.svg"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-repo",
+      "kind": "subnet-api",
+      "name": "Gittensor GET repos by repo",
+      "notes": "GET /repos/{repo} on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Live-verified 2026-07-21 with a real, valid value: HTTP 200. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/%7Brepo%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-repo-issues",
+      "kind": "subnet-api",
+      "name": "Gittensor GET repos by repo issues",
+      "notes": "GET /repos/{repo}/issues on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-repos-repo` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/%7Brepo%7D/issues"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-repo-maintainers",
+      "kind": "subnet-api",
+      "name": "Gittensor GET repos by repo maintainers",
+      "notes": "GET /repos/{repo}/maintainers on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-repos-repo` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/%7Brepo%7D/maintainers"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-repo-miners",
+      "kind": "subnet-api",
+      "name": "Gittensor GET repos by repo miners",
+      "notes": "GET /repos/{repo}/miners on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-repos-repo` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/%7Brepo%7D/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-og-image",
+      "kind": "subnet-api",
+      "name": "Gittensor GET og image",
+      "notes": "GET /og-image on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Required query params: type, id, repo, number. Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-dash-lines-hotkey` sibling. probe.enabled:false is the safer default here: an auto-probe with no query params would just error, misreporting the surface as down. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/og-image"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-issues-repo-repofullname-summary",
+      "kind": "subnet-api",
+      "name": "Gittensor GET issues repo by repoFullName summary",
+      "notes": "GET /issues/repo/{repoFullName}/summary on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Not individually curled — same no-auth, no-declared-security shape as the verified `sn-74-gittensor-repos-repo` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/issues/repo/%7BrepoFullName%7D/summary"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-issues-id",
+      "kind": "subnet-api",
+      "name": "Gittensor GET issues by id",
+      "notes": "GET /issues/{id} on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Live-verified 2026-07-21 with a real, valid value: HTTP 200. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/issues/%7Bid%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-issues-id-details",
+      "kind": "subnet-api",
+      "name": "Gittensor GET issues by id details",
+      "notes": "GET /issues/{id}/details on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Live-verified 2026-07-21 with a real, valid value: HTTP 200. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/issues/%7Bid%7D/details"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-issues-id-submissions",
+      "kind": "subnet-api",
+      "name": "Gittensor GET issues by id submissions",
+      "notes": "GET /issues/{id}/submissions on api.gittensor.io — public, no auth declared in the OpenAPI schema (Gittensor's whole public API is no-auth). Live-verified 2026-07-21 with a real, valid value: HTTP 200. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7087).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/issues/%7Bid%7D/submissions"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## Summary

Closes #7087. PR #7291 (already merged) touched the registry — but only tweaked `probe.expect` on 2 already-registered surfaces (`openapi`/`miners`, `any` → `json`) and closed the issue without adding any of the 20 additional endpoints the issue's own OpenAPI sweep found. Slightly different flavor of the pattern behind #7465/#7466/#7481/#7491/#7506 (a partial fix rather than zero registry changes), but the net effect is the same: the issue's actual full-API-parity ask was never delivered.

## What this adds (20 new surfaces)

Diffed the live OpenAPI spec (`https://api.gittensor.io/swagger-json`, 35 total paths) against the registry (15 already covered) → **20 missing paths**, independently re-derived and matching the issue's own count exactly. Unlike the last five subnets, Gittensor's entire public API is no-auth — no auth classification needed, purely a "register what's missing" pass.

**4 public, no-auth, required-query-param** (`probe.enabled:false`, registered with the fixed base url — already callable today via `call_subnet_surface`'s own `query` arg): `dash/lines/hotkey`, `prs/details`, `prs/comments`, `og-image`. Live-verified `dash/lines/hotkey` with a real hotkey (pulled from the already-registered `/miners` list): `200` → `66713`.

**16 public, no-auth, path-param** (`probe.enabled:false`, Phase 2): miner detail + PRs + GitHub link (3), miner↔hotkey lookups (2), repo detail + impact/PRs/issues/maintainers/miners/badge (7), issue detail + details/submissions + repo-summary (4). Live-verified 9 of the 16 with real values pulled from already-registered list endpoints (a real repo full-name from `/dash/repos`, a real `githubId` from `/miners`, a real issue `id` from `/issues`): all returned `200`.

## One divergence from the issue's own suggestion

The issue says `og-image` should get `probe.enabled:true` "same as the Targon precedent" despite needing 4 required query params (and 500ing without them). I looked for that precedent in `registry/subnets/targon.json` and couldn't find a matching case — nothing there has a required-query-param surface registered with `probe.enabled:true`. Per this issue family's own standing rule ("every claim... has to trace back to a request you actually made, don't guess"), I didn't carry forward a claim I couldn't verify. Registered `og-image` with `probe.enabled:false` instead, consistent with every other required-query-param surface across this whole series (#7465/#7466/#7481/#7491/#7506) — an auto-probe with no params would just error, misreporting the surface as down.

## Schema/tooling notes (same as the last five)
- Path-param URLs use the percent-encoded brace form (`%7Brepo%7D` etc.).
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`.
- `validate:surface` flags `gittensor.json` as a "pilot manifest" self-referential exemption (Gittensor/loopover being JSONbored's own product) — informational, not an error.

## Validation
- [x] `npm run validate:surface -- registry/subnets/gittensor.json` — 50 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2086 total surfaces, clean
- [x] `npx vitest run tests/sn74-call-subnet-surface-verify.test.mjs` — 14 passed (unchanged — already accurate)
- [x] `npm test` — full suite, clean
- [x] `npx prettier --check` — clean

Closes #7087
