### PR TITLE
fix(registry): SN9 iota full API parity (14 missing surfaces)

### DIFF
--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -184,6 +184,408 @@
       "public_safe": true,
       "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
       "url": "https://iota.api.macrocosmos.ai/common/get_run_info"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-9-iota-profiler-status",
+      "kind": "subnet-api",
+      "name": "iota orchestrator profiler status",
+      "notes": "Public no-auth GET returning the orchestrator's profiler state. Live-verified 2026-07-21: HTTP 200 {\"running\":false,\"profiler_exists\":false}. Unlike its /profiler/start and /profiler/stop siblings (write actions), this read declares no Epistula-signing headers in the registered schema and needs none.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/profiler/status"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-get-activations",
+      "kind": "subnet-api",
+      "name": "iota miner activations read",
+      "notes": "Epistula-signed orchestrator read (the subnet's non-bearer hotkey-signing scheme, same caveat as SN1 Apex). Live-verified 2026-07-21: unsigned GET returns HTTP 422 listing the required request body, proving the route is real; its siblings return the EpistulaError signature failure. Not probe-enabled (a probe cannot sign).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/get_activations"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-heartbeat",
+      "kind": "subnet-api",
+      "name": "iota miner heartbeat read",
+      "notes": "Epistula-signed orchestrator read (the subnet's non-bearer hotkey-signing scheme, same caveat as SN1 Apex). Live-verified 2026-07-21: unsigned GET returns HTTP 400 EpistulaError \"Invalid SS58 address\", proving the route is real and enforcing signature auth. Not probe-enabled (a probe cannot sign).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/heartbeat"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-layer-state",
+      "kind": "subnet-api",
+      "name": "iota miner layer-state read",
+      "notes": "Epistula-signed orchestrator read (the subnet's non-bearer hotkey-signing scheme, same caveat as SN1 Apex). Live-verified 2026-07-21: unsigned GET returns HTTP 400 EpistulaError \"Invalid SS58 address\", proving the route is real and enforcing signature auth. Not probe-enabled (a probe cannot sign).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/layer_state"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-get-previous-partitions",
+      "kind": "subnet-api",
+      "name": "iota miner previous-partitions read",
+      "notes": "Epistula-signed orchestrator read (the subnet's non-bearer hotkey-signing scheme, same caveat as SN1 Apex). Live-verified 2026-07-21: unsigned GET returns HTTP 422 listing the required request body, proving the route is real; its siblings return the EpistulaError signature failure. Not probe-enabled (a probe cannot sign).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/get_previous_partitions"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-get-partitions",
+      "kind": "subnet-api",
+      "name": "iota miner partitions read",
+      "notes": "Epistula-signed orchestrator read (the subnet's non-bearer hotkey-signing scheme, same caveat as SN1 Apex). Live-verified 2026-07-21: unsigned GET returns HTTP 400 EpistulaError \"Invalid SS58 address\", proving the route is real and enforcing signature auth. Not probe-enabled (a probe cannot sign).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/get_partitions"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-get-weight-path-per-layer",
+      "kind": "subnet-api",
+      "name": "iota miner weight-path-per-layer read",
+      "notes": "Epistula-signed orchestrator read (the subnet's non-bearer hotkey-signing scheme, same caveat as SN1 Apex). Live-verified 2026-07-21: unsigned GET returns HTTP 400 EpistulaError \"Invalid SS58 address\", proving the route is real and enforcing signature auth. Not probe-enabled (a probe cannot sign).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/get_weight_path_per_layer"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-validator-code",
+      "kind": "subnet-api",
+      "name": "iota validator code read",
+      "notes": "Epistula-signed orchestrator read (the subnet's non-bearer hotkey-signing scheme, same caveat as SN1 Apex). Live-verified 2026-07-21: unsigned GET returns HTTP 400 EpistulaError \"Invalid SS58 address\", proving the route is real and enforcing signature auth. Not probe-enabled (a probe cannot sign).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/validator/get_validator_code"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-merged-partitions",
+      "kind": "subnet-api",
+      "name": "iota merged-partitions read",
+      "notes": "Epistula-signed orchestrator read (the subnet's non-bearer hotkey-signing scheme, same caveat as SN1 Apex). Live-verified 2026-07-21: unsigned GET returns HTTP 400 EpistulaError \"Invalid SS58 address\", proving the route is real and enforcing signature auth. Not probe-enabled (a probe cannot sign).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/common/get_merged_partitions"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-all-layers-training",
+      "kind": "subnet-api",
+      "name": "iota miner all-layers-training read",
+      "notes": "Epistula-signed orchestrator read declared in the registered OpenAPI schema. Live-verified 2026-07-21 across repeated calls: alternates between HTTP 400 EpistulaError \"Invalid SS58 address\" (route served, signature enforced) and HTTP 404 from the fronting proxy, i.e. the route is real but not served by every backend behind the load balancer. Registered with the observed behavior noted; not probe-enabled (a probe cannot sign, and the 404-flap would misreport health).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/all_layers_training"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-layer-optimizer-state",
+      "kind": "subnet-api",
+      "name": "iota miner layer-optimizer-state read",
+      "notes": "Epistula-signed orchestrator read declared in the registered OpenAPI schema. Live-verified 2026-07-21 across repeated calls: alternates between HTTP 400 EpistulaError \"Invalid SS58 address\" (route served, signature enforced) and HTTP 404 from the fronting proxy, i.e. the route is real but not served by every backend behind the load balancer. Registered with the observed behavior noted; not probe-enabled (a probe cannot sign, and the 404-flap would misreport health).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/get_layer_optimizer_state"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-notify-state-call",
+      "kind": "subnet-api",
+      "name": "iota miner state-call notification read",
+      "notes": "Epistula-signed orchestrator read declared in the registered OpenAPI schema. Live-verified 2026-07-21 across repeated calls: alternates between HTTP 400 EpistulaError \"Invalid SS58 address\" (route served, signature enforced) and HTTP 404 from the fronting proxy, i.e. the route is real but not served by every backend behind the load balancer. Registered with the observed behavior noted; not probe-enabled (a probe cannot sign, and the 404-flap would misreport health).",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/notify_orchestrator_of_state_call"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-run-epoch",
+      "kind": "subnet-api",
+      "name": "iota run-epoch read",
+      "notes": "Epistula-signed orchestrator read requiring a run_id query parameter. Live-verified 2026-07-21: unparameterized GET returns HTTP 422 {\"detail\":[{\"loc\":[\"query\",\"run_id\"],\"msg\":\"Field required\"}]}, a clean validation error naming the required field and proving the route is real. Registered with the fixed base URL (no query baked in) so callers supply run_id themselves; not probe-enabled.",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/common/get_run_epoch"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Epistula hotkey-signed request headers; no bearer token."
+      },
+      "id": "sn-9-iota-register-status",
+      "kind": "subnet-api",
+      "name": "iota miner registration status",
+      "notes": "Epistula-signed orchestrator read taking a {queue_id} path parameter. Live-verified 2026-07-21 with a placeholder id: HTTP 400 EpistulaError \"Invalid SS58 address\", proving the route is real and signature-gated. Path parameter registered in the percent-encoded brace form; not probe-enabled.",
+      "probe": {
+        "enabled": false,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "shin-core"
+      },
+      "source_urls": [
+        "https://iota.api.macrocosmos.ai/openapi.json",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "url": "https://iota.api.macrocosmos.ai/miner/register/status/%7Bqueue_id%7D"
     }
   ],
   "website_url": "https://iota.macrocosmos.ai/"


### PR DESCRIPTION
## Summary

Closes #7025. Same pattern as the recently-merged #7581/#7582/#7583/#7584/#7587/#7588/#7594: the issue's 3 registered surfaces (`/healthcheck`, `/metrics`, `/common/get_run_info`) still verify as registered, and the issue's own "Additional surface(s) found during review" section itemizes the remaining registry gap — this PR registers exactly that itemized list, nothing more (the issue's own "Not itemized" note explicitly leaves the write/protocol-mutation POSTs out, and finding surfaces beyond the itemized list is out of scope on this issue).

## What this adds (14 new surfaces)

Diffed the already-registered orchestrator schema (`https://iota.api.macrocosmos.ai/openapi.json`, 35 paths) against `registry/subnets/iota.json`. Duplicate-URL and duplicate-id checks run against all 8 existing surfaces before generating (zero collisions).

**1 public, no auth — live-verified 2026-07-21:**
- `GET /profiler/status` → HTTP 200 `{"running":false,"profiler_exists":false}`. No Epistula-signing headers declared for this path (unlike its `/profiler/start` and `/profiler/stop` write siblings). Registered `probe.enabled:true, expect:"json"`.

**8 Epistula-signed fixed reads** (`auth_required:true`, `probe.enabled:false`) — each individually curled unauthenticated on 2026-07-21:
- `/miner/heartbeat`, `/miner/layer_state`, `/miner/get_partitions`, `/miner/get_weight_path_per_layer`, `/validator/get_validator_code`, `/common/get_merged_partitions` → HTTP 400 `{"detail":{"error":"Invalid SS58 address: Base 58 requirement is violated","message":"EpistulaError: ..."}}` — the route is real and enforcing the subnet's hotkey-signing scheme.
- `/miner/get_activations`, `/miner/get_previous_partitions` → HTTP 422 `{"detail":[{"loc":["body"],"msg":"Field required"}]}` — reaches the handler, names the required body.

**3 schema-declared reads that currently flap** (`auth_required:true`, `probe.enabled:false`):
- `/miner/all_layers_training`, `/miner/get_layer_optimizer_state`, `/miner/notify_orchestrator_of_state_call` — repeated calls alternate between HTTP 400 `EpistulaError` (route served, signature enforced) and HTTP 404 from the fronting proxy. They are declared in the registered schema and demonstrably real, but not served by every backend behind the load balancer. Registered with that observed behavior documented on each surface and the probe disabled, so a probe never misreports the 404 flap as subnet health (the same "register the real endpoint, note what it actually does" treatment the issue's own scope note calls for).

**2 param-taking reads** (`auth_required:true`, `probe.enabled:false`):
- `GET /common/get_run_epoch` → HTTP 422 `{"detail":[{"loc":["query","run_id"],"msg":"Field required"}]}`. Registered with the fixed base URL, no query baked in — callable via `call_subnet_surface`'s own `query` argument.
- `GET /miner/register/status/{queue_id}` → HTTP 400 `EpistulaError` with a placeholder id. Path parameter registered in the percent-encoded brace form (`%7Bqueue_id%7D`) — raw braces fail this repo's `url` `format:"uri"` check.

## Schema/tooling notes

- Every Epistula entry carries `auth:{scheme:"custom", scopes_note:...}` — scheme only, no header-name or credential literals. Same non-bearer signing caveat already documented for SN1 Apex (shared macrocosm-os codebase).
- `probe.method` is `GET` throughout; only the one public surface is probe-enabled.
- **Append-only**: `surfaces[]` additions only — the file's top-level `notes` / `curation` / `gap_notes` are untouched (`git diff` shows +402/−0, zero existing lines modified).
- `provider: "macrocosmos"` — matches the file's existing surfaces and the registered `registry/providers/macrocosmos.json`.
- `public/metagraph/operational-surfaces.json` changed on `npm run build` but is **not** in this diff — committed-but-excluded from the freshness gate per `reference.md`.

## Validation

- [x] `npm run validate:surface -- registry/subnets/iota.json` — 22 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — clean
- [x] `npx prettier --check registry/subnets/iota.json` — clean

Closes #7025
