### PR TITLE
build(typescript): add tsconfig, typecheck CI gate, and TS eslint support

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -288,6 +288,7 @@ in the contributor PR.
 ```sh
 git diff --check
 npm run lint && npm run format:check        # NOTE: main isn't fully prettier-clean — never reformat whole files you didn't change
+npm run typecheck                           # tsc --noEmit, whole in-scope tree (src/workers/scripts/tests)
 npm run validate                            # registry + API + OpenAPI checks
 npm test                                    # or: npm run test:coverage for the coverage gate
 # Then the focused validators for what you touched (full list in reference.md), e.g.:
@@ -558,7 +559,7 @@ confidence — this is a deliberate exception to the normal one-shot autonomous 
       deploy/publish-pipeline-owned, not contract artifacts). Revert them against your base remote
       (the Phase B3 command above) before committing if `npm run build` touched them. `npm run build`
       itself warns you if either changed.
-- [ ] `git diff --check` clean · `lint` + `format:check` clean · `npm run validate` green ·
+- [ ] `git diff --check` clean · `lint` + `format:check` + `typecheck` clean · `npm run validate` green ·
       `npm run test:coverage` green · the focused `validate:*` for what you touched green.
 - [ ] Branch current with `main`; Conventional Commit (no AI attribution); PR template filled; `Closes #<issue>` — required, referencing an issue that's still open.
 

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -129,7 +129,8 @@ touch registry data, schemas, code, or CI config; a non-`.md` file anywhere, inc
 future non-`.md` file under `.claude/skills/`, disqualifies the whole PR), the `changes` job sets
 `docs_only=true` and `checks` skips only its build/contract/registry/deploy-dry-run steps via a
 **per-step** `if: env.DOCS_ONLY != 'true'` guard — never a job-level skip, so `checks` always reports
-a real `success`/`failure` conclusion, never `skipped`. `Lint + format`, `validate:docs`,
+a real `success`/`failure` conclusion, never `skipped`. `Lint + format`, `Typecheck` (`tsc --noEmit`,
+added by the TypeScript migration, metagraphed#7510), `validate:docs`,
 `validate:intake`, `scan:public-safety`, and `validate:private-boundary` still run
 unconditionally on every PR, docs-only or not — they're cheap (no build, no network) and are
 exactly what a stray secret, private-boundary leak, or broken doc-contract reference in a
@@ -166,7 +167,8 @@ no per-subject directory structure (all 154 files sit flat in `tests/`), a third
 for a filesystem-race reason (see below) unrelated to subject area — splitting by area would need a
 real test-tree/module-boundary refactor, not a CI config change.
 
-**Gates (all must pass):** `lint` · `format:check` · `validate:contract-drift` ·
+**Gates (all must pass):** `lint` · `format:check` · `typecheck` (`tsc --noEmit`, whole-tree, not
+diff-scoped — reads `tsconfig.json`'s own `include`/`exclude`) · `validate:contract-drift` ·
 `validate:schema-enums` · `validate:openapi-examples` · `validate:generated-client` ·
 `validate:committed-seed` · `npm run build` · committed-derived-artifact freshness (working tree clean
 under `public/` after a fresh build — only CONTRACT artifacts are gated; DATA/CONTENT-derived artifacts
@@ -231,6 +233,7 @@ The gate's private scoring rubric/thresholds must **never** appear in this repo 
 | Validate a surface contribution _(new)_   | `npm run validate:surface -- registry/subnets/<slug>.json`                                                                                                                                                                                                  |
 | Public-safety scan                        | `npm run scan:public-safety`                                                                                                                                                                                                                                |
 | Code/schema: regenerate the contract      | `npm run build`                                                                                                                                                                                                                                             |
+| Code/schema: typecheck _(new)_            | `npm run typecheck` (`tsc --noEmit`; `src/`+`workers/`+`scripts/`+`tests/` are still mostly `.mjs` — see the TypeScript migration epic, metagraphed#7510)                                                                                                   |
 | Code/schema: validators                   | `npm run validate` · `validate:schemas` · `validate:api` · `validate:openapi` · `validate:types` · `validate:contract-drift` · `validate:mcp` · `validate:ai` · `validate:docs` · `validate:intake` · `validate:workflows`                                  |
 | Tests / coverage                          | `npm test` · `npm run test:coverage`                                                                                                                                                                                                                        |
 | Full local pipeline (after a clean build) | `npm run pipeline:check`                                                                                                                                                                                                                                    |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -440,6 +440,15 @@ jobs:
           npm run lint
           npm run format:check
 
+      # Same class of check as Lint + format above: cheap, no build, no network
+      # — runs unconditionally rather than gating on DOCS_ONLY since a real
+      # docs-only diff can't touch a .ts file anyway (see typescript-migration
+      # epic metagraphed#7510). tsc reads tsconfig.json's own include/exclude,
+      # not the file list — this typechecks the whole in-scope tree every run,
+      # not just files this PR touched.
+      - name: Typecheck
+        run: npm run typecheck
+
       # Drift gate: these compare the COMMITTED contract (openapi.json, the schema
       # bundle, generated types + client) against what the schemas regenerate, so
       # they MUST run before the build step below overwrites those committed files.

--- a/docs/typescript-migration-checklist.md
+++ b/docs/typescript-migration-checklist.md
@@ -1,0 +1,29 @@
+# TypeScript migration — per-file conversion checklist
+
+Canonical checklist for the TypeScript migration tracked at
+[#7510](https://github.com/JSONbored/metagraphed/issues/7510). Every phase issue under that epic
+links here instead of restating this list — if a step here turns out to be wrong or incomplete once
+exercised on real files, fix it here (and explain the change in the PR that found the gap), don't
+fork a divergent copy in an issue body.
+
+For every file in a batch:
+
+1. `git mv <file>.mjs <file>.ts` — never copy+delete, preserve history.
+2. Fix every relative import specifier repo-wide that pointed at the old filename, from `./foo.mjs`
+   to `./foo.js` (TypeScript+NodeNext convention: the import specifier keeps a `.js`-shaped extension
+   even though the source file is now `.ts` — never use `.ts` in an import specifier). Check dynamic
+   `import()` calls too, not just static `import`/`export from`.
+3. Add real type annotations for every exported function's parameters/return type and every exported
+   constant's shape. Do not just rename-and-ship untyped. Module-local helpers can rely on inference
+   where TS already infers correctly.
+4. Replace any JSDoc `@param`/`@type`/`@typedef` blocks with real TS types/interfaces and delete the
+   JSDoc.
+5. Where a shape already exists in the generated OpenAPI types (`packages/contract`,
+   `public/metagraph/types.d.ts`), import and reuse it — do not hand-redeclare it.
+6. `npx tsc --noEmit` must be clean for the file. No `any` / `@ts-ignore` / `@ts-expect-error` without
+   an inline comment explaining the specific reason (e.g. a genuinely untyped third-party import).
+7. Confirm the file is covered by `vitest.config.mjs`'s `coverage.include` (widened to `.{mjs,ts}`
+   repo-wide in #7511, so after that PR this is a verification step, not an edit).
+8. Run `npm run lint`, `npm run typecheck`, `npm run test:coverage`, and `npm run validate:types`
+   locally — all must stay green, and the file's own coverage % must not regress.
+9. Do not touch any file outside the batch's explicit list in the same PR.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,39 @@
 import js from "@eslint/js";
+import tseslint from "typescript-eslint";
 
-export default [
+const runtimeGlobals = {
+  AbortController: "readonly",
+  AbortSignal: "readonly",
+  Blob: "readonly",
+  Buffer: "readonly",
+  CompressionStream: "readonly",
+  CountQueuingStrategy: "readonly",
+  Headers: "readonly",
+  ReadableStream: "readonly",
+  Request: "readonly",
+  Response: "readonly",
+  URL: "readonly",
+  URLSearchParams: "readonly",
+  atob: "readonly",
+  btoa: "readonly",
+  console: "readonly",
+  crypto: "readonly",
+  fetch: "readonly",
+  globalThis: "readonly",
+  performance: "readonly",
+  process: "readonly",
+  setTimeout: "readonly",
+  clearTimeout: "readonly",
+  setInterval: "readonly",
+  clearInterval: "readonly",
+  TextDecoder: "readonly",
+  TextEncoder: "readonly",
+  WebSocket: "readonly",
+  WebSocketPair: "readonly",
+  structuredClone: "readonly",
+};
+
+export default tseslint.config(
   {
     ignores: [
       "node_modules/**",
@@ -11,6 +44,12 @@ export default [
       // this repo's root config has no TSX/JSX parser wired in and would just
       // error on syntax it can't parse, not meaningfully lint it.
       "apps/ui/**",
+      // packages/ui-kit has its own eslint.config.js + tsconfig.json; packages/client
+      // has its own tsconfig.json. Linting either from here creates a multi-root
+      // tsconfig ambiguity for the TS parser (typescript-eslint can't tell which
+      // tsconfig.json is authoritative for a file under two candidate roots).
+      "packages/client/**",
+      "packages/ui-kit/**",
       "public/metagraph/**",
       "registry/candidates/generated/**",
       "registry/subnets/generated/**",
@@ -27,37 +66,7 @@ export default [
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
-      globals: {
-        AbortController: "readonly",
-        AbortSignal: "readonly",
-        Blob: "readonly",
-        Buffer: "readonly",
-        CompressionStream: "readonly",
-        CountQueuingStrategy: "readonly",
-        Headers: "readonly",
-        ReadableStream: "readonly",
-        Request: "readonly",
-        Response: "readonly",
-        URL: "readonly",
-        URLSearchParams: "readonly",
-        atob: "readonly",
-        btoa: "readonly",
-        console: "readonly",
-        crypto: "readonly",
-        fetch: "readonly",
-        globalThis: "readonly",
-        performance: "readonly",
-        process: "readonly",
-        setTimeout: "readonly",
-        clearTimeout: "readonly",
-        setInterval: "readonly",
-        clearInterval: "readonly",
-        TextDecoder: "readonly",
-        TextEncoder: "readonly",
-        WebSocket: "readonly",
-        WebSocketPair: "readonly",
-        structuredClone: "readonly",
-      },
+      globals: runtimeGlobals,
     },
     rules: {
       "no-unused-vars": [
@@ -66,4 +75,17 @@ export default [
       ],
     },
   },
-];
+  {
+    files: ["**/*.ts"],
+    extends: [tseslint.configs.recommended],
+    languageOptions: {
+      globals: runtimeGlobals,
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "workers-og": "^0.0.27"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260721.1",
         "@eslint/js": "^10.0.1",
         "@sentry/cli": "^3.6.0",
         "@vitest/coverage-v8": "^4.1.10",
@@ -39,6 +40,8 @@
         "eslint": "^10.7.0",
         "openapi-typescript": "^7.13.0",
         "prettier": "^3.9.5",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.65.0",
         "vite": "^7.3.6",
         "vitest": "^4.1.10",
         "wrangler": "4.111.0"
@@ -49,7 +52,7 @@
     },
     "apps/ui": {
       "name": "metagraphed-ui",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -1115,6 +1118,13 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.8.2.tgz",
       "integrity": "sha512-Pho5qWDl4qj1STI5QYMQfPmJBBkxyrFpXyDl9BrtYOfWHxThabEzdi9p3ezS2cUkbjA0E6L5ki/kq2pcbRUtlg==",
       "license": "MIT"
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260721.1.tgz",
+      "integrity": "sha512-J6HZRuQOP3gVe9G5rxHQVS8kQRjo7NIaF+Lz4kO2lVmaCkQ1E78APOOthaI7KyCQzp+A2NbXBQI6QLRIswdWbA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -8208,17 +8218,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -8231,15 +8241,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8247,16 +8257,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -8272,14 +8282,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -8294,14 +8304,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8312,9 +8322,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8329,15 +8339,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -8354,9 +8364,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8368,16 +8378,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -8396,16 +8406,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8420,13 +8430,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -15821,16 +15831,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
-      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.64.0",
-        "@typescript-eslint/parser": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -16925,7 +16935,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "smoke:live": "node scripts/smoke-live-api.mjs",
     "lint": "eslint .",
     "format:check": "prettier --check .",
-    "check": "npm run lint && npm run format:check && npm run pipeline:check && npm run validate:docs",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run lint && npm run format:check && npm run typecheck && npm run pipeline:check && npm run validate:docs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:ci": "vitest run --coverage --fileParallelism --testTimeout=30000 --exclude '**/artifacts.test.mjs' --exclude '**/discovery-artifacts.test.mjs' --exclude '**/public-safety.test.mjs' --exclude '**/validate-error-messages.test.mjs' --exclude '**/refresh-build-summary.test.mjs'",
@@ -142,6 +143,7 @@
     "workers-og": "^0.0.27"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260721.1",
     "@eslint/js": "^10.0.1",
     "@sentry/cli": "^3.6.0",
     "@vitest/coverage-v8": "^4.1.10",
@@ -150,6 +152,8 @@
     "eslint": "^10.7.0",
     "openapi-typescript": "^7.13.0",
     "prettier": "^3.9.5",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.65.0",
     "vite": "^7.3.6",
     "vitest": "^4.1.10",
     "wrangler": "4.111.0"

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -9,7 +9,7 @@ import {
   metagraphedFetch,
   metagraphedPaginate,
   metagraphedRpc,
-} from "../generated/metagraphed-client";
+} from "../generated/metagraphed-client.js";
 
 function stubFetch(
   impl: (url: URL, init: RequestInit) => Promise<Response>,
@@ -207,7 +207,7 @@ describe("metagraphedRpc", () => {
 
 describe("createMetagraphedClient", () => {
   test("convenience methods build typed paths + queries", async () => {
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (_url: URL, _init?: RequestInit) =>
       jsonResponse({ ok: true, data: { netuid: 7 }, meta: {} }),
     );
     const client = createMetagraphedClient({
@@ -407,7 +407,9 @@ describe("createMetagraphedClient", () => {
       },
     ];
     let index = 0;
-    const fetchMock = vi.fn(async () => jsonResponse(pages[index++]));
+    const fetchMock = vi.fn(async (_url: URL, _init?: RequestInit) =>
+      jsonResponse(pages[index++]),
+    );
     const client = createMetagraphedClient({
       fetch: fetchMock as unknown as typeof fetch,
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "workers/**/*", "scripts/**/*", "tests/**/*"],
+  "exclude": [
+    "node_modules",
+    "apps/ui",
+    "packages/*/node_modules",
+    "packages/*/dist",
+    "deploy/**"
+  ]
+}

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -86,11 +86,15 @@ export default defineConfig({
       // listed file-by-file here rather than via `scripts/lib/**/*.mjs`: a future
       // module dropped into that directory without a dedicated test would
       // otherwise be auto-measured and trip the floors below.
+      // .{mjs,ts} everywhere below: the TypeScript migration (metagraphed#7510)
+      // converts these files to .ts in place over time, and a renamed file must
+      // stay measured -- an .mjs-only glob would silently drop it from coverage
+      // the moment it's renamed, rather than failing loud.
       include: [
-        "src/**/*.mjs",
-        "workers/**/*.mjs",
-        "scripts/{artifact-budgets,lib,openapi-components,registry-identity}.mjs",
-        "scripts/lib/{build-readiness,economics-artifacts,endpoint-artifacts,enrichment-queue-artifacts,formatting,readme-links}.mjs",
+        "src/**/*.{mjs,ts}",
+        "workers/**/*.{mjs,ts}",
+        "scripts/{artifact-budgets,lib,openapi-components,registry-identity}.{mjs,ts}",
+        "scripts/lib/{build-readiness,economics-artifacts,endpoint-artifacts,enrichment-queue-artifacts,formatting,readme-links}.{mjs,ts}",
       ],
       // The workers/*.sentry.mjs deploy-entry wrappers (metagraphed#6479;
       // currently data-api.sentry.mjs + registry-sync-api.sentry.mjs --
@@ -108,7 +112,7 @@ export default defineConfig({
       // it wraps (workers/data-api.mjs, workers/registry-sync-api.mjs) is
       // unaffected and stays fully covered as before -- these tests were
       // never routed through the wrapper.
-      exclude: ["workers/*.sentry.mjs"],
+      exclude: ["workers/*.sentry.{mjs,ts}"],
       // BACKSTOP floors only — NOT the primary gate. The real PR coverage gate is
       // Codecov (delta-based project + patch coverage, see codecov.yml). That
       // avoids the fixed-pin churn where every PR must match a near-peak absolute


### PR DESCRIPTION
## Summary

- Foundational, zero-file-renamed tooling PR for the TypeScript migration (#7510): root `tsconfig.json`, `typescript` devDependency, a `typecheck` CI gate, TS-aware root ESLint, and a widened Vitest coverage glob so a future `.mjs` → `.ts` rename can never silently drop out of coverage.

## What Changed

- Added root `tsconfig.json`: `NodeNext`/`NodeNext` module resolution (matches this repo's native-ESM `"type": "module"` and the fact that `src/`/`workers/`/`scripts/`/`tests/` run directly under Node or Wrangler's bundler, not through a separate emit step), `target: "ES2023"`, `strict: true`, `allowJs`/`checkJs: false` so `.ts` and the remaining `.mjs` can coexist during the transition, `noEmit: true`. Scoped to `src/`, `workers/`, `scripts/`, `tests/`; excludes `apps/ui` and `packages/*` (those keep their own existing `tsconfig.json`s) and `deploy/**` (not a root workspace member — gets its own tsconfig when its phase lands).
- Added `typescript@^5.9.3` (matching the version already pinned in `apps/ui`/`packages/client`/`packages/ui-kit`) and `@cloudflare/workers-types@^5.20260721.1` as root devDependencies. The latter isn't in the original issue's deliverable list — added it now because without it, `workers/` conversion (the next phase) would have no real types for `Request`/`Response`/KV/D1/R2 bindings and would need a disruptive follow-up fix later.
- Added `"typecheck": "tsc --noEmit"` to `package.json` and a new unconditional `Typecheck` step in the `checks` CI job (`.github/workflows/validate.yml`), placed next to `Lint + format` since it's the same class of check (cheap, no build, no network).
- Added a `files: ["**/*.ts"]` block to `eslint.config.mjs` using `typescript-eslint`'s recommended config (added `typescript-eslint@^8.65.0`), with the same `^_`-ignore unused-vars convention already used for `.mjs`. Extracted the shared runtime globals into one `runtimeGlobals` constant reused by both the `.mjs` and `.ts` blocks instead of duplicating the object. Also had to add `packages/client/**` and `packages/ui-kit/**` to the root `ignores` list (alongside the existing `apps/ui/**` entry) — both have their own `tsconfig.json`, and linting them from the root config hit a real "multiple candidate TSConfigRootDirs" parser error; they're independently linted via their own `eslint.config.js`/`npm run lint --workspace=...` already.
- Widened `vitest.config.mjs`'s `coverage.include`/`coverage.exclude` globs from `.mjs` to `.{mjs,ts}` — this is the one gate that actually matters for this migration (see #7510): an extension-specific glob means a file silently drops out of coverage the moment it's renamed, rather than failing loud. Verified `test:ci` + `test:ci:artifacts` coverage output is unchanged (98.97% statements / 97.67% branches, matching this repo's documented ~98%/~90% baseline) since zero `.ts` files exist in the covered scope yet.
- Added `docs/typescript-migration-checklist.md` — the canonical per-file conversion checklist every phase issue under #7510 links to instead of restating.
- Fixed 3 pre-existing type errors in `tests/client-sdk.test.ts` (the one file that was already `.ts` before this PR, and had therefore never been type-checked by anything): a missing `.js` extension on a relative import (required under `NodeNext` resolution), and two `vi.fn()` mocks declared with no parameters whose `.mock.calls[N][0]` was still indexed as a `URL` — typed the mocks' parameters explicitly, matching the pattern already used elsewhere in the same file (`stubFetch`'s `(url: URL, init: RequestInit)`). All 27 tests in that file still pass.
- Updated `.claude/skills/metagraphed/SKILL.md` and `reference.md` (Phase B4 command list, the pre-push checklist, the docs-only-lane unconditional-steps list, the "Gates (all must pass)" line, and the npm-scripts table) to document the new `typecheck` gate — this repo's CLAUDE.md/AGENTS.md requires the skill stay current with the actual contributor flow.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7511`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (`public/metagraph/operational-surfaces.json` and `public/metagraph/r2-manifest.json` changed under a local `npm run build` for reasons unrelated to this PR — both reverted against `origin/main` before committing, per the skill's documented deploy-owned-artifact handling.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — this PR is tooling-only, zero `.mjs`/`.js` files renamed.)

## Validation

- [ ] `npm run check` — left unchecked: this composite includes `pipeline:check`, whose
      `r2:manifest:dry-run` sub-step fails locally with `"r2 compact manifest is stale"`
      (`expected_full_artifact_count: 1813` vs `actual_full_artifact_count: 2261`). Verified this is
      **pre-existing and unrelated to this PR** — it reproduces identically on a clean, unmodified
      `origin/main` checkout (confirmed via `git stash` + direct run before writing this PR). It's a
      local-environment artifact-count drift against real R2 bucket state that a sandboxed local
      checkout can't reflect, not something CI's actual `checks` job hits — that job runs
      `npm run r2:manifest` (write mode, not `--dry-run`) on a fresh checkout, a different code path.
      Every individual command `check` composes — `lint`, `format:check`, `typecheck`,
      `validate:docs` — was run directly and is green; see below.
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage` (via `test:ci` + `test:ci:artifacts`: 473 test files, 11159 tests, all passing; 98.97% statement coverage, unchanged from baseline)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Closes #7511
