### PR TITLE
fix(registry): SN45 AlphaRidge.ai full API parity (31 missing surfaces)

### DIFF
--- a/registry/subnets/alpharidge-ai.json
+++ b/registry/subnets/alpharidge-ai.json
@@ -274,6 +274,788 @@
       "public_safe": true,
       "source_urls": ["https://api.alpharidge.ai/openapi.json"],
       "url": "https://api.alpharidge.ai/dashboard/articles/sources"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-config-subnet",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET config subnet",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /config/subnet on api.alpharidge.ai. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Missing authentication headers. Required: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, X-Auth-Timestamp\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/config/subnet"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-validators-versions",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET validators versions",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /validators/versions on api.alpharidge.ai. Live-verified 2026-07-21: HTTP 403 {\"detail\":\"Access restricted.\"} — same gated tier as the SS58-signature group, different message. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/validators/versions"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-axon-check",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST axon check",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /axon/check on api.alpharidge.ai. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Missing authentication headers. Required: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, X-Auth-Timestamp\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/axon/check"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-reputation-snapshot",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST reputation snapshot",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /reputation/snapshot on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/reputation/snapshot"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-tweets-unscored",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET tweets unscored",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /tweets/unscored on api.alpharidge.ai. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Missing authentication headers. Required: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, X-Auth-Timestamp\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/tweets/unscored"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-tweets-completed",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST tweets completed",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /tweets/completed on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/tweets/completed"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-telegram-messages-unscored",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET telegram messages unscored",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /telegram/messages/unscored on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/telegram/messages/unscored"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-telegram-messages-completed",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST telegram messages completed",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /telegram/messages/completed on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/telegram/messages/completed"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-articles-unscored",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET articles unscored",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /articles/unscored on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/articles/unscored"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-articles-completed",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST articles completed",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /articles/completed on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/articles/completed"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-rewards",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET rewards",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /rewards on api.alpharidge.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Missing authentication headers. Required: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, X-Auth-Timestamp\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/rewards"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-penalties",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET penalties",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /penalties on api.alpharidge.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/penalties"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-blacklist",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET blacklist",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /blacklist on api.alpharidge.ai (this path also supports POST — same auth boundary, not registered as a separate surface since the url would collide). Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Missing authentication headers. Required: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, X-Auth-Timestamp\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/blacklist"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-blacklist-hotkey",
+      "kind": "subnet-api",
+      "name": "AlphaRidge DELETE blacklist by hotkey",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) DELETE /blacklist/{hotkey} on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/blacklist/%7Bhotkey%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-attestation",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET attestation",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /attestation on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/attestation"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-reports",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST reports",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /reports on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/reports"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-verdicts",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET verdicts",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) GET /verdicts on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/verdicts"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-diagnostics-penalty-detail",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST diagnostics penalty detail",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /diagnostics/penalty-detail on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/diagnostics/penalty-detail"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-diagnostics-dispatch-status",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST diagnostics dispatch status",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /diagnostics/dispatch-status on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/diagnostics/dispatch-status"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "scheme": "custom",
+        "scopes_note": "Not declared in the OpenAPI schema (no security block anywhere) — a custom SS58-signature scheme confirmed live: requires X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers (proving control of a registered validator's coldkey/hotkey via a chain-native signature, not a bearer token)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-45-alpharidge-diagnostics-miner-event",
+      "kind": "subnet-api",
+      "name": "AlphaRidge POST diagnostics miner event",
+      "notes": "Auth-gated (SS58 signature headers, Phase 3 credential passthrough, not built yet) POST /diagnostics/miner-event on api.alpharidge.ai. Not individually curled — same SS58-signature gating as the verified `sn-45-alpharidge-config-subnet` (401, same message). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7059) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/diagnostics/miner-event"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-miner-dispatch",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard miner dispatch",
+      "notes": "GET /dashboard/miner-dispatch on api.alpharidge.ai — part of the public /dashboard/* tree architecturally, but live-verified 2026-07-21 to consistently return HTTP 403 {\"detail\":\"Access restricted.\"} regardless of the optional `hotkey` query param (tested both with and without a real hotkey). This is NOT the same shape as the SS58-signature 401s on the auth-gated group elsewhere in this subnet, so it isn't registered as auth_required:true either -- the restriction's real cause (feature flag, business rule, something else) isn't identifiable from the outside. Registered accurately reflecting the current observed state rather than the issue's \"public, works\" characterization. Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/miner-dispatch"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-miners-hotkey",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard miners by hotkey",
+      "notes": "GET /dashboard/miners/{hotkey} on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Live-verified 2026-07-21 with a dummy value: HTTP 404 {\"detail\":\"Miner not found\"} — no real miners currently registered on this subnet to test with a genuine match, but the 404 (not 401/403/500) confirms the route itself is real and reachable. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/miners/%7Bhotkey%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-miners-hotkey-batches",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard miners by hotkey batches",
+      "notes": "GET /dashboard/miners/{hotkey}/batches on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Not individually curled — same no-declared-auth shape as the verified `sn-45-alpharidge-dashboard-miners-hotkey` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/miners/%7Bhotkey%7D/batches"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-miners-hotkey-batches-epoch-items",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard miners by hotkey batches by epoch items",
+      "notes": "GET /dashboard/miners/{hotkey}/batches/{epoch}/items on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Not individually curled — same no-declared-auth shape as the verified `sn-45-alpharidge-dashboard-miners-hotkey` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/miners/%7Bhotkey%7D/batches/%7Bepoch%7D/items"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-miners-hotkey-reputation",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard miners by hotkey reputation",
+      "notes": "GET /dashboard/miners/{hotkey}/reputation on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Not individually curled — same no-declared-auth shape as the verified `sn-45-alpharidge-dashboard-miners-hotkey` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/miners/%7Bhotkey%7D/reputation"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-miners-hotkey-events",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard miners by hotkey events",
+      "notes": "GET /dashboard/miners/{hotkey}/events on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Not individually curled — same no-declared-auth shape as the verified `sn-45-alpharidge-dashboard-miners-hotkey` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/miners/%7Bhotkey%7D/events"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-events",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard events",
+      "notes": "GET /dashboard/events on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Live-verified 2026-07-21: currently HTTP 500 (Internal Server Error) with no request params — registered anyway so probe monitoring reflects the real current state, matching the precedent at registry/subnets/targon.json's sn-4-targon-healthz-api (a live-500ing endpoint registered probe.enabled:true rather than left out). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/events"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-events-trending",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard events trending",
+      "notes": "GET /dashboard/events/trending on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Live-verified 2026-07-21: currently HTTP 500 (Internal Server Error) with no request params — registered anyway so probe monitoring reflects the real current state, matching the precedent at registry/subnets/targon.json's sn-4-targon-healthz-api (a live-500ing endpoint registered probe.enabled:true rather than left out). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/events/trending"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-events-event-id",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard events by event id",
+      "notes": "GET /dashboard/events/{event_id} on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Not individually curled — same no-declared-auth shape as the verified `sn-45-alpharidge-dashboard-miners-hotkey` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/events/%7Bevent_id%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-narratives",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard narratives",
+      "notes": "GET /dashboard/narratives on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Live-verified 2026-07-21: currently HTTP 500 (Internal Server Error) with no request params — registered anyway so probe monitoring reflects the real current state, matching the precedent at registry/subnets/targon.json's sn-4-targon-healthz-api (a live-500ing endpoint registered probe.enabled:true rather than left out). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/narratives"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-dashboard-narratives-trending",
+      "kind": "subnet-api",
+      "name": "AlphaRidge GET dashboard narratives trending",
+      "notes": "GET /dashboard/narratives/trending on api.alpharidge.ai — public, no auth declared or observed, part of the /dashboard/* tree (same pattern as the already-registered dashboard/stats, dashboard/sentiment, etc). Live-verified 2026-07-21: currently HTTP 500 (Internal Server Error) with no request params — registered anyway so probe monitoring reflects the real current state, matching the precedent at registry/subnets/targon.json's sn-4-targon-healthz-api (a live-500ing endpoint registered probe.enabled:true rather than left out). Registered per the registry's full-API-parity policy (metagraphed#7059).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.alpharidge.ai/openapi.json"],
+      "url": "https://api.alpharidge.ai/dashboard/narratives/trending"
     }
   ],
   "website_url": "https://ai.talisman.xyz/"


### PR DESCRIPTION
## Summary

Closes #7059. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527: PR #7341 (already merged) closed this issue by verifying the 3 originally-listed surfaces (still accurate) but added zero registry changes, leaving the issue's own OpenAPI sweep findings unregistered.

## What this adds (31 new surfaces)

Diffed the live OpenAPI spec (`https://api.alpharidge.ai/openapi.json`, 53 total operations) against the registry (10 already covered) and excluded the dead `/v2` legacy shim (confirmed live: `GET /v2/status` → `410 {"error":"deprecated_api_version"}`) → **31 unique missing paths**, independently re-derived and cross-checked with live requests.

**10 public `/dashboard/*` tree** (matches the already-registered `dashboard/stats`/`dashboard/sentiment`/etc. pattern): 5 no-param, `probe.enabled:true` (2 of these — `dashboard/events`, `dashboard/narratives`, and their `/trending` siblings — currently return `500`; registered anyway so probe monitoring reflects the real state, matching the verified precedent at `registry/subnets/targon.json`'s `sn-4-targon-healthz-api`, itself a live-500ing endpoint registered `probe.enabled:true`). 5 path-param (`miners/{hotkey}` + 4 sub-resources), `probe.enabled:false`. Live-verified `dashboard/miners/{hotkey}` with a dummy value: `404 {"detail":"Miner not found"}` — no real miners currently registered on this subnet to test with a genuine match, but the 404 (not 401/403/500) confirms the route is real.

**1 genuine finding that diverges from the issue's characterization**: the issue lists `dashboard/miner-dispatch` under "public, no-auth, register with `probe.enabled:true`." Live-verified: it has only an *optional* `hotkey` query param, yet consistently returns `403 {"detail":"Access restricted."}` — with or without a real hotkey supplied. That's a different response shape than every other gated endpoint in this subnet (which uniformly 401 with `"Missing authentication headers"`), so it doesn't fit the SS58-signature auth group either — the real cause (feature flag, business rule, something else) isn't identifiable from the outside. Registered `auth_required:false` (matching its `/dashboard/*` architectural placement) with a note documenting the actual observed 403, rather than the issue's "works" framing.

**20 auth-gated, SS58-signature scheme** (`auth_required:true`, `auth:{scheme:"custom",...}`, `probe.enabled:false`) — not declared anywhere in the OpenAPI schema, but a consistent custom mechanism confirmed live: `401` requiring `X-Auth-SS58Address`, `X-Auth-Signature`, `X-Auth-Message`, and `X-Auth-Timestamp` headers (a chain-native signature, not a bearer token). Independently spot-checked 5 of the 20 across different functional groups (config, content-scoring, blacklist, rewards, axon) — all uniform. One (`validators/versions`) returns a differently-worded `403 "Access restricted."` rather than the `401`, but is grouped with this auth family per the issue's own characterization since it sits in the same gated tier.

## Schema/tooling notes (same as the last six)
- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC`; not applicable here since every op in this spec is `GET`/`POST` and the auth-gated ones already use `probe.enabled:false`.
- Path-param URLs use the percent-encoded brace form.
- Registered `provider: "talisman-ai"` (not `"alpharidge-ai"`) — the subnet's identity pivoted from Talisman AI to AlphaRidge.ai, but the registered *provider* entity (`registry/providers/talisman-ai.json`) kept its original slug; every existing surface in this file already uses it. Caught this via `validate:surface` failing on my first draft, which had guessed the file's own basename as the provider slug.
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`.

## Validation
- [x] `npm run validate:surface -- registry/subnets/alpharidge-ai.json` — 43 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2187 total surfaces, clean
- [x] `npx vitest run tests/alpharidge-ai-call-subnet-surface-verify.test.mjs` — 3 passed (unchanged — already accurate)
- [x] `npm test` — full suite, clean
- [x] `npx prettier --check` — clean

Closes #7059
