### PR TITLE
feat(registry): register SN113 TensorUSD auth-gated backend OpenAPI surface (#7124)

### DIFF
--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -183,6 +183,26 @@
         "https://github.com/TensorUSD/subnet/blob/main/README.md"
       ],
       "url": "https://agent-api.tensorusd.com/health"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Not publicly documented — unauthenticated GET returns HTTP 401 with an empty body (live-verified 2026-07-22), so the credential type is unknown; #7124 flags it for re-probing with a maintainer/contributor API key."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-113-tensorusd-openapi",
+      "kind": "openapi",
+      "name": "TensorUSD backend OpenAPI schema (auth-gated)",
+      "notes": "Live-verified 2026-07-22: GET returns HTTP 401 with an empty body unauthenticated — a real, credential-gated schema endpoint, unlike the bare /openapi.json, /swagger.json, /docs and /redoc paths on this host, which all return clean 404s (re-confirmed the same day). Registered per #7124; re-probe with a credential would unlock full endpoint discovery.",
+      "provider": "tensorusd",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "michiot05"
+      },
+      "source_urls": ["https://github.com/TensorUSD/subnet"],
+      "url": "https://api.tensorusd.com/api/openapi.json"
     }
   ],
   "website_url": "https://tensorusd.com/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one surface to exactly one subnet manifest — `registry/subnets/tensorusd.json` — delivering the "Additional surface(s) found during review (now in scope)" registration ask of #7124, in the same pattern as the recent per-subnet parity PRs (#7583/#7584/#7594).

Closes #7124

## Verification of the issue's original surfaces (2026-07-22, direct GETs)

Both of #7124's listed surfaces still verify exactly as documented:

- `sn-113-tensorusd-subnet-api` — `GET https://api.tensorusd.com/health` → HTTP 200 `application/json`, `{"status":"healthy","components":{"database":{"connected":true,…}},"system":{…}}`.
- `sn-113-tensorusd-agent-api-health` — `GET https://agent-api.tensorusd.com/health` → HTTP 200 `application/json`, `{"success":true,"data":{"status":"ok","env":"prod"}}`.

No registry fixes needed for either — config matches reality, so their entries are untouched.

## Surface

- Netuid: 113
- Kind: openapi (`auth_required: true`, structured `auth{}` with `scheme: custom`)
- Public URL: `https://api.tensorusd.com/api/openapi.json`
- Source URL (proves the claim): https://github.com/TensorUSD/subnet (the subnet's registered backend source)
- Provider slug: `tensorusd`

## Live verification of the added surface (2026-07-22)

Reproduced #7124's finding exactly, same day, every path individually curled:

- `GET https://api.tensorusd.com/api/openapi.json` → **HTTP 401, empty body** — a real, existing, credential-gated schema endpoint.
- Controls, distinguishing it from the plain-404 paths the file's `gap_notes` already record: `GET /openapi.json` → 404 `{"message":"Cannot GET /openapi.json",…}`; `GET /swagger.json` → 404; `GET /docs` → 404; `GET /redoc` → 404 (all `application/json` error bodies on the same host).
- Registered with `auth_required: true` and no probe block, per #7124's instruction; the `auth{}` `scopes_note` records that the credential type is not publicly documented (401 with empty body) and that #7124 flags it for re-probing with a maintainer/contributor key to unlock full endpoint discovery.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest (`git diff upstream/main --stat`: 1 file, +20/−0).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it (registered backend source repo; the live 401-vs-404 distinction above is the behavioral evidence #7124 itself documents).
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts (the `auth{}` object is a placeholder note only).
- [x] Does not duplicate an existing Metagraphed surface (distinct from both registered health surfaces and from the 404 schema paths in `gap_notes`).
- [x] Links a tracked issue that is still OPEN (`Closes #7124`).

## Validation

- `npm run validate:surface -- registry/subnets/tensorusd.json` — passed (8 surfaces)
- `npm run scan:public-safety` — passed
- `git diff --check` — clean
