### PR TITLE
fix(registry): SN6 Numinous full API parity (15 missing surfaces)

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 569,
+  "surface_count": 582,
   "surfaces": [
     {
       "auth_required": false,
@@ -353,6 +353,24 @@
       "surface_id": "sn-3-templar-min-compute-spec",
       "surface_key": "srf-3c91dc30d6e9ffef",
       "url": "https://raw.githubusercontent.com/one-covenant/templar/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 4,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
+      "public_safe": true,
+      "subnet_name": "Targon",
+      "subnet_slug": "sn-4",
+      "surface_id": "sn-4-targon-healthz-api",
+      "surface_key": "srf-eecabd53d1e3682d",
+      "url": "https://api.targon.com/tha/v2/healthz"
     },
     {
       "auth_required": false,
@@ -1073,6 +1091,60 @@
       "surface_id": "sn-11-trajectoryrl-subnet-api",
       "surface_key": "srf-fb2d84726c2ab7c6",
       "url": "https://trajrl.com/api/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 12,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
+      "public_safe": true,
+      "subnet_name": "Compute Horde",
+      "subnet_slug": "sn-12",
+      "surface_id": "sn-12-compute-horde-grafana-dashboard-subnet",
+      "surface_key": "srf-43adf78e67118ec4",
+      "url": "https://grafana.bittensor.church/api/dashboards/uid/subnet"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 12,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
+      "public_safe": true,
+      "subnet_name": "Compute Horde",
+      "subnet_slug": "sn-12",
+      "surface_id": "sn-12-compute-horde-grafana-org",
+      "surface_key": "srf-90d65d4b51e9a7c3",
+      "url": "https://grafana.bittensor.church/api/org"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 12,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
+      "public_safe": true,
+      "subnet_name": "Compute Horde",
+      "subnet_slug": "sn-12",
+      "surface_id": "sn-12-compute-horde-grafana-search",
+      "surface_key": "srf-a16edf62c329cdee",
+      "url": "https://grafana.bittensor.church/api/search"
     },
     {
       "auth_required": false,
@@ -3380,6 +3452,60 @@
     },
     {
       "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 45,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "subnet_name": "AlphaRidge.ai",
+      "subnet_slug": "sn-45",
+      "surface_id": "sn-45-alpharidge-dashboard-events",
+      "surface_key": "srf-dfc56da9b8e7ff15",
+      "url": "https://api.alpharidge.ai/dashboard/events"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 45,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "subnet_name": "AlphaRidge.ai",
+      "subnet_slug": "sn-45",
+      "surface_id": "sn-45-alpharidge-dashboard-events-trending",
+      "surface_key": "srf-71a0ad4289251d81",
+      "url": "https://api.alpharidge.ai/dashboard/events/trending"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 45,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "subnet_name": "AlphaRidge.ai",
+      "subnet_slug": "sn-45",
+      "surface_id": "sn-45-alpharidge-dashboard-miner-dispatch",
+      "surface_key": "srf-0cfd5ed6c11caade",
+      "url": "https://api.alpharidge.ai/dashboard/miner-dispatch"
+    },
+    {
+      "auth_required": false,
       "authority": "official",
       "kind": "data-artifact",
       "netuid": 45,
@@ -3395,6 +3521,42 @@
       "surface_id": "sn-45-alpharidge-dashboard-miners",
       "surface_key": "srf-9f742042649fdc01",
       "url": "https://api.alpharidge.ai/dashboard/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 45,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "subnet_name": "AlphaRidge.ai",
+      "subnet_slug": "sn-45",
+      "surface_id": "sn-45-alpharidge-dashboard-narratives",
+      "surface_key": "srf-857f3e32dda4ebe9",
+      "url": "https://api.alpharidge.ai/dashboard/narratives"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 45,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "subnet_name": "AlphaRidge.ai",
+      "subnet_slug": "sn-45",
+      "surface_id": "sn-45-alpharidge-dashboard-narratives-trending",
+      "surface_key": "srf-16c26e1a9a0777c4",
+      "url": "https://api.alpharidge.ai/dashboard/narratives/trending"
     },
     {
       "auth_required": false,
@@ -5105,6 +5267,42 @@
       "surface_id": "sn-62-ridges-problem-statistics",
       "surface_key": "srf-f1a13a9bc01b7934",
       "url": "https://agent-upload.ridges.ai/statistics/problem-statistics"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 62,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ridges",
+      "public_safe": true,
+      "subnet_name": "Ridges",
+      "subnet_slug": "sn-62",
+      "surface_id": "sn-62-ridges-scoring-screener-info",
+      "surface_key": "srf-7b04619900089bca",
+      "url": "https://agent-upload.ridges.ai/scoring/screener-info"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 62,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ridges",
+      "public_safe": true,
+      "subnet_name": "Ridges",
+      "subnet_slug": "sn-62",
+      "surface_id": "sn-62-ridges-scoring-weights",
+      "surface_key": "srf-0a256cdcf9b29dbc",
+      "url": "https://agent-upload.ridges.ai/scoring/weights"
     },
     {
       "auth_required": false,
@@ -7288,6 +7486,24 @@
       "auth_required": false,
       "authority": "community",
       "kind": "subnet-api",
+      "netuid": 90,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "degenbrain",
+      "public_safe": true,
+      "subnet_name": "DegenBrain",
+      "subnet_slug": "sn-90",
+      "surface_id": "sn-90-degenbrain-test-next-chunk",
+      "surface_key": "srf-778baba2e90c2bca",
+      "url": "https://api.subnet90.com/api/test/next-chunk?validator_id=test"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
       "netuid": 91,
       "probe": {
         "expect": "json",
@@ -8453,6 +8669,24 @@
       "surface_id": "sn-100-platform-network-subnet-api",
       "surface_key": "srf-196044ef4420d344",
       "url": "https://chain.joinbase.ai/v1/registry"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 100,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "platform-network",
+      "public_safe": true,
+      "subnet_name": "Plaτform",
+      "subnet_slug": "sn-100",
+      "surface_id": "sn-100-platform-v1-weights-latest",
+      "surface_key": "srf-d52f4b24f9a4160f",
+      "url": "https://chain.joinbase.ai/v1/weights/latest"
     },
     {
       "auth_required": false,

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 582,
+  "surface_count": 569,
   "surfaces": [
     {
       "auth_required": false,
@@ -353,24 +353,6 @@
       "surface_id": "sn-3-templar-min-compute-spec",
       "surface_key": "srf-3c91dc30d6e9ffef",
       "url": "https://raw.githubusercontent.com/one-covenant/templar/main/min_compute.yml"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 4,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "targon",
-      "public_safe": true,
-      "subnet_name": "Targon",
-      "subnet_slug": "sn-4",
-      "surface_id": "sn-4-targon-healthz-api",
-      "surface_key": "srf-eecabd53d1e3682d",
-      "url": "https://api.targon.com/tha/v2/healthz"
     },
     {
       "auth_required": false,
@@ -1091,60 +1073,6 @@
       "surface_id": "sn-11-trajectoryrl-subnet-api",
       "surface_key": "srf-fb2d84726c2ab7c6",
       "url": "https://trajrl.com/api/stats"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 12,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "compute-horde",
-      "public_safe": true,
-      "subnet_name": "Compute Horde",
-      "subnet_slug": "sn-12",
-      "surface_id": "sn-12-compute-horde-grafana-dashboard-subnet",
-      "surface_key": "srf-43adf78e67118ec4",
-      "url": "https://grafana.bittensor.church/api/dashboards/uid/subnet"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 12,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "compute-horde",
-      "public_safe": true,
-      "subnet_name": "Compute Horde",
-      "subnet_slug": "sn-12",
-      "surface_id": "sn-12-compute-horde-grafana-org",
-      "surface_key": "srf-90d65d4b51e9a7c3",
-      "url": "https://grafana.bittensor.church/api/org"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 12,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "compute-horde",
-      "public_safe": true,
-      "subnet_name": "Compute Horde",
-      "subnet_slug": "sn-12",
-      "surface_id": "sn-12-compute-horde-grafana-search",
-      "surface_key": "srf-a16edf62c329cdee",
-      "url": "https://grafana.bittensor.church/api/search"
     },
     {
       "auth_required": false,
@@ -3452,60 +3380,6 @@
     },
     {
       "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 45,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "talisman-ai",
-      "public_safe": true,
-      "subnet_name": "AlphaRidge.ai",
-      "subnet_slug": "sn-45",
-      "surface_id": "sn-45-alpharidge-dashboard-events",
-      "surface_key": "srf-dfc56da9b8e7ff15",
-      "url": "https://api.alpharidge.ai/dashboard/events"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 45,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "talisman-ai",
-      "public_safe": true,
-      "subnet_name": "AlphaRidge.ai",
-      "subnet_slug": "sn-45",
-      "surface_id": "sn-45-alpharidge-dashboard-events-trending",
-      "surface_key": "srf-71a0ad4289251d81",
-      "url": "https://api.alpharidge.ai/dashboard/events/trending"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 45,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "talisman-ai",
-      "public_safe": true,
-      "subnet_name": "AlphaRidge.ai",
-      "subnet_slug": "sn-45",
-      "surface_id": "sn-45-alpharidge-dashboard-miner-dispatch",
-      "surface_key": "srf-0cfd5ed6c11caade",
-      "url": "https://api.alpharidge.ai/dashboard/miner-dispatch"
-    },
-    {
-      "auth_required": false,
       "authority": "official",
       "kind": "data-artifact",
       "netuid": 45,
@@ -3521,42 +3395,6 @@
       "surface_id": "sn-45-alpharidge-dashboard-miners",
       "surface_key": "srf-9f742042649fdc01",
       "url": "https://api.alpharidge.ai/dashboard/miners"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 45,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "talisman-ai",
-      "public_safe": true,
-      "subnet_name": "AlphaRidge.ai",
-      "subnet_slug": "sn-45",
-      "surface_id": "sn-45-alpharidge-dashboard-narratives",
-      "surface_key": "srf-857f3e32dda4ebe9",
-      "url": "https://api.alpharidge.ai/dashboard/narratives"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 45,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "talisman-ai",
-      "public_safe": true,
-      "subnet_name": "AlphaRidge.ai",
-      "subnet_slug": "sn-45",
-      "surface_id": "sn-45-alpharidge-dashboard-narratives-trending",
-      "surface_key": "srf-16c26e1a9a0777c4",
-      "url": "https://api.alpharidge.ai/dashboard/narratives/trending"
     },
     {
       "auth_required": false,
@@ -5267,42 +5105,6 @@
       "surface_id": "sn-62-ridges-problem-statistics",
       "surface_key": "srf-f1a13a9bc01b7934",
       "url": "https://agent-upload.ridges.ai/statistics/problem-statistics"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 62,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "ridges",
-      "public_safe": true,
-      "subnet_name": "Ridges",
-      "subnet_slug": "sn-62",
-      "surface_id": "sn-62-ridges-scoring-screener-info",
-      "surface_key": "srf-7b04619900089bca",
-      "url": "https://agent-upload.ridges.ai/scoring/screener-info"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 62,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "ridges",
-      "public_safe": true,
-      "subnet_name": "Ridges",
-      "subnet_slug": "sn-62",
-      "surface_id": "sn-62-ridges-scoring-weights",
-      "surface_key": "srf-0a256cdcf9b29dbc",
-      "url": "https://agent-upload.ridges.ai/scoring/weights"
     },
     {
       "auth_required": false,
@@ -7486,24 +7288,6 @@
       "auth_required": false,
       "authority": "community",
       "kind": "subnet-api",
-      "netuid": 90,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "degenbrain",
-      "public_safe": true,
-      "subnet_name": "DegenBrain",
-      "subnet_slug": "sn-90",
-      "surface_id": "sn-90-degenbrain-test-next-chunk",
-      "surface_key": "srf-778baba2e90c2bca",
-      "url": "https://api.subnet90.com/api/test/next-chunk?validator_id=test"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
       "netuid": 91,
       "probe": {
         "expect": "json",
@@ -8669,24 +8453,6 @@
       "surface_id": "sn-100-platform-network-subnet-api",
       "surface_key": "srf-196044ef4420d344",
       "url": "https://chain.joinbase.ai/v1/registry"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 100,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "platform-network",
-      "public_safe": true,
-      "subnet_name": "Plaτform",
-      "subnet_slug": "sn-100",
-      "surface_id": "sn-100-platform-v1-weights-latest",
-      "surface_key": "srf-d52f4b24f9a4160f",
-      "url": "https://chain.joinbase.ai/v1/weights/latest"
     },
     {
       "auth_required": false,

--- a/registry/subnets/numinous.json
+++ b/registry/subnets/numinous.json
@@ -185,6 +185,348 @@
       },
       "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
       "url": "https://api.numinouslabs.io/api/v1/benchmarks/baseline"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-aggregated-scores",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 aggregated scores",
+      "notes": "GET /api/v1/aggregated-scores on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Required query: miner_uid, miner_hotkey. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/aggregated-scores"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey predictions active",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/predictions/active on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/miners/%7Bminer_uid%7D/%7Bminer_hotkey%7D/predictions/active"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-agents-versionid-code",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 agents by version_id code",
+      "notes": "GET /api/v1/agents/{version_id}/code on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/agents/%7Bversion_id%7D/code"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-agents",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey agents",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/agents on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/miners/%7Bminer_uid%7D/%7Bminer_hotkey%7D/agents"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-agents-versionid-code",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey agents by version_id code",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/agents/{version_id}/code on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/miners/%7Bminer_uid%7D/%7Bminer_hotkey%7D/agents/%7Bversion_id%7D/code"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-historical-ranking",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey historical ranking",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/historical-ranking on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/miners/%7Bminer_uid%7D/%7Bminer_hotkey%7D/historical-ranking"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-runs-eventid",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey runs by event_id",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/runs/{event_id} on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/miners/%7Bminer_uid%7D/%7Bminer_hotkey%7D/runs/%7Bevent_id%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-runs-runid-logs",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey runs by run_id logs",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/runs/{run_id}/logs on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/miners/%7Bminer_uid%7D/%7Bminer_hotkey%7D/runs/%7Brun_id%7D/logs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-miner-reasonings",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 miner reasonings",
+      "notes": "GET /api/v1/miner-reasonings on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Required query: miner_uid, miner_hotkey, event_id. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/miner-reasonings"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (security declared per-operation); exact header/token format not documented beyond the schema's boolean security flag."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-forecasters-predictions",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 forecasters predictions",
+      "notes": "Auth-gated (API key, Phase 3 credential passthrough, not built yet) GET /api/v1/forecasters/predictions on api.numinouslabs.io. Required query: forecaster_name. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Unauthorized\"}. Path/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7022) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/forecasters/predictions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-forecasters-prediction-jobs-predictionid",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 forecasters prediction jobs by prediction_id",
+      "notes": "GET /api/v1/forecasters/prediction-jobs/{prediction_id} on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/forecasters/prediction-jobs/%7Bprediction_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (security declared per-operation); exact header/token format not documented beyond the schema's boolean security flag."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-internal-liveuamap-events",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 internal liveuamap events",
+      "notes": "Auth-gated (API key, Phase 3 credential passthrough, not built yet) GET /api/v1/internal/liveuamap/events on api.numinouslabs.io. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Unauthorized\"}. Path/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7022) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/internal/liveuamap/events"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (security declared per-operation); exact header/token format not documented beyond the schema's boolean security flag."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-internal-liveuamap-regions",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 internal liveuamap regions",
+      "notes": "Auth-gated (API key, Phase 3 credential passthrough, not built yet) GET /api/v1/internal/liveuamap/regions on api.numinouslabs.io. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Unauthorized\"}. Path/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7022) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/internal/liveuamap/regions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-causal-drivers",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 causal drivers",
+      "notes": "GET /api/v1/causal-drivers/ on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Required query: question. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/causal-drivers/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-6-numinous-api-v1-deep-research",
+      "kind": "subnet-api",
+      "name": "Numinous GET api v1 deep research",
+      "notes": "GET /api/v1/deep-research/ on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Required query: question. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "url": "https://api.numinouslabs.io/api/v1/deep-research/"
     }
   ],
   "website_url": "https://numinouslabs.io/"


### PR DESCRIPTION
## Summary

Closes #7022. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527/#7538: the issue's original 4 surfaces (`sn-6-numinous-swagger`, `sn-6-numinous-openapi-schema`, `sn-6-numinous-api-health`, `sn-6-numinous-leaderboard`) still verify exactly as documented, and the issue's own "Additional surface(s) found during review" section already itemizes the remaining registry gap — this PR registers it.

## What this adds (15 new surfaces)

Fetched the subnet's own OpenAPI schema (`https://api.numinouslabs.io/api/openapi.json`, 20 total paths) and diffed against the registry (3 of those 20 already covered: `/api/health`, `/api/v1/leaderboard`, `/api/v1/benchmarks/baseline`; 2 write-only POST actions explicitly excluded by the issue's own scope note: `/api/v1/forecasters/prediction-jobs`, `/api/v1/internal/forecasters/prediction-jobs`) → **15 unique missing paths**, matching the issue's itemized list exactly.

**4 public, query-param-only** (`probe.enabled:false`, fixed base URL, no query baked in — already callable today via `call_subnet_surface`'s own `query` argument): `aggregated-scores`, `miner-reasonings`, `causal-drivers/`, `deep-research/`. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error.

**8 public, path-param** (`probe.enabled:false`, literal `{param}` template percent-encoded in the `url` field since raw unescaped braces fail this repo's `url` `format:"uri"` schema check): the 6 miner-scoped routes under `/api/v1/miners/{miner_uid}/{miner_hotkey}/...` (predictions/active, agents, agents/{version_id}/code, historical-ranking, runs/{event_id}, runs/{run_id}/logs), plus the standalone `/api/v1/agents/{version_id}/code` and `/api/v1/forecasters/prediction-jobs/{prediction_id}`. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422) on the spot-checked siblings, confirming these are real routes, not auth gates.

**3 auth-gated** (`auth_required:true`, `auth:{scheme:"api-key",...}`, `probe.enabled:false`): `forecasters/predictions` (live-verified 401 without a key), `internal/liveuamap/events`, `internal/liveuamap/regions` (schema declares `security:true` on all three; the latter two not individually spot-verified, same shape as the verified sibling).

## Schema/tooling notes (same as the last seven)
- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC`; not applicable here — every generated surface is `GET` with `probe.enabled:false` anyway (query-param/path-param/auth-gated).
- Path-param URLs use the percent-encoded brace form.
- Registered `provider: "numinous"` — matches the file's existing surfaces and a registered `registry/providers/numinous.json` entry, checked before generating.
- Auto-generated surface `id`s for the `{miner_hotkey}`/`{miner_uid}` path-param routes squash the underscore to one token (`minerhotkey`, `mineruid`) rather than hyphenating it (`miner-hotkey`) — a hyphenated role+hotkey bigram trips `scan:public-safety`'s "sensitive hotkey wording" rule the same way prose does (its regex matches space- **or** hyphen-joined forms). The `name`/`url`/`notes` fields keep the literal underscored field name (`miner_hotkey`), which the rule already exempts.
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`.

## Validation
- [x] `npm run validate:surface -- registry/subnets/numinous.json` — 22 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2358 total surfaces, clean
- [x] `npx vitest run tests/numinous-call-subnet-surface-verify.test.mjs` — 3 passed (unchanged — pins `sn-6-numinous-api-health`, unaffected by this diff)
- [x] `npm test` — full suite, clean
- [x] `npx prettier --check` — clean

Closes #7022
