### PR TITLE
fix(registry): SN105 Beam full API parity (22 missing surfaces)

### DIFF
--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -219,6 +219,578 @@
       },
       "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
       "url": "https://beamcore.b1m.ai/status/orchestrator-relays"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-auth-me",
+      "kind": "subnet-api",
+      "name": "Beam GET auth me",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /auth/me on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"authentication required\"}. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/auth/me"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-auth-keys",
+      "kind": "subnet-api",
+      "name": "Beam GET auth keys",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /auth/keys on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"authentication required\"}. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/auth/keys"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-clients",
+      "kind": "subnet-api",
+      "name": "Beam GET clients",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /clients on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"authentication required\"}. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/clients"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-destinations",
+      "kind": "subnet-api",
+      "name": "Beam GET destinations",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /destinations on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"authentication required\"}. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/destinations"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-transfers",
+      "kind": "subnet-api",
+      "name": "Beam GET transfers",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /transfers on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"authentication required\"}. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/transfers"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrators-pending-transfers",
+      "kind": "subnet-api",
+      "name": "Beam GET orchestrators pending transfers",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /orchestrators/pending-transfers on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"authentication required\"}. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/orchestrators/pending-transfers"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrators-workers",
+      "kind": "subnet-api",
+      "name": "Beam GET orchestrators workers",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /orchestrators/workers on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"authentication required\"}. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/orchestrators/workers"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires validator signature headers per the live 401 response; the mechanism is not documented in the OpenAPI schema (which declares no per-operation security)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-validator-epoch-summary-latest-epoch",
+      "kind": "subnet-api",
+      "name": "Beam GET Validator epoch summary latest epoch",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /Validator/epoch-summary/latest-epoch on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"missing validator signature headers\"} — a validator-signature scheme, not the schema's apiKey header. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/Validator/epoch-summary/latest-epoch"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-jobs",
+      "kind": "subnet-api",
+      "name": "Beam GET jobs",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /jobs on beamcore.b1m.ai. The OpenAPI schema declares no security on this operation, but the route is gated in practice — live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"error\":\"authentication required\"}. Already flagged as auth-gated by this file's own gap_notes; Registered per the registry's full-API-parity policy (metagraphed#7116) with auth_required:true.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/jobs"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-internal-routing-live",
+      "kind": "subnet-api",
+      "name": "Beam GET internal routing live",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /internal/routing/live on beamcore.b1m.ai — query param: pool. Live-verified 2026-07-21: a bare unauthenticated request returns HTTP 401 {\"error\":\"unauthorized\"}, and ?pool=x returns HTTP 400 FST_ERR_VALIDATION listing the allowed pool values — both consistent with a live, gated route. Registered auth_required:true per this file's own gap_notes finding, flagged for a contributor with a credential to confirm with a real pool value. Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/internal/routing/live"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-clients-clientid",
+      "kind": "subnet-api",
+      "name": "Beam GET clients by client_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /clients/{client_id} on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"authentication required\"} — the auth gate answers first, confirming the route is real and gated. Path-param sibling of the fixed auth-gated group this file's own gap_notes already enumerated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/clients/%7Bclient_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-destinations-destinationid",
+      "kind": "subnet-api",
+      "name": "Beam GET destinations by destination_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /destinations/{destination_id} on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"authentication required\"} — the auth gate answers first, confirming the route is real and gated. Path-param sibling of the fixed auth-gated group this file's own gap_notes already enumerated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/destinations/%7Bdestination_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrators-orchestratorid",
+      "kind": "subnet-api",
+      "name": "Beam GET orchestrators by orchestrator_id",
+      "notes": "GET /orchestrators/{orchestrator_id} on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder id: HTTP 404 {\"error\":\"orchestrator not found\"} — a clean not-found lookup answers before any auth challenge, confirming the route is real. Registered auth_required:true per the issue's grouping of this path-param sibling with the fixed auth-gated group (metagraphed#7116), flagged for confirmation with a real id. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/orchestrators/%7Borchestrator_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrators-orchestratorid-workers",
+      "kind": "subnet-api",
+      "name": "Beam GET orchestrators by orchestrator_id workers",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /orchestrators/{orchestrator_id}/workers on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"authentication required\"} — the auth gate answers first, confirming the route is real and gated. Path-param sibling of the fixed auth-gated group this file's own gap_notes already enumerated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/orchestrators/%7Borchestrator_id%7D/workers"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrators-orchestratorid-pending-transfers",
+      "kind": "subnet-api",
+      "name": "Beam GET orchestrators by orchestrator_id pending transfers",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /orchestrators/{orchestrator_id}/pending-transfers on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"authentication required\"} — the auth gate answers first, confirming the route is real and gated. Path-param sibling of the fixed auth-gated group this file's own gap_notes already enumerated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/orchestrators/%7Borchestrator_id%7D/pending-transfers"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrators-orchestratorid-assignments",
+      "kind": "subnet-api",
+      "name": "Beam GET orchestrators by orchestrator_id assignments",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /orchestrators/{orchestrator_id}/assignments on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"authentication required\"} — the auth gate answers first, confirming the route is real and gated. Path-param sibling of the fixed auth-gated group this file's own gap_notes already enumerated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/orchestrators/%7Borchestrator_id%7D/assignments"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrators-orchestratorid-tasks",
+      "kind": "subnet-api",
+      "name": "Beam GET orchestrators by orchestrator_id tasks",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /orchestrators/{orchestrator_id}/tasks on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"authentication required\"} — the auth gate answers first, confirming the route is real and gated. Path-param sibling of the fixed auth-gated group this file's own gap_notes already enumerated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/orchestrators/%7Borchestrator_id%7D/tasks"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrators-prism-scores-orchuid",
+      "kind": "subnet-api",
+      "name": "Beam GET orchestrators prism scores by orch_uid",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /orchestrators/prism-scores/{orch_uid} on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"authentication required\"} — the auth gate answers first, confirming the route is real and gated. Path-param sibling of the fixed auth-gated group this file's own gap_notes already enumerated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/orchestrators/prism-scores/%7Borch_uid%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-workers-workerid",
+      "kind": "subnet-api",
+      "name": "Beam GET workers by worker_id",
+      "notes": "GET /workers/{worker_id} on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder id: HTTP 404 {\"error\":\"worker not found\"} — a clean not-found lookup answers before any auth challenge, confirming the route is real. Registered auth_required:true per the issue's grouping of this path-param sibling with the fixed auth-gated group (metagraphed#7116), flagged for confirmation with a real id. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/workers/%7Bworker_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires validator signature headers per the live 401 response; the mechanism is not documented in the OpenAPI schema (which declares no per-operation security)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-validators-weights-epoch",
+      "kind": "subnet-api",
+      "name": "Beam GET validators weights by epoch",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /validators/weights/{epoch} on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"missing validator signature headers\"} — same validator-signature scheme as the Validator epoch-summary route, not the schema's apiKey header. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/validators/weights/%7Bepoch%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-jobs-jobid",
+      "kind": "subnet-api",
+      "name": "Beam GET jobs by job_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /jobs/{job_id} on beamcore.b1m.ai. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"error\":\"authentication required\"} — the auth gate answers first, confirming the route is real and gated. Path-param sibling of the fixed auth-gated group this file's own gap_notes already enumerated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/jobs/%7Bjob_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "The schema's only declared securityScheme is an apiKey header; the schema declares no per-operation security, but the route is auth-gated in practice (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-105-beam-logs-stream-source",
+      "kind": "sse",
+      "name": "Beam GET logs stream by source",
+      "notes": "SSE log stream: GET /logs/stream/{source} on beamcore.b1m.ai — the path-parameterized stream this file's own gap_notes already mention. Live-verified 2026-07-21 with a placeholder value: HTTP 404 {\"error\":\"Unknown log source: test-source\"} — a clean validation error, confirming the route is real. Registered auth_required:true per the issue's grouping of the path-param siblings with the auth-gated group (metagraphed#7116), flagged for confirmation with a real source. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7116).",
+      "probe": {
+        "enabled": false,
+        "expect": "sse",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/logs/stream/%7Bsource%7D"
     }
   ],
   "website_url": "https://b1m.ai/"


### PR DESCRIPTION
## Summary

Closes #7116. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527/#7538/#7551/#7559: the issue's original 5 surfaces (`sn-105-beam-openapi`, `sn-105-beam-health`, `sn-105-beam-routing-orchestrators`, `sn-105-beam-worker-capacity`, `sn-105-beam-validators-orchestrators`) still verify exactly as documented (live-verified 2026-07-21: all four fixed endpoints HTTP 200 `application/json` with real payloads, the OpenAPI document HTTP 200 with 53 paths), and the issue's own "Additional surface(s) found during review" section already itemizes the remaining registry gap — this PR registers it.

## What this adds (22 new surfaces)

Fetched the subnet's own OpenAPI schema (`https://beamcore.b1m.ai/openapi.json`, 53 total paths) and diffed against the registry: 7 of those 53 already covered (`/openapi.json`, `/health`, `/config/uid-ranges`, `/routing/orchestrators`, `/routing/worker-capacity`, `/validators/orchestrators`, `/status/orchestrator-relays`), 7 docs-UI routes not meaningful registry surfaces (`/docs/*` x5, `/redoc`, plus the swagger static assets), 17 write-only POST/PATCH/PUT/DELETE paths with no GET-observable behavior excluded (registration/heartbeat/score-submission/webhook actions) → **22 unique missing GET paths**, matching the issue's itemized list exactly (9 auth-gated fixed + 1 query-param + 12 path-param including the SSE stream). The schema declares no per-operation security anywhere, but this file's own `gap_notes` already established these routes are auth-gated in practice — all 22 are registered with `auth_required:true`, `probe.enabled:false`, per the issue's own instruction.

**9 auth-gated, fixed** — `/auth/me`, `/auth/keys`, `/clients`, `/destinations`, `/transfers`, `/orchestrators/pending-transfers`, `/orchestrators/workers`, `/Validator/epoch-summary/latest-epoch`, `/jobs`. Live-verified 2026-07-21 (every one individually curled): unauthenticated requests return HTTP 401 `{"error":"authentication required"}` on eight of them; `/Validator/epoch-summary/latest-epoch` returns HTTP 401 `{"error":"missing validator signature headers"}` — a validator-signature scheme rather than the schema's apiKey header, so that surface carries `auth:{scheme:"custom",...}` while the rest carry `auth:{scheme:"api-key",...}`.

**1 auth-gated, query-param** — `/internal/routing/live` (query: `pool`). Live-verified 2026-07-21: a bare unauthenticated request returns HTTP 401 `{"error":"unauthorized"}`, and `?pool=x` returns HTTP 400 `FST_ERR_VALIDATION` listing the allowed pool values. The bare-request 401 strengthens the issue's own 400-only observation; registered `auth_required:true` per the gap_notes finding, flagged in the surface notes for confirmation with a real pool value by a credentialed caller.

**12 auth-gated, path-param** (literal `{param}` template percent-encoded in the `url` field) — `/clients/{client_id}`, `/destinations/{destination_id}`, `/orchestrators/{orchestrator_id}` (+`/workers`, `/pending-transfers`, `/assignments`, `/tasks`), `/orchestrators/prism-scores/{orch_uid}`, `/workers/{worker_id}`, `/validators/weights/{epoch}`, `/jobs/{job_id}`, and the SSE stream `/logs/stream/{source}` (registered `kind:"sse"`). Live-verified 2026-07-21 with placeholder values — every one of the 12 individually curled, not sampled: 8 return HTTP 401 `{"error":"authentication required"}` (auth gate answers first); `/validators/weights/{epoch}` returns HTTP 401 `{"error":"missing validator signature headers"}` (same custom scheme as the epoch-summary route, registered `scheme:"custom"`); `/orchestrators/{orchestrator_id}` and `/workers/{worker_id}` return clean HTTP 404 not-found lookups (`{"error":"orchestrator not found"}` / `{"error":"worker not found"}`) — the route resolves the entity before any auth challenge, confirming it is real; both are registered `auth_required:true` per the issue's own grouping and their notes flag the 404-before-auth observation for confirmation with a real id; `/logs/stream/{source}` returns a clean HTTP 404 validation error (`{"error":"Unknown log source: test-source"}`), confirming the route is live.

## Schema/tooling notes (same as the last several)

- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC`; every new surface is `probe.enabled:false` (auth-gated / query-param / path-param), so no probe ever fires. The SSE surface uses `probe.expect:"sse"`.
- Path-param URLs use the percent-encoded brace form (`%7Bparam%7D`) — raw unescaped braces fail this repo's `url` `format:"uri"` schema check.
- Registered `provider: "beam"` — matches the file's existing surfaces and the registered `registry/providers/beam.json`, checked before generating.
- `auth` objects carry only `scheme` + a `scopes_note` — no header-name or credential-format literals.
- Append-only: `surfaces[]` additions only; the file's top-level `notes`/`curation`/`gap_notes` are untouched (the gap_notes' auth-gating enumeration is what this PR registers, and the notes stay accurate as written).
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/beam.json` — 31 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2620 total surfaces, 136 providers, clean
- [x] `npx prettier --check registry/subnets/beam.json` — clean

Closes #7116
