### PR TITLE
build(typescript): Phase 1 pilot — convert 7 leaf-utility src/ files to .ts

### DIFF
--- a/scripts/refresh-economics.mjs
+++ b/scripts/refresh-economics.mjs
@@ -25,7 +25,7 @@ import {
 } from "./lib.mjs";
 import { loadAlphaPriceHistoryByNetuid } from "./lib/load-alpha-price-history.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
-import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
 import { shouldPublishEconomics } from "./economics-floor.mjs";
 import { initSentry, endSessionAndFlush } from "./observability.mjs";
 

--- a/src/account-identity-history.mjs
+++ b/src/account-identity-history.mjs
@@ -19,7 +19,7 @@ import {
   IDENTITY_FIELDS,
   sanitizeAccountIdentityFields,
 } from "./account-identity.mjs";
-import { encodeCursor, decodeCursor } from "./cursor.mjs";
+import { encodeCursor, decodeCursor } from "./cursor.ts";
 import {
   clampLimit,
   clampOffset,

--- a/src/account-root-claim.mjs
+++ b/src/account-root-claim.mjs
@@ -20,9 +20,9 @@
 // pattern; I96F32 decode mirrors network-parameters' fixed-point split.
 
 import { blake2b } from "@noble/hashes/blake2.js";
-import { encodeAccountId32 } from "./ss58.mjs";
+import { encodeAccountId32 } from "./ss58.ts";
 import { isFinneySs58Address } from "./account-balance.mjs";
-import { storageMapPrefix, bytesToHex } from "./twox-storage-key.mjs";
+import { storageMapPrefix, bytesToHex } from "./twox-storage-key.ts";
 
 export const ROOT_CLAIM_KV_TTL = 120; // seconds
 export const ROOT_CLAIM_NEGATIVE_KV_TTL = 10; // seconds

--- a/src/address-mapping.mjs
+++ b/src/address-mapping.mjs
@@ -11,7 +11,7 @@
 // (sudo-key.mjs/network-parameters.mjs/etc use FINNEY_RPC_URL for
 // Substrate-native methods; eth_call is the Ethereum-native sibling on that
 // identical endpoint). Mirrors src/sudo-key.mjs's live-RPC + KV-cache shape.
-import { encodeAccountId32 } from "./ss58.mjs";
+import { encodeAccountId32 } from "./ss58.ts";
 import { functionSelector } from "./evm-precompiles.mjs";
 
 const ADDRESS_MAPPING_PRECOMPILE_ADDRESS =

--- a/src/big-int-safe-json.ts
+++ b/src/big-int-safe-json.ts
@@ -28,7 +28,7 @@
 const JSON_STRING_OR_NUMBER =
   /"(?:[^"\\]|\\.)*"|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/g;
 
-function quoteUnsafeIntegers(text) {
+function quoteUnsafeIntegers(text: string): string {
   return text.replace(JSON_STRING_OR_NUMBER, (token) => {
     if (token[0] === '"') return token; // already a string -- leave untouched
     if (!/^-?\d+$/.test(token)) return token; // has a decimal point/exponent -- not a bare integer, Number() already the only sane representation
@@ -42,6 +42,6 @@ function quoteUnsafeIntegers(text) {
  * literal past Number.MAX_SAFE_INTEGER -- which is every call_args payload
  * except the specific numeric fields (U256 limbs, u64 PoW nonces, ...) large
  * enough to need it. */
-export function parseJsonPreservingBigInts(text) {
+export function parseJsonPreservingBigInts(text: string): unknown {
   return JSON.parse(quoteUnsafeIntegers(text));
 }

--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -8,7 +8,7 @@ import {
   clampLimit,
   clampOffset,
 } from "../workers/request-params.mjs";
-import { decodeCursor, encodeCursor } from "./cursor.mjs";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
 
 function toIso(ms) {
   if (ms == null) return null;

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -11,7 +11,7 @@
 // can't import from directly -- same split already established for
 // ss58.ts/ss58.mjs and chain-event-args.ts/chain-event-args.mjs.
 
-function isIntArray(value) {
+function isIntArray(value: unknown): value is number[] {
   return (
     Array.isArray(value) &&
     value.every(
@@ -28,7 +28,7 @@ function isIntArray(value) {
  * newtype-wrapped `Hash`/`H256`/`BoundedVec<u8>` field with one or more
  * wraps (e.g. a `commit_hash`, or `commit`/`ciphertext`'s variable-length
  * payload) with the same function. */
-export function unwrapByteArray(value) {
+export function unwrapByteArray(value: unknown): number[] | null {
   let current = value;
   while (
     Array.isArray(current) &&
@@ -42,7 +42,7 @@ export function unwrapByteArray(value) {
 
 /** Canonical lowercase `0x`-prefixed hex, matching D1's existing convention
  * for opaque byte blobs. */
-export function bytesToHex(bytes) {
+export function bytesToHex(bytes: number[]): string {
   return "0x" + bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
@@ -61,11 +61,16 @@ const TEXTUAL_FIELDS = new Set([
  * hex for everything else (the safe default for opaque payloads, and the
  * same fix for D1's own Ethereum.transact.input mojibake bug that field is
  * deliberately NOT in the allowlist). */
-export function decodeBytesField(callModule, callFunction, fieldName, bytes) {
+export function decodeBytesField(
+  callModule: string | null | undefined,
+  callFunction: string | null | undefined,
+  fieldName: string,
+  bytes: number[],
+): string {
   const key = `${callModule ?? ""}.${callFunction ?? ""}.${fieldName}`;
   if (TEXTUAL_FIELDS.has(key)) {
     try {
-      return new TextDecoder("utf-8", { fatal: true }).decode(
+      return new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(
         Uint8Array.from(bytes),
       );
     } catch {

--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -27,7 +27,7 @@
 // (e.g. a MultiAddress::Signed(AccountId32) tag once the account itself is
 // hex, or a Result<(),E>::Ok(()) down to bare "Ok"). Everything else is
 // untouched.
-import { encodeAccountId32 } from "./ss58.mjs";
+import { encodeAccountId32 } from "./ss58.ts";
 
 const ACCOUNT_KEYS = new Set([
   "who",
@@ -206,7 +206,7 @@ function toHex(bytes) {
 }
 
 // Known free-text/opaque variable-length byte fields, keyed by
-// "Pallet.method.field" -- mirrors src/bytes.mjs's TEXTUAL_FIELDS (#4689)
+// "Pallet.method.field" -- mirrors src/bytes.ts's TEXTUAL_FIELDS (#4689)
 // for the analogous call_args gap, scoped narrowly by exact pallet/method/
 // field triple rather than any shape heuristic (chain_events.args carries
 // no per-field type string, so a length-based guess would risk the same

--- a/src/child-hotkey-delegation.mjs
+++ b/src/child-hotkey-delegation.mjs
@@ -37,9 +37,9 @@
 // implementation because no XXHash64 dependency exists in this repo.
 
 import { blake2b } from "@noble/hashes/blake2.js";
-import { encodeAccountId32 } from "./ss58.mjs";
+import { encodeAccountId32 } from "./ss58.ts";
 import { isFinneySs58Address } from "./account-balance.mjs";
-import { storageMapPrefix, bytesToHex } from "./twox-storage-key.mjs";
+import { storageMapPrefix, bytesToHex } from "./twox-storage-key.ts";
 
 export const CHILD_HOTKEY_KV_TTL = 120; // seconds -- live chain state, same profile as subnet-lease.mjs
 export const CHILD_HOTKEY_NEGATIVE_KV_TTL = 10; // seconds

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -14,8 +14,9 @@
 
 // Normalize one cursor part: non-negative safe integers, or D1-style numeric
 // strings (decodeCursor accepts `/^\d+$/` segments; encode must be symmetric).
-function cursorPart(value) {
-  if (Number.isSafeInteger(value) && value >= 0) return value;
+function cursorPart(value: number | string): number | null {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0)
+    return value;
   if (typeof value === "string" && /^\d+$/.test(value)) {
     const n = Number(value);
     if (Number.isSafeInteger(n) && n >= 0) return n;
@@ -28,9 +29,9 @@ function cursorPart(value) {
 // arrive as strings). Returns null for empty/invalid input (no next_cursor).
 // Values above Number.MAX_SAFE_INTEGER are rejected — they cannot survive the
 // Number() round-trip the decoder performs.
-export function encodeCursor(parts) {
+export function encodeCursor(parts: Array<number | string>): string | null {
   if (!Array.isArray(parts) || parts.length === 0) return null;
-  const normalized = [];
+  const normalized: number[] = [];
   for (const part of parts) {
     const n = cursorPart(part);
     if (n == null) return null;
@@ -42,11 +43,11 @@ export function encodeCursor(parts) {
 // Decode a cursor token back to exactly `arity` non-negative integers. Returns
 // null on any malformed/garbage input (the handler then ignores the cursor),
 // preserving the never-throw contract of the chain routes.
-export function decodeCursor(raw, arity) {
+export function decodeCursor(raw: unknown, arity: number): number[] | null {
   if (typeof raw !== "string" || raw === "") return null;
   const segs = raw.split(".");
   if (segs.length !== arity) return null;
-  const parts = [];
+  const parts: number[] = [];
   for (const s of segs) {
     if (!/^\d+$/.test(s)) return null;
     const n = Number(s);

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -10,11 +10,11 @@ import {
   clampLimit,
   clampOffset,
 } from "../workers/request-params.mjs";
-import { decodeCursor, encodeCursor } from "./cursor.mjs";
-import { normalizePostgresValue } from "./scale-normalize.mjs";
+import { decodeCursor, encodeCursor } from "./cursor.ts";
+import { normalizePostgresValue } from "./scale-normalize.ts";
 import { decodePostgresCallArgs } from "./postgres-call-args.mjs";
 import { decodeEthereumEvmCallArgs } from "./indexer-rs-ethereum-decode.mjs";
-import { parseJsonPreservingBigInts } from "./big-int-safe-json.mjs";
+import { parseJsonPreservingBigInts } from "./big-int-safe-json.ts";
 import { decodeBTreeSetFields } from "./postgres-collection-normalize.mjs";
 
 // Was the D1 prune-cron's retention window (a 2026-07-10 capacity emergency:

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -334,7 +334,7 @@ import {
   buildCounterparties,
   buildCounterpartyRelationship,
 } from "./counterparties.mjs";
-import { KV_HEALTH_META, KV_HEALTH_RPC_POOL } from "./kv-keys.mjs";
+import { KV_HEALTH_META, KV_HEALTH_RPC_POOL } from "./kv-keys.ts";
 import {
   ANALYTICS_WINDOWS,
   DEFAULT_ANALYTICS_WINDOW,

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -34,7 +34,7 @@ import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
-} from "./kv-keys.mjs";
+} from "./kv-keys.ts";
 import {
   diffChangedSubnetNetuids,
   notifySubnetStatusChanged,

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -17,7 +17,7 @@ import {
   normalizeProbeStatus,
   okLatencyMs,
 } from "./health-probe-core.mjs";
-import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.mjs";
+import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 
 // Must exceed the probe cadence (15 min) so a live D1 health row is never treated

--- a/src/indexer-rs-ethereum-decode.mjs
+++ b/src/indexer-rs-ethereum-decode.mjs
@@ -47,13 +47,13 @@
 // past 2^53 the exact same way -- so a limb like 9131459485341369597 arrived
 // here already rounded to 9131459485341369344, and the resulting decimal
 // string LOOKED exact while being built from imprecise input. Fixed by
-// routing row.call_args through src/big-int-safe-json.mjs's
+// routing row.call_args through src/big-int-safe-json.ts's
 // parseJsonPreservingBigInts instead of bare JSON.parse -- see that module's
 // header for the mechanism. toLimbBigInt below accepts either a plain number
 // (the common case: 3 of a U256's 4 limbs are usually 0, safe either way) or
 // the numeric STRING that parser produces for a limb large enough to need it.
-import { isEnumTreeNode } from "./scale-normalize.mjs";
-import { unwrapByteArray, bytesToHex } from "./bytes.mjs";
+import { isEnumTreeNode } from "./scale-normalize.ts";
+import { unwrapByteArray, bytesToHex } from "./bytes.ts";
 import { decodeEvmPrecompileCall } from "./evm-precompiles.mjs";
 
 // A single limb (u64, up to 2^64-1) as delivered by src/extrinsics.mjs's

--- a/src/kv-keys.ts
+++ b/src/kv-keys.ts
@@ -3,7 +3,7 @@
 // resolveLiveEconomics) so a key string can never drift between writer and reader
 // — a typo on one side would silently degrade the live tier to its R2 fallback
 // with no error. Leaf module (no imports) so any side can depend on it safely.
-export const KV_HEALTH_CURRENT = "health:current";
-export const KV_HEALTH_RPC_POOL = "health:rpc-pool";
-export const KV_HEALTH_META = "health:meta";
-export const KV_ECONOMICS_CURRENT = "economics:current";
+export const KV_HEALTH_CURRENT = "health:current" as const;
+export const KV_HEALTH_RPC_POOL = "health:rpc-pool" as const;
+export const KV_HEALTH_META = "health:meta" as const;
+export const KV_ECONOMICS_CURRENT = "economics:current" as const;

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -616,7 +616,7 @@ import {
   withinRateLimit,
 } from "./ai-search.mjs";
 import { keywordScore, queryTerms } from "./keyword-search.mjs";
-import { KV_HEALTH_META } from "./kv-keys.mjs";
+import { KV_HEALTH_META } from "./kv-keys.ts";
 import {
   buildAccountsList,
   ACCOUNTS_LIST_SORTS,

--- a/src/postgres-call-args.mjs
+++ b/src/postgres-call-args.mjs
@@ -22,9 +22,9 @@
 // later pass over the combined tree recurses into it generically and never
 // misidentifies it -- see src/extrinsics.mjs's formatExtrinsic for the call
 // order this depends on.
-import { isEnumTreeNode } from "./scale-normalize.mjs";
-import { normalizeAccountId32Field } from "./ss58.mjs";
-import { unwrapByteArray, decodeBytesField, bytesToHex } from "./bytes.mjs";
+import { isEnumTreeNode } from "./scale-normalize.ts";
+import { normalizeAccountId32Field } from "./ss58.ts";
+import { unwrapByteArray, decodeBytesField, bytesToHex } from "./bytes.ts";
 import { BTREESET_FIELDS } from "./postgres-collection-normalize.mjs";
 
 // True when `value` is D1/indexer-rs's typed call_args field descriptor

--- a/src/randomness.mjs
+++ b/src/randomness.mjs
@@ -11,7 +11,7 @@
 //
 // Storage keys = twox128("Drand") ++ twox128(<item name>), no further
 // hashing (each is a StorageValue, not a map) -- computed via
-// src/twox-storage-key.mjs's storageMapPrefix and hardcoded below, matching
+// src/twox-storage-key.ts's storageMapPrefix and hardcoded below, matching
 // network-parameters.mjs's own precedent of precomputing fixed pallet/item
 // prefixes rather than hashing on every request (the pallet/item name never
 // changes). Cross-checked against that module's already-verified

--- a/src/scale-normalize.ts
+++ b/src/scale-normalize.ts
@@ -54,7 +54,9 @@
 // postgres-collection-normalize.mjs's narrow per-field allowlist for how
 // that side is handled instead).
 
-function isPlainScalar(value) {
+function isPlainScalar(
+  value: unknown,
+): value is string | number | boolean | null {
   return (
     value === null ||
     typeof value === "number" ||
@@ -71,16 +73,25 @@ function isPlainScalar(value) {
  * never collide. Postgres/indexer-rs's raw dump never produces this shape
  * (its call_args is either a flat `{fieldName: value}` object or a bare
  * array), so this is D1-specific by construction, not just by convention. */
-export function isTypedFieldDescriptor(value) {
+interface TypedFieldDescriptor {
+  name: string;
+  type: string;
+  value: unknown;
+}
+
+export function isTypedFieldDescriptor(
+  value: unknown,
+): value is TypedFieldDescriptor {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const keys = Object.keys(value);
+  const candidate = value as Record<string, unknown>;
   return (
     keys.length === 3 &&
     keys.includes("name") &&
     keys.includes("type") &&
     keys.includes("value") &&
-    typeof value.name === "string" &&
-    typeof value.type === "string"
+    typeof candidate.name === "string" &&
+    typeof candidate.type === "string"
   );
 }
 
@@ -99,7 +110,7 @@ export function isTypedFieldDescriptor(value) {
 const COLLECTION_TYPE_RE =
   /(?:Vec|BoundedVec|WeakBoundedVec|BTreeSet|BoundedBTreeSet|BTreeMap|BoundedBTreeMap)</;
 
-function isCollectionType(type) {
+function isCollectionType(type: string): boolean {
   return COLLECTION_TYPE_RE.test(type);
 }
 
@@ -109,7 +120,7 @@ function isCollectionType(type) {
 // could itself be an Option, nested struct, etc). Falls through to the
 // generic normalize() if `value` isn't actually an array (defensive; not
 // expected for a real collection-typed field).
-function normalizeCollectionValue(value) {
+function normalizeCollectionValue(value: unknown): unknown {
   if (!Array.isArray(value)) return normalize(value);
   return value.map(normalize);
 }
@@ -119,19 +130,25 @@ function normalizeCollectionValue(value) {
  * needs the identical shape check to distinguish a nested call from an
  * ordinary enum-with-data node (both share this two-key shape; the
  * distinction is whether `values[0]` is ITSELF another such node). */
-export function isEnumTreeNode(value) {
+interface EnumTreeNode {
+  name: string;
+  values: unknown[];
+}
+
+export function isEnumTreeNode(value: unknown): value is EnumTreeNode {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const keys = Object.keys(value);
+  const candidate = value as Record<string, unknown>;
   return (
     keys.length === 2 &&
     keys.includes("name") &&
     keys.includes("values") &&
-    typeof value.name === "string" &&
-    Array.isArray(value.values)
+    typeof candidate.name === "string" &&
+    Array.isArray(candidate.values)
   );
 }
 
-function normalize(value) {
+function normalize(value: unknown): unknown {
   if (Array.isArray(value)) {
     // Generic single-field newtype/tuple-struct wrap around a plain scalar
     // (e.g. LimitOrders.execute_batched_orders' fee_rate: [0] -> 0). Scoped to
@@ -176,7 +193,7 @@ function normalize(value) {
     };
   }
   if (value && typeof value === "object") {
-    const out = {};
+    const out: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) out[key] = normalize(val);
     return out;
   }
@@ -194,6 +211,6 @@ function normalize(value) {
  * PREVIOUSLY (incorrectly) documented and tested as an unconditional no-op on
  * D1 data; that was false whenever a collection-typed field held exactly one
  * element, e.g. SubtensorModule.set_weights' dests/weights). */
-export function normalizePostgresValue(value) {
+export function normalizePostgresValue(value: unknown): unknown {
   return normalize(value);
 }

--- a/src/ss58.ts
+++ b/src/ss58.ts
@@ -20,7 +20,7 @@ export const DEFAULT_SS58_PREFIX = 42;
 // doesn't apply to any caller here: the payload always starts with a
 // non-zero network prefix byte, so the byte array this ever sees can't start
 // with a zero byte.
-function encodeBase58(bytes) {
+function encodeBase58(bytes: Uint8Array): string {
   let num = 0n;
   for (const b of bytes) num = (num << 8n) | BigInt(b);
   let out = "";
@@ -39,9 +39,9 @@ function encodeBase58(bytes) {
  * tested in tests/ss58.test.mjs against real production data.
  */
 export function encodeAccountId32(
-  accountIdBytes,
+  accountIdBytes: Uint8Array | number[],
   prefix = DEFAULT_SS58_PREFIX,
-) {
+): string | null {
   const bytes =
     accountIdBytes instanceof Uint8Array
       ? accountIdBytes
@@ -74,7 +74,7 @@ const SS58_ACCOUNT_ID32_BYTE_LENGTH = 35;
 // this deliberately doesn't handle can't arise for a well-formed address.
 // Returns null for a character outside the alphabet or a value too large to
 // fit in that many bytes (either way, not a valid encoding of that length).
-function decodeBase58(str, byteLength) {
+function decodeBase58(str: string, byteLength: number): Uint8Array | null {
   let num = 0n;
   for (const char of str) {
     const index = BASE58_ALPHABET.indexOf(char);
@@ -99,7 +99,9 @@ function decodeBase58(str, byteLength) {
  * Round-trip tested against tests/ss58.test.mjs's existing encode golden
  * values.
  */
-export function decodeSs58(address) {
+export function decodeSs58(
+  address: unknown,
+): { prefix: number; publicKey: Uint8Array } | null {
   if (typeof address !== "string" || address.length === 0) return null;
   const decoded = decodeBase58(address, SS58_ACCOUNT_ID32_BYTE_LENGTH);
   if (!decoded) return null;
@@ -113,7 +115,7 @@ export function decodeSs58(address) {
   return { prefix: payload[0], publicKey: payload.slice(1) };
 }
 
-function isByteArray(value, len) {
+function isByteArray(value: unknown, len: number): value is number[] {
   return (
     Array.isArray(value) &&
     value.length === len &&
@@ -127,7 +129,7 @@ function isByteArray(value, len) {
  * bare AccountId32 field arrives as `[[b0..b31]]`, not a flat 32-byte array.
  * Unwraps that one layer; returns null if `value` isn't that shape.
  */
-function unwrapAccountId32Newtype(value) {
+function unwrapAccountId32Newtype(value: unknown): number[] | null {
   if (Array.isArray(value) && value.length === 1 && isByteArray(value[0], 32)) {
     return value[0];
   }
@@ -143,18 +145,17 @@ function unwrapAccountId32Newtype(value) {
  * integer, `Raw` is arbitrary-length bytes), and none have been observed on
  * this chain, so declining is safer than guessing (#4669/#4688).
  */
-export function unwrapMultiAddressId(value) {
+export function unwrapMultiAddressId(value: unknown): number[] | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as { name?: unknown; values?: unknown };
   if (
-    !value ||
-    typeof value !== "object" ||
-    Array.isArray(value) ||
-    value.name !== "Id" ||
-    !Array.isArray(value.values) ||
-    value.values.length !== 1
+    candidate.name !== "Id" ||
+    !Array.isArray(candidate.values) ||
+    candidate.values.length !== 1
   ) {
     return null;
   }
-  return unwrapAccountId32Newtype(value.values[0]);
+  return unwrapAccountId32Newtype(candidate.values[0]);
 }
 
 /**
@@ -166,7 +167,10 @@ export function unwrapMultiAddressId(value) {
  * structurally indistinguishable from a `Hash`/`H256` (#4669's accepted
  * ambiguity note), so callers must gate on field-name/context first.
  */
-export function normalizeAccountId32Field(value, prefix = DEFAULT_SS58_PREFIX) {
+export function normalizeAccountId32Field(
+  value: unknown,
+  prefix = DEFAULT_SS58_PREFIX,
+): string | null {
   if (isByteArray(value, 32)) return encodeAccountId32(value, prefix);
   const unwrapped =
     unwrapAccountId32Newtype(value) ?? unwrapMultiAddressId(value);

--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -7,7 +7,7 @@
 // recordSubnetIdentityChanges' own header comment). Pure + injectable for
 // tests.
 
-import { encodeCursor, decodeCursor } from "./cursor.mjs";
+import { encodeCursor, decodeCursor } from "./cursor.ts";
 import {
   sanitizeIdentityHistoryFields,
   sanitizeIdentityHistoryText,

--- a/src/subnet-lease.mjs
+++ b/src/subnet-lease.mjs
@@ -34,12 +34,12 @@
 // single hardcoded prefix, this file needs three different item prefixes so
 // they're computed via that shared module rather than each hardcoded here.
 
-import { encodeAccountId32 } from "./ss58.mjs";
+import { encodeAccountId32 } from "./ss58.ts";
 import { isU16Netuid } from "./subnet-recycled.mjs";
 import {
   twox64ConcatU16StorageKey,
   twox64ConcatU32StorageKey,
-} from "./twox-storage-key.mjs";
+} from "./twox-storage-key.ts";
 
 export const SUBNET_LEASE_KV_TTL = 120; // seconds -- same freshness profile as subnet-burn.mjs
 export const SUBNET_LEASE_NEGATIVE_KV_TTL = 10; // seconds

--- a/src/sudo-key.mjs
+++ b/src/sudo-key.mjs
@@ -10,7 +10,7 @@
 // Server-side SS58 encoding lives in src/ss58.mjs (extracted #4688) -- see
 // that module's header for why @noble/hashes' blake2b is required over
 // node:crypto's createHash("blake2b512") (unsupported in workerd).
-import { encodeAccountId32 } from "./ss58.mjs";
+import { encodeAccountId32 } from "./ss58.ts";
 
 const SUDO_KEY_STORAGE_KEY =
   "0x5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b";

--- a/src/twox-storage-key.ts
+++ b/src/twox-storage-key.ts
@@ -23,12 +23,12 @@ const PRIME64_4 = 0x85ebca77c2b2ae63n;
 const PRIME64_5 = 0x27d4eb2f165667c5n;
 const MASK64 = (1n << 64n) - 1n;
 
-function rotl64(x, r) {
+function rotl64(x: bigint, r: bigint): bigint {
   x &= MASK64;
   return ((x << r) | (x >> (64n - r))) & MASK64;
 }
 
-function readU64LE(bytes, offset) {
+function readU64LE(bytes: Uint8Array, offset: number): bigint {
   let v = 0n;
   for (let i = 7; i >= 0; i -= 1) {
     v = (v << 8n) | BigInt(bytes[offset + i]);
@@ -36,7 +36,7 @@ function readU64LE(bytes, offset) {
   return v;
 }
 
-function readU32LE(bytes, offset) {
+function readU32LE(bytes: Uint8Array, offset: number): bigint {
   return (
     BigInt(bytes[offset]) |
     (BigInt(bytes[offset + 1]) << 8n) |
@@ -50,7 +50,7 @@ function readU32LE(bytes, offset) {
 // name or a 2-8 byte SCALE-encoded map key, well under 32 bytes, but the long
 // path is implemented too rather than asserting a length ceiling, so this
 // stays correct if a future storage item's key ever needs it.
-export function xxh64(input, seed = 0n) {
+export function xxh64(input: Uint8Array | string, seed = 0n): bigint {
   const bytes =
     input instanceof Uint8Array ? input : new TextEncoder().encode(input);
   const len = bytes.length;
@@ -135,7 +135,7 @@ export function xxh64(input, seed = 0n) {
   return h64 & MASK64;
 }
 
-function u64ToLeBytes(v) {
+function u64ToLeBytes(v: bigint): Uint8Array {
   const out = new Uint8Array(8);
   for (let i = 0; i < 8; i += 1) {
     out[i] = Number((v >> BigInt(i * 8)) & 0xffn);
@@ -143,7 +143,7 @@ function u64ToLeBytes(v) {
   return out;
 }
 
-function concatBytes(...parts) {
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
   const total = parts.reduce((sum, p) => sum + p.length, 0);
   const out = new Uint8Array(total);
   let offset = 0;
@@ -154,21 +154,21 @@ function concatBytes(...parts) {
   return out;
 }
 
-function toHex(bytes) {
+function toHex(bytes: Uint8Array): string {
   return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 // twox64(input) -- one XXH64 hash (seed 0), little-endian bytes. This IS the
 // Twox64Concat map-key hash (not "prefix"); see twox64Concat below for the
 // full concat form actually used in a StorageMap key.
-export function twox64(input) {
+export function twox64(input: Uint8Array | string): Uint8Array {
   return u64ToLeBytes(xxh64(input, 0n));
 }
 
 // twox128(input) -- the fixed pallet-name/item-name prefix hash: two XXH64
 // hashes (seeds 0 and 1) concatenated, little-endian. Matches sudo-key.mjs's
 // own already-verified reference value exactly (see this module's header).
-export function twox128(input) {
+export function twox128(input: Uint8Array | string): Uint8Array {
   return concatBytes(
     u64ToLeBytes(xxh64(input, 0n)),
     u64ToLeBytes(xxh64(input, 1n)),
@@ -182,7 +182,10 @@ export function twox128(input) {
 // per-request Twox64Concat suffix, precomputing just the prefix independently
 // saves nothing (the pallet+item strings are already known constants either
 // way), so both are exposed for callers to compose as needed.
-export function storageMapPrefix(palletName, itemName) {
+export function storageMapPrefix(
+  palletName: string,
+  itemName: string,
+): Uint8Array {
   return concatBytes(twox128(palletName), twox128(itemName));
 }
 
@@ -191,7 +194,7 @@ export function storageMapPrefix(palletName, itemName) {
 // to recover the original key by reading the tail of each returned storage
 // key, unlike a Blake2_128Concat-hashed key of variable/opaque original width
 // stored the same way but requiring a different hash-length skip).
-export function twox64Concat(keyBytes) {
+export function twox64Concat(keyBytes: Uint8Array): Uint8Array {
   return concatBytes(twox64(keyBytes), keyBytes);
 }
 
@@ -199,14 +202,18 @@ export function twox64Concat(keyBytes) {
 // burn.mjs's own netuidStorageKeySuffix, duplicated rather than imported
 // (this codebase's established self-contained-module convention for small
 // codec helpers -- see subnet-burn.mjs's own comment on why).
-export function u16LeBytes(n) {
+export function u16LeBytes(n: number): Uint8Array {
   return new Uint8Array([n & 0xff, (n >> 8) & 0xff]);
 }
 
 // Full storage key for a StorageMap<_, Twox64Concat, u16, V> entry (e.g.
 // SubtensorModule::SubnetUidToLeaseId), as a "0x"-prefixed hex string ready
 // for a state_getStorage RPC call.
-export function twox64ConcatU16StorageKey(palletName, itemName, netuid) {
+export function twox64ConcatU16StorageKey(
+  palletName: string,
+  itemName: string,
+  netuid: number,
+): string {
   const prefix = storageMapPrefix(palletName, itemName);
   const suffix = twox64Concat(u16LeBytes(netuid));
   return "0x" + toHex(concatBytes(prefix, suffix));
@@ -215,7 +222,7 @@ export function twox64ConcatU16StorageKey(palletName, itemName, netuid) {
 // u32 SCALE encoding: little-endian, 4 bytes -- Substrate's `LeaseId = u32`
 // (pallets/subtensor/src/subnets/leasing.rs), the map key for SubnetLeases
 // and AccumulatedLeaseDividends.
-export function u32LeBytes(n) {
+export function u32LeBytes(n: number): Uint8Array {
   return new Uint8Array([
     n & 0xff,
     (n >> 8) & 0xff,
@@ -224,12 +231,16 @@ export function u32LeBytes(n) {
   ]);
 }
 
-export function twox64ConcatU32StorageKey(palletName, itemName, id) {
+export function twox64ConcatU32StorageKey(
+  palletName: string,
+  itemName: string,
+  id: number,
+): string {
   const prefix = storageMapPrefix(palletName, itemName);
   const suffix = twox64Concat(u32LeBytes(id));
   return "0x" + toHex(concatBytes(prefix, suffix));
 }
 
-export function bytesToHex(bytes) {
+export function bytesToHex(bytes: Uint8Array): string {
   return "0x" + toHex(bytes);
 }

--- a/src/wallet-auth.mjs
+++ b/src/wallet-auth.mjs
@@ -11,7 +11,7 @@
 // signing key material never reaches this codebase: the wallet extension
 // signs client-side, this module only ever sees the resulting signature.
 import { verify as sr25519Verify } from "@scure/sr25519";
-import { DEFAULT_SS58_PREFIX, decodeSs58 } from "./ss58.mjs";
+import { DEFAULT_SS58_PREFIX, decodeSs58 } from "./ss58.ts";
 import { signPayload, timingSafeEqual } from "./webhooks.mjs";
 
 const CHALLENGE_KV_PREFIX = "wallet-challenge:";

--- a/tests/account-identity-history.test.mjs
+++ b/tests/account-identity-history.test.mjs
@@ -7,7 +7,7 @@ import {
   identityHash,
   loadAccountIdentityHistory,
 } from "../src/account-identity-history.mjs";
-import { encodeCursor } from "../src/cursor.mjs";
+import { encodeCursor } from "../src/cursor.ts";
 
 describe("identityHash", () => {
   test("is stable for the same snapshot", async () => {

--- a/tests/account-root-claim.test.mjs
+++ b/tests/account-root-claim.test.mjs
@@ -11,7 +11,7 @@ import {
   ROOT_CLAIM_KV_TTL,
   ROOT_CLAIM_NEGATIVE_KV_TTL,
 } from "../src/account-root-claim.mjs";
-import { encodeAccountId32 } from "../src/ss58.mjs";
+import { encodeAccountId32 } from "../src/ss58.ts";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 

--- a/tests/big-int-safe-json.test.mjs
+++ b/tests/big-int-safe-json.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { parseJsonPreservingBigInts } from "../src/big-int-safe-json.mjs";
+import { parseJsonPreservingBigInts } from "../src/big-int-safe-json.ts";
 
 describe("parseJsonPreservingBigInts", () => {
   test("preserves a large integer literal as an exact string instead of rounding it (the real corruption case caught by Gittensory review on #4692's original PR)", () => {

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -15,7 +15,7 @@ import {
   loadBlocks,
   MAX_BLOCK_COUNT_FILTER,
 } from "../src/blocks.mjs";
-import { encodeCursor } from "../src/cursor.mjs";
+import { encodeCursor } from "../src/cursor.ts";
 
 // ---- Pure module (#1345) ---------------------------------------------------
 

--- a/tests/bytes.test.mjs
+++ b/tests/bytes.test.mjs
@@ -1,10 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import {
-  unwrapByteArray,
-  bytesToHex,
-  decodeBytesField,
-} from "../src/bytes.mjs";
+import { unwrapByteArray, bytesToHex, decodeBytesField } from "../src/bytes.ts";
 
 describe("unwrapByteArray", () => {
   test("returns a flat byte array unchanged (zero wraps, e.g. Multisig's raw call_hash)", () => {

--- a/tests/child-hotkey-delegation.test.mjs
+++ b/tests/child-hotkey-delegation.test.mjs
@@ -8,7 +8,7 @@ import {
   loadAccountChildren,
   loadAccountParents,
 } from "../src/child-hotkey-delegation.mjs";
-import { encodeAccountId32 } from "../src/ss58.mjs";
+import { encodeAccountId32 } from "../src/ss58.ts";
 import { handleRequest } from "../workers/api.mjs";
 
 function req(path) {

--- a/tests/cursor.test.mjs
+++ b/tests/cursor.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { encodeCursor, decodeCursor } from "../src/cursor.mjs";
+import { encodeCursor, decodeCursor } from "../src/cursor.ts";
 
 // ---- Keyset cursor codec (#1851) ------------------------------------------
 

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3,7 +3,7 @@
 // Hyperdrive→Railway path is validated separately.
 import { beforeEach, test, expect, vi } from "vitest";
 import { BLOCK_PAGINATION, MAX_OFFSET } from "../workers/request-params.mjs";
-import { encodeCursor } from "../src/cursor.mjs";
+import { encodeCursor } from "../src/cursor.ts";
 import { formatSubnetHyperparams } from "../src/subnet-hyperparams.mjs";
 import { hyperparamsHash } from "../src/subnet-hyperparams-history.mjs";
 import { IDENTITY_FIELDS } from "../src/account-identity.mjs";

--- a/tests/economics-current-kv-cache.test.mjs
+++ b/tests/economics-current-kv-cache.test.mjs
@@ -4,7 +4,7 @@ import {
   ECONOMICS_CURRENT_KV_TTL_MS,
   readEconomicsCurrentKv,
 } from "../workers/api.mjs";
-import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
 
 // readEconomicsCurrentKv wraps readHealthKv(env, KV_ECONOMICS_CURRENT) with a
 // 60-second in-isolate memo — same pattern as readHealthMetaKv (#1375),

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -12,7 +12,7 @@ import {
   formatExtrinsic,
   loadExtrinsics,
 } from "../src/extrinsics.mjs";
-import { encodeCursor } from "../src/cursor.mjs";
+import { encodeCursor } from "../src/cursor.ts";
 import { DAY_MS } from "../workers/config.mjs";
 
 // ---- Pure module (#1345) ---------------------------------------------------

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -34,7 +34,7 @@ import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
-} from "../src/kv-keys.mjs";
+} from "../src/kv-keys.ts";
 
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
 const emptyEnv = {};

--- a/tests/indexer-rs-ethereum-decode.test.mjs
+++ b/tests/indexer-rs-ethereum-decode.test.mjs
@@ -9,7 +9,7 @@ import {
   decodeEthereumEvmCallArgs,
 } from "../src/indexer-rs-ethereum-decode.mjs";
 import { decodePostgresCallArgs } from "../src/postgres-call-args.mjs";
-import { normalizePostgresValue } from "../src/scale-normalize.mjs";
+import { normalizePostgresValue } from "../src/scale-normalize.ts";
 
 // Full formatExtrinsic-equivalent pipeline, matching src/extrinsics.mjs's
 // actual call order (decodePostgresCallArgs -> normalizePostgresValue ->
@@ -87,7 +87,7 @@ describe("decodeU256Limbs", () => {
 
     test("preserves exact precision when one limb arrives as a string (the real corruption case caught by Gittensory review)", () => {
       // 9131459485341369597 exceeds Number.MAX_SAFE_INTEGER -- this is exactly
-      // the shape src/big-int-safe-json.mjs's parseJsonPreservingBigInts
+      // the shape src/big-int-safe-json.ts's parseJsonPreservingBigInts
       // produces: the large limb pre-quoted as a string, the other 3 (small,
       // usually 0) limbs left as plain numbers.
       assert.equal(

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -17411,7 +17411,7 @@ describe("MCP get_subnet_lease", () => {
       ]),
     );
     const { twox64ConcatU32StorageKey } =
-      await import("../src/twox-storage-key.mjs");
+      await import("../src/twox-storage-key.ts");
     const leaseKey = twox64ConcatU32StorageKey(
       "SubtensorModule",
       "SubnetLeases",

--- a/tests/postgres-call-args.test.mjs
+++ b/tests/postgres-call-args.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { decodePostgresCallArgs } from "../src/postgres-call-args.mjs";
-import { normalizePostgresValue } from "../src/scale-normalize.mjs";
+import { normalizePostgresValue } from "../src/scale-normalize.ts";
 
 // decodePostgresCallArgs must run BEFORE normalizePostgresValue (see
 // src/postgres-call-args.mjs's own header for why) -- every test below

--- a/tests/postgres-collection-normalize.test.mjs
+++ b/tests/postgres-collection-normalize.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { decodeBTreeSetFields } from "../src/postgres-collection-normalize.mjs";
-import { normalizePostgresValue } from "../src/scale-normalize.mjs";
+import { normalizePostgresValue } from "../src/scale-normalize.ts";
 
 // Chains after normalizePostgresValue, matching src/extrinsics.mjs's actual
 // formatExtrinsic call order.

--- a/tests/scale-normalize.test.mjs
+++ b/tests/scale-normalize.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { normalizePostgresValue } from "../src/scale-normalize.mjs";
+import { normalizePostgresValue } from "../src/scale-normalize.ts";
 
 describe("normalizePostgresValue", () => {
   describe("Option<T> (Some/None)", () => {

--- a/tests/ss58.test.mjs
+++ b/tests/ss58.test.mjs
@@ -6,7 +6,7 @@ import {
   encodeAccountId32,
   normalizeAccountId32Field,
   unwrapMultiAddressId,
-} from "../src/ss58.mjs";
+} from "../src/ss58.ts";
 
 // Carried over from tests/sudo-key.test.mjs -- live-confirmed 2026-07-08
 // against finney (bittensor 10.5.0, substrate.create_storage_key("Sudo",

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -15,7 +15,7 @@ import {
   recordSubnetIdentityChanges,
   syncSubnetIdentityToPostgres,
 } from "../src/subnet-identity-history.mjs";
-import { encodeCursor } from "../src/cursor.mjs";
+import { encodeCursor } from "../src/cursor.ts";
 
 function identityHistoryRow(overrides = {}) {
   return {

--- a/tests/subnet-lease.test.mjs
+++ b/tests/subnet-lease.test.mjs
@@ -7,7 +7,7 @@ import {
   decodeSubnetLease,
   loadSubnetLease,
 } from "../src/subnet-lease.mjs";
-import { encodeAccountId32 } from "../src/ss58.mjs";
+import { encodeAccountId32 } from "../src/ss58.ts";
 import { handleRequest } from "../workers/api.mjs";
 
 function req(path) {
@@ -234,7 +234,7 @@ describe("loadSubnetLease", () => {
     // SubnetLeases(3)/AccumulatedLeaseDividends(3) fire in parallel under
     // Promise.all, so route the stub by key rather than call order.
     const { twox64ConcatU32StorageKey } =
-      await import("../src/twox-storage-key.mjs");
+      await import("../src/twox-storage-key.ts");
     const leaseKey = twox64ConcatU32StorageKey(
       "SubtensorModule",
       "SubnetLeases",
@@ -285,7 +285,7 @@ describe("loadSubnetLease", () => {
       costRao: 500_000_000_000,
     });
     const { twox64ConcatU32StorageKey } =
-      await import("../src/twox-storage-key.mjs");
+      await import("../src/twox-storage-key.ts");
     const leaseKey = twox64ConcatU32StorageKey(
       "SubtensorModule",
       "SubnetLeases",
@@ -362,7 +362,7 @@ describe("loadSubnetLease", () => {
       costRao: 0,
     });
     const { twox64ConcatU32StorageKey } =
-      await import("../src/twox-storage-key.mjs");
+      await import("../src/twox-storage-key.ts");
     const leaseKey = twox64ConcatU32StorageKey(
       "SubtensorModule",
       "SubnetLeases",
@@ -398,7 +398,7 @@ describe("loadSubnetLease", () => {
       costRao: 0,
     });
     const { twox64ConcatU32StorageKey } =
-      await import("../src/twox-storage-key.mjs");
+      await import("../src/twox-storage-key.ts");
     const leaseKey = twox64ConcatU32StorageKey(
       "SubtensorModule",
       "SubnetLeases",

--- a/tests/twox-storage-key.test.mjs
+++ b/tests/twox-storage-key.test.mjs
@@ -11,7 +11,7 @@ import {
   twox64ConcatU16StorageKey,
   twox64ConcatU32StorageKey,
   bytesToHex,
-} from "../src/twox-storage-key.mjs";
+} from "../src/twox-storage-key.ts";
 
 // Official xxHash64 reference vectors (seed=0), from the upstream xxHash
 // test suite -- verifies the algorithm itself, independent of any

--- a/tests/wallet-auth-keys-route.test.mjs
+++ b/tests/wallet-auth-keys-route.test.mjs
@@ -14,7 +14,7 @@ import {
   secretFromSeed,
   sign as sr25519Sign,
 } from "@scure/sr25519";
-import { encodeAccountId32 } from "../src/ss58.mjs";
+import { encodeAccountId32 } from "../src/ss58.ts";
 import { createSessionToken } from "../src/wallet-auth.mjs";
 
 const mockQueue = vi.hoisted(() => ({ current: [] }));

--- a/tests/wallet-auth.test.mjs
+++ b/tests/wallet-auth.test.mjs
@@ -5,7 +5,7 @@ import {
   secretFromSeed,
   sign as sr25519Sign,
 } from "@scure/sr25519";
-import { encodeAccountId32 } from "../src/ss58.mjs";
+import { encodeAccountId32 } from "../src/ss58.ts";
 import { signPayload } from "../src/webhooks.mjs";
 import {
   createSessionToken,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -251,7 +251,7 @@ import {
   runHealthProber,
   writeSubnetSnapshot,
 } from "../src/health-prober.mjs";
-import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
 import {
   mergeFreshness,
   mergeRpcEndpoints,

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -22,7 +22,7 @@
 import postgres from "postgres";
 import * as Sentry from "@sentry/cloudflare";
 import { parseJsonPreservingBigIntegers } from "../src/postgres-json-parse.mjs";
-import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
+import { decodeCursor, encodeCursor } from "../src/cursor.ts";
 import { buildBlock, buildBlockFeed } from "../src/blocks.mjs";
 import {
   buildExtrinsic,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -227,7 +227,7 @@ import {
   MAX_OHLC_WINDOW_DAYS,
 } from "../../src/subnet-ohlc.mjs";
 import { resolveLiveEconomics } from "../../src/health-serving.mjs";
-import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.mjs";
+import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
 import { readArtifact, readHealthKv } from "../storage.mjs";
 import { buildAccountStakeFlow } from "../../src/account-stake-flow.mjs";
 import {


### PR DESCRIPTION
## Summary

- Phase 1 pilot of the TypeScript migration (#7510): converts 7 pure leaf-utility files in `src/` to real, typed `.ts` end-to-end, proving the conversion checklist (`docs/typescript-migration-checklist.md`) actually works against real files before the larger phases (workers/, src/, scripts/, tests/) begin. Stacked on #7554 (the import-specifier convention fix that PR found necessary) — will auto-retarget to `main` once that merges.

## Why these 7 files

Picked deliberately as the lowest-risk possible pilot: pure leaf utilities with zero-or-one internal `src/` imports of their own (verified by grep), so converting them can't ripple into files this PR doesn't touch, while still having real external callers (4-14 importers each) to prove `.mjs` files importing a freshly-converted `.ts` file works with no shims, under plain `node`, Wrangler's bundler, and Vitest alike.

- `src/bytes.mjs` → `.ts`
- `src/cursor.mjs` → `.ts`
- `src/kv-keys.mjs` → `.ts`
- `src/big-int-safe-json.mjs` → `.ts`
- `src/ss58.mjs` → `.ts`
- `src/twox-storage-key.mjs` → `.ts`
- `src/scale-normalize.mjs` → `.ts`

## What this PR proves (per #7512's acceptance criteria)

1. **The import-specifier convention works cleanly through the full local pipeline**: `npm run lint`, `npm run typecheck`, `npm run test:coverage`, `npm run validate:types`, `npm run validate:contract-drift`, and `npm run build` all pass with a mixed `.mjs`/`.ts` tree.
2. **Wrangler's bundler handles the mixed tree**: `npm run cloudflare:verify:dry-run`, `npm run worker:deploy:dry-run`, and `npm run worker:bundle:budget` (448.7 KiB gzipped, well under the 1024 KiB Cloudflare limit) all pass — `workers/api.mjs`, `workers/data-api.mjs`, and others still-`.mjs` import these now-`.ts` files transitively.
3. **Coverage for these 7 files is measured correctly, not silently dropped**: all 7 report 100% lines/statements/branches/functions in the coverage summary — the Phase 0 glob widening is genuinely picking up renamed files, not just theoretically.
4. **Real type annotations caught real bugs**, not just a mechanical rename — two concrete examples from `tsc --noEmit` on the actual converted code:
   - `src/cursor.ts`'s `cursorPart(value: number | string)` called `Number.isSafeInteger(value)` directly as a narrowing guard — but `Number.isSafeInteger` isn't a TS type predicate, so it doesn't narrow the `number | string` union at all, and the compiler correctly flagged `value >= 0` as comparing a possibly-`string` operand. Fixed with an explicit `typeof value === "number"` guard first — same runtime behavior, now provably correct.
   - `src/bytes.ts`'s `TextDecoder("utf-8", { fatal: true })` failed under `@cloudflare/workers-types`' `TextDecoderConstructorOptions`, which (unlike lib.dom.d.ts) makes `ignoreBOM` non-optional — a real difference between the Workers runtime's actual type surface and the browser DOM types most JS code implicitly assumes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No registry/schema/API changes — pure internal refactor.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run validate:types`
- [x] `npm run validate:contract-drift`
- [x] `npm run build`
- [x] `npm run cloudflare:verify:dry-run`
- [x] `npm run worker:deploy:dry-run`
- [x] `npm run worker:bundle:budget`
- [x] `npm run test:coverage` (via `test:ci` + `test:ci:artifacts`: 473 test files, 11159 tests, all passing; 98.97% statement coverage, unchanged from Phase 0's baseline; the 7 converted files individually at 100%)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Closes #7512
