### PR TITLE
fix(registry): SN107 Minos full API parity (9 missing surfaces)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -9,7 +9,7 @@
     "gap_notes": [
       "No verified official docs URL yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet -- api.theminos.ai/openapi.json and /docs both 404.",
-      "The /v2/* Minos Platform task endpoints (round-status, submit-config, get-scoring-rounds, etc.) are all POST-only and require hotkey auth; not promoted as their own surfaces."
+      "The /v2/* Minos Platform task endpoints (round-status, submit-config, get-scoring-rounds, etc.) are all POST-only and auth-gated; now registered as their own auth_required surfaces."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -132,6 +132,258 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://mcp.theminos.ai/"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-round-status",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 round status (auth-gated)",
+      "notes": "POST /v2/round-status on api.theminos.ai (same host as the registered /health surface) -- Poll active rounds and retrieve the time-limited artifact-download URL for the current round (participant-facing). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/round-status"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-submit-config",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 config submission (auth-gated)",
+      "notes": "POST /v2/submit-config on api.theminos.ai (same host as the registered /health surface) -- Submit a variant-calling tool configuration for the active round (participant-facing write). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/submit-config"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-scoring-rounds",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 scoring rounds (auth-gated)",
+      "notes": "POST /v2/get-scoring-rounds on api.theminos.ai (same host as the registered /health surface) -- List rounds that are ready for scoring (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-scoring-rounds"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-submissions",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 round submissions (auth-gated)",
+      "notes": "POST /v2/get-submissions on api.theminos.ai (same host as the registered /health surface) -- Fetch the submitted configurations for a round (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-submissions"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-assignment",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 scoring assignment (auth-gated)",
+      "notes": "POST /v2/get-assignment on api.theminos.ai (same host as the registered /health surface) -- Fetch the caller's scoring assignment for a round (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-assignment"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-submit-score",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 score submission (auth-gated)",
+      "notes": "POST /v2/submit-score on api.theminos.ai (same host as the registered /health surface) -- Submit per-participant scores for a round (scoring-side write). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/submit-score"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-backfill-scores",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 backfill scores (auth-gated)",
+      "notes": "POST /v2/get-backfill-scores on api.theminos.ai (same host as the registered /health surface) -- Fetch peer scores after the scoring window closes (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-backfill-scores"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-submit-weight-history",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 weight-history submission (auth-gated)",
+      "notes": "POST /v2/submit-weight-history on api.theminos.ai (same host as the registered /health surface) -- Submit scores, eligibility, and weight entries for a round (scoring-side write). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/submit-weight-history"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented in the official minos_subnet README as requiring authenticated requests from a registered subnet participant: the POST body must carry the caller's registered subnet identity plus per-request verification fields. Enforced in practice: an unauthenticated empty-body POST returns HTTP 422 listing those exact required fields, live-verified 2026-07-22. Exact request format not documented beyond the README."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-107-minos-v2-get-validator-state",
+      "kind": "subnet-api",
+      "name": "Minos Platform v2 validator state (auth-gated)",
+      "notes": "POST /v2/get-validator-state on api.theminos.ai (same host as the registered /health surface) -- Recover round state after a restart (scoring-side). One of the 9 POST-only /v2 Minos Platform task endpoints documented in the official minos_subnet README route table (no OpenAPI/Swagger schema exists for this API -- openapi.json and /docs both 404, per the linked issue's own live check). Live-verified 2026-07-22 (~00:14 UTC): an unauthenticated POST with an empty JSON body returns HTTP 422 with a field-by-field validation error listing the route's required body fields -- the route is live and body-validated, matching the README's documented authentication requirement. Registered auth_required:true with probe.enabled:false per the linked issue's guidance; the probe pipeline only supports GET/HEAD, so a POST operation is never probed.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
+      ],
+      "url": "https://api.theminos.ai/v2/get-validator-state"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Closes #7118. Same pattern as #7465/#7466/#7481/#7491/#7506/#7527/#7538/#7551/#7559/#7581/#7582/#7584. This supersedes closed #7588 (same scope, same author): that PR's review confirmed the registration itself satisfied the linked issue ("registers all 9 in-scope /v2/* endpoints named in the issue's 'now in scope' section with auth_required:true, citing the same live 422 verification method the issue itself demonstrated") but flagged the manifest's stale curation line and per-surface prose. This version resolves both, rebuilt fresh on current `main`.

The issue's three original surfaces still verify exactly as documented — re-verified live 2026-07-22 (~00:14 UTC): `sn-107-minos-subnet-api` (`/health`) HTTP 200 `application/json` `{"status":"healthy","version":"2.0.0","mode":"active"}`; `sn-107-taomarketcap-subnet-api` HTTP 200 `application/json`; `sn-107-minos-mcp` a plain GET returns the documented JSON-RPC protocol-negotiation error (HTTP 406) rather than an auth rejection, exactly as its registered notes describe (also pinned by the already-merged verify test `tests/sn107-call-subnet-surface-verify.test.mjs`, which passes against this diff: 6/6) — and the issue's "Additional surface(s) found during review (now in scope)" section itemizes the remaining registry gap. This PR registers all of it.

## What this adds (9 new surfaces)

No OpenAPI/Swagger schema exists for this API (`api.theminos.ai/openapi.json` and `/docs` both 404 — the issue's own live check, and the file's `gap_notes` say the same), so the authoritative route inventory is the official `minos-protocol/minos_subnet` README's route table. It documents exactly **9 `/v2/*` Minos Platform task endpoints**, and the registry covered **0** of them (the file's 5 existing surfaces are `/health`, the TaoMarketCap snapshot, the website, the source repo, and the MCP server). 9 documented routes − 0 already covered = **9 missing**, one surface per route, matching the issue's itemized list exactly.

**All 9 are auth-gated POST-only** (`auth_required:true`, minimal `auth:{scheme:"custom", scopes_note}`, `probe.enabled:false`), all on `api.theminos.ai`, the same host as the registered `/health` surface. The issue had live-verified only `/v2/round-status` (422 on an empty body); this registration individually live-verified **all 9** the same way, fresh on 2026-07-22 (~00:14 UTC) — every route returns HTTP 422 with a field-by-field validation error listing its required request-body fields (identity plus per-request verification fields, per the README's documented request-authentication requirement), proving each route is live and body-validated:

- `sn-107-minos-v2-round-status` — `POST /v2/round-status` (poll active rounds + time-limited artifact-download URL). Live 422, 3 required fields listed.
- `sn-107-minos-v2-submit-config` — `POST /v2/submit-config` (submit variant-calling tool config). Live 422, 6 required fields listed.
- `sn-107-minos-v2-get-scoring-rounds` — `POST /v2/get-scoring-rounds` (rounds ready for scoring). Live 422, 3 required fields listed.
- `sn-107-minos-v2-get-submissions` — `POST /v2/get-submissions` (fetch submitted configs for a round). Live 422, 4 required fields listed.
- `sn-107-minos-v2-get-assignment` — `POST /v2/get-assignment` (scoring assignment). Live 422, 4 required fields listed.
- `sn-107-minos-v2-submit-score` — `POST /v2/submit-score` (submit per-participant scores). Live 422, 5 required fields listed.
- `sn-107-minos-v2-get-backfill-scores` — `POST /v2/get-backfill-scores` (peer scores after the scoring window). Live 422, 4 required fields listed.
- `sn-107-minos-v2-submit-weight-history` — `POST /v2/submit-weight-history` (scores/eligibility/weight entries). Live 422, 5 required fields listed.
- `sn-107-minos-v2-get-validator-state` — `POST /v2/get-validator-state` (recover round state after restart). Live 422, 3 required fields listed.

Per the issue's instruction ("Register all 9 with `auth_required:true`"), and since these are POST-only authenticated operations with no GET-observable behavior, none carry a live probe — same merged precedent as #7582's POST-operation surfaces. An unauthenticated probe request would be a state-adjacent call against a production round-coordination service, so verification stops at the 422 body-validation proof, which is exactly the evidence the issue itself used.

## The one-line `gap_notes` correction (requested by #7588's own review)

Diff shape is **+253/−1**. The single removed line is the `curation.gap_notes` entry that #7588's LoopOver review summary called out as "left contradicting the new content" and whose review checklist explicitly requested:

> Update or remove the stale gap_notes line in registry/subnets/minos.json to reflect that the /v2/* endpoints are now registered as auth-gated surfaces.

That exact line is updated, and only it: "…are all POST-only and auth-gated; now registered as their own auth_required surfaces." Nothing else in `curation` or top-level `notes` is touched — `reviewed_at`/`verified_at`/`source_count`/`level`/`review_state` and the other two `gap_notes` lines (both still accurate) are byte-identical, deliberately keeping the maintainer-owned metadata edit to the single correction the review itself asked for (mindful of #7561, where broader metadata edits on this pattern of PR were treated as out of bounds for a community submission).

## Schema/tooling notes (same as the lineage)

- `probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC` — all 9 new surfaces are `probe.enabled:false` (POST operations are never probed); the file's existing probes are untouched.
- No path parameters on any of the 9 routes — no brace-encoding needed; all URLs are fixed.
- Registered `provider: "minos"` — matches the file's existing first-party surfaces and the registered `registry/providers/minos.json` entry, checked before generating.
- The `auth` blocks use the minimal `{scheme:"custom", scopes_note}` shape (as in merged #7551/#7582) — the README documents request-body-level authentication for registered subnet participants, not a header value; no format or placeholder value of any kind is asserted anywhere in the manifest or this PR.
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate.

## Validation

- [x] `npm run validate:surface` — 2301 surfaces across 129 subnet files, passed (14 on `minos.json`)
- [x] `node scripts/scan-public-safety.mjs` — passed, zero findings
- [x] `npm run build && npm run validate` — 129 subnets, 3003 total surfaces, clean
- [x] `npm run validate:artifact-budgets` — passed (2321 artifacts)
- [x] `npx vitest run tests/sn107-call-subnet-surface-verify.test.mjs` — 6 passed (pins the original `sn-107-*` surfaces, unaffected by this append-only diff)
- [x] `npx prettier --check registry/subnets/minos.json` — clean

Closes #7118
