### PR TITLE
fix(registry): SN85 Vidaio API parity (8 missing surfaces) (#7098)

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -159,6 +159,230 @@
         "https://vidaio.io/"
       ],
       "url": "https://api.vidaio.io/ready"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "X-API-Key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (APIKeyHeader), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-available-credits",
+      "kind": "subnet-api",
+      "name": "Vidaio available credits",
+      "notes": "Get available credits operation on the Vidaio API (GET /available_credits), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET returns HTTP 401 {\"detail\":\"Invalid or missing API key\"}, confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/available_credits"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "X-API-Key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (APIKeyHeader), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-compression",
+      "kind": "subnet-api",
+      "name": "Vidaio compression",
+      "notes": "Start compression operation on the Vidaio API (POST /compression), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/compression"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "X-API-Key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (APIKeyHeader), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-compression-task-id",
+      "kind": "subnet-api",
+      "name": "Vidaio compression task id",
+      "notes": "Get compression status operation on the Vidaio API (GET /compression/{task_id}), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/compression/%7Btask_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "X-API-Key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (APIKeyHeader), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-compression-task-id-result",
+      "kind": "subnet-api",
+      "name": "Vidaio compression task id result",
+      "notes": "Get compression result operation on the Vidaio API (GET /compression/{task_id}/result), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/compression/%7Btask_id%7D/result"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "X-API-Key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (APIKeyHeader), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-rate-limits",
+      "kind": "subnet-api",
+      "name": "Vidaio rate limits",
+      "notes": "Get API key rate limits operation on the Vidaio API (GET /rate_limits), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET returns HTTP 401 {\"detail\":\"Invalid or missing API key\"}, confirming the gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/rate_limits"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "X-API-Key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (APIKeyHeader), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-upscaling",
+      "kind": "subnet-api",
+      "name": "Vidaio upscaling",
+      "notes": "Start upscaling operation on the Vidaio API (POST /upscaling), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/upscaling"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "X-API-Key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (APIKeyHeader), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-upscaling-task-id",
+      "kind": "subnet-api",
+      "name": "Vidaio upscaling task id",
+      "notes": "Get upscaling status operation on the Vidaio API (GET /upscaling/{task_id}), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/upscaling/%7Btask_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "X-API-Key",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (APIKeyHeader), declared per-operation."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-upscaling-task-id-result",
+      "kind": "subnet-api",
+      "name": "Vidaio upscaling task id result",
+      "notes": "Get upscaling result operation on the Vidaio API (GET /upscaling/{task_id}/result), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/upscaling/%7Btask_id%7D/result"
     }
   ],
   "website_url": "https://vidaio.io/"


### PR DESCRIPTION
## Summary

Closes #7098.

Brings SN85 (Vidaio) up to **full subnet API parity** — the completeness bar in `.claude/skills/contributor-pipeline-gardening/SKILL.md`'s "MCP execute verify + wire SN*" special-sweep section. Same approach as SN15 ORO (#7556), SN35 OxMarkets (#7553) and SN37 Aurelius (#7466).

The Vidaio API's OpenAPI spec (**10 paths**) had 2 of its paths registered. This adds the other **8**.

## Auth — declared in the spec and confirmed live

All 8 declare the `APIKeyHeader` security scheme, so each is `auth_required: true`, `probe.enabled: false` (Phase 3), with an `auth{}` object naming the header **`X-API-Key`** taken from the spec's own `securitySchemes` — not inferred.

Live-verified 2026-07-21:

| request | result |
|---|---|
| `GET /rate_limits` | **401** `{"detail":"Invalid or missing API key"}` |
| `GET /available_credits` | **401** `{"detail":"Invalid or missing API key"}` |

The other six are the task-oriented routes — state-changing POSTs (`/compression`, `/upscaling`) and their path-parameterized result reads (`/{task_id}`, `/{task_id}/result`) — so they use percent-encoded `{param}` templates and keep probes disabled.

Unlike the larger sweeps in this series, no inference was needed here: every surface's auth requirement comes from an explicit per-operation `security` declaration in the spec, and the two directly probeable routes confirm the gate is real rather than schema-only.

## Checklist

- [x] Changes exactly one `registry/subnets/vidaio.json` file (+224/−0, clean append)
- [x] Every added surface: `authority: community`, `review.state: community-submitted`, `public_safe: true`; no health/`verification` set by hand
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed (1904 surfaces / 129 files), **no `auth_required` advisories**
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` (6 passed)
- [x] `npx vitest run tests/sn85-call-subnet-surface-verify.test.mjs` (9 passed — unaffected)
- [x] `npm run scan:public-safety` — no vidaio findings
- [x] Surface ids asserted unique after generation
- [x] `provider` uses the already-registered `vidaio` slug
- [x] No other open PR references #7098
- [x] Rebased on latest `main`

> Heads-up: `scan:public-safety` currently exits 1 on a clean `main` due to a pre-existing `sensitive hotkey wording` finding in `registry/subnets/cacheon.json` (plus its generated `dist/**` copies) — unrelated to this PR, which touches only `vidaio.json`. Details in #7546.

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] All 8 become callable once Phase 3 credential passthrough (#7016) lands
