### PR TITLE
fix(registry): SN126 Poker44 full API parity (2 missing surfaces)

### DIFF
--- a/registry/subnets/poker44.json
+++ b/registry/subnets/poker44.json
@@ -183,6 +183,55 @@
         "https://poker44.net/"
       ],
       "url": "https://poker44.net/Poker44_Whitepaper.pdf"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-benchmark-chunks",
+      "kind": "data-artifact",
+      "name": "Poker44 benchmark chunks by source date",
+      "notes": "GET /api/v1/benchmark/chunks on api.poker44.net, documented in the subnet repo's docs/training-benchmark.md alongside the already-registered /api/v1/benchmark status and /api/v1/benchmark/releases routes. Requires a sourceDate query param (optional limit) rather than a path param, so it is callable today via call_subnet_surface's query argument against this fixed base URL. Live-verified 2026-07-21 (~23:52 UTC): bare URL HTTP 422 VALIDATION_ERROR listing the required sourceDate field (a clean validation response, not an auth rejection, confirming the route is live and unauthenticated); with sourceDate=2026-07-21&limit=1 (the latestSourceDate reported by the registered /api/v1/benchmark status surface) HTTP 200 application/json returning the v1.13 shadow-training release's chunk list with per-chunk ids, hashes and hand data. probe.enabled:false (the unparameterized URL 422s, so a scheduled GET probe cannot succeed without a query argument).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md",
+        "https://api.poker44.net/api/v1/benchmark"
+      ],
+      "url": "https://api.poker44.net/api/v1/benchmark/chunks"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-benchmark-chunk-by-id",
+      "kind": "data-artifact",
+      "name": "Poker44 single benchmark chunk by id",
+      "notes": "GET /api/v1/benchmark/chunks/{chunkId} on api.poker44.net, the second undocumented-in-registry route under the /api/v1/benchmark prefix from docs/training-benchmark.md -- fetches one released benchmark chunk by its UUID (chunk ids come from the sibling chunks-by-source-date listing). Live-verified 2026-07-21 (~23:53 UTC): with a real chunkId from that listing (069386f8-998f-4437-9402-2a4ea6e520a0) HTTP 200 application/json (~451 KB chunk payload: chunkHash, hand batches, release metadata); with a non-UUID placeholder HTTP 422 VALIDATION_ERROR Invalid UUID -- a clean validation response, not an auth rejection, confirming the route is live and unauthenticated. probe.enabled:false (the URL is a percent-encoded {chunkId} template; the probe pipeline has no per-surface path-param injection).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md"
+      ],
+      "url": "https://api.poker44.net/api/v1/benchmark/chunks/%7BchunkId%7D"
     }
   ],
   "website_url": "https://poker44.net/"


### PR DESCRIPTION
## Summary

Closes #7134

Registers the 2 missing `/api/v1/benchmark` routes that #7134's "Additional surface(s) found during review (now in scope)" section itemizes for SN126 (Poker44), completing the issue's full scope — same pattern as the merged full-parity registry PRs #7465/#7466/#7481/#7491/#7506/#7527/#7538/#7551/#7582/#7584. Registry-only, single file, append-only: 2 new entries appended to `surfaces[]` in `registry/subnets/poker44.json`, +49/−0, no top-level `notes`/`curation` edits, no other files.

Per the maintainer's re-review on the prior attempt (#7469): the remaining gap on this issue was that only 1 of the 2 additional surfaces had been submitted — "a follow-up adding that surface too would close it out." This PR adds both.

## What this adds (2 new surfaces)

The issue's arithmetic: `docs/training-benchmark.md` documents 2 routes under the `/api/v1/benchmark` prefix that were never registered, beyond the already-registered `/api/v1/benchmark` (status) and `/api/v1/benchmark/releases`. 2 documented − 0 already covered = 2 missing. Both are no-auth GETs; both live-verified today.

**1. `sn-126-poker44-benchmark-chunks`** — `GET /api/v1/benchmark/chunks` (query-param only: required `sourceDate`, optional `limit`), registered with the fixed base URL and no baked-in date, exactly as the issue specifies. Callable today via `call_subnet_surface`'s `query` argument.
- Live-verified 2026-07-21 ~23:52 UTC: bare URL → HTTP 422 `VALIDATION_ERROR` listing the required `sourceDate` field — a clean validation response proving the route is live and unauthenticated, not an auth rejection.
- `GET /api/v1/benchmark/chunks?sourceDate=2026-07-21&limit=1` (using `latestSourceDate` from the registered `/api/v1/benchmark` status surface, which returned 200 with `releaseVersion v1.13`, 383 chunks / 99,680 hands at 23:52 UTC) → HTTP 200 `application/json`, chunk list with per-chunk ids/hashes/hand batches.

**2. `sn-126-poker44-benchmark-chunk-by-id`** — `GET /api/v1/benchmark/chunks/{chunkId}` (path param), registered with the percent-encoded `%7BchunkId%7D` template as the issue specifies.
- Live-verified 2026-07-21 ~23:53 UTC: with a real `chunkId` pulled from the listing above (`069386f8-998f-4437-9402-2a4ea6e520a0`) → HTTP 200 `application/json` (~451 KB chunk payload).
- With a non-UUID placeholder → HTTP 422 `VALIDATION_ERROR` "Invalid UUID" — again a clean validation response, live and unauthenticated.

## Original scope re-verified

The issue's 1 original surface still verifies as documented: `GET https://api.poker44.net/health` → HTTP 200 `application/json` at 2026-07-21T23:55:17Z (`status: healthy`, database/redis connected), matching its registered `probe` config.

## Schema/tooling notes

- Both entries use `probe.enabled:false`: the chunks base URL 422s unparameterized, and the by-id URL is a `{chunkId}` template (percent-encoded braces to satisfy the `format:"uri"` schema check; the probe pipeline has no per-surface path-param injection). Both remain callable through `call_subnet_surface` with `query`/path substitution.
- `provider: "poker44"` matches the file's existing surfaces and the registered `registry/providers/poker44.json`.
- `authority: community` / `review.state: community-submitted`, mirroring the file's existing community entries.
- The pre-existing `curation.gap_notes` line calling `/api/v1/benchmark/chunks` "not promotable" is now stale given these entries, but it is deliberately left untouched per the append-only rule for community surface PRs on existing manifests (top-level `curation` is maintainer-owned) — flagging it here in prose instead.
- `npm run build`, `npm run validate` (full suite incl. `validate:surface`: 2294 surfaces / 129 files passed, `validate:artifact-budgets` passed), `npm run scan:public-safety`, and `prettier --check` all pass locally on this diff; zero new scanner hits from this file.
