### PR TITLE
fix(registry): SN107 Minos full API parity (9 missing surfaces)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -132,6 +132,258 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://mcp.theminos.ai/"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-round-status",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 round status (auth-gated)",
+      "notes": "POST /v2/round-status on api.theminos.ai (same host as the registered /health surface) -- Poll active rounds and retrieve the presigned artifact-download URL for the current round (participant-facing). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/round-status"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-submit-config",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 config submission (auth-gated)",
+      "notes": "POST /v2/submit-config on api.theminos.ai (same host as the registered /health surface) -- Submit a variant-calling tool configuration for the active round (participant-facing write). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/submit-config"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-scoring-rounds",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 scoring rounds (auth-gated)",
+      "notes": "POST /v2/get-scoring-rounds on api.theminos.ai (same host as the registered /health surface) -- List rounds that are ready for scoring (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-scoring-rounds"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-submissions",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 round submissions (auth-gated)",
+      "notes": "POST /v2/get-submissions on api.theminos.ai (same host as the registered /health surface) -- Fetch the submitted configurations for a round (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-submissions"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-assignment",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 scoring assignment (auth-gated)",
+      "notes": "POST /v2/get-assignment on api.theminos.ai (same host as the registered /health surface) -- Fetch the caller's scoring assignment for a round (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-assignment"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-submit-score",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 score submission (auth-gated)",
+      "notes": "POST /v2/submit-score on api.theminos.ai (same host as the registered /health surface) -- Submit per-participant scores for a round (scoring-side write). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/submit-score"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-backfill-scores",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 backfill scores (auth-gated)",
+      "notes": "POST /v2/get-backfill-scores on api.theminos.ai (same host as the registered /health surface) -- Fetch peer scores after the scoring window closes (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-backfill-scores"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-submit-weight-history",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 weight-history submission (auth-gated)",
+      "notes": "POST /v2/submit-weight-history on api.theminos.ai (same host as the registered /health surface) -- Submit scores, eligibility, and weight entries for a round (scoring-side write). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/submit-weight-history"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring hotkey-signed requests: the POST body must carry the caller's registered subnet identity plus timestamp and signature fields (no static API token exists). Enforced in practice: an unsigned empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-21. No credential format or placeholder value is asserted here."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-validator-state",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 validator state (auth-gated)",
+      "notes": "POST /v2/get-validator-state on api.theminos.ai (same host as the registered /health surface) -- Recover round state after a restart (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-21 (~23:35 UTC): an unsigned POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the required signed-request body fields -- the route is live and body-validated, matching the README's documented hotkey-signed auth requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-validator-state"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Closes #7118. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527/#7538/#7551/#7559/#7581/#7582: the issue's three original surfaces still verify exactly as documented — live-verified 2026-07-21 (~23:35 UTC): `sn-107-minos-subnet-api` (`/health`) HTTP 200 `application/json` `{"status":"healthy","version":"2.0.0","mode":"active"}`; `sn-107-taomarketcap-subnet-api` HTTP 200 `application/json`; `sn-107-minos-mcp` a plain GET returns the documented JSON-RPC protocol-negotiation error ("Client must accept text/event-stream", HTTP 406) rather than 401/403, exactly as its registered notes describe (also pinned by the already-merged verify test `tests/sn107-call-subnet-surface-verify.test.mjs`, which still passes against this diff: 6/6) — and the issue's "Additional surface(s) found during review (now in scope)" section itemizes the remaining registry gap. This PR registers all of it.

## What this adds (9 new surfaces)

No OpenAPI/Swagger schema exists for this API (`api.theminos.ai/openapi.json` and `/docs` both 404 — the issue's own live check, and the file's `gap_notes` say the same), so the authoritative route inventory is the official `minos-protocol/minos_subnet` README's route table. It documents exactly **9 `/v2/*` Minos Platform task endpoints** — re-confirmed against the live README before generating — and the registry covered **0** of them (the file's 5 existing surfaces are `/health`, the TaoMarketCap snapshot, the website, the source repo, and the MCP server). 9 documented routes − 0 already covered = **9 missing**, one surface per route, matching the issue's itemized list exactly.

**9 auth-gated POST-only (`auth_required:true`, minimal `auth:{scheme:"custom", scopes_note}`, `probe.enabled:false`)** — all on `api.theminos.ai`, the same host as the registered `/health` surface. The issue had live-verified only `/v2/round-status` (422 on an empty body); this registration individually live-verified **all 9** the same way, 2026-07-21 (~23:35 UTC) — every route returns HTTP 422 with a field-by-field validation error listing its required signed-request body fields (timestamp + signature plus the route's own identity/round fields), proving each route is live and body-validated, and matching the README's documented hotkey-signed auth requirement:

- `sn-107-minos-v2-round-status` — `POST /v2/round-status` (poll active rounds + presigned artifact URL). Live 422, 3 required fields listed.
- `sn-107-minos-v2-submit-config` — `POST /v2/submit-config` (submit variant-calling tool config). Live 422, required fields listed incl. `round_id`/`tool_name`/`tool_config`.
- `sn-107-minos-v2-get-scoring-rounds` — `POST /v2/get-scoring-rounds` (rounds ready for scoring). Live 422.
- `sn-107-minos-v2-get-submissions` — `POST /v2/get-submissions` (fetch submitted configs for a round). Live 422.
- `sn-107-minos-v2-get-assignment` — `POST /v2/get-assignment` (scoring assignment). Live 422.
- `sn-107-minos-v2-submit-score` — `POST /v2/submit-score` (submit per-participant scores). Live 422.
- `sn-107-minos-v2-get-backfill-scores` — `POST /v2/get-backfill-scores` (peer scores after the scoring window). Live 422.
- `sn-107-minos-v2-submit-weight-history` — `POST /v2/submit-weight-history` (scores/eligibility/weight entries). Live 422, `entries` among required fields.
- `sn-107-minos-v2-get-validator-state` — `POST /v2/get-validator-state` (recover round state after restart). Live 422.

Per the issue's instruction ("Register all 9 with `auth_required:true`"), and since these are POST-only signed-request operations with no GET-observable behavior, none carry a live probe — same merged precedent as #7582's POST-operation surfaces. An unsigned probe request would be a state-adjacent call against a production round-coordination service, so verification stops at the 422 body-validation proof, which is exactly the evidence the issue itself used.

## Schema/tooling notes (same as the lineage)

- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC` — all 9 new surfaces are `probe.enabled:false` (POST operations are never probed); the file's existing probes are untouched.
- No path parameters on any of the 9 routes — no brace-encoding needed; all URLs are fixed.
- Registered `provider: "minos"` — matches the file's existing first-party surfaces and the registered `registry/providers/minos.json` entry, checked before generating.
- The `auth` blocks use the minimal `{scheme:"custom", scopes_note}` shape (as in merged #7551/#7582) — the auth is a signed request body per the README, not a header credential; no credential format or placeholder value is asserted anywhere.
- Strictly append-only into `surfaces[]`: **+252/−0**, top-level `notes`/`curation` untouched. (The file's `gap_notes` still carry the now-stale "not promoted as their own surfaces" line about these exact routes — left alone as maintainer-owned metadata; flagged here in prose instead.)
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate.

## Validation

- [x] `npm run validate:surface` — 2250 surfaces across 129 subnet files, passed (14 on `minos.json`)
- [x] `node scripts/scan-public-safety.mjs` — zero findings introduced by this diff
- [x] `npm run build && npm run validate` — 129 subnets, 2952 total surfaces, clean
- [x] `npm run validate:artifact-budgets` — passed
- [x] `npx vitest run tests/sn107-call-subnet-surface-verify.test.mjs` — 6 passed (pins the original `sn-107-*` surfaces, unaffected by this append-only diff)
- [x] `npx prettier --check registry/subnets/minos.json` — clean

Closes #7118
