### PR TITLE
fix(registry): SN78 Vocence full API parity (45 missing surfaces)

### DIFF
--- a/registry/subnets/vocence.json
+++ b/registry/subnets/vocence.json
@@ -37,7 +37,9 @@
       },
       "provider": "vocence",
       "public_safe": true,
-      "source_urls": ["https://www.vocence.ai/"],
+      "source_urls": [
+        "https://www.vocence.ai/"
+      ],
       "url": "https://www.vocence.ai/"
     },
     {
@@ -55,7 +57,9 @@
       },
       "provider": "vocence",
       "public_safe": true,
-      "source_urls": ["https://github.com/vocence-78/vocence"],
+      "source_urls": [
+        "https://github.com/vocence-78/vocence"
+      ],
       "url": "https://github.com/vocence-78/vocence"
     },
     {
@@ -134,6 +138,1401 @@
         "https://github.com/vocence-78/vocence/blob/master/README.md"
       ],
       "url": "https://www.vocence.ai/llms.txt"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-account",
+      "kind": "subnet-api",
+      "name": "Vocence account info (auth-gated)",
+      "notes": "GET + POST /v1/account on api.vocence.ai \u2014 live-verified 2026-07-21: HTTP 401 without bearer token. Schema declares no security block but bearer auth is enforced empirically. probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/account"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-account-keys",
+      "kind": "subnet-api",
+      "name": "Vocence account API keys (auth-gated)",
+      "notes": "GET + POST /v1/account/keys on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/account/keys"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-account-keys-item-revoke",
+      "kind": "subnet-api",
+      "name": "Vocence account API key revoke (auth-gated)",
+      "notes": "POST /v1/account/keys/{key_id}/revoke on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/account/keys/%7Bkey_id%7D/revoke"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-account-usage",
+      "kind": "subnet-api",
+      "name": "Vocence account usage stats (auth-gated)",
+      "notes": "GET /v1/account/usage on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/account/usage"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agent-tools",
+      "kind": "subnet-api",
+      "name": "Vocence agent tools library (auth-gated)",
+      "notes": "GET + POST /v1/agent-tools on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agent-tools"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agent-tools-item",
+      "kind": "subnet-api",
+      "name": "Vocence agent tool by ID (auth-gated)",
+      "notes": "GET + PATCH + DELETE /v1/agent-tools/{tool_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agent-tools/%7Btool_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents",
+      "kind": "subnet-api",
+      "name": "Vocence agents list (auth-gated)",
+      "notes": "GET + POST /v1/agents on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-architect-chat",
+      "kind": "subnet-api",
+      "name": "Vocence agent architect chat (auth-gated)",
+      "notes": "POST /v1/agents/architect/chat on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/architect/chat"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-draft",
+      "kind": "subnet-api",
+      "name": "Vocence agent draft (auth-gated)",
+      "notes": "POST /v1/agents/draft on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/draft"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-models",
+      "kind": "subnet-api",
+      "name": "Vocence available agent models (auth-gated)",
+      "notes": "GET /v1/agents/models on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/models"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-templates",
+      "kind": "subnet-api",
+      "name": "Vocence agent templates (auth-gated)",
+      "notes": "GET /v1/agents/templates on api.vocence.ai \u2014 live-verified 2026-07-21: HTTP 401 without bearer token. Schema declares no security block but bearer auth is enforced empirically. probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/templates"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-templates-item",
+      "kind": "subnet-api",
+      "name": "Vocence agent template by ID (auth-gated)",
+      "notes": "GET /v1/agents/templates/{template_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/templates/%7Btemplate_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-tools-builtin",
+      "kind": "subnet-api",
+      "name": "Vocence agent built-in tools (auth-gated)",
+      "notes": "GET /v1/agents/tools/builtin on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/tools/builtin"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item",
+      "kind": "subnet-api",
+      "name": "Vocence agent by ID (auth-gated)",
+      "notes": "GET + PATCH + DELETE /v1/agents/{agent_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-calls",
+      "kind": "subnet-api",
+      "name": "Vocence agent call sessions (auth-gated)",
+      "notes": "GET /v1/agents/{agent_id}/calls on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/calls"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-calls-item-recording",
+      "kind": "subnet-api",
+      "name": "Vocence agent call recording (auth-gated)",
+      "notes": "GET + DELETE /v1/agents/{agent_id}/calls/{session_id}/recording on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/calls/%7Bsession_id%7D/recording"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-calls-item-transcript",
+      "kind": "subnet-api",
+      "name": "Vocence agent call transcript (auth-gated)",
+      "notes": "GET /v1/agents/{agent_id}/calls/{session_id}/transcript on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/calls/%7Bsession_id%7D/transcript"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-embed-tokens",
+      "kind": "subnet-api",
+      "name": "Vocence agent embed tokens (auth-gated)",
+      "notes": "GET + POST /v1/agents/{agent_id}/embed-tokens on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/embed-tokens"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-embed-tokens-item",
+      "kind": "subnet-api",
+      "name": "Vocence agent embed token by ID (auth-gated)",
+      "notes": "DELETE /v1/agents/{agent_id}/embed-tokens/{token_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/embed-tokens/%7Btoken_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-knowledge-ingest-markdown",
+      "kind": "subnet-api",
+      "name": "Vocence agent knowledge ingest markdown (auth-gated)",
+      "notes": "POST /v1/agents/{agent_id}/knowledge/ingest/markdown on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/markdown"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-knowledge-ingest-pdf",
+      "kind": "subnet-api",
+      "name": "Vocence agent knowledge ingest PDF (auth-gated)",
+      "notes": "POST /v1/agents/{agent_id}/knowledge/ingest/pdf on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/pdf"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-knowledge-ingest-sitemap",
+      "kind": "subnet-api",
+      "name": "Vocence agent knowledge ingest sitemap (auth-gated)",
+      "notes": "POST /v1/agents/{agent_id}/knowledge/ingest/sitemap on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/sitemap"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-knowledge-ingest-text",
+      "kind": "subnet-api",
+      "name": "Vocence agent knowledge ingest text (auth-gated)",
+      "notes": "POST /v1/agents/{agent_id}/knowledge/ingest/text on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/text"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-knowledge-ingest-url",
+      "kind": "subnet-api",
+      "name": "Vocence agent knowledge ingest URL (auth-gated)",
+      "notes": "POST /v1/agents/{agent_id}/knowledge/ingest/url on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/url"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-knowledge-jobs-item",
+      "kind": "subnet-api",
+      "name": "Vocence agent knowledge ingest job status (auth-gated)",
+      "notes": "GET /v1/agents/{agent_id}/knowledge/jobs/{job_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/jobs/%7Bjob_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-knowledge-sources",
+      "kind": "subnet-api",
+      "name": "Vocence agent knowledge sources (auth-gated)",
+      "notes": "GET /v1/agents/{agent_id}/knowledge/sources on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/sources"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-knowledge-sources-item",
+      "kind": "subnet-api",
+      "name": "Vocence agent knowledge source by ID (auth-gated)",
+      "notes": "DELETE /v1/agents/{agent_id}/knowledge/sources/{source_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/sources/%7Bsource_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-runs",
+      "kind": "subnet-api",
+      "name": "Vocence agent runs (auth-gated)",
+      "notes": "GET + POST /v1/agents/{agent_id}/runs on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/runs"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-runs-item",
+      "kind": "subnet-api",
+      "name": "Vocence agent run by ID (auth-gated)",
+      "notes": "GET /v1/agents/{agent_id}/runs/{run_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/runs/%7Brun_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-runs-item-cancel",
+      "kind": "subnet-api",
+      "name": "Vocence agent run cancel (auth-gated)",
+      "notes": "POST /v1/agents/{agent_id}/runs/{run_id}/cancel on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/runs/%7Brun_id%7D/cancel"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-tools",
+      "kind": "subnet-api",
+      "name": "Vocence agent attached tools (auth-gated)",
+      "notes": "GET /v1/agents/{agent_id}/tools on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/tools"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-agents-item-tools-item",
+      "kind": "subnet-api",
+      "name": "Vocence agent tool attachment (auth-gated)",
+      "notes": "POST + DELETE /v1/agents/{agent_id}/tools/{tool_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/tools/%7Btool_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-audio-noise-remover",
+      "kind": "subnet-api",
+      "name": "Vocence audio noise remover (auth-gated)",
+      "notes": "POST /v1/audio/noise-remover on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/audio/noise-remover"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-feedback",
+      "kind": "subnet-api",
+      "name": "Vocence feedback (auth-gated)",
+      "notes": "GET + POST /v1/feedback on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/feedback"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-stt-transcribe",
+      "kind": "subnet-api",
+      "name": "Vocence speech-to-text transcribe (auth-gated)",
+      "notes": "POST /v1/stt/transcribe on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/stt/transcribe"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-tts-generate",
+      "kind": "subnet-api",
+      "name": "Vocence text-to-speech generate (auth-gated)",
+      "notes": "POST /v1/tts/generate on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/tts/generate"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-tts-speak",
+      "kind": "subnet-api",
+      "name": "Vocence text-to-speech speak (auth-gated)",
+      "notes": "POST /v1/tts/speak on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/tts/speak"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-voice-clone",
+      "kind": "subnet-api",
+      "name": "Vocence voice clone (auth-gated)",
+      "notes": "POST /v1/voice/clone on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/voice/clone"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-voice-clone-save",
+      "kind": "subnet-api",
+      "name": "Vocence voice clone save (auth-gated)",
+      "notes": "POST /v1/voice/clone/save on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/voice/clone/save"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-voice-design-preview",
+      "kind": "subnet-api",
+      "name": "Vocence voice design preview (auth-gated)",
+      "notes": "POST /v1/voice/design/preview on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/voice/design/preview"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-voice-design-save",
+      "kind": "subnet-api",
+      "name": "Vocence voice design save (auth-gated)",
+      "notes": "POST /v1/voice/design/save on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/voice/design/save"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-voices",
+      "kind": "subnet-api",
+      "name": "Vocence voices library (auth-gated)",
+      "notes": "GET /v1/voices on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/voices"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-voices-builtin",
+      "kind": "subnet-api",
+      "name": "Vocence built-in voices (auth-gated)",
+      "notes": "GET /v1/voices/builtin on api.vocence.ai \u2014 live-verified 2026-07-21: HTTP 401 without bearer token. Schema declares no security block but bearer auth is enforced empirically. probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/voices/builtin"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-voices-item",
+      "kind": "subnet-api",
+      "name": "Vocence voice by ID (auth-gated)",
+      "notes": "GET + DELETE /v1/voices/{voice_id} on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/voices/%7Bvoice_id%7D"
+    },
+    {
+      "auth": {
+        "location": "header",
+        "name": "Authorization",
+        "scheme": "bearer",
+        "scopes_note": "Derived from the subnet's own OpenAPI schema (bearer auth enforced in practice despite the schema declaring no top-level security \u2014 live-verified HTTP 401 unauthenticated on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates, 2026-07-21). No credential scope restrictions are documented.",
+        "value_format": "Bearer <token>"
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-78-vocence-api-voices-item-speak",
+      "kind": "subnet-api",
+      "name": "Vocence voice speak (auth-gated)",
+      "notes": "POST /v1/voices/{voice_id}/speak on api.vocence.ai \u2014 auth-gated per the same bearer-enforced pattern spot-verified on GET /v1/account, GET /v1/voices/builtin, and GET /v1/agents/templates (all HTTP 401 without bearer, 2026-07-21); not individually re-verified (pattern is consistent across the full API). probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json"
+      ],
+      "url": "https://api.vocence.ai/v1/voices/%7Bvoice_id%7D/speak"
     }
   ],
   "source_repo": "https://github.com/vocence-78/vocence",


### PR DESCRIPTION
## Summary

Adds 45 auth-gated surfaces to `registry/subnets/vocence.json`, completing full API parity for the Vocence Developer API (api.vocence.ai) against the 46-path OpenAPI schema already registered as `sn-78-vocence-openapi`.

The existing 5 surfaces cover the public endpoints (website, source-repo, health, openapi, llms.txt). All 45 remaining paths require bearer authentication — spot-verified: `GET /v1/account` (HTTP 401), `GET /v1/voices/builtin` (HTTP 401), `GET /v1/agents/templates` (HTTP 401) without a token. Schema declares no top-level security but bearer auth is enforced empirically across the full API.

All 45 surfaces registered with `auth_required: true`, `probe.enabled: false`, `auth.scheme: "bearer"`, `source_urls: ["https://api.vocence.ai/openapi.json"]`.

## Validation

```
npm run validate:surface -- registry/subnets/vocence.json
# Surface validation passed: 50 surface(s) across 1 subnet file(s).

npm run scan:public-safety
# Public-safety scan passed.
```

## Changes

- `registry/subnets/vocence.json`: +45 community surfaces (account, agent-tools, agents, calls, embed-tokens, knowledge ingestion, runs, TTS/STT/voice, feedback, voices)

Closes #7091