### PR TITLE
fix(registry): reword bitcast.json entries tripping public-safety scan

### DIFF
--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -2105,7 +2105,7 @@
       "authority": "community",
       "id": "sn-93-bitcast-post-api-v2-twitter-coldkeys",
       "kind": "subnet-api",
-      "name": "Bitcast Register a coldkey with additional metadata and get registration tag",
+      "name": "Bitcast Register a Twitter payout wallet with additional metadata and get registration tag",
       "notes": "Auth-gated POST /api/v2/twitter/coldkeys on bitcast-api.bitcast.network from the Bitcast OpenAPI schema (sn-93-bitcast-network-openapi). auth_required:true, probe.enabled:false.",
       "probe": {
         "enabled": false,
@@ -2134,7 +2134,7 @@
       "authority": "community",
       "id": "sn-93-bitcast-post-api-v2-twitter-coldkeys-coldkey",
       "kind": "subnet-api",
-      "name": "Bitcast Register a coldkey and get registration tag (legacy)",
+      "name": "Bitcast Register a Twitter payout wallet and get registration tag (legacy)",
       "notes": "Auth-gated POST /api/v2/twitter/coldkeys/{coldkey} on bitcast-api.bitcast.network from the Bitcast OpenAPI schema (sn-93-bitcast-network-openapi). auth_required:true, probe.enabled:false; path-parameterized template.",
       "probe": {
         "enabled": false,
@@ -3584,7 +3584,7 @@
       "authority": "community",
       "id": "sn-93-bitcast-put-api-v2-youtube-users-portal-user-id-payment-coldkey",
       "kind": "subnet-api",
-      "name": "Bitcast Update Payment Coldkey",
+      "name": "Bitcast Update Payment Wallet Address",
       "notes": "Auth-gated PUT /api/v2/youtube/users/{portal_user_id}/payment-coldkey on bitcast-api.bitcast.network from the Bitcast OpenAPI schema (sn-93-bitcast-network-openapi). auth_required:true, probe.enabled:false; path-parameterized template.",
       "probe": {
         "enabled": false,


### PR DESCRIPTION
## Summary

`scan:public-safety`'s Bittensor-key-terminology rule (`\bcoldkey\b`) is currently failing on `main` because of 3 surface `name` fields in `registry/subnets/bitcast.json` (merged via #7568) that use bare "coldkey" in prose — outside the rule's allowlisted field-name/code-identifier forms. Since this is a shared, already-merged file, it's failing `scan:public-safety` on every PR right now regardless of what that PR touches.

## Fix

Reworded the 3 affected `name` fields to describe the same endpoints without the bare trigger word:
- `sn-93-bitcast-post-api-v2-twitter-coldkeys`: "Register a coldkey..." → "Register a Twitter payout wallet..."
- `sn-93-bitcast-post-api-v2-twitter-coldkeys-coldkey`: "Register a coldkey... (legacy)" → "Register a Twitter payout wallet... (legacy)"
- `sn-93-bitcast-put-api-v2-youtube-users-portal-user-id-payment-coldkey`: "Update Payment Coldkey" → "Update Payment Wallet Address"

`id`, `url`, and `notes` on all three are untouched — they already reference the literal `coldkey`/`payment-coldkey` path segments safely (matching the rule's own field-name/code-identifier allowlist), so no accuracy is lost.

## Validation

- [x] `node scripts/scan-public-safety.mjs` — now passes clean
- [x] `npm run validate:surface -- registry/subnets/bitcast.json` — 137 surfaces, passed
- [x] `npx prettier --check registry/subnets/bitcast.json` — clean

## Scope

`registry/subnets/bitcast.json` only — wording fix, no surface additions/removals.