### PR TITLE
fix(registry): SN28 gm full API parity (4 missing surfaces)

### DIFF
--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -160,6 +160,110 @@
         "https://github.com/taostat/gm-miner/blob/main/image/envoy.yaml"
       ],
       "url": "https://raw.githubusercontent.com/taostat/gm-miner/refs/heads/main/image/envoy.yaml"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "scopes_note": "The subnet's own OpenAPI schema declares a single global bearer-token security requirement covering all four Gateway API operations. Enforced in practice: live-verified HTTP 401 unauthenticated on this endpoint (2026-07-21)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-28-gm-chat-completions",
+      "kind": "subnet-api",
+      "name": "gm chat completions (write, auth-gated)",
+      "notes": "POST /chat/completions on the gm Gateway API (schema servers base https://api.saygm.com/v1) -- OpenAI-compatible chat-completions inference endpoint, one of the four operations documented in the subnet's own OpenAPI schema, all under the schema's global bearer security requirement. Live-verified 2026-07-21 (~23:35 UTC): HTTP 401 unauthenticated with a JSON invalid-authentication error body. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1/chat/completions"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "scopes_note": "The subnet's own OpenAPI schema declares a single global bearer-token security requirement covering all four Gateway API operations. Enforced in practice: live-verified HTTP 401 unauthenticated on this endpoint (2026-07-21)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-28-gm-messages",
+      "kind": "subnet-api",
+      "name": "gm messages (write, auth-gated)",
+      "notes": "POST /messages on the gm Gateway API (schema servers base https://api.saygm.com/v1) -- Anthropic Messages-API-compatible inference endpoint documented in the subnet's own OpenAPI schema under the same global bearer security requirement as the sibling /chat/completions operation. Live-verified 2026-07-21 (~23:35 UTC): HTTP 401 unauthenticated with a JSON authentication-error body (the linked issue listed this sibling as not individually spot-verified; this registration verified it directly). Registered auth_required:true with probe.enabled:false; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1/messages"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "scopes_note": "The subnet's own OpenAPI schema declares a single global bearer-token security requirement covering all four Gateway API operations. Enforced in practice: live-verified HTTP 401 unauthenticated on this endpoint (2026-07-21)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-28-gm-responses",
+      "kind": "subnet-api",
+      "name": "gm responses (write, auth-gated)",
+      "notes": "POST /responses on the gm Gateway API (schema servers base https://api.saygm.com/v1) -- OpenAI Responses-API-compatible inference endpoint documented in the subnet's own OpenAPI schema under the same global bearer security requirement as the sibling /chat/completions operation. Live-verified 2026-07-21 (~23:35 UTC): HTTP 401 unauthenticated with a JSON invalid-authentication error body (the linked issue listed this sibling as not individually spot-verified; this registration verified it directly). Registered auth_required:true with probe.enabled:false; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1/responses"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "scopes_note": "The subnet's own OpenAPI schema declares a single global bearer-token security requirement covering all four Gateway API operations. Enforced in practice: live-verified HTTP 401 unauthenticated on this endpoint (2026-07-21)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-28-gm-gemini-model-actions",
+      "kind": "subnet-api",
+      "name": "gm Gemini-compatible model actions (write, auth-gated)",
+      "notes": "POST /v1beta/models/{modelAndAction} -- Gemini-compatible generateContent / streamGenerateContent endpoint (modelAndAction e.g. gemini-2.5-pro:generateContent), the fourth operation in the subnet's own OpenAPI schema. Per the operation's own description it ignores the schema's global servers entry (https://api.saygm.com/v1): the real base is https://api.saygm.com with no /v1 prefix. Live-verified 2026-07-21 (~23:35 UTC): HTTP 401 UNAUTHENTICATED JSON error at the correct un-prefixed URL, while the naively /v1-prefixed URL returns 404 -- confirming the un-prefixed base is the live one. Path parameter registered with percent-encoded braces per the registry URL format. Registered auth_required:true with probe.enabled:false; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1beta/models/%7BmodelAndAction%7D"
     }
   ],
   "website_url": "https://saygm.com/"


### PR DESCRIPTION
## Summary

Closes #7044. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527/#7538/#7551/#7559/#7581/#7582: the issue's three original surfaces still verify exactly as documented — live-verified 2026-07-21 (~23:35 UTC): `sn-28-gm-openapi` HTTP 200 `application/json` (the schema itself), `sn-28-gm-subnet-api` (`/v1/models`) HTTP 200 `application/json` with the live model-catalog list body, `sn-28-gm-health` (`/healthz`) HTTP 200 `text/plain` body `ok` (also pinned by the already-merged verify test `tests/sn28-call-subnet-surface-verify.test.mjs`, which still passes against this diff) — and the issue's "Additional surface(s) found during review (now in scope)" section itemizes the remaining registry gap. This PR registers all of it.

## What this adds (4 new surfaces)

Fetched the subnet's own OpenAPI schema (`https://saygm.com/openapi.json` — live-verified 2026-07-21 ~23:34 UTC: HTTP 200, exactly **4 paths**, all POST, all under the schema's single global bearer security requirement) and diffed against the registry: **0 of the 4 paths were covered** — the file's 6 existing surfaces are the website, source repo, the OpenAPI spec itself, the model catalog (`/v1/models`, which is not one of the schema's paths), the health endpoint, and an Envoy-config data artifact; none register a Gateway API operation. 4 schema paths − 0 already covered = **4 missing**, one surface per path, matching the issue's itemized list exactly.

**4 auth-gated write POST (`auth_required:true`, minimal `auth:{scheme:"bearer", scopes_note}`, `probe.enabled:false`)** — every one individually live-verified 2026-07-21 (~23:35 UTC), each returning HTTP 401 with a JSON authentication-error body unauthenticated (the issue had spot-verified only `/chat/completions` and the Gemini endpoint; this registration verified all four directly, including the two siblings the issue listed as "not spot-verified individually"):

- `sn-28-gm-chat-completions` — `POST /v1/chat/completions` (OpenAI-compatible chat completions). Live 401, JSON invalid-authentication error body.
- `sn-28-gm-messages` — `POST /v1/messages` (Anthropic Messages-API-compatible). Live 401, JSON authentication-error body.
- `sn-28-gm-responses` — `POST /v1/responses` (OpenAI Responses-API-compatible). Live 401, JSON invalid-authentication error body.
- `sn-28-gm-gemini-model-actions` — `POST /v1beta/models/{modelAndAction}` (Gemini-compatible generateContent / streamGenerateContent). Registered at the real base per the operation's own description — `https://api.saygm.com` with **no `/v1` prefix**, overriding the schema's global `servers` entry. Live-verified both directions 2026-07-21 (~23:35 UTC): the correct un-prefixed URL returns 401 with a Gemini-style `UNAUTHENTICATED` JSON error; the naively `/v1`-prefixed URL returns **404**, confirming the un-prefixed base is the live one, exactly as the issue's review section describes.

These are inference-call (write) operations with no GET-observable behavior, so none carry a live probe; per the issue's instruction they are registered `auth_required:true` with `probe.enabled:false`, following the same merged precedent as #7582's POST-operation surfaces.

## Schema/tooling notes (same as the lineage)

- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC` — all 4 new surfaces are `probe.enabled:false` (POST operations are never probed); the file's 6 existing live probes are untouched.
- The path-param URL uses the percent-encoded brace form (`%7BmodelAndAction%7D`) since raw braces fail the `url` `format:"uri"` schema check.
- Registered `provider: "gm"` — matches the file's existing surfaces and the registered `registry/providers/gm.json` entry, checked before generating.
- The `auth` blocks use the minimal `{scheme:"bearer", scopes_note}` shape (as in merged #7551/#7582) — derived from the schema's global `bearerAuth` `securitySchemes` declaration; no credential format or placeholder value is asserted anywhere.
- Strictly append-only into `surfaces[]`: **+104/−0**, top-level `notes`/`curation` untouched. (The file's top-level `notes` still carry a now-stale "none are promoted as additional surfaces" line about these exact 4 paths — left alone as maintainer-owned metadata; flagged here in prose instead.)
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate.

## Validation

- [x] `npm run validate:surface` — 2245 surfaces across 129 subnet files, passed (10 on `gm.json`)
- [x] `node scripts/scan-public-safety.mjs` — zero findings introduced by this diff
- [x] `npm run build && npm run validate` — 129 subnets, 2947 total surfaces, clean
- [x] `npm run validate:artifact-budgets` — passed
- [x] `npx vitest run tests/sn28-call-subnet-surface-verify.test.mjs` — 3 passed (pins the original `sn-28-gm-*` surfaces, unaffected by this append-only diff)
- [x] `npx prettier --check registry/subnets/gm.json` — clean

Closes #7044
