### PR TITLE
fix(registry): SN96 Verathos API parity (16 missing surfaces) (#7108)

### DIFF
--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -644,6 +644,363 @@
       },
       "source_urls": ["https://api.verathos.ai/openapi.json"],
       "url": "https://api.verathos.ai/v1/price"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-auth-create-key",
+      "kind": "subnet-api",
+      "name": "Verathos api auth create key",
+      "notes": "Create Key operation on the Verathos API (POST /api/auth/create-key), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security on it; it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/auth/create-key"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-auth-login",
+      "kind": "subnet-api",
+      "name": "Verathos api auth login",
+      "notes": "Login operation on the Verathos API (POST /api/auth/login), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security on it; it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/auth/login"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "The subnet's own OpenAPI spec declares no securitySchemes, but this route empirically rejects an unauthenticated request with HTTP 401 \"No API key provided\" (live-checked 2026-07-21). The header name is not documented in the spec, so only the location is asserted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-96-verathos-api-auth-me",
+      "kind": "subnet-api",
+      "name": "Verathos api auth me",
+      "notes": "Me operation on the Verathos API (GET /api/auth/me), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security for it, but live-verified 2026-07-21 an unauthenticated GET returns HTTP 401 {\"error\":\"No API key provided\"} -- so it is registered auth_required:true, correcting what the schema implies.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/auth/me"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-auth-register",
+      "kind": "subnet-api",
+      "name": "Verathos api auth register",
+      "notes": "Register operation on the Verathos API (POST /api/auth/register), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security on it; it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/auth/register"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-chat-conversation-id",
+      "kind": "subnet-api",
+      "name": "Verathos api chat conversation id",
+      "notes": "Chat Stream operation on the Verathos API (POST /api/chat/{conversation_id}), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. Path-parameterized on {conversation_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/chat/%7Bconversation_id%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-conversations",
+      "kind": "subnet-api",
+      "name": "Verathos api conversations",
+      "notes": "List Conversations operation on the Verathos API (GET, POST /api/conversations/), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. Live-verified 2026-07-21: GET -> HTTP 200 application/json (empty list for an anonymous caller). Public, no-auth and fixed-URL, so its probe is enabled.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/conversations/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-conversations-claim",
+      "kind": "subnet-api",
+      "name": "Verathos api conversations claim",
+      "notes": "Claim Conversations operation on the Verathos API (POST /api/conversations/claim), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security on it; it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/conversations/claim"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-conversations-conversation-id",
+      "kind": "subnet-api",
+      "name": "Verathos api conversations conversation id",
+      "notes": "Delete Conversation operation on the Verathos API (DELETE, GET, PATCH /api/conversations/{conversation_id}), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. Path-parameterized on {conversation_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/conversations/%7Bconversation_id%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-deposits-address",
+      "kind": "subnet-api",
+      "name": "Verathos api deposits address",
+      "notes": "Deposit Address operation on the Verathos API (GET /api/deposits/address), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. Live-checked 2026-07-21: GET returns HTTP 503 {\"error\":{\"message\":\"API is in preview mode. Public access coming soon.\"}} -- documented but not yet publicly serving, so the probe is left disabled and the observation recorded rather than asserting a working surface.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/deposits/address"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-deposits-balance",
+      "kind": "subnet-api",
+      "name": "Verathos api deposits balance",
+      "notes": "Balance operation on the Verathos API (GET /api/deposits/balance), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. Live-checked 2026-07-21: GET returns HTTP 503 {\"error\":{\"message\":\"API is in preview mode. Public access coming soon.\"}} -- documented but not yet publicly serving, so the probe is left disabled and the observation recorded rather than asserting a working surface.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/deposits/balance"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-deposits-withdraw",
+      "kind": "subnet-api",
+      "name": "Verathos api deposits withdraw",
+      "notes": "Withdraw operation on the Verathos API (POST /api/deposits/withdraw), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security on it; it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/deposits/withdraw"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-docs-slug",
+      "kind": "subnet-api",
+      "name": "Verathos api docs slug",
+      "notes": "Get Doc operation on the Verathos API (GET /api/docs/{slug}), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. Path-parameterized on {slug}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/docs/%7Bslug%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-models-load",
+      "kind": "subnet-api",
+      "name": "Verathos api models load",
+      "notes": "Load Model operation on the Verathos API (POST /api/models/load), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security on it; it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/models/load"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-models-refresh",
+      "kind": "subnet-api",
+      "name": "Verathos api models refresh",
+      "notes": "Refresh Miners operation on the Verathos API (POST /api/models/refresh), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security on it; it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/models/refresh"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-api-models-unload",
+      "kind": "subnet-api",
+      "name": "Verathos api models unload",
+      "notes": "Unload Model operation on the Verathos API (POST /api/models/unload), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. The spec declares no security on it; it is a state-changing POST and not probe-safe, so the probe is disabled and no auth requirement is asserted without evidence.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/models/unload"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-install-sh",
+      "kind": "data-artifact",
+      "name": "Verathos install sh",
+      "notes": "Install Script operation on the Verathos API (GET /install.sh), declared in the subnet's own OpenAPI spec at https://verathos.ai/openapi.json. Live-verified 2026-07-21: GET -> HTTP 200 text/plain (the published installer script). Public, no-auth and fixed-URL, so its probe is enabled.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/install.sh"
     }
   ],
   "website_url": "https://verathos.ai/"


### PR DESCRIPTION
## Summary

Closes #7108.

Brings SN96 (Verathos) up to **full subnet API parity** — the completeness bar in `.claude/skills/contributor-pipeline-gardening/SKILL.md`'s "MCP execute verify + wire SN*" special-sweep section. Same approach as SN62 Ridges (#7537), SN100 Plaτform (#7539) and SN56 Gradients (#7532).

The Verathos OpenAPI spec (**24 paths**) had 7 of its paths registered. This adds **16** of the remaining 17 — see below for the one deliberate omission.

## Live findings (the spec's "no security anywhere" isn't accurate)

| request | result | how it's registered |
|---|---|---|
| `GET /api/auth/me` | **401** `{"error":"No API key provided"}` | `auth_required: true` + `auth{}` — **correcting** what the schema implies |
| `GET /api/deposits/address` | **503** *"API is in preview mode. Public access coming soon."* | probe disabled, observation recorded |
| `GET /api/deposits/balance` | **503** *"API is in preview mode. Public access coming soon."* | probe disabled, observation recorded |
| `GET /api/conversations/` | **200** `application/json` (`[]` for an anonymous caller) | **`probe.enabled: true`** |
| `GET /install.sh` | **200** `text/plain` (published installer script) | `data-artifact`, **`probe.enabled: true`** |

For `/api/auth/me` the response doesn't name the header, so I assert only the location (`scheme: api-key`, `location: header`) rather than guessing a header name.

## One deliberate omission

The spec's 17th unregistered path is **`GET /{full_path}`** — a catch-all that serves the SPA fallback for any unmatched route, not a distinct API surface. Registering it would add a wildcard entry that matches everything and probes nothing meaningful, so it is intentionally left out. Flagging it explicitly so the omission is a decision, not an oversight.

## The rest

State-changing POSTs and path-parameterized routes (percent-encoded `{param}` templates, matching SN37 Aurelius's encoding) — all probe-disabled, no auth asserted without evidence.

## Checklist

- [x] Changes exactly one `registry/subnets/verathos.json` file (+357/−0, clean append)
- [x] Every added surface: `authority: community`, `review.state: community-submitted`, `public_safe: true`; no health/`verification` set by hand
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed, **no `auth_required` advisories**
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` (6 passed)
- [x] `npm run scan:public-safety` — no verathos findings
- [x] `provider` uses the already-registered `verathos` slug
- [x] No other open PR references #7108
- [x] Rebased on latest `main`

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] `/api/conversations/` and `/install.sh` are good no-auth MCP smoke targets
- [ ] The deposits routes are worth re-probing once preview mode lifts — their probes can then be enabled
