### PR TITLE
chore(ci): raise search-index.json artifact-size budget

### DIFF
--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -8,6 +8,9 @@ export const ARTIFACT_SIZE_BUDGETS = [
   budget("evidence-ledger.json", 1_000_000, 3_000_000),
   budget("health/history/*.json", 650_000, 1_250_000),
   budget("search.json", 750_000, 2_000_000),
+  // search-index.json is rebuilt from the full surface corpus; organic registry
+  // growth pushed it past the default 1_000_000 fail ceiling on main (#7567/#7568).
+  budget("search-index.json", 1_200_000, 2_500_000),
   budget("openapi.json", 1_800_000, 2_500_000),
   // Per-surface schema snapshots now embed the full upstream OpenAPI document.
   budget("schemas/*.json", 1_500_000, 5_000_000),


### PR DESCRIPTION
﻿## Summary
- Add an explicit `search-index.json` artifact budget (`1.2MB` warn / `2.5MB` fail), matching the pattern used for `openapi.json` in #6806.
- Main Validate is already hard-failing: `search-index.json: ~1.008MB >= 1.000MB` default ceiling (also blocked #7567/#7568).
- Budget-only change; no registry data bundled.

## Test plan
- [ ] CI Validate `checks` / `validate:artifact-budgets` green
- [ ] Confirms search-index no longer fails under the new ceiling
