### PR TITLE
fix(registry): SN69 ain full API parity (36 missing surfaces)

### DIFF
--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -134,6 +134,870 @@
         "https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/min_compute.yml"
       ],
       "url": "https://raw.githubusercontent.com/HeraldMedia/herald/4de1577e82b74807d4081c3f61edffaee9ed718a/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-health",
+      "kind": "subnet-api",
+      "name": "ain (Herald) first-party API health",
+      "notes": "Public no-auth GET /health on the first-party Herald backend API (api.heraldmedia.ai), documented in the subnet's own OpenAPI schema (api.heraldmedia.ai/openapi.json, 36 paths) with no security scheme. Live-verified 2026-07-21 (~21:35 UTC): HTTP 200 JSON ({\"ok\":true,\"version\":\"0.1.0\"}).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-ready",
+      "kind": "subnet-api",
+      "name": "ain (Herald) first-party API readiness",
+      "notes": "Public no-auth GET /ready on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with no security scheme. Live-verified 2026-07-21 (~21:35 UTC): HTTP 503 with a well-formed JSON body ({\"ok\":false, per-network/netuid readiness scope checks}) -- a real, currently-not-ready endpoint, not a dead route. Registered anyway per the existing project precedent of cataloguing real documented endpoints even when currently reporting unhealthy (probe.expect:json checks content-type, not status code, so a 5xx here surfaces as the recognized 'transient' probe status rather than a hard failure).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/ready"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-briefs",
+      "kind": "subnet-api",
+      "name": "ain (Herald) briefs list",
+      "notes": "Public no-auth GET /briefs on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with no security scheme and no parameters. Live-verified 2026-07-21 (~21:35 UTC): HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/briefs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-validator-briefs-v2",
+      "kind": "subnet-api",
+      "name": "ain (Herald) validator briefs (v2)",
+      "notes": "Public no-auth GET /api/v2/validator/briefs on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with no security scheme and no parameters. Live-verified 2026-07-21 (~21:35 UTC): HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/api/v2/validator/briefs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-registry-outlets",
+      "kind": "subnet-api",
+      "name": "ain (Herald) live outlet registry",
+      "notes": "Public no-auth GET /registry/outlets.json on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with optional network/netuid query params, neither required. Live-verified 2026-07-21 (~21:35 UTC) (no params): HTTP 200 JSON. Distinct from the already-registered static outlets.seed.json on raw GitHub -- this is the API-served live version of the same registry.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/registry/outlets.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-validator-registry-v3",
+      "kind": "subnet-api",
+      "name": "ain (Herald) validator registry (v3)",
+      "notes": "Public no-auth GET /api/v3/validator/registry on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with optional network/netuid query params, neither required. Live-verified 2026-07-21 (~21:35 UTC) (no params): HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/api/v3/validator/registry"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-reporting-export",
+      "kind": "subnet-api",
+      "name": "ain (Herald) reporting export",
+      "notes": "Public no-auth GET /reporting/export on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with optional network/netuid query params, neither required. Live-verified 2026-07-21 (~21:35 UTC) (no params): HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/reporting/export"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-disputes-list",
+      "kind": "subnet-api",
+      "name": "ain (Herald) disputes list",
+      "notes": "Public no-auth GET /disputes on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with no parameters and no header requirement (the sibling POST /disputes declares a required-in-practice x-disputes-token header; the GET list route does not). Live-verified 2026-07-21 (~21:35 UTC): HTTP 200 JSON. The sibling POST /disputes (dispute submission) shares this exact URL; the registry's one-surface-per-URL rule (validate:surface duplicate-URL check) means this single surface represents the path -- the POST operation carries a schema-declared x-disputes-token header.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/disputes"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-funding-list",
+      "kind": "subnet-api",
+      "name": "ain (Herald) funding list",
+      "notes": "Public no-auth GET /funding on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with no parameters and no header requirement (the sibling POST /funding declares an x-funding-token header; the GET list route does not). Live-verified 2026-07-21 (~21:35 UTC): HTTP 200 JSON. The sibling POST /funding (funding submission) shares this exact URL; the registry's one-surface-per-URL rule (validate:surface duplicate-URL check) means this single surface represents the path -- the POST operation carries a schema-declared x-funding-token header.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/funding"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-public-subnet-status",
+      "kind": "subnet-api",
+      "name": "ain (Herald) public subnet status",
+      "notes": "Public no-auth GET /public/subnet/status on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with required network/netuid query params. Live-verified 2026-07-21 (~21:35 UTC) with network=finney&netuid=69: HTTP 200 JSON; without params: HTTP 422 (confirms live validation, not auth). probe.enabled:false since the probe pipeline has no per-surface query-param injection for required params.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/subnet/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-public-epochs",
+      "kind": "subnet-api",
+      "name": "ain (Herald) public epochs",
+      "notes": "Public no-auth GET /public/epochs on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with required network/netuid query params. Live-verified 2026-07-21 (~21:35 UTC) with network=finney&netuid=69: HTTP 200 JSON. probe.enabled:false (required params, no query-injection in the probe pipeline).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/epochs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-public-validators",
+      "kind": "subnet-api",
+      "name": "ain (Herald) public validators",
+      "notes": "Public no-auth GET /public/validators on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with required network/netuid query params. Live-verified 2026-07-21 (~21:35 UTC) with network=finney&netuid=69: HTTP 200 JSON ({\"reporters\":[],\"latest_epoch\":null}); without params: HTTP 422 listing the required query fields (confirms live validation, not auth). probe.enabled:false (required params, no query-injection in the probe pipeline).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/validators"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-public-events",
+      "kind": "sse",
+      "name": "ain (Herald) public events stream (SSE)",
+      "notes": "GET /public/events on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with required network/netuid query params. Live-verified 2026-07-21 (~21:35 UTC) with network=finney&netuid=69: HTTP 200 with content-type text/event-stream -- a long-lived Server-Sent Events stream of finalized_block/indexer events, not a one-shot JSON body; without params: HTTP 422 listing the required query fields (confirms live validation, not auth). Registered kind:sse accordingly. probe.enabled:false (required params, no query-injection in the probe pipeline, and the stream never terminates on its own).",
+      "probe": {
+        "enabled": false,
+        "expect": "sse",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/events"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-public-commitments",
+      "kind": "subnet-api",
+      "name": "ain (Herald) public commitments",
+      "notes": "Public no-auth GET /public/commitments on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with required network/netuid query params (plus an optional hotkey filter param). Live-verified 2026-07-21 (~21:35 UTC) with network=finney&netuid=69: HTTP 200 JSON; without params: HTTP 422 listing the required query fields (confirms live validation, not auth). probe.enabled:false (required params, no query-injection in the probe pipeline).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/commitments"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-public-articles",
+      "kind": "subnet-api",
+      "name": "ain (Herald) public articles",
+      "notes": "Public no-auth GET /public/articles on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with optional network/netuid query params, neither required. Live-verified 2026-07-21 (~21:35 UTC) (no params): HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/articles"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-public-stats",
+      "kind": "subnet-api",
+      "name": "ain (Herald) public stats",
+      "notes": "Public no-auth GET /public/stats on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with optional network/netuid query params, neither required. Live-verified 2026-07-21 (~21:35 UTC) (no params): HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-public-leaderboard",
+      "kind": "subnet-api",
+      "name": "ain (Herald) public leaderboard",
+      "notes": "Public no-auth GET /public/leaderboard on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with optional network/netuid query params, neither required. Live-verified 2026-07-21 (~21:35 UTC) (no params): HTTP 200 JSON.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/leaderboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-api-brief-economics",
+      "kind": "subnet-api",
+      "name": "ain (Herald) per-brief economics",
+      "notes": "GET /public/briefs/{brief_id}/economics on api.heraldmedia.ai, documented in the subnet's own OpenAPI schema with a required brief_id path param plus required network/netuid query params. Live-verified 2026-07-21 (~21:35 UTC): without query params HTTP 422 listing the required network/netuid fields (the placeholder path segment itself is accepted); with network=finney&netuid=69 and a placeholder brief_id, HTTP 404 {\"detail\":\"no confirmed economics for brief\"} -- a clean domain not-found, not an auth rejection, confirming the route is live and genuinely unauthenticated. probe.enabled:false (the URL is a percent-encoded {brief_id} template; the probe pipeline has no per-surface path-param injection).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/public/briefs/%7Bbrief_id%7D/economics"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-validator-results",
+      "kind": "subnet-api",
+      "name": "ain (Herald) validator results (auth-gated)",
+      "notes": "GET /validator/results on api.heraldmedia.ai declares network/netuid query params plus an x-results-token header (all required:false in the schema) -- live-verified 2026-07-21: HTTP 401 {\"detail\":\"unauthorized\"} both with and without network/netuid query params, confirming the header is enforced in practice despite the schema not marking it required. probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/validator/results"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-reveals-list",
+      "kind": "subnet-api",
+      "name": "ain (Herald) reveals list (auth-gated)",
+      "notes": "GET /reveals on api.heraldmedia.ai declares an x-reveals-token header (required:false in the schema). Live-verified 2026-07-21 (~21:35 UTC): HTTP 401 {\"detail\":\"unauthorized\"} unauthenticated, confirming the header is enforced in practice. probe.enabled:false. The sibling POST /reveals (reveal submission) shares this exact URL; the registry's one-surface-per-URL rule (validate:surface duplicate-URL check) means this single surface represents the path -- the POST operation carries the same x-reveals-token gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/reveals"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-users-coverage",
+      "kind": "subnet-api",
+      "name": "ain (Herald) user coverage (auth-gated)",
+      "notes": "GET /users/coverage on api.heraldmedia.ai declares optional network/netuid query params plus two service header parameters, a user-identity header and x-service-token (all required:false in the schema). Live-verified 2026-07-21 (~21:35 UTC): HTTP 401 {\"detail\":\"unauthorized\"} unauthenticated, confirming at least one of the two header parameters is enforced in practice despite neither being schema-required. probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/users/coverage"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-briefs",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin briefs list (auth-gated)",
+      "notes": "GET /admin/briefs on api.heraldmedia.ai declares an x-admin-token header (required:false in the schema). Live-verified 2026-07-21 (~21:35 UTC): HTTP 401 {\"detail\":\"unauthorized\"} unauthenticated, confirming the header is enforced in practice. probe.enabled:false. The sibling POST /admin/briefs (brief creation) shares this exact URL; the registry's one-surface-per-URL rule (validate:surface duplicate-URL check) means this single surface represents the path -- the POST operation carries the same x-admin-token gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/briefs"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-reporters",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin reporters list (auth-gated)",
+      "notes": "GET /admin/reporters on api.heraldmedia.ai declares network/netuid query params plus an x-admin-token header (all required:false in the schema). Live-verified 2026-07-21 (~21:35 UTC): HTTP 401 {\"detail\":\"unauthorized\"} unauthenticated, confirming the header is enforced in practice. probe.enabled:false. The sibling POST /admin/reporters (reporter registration) shares this exact URL; the registry's one-surface-per-URL rule (validate:surface duplicate-URL check) means this single surface represents the path -- the POST operation carries the same x-admin-token gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/reporters"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-registry-draft",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin registry draft (auth-gated)",
+      "notes": "GET /admin/registry/draft on api.heraldmedia.ai declares network/netuid query params plus an x-admin-token header (all required:false in the schema). Live-verified 2026-07-21 (~21:35 UTC): HTTP 401 {\"detail\":\"unauthorized\"} unauthenticated, confirming the header is enforced in practice. probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/registry/draft"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-contact-list",
+      "kind": "subnet-api",
+      "name": "ain (Herald) contact list (auth-gated)",
+      "notes": "GET /contact on api.heraldmedia.ai declares an x-service-token header (required:false in the schema). Live-verified 2026-07-21 (~21:35 UTC): HTTP 401 {\"detail\":\"unauthorized\"} unauthenticated, confirming the header is enforced in practice. probe.enabled:false. The sibling POST /contact (contact submission) shares this exact URL; the registry's one-surface-per-URL rule (validate:surface duplicate-URL check) means this single surface represents the path -- the POST operation carries the same x-service-token gate.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/contact"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-briefs-close",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin brief close (write, auth-gated)",
+      "notes": "POST /admin/briefs/{brief_id}/close on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-admin-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-admin-token gate is live-verified enforced on the sibling GET /admin/briefs (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/briefs/%7Bbrief_id%7D/close"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-briefs-fund",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin brief fund (write, auth-gated)",
+      "notes": "POST /admin/briefs/{brief_id}/fund on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-admin-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-admin-token gate is live-verified enforced on the sibling GET /admin/briefs (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/briefs/%7Bbrief_id%7D/fund"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-registry-editions",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin registry editions (write, auth-gated)",
+      "notes": "POST /admin/registry/editions on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-admin-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-admin-token gate is live-verified enforced on the sibling GET /admin/briefs (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/registry/editions"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-registry-outlets",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin registry outlets (write, auth-gated)",
+      "notes": "POST /admin/registry/outlets on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-admin-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-admin-token gate is live-verified enforced on the sibling GET /admin/briefs (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/registry/outlets"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-registry-outlet-status",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin registry outlet status (write, auth-gated)",
+      "notes": "POST /admin/registry/outlets/{outlet_id}/status on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-admin-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-admin-token gate is live-verified enforced on the sibling GET /admin/briefs (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/registry/outlets/%7Boutlet_id%7D/status"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-admin-registry-discard",
+      "kind": "subnet-api",
+      "name": "ain (Herald) admin registry discard (write, auth-gated)",
+      "notes": "POST /admin/registry/discard on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-admin-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-admin-token gate is live-verified enforced on the sibling GET /admin/briefs (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/admin/registry/discard"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-results-submit",
+      "kind": "subnet-api",
+      "name": "ain (Herald) results submission (write, auth-gated)",
+      "notes": "POST /results on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-results-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-results-token gate is live-verified enforced on the sibling GET /validator/results (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/results"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-validator-snapshots",
+      "kind": "subnet-api",
+      "name": "ain (Herald) validator snapshots submission (write, auth-gated)",
+      "notes": "POST /api/v3/validator/snapshots on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-results-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-results-token gate is live-verified enforced on the sibling GET /validator/results (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/api/v3/validator/snapshots"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-validator-weight-receipts",
+      "kind": "subnet-api",
+      "name": "ain (Herald) validator weight receipts submission (write, auth-gated)",
+      "notes": "POST /api/v3/validator/weight-receipts on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-results-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-results-token gate is live-verified enforced on the sibling GET /validator/results (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/api/v3/validator/weight-receipts"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-users-upsert",
+      "kind": "subnet-api",
+      "name": "ain (Herald) users upsert (write, auth-gated)",
+      "notes": "POST /users/upsert on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-service-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-service-token gate is live-verified enforced on the sibling GET /contact (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/users/upsert"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (the operation declares a service header parameter; enforced in practice, live-verified HTTP 401 unauthenticated on this API). Exact header/credential format not documented beyond the schema."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-69-ain-api-contact-status",
+      "kind": "subnet-api",
+      "name": "ain (Herald) contact status update (write, auth-gated)",
+      "notes": "POST /contact/{contact_id}/status on api.heraldmedia.ai -- a write/mutation operation declared in the subnet's own OpenAPI schema with an x-service-token header. Not spot-verified individually (a state-changing POST against a production validator-facing system; the linked issue's own review section lists these write endpoints as not individually spot-verified), but the same x-service-token gate is live-verified enforced on the sibling GET /contact (HTTP 401 unauthenticated, 2026-07-21 (~21:35 UTC)). Registered auth_required:true with probe.enabled:false per the linked issue's guidance for the auth-gated set; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.heraldmedia.ai/openapi.json"],
+      "url": "https://api.heraldmedia.ai/contact/%7Bcontact_id%7D/status"
     }
   ],
   "website_url": "https://www.heraldmedia.ai/"


### PR DESCRIPTION
## Summary

Closes #7082. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527/#7538/#7551/#7559: the issue's original surface (`sn-69-taomarketcap-subnet-api`) still verifies exactly as documented — live-verified 2026-07-21 (~21:45 UTC): HTTP 200 `application/json`, no auth, real SN69 snapshot body (also pinned by the already-merged verify test `tests/sn69-call-subnet-surface-verify.test.mjs` from #7332, which still passes against this diff) — and the issue's own "Additional surface(s) found during review (now in scope)" section itemizes the remaining registry gap. This PR registers all of it.

**Resubmission of #7574** — same 36-surface registration, on a branch based on current `main` so its own tree carries #7580's `search-index.json` budget fix. History, for the record: #7574 was swept by automated maintenance while `validate:artifact-budgets` was failing on main's own HEAD (`search-index.json` 1,008,520 >= 1,000,000 on `37bc84a9`, independent of the diff), alongside a registry-surface-review "secret/PAT material" flag the maintainer explicitly identified as a false positive when reopening it ("no secret text anywhere in the diff"). The reopen's fresh CI run then deterministically re-failed the same budget check — the `checks` job checks out `pull_request.head.sha`, and that branch's own `scripts/artifact-budgets.mjs` predates #7580 — which a fresh PR from a current-main base fixes without pushing to the reopened PR (one-shot rule). Two content changes versus #7574, both from its review feedback: the auth-gated surfaces' `auth` blocks are reduced to the minimal `scheme` + `scopes_note` form used by merged precedent (no literal credential-placeholder fields), and issue-tracking references are removed from long-lived `notes` fields per the review's nits. The registered surface set, URLs, auth classifications, and probe configs are otherwise identical to #7574, which the review assessed as matching the issue's itemized list ("Linked issue satisfaction: Addressed") with correct GET/POST URL-collision handling.

## What this adds (36 new surfaces)

Fetched the subnet's own OpenAPI schema (`https://api.heraldmedia.ai/openapi.json` — live-verified 2026-07-21 ~21:33 UTC: 200, exactly the **36 paths** the issue counted) and diffed against the registry: **0 of the 36 paths were covered** — the file's 5 existing surfaces are the website, the source repo, two raw-GitHub data artifacts, and the third-party TaoMarketCap snapshot; none touch the first-party API domain. 36 paths − 0 already covered = **36 missing**, one surface per path, matching the issue's itemized list exactly.

Six paths (`/admin/briefs`, `/admin/reporters`, `/contact`, `/disputes`, `/funding`, `/reveals`) carry both a GET and a POST operation on the same URL; this repo's one-surface-per-URL rule (`validate:surface`'s duplicate-URL check) keys surfaces by URL, so each such path is one surface with the POST counterpart and its header gate documented in that surface's `notes` — every operation in the issue's list is represented.

**12 public, fixed or optional-query-only, no-auth (`probe.enabled:true`)** — live-verified 2026-07-21 (~21:33 UTC), each with an unparameterized request: `/health` 200, `/briefs` 200, `/api/v2/validator/briefs` 200, `/registry/outlets.json` 200 (the API-served live version, distinct from the already-registered static `outlets.seed.json` on raw GitHub), `/api/v3/validator/registry` 200, `/reporting/export` 200, `/disputes` 200, `/funding` 200, `/public/articles` 200, `/public/stats` 200, `/public/leaderboard` 200 — and `/ready` **503** with a well-formed JSON readiness body (a real endpoint currently reporting not-ready — registered anyway per the issue's own Targon-precedent instruction; the probe reflects real status). Note on `/funding`: the issue grouped it with the auth-gated set ("same `/admin`-adjacent auth posture, not spot-verified individually"), but the schema declares no header params on the GET and it live-verifies **200 no-auth** — registered per observed reality, per the issue's own "every claim has to trace back to a request you actually made."

**4 public, required-query-param (`probe.enabled:false`)**: `/public/subnet/status`, `/public/epochs`, `/public/validators`, `/public/commitments`. Live-verified 2026-07-21 (~21:33 UTC), both directions on all four: unparameterized → HTTP 422 listing the exact required `network`/`netuid` fields (live validation, not an auth error); with `network=finney&netuid=69` → HTTP 200 real JSON (e.g. `/public/subnet/status` returns the live finalized-block/neuron snapshot). Callable today via `call_subnet_surface`'s own `query` argument.

**1 public SSE stream (`kind:"sse"`, `probe.enabled:false`)**: `/public/events`. The issue listed it with the query-param JSON group, but live verification (2026-07-21 ~21:35 UTC, `network=finney&netuid=69`) shows HTTP 200 with `content-type: text/event-stream` — a long-lived Server-Sent Events stream of `finalized_block`/indexer events, not a one-shot JSON body; unparameterized → 422 listing the required fields. Registered `kind:"sse"` accordingly (matching the registry's existing SSE-surface convention).

**1 public path-param (`probe.enabled:false`, literal `{brief_id}` template percent-encoded in the `url` since raw braces fail the `url` `format:"uri"` schema check)**: `/public/briefs/{brief_id}/economics`. Live-verified 2026-07-21 (~21:34 UTC) with a placeholder id: without query params → 422 listing the required `network`/`netuid` fields (the placeholder path segment itself is accepted); with `network=finney&netuid=69` → 404 `{"detail":"no confirmed economics for brief"}` — a clean domain not-found, not an auth gate.

**7 auth-gated GET (`auth_required:true`, minimal `auth:{scheme:"custom",scopes_note}`, `probe.enabled:false`)** — every one individually live-verified 2026-07-21 (~21:33 UTC): HTTP 401 `{"detail":"unauthorized"}` unauthenticated: `/admin/briefs`, `/admin/reporters`, `/admin/registry/draft`, `/validator/results`, `/reveals`, `/users/coverage`, `/contact`. Each declares a service header parameter on the operation in the OpenAPI schema (marked `required:false` there, but enforced in practice — the 401s prove it); the specific header name is documented once in each surface's `notes`. Three of these (`/validator/results`, `/reveals`, `/users/coverage`) were listed as no-auth in the issue's review section, but they 401 live — registered per observed reality with the evidence in each surface's notes.

**11 auth-gated write-only POST (`auth_required:true`, `probe.enabled:false`)** — the issue's remaining itemized operations, each on its own unique URL: `/admin/briefs/{brief_id}/close`, `/admin/briefs/{brief_id}/fund`, `/admin/registry/editions`, `/admin/registry/outlets`, `/admin/registry/outlets/{outlet_id}/status`, `/admin/registry/discard`, `/results`, `/api/v3/validator/snapshots`, `/api/v3/validator/weight-receipts`, `/users/upsert`, `/contact/{contact_id}/status`. Registered per the issue's own instruction for the auth-gated set ("register with `auth_required:true`, `probe.enabled:false`"). Not spot-verified individually — the issue's own section says the write endpoints were "not spot-verified individually," and an unauthenticated state-changing POST against a production validator-facing system isn't a safe verification to run — but each operation's header gate is live-verified enforced (401) on a sibling GET declaring the same header parameter (documented per-surface in `notes`), and the registration follows the same merged precedent as #7540 (SN59)'s POST-operation surfaces.

## Schema/tooling notes (same as the lineage)

- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC` — every query-param/path-param/auth-gated/POST surface here is `probe.enabled:false`; the 12 fixed no-auth GETs keep live probes.
- Path-param URLs use the percent-encoded brace form (`%7Bbrief_id%7D`, `%7Boutlet_id%7D`, `%7Bcontact_id%7D`).
- Registered `provider: "herald"` — matches the file's existing first-party surfaces and the registered `registry/providers/herald.json` entry, checked before generating.
- The auth-gated surfaces use the minimal `auth:{scheme:"custom", scopes_note}` shape (as in merged #7551) — these are per-operation header parameters in the schema, not a formal `securitySchemes` entry; no credential format or placeholder value is asserted anywhere.
- Strictly append-only into `surfaces[]`: **+864/−0**, top-level `notes`/`curation` untouched. (The file's `gap_notes` still carry a now-stale "no verified first-party API/OpenAPI schema" line — left alone as maintainer-owned metadata; flagged here in prose instead.)
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/ain.json` — 41 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2634 total surfaces, clean
- [x] `npx vitest run tests/sn69-call-subnet-surface-verify.test.mjs` — 3 passed (unchanged — pins `sn-69-taomarketcap-subnet-api`, unaffected by this diff)
- [x] `npm test` — full suite (473 files, 11,159 tests), clean
- [x] `npx prettier --check registry/subnets/ain.json` — clean

Closes #7082
