### PR TITLE
fix(registry): SN60 Bitsec full API parity (19 missing surfaces)

### DIFF
--- a/registry/subnets/bitsec.json
+++ b/registry/subnets/bitsec.json
@@ -318,6 +318,468 @@
       "public_safe": true,
       "source_urls": ["https://bitsec.ai/api/openapi.json"],
       "url": "https://bitsec.ai/api/projects/sets"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-agents-count",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agents count",
+      "notes": "Public no-auth GET /api/agents/count on bitsec.ai, returning the total registered agent count (optional hotkey/project_set_id/hide_failed_screeners query filters). Documented in the subnet's own OpenAPI schema with no security scheme and no header parameters. Live-verified 2026-07-21 (~22:05 UTC): HTTP 200 application/json {\"total_agents\":1094}.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/count"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-jobs-leaderboard-old",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai legacy jobs leaderboard",
+      "notes": "GET /api/jobs/leaderboard_old on bitsec.ai — legacy sibling of the already-registered /api/jobs/leaderboard, documented in the subnet's own OpenAPI schema with no security scheme. Live-verified 2026-07-21 (~22:05 UTC): HTTP 500 text/plain (currently erroring in production). Registered anyway, matching the registry's existing precedent of cataloguing real documented endpoints in their actual live state (e.g. Targon SN4's /tha/v2/healthz); probe expect:any since the current error body is not JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/jobs/leaderboard_old"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-agent-detail",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agent detail",
+      "notes": "GET /api/agents/{agent_id}/detail on bitsec.ai, documented in the subnet's own OpenAPI schema with no security scheme and no header parameters. Live-verified 2026-07-21 (~22:05 UTC): a placeholder agent_id returns HTTP 422 int_parsing validation error (\"Input should be a valid integer\") — a clean parameter-validation rejection, not an auth gate, confirming the route is live and unauthenticated. Path-parameterized (integer id; no stable canonical value to probe against), so probe.enabled:false; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw braces fail the url format:\"uri\" schema check).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/%7Bagent_id%7D/detail"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-agent-runs-export",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agent runs export",
+      "notes": "GET /api/agents/{agent_id}/runs-export on bitsec.ai, documented in the subnet's own OpenAPI schema with no security scheme and no header parameters. Live-verified 2026-07-21 (~22:05 UTC): a placeholder agent_id returns HTTP 422 int_parsing validation error, not an auth rejection. Path-parameterized (integer id; no stable canonical value to probe against), so probe.enabled:false; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw braces fail the url format:\"uri\" schema check).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/%7Bagent_id%7D/runs-export"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-agent-screener",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agent screener results",
+      "notes": "GET /api/agents/{agent_id}/screener on bitsec.ai, documented in the subnet's own OpenAPI schema with no security scheme and no header parameters. Live-verified 2026-07-21 (~22:05 UTC): a placeholder agent_id returns HTTP 422 int_parsing validation error, not an auth rejection. Path-parameterized (integer id; no stable canonical value to probe against), so probe.enabled:false; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw braces fail the url format:\"uri\" schema check).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/%7Bagent_id%7D/screener"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-agent-known-solutions",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai per-agent known-solutions",
+      "notes": "GET /api/agents/{agent_id}/known-solutions on bitsec.ai — per-agent sibling of the already-registered project-set-wide /api/projects/known-solutions, documented in the subnet's own OpenAPI schema with no security scheme and no header parameters. Live-verified 2026-07-21 (~22:05 UTC): a placeholder agent_id returns HTTP 422 int_parsing validation error, not an auth rejection. Path-parameterized (integer id; no stable canonical value to probe against), so probe.enabled:false; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw braces fail the url format:\"uri\" schema check).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/%7Bagent_id%7D/known-solutions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-agent-scores",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agent scores",
+      "notes": "GET /api/agents/{agent_id}/scores on bitsec.ai, documented in the subnet's own OpenAPI schema with no security scheme and no header parameters. Live-verified 2026-07-21 (~22:05 UTC): a placeholder agent_id returns HTTP 422 int_parsing validation error, not an auth rejection. Path-parameterized (integer id; no stable canonical value to probe against), so probe.enabled:false; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw braces fail the url format:\"uri\" schema check).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/%7Bagent_id%7D/scores"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-60-bitsec-jobs-runs-by-validator",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai job runs by validator",
+      "notes": "GET /api/jobs/runs/validator/{validator_id} on bitsec.ai, documented in the subnet's own OpenAPI schema with no security scheme and no header parameters. Live-verified 2026-07-21 (~22:05 UTC): a placeholder validator_id returns HTTP 422 int_parsing validation error, not an auth rejection. Path-parameterized (integer id; no stable canonical value to probe against), so probe.enabled:false; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw braces fail the url format:\"uri\" schema check).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/jobs/runs/validator/%7Bvalidator_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-agent-cancel",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agent job cancel",
+      "notes": "POST /api/agents/{agent_id}/cancel on bitsec.ai — write endpoint cancelling an agent's active job. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false. Path-parameterized; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/%7Bagent_id%7D/cancel"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-agents-execution",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agent execution trigger",
+      "notes": "POST /api/agents/execution/ on bitsec.ai — write endpoint recording an agent execution. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/execution/"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-agents-evaluation",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agent evaluation trigger",
+      "notes": "POST /api/agents/evaluation/ on bitsec.ai — write endpoint recording an agent evaluation. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/evaluation/"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-agents-submit",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai agent submit",
+      "notes": "POST /api/agents/submit/ on bitsec.ai — write endpoint for miner agent submission. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/agents/submit/"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-jobs-run-agent",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai job-run agent lookup",
+      "notes": "GET /api/jobs/runs/{job_run_id}/agent on bitsec.ai — gated read endpoint resolving the agent for a job run. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false. Path-parameterized; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/jobs/runs/%7Bjob_run_id%7D/agent"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-jobs-run-start",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai job run start",
+      "notes": "POST /api/jobs/runs/{job_run_id}/start on bitsec.ai — write endpoint marking a job run started. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false. Path-parameterized; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/jobs/runs/%7Bjob_run_id%7D/start"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-jobs-run-complete",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai job run complete",
+      "notes": "POST /api/jobs/runs/{job_run_id}/complete on bitsec.ai — write endpoint marking a job run complete. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false. Path-parameterized; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/jobs/runs/%7Bjob_run_id%7D/complete"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-jobs-run-proxy-summary",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai job run proxy summary",
+      "notes": "POST /api/jobs/runs/{job_run_id}/proxy-summary on bitsec.ai — write endpoint submitting a job run's proxy summary. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false. Path-parameterized; the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/jobs/runs/%7Bjob_run_id%7D/proxy-summary"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-users-create",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai user create",
+      "notes": "POST /api/users/ on bitsec.ai — write endpoint creating a user record. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/users/"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-users-validators-me",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai validator self-lookup",
+      "notes": "GET /api/users/validators/me on bitsec.ai — gated read endpoint resolving the calling validator's own record. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/users/validators/me"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema: this API declares no formal security scheme anywhere; instead each gated operation declares a required credential header parameter on the operation itself. Exact credential format is not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-60-bitsec-users-validators-heartbeat",
+      "kind": "subnet-api",
+      "name": "Bitsec.ai validator heartbeat",
+      "notes": "POST /api/users/validators/heartbeat on bitsec.ai — write endpoint recording a validator heartbeat. The subnet's own OpenAPI schema declares a required credential header parameter on this operation (this API declares no formal security scheme anywhere). Live-verified 2026-07-21 (~22:05 UTC): unauthenticated request returns HTTP 422 with a missing-required-header validation error on that exact parameter, consistent with the gate being enforced at the framework layer. Not callable by the anonymous Phase-1 call_subnet_surface tool, so probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitsec-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://bitsec.ai/api/openapi.json"],
+      "url": "https://bitsec.ai/api/users/validators/heartbeat"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Closes #7073. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527/#7538/#7551/#7559: the issue's original 10 surfaces (`sn-60-bitsec-ai-openapi`, `sn-60-bitsec-ai-subnet-api`, `sn-60-bitsec-agents-list`, `sn-60-bitsec-agents-evaluation-status`, `sn-60-bitsec-agents-top-with-burn`, `sn-60-bitsec-agents-top`, `sn-60-bitsec-analytics-validators`, `sn-60-bitsec-jobs-leaderboard`, `sn-60-bitsec-jobs-runs-active`, `sn-60-bitsec-jobs-stats`) all still verify exactly as documented — re-requested 2026-07-21 (~22:10 UTC), every one HTTP 200 `application/json` — and the issue's own "Additional surface(s) found during review (now in scope)" section itemizes the remaining registry gap. This PR registers it, append-only, one file: 19 new entries in `registry/subnets/bitsec.json` `surfaces[]`, no top-level metadata touched.

## What this adds (19 new surfaces)

Fetched the subnet's own OpenAPI schema (`https://bitsec.ai/api/openapi.json`) fresh on 2026-07-21: it now documents **31 paths** (one more than the 30 counted when the issue was filed — `GET /agents/count` has since been added to the schema; registered here too, so the file lands at true parity with the live schema). **12 of the 31 are already covered** by registered surfaces: `/analytics`, `/analytics/validators`, `/agents/`, `/agents/evaluation-status`, `/agents/top/`, `/agents/top-with-burn/`, `/jobs/leaderboard`, `/jobs/runs/active`, `/jobs/stats`, plus the three `/projects/` paths from the issue's "No-auth, fixed" list (`/projects/`, `/projects/sets`, `/projects/known-solutions`), which have been registered since the issue was written. 31 − 12 = **19 missing paths**, all registered here. Nothing is excluded: this issue's scope note itemizes the gated write endpoints as in scope ("Register with `auth_required:true`, `probe.enabled:false`"), so there is no write-only-POST carve-out to apply.

**2 public, fixed-path** (`probe.enabled:true`):
- `GET /agents/count` — live-verified 2026-07-21: HTTP 200 `application/json`, `{"total_agents":1094}`.
- `GET /jobs/leaderboard_old` — live-verified 2026-07-21: HTTP 500 `text/plain` (currently erroring in production). Registered anyway, exactly as the issue's own scope note instructs, matching the existing precedent of cataloguing real documented endpoints in their actual live state (e.g. Targon SN4's `/tha/v2/healthz`); `probe.expect:"any"` since the current error body isn't JSON.

**6 public, path-param** (`probe.enabled:false`, literal `{param}` template percent-encoded in the `url` field since raw unescaped braces fail this repo's `url` `format:"uri"` schema check): `/agents/{agent_id}/detail`, `/agents/{agent_id}/runs-export`, `/agents/{agent_id}/screener`, `/agents/{agent_id}/known-solutions`, `/agents/{agent_id}/scores`, `/jobs/runs/validator/{validator_id}`. Live-verified 2026-07-21 — **each of the 6 individually**, not spot-checked: a placeholder id returns HTTP 422 `int_parsing` ("Input should be a valid integer"), a clean parameter-validation rejection that proves the route is live and unauthenticated, not an auth gate.

**11 gated** (`auth_required:true`, `auth:{scheme:"custom",...}`, `probe.enabled:false`): `POST /agents/{agent_id}/cancel`, `POST /agents/execution/`, `POST /agents/evaluation/`, `POST /agents/submit/`, `GET /jobs/runs/{job_run_id}/agent`, `POST /jobs/runs/{job_run_id}/start`, `POST /jobs/runs/{job_run_id}/complete`, `POST /jobs/runs/{job_run_id}/proxy-summary`, `POST /users/`, `GET /users/validators/me`, `POST /users/validators/heartbeat`. This API declares no formal OpenAPI security scheme anywhere; each of these operations instead declares a **required credential header parameter** on the operation itself. Live-verified 2026-07-21 — **all 11 individually**: every unauthenticated request returns HTTP 422 whose validation detail names exactly that missing required header (e.g. `{"detail":[{"type":"missing","loc":["header","..."],"msg":"Field required"}]}`), confirming the gate is enforced at the framework layer, consistent with the issue's own verification of `/agents/submit/` and `/users/validators/me`. `scheme:"custom"` because the exact credential format isn't publicly documented beyond the schema's header-parameter declaration.

## Schema/tooling notes (same as the last nine)

- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC`; every new surface uses `GET`, with `probe.enabled:false` on all path-param and gated entries.
- Path-param URLs use the percent-encoded brace form (`%7Bparam%7D`).
- Registered `provider: "bitsec-ai"` — matches the file's existing surfaces and the registered `registry/providers/bitsec-ai.json`, checked before generating.
- Append-only: zero changes to the file's top-level `notes`/`curation` fields. One prose note for the maintainer rather than a file edit: the top-level `notes` sentence about excluding `/jobs/leaderboard_old` and `/users/validators/me` ("declared no-auth status doesn't match live behavior") predates this issue's required-header classification and is now superseded by their registered entries — left untouched as maintainer-owned metadata.
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — it's the bot-synced deploy artifact, excluded per the established pattern.

## Validation

- [x] `npm run validate:surface` — 1915 surfaces across 129 subnet files, passed
- [x] `npm run build && npm run validate` — 129 native subnets, 129 curated overlays, 2617 surfaces, 136 providers, 2037 candidates, clean
- [x] `npm run validate:api` — 177 Worker API routes validated, clean
- [x] `npm run validate:mcp` — 200 tools, full lifecycle round trips, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npx vitest run tests/sn60-call-subnet-surface-verify.test.mjs` — 30 passed (pins the pre-existing SN60 surfaces; unaffected by this append-only diff)
- [x] `npx prettier --check registry/subnets/bitsec.json` — clean

Closes #7073
