### PR TITLE
fix(registry): SN120 Affine full API parity (4 missing surfaces)

### DIFF
--- a/registry/subnets/affine.json
+++ b/registry/subnets/affine.json
@@ -200,6 +200,94 @@
       },
       "source_urls": ["https://api.affine.io/openapi.json"],
       "url": "https://api.affine.io/api/v1/config"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-120-affine-miner-by-uid",
+      "kind": "subnet-api",
+      "name": "Affine miner detail by uid",
+      "notes": "GET /api/v1/miners/uid/{uid} on api.affine.io -- per-miner detail record (model reference, revision, validity, block numbers) for a registered uid; path-parameterized sibling of the already-registered list-style surfaces. Documented in the subnet's own OpenAPI 3.1 schema (the already-registered sn-120-affine-openapi surface) with no security declared. Live-verified 2026-07-22: uid 0 returns HTTP 200 JSON with the matching miner record; a non-integer path value returns a clean HTTP 422 validation error naming the uid path field. probe.enabled:false -- the URL is a percent-encoded path template and the probe pipeline has no per-surface path-param injection.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "affine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.affine.io/openapi.json"],
+      "url": "https://api.affine.io/api/v1/miners/uid/%7Buid%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-120-affine-miner-by-hotkey",
+      "kind": "subnet-api",
+      "name": "Affine miner detail by hotkey",
+      "notes": "GET /api/v1/miners/hotkey/{hotkey} on api.affine.io -- the same per-miner detail record as the uid lookup, addressed by the miner's hotkey instead. Documented in the subnet's own OpenAPI 3.1 schema with no security declared. Live-verified 2026-07-22 using a real value obtained from the uid-0 lookup on the sibling surface: HTTP 200 JSON returning the identical miner record; an unknown value returns a clean HTTP 404 not-found response, not an auth rejection. probe.enabled:false -- percent-encoded path template; no per-surface path-param injection in the probe pipeline.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "affine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.affine.io/openapi.json"],
+      "url": "https://api.affine.io/api/v1/miners/hotkey/%7Bhotkey%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-120-affine-score-by-uid",
+      "kind": "subnet-api",
+      "name": "Affine score detail by uid",
+      "notes": "GET /api/v1/scores/uid/{uid} on api.affine.io -- per-miner score detail (overall and average score, per-environment scores, sample count) for a registered uid; path-parameterized sibling of the already-registered scores/latest surface. Documented in the subnet's own OpenAPI 3.1 schema with no security declared. Live-verified 2026-07-22: uid 0 returns HTTP 200 JSON with the matching score record. probe.enabled:false -- percent-encoded path template; no per-surface path-param injection in the probe pipeline.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "affine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.affine.io/openapi.json"],
+      "url": "https://api.affine.io/api/v1/scores/uid/%7Buid%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-120-affine-config-param",
+      "kind": "subnet-api",
+      "name": "Affine config parameter detail",
+      "notes": "GET /api/v1/config/{key} on api.affine.io -- detail record for a single named config parameter (value, type, version, update metadata), the per-item sibling of the already-registered bulk /api/v1/config surface. Documented in the subnet's own OpenAPI 3.1 schema with no security declared. Live-verified 2026-07-22 using a parameter name obtained from the bulk config surface: HTTP 200 JSON with the full parameter record; an unknown parameter name returns a clean HTTP 404 not-found response. probe.enabled:false -- percent-encoded path template; no per-surface path-param injection in the probe pipeline.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "affine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://api.affine.io/openapi.json"],
+      "url": "https://api.affine.io/api/v1/config/%7Bkey%7D"
     }
   ],
   "website_url": "https://www.affine.io/"


### PR DESCRIPTION
## Summary

Closes #7129. Same pattern as #7581/#7582/#7583/#7584: the issue's original 4 surfaces still verify as registered, and the issue's own "Additional surface(s) found during review" section itemizes the remaining registry gap exactly — this PR registers exactly that itemized list of 4 path-parameterized sibling routes, nothing more.

Original surfaces re-verified live 2026-07-22 (~00:31 UTC), all HTTP 200 `application/json`: `sn-120-affine-openapi` (the schema itself, 10 paths), `sn-120-affine-health`, `sn-120-affine-scores-latest`, `sn-120-affine-scores-weights-latest` (plus the file's other two API surfaces, `rank/current` and the bulk `config`, also 200). Nothing broken, no probe/config fixes needed on the existing entries.

## What this adds (4 new surfaces)

Re-fetched the already-registered schema (`https://api.affine.io/openapi.json`, 10 total paths) and diffed against `registry/subnets/affine.json`: 5 of the 10 paths are already covered by registered surfaces (`health`, `rank/current`, `scores/latest`, `scores/weights/latest`, bulk `config`), 1 is already noted as excluded (the API root `/`, which 500s, per the file's existing gap_notes) → the issue's itemized list of **4 missing path-parameterized surfaces**, all registered here. Duplicate-URL check against all 8 existing surfaces done before generating (zero collisions). All 4 declare no `security` in the schema and behave that way live; every one was individually curled 2026-07-22 (~00:31-00:32 UTC), none sampled:

- `GET /api/v1/miners/uid/{uid}` — uid 0 returns HTTP 200 JSON with the per-miner detail record (model reference, revision, validity, block numbers); a non-integer path value returns a clean HTTP 422 validation error naming the `uid` path field. (The issue verified this one too — matches.)
- `GET /api/v1/miners/hotkey/{hotkey}` — the issue could not spot-verify this one for lack of a value; verified here with a real value obtained from the uid-0 lookup on the sibling route: HTTP 200 JSON returning the identical miner record. An unknown value returns a clean HTTP 404 not-found response — a domain lookup miss, not an auth rejection.
- `GET /api/v1/scores/uid/{uid}` — uid 0 returns HTTP 200 JSON with the per-miner score detail (overall/average score, per-environment scores, sample count). (Matches the issue's own verification.)
- `GET /api/v1/config/{key}` — verified with a parameter name obtained from the already-registered bulk `/api/v1/config` surface: HTTP 200 JSON with the full parameter record (value, type, version, update metadata); an unknown parameter name returns a clean HTTP 404 not-found response. (Matches the issue's own verification.)

All 4 registered `auth_required:false`, `probe.enabled:false` exactly as the issue instructs.

## Schema/tooling notes (same as the last several)

- `probe.enabled:false` on all 4 — the URLs are path templates and the probe pipeline has no per-surface path-param injection (`probe.method` only accepts `GET, HEAD, JSON-RPC, WSS-RPC` regardless).
- Path-param URLs use the percent-encoded brace form (`%7Bparam%7D`) — raw unescaped braces fail this repo's `url` `format:"uri"` schema check.
- Registered `provider: "affine"` — matches the file's existing surfaces and the registered `registry/providers/affine.json`, checked before generating.
- No `auth` objects needed — every added surface is public per both the schema and live behavior.
- Append-only: `surfaces[]` additions only (+88/−0, one file); the file's top-level `notes`/`curation`/`gap_notes` are untouched.
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — deploy-owned sync artifact, excluded as in the merged lineage.

## Validation

- [x] `npm run validate:surface` — 2296 surfaces across 129 subnet files, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — 129 subnets, 2998 total surfaces, 136 providers, clean
- [x] `npx vitest run tests/affine-call-subnet-surface-verify.test.mjs` — 24 passed (unchanged — pins existing surfaces, unaffected by this append-only diff)
- [x] `npx prettier --check registry/subnets/affine.json` — clean

Closes #7129
