### PR TITLE
fix(registry): wire SN14 Cacheon MCP execute probe config (#7030)

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -194,7 +194,13 @@
       "id": "sn-14-cacheon-leader-api",
       "kind": "subnet-api",
       "name": "Cacheon current leader API",
-      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data.",
+      "notes": "Public no-auth GET returning the reigning challenger leader record (UID, score, image, per-prompt stats). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader); same host as the existing /api/status subnet-api surface. Distinct functional endpoint with substantive coordinator data. Live-verified 2026-07-22: HTTP 200 application/json (~0.8 KB), leader record with uid, hotkey, commit_block, score, image, per-prompt stats.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -213,7 +219,13 @@
       "id": "sn-14-cacheon-health",
       "kind": "subnet-api",
       "name": "Cacheon API health",
-      "notes": "Public no-auth GET /api/health on api.cacheon.ai returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /api/health in the subnet OpenAPI spec on the same host as the existing /api/status and /api/leader subnet-api surfaces.",
+      "notes": "Public no-auth GET /api/health on api.cacheon.ai returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /api/health in the subnet OpenAPI spec on the same host as the existing /api/status and /api/leader subnet-api surfaces. Live-verified 2026-07-22: HTTP 200 application/json, body {\"status\":\"ok\"}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -232,7 +244,13 @@
       "id": "sn-14-cacheon-rounds-api",
       "kind": "subnet-api",
       "name": "Cacheon evaluation rounds API",
-      "notes": "Public no-auth GET returning evaluation round history with challenger counts, scores, speed improvement, and per-round evaluation metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/rounds); same host as the existing /api/status and /api/leader subnet-api surfaces.",
+      "notes": "Public no-auth GET returning evaluation round history with challenger counts, scores, speed improvement, and per-round evaluation metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/rounds); same host as the existing /api/status and /api/leader subnet-api surfaces. Live-verified 2026-07-22: HTTP 200 application/json (~95 KB), rounds[] with evaluation_block, evaluated_at, challenger entries and scores.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {
@@ -251,7 +269,13 @@
       "id": "sn-14-cacheon-leader-history-api",
       "kind": "subnet-api",
       "name": "Cacheon leader overtake history API",
-      "notes": "Public no-auth GET returning leader overtake history with timestamps, blocks, leader UID, scores, and image metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader/history); same host as the existing /api/status, /api/leader, and /api/rounds subnet-api surfaces.",
+      "notes": "Public no-auth GET returning leader overtake history with timestamps, blocks, leader UID, scores, and image metadata. Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, path /api/leader/history); same host as the existing /api/status, /api/leader, and /api/rounds subnet-api surfaces. Live-verified 2026-07-22: HTTP 200 application/json (~24 KB), history[] of leader overtakes with ts, block, new_leader_uid, new_leader_hotkey.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "cacheon",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Prepare SN14 (Cacheon) for MCP execute (`call_subnet_surface`, #7013) by adding the missing `probe` config on the four subnet-api surfaces that lacked it, and live-verifying all ten issue-scoped endpoints return real JSON.

Closes #7030

## Surfaces verified (live 2026-07-22, direct GET against each URL)

| surface_id | status | response |
|---|---|---|
| sn-14-cacheon-openapi | 200 | OpenAPI 3.1 JSON, title "Cacheon Monitoring API" (~8 KB) |
| sn-14-cacheon-subnet-api | 200 | JSON coordinator status: leader_uid, leader_score, leader_image (~270 B) |
| sn-14-cacheon-leader-api | 200 | JSON leader record: uid, hotkey, commit_block, score, image, per-prompt stats (~0.8 KB) |
| sn-14-cacheon-health | 200 | JSON `{"status":"ok"}` |
| sn-14-cacheon-rounds-api | 200 | JSON rounds[] with evaluation_block, evaluated_at, challenger scores (~95 KB) |
| sn-14-cacheon-leader-history-api | 200 | JSON history[] of leader overtakes: ts, block, new_leader_uid, new_leader_hotkey (~24 KB) |
| sn-14-cacheon-evaluations | 200 | JSON evaluations[]: uid, hotkey, commit_block, image (~330 KB) |
| sn-14-cacheon-eval-progress | 200 | JSON live round progress: status, phase, round_block (~2.4 KB) |
| sn-14-cacheon-validator-logs | 200 | JSON logs[] of GPU log files with label, filename, size (~9.4 KB) |
| sn-14-cacheon-eval-job | 200 | JSON current eval job: block, block_hash (~1.3 KB) |

## Registry changes

- **sn-14-cacheon-leader-api**: add probe (GET, expect: json) — was missing
- **sn-14-cacheon-health**: add probe (GET, expect: json) — was missing
- **sn-14-cacheon-rounds-api**: add probe (GET, expect: json) — was missing
- **sn-14-cacheon-leader-history-api**: add probe (GET, expect: json) — was missing

All four are community-submitted surfaces predating probe config being expected on callable surfaces; their six siblings on the same host (api.cacheon.ai) already carry the identical `{enabled, method: GET, expect: json, timeout_ms: 10000}` shape, so this closes the gap consistently within the one subnet file. Each wired surface's notes gain a dated `Live-verified 2026-07-22: …` line recording the observed status, content type, and response shape. The other six issue-scoped surfaces already had correct probe config and required no edits.

## Checklist

- [x] Changes exactly one `registry/subnets/cacheon.json` file
- [x] `npm run validate:surface -- registry/subnets/cacheon.json` passed (15 surfaces)
- [x] All ten issue-scoped surfaces live-probed with direct GETs; every claim above traces to a request actually made
- [x] No health/`verification` fields touched (probe config + notes only)

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] Post-merge: each wired surface resolvable through `call_subnet_surface` (prefer health/leader over evaluations for smoke tests — the evaluations payload is ~330 KB)
