### PR TITLE
fix(ci): pin Codecov CLI version instead of 'latest'

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -286,6 +286,17 @@ jobs:
       # checkout step above pins to the real head sha instead (so tests run the
       # contributor's actual commit) -- so auto-detection would otherwise attach
       # the report to a merge sha that never appears in the PR's own checks list.
+      #
+      # version: pinned, not the action's own 'latest' default (metagraphed#7554's
+      # own CI hit "Could not verify signature" on the CLI's self-download+GPG-verify
+      # step -- root-caused by reading codecov-action's dist/codecov.sh: it builds
+      # the download URL as cli.codecov.io/${CC_VERSION}/..., and with 'latest' that
+      # resolves through Codecov's CDN alias, where the binary/SHA256SUM/.sig can
+      # momentarily disagree across edge nodes -- confirmed transient: a re-run
+      # ~1 min later succeeded with no other change. A pinned version tag is an
+      # immutable, long-since-fully-propagated path, so this class of race can't
+      # recur here. Bump deliberately (not blindly to whatever's newest) if pinning
+      # ever needs to move.
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -293,6 +304,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           disable_search: true
+          version: v11.3.1
           override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
@@ -311,6 +323,7 @@ jobs:
         with:
           files: ./coverage/lcov.info
           disable_search: true
+          version: v11.3.1
           override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
           override_commit: ${{ github.event.pull_request.head.sha }}
           override_pr: ${{ github.event.pull_request.number }}
@@ -324,6 +337,7 @@ jobs:
           files: ./reports/junit/vitest.xml
           report_type: test_results
           disable_search: true
+          version: v11.3.1
           override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
@@ -336,6 +350,7 @@ jobs:
           files: ./reports/junit/vitest.xml
           report_type: test_results
           disable_search: true
+          version: v11.3.1
           override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
           override_commit: ${{ github.event.pull_request.head.sha }}
           override_pr: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- CI has hit `Could not verify signature` from the Codecov CLI's own self-download+GPG-verify step multiple times, always transiently — a re-run with no other code change succeeds. Root-caused by reading `codecov-action`'s `dist/codecov.sh`: the download URL is `cli.codecov.io/${CC_VERSION}/...`, and with the action's `latest` default that resolves through Codecov's CDN alias, where the binary, its `SHA256SUM`, and its `.sig` file can momentarily disagree across edge nodes. A pinned version tag is an immutable, long-since-propagated path that can't hit this specific race.

No existing open issue tracks this specifically (searched — closest is #3064, closed, and about a different Codecov topic). Referencing where I first hit it below instead; I'm exempt from the linked-issue requirement as the repo owner.

## What Changed

- Pinned all 4 `codecov/codecov-action` steps in `.github/workflows/validate.yml`'s `test` job to `version: v11.3.1` (current stable `codecov-cli` release), instead of the action's own `latest` default.
- Did **not** touch `skip_validation`/`binary` (both bypass GPG signature verification entirely) — that would silence the real security check this step performs, not fix the flakiness.
- The action's own built-in `curl --retry 5` already covers plain network blips; this closes the specific gap that retry can't — a CDN alias serving an internally-inconsistent binary/signature triplet.

## Validation

- `npm run validate:workflows` — clean.
- `npm run scan:public-safety` — clean.
- `npm run lint` / `npm run format:check` — clean.
- YAML parses (`js-yaml`) — well-formed.

Refs #7554 (where this was first observed, re-run confirmed transient).