### PR TITLE
fix(registry): SN94 Bitsota API parity (24 missing surfaces) (#7106)

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -440,6 +440,544 @@
       },
       "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
       "url": "https://autoresearch.bitsota.com/api/v1/disclaimer.md"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-claims-claim-id-cancel",
+      "kind": "subnet-api",
+      "name": "Bitsota claims claim id cancel",
+      "notes": "Cancel Claim Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/claims/{claim_id}/cancel), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {claim_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/claims/%7Bclaim_id%7D/cancel"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-planner-run",
+      "kind": "subnet-api",
+      "name": "Bitsota planner run",
+      "notes": "Planner Run Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/planner/run), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. The spec declares no security for it, but it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/planner/run"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-planner-run-agentic",
+      "kind": "subnet-api",
+      "name": "Bitsota planner run agentic",
+      "notes": "Agentic Planner Run Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/planner/run-agentic), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. The spec declares no security for it, but it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/planner/run-agentic"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "location": "header",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes, but this route empirically rejects an unauthenticated request (live-checked 2026-07-21). The header name and credential format are not documented in the spec, so only the location is asserted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-94-bitsota-reward-policy",
+      "kind": "subnet-api",
+      "name": "Bitsota reward policy",
+      "notes": "Reward Policy Route operation on the Bitsota autoresearch coordinator API (GET, PUT /api/v1/reward-policy), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated GET returns HTTP 401 {\"detail\":\"invalid admin token\"} -- so it is registered auth_required:true, correcting what the schema implies.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/reward-policy"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "location": "header",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes, but this route empirically rejects an unauthenticated request (live-checked 2026-07-21). The header name and credential format are not documented in the spec, so only the location is asserted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions",
+      "notes": "List Submissions Route operation on the Bitsota autoresearch coordinator API (GET, POST /api/v1/submissions), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated GET returns HTTP 401 {\"detail\":\"missing auth headers\"} -- so it is registered auth_required:true, correcting what the schema implies.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions-submission-id",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions submission id",
+      "notes": "Get Submission Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/submissions/{submission_id}), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {submission_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions/%7Bsubmission_id%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions-submission-id-artifact",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions submission id artifact",
+      "notes": "Submission Artifact Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/submissions/{submission_id}/artifact), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {submission_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions/%7Bsubmission_id%7D/artifact"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions-submission-id-detail",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions submission id detail",
+      "notes": "Get Submission Detail Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/submissions/{submission_id}/detail), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {submission_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions/%7Bsubmission_id%7D/detail"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions-submission-id-execution-log",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions submission id execution log",
+      "notes": "Submission Execution Log Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/submissions/{submission_id}/execution.log), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {submission_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions/%7Bsubmission_id%7D/execution.log"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions-submission-id-peer-consensus",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions submission id peer consensus",
+      "notes": "Peer Consensus Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/submissions/{submission_id}/peer-consensus), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {submission_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions/%7Bsubmission_id%7D/peer-consensus"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions-submission-id-peer-evaluate",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions submission id peer evaluate",
+      "notes": "Peer Evaluate Submission Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/submissions/{submission_id}/peer-evaluate), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {submission_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions/%7Bsubmission_id%7D/peer-evaluate"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions-submission-id-replay-log",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions submission id replay log",
+      "notes": "Submission Replay Log Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/submissions/{submission_id}/replay.log), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {submission_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions/%7Bsubmission_id%7D/replay.log"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-submissions-submission-id-verify",
+      "kind": "subnet-api",
+      "name": "Bitsota submissions submission id verify",
+      "notes": "Verify Submission Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/submissions/{submission_id}/verify), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {submission_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/submissions/%7Bsubmission_id%7D/verify"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-tasks-task-id",
+      "kind": "subnet-api",
+      "name": "Bitsota tasks task id",
+      "notes": "Get Task Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/tasks/{task_id}), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/tasks/%7Btask_id%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-tasks-task-id-best",
+      "kind": "subnet-api",
+      "name": "Bitsota tasks task id best",
+      "notes": "Best Result Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/tasks/{task_id}/best), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/tasks/%7Btask_id%7D/best"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-tasks-task-id-claim",
+      "kind": "subnet-api",
+      "name": "Bitsota tasks task id claim",
+      "notes": "Claim Task Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/tasks/{task_id}/claim), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/tasks/%7Btask_id%7D/claim"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-tasks-task-id-close",
+      "kind": "subnet-api",
+      "name": "Bitsota tasks task id close",
+      "notes": "Close Task Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/tasks/{task_id}/close), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/tasks/%7Btask_id%7D/close"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-tasks-task-id-onboard-md",
+      "kind": "subnet-api",
+      "name": "Bitsota tasks task id onboard md",
+      "notes": "Task Onboarding Route operation on the Bitsota autoresearch coordinator API (GET /api/v1/tasks/{task_id}/onboard.md), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/tasks/%7Btask_id%7D/onboard.md"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-tasks-task-id-pause",
+      "kind": "subnet-api",
+      "name": "Bitsota tasks task id pause",
+      "notes": "Pause Task Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/tasks/{task_id}/pause), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/tasks/%7Btask_id%7D/pause"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-tasks-task-id-resume",
+      "kind": "subnet-api",
+      "name": "Bitsota tasks task id resume",
+      "notes": "Resume Task Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/tasks/{task_id}/resume), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/tasks/%7Btask_id%7D/resume"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-validator-jobs-claim",
+      "kind": "subnet-api",
+      "name": "Bitsota validator jobs claim",
+      "notes": "Claim Validator Job Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/validator/jobs/claim), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. The spec declares no security for it, but it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/validator/jobs/claim"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-validator-jobs-job-id-result",
+      "kind": "subnet-api",
+      "name": "Bitsota validator jobs job id result",
+      "notes": "Submit Validator Job Result Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/validator/jobs/{job_id}/result), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {job_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/validator/jobs/%7Bjob_id%7D/result"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-validator-submissions-scan",
+      "kind": "subnet-api",
+      "name": "Bitsota validator submissions scan",
+      "notes": "Scan Validator Submissions Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/validator/submissions/scan), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. The spec declares no security for it, but it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/validator/submissions/scan"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-work-items-work-item-id-claim",
+      "kind": "subnet-api",
+      "name": "Bitsota work items work item id claim",
+      "notes": "Claim Work Item Route operation on the Bitsota autoresearch coordinator API (POST /api/v1/work-items/{work_item_id}/claim), declared in the subnet's own OpenAPI spec at https://autoresearch.bitsota.com/openapi.json. Path-parameterized on {work_item_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2). The spec declares no security for it; the fixed sibling collection route on this host does reject unauthenticated reads, so it may also be gated -- not asserted here because confirming it needs a valid identifier.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/work-items/%7Bwork_item_id%7D/claim"
     }
   ],
   "website_url": "https://bitsota.ai/"


### PR DESCRIPTION
## Summary

Closes #7106.

Brings SN94 (Bitsota) up to **full subnet API parity** — the completeness bar in `.claude/skills/contributor-pipeline-gardening/SKILL.md`'s "MCP execute verify + wire SN*" special-sweep section. Same approach as SN50 Synth (#7506), SN37 Aurelius (#7466) and my SN118 Ditto (#7492) / SN33 ReadyAI (#7502) / SN65 TPN (#7522).

The already-registered `sn-94-alveus-labs-openapi` surface points at the autoresearch coordinator's OpenAPI spec (**37 paths**). 13 had registry entries; the other **24 had none**.

## The correction

The spec declares **no `securitySchemes` and no per-operation `security` at all** — which reads as "everything is open." That isn't accurate. Live-verified 2026-07-21:

| request | result |
|---|---|
| `GET /api/v1/submissions` | **401** `{"detail":"missing auth headers"}` |
| `GET /api/v1/reward-policy` | **401** `{"detail":"invalid admin token"}` |
| `GET /healthz` (already registered) | 200 `{"status":"ok"}` — unchanged |
| `GET /api/v1/tasks` (already registered) | 200 task list — unchanged |

Both gated routes are registered `auth_required: true` with an `auth{}` object recording the **header** location, correcting what the schema implies. The header *name* and credential format aren't documented anywhere in the spec, so I assert only the location (`scheme: custom`) rather than guessing.

## The other 22

Path-parameterized reads (percent-encoded `{param}` templates, matching SN37 Aurelius's encoding) and state-changing POSTs. All `probe.enabled: false`.

I deliberately did **not** mark these `auth_required: true` by inference. Their fixed sibling collection route *does* reject unauthenticated reads, so they may well be gated too — each such entry's `notes` records that observation and flags that confirming it needs a valid identifier. Every auth claim in this PR traces to a request I actually made.

## Checklist

- [x] Changes exactly one `registry/subnets/bitsota.json` file (+538/−0, clean append)
- [x] Every added surface: `authority: community`, `review.state: community-submitted`, `public_safe: true`; no health/`verification` set by hand
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed (1478 surfaces / 129 files), **no `auth_required` advisories**
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` (6 passed)
- [x] `npx vitest run tests/bitsota-call-subnet-surface-verify.test.mjs` (3 passed — unaffected)
- [x] `npm run scan:public-safety` passed (no bitsota findings)
- [x] README catalog unchanged (subnet count is the same)
- [x] `provider` uses the already-registered `alveus-labs` slug
- [x] No other open PR references #7106
- [x] Rebased on latest `main`

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] The two gated routes become callable once Phase 3 credential passthrough (#7016) lands
- [ ] Worth re-checking the `{submission_id}`/`{task_id}` reads with a real identifier to confirm whether they share the collection route's auth gate
