### PR TITLE
fix(registry): SN64 Chutes full API parity (29 missing surfaces)

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -902,6 +902,716 @@
       "public_safe": true,
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "url": "https://api.chutes.ai/audit/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-chutes-miner-means",
+      "kind": "subnet-api",
+      "name": "Chutes GET chutes miner means",
+      "notes": "GET /chutes/miner_means on api.chutes.ai — public, no auth declared in the OpenAPI schema. Per-chute mean scoring summary across miners. Live-verified 2026-07-21: HTTP 200 text/html (a rendered outlier-index page, not JSON — probe.expect:\"html\" accordingly), same result with a JSON accept header. Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/miner_means"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-guess-vllm-config",
+      "kind": "subnet-api",
+      "name": "Chutes GET guess vllm config",
+      "notes": "GET /guess/vllm_config on api.chutes.ai — public, no auth declared in the OpenAPI schema. Required query: model. Live-verified 2026-07-21: an unparameterized request returns HTTP 400 {\"error\":\"$.query.model: required parameter missing\"} — a clean validation error listing the required field, not an auth error. probe.enabled:false is the safer default: an auto-probe with no query params would just 400. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/guess/vllm_config"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-invocations-exports-recent",
+      "kind": "subnet-api",
+      "name": "Chutes GET invocations exports recent",
+      "notes": "GET /invocations/exports/recent on api.chutes.ai — public, no auth declared in the OpenAPI schema; optional hotkey/limit query params. Live-verified 2026-07-21: HTTP 500 Internal Server Error — a real endpoint currently live-erroring, registered with probe.enabled:true so the probe reports the real status (same handling as the Targon healthz precedent, per the issue's own scope note). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/invocations/exports/recent"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-misc-hf-repo-info",
+      "kind": "subnet-api",
+      "name": "Chutes GET misc hf repo info",
+      "notes": "GET /misc/hf_repo_info on api.chutes.ai — public, no auth declared in the OpenAPI schema. Required query: repo_id. Live-verified 2026-07-21: an unparameterized request returns HTTP 400 {\"error\":\"$.query.repo_id: required parameter missing\"} — a clean validation error listing the required field, not an auth error. probe.enabled:false is the safer default: an auto-probe with no query params would just 400. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/misc/hf_repo_info"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-audit-download",
+      "kind": "subnet-api",
+      "name": "Chutes GET audit download",
+      "notes": "GET /audit/download on api.chutes.ai — public, no auth declared in the OpenAPI schema. Required query: path. Live-verified 2026-07-21: an unparameterized request returns HTTP 400 {\"error\":\"$.query.path: required parameter missing\"} — a clean validation error listing the required field, not an auth error. probe.enabled:false is the safer default: an auto-probe with no query params would just 400. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7077). Complements the already-registered sn-64-chutes-audit-log surface.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/audit/download"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-misc-proxy",
+      "kind": "subnet-api",
+      "name": "Chutes GET misc proxy",
+      "notes": "GET /misc/proxy on api.chutes.ai — public, no auth declared in the OpenAPI schema. Required query: url (optional stream). Live-verified 2026-07-21: an unparameterized request returns HTTP 400 {\"error\":\"$.query.url: required parameter missing\"}. This is a raw outbound-fetch passthrough — registered for schema parity per the issue's own itemized scope, with probe deliberately disabled and flagged for awareness rather than auto-probing (per the issue's own note). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/misc/proxy"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-chutes-miner-means-chuteid",
+      "kind": "subnet-api",
+      "name": "Chutes GET chutes miner means by chute_id",
+      "notes": "GET /chutes/miner_means/{chute_id} on api.chutes.ai — public, no auth declared in the OpenAPI schema; per-chute detail view of the miner-means summary. Live-verified 2026-07-21 with a placeholder id: HTTP 200 text/html (a rendered per-chute metrics page), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "html",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/miner_means/%7Bchute_id%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-chutes-miner-means-chuteid-ext",
+      "kind": "subnet-api",
+      "name": "Chutes GET chutes miner means by chute_id by ext",
+      "notes": "GET /chutes/miner_means/{chute_id}.{ext} on api.chutes.ai — public, no auth declared in the OpenAPI schema; machine-readable export of the per-chute miner-means detail. Live-verified 2026-07-21 with a placeholder id and .csv: HTTP 200 text/csv with a header row, confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/miner_means/%7Bchute_id%7D.%7Bext%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-invocations-exports-dated",
+      "kind": "subnet-api",
+      "name": "Chutes GET invocations exports by year month day hour",
+      "notes": "GET /invocations/exports/{year}/{month}/{day}/{hour_format} on api.chutes.ai — public, no auth declared in the OpenAPI schema; historical invocation export by date. Live-verified 2026-07-21 with placeholder values: HTTP 400 {\"detail\":\"Invalid format: 00\"} — a clean validation error, confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/invocations/exports/%7Byear%7D/%7Bmonth%7D/%7Bday%7D/%7Bhour_format%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-unique-chute-history-byhotkey",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner unique chute history",
+      "notes": "GET /miner/unique_chute_history/{hotkey} on api.chutes.ai — public, no auth declared in the OpenAPI schema; per-miner unique-chute history. Live-verified 2026-07-21 with a placeholder value: HTTP 404 {\"detail\":\"Miner test-value not found in metagraph.\"} — a clean not-found lookup, confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/unique_chute_history/%7Bhotkey%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-logos-logoid-extension",
+      "kind": "subnet-api",
+      "name": "Chutes GET logos by logo_id by extension",
+      "notes": "GET /logos/{logo_id}.{extension} on api.chutes.ai — public, no auth declared in the OpenAPI schema; logo image asset lookup. Live-verified 2026-07-21 with a placeholder value: HTTP 400 path-parameter validation error listing the required params, confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/logos/%7Blogo_id%7D.%7Bextension%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-chutes",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner chutes",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/chutes/ on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid BT Auth.\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/chutes/"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-nodes",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner nodes",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/nodes/ on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid BT Auth.\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/nodes/"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-servers",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner servers",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/servers/ on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid BT Auth.\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/servers/"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-instances",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner instances",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/instances/ on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid BT Auth.\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/instances/"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-jobs",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner jobs",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/jobs/ on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid BT Auth.\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/jobs/"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-inventory",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner inventory",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/inventory on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid BT Auth.\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/inventory"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-active-instances",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner active instances",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/active_instances/ on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid BT Auth.\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/active_instances/"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-thrash-cooldowns",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner thrash cooldowns",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/thrash_cooldowns on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid BT Auth.\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/thrash_cooldowns"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "The schema declares a required authorization header parameter directly on this operation instead of an OpenAPI security block — functionally auth-gated (verified live)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-miner-instance-logs",
+      "kind": "subnet-api",
+      "name": "Chutes GET miner instance logs",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /miner/instance_logs on api.chutes.ai. The schema declares no security block here but marks its authorization header parameter required:true — functionally auth-gated. Live-verified 2026-07-21: an unauthenticated request returns HTTP 400 stating the required authorization header parameter is missing, confirming enforcement. Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/miner/instance_logs"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-chutes-chuteidorname",
+      "kind": "subnet-api",
+      "name": "Chutes GET chutes by chute_id_or_name",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /chutes/{chute_id_or_name} on api.chutes.ai — chute detail. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21 with a placeholder value: HTTP 404 {\"detail\":\"Chute not found, or does not belong to you\"} — an ownership-scoped lookup answers with a clean not-found for an unknown name, confirming the route is real; registered auth_required:true per the schema's security declaration. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/%7Bchute_id_or_name%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-chutes-chuteidorname-evidence",
+      "kind": "subnet-api",
+      "name": "Chutes GET chutes by chute_id_or_name evidence",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /chutes/{chute_id_or_name}/evidence on api.chutes.ai — TEE attestation evidence for a chute; required query: nonce. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21 with a placeholder value and ?nonce=1: HTTP 404 {\"detail\":\"Chute not found\"} — a clean not-found lookup, confirming the route is real; registered auth_required:true per the schema's security declaration. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/chutes/%7Bchute_id_or_name%7D/evidence"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-users-useridorusername-balance",
+      "kind": "subnet-api",
+      "name": "Chutes GET users by user_id_or_username balance",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /users/{user_id_or_username}/balance on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"detail\":\"Can't find a user with that api key in our db :(\"} — the auth gate answers, confirming the route is real and gated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/users/%7Buser_id_or_username%7D/balance"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-users-userid-usage",
+      "kind": "subnet-api",
+      "name": "Chutes GET users by user_id usage",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /users/{user_id}/usage on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"detail\":\"Can't find a user with that api key in our db :(\"} — the auth gate answers, confirming the route is real and gated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/users/%7Buser_id%7D/usage"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-instances-instanceid-evidence",
+      "kind": "subnet-api",
+      "name": "Chutes GET instances by instance_id evidence",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /instances/{instance_id}/evidence on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"detail\":\"Can't find a user with that api key in our db :(\"} — the auth gate answers, confirming the route is real and gated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077). Required query: nonce (included in the live check).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/instances/%7Binstance_id%7D/evidence"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-instances-instanceid-logs",
+      "kind": "subnet-api",
+      "name": "Chutes GET instances by instance_id logs",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /instances/{instance_id}/logs on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"detail\":\"Can't find a user with that api key in our db :(\"} — the auth gate answers, confirming the route is real and gated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/instances/%7Binstance_id%7D/logs"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-servers-serverid",
+      "kind": "subnet-api",
+      "name": "Chutes GET servers by server_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /servers/{server_id} on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"detail\":\"Invalid nonce!\"} — the auth gate answers, confirming the route is real and gated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/servers/%7Bserver_id%7D"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-servers-maintenance-policy",
+      "kind": "subnet-api",
+      "name": "Chutes GET servers maintenance policy",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /servers/maintenance/policy on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21: an unauthenticated request returns HTTP 401 {\"detail\":\"Invalid nonce!\"}. Registered per the registry's full-API-parity policy (metagraphed#7077) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/servers/maintenance/policy"
+    },
+    {
+      "auth": {
+        "scheme": "api-key",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (APIKeyHeader security declared per-operation); exact token format not documented beyond the schema's security declaration."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-jobs-jobid",
+      "kind": "subnet-api",
+      "name": "Chutes GET jobs by job_id",
+      "notes": "Auth-gated (Phase 3 credential passthrough, not built yet) GET /jobs/{job_id} on api.chutes.ai. The OpenAPI schema declares APIKeyHeader security on this operation. Live-verified 2026-07-21 with a placeholder value: HTTP 401 {\"detail\":\"Can't find a user with that api key in our db :(\"} — the auth gate answers, confirming the route is real and gated. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7077).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/jobs/%7Bjob_id%7D"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Summary

Closes #7077. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527/#7538/#7551/#7559: the issue's original 13 surfaces (pricing, openapi, `llm.chutes.ai/v1/models`, the bearer-gated SSE completions surface, bounties, llm-stats, ping, health, fmv, tao-payment-totals, miner-scores, miner-stats, miner-metrics) still verify as registered, and the issue's own "Additional surface(s) found during review" section already itemizes the remaining registry gap — this PR registers exactly that itemized list, nothing more (the issue's own scope note explicitly leaves the ~account-administration/OAuth/build internals not enumerated, and finding surfaces beyond the itemized list is explicitly out of scope on this issue).

## What this adds (29 new surfaces)

Fetched the already-registered schema (`https://api.chutes.ai/openapi.json`, 165 total paths) and diffed against `registry/subnets/chutes.json`: 26 of those 165 paths are already covered by registered surfaces, 51 are write-only POST/PUT/DELETE/PATCH paths with no GET-observable behavior, 59 are the account/platform-plumbing GETs the issue's own "Explicitly not enumerated" note groups and deliberately leaves out (`/users/*` account admin, `/idp/*` OAuth, `/api_keys/*`, `/secrets/*`, `/images/*` build management, `/instances/*` launch-config/nonce internals, `/servers/*` nonce/attestation internals, `/model_aliases/*`, `/encrypted_logs/*`, `/e2e/*`, etc.) → the issue's itemized list of **29 subnet/mining-relevant missing surfaces**, all registered here. Duplicate-URL check against all 41 existing surfaces done before generating (zero collisions).

**6 public, fixed/query-param, no auth declared** — live-verified 2026-07-21:
- `GET /chutes/miner_means` — HTTP 200 `text/html` (a rendered outlier-index page, not JSON; same with a JSON accept header) — registered `probe.enabled:true, expect:"html"`.
- `GET /invocations/exports/recent` — HTTP 500 Internal Server Error, a real endpoint currently live-erroring — registered anyway with `probe.enabled:true` so the probe reports the real status, exactly as the issue's own scope note instructs (Targon healthz precedent).
- `GET /guess/vllm_config` (required query `model`), `GET /misc/hf_repo_info` (required `repo_id`), `GET /audit/download` (required `path`), `GET /misc/proxy` (required `url`) — each returns HTTP 400 `{"error":"$.query.<field>: required parameter missing"}` unparameterized: a clean validation error listing the required field, proving live + no auth gate. Registered `probe.enabled:false` with the fixed base URL, no query baked in — callable today via `call_subnet_surface`'s own `query` argument. `/misc/proxy` is additionally flagged in its surface notes as a raw outbound-fetch passthrough (probe deliberately disabled), per the issue's own awareness note.

**5 public, path-param** (`probe.enabled:false`, literal `{param}` templates percent-encoded) — live-verified 2026-07-21, every one individually curled with placeholder values: `/chutes/miner_means/{chute_id}` (HTTP 200 `text/html` per-chute metrics page), `/chutes/miner_means/{chute_id}.{ext}` (HTTP 200 `text/csv` with header row for `.csv`), `/invocations/exports/{year}/{month}/{day}/{hour_format}` (HTTP 400 `{"detail":"Invalid format: 00"}`), `/miner/unique_chute_history/{hotkey}` (HTTP 404 clean "not found in metagraph" lookup), `/logos/{logo_id}.{extension}` (HTTP 400 path-param validation error). All clean validation/not-found responses — real routes, no auth gates.

**18 auth-gated** (`auth_required:true`, `auth:{scheme:"api-key",...}` per the schema's APIKeyHeader security declarations, `probe.enabled:false`) — live-verified 2026-07-21, every one individually curled unauthenticated, none sampled:
- The 8 miner fleet-introspection routes (`/miner/chutes/`, `/miner/nodes/`, `/miner/servers/`, `/miner/instances/`, `/miner/jobs/`, `/miner/inventory`, `/miner/active_instances/`, `/miner/thrash_cooldowns`) — all HTTP 401 `{"detail":"Invalid BT Auth."}`.
- `/miner/instance_logs` — the schema declares no security block but marks its authorization header parameter `required:true` (the discrepancy the issue itself flags); live HTTP 400 stating the required authorization header parameter is missing, confirming enforcement — registered `auth:{scheme:"custom",...}`.
- `/users/{user_id_or_username}/balance`, `/users/{user_id}/usage`, `/instances/{instance_id}/evidence` (required query `nonce` included in the check), `/instances/{instance_id}/logs`, `/jobs/{job_id}` — all HTTP 401 (api-key detail message).
- `/servers/{server_id}`, `/servers/maintenance/policy` — HTTP 401 `{"detail":"Invalid nonce!"}`.
- `/chutes/{chute_id_or_name}` and `/chutes/{chute_id_or_name}/evidence` — placeholder lookups return clean HTTP 404s (`"Chute not found, or does not belong to you"` / `"Chute not found"`), confirming the routes are real; both registered `auth_required:true` per the schema's APIKeyHeader security declaration on these operations, with the 404-before-auth observation noted on the surfaces.

## Schema/tooling notes (same as the last several)

- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC`; only the two probe-enabled surfaces above ever fire, everything param/auth-gated is `probe.enabled:false`.
- Path-param URLs use the percent-encoded brace form (`%7Bparam%7D`) — raw unescaped braces fail this repo's `url` `format:"uri"` schema check.
- Registered `provider: "chutes"` — matches the file's existing surfaces and the registered `registry/providers/chutes.json`, checked before generating.
- `auth` objects carry only `scheme` + a `scopes_note` — no header-name or credential-format literals.
- Append-only: `surfaces[]` additions only; the file's top-level `notes`/`curation`/`gap_notes` are untouched.
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/chutes.json` — 70 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2627 total surfaces, 136 providers, clean
- [x] `npx vitest run tests/chutes-call-subnet-surface-verify.test.mjs` — 3 passed (unchanged — pins existing surfaces, unaffected by this append-only diff)
- [x] `npx prettier --check registry/subnets/chutes.json` — clean

Closes #7077
