### PR TITLE
fix(registry): SN49 Nepher Robotics tournament API parity (#7062)

### DIFF
--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -481,6 +481,4046 @@
       "public_safe": true,
       "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
       "url": "https://tournament-api.nepher.ai/api/v1/tournaments/pricing?subnet_uid=49"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-agents-agent-id-disqualify",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin agents agent id disqualify",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/agents/{agent_id}/disqualify on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/agents/%7Bagent_id%7D/disqualify",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-agents-agent-id-hotkey",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin agents agent id hotkey",
+      "notes": "Auth-gated tournament API route PATCH /api/v1/admin/agents/{agent_id}/hotkey on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/agents/%7Bagent_id%7D/hotkey",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-audit-logs",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin audit logs",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/audit/logs on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/audit/logs",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-cleanup-agents-superseded-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin cleanup agents superseded tournament id",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/cleanup/agents/superseded/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/cleanup/agents/superseded/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-cleanup-agents-superseded-tournament-id-list",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin cleanup agents superseded tournament id list",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/cleanup/agents/superseded/{tournament_id}/list on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/cleanup/agents/superseded/%7Btournament_id%7D/list",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-cleanup-agents-unevaluated-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin cleanup agents unevaluated tournament id",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/cleanup/agents/unevaluated/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/cleanup/agents/unevaluated/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-cleanup-agents-unevaluated-tournament-id-list",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin cleanup agents unevaluated tournament id list",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/cleanup/agents/unevaluated/{tournament_id}/list on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/cleanup/agents/unevaluated/%7Btournament_id%7D/list",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-cleanup-eligible-miners",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin cleanup eligible miners",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/cleanup/eligible-miners on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/cleanup/eligible-miners",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-cleanup-evaluations-failed-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin cleanup evaluations failed tournament id",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/cleanup/evaluations/failed/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/cleanup/evaluations/failed/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-cleanup-evaluations-stale-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin cleanup evaluations stale tournament id",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/cleanup/evaluations/stale/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/cleanup/evaluations/stale/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-clone-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin clone tournament id",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/clone/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/clone/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-config",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin config",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/config on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Live-verified 2026-07-21: unauthenticated GET returns HTTP 401. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/config",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-emergency-deactivate-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin emergency deactivate tournament id",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/emergency/deactivate/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/emergency/deactivate/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-emergency-pause-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin emergency pause tournament id",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/emergency/pause/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/emergency/pause/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-emergency-unpause-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin emergency unpause tournament id",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/emergency/unpause/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/emergency/unpause/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-evaluations-evaluation-id-exclude",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin evaluations evaluation id exclude",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/evaluations/{evaluation_id}/exclude on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/evaluations/%7Bevaluation_id%7D/exclude",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-export-audit-logs",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin export audit logs",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/export/audit-logs on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/export/audit-logs",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-export-evaluations-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin export evaluations tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/export/evaluations/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/export/evaluations/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-export-leaderboard-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin export leaderboard tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/export/leaderboard/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/export/leaderboard/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-export-summary-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin export summary tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/export/summary/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/export/summary/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-gallery",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin gallery",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/gallery on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/gallery",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-gallery-media-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin gallery media id",
+      "notes": "Auth-gated tournament API route GET, PATCH, and DELETE /api/v1/admin/gallery/{media_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET, PATCH, and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/gallery/%7Bmedia_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-gallery-media-id-download",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin gallery media id download",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/gallery/{media_id}/download on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/gallery/%7Bmedia_id%7D/download",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-integrity-duplicate-hashes-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin integrity duplicate hashes tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/integrity/duplicate-hashes/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/integrity/duplicate-hashes/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-monitoring-blockchain",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin monitoring blockchain",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/monitoring/blockchain on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/monitoring/blockchain",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-monitoring-database",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin monitoring database",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/monitoring/database on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/monitoring/database",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-monitoring-health",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin monitoring health",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/monitoring/health on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/monitoring/health",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-monitoring-miners-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin monitoring miners tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/monitoring/miners/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/monitoring/miners/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-monitoring-storage",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin monitoring storage",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/monitoring/storage on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/monitoring/storage",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-monitoring-sync-status",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin monitoring sync status",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/monitoring/sync-status on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/monitoring/sync-status",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-monitoring-tournament-tournament-id-dashboard",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin monitoring tournament tournament id dashboard",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/monitoring/tournament/{tournament_id}/dashboard on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/monitoring/tournament/%7Btournament_id%7D/dashboard",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-monitoring-validators",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin monitoring validators",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/monitoring/validators on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/monitoring/validators",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-status",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications status",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/notifications/status on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/status",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-tournament-id-config",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications tournament id config",
+      "notes": "Auth-gated tournament API route GET and PUT /api/v1/admin/notifications/{tournament_id}/config on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and PUT on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/%7Btournament_id%7D/config",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-tournament-id-discard",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications tournament id discard",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/notifications/{tournament_id}/discard on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/%7Btournament_id%7D/discard",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-tournament-id-logs",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications tournament id logs",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/notifications/{tournament_id}/logs on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/%7Btournament_id%7D/logs",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-tournament-id-manual-send",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications tournament id manual send",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/notifications/{tournament_id}/manual-send on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/%7Btournament_id%7D/manual-send",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-tournament-id-preview",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications tournament id preview",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/notifications/{tournament_id}/preview on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/%7Btournament_id%7D/preview",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-tournament-id-queued",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications tournament id queued",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/notifications/{tournament_id}/queued on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/%7Btournament_id%7D/queued",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-tournament-id-retry-failed",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications tournament id retry failed",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/notifications/{tournament_id}/retry-failed on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/%7Btournament_id%7D/retry-failed",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-notifications-tournament-id-send",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin notifications tournament id send",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/notifications/{tournament_id}/send on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/notifications/%7Btournament_id%7D/send",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-platform-faqs",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin platform faqs",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/platform-faqs on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/platform-faqs",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-platform-faqs-faq-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin platform faqs faq id",
+      "notes": "Auth-gated tournament API route PATCH and DELETE /api/v1/admin/platform-faqs/{faq_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares PATCH and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/platform-faqs/%7Bfaq_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reports",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reports",
+      "notes": "Auth-gated tournament API route GET and DELETE /api/v1/admin/reports on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and DELETE on this URL; one surface per URL per registry collision policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reports",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reports-count",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reports count",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/reports/count on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reports/count",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reports-filters",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reports filters",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/reports/filters on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reports/filters",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reports-report-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reports report id",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/reports/{report_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reports/%7Breport_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reports-report-id-block",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reports report id block",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/reports/{report_id}/block on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reports/%7Breport_id%7D/block",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reports-report-id-review",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reports report id review",
+      "notes": "Auth-gated tournament API route PATCH /api/v1/admin/reports/{report_id}/review on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reports/%7Breport_id%7D/review",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reset-blockchain-sync",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reset blockchain sync",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/reset/blockchain-sync on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reset/blockchain-sync",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reset-evaluations-in-progress",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reset evaluations in progress",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/reset/evaluations/in-progress on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reset/evaluations/in-progress",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reset-tournament-tournament-id-eligible-miners",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reset tournament tournament id eligible miners",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/reset/tournament/{tournament_id}/eligible-miners on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reset/tournament/%7Btournament_id%7D/eligible-miners",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reset-tournament-tournament-id-evaluations",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reset tournament tournament id evaluations",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/reset/tournament/{tournament_id}/evaluations on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reset/tournament/%7Btournament_id%7D/evaluations",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reset-tournament-tournament-id-full",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reset tournament tournament id full",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/reset/tournament/{tournament_id}/full on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reset/tournament/%7Btournament_id%7D/full",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reset-tournament-tournament-id-scores",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reset tournament tournament id scores",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/reset/tournament/{tournament_id}/scores on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reset/tournament/%7Btournament_id%7D/scores",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-reset-user-user-id-cooldown",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin reset user user id cooldown",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/reset/user/{user_id}/cooldown on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/reset/user/%7Buser_id%7D/cooldown",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-agents-agent-id-flag",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security agents agent id flag",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/security/agents/{agent_id}/flag on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/agents/%7Bagent_id%7D/flag",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-agents-agent-id-violations",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security agents agent id violations",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/security/agents/{agent_id}/violations on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/agents/%7Bagent_id%7D/violations",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-queue",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security queue",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/security/queue on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/queue",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-queue-count",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security queue count",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/security/queue/count on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/queue/count",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-queue-queue-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security queue queue id",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/security/queue/{queue_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/queue/%7Bqueue_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-queue-queue-id-block",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security queue queue id block",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/security/queue/{queue_id}/block on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/queue/%7Bqueue_id%7D/block",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-queue-queue-id-clear",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security queue queue id clear",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/security/queue/{queue_id}/clear on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/queue/%7Bqueue_id%7D/clear",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-tournament-tournament-id-rescan",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security tournament tournament id rescan",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/security/tournament/{tournament_id}/rescan on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/tournament/%7Btournament_id%7D/rescan",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-security-tournaments",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin security tournaments",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/security/tournaments on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/security/tournaments",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-tournaments-tournament-id-faqs",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin tournaments tournament id faqs",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/tournaments/{tournament_id}/faqs on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/tournaments/%7Btournament_id%7D/faqs",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-tournaments-tournament-id-faqs-faq-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin tournaments tournament id faqs faq id",
+      "notes": "Auth-gated tournament API route PATCH and DELETE /api/v1/admin/tournaments/{tournament_id}/faqs/{faq_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares PATCH and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/tournaments/%7Btournament_id%7D/faqs/%7Bfaq_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-tournaments-tournament-id-gallery",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin tournaments tournament id gallery",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/tournaments/{tournament_id}/gallery on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/tournaments/%7Btournament_id%7D/gallery",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-tournaments-tournament-id-gallery-upload",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin tournaments tournament id gallery upload",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/tournaments/{tournament_id}/gallery/upload on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/tournaments/%7Btournament_id%7D/gallery/upload",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-tournaments-tournament-id-gallery-media-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin tournaments tournament id gallery media id",
+      "notes": "Auth-gated tournament API route PATCH and DELETE /api/v1/admin/tournaments/{tournament_id}/gallery/{media_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares PATCH and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/tournaments/%7Btournament_id%7D/gallery/%7Bmedia_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-validators-available",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin validators available",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/validators/available on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/validators/available",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-validators-hotkeys",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin validators hotkeys",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/validators/hotkeys on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/validators/hotkeys",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-validators-link",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin validators link",
+      "notes": "Auth-gated tournament API route POST /api/v1/admin/validators/link on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/validators/link",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-validators-link-link-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin validators link link id",
+      "notes": "Auth-gated tournament API route PATCH and DELETE /api/v1/admin/validators/link/{link_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares PATCH and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/validators/link/%7Blink_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-validators-links",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin validators links",
+      "notes": "Auth-gated tournament API route GET /api/v1/admin/validators/links on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/validators/links",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-whitelist-domains",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin whitelist domains",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/whitelist/domains on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/whitelist/domains",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-whitelist-domains-domain-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin whitelist domains domain id",
+      "notes": "Auth-gated tournament API route GET, PATCH, and DELETE /api/v1/admin/whitelist/domains/{domain_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET, PATCH, and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/whitelist/domains/%7Bdomain_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-whitelist-ips",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin whitelist ips",
+      "notes": "Auth-gated tournament API route GET and POST /api/v1/admin/whitelist/ips on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and POST on this URL; one surface per URL per registry collision policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/whitelist/ips",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-admin-whitelist-ips-ip-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 admin whitelist ips ip id",
+      "notes": "Auth-gated tournament API route GET, PATCH, and DELETE /api/v1/admin/whitelist/ips/{ip_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET, PATCH, and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/admin/whitelist/ips/%7Bip_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-delete-unevaluated-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents delete unevaluated tournament id",
+      "notes": "Auth-gated tournament API route DELETE /api/v1/agents/delete-unevaluated/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/delete-unevaluated/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-download-agent-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents download agent id",
+      "notes": "Auth-gated tournament API route GET /api/v1/agents/download/{agent_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/download/%7Bagent_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-eligible-miners-status-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents eligible miners status tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/agents/eligible-miners-status/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/eligible-miners-status/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-list",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents list",
+      "notes": "Auth-gated tournament API route GET /api/v1/agents/list on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/list",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-list-public",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents list public",
+      "notes": "Auth-gated tournament API route GET /api/v1/agents/list/public on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/list/public",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-list-unevaluated",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents list unevaluated",
+      "notes": "Auth-gated tournament API route GET /api/v1/agents/list/unevaluated on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/list/unevaluated",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-list-validators",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents list validators",
+      "notes": "Auth-gated tournament API route GET /api/v1/agents/list/validators on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/list/validators",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-upload-verify",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents upload verify",
+      "notes": "Auth-gated tournament API route POST /api/v1/agents/upload/verify on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/upload/verify",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-upload-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents upload tournament id",
+      "notes": "Auth-gated tournament API route POST /api/v1/agents/upload/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/upload/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-agents-agent-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 agents agent id",
+      "notes": "Auth-gated tournament API route GET and DELETE /api/v1/agents/{agent_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/agents/%7Bagent_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-evaluations-eligible-miners-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 evaluations eligible miners tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/evaluations/eligible-miners/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/evaluations/eligible-miners/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-evaluations-in-progress-cli",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 evaluations in progress cli",
+      "notes": "Auth-gated tournament API route POST /api/v1/evaluations/in-progress/cli on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/evaluations/in-progress/cli",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-evaluations-progress-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 evaluations progress tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/evaluations/progress/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/evaluations/progress/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-evaluations-submit",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 evaluations submit",
+      "notes": "Public tournament API route POST /api/v1/evaluations/submit on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Live-verified 2026-07-21: empty POST returns HTTP 422 validation error, not 401 -- genuinely no-auth but requires a request body. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/evaluations/submit",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-evaluations-submit-verify",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 evaluations submit verify",
+      "notes": "Auth-gated tournament API route POST /api/v1/evaluations/submit/verify on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/evaluations/submit/verify",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-evaluations-evaluation-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 evaluations evaluation id",
+      "notes": "Auth-gated tournament API route GET and DELETE /api/v1/evaluations/{evaluation_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and DELETE on this URL; one surface per URL per registry collision policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/evaluations/%7Bevaluation_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-evaluations-evaluation-id-log",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 evaluations evaluation id log",
+      "notes": "Auth-gated tournament API route GET /api/v1/evaluations/{evaluation_id}/log on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/evaluations/%7Bevaluation_id%7D/log",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-notifications-preferences",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 notifications preferences",
+      "notes": "Auth-gated tournament API route GET and PUT /api/v1/notifications/preferences on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. OpenAPI declares GET and PUT on this URL; one surface per URL per registry collision policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/notifications/preferences",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-notifications-unsubscribe",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 notifications unsubscribe",
+      "notes": "Public tournament API route GET /api/v1/notifications/unsubscribe on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Live-verified 2026-07-21: GET without user_id returns HTTP 422, not 401. Registered with bare base URL (no query baked in). probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/notifications/unsubscribe",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-reports",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 reports",
+      "notes": "Auth-gated tournament API route POST /api/v1/reports on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/reports",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-scores-agent-agent-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 scores agent agent id",
+      "notes": "Auth-gated tournament API route GET /api/v1/scores/agent/{agent_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/scores/agent/%7Bagent_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-scores-bulk",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 scores bulk",
+      "notes": "Auth-gated tournament API route POST /api/v1/scores/bulk on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Live-verified 2026-07-21: unauthenticated POST returns HTTP 401 despite missing security block in schema. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/scores/bulk",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-scores-leaderboard-active",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 scores leaderboard active",
+      "notes": "Auth-gated tournament API route GET /api/v1/scores/leaderboard/active on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/scores/leaderboard/active",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-scores-leaderboard-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 scores leaderboard tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/scores/leaderboard/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/scores/leaderboard/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-scores-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 scores tournament id",
+      "notes": "Auth-gated tournament API route GET /api/v1/scores/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/scores/%7Btournament_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-scores-tournament-id-aggregate",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 scores tournament id aggregate",
+      "notes": "Auth-gated tournament API route POST /api/v1/scores/{tournament_id}/aggregate on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/scores/%7Btournament_id%7D/aggregate",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-scores-tournament-id-aggregated",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 scores tournament id aggregated",
+      "notes": "Auth-gated tournament API route GET /api/v1/scores/{tournament_id}/aggregated on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/scores/%7Btournament_id%7D/aggregated",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-create",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments create",
+      "notes": "Auth-gated tournament API route POST /api/v1/tournaments/create on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/create",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-preload-cache",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments preload cache",
+      "notes": "Auth-gated tournament API route POST /api/v1/tournaments/preload-cache on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/preload-cache",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id",
+      "notes": "Public tournament API route GET, PATCH, and DELETE /api/v1/tournaments/{tournament_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Public read once a tournament ID is known; PATCH/DELETE/status/auto-start siblings on the same path template are auth-gated. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-approve-winner-agent-id",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id approve winner agent id",
+      "notes": "Auth-gated tournament API route POST /api/v1/tournaments/{tournament_id}/approve-winner/{agent_id} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/approve-winner/%7Bagent_id%7D",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-auto-start",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id auto start",
+      "notes": "Auth-gated tournament API route PATCH /api/v1/tournaments/{tournament_id}/auto-start on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/auto-start",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-config-active-eval-config",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id config active eval config",
+      "notes": "Public tournament API route GET /api/v1/tournaments/{tournament_id}/config/active_eval_config on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/config/active_eval_config",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-config-eval-config",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id config eval config",
+      "notes": "Public tournament API route GET /api/v1/tournaments/{tournament_id}/config/eval_config on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/config/eval_config",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-config-public-eval-config",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id config public eval config",
+      "notes": "Public tournament API route GET /api/v1/tournaments/{tournament_id}/config/public_eval_config on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/config/public_eval_config",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-config-subnet-config",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id config subnet config",
+      "notes": "Public tournament API route GET /api/v1/tournaments/{tournament_id}/config/subnet_config on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/config/subnet_config",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-confirm-no-winner",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id confirm no winner",
+      "notes": "Auth-gated tournament API route POST /api/v1/tournaments/{tournament_id}/confirm-no-winner on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/confirm-no-winner",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-gallery-media-type-index",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id gallery media type index",
+      "notes": "Public tournament API route GET /api/v1/tournaments/{tournament_id}/gallery/{media_type}/{index} on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/gallery/%7Bmedia_type%7D/%7Bindex%7D",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-preliminary-leader",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id preliminary leader",
+      "notes": "Auth-gated tournament API route GET /api/v1/tournaments/{tournament_id}/preliminary-leader on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/preliminary-leader",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-reset-winner",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id reset winner",
+      "notes": "Auth-gated tournament API route POST /api/v1/tournaments/{tournament_id}/reset-winner on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/reset-winner",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-status",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id status",
+      "notes": "Auth-gated tournament API route PATCH /api/v1/tournaments/{tournament_id}/status on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/status",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-winner",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id winner",
+      "notes": "Auth-gated tournament API route GET /api/v1/tournaments/{tournament_id}/winner on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/winner",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-tournaments-tournament-id-winner-hotkey",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 tournaments tournament id winner hotkey",
+      "notes": "Auth-gated tournament API route GET /api/v1/tournaments/{tournament_id}/winner-hotkey on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Path-parameterized; template uses literal placeholders URI-encoded in url. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/%7Btournament_id%7D/winner-hotkey",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-users-list",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 users list",
+      "notes": "Auth-gated tournament API route GET /api/v1/users/list on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/users/list",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-users-me",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 users me",
+      "notes": "Auth-gated tournament API route GET /api/v1/users/me on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/users/me",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-users-me-dashboard-stats",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 users me dashboard stats",
+      "notes": "Auth-gated tournament API route GET /api/v1/users/me/dashboard-stats on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/users/me/dashboard-stats",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-users-validators",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 users validators",
+      "notes": "Auth-gated tournament API route GET /api/v1/users/validators on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/users/validators",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-weight-commits",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 weight commits",
+      "notes": "Auth-gated tournament API route POST /api/v1/weight-commits on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Same host/family as weight-commits/latest; registered auth_required:true per sibling auth behavior (metagraphed#7062). probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/weight-commits",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-49-nepher-api-v1-weight-commits-latest",
+      "kind": "subnet-api",
+      "name": "Nepher api v1 weight commits latest",
+      "notes": "Auth-gated tournament API route GET /api/v1/weight-commits/latest on tournament-api.nepher.ai -- from the SN49 Nepher OpenAPI schema (138 paths). Registered per metagraphed#7062 full-API-parity policy. Live-verified 2026-07-21: unauthenticated GET returns HTTP 401 despite missing security block in schema. probe.enabled:false -- not suitable for anonymous recurring probes.",
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
+      "url": "https://tournament-api.nepher.ai/api/v1/weight-commits/latest",
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions. Live-checked 2026-07-21: unauthenticated calls to sampled admin routes return HTTP 401. No credential format or placeholder value is asserted here."
+      },
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     }
   ],
   "website_url": "https://nepher.ai"


### PR DESCRIPTION
## Summary

Completes [#7062](https://github.com/JSONbored/metagraphed/issues/7062) by appending **128 missing tournament-api surfaces** from the 138-path OpenAPI schema — the full "Additional surface(s) found during review" deliverable JSONbored itemized in the reopen.

Closes #7062

## Why the issue was reopened (twice)

1. **First reopen** — merged test-only PRs ([#7379](https://github.com/JSONbored/metagraphed/pull/7379), [#7427](https://github.com/JSONbored/metagraphed/pull/7427)) closed #7062 without touching `registry/subnets/nepher-robotics.json`. JSONbored:

   > A verification test alone doesn't satisfy this issue — the registry file itself needs the actual surface entries added.

2. **Second reopen** — originals (health, current-block, tournaments list/active/ids, evaluations, readiness, pricing, etc.) are correct; **none of the additional-scope surfaces are registered**. JSONbored:

   > A PR claiming `Closes #7062` needs to cover all of it. A PR that only re-verifies the originals or adds a handful of the ~90 admin operations does not satisfy this issue.

## How to implement without failing the gate

Lessons baked into this PR:

| Failure mode | Avoidance |
|---|---|
| Test-only PR | Append surfaces to `nepher-robotics.json`, not just tests |
| Partial scope | All 128 missing OpenAPI paths registered (6 named + 5 gallery/config + ~117 bearer-auth operator routes) |
| Duplicate URL | Skip `/api/v1/tournaments/pricing` bare path — already registered as `sn-49-nepher-tournament-pricing` with stable `?subnet_uid=49` |
| LoopOver secret false-positive (#7597 pattern) | Bearer `scopes_note` includes *"No credential format or placeholder value is asserted here."* — no terse signing/header shorthand |
| URL collision | One surface per unique URL; multi-method paths merged in `notes` |
| Path params | URI-encoded templates (`%7Bparam%7D`); `probe.enabled:false` |
| Schema/auth mismatch | Issue overrides: `weight-commits/latest`, `scores/bulk`, `weight-commits` → `auth_required:true` despite missing OpenAPI security; `evaluations/submit` → `auth_required:false` (422, not 401) |

## What this PR adds (+4040 lines, append-only)

**128 new surfaces** (120 auth-gated bearer, 8 public catalog):

| Group | Count | Examples |
|---|---|---|
| Named individually in issue | 6 | weight-commits/latest (**401**), scores/bulk (**401**), weight-commits, evaluations/submit (**422**), notifications/unsubscribe (**422**), tournaments/{id} |
| Gallery/config family | 5 | gallery/{media_type}/{index}, config/subnet_config, eval_config, active_eval_config, public_eval_config |
| Bearer-auth operator/admin | ~117 | all `/api/v1/admin/*`, auth-gated agents/evaluations/scores/users routes, tournament lifecycle (create, preload-cache, winner/status/auto-start family) |

Auth surfaces use the same HTTPBearer block as the existing `sn-49-nepher-tournament-api` surface, with gate-safe scopes note. All new surfaces: `authority: community`, `review.state: community-submitted`.

## Checklist

- [x] Changes exactly one `registry/subnets/nepher-robotics.json` file (**+4040, 0 deletions**)
- [x] Append-only — no edits to existing surfaces or top-level metadata
- [x] Full #7062 scope (not partial admin subset)
- [x] `validate:surface` — 148 surfaces, passed
- [x] `scan:public-safety` — passed
- [x] `tests/nepher-robotics-call-subnet-surface-verify.test.mjs` — 32/32

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] MCP smoke: `sn-49-nepher-tournament-health` (existing), `sn-49-nepher-api-v1-weight-commits-latest`, `sn-49-nepher-api-v1-evaluations-submit`
