### PR TITLE
chore(ci): add missing search-index.json artifact-size budget

### DIFF
--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -8,6 +8,7 @@ export const ARTIFACT_SIZE_BUDGETS = [
   budget("evidence-ledger.json", 1_000_000, 3_000_000),
   budget("health/history/*.json", 650_000, 1_250_000),
   budget("search.json", 750_000, 2_000_000),
+  budget("search-index.json", 1_500_000, 3_000_000),
   budget("openapi.json", 1_800_000, 2_500_000),
   // Per-surface schema snapshots now embed the full upstream OpenAPI document.
   budget("schemas/*.json", 1_500_000, 5_000_000),


### PR DESCRIPTION
## Summary

`search-index.json` had no dedicated entry in `ARTIFACT_SIZE_BUDGETS`, so it was falling through to the generic `DEFAULT_BUDGET` (250KB warn / 1MB fail) — the same file's sibling, `search.json`, has always had its own budget (750KB/2MB).

Today's MCP-execute full-API-parity sweep (dozens of PRs each adding 20–60+ surfaces to the registry) has grown `search-index.json` past that 1MB default, which was failing the `checks` job's artifact-budget step on **every** registry-touching PR — regardless of the PR's own content — since it's a shared, generated aggregate artifact.

Surfaced by a contributor (`joaovictor91123`) self-reporting the issue on a closed PR, who correctly separated it from the (non-blocking) `surfaces.json`/`search.json` warn-level noise in a follow-up correction.

## Fix

Add a dedicated budget for `search-index.json`, sized proportionally like `search.json`'s:

```js
budget("search-index.json", 1_500_000, 3_000_000),
```

Sized with headroom (current usage ~1.01MB) rather than just clearing the immediate overage, since 15 issues remain open in the `MCP execute: verify + wire SN*` family and will keep growing this artifact.

## Validation

- [x] `npx eslint scripts/artifact-budgets.mjs` — clean
- [x] `npx prettier --check scripts/artifact-budgets.mjs` — clean
- [x] `npx vitest run tests/contracts.test.mjs tests/script-utils.test.mjs` — 67 passed (includes the test that asserts every `ARTIFACT_SIZE_BUDGETS` entry maps to a real `artifactFile()` write — confirmed `search-index.json` is written in `scripts/build-artifacts.mjs`)
- [x] `npm run validate:artifact-budgets` — passes clean, no failures

## Scope

`scripts/` only — no registry/schema/route changes, no regeneration needed.