### PR TITLE
fix(registry): append SN14 Cacheon path-param API surfaces (#7030)

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -351,6 +351,106 @@
       },
       "source_urls": ["https://api.cacheon.ai/api/eval-job"],
       "url": "https://api.cacheon.ai/api/eval-job"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-evaluations-hotkey-hotkey",
+      "kind": "subnet-api",
+      "name": "Cacheon api evaluations by hotkey",
+      "notes": "Public no-auth GET /api/evaluations/hotkey/{hotkey} on api.cacheon.ai returning evaluation entries for one miner hotkey -- distinct from the already-tracked sn-14-cacheon-evaluations list surface. Documented in the subnet OpenAPI schema (sn-14-cacheon-openapi, path /api/evaluations/hotkey/{hotkey}). Path-param endpoint (Phase 2 of #7013) -- probe.enabled:false because a {hotkey} template is not a fixed callable URL today. Not spot-verified individually (no representative hotkey on hand); same host and no-auth pattern as the live-verified sn-14-cacheon-evaluations sibling. Registered per metagraphed#7030 reopen.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "url": "https://api.cacheon.ai/api/evaluations/hotkey/%7Bhotkey%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-evaluations-uid",
+      "kind": "subnet-api",
+      "name": "Cacheon api evaluations by uid",
+      "notes": "Public no-auth GET /api/evaluations/{uid} on api.cacheon.ai returning a single evaluation record by UID -- distinct from the already-tracked sn-14-cacheon-evaluations list surface. Documented in the subnet OpenAPI schema (sn-14-cacheon-openapi, path /api/evaluations/{uid}). Path-param endpoint (Phase 2 of #7013) -- probe.enabled:false because a {uid} template is not a fixed callable URL today. Not spot-verified individually (no representative uid on hand); same host and no-auth pattern as the live-verified sn-14-cacheon-evaluations sibling. Registered per metagraphed#7030 reopen.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "url": "https://api.cacheon.ai/api/evaluations/%7Buid%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-container-log-label",
+      "kind": "subnet-api",
+      "name": "Cacheon api container log by label",
+      "notes": "Public no-auth GET /api/container-log/{label} on api.cacheon.ai returning one validator container evaluation log file -- distinct from the already-tracked sn-14-cacheon-data-artifact /api/container-logs listing surface. Documented in the subnet OpenAPI schema (sn-14-cacheon-openapi, path /api/container-log/{label}). Path-param endpoint (Phase 2 of #7013) -- probe.enabled:false because a {label} template is not a fixed callable URL today. Not spot-verified individually (no representative label on hand); same host and no-auth pattern as the live-verified sn-14-cacheon-data-artifact and sn-14-cacheon-validator-logs siblings. Registered per metagraphed#7030 reopen.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "url": "https://api.cacheon.ai/api/container-log/%7Blabel%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-validator-log-label",
+      "kind": "subnet-api",
+      "name": "Cacheon api validator log by label",
+      "notes": "Public no-auth GET /api/validator-log/{label} on api.cacheon.ai returning one validator GPU evaluation log file -- distinct from the already-tracked sn-14-cacheon-validator-logs listing surface. Documented in the subnet OpenAPI schema (sn-14-cacheon-openapi, path /api/validator-log/{label}). Path-param endpoint (Phase 2 of #7013) -- probe.enabled:false because a {label} template is not a fixed callable URL today. Not spot-verified individually (no representative label on hand); same host and no-auth pattern as the live-verified sn-14-cacheon-validator-logs sibling. Registered per metagraphed#7030 reopen.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "url": "https://api.cacheon.ai/api/validator-log/%7Blabel%7D"
     }
   ],
   "website_url": "https://cacheon.ai/"


### PR DESCRIPTION
## Summary

Append the four missing path-param Cacheon monitoring API surfaces flagged in [#7030](https://github.com/JSONbored/metagraphed/issues/7030)'s reopen — the gap [#7523](https://github.com/JSONbored/metagraphed/pull/7523) did not address.

Closes #7030

## Why #7523 failed

JSONbored closed [#7523](https://github.com/JSONbored/metagraphed/pull/7523) manually (CI `test` also red):

> This adds **zero new surfaces** — it only edits probe config and notes wording on the same 4 surfaces (leader-api, health, rounds-api, leader-history-api) that three earlier PRs already touched (#7468, #7474, #7483), plus a wording tweak on `evaluations`. **#7030 still needs the 4 additional path-param surfaces** (evaluations by hotkey/uid, container-log/validator-log by label) — none are here.

Issue reopen comment (same root cause):

> A verification test alone doesn't satisfy this issue — `registry/subnets/cacheon.json` still needs those surface entries added.

This PR does what #7523 skipped: **pure append-only** registration of the four OpenAPI path-param routes.

## New surfaces (4)

All from `https://api.cacheon.ai/openapi.json` (14 paths), `auth_required:false`, `probe.enabled:false`, URI-encoded templates:

| surface_id | path |
|---|---|
| `sn-14-cacheon-evaluations-hotkey-hotkey` | `GET /api/evaluations/hotkey/{hotkey}` |
| `sn-14-cacheon-evaluations-uid` | `GET /api/evaluations/{uid}` |
| `sn-14-cacheon-container-log-label` | `GET /api/container-log/{label}` |
| `sn-14-cacheon-validator-log-label` | `GET /api/validator-log/{label}` |

Not individually spot-verified (no representative hotkey/uid/label on hand), per issue — same host/no-auth pattern as live-verified siblings:

- `GET /api/health` → **200** `{"status":"ok"}`
- `GET /api/evaluations` → **200** JSON list (covered by existing `tests/cacheon-call-subnet-surface-verify.test.mjs`)

## Checklist

- [x] Changes exactly one `registry/subnets/cacheon.json` file (**+100 lines, 0 deletions** — append-only)
- [x] Does not re-edit leader/health/rounds/evaluations probe blocks (#7523 scope — already churned)
- [x] `npm run validate:surface -- registry/subnets/cacheon.json`
- [x] `npx vitest run tests/cacheon-call-subnet-surface-verify.test.mjs` (3/3)

## Test plan

- [ ] Gittensory Gate + CI green
