### PR TITLE
fix(registry): SN85 Vidaio API parity (8 missing surfaces) (#7098)

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -159,6 +159,222 @@
         "https://vidaio.io/"
       ],
       "url": "https://api.vidaio.io/ready"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes, which declares a header-based scheme per operation and names the header in the spec. Only the scheme and location are asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-available-credits",
+      "kind": "subnet-api",
+      "name": "Vidaio available credits",
+      "notes": "Get available credits operation on the Vidaio API (GET /available_credits), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares a header-based security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET returns HTTP 401, confirming the gate is real rather than schema-only.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/available_credits"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes, which declares a header-based scheme per operation and names the header in the spec. Only the scheme and location are asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-compression",
+      "kind": "subnet-api",
+      "name": "Vidaio compression",
+      "notes": "Start compression operation on the Vidaio API (POST /compression), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares a header-based security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/compression"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes, which declares a header-based scheme per operation and names the header in the spec. Only the scheme and location are asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-compression-task-id",
+      "kind": "subnet-api",
+      "name": "Vidaio compression task id",
+      "notes": "Get compression status operation on the Vidaio API (GET /compression/{task_id}), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares a header-based security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/compression/%7Btask_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes, which declares a header-based scheme per operation and names the header in the spec. Only the scheme and location are asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-compression-task-id-result",
+      "kind": "subnet-api",
+      "name": "Vidaio compression task id result",
+      "notes": "Get compression result operation on the Vidaio API (GET /compression/{task_id}/result), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares a header-based security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/compression/%7Btask_id%7D/result"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes, which declares a header-based scheme per operation and names the header in the spec. Only the scheme and location are asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-rate-limits",
+      "kind": "subnet-api",
+      "name": "Vidaio rate limits",
+      "notes": "Get authentication rate limits operation on the Vidaio API (GET /rate_limits), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares a header-based security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET returns HTTP 401, confirming the gate is real rather than schema-only.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/rate_limits"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes, which declares a header-based scheme per operation and names the header in the spec. Only the scheme and location are asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-upscaling",
+      "kind": "subnet-api",
+      "name": "Vidaio upscaling",
+      "notes": "Start upscaling operation on the Vidaio API (POST /upscaling), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares a header-based security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/upscaling"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes, which declares a header-based scheme per operation and names the header in the spec. Only the scheme and location are asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-upscaling-task-id",
+      "kind": "subnet-api",
+      "name": "Vidaio upscaling task id",
+      "notes": "Get upscaling status operation on the Vidaio API (GET /upscaling/{task_id}), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares a header-based security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/upscaling/%7Btask_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes, which declares a header-based scheme per operation and names the header in the spec. Only the scheme and location are asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-85-vidaio-upscaling-task-id-result",
+      "kind": "subnet-api",
+      "name": "Vidaio upscaling task id result",
+      "notes": "Get upscaling result operation on the Vidaio API (GET /upscaling/{task_id}/result), declared in the subnet's own OpenAPI spec at https://api.vidaio.io/openapi.json. The spec declares a header-based security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Path-parameterized on {task_id}, so there is no single fixed callable URL; the template is registered per the registry's catalog-everything policy (Phase 2).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://api.vidaio.io/openapi.json"],
+      "url": "https://api.vidaio.io/upscaling/%7Btask_id%7D/result"
     }
   ],
   "website_url": "https://vidaio.io/"


### PR DESCRIPTION
## Summary

Closes #7098.

Brings SN85 (Vidaio) up to **full subnet API parity** — the completeness bar in `.claude/skills/contributor-pipeline-gardening/SKILL.md`'s "MCP execute verify + wire SN*" special-sweep section.

The Vidaio API's OpenAPI spec (**10 paths**) had 2 of its paths registered. This adds the other **8**.

> **Resubmits #7563**, which was closed on a red `checks` job caused by a repo-wide artifact budget (`search-index.json`), not by anything in `vidaio.json`. While rebuilding I also neutralised the prose: the old notes quoted an upstream 401 body verbatim, and that vocabulary is what the registry review flagged on a sibling PR (#7565). Same findings, neutral wording, and `auth{}` now carries only `scheme` + `location` rather than repeating the header name.

## Auth — declared in the spec and confirmed live

All 8 declare a header-based security scheme per-operation, so each is `auth_required: true`, `probe.enabled: false` (Phase 3).

Live-verified 2026-07-21:

| request | result |
|---|---|
| `GET /rate_limits` | **401** — gate is real, not schema-only |
| `GET /available_credits` | **401** — same |

The other six are the task-oriented routes — state-changing POSTs (`/compression`, `/upscaling`) and their path-parameterized result reads (`/{task_id}`, `/{task_id}/result`) — so they use percent-encoded `{param}` templates and keep probes disabled.

No inference was needed on this subnet: every surface's auth requirement comes from an explicit per-operation `security` declaration in the spec, and the two directly probeable routes confirm it.

## Checklist

- [x] Changes exactly one `registry/subnets/vidaio.json` file (clean append)
- [x] Every added surface: `authority: community`, `review.state: community-submitted`, `public_safe: true`; no health/`verification` set by hand
- [x] Audited every added `id`/`name`/`notes` for credential vocabulary — **zero** occurrences
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed (1904 surfaces / 129 files), **no `auth_required` advisories**
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` + `tests/sn85-call-subnet-surface-verify.test.mjs` (15 passed)
- [x] `npm run scan:public-safety` — no vidaio findings
- [x] Surface ids asserted unique against the full manifest
- [x] `provider` uses the already-registered `vidaio` slug
- [x] No other open PR references #7098
- [x] Rebased on latest `main`

> Note on the `checks` job: it currently fails repo-wide on one artifact budget — `search-index.json` at 1,011,138 bytes vs the 1,000,000 `DEFAULT_BUDGET` fail threshold in `scripts/artifact-budgets.mjs`. That artifact has no entry of its own in `ARTIFACT_SIZE_BUDGETS` (unlike `search.json` at 750 KB/2 MB), so it inherits the catch-all. Unrelated to this PR; happy to submit the one-line budget entry against an issue if you'd like.

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] All 8 become callable once Phase 3 credential passthrough (#7016) lands
