### PR TITLE
fix(registry): SN2 DSperse full API parity (8 missing surfaces)

### DIFF
--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -279,6 +279,182 @@
       },
       "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
       "url": "https://repository.inferencelabs.com/models"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-circuit-detail",
+      "kind": "subnet-api",
+      "name": "DSperse circuit repository circuit detail",
+      "notes": "Public no-auth GET returning a single registered circuit's metadata record by repository id; path-parameterized sibling of the already-tracked circuit list on the same host. Documented in the circuit repository's own OpenAPI 3.1 schema (path /circuits/{id}) with no security declared. Live-verified 2026-07-22: a placeholder path value returns a clean HTTP 400 JSON validation error naming the id path field (the circuit collection is currently empty, so no stored record id exists to fetch); the confirmed-live collection root is served by the same routing layer. probe.enabled:false -- percent-encoded path template, no stable canonical id to probe.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
+      "url": "https://repository.inferencelabs.com/circuits/%7Bid%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-circuit-download",
+      "kind": "subnet-api",
+      "name": "DSperse circuit repository circuit artifact download",
+      "notes": "Public no-auth GET streaming a registered circuit's packaged artifact by repository id. Documented in the circuit repository's own OpenAPI 3.1 schema (path /circuits/{id}/download) with no security declared. Live-verified 2026-07-22: a placeholder path value returns a clean HTTP 400 JSON validation error naming the id path field (circuit collection currently empty; the equivalent component file route on this host serves real bytes -- see sn-2-dsperse-component-file-by-name). probe.enabled:false -- percent-encoded path template.",
+      "probe": {
+        "enabled": false,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
+      "url": "https://repository.inferencelabs.com/circuits/%7Bid%7D/download"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-circuit-file-by-name",
+      "kind": "subnet-api",
+      "name": "DSperse circuit repository circuit file by name",
+      "notes": "Public no-auth GET returning a named file within a registered circuit. Documented in the circuit repository's own OpenAPI 3.1 schema (path /circuits/files/{circuitId}/{filename}) with no security declared. Live-verified 2026-07-22: placeholder path values return a clean HTTP 400 JSON validation error naming the circuitId path field (circuit collection currently empty). probe.enabled:false -- percent-encoded path template.",
+      "probe": {
+        "enabled": false,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
+      "url": "https://repository.inferencelabs.com/circuits/files/%7BcircuitId%7D/%7Bfilename%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-circuit-metrics",
+      "kind": "subnet-api",
+      "name": "DSperse circuit repository circuit metrics",
+      "notes": "Public no-auth GET returning a registered circuit's usage metrics by repository id. Documented in the circuit repository's own OpenAPI 3.1 schema (path /circuits/{id}/metrics); the GET read declares no security. The same path also accepts POST metric submissions, which the schema marks as protected (security: true) -- one URL registers once, so this entry tracks the public GET read and notes the write route here (observed 2026-07-22: a bare POST returns HTTP 503 'Metrics submission not configured'). Live-verified 2026-07-22: a placeholder path value on the GET returns a clean HTTP 400 JSON validation error naming the id path field. probe.enabled:false -- percent-encoded path template.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
+      "url": "https://repository.inferencelabs.com/circuits/%7Bid%7D/metrics"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-component-detail",
+      "kind": "subnet-api",
+      "name": "DSperse circuit repository component detail",
+      "notes": "Public no-auth GET returning a single circuit component's metadata record by its content digest; path-parameterized sibling of the already-tracked component list. Documented in the circuit repository's own OpenAPI 3.1 schema (path /components/{sha256}) with no security declared. Live-verified 2026-07-22: a real digest taken from the live component list returns HTTP 200 application/json with the matching component record (name, proof_system, file listing). probe.enabled:false -- percent-encoded path template.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
+      "url": "https://repository.inferencelabs.com/components/%7Bsha256%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-component-file-by-name",
+      "kind": "subnet-api",
+      "name": "DSperse circuit repository component file by name",
+      "notes": "Public no-auth GET returning a named file within a circuit component, addressed by the component's content digest. Documented in the circuit repository's own OpenAPI 3.1 schema (path /components/{sha256}/files/{filename}) with no security declared. Live-verified 2026-07-22: a real digest and filename taken from the live component list return HTTP 200 application/octet-stream with the file bytes (circuit.bin, ~6.7 MB). probe.enabled:false -- percent-encoded path template.",
+      "probe": {
+        "enabled": false,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
+      "url": "https://repository.inferencelabs.com/components/%7Bsha256%7D/files/%7Bfilename%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-model-detail",
+      "kind": "subnet-api",
+      "name": "DSperse circuit repository model detail",
+      "notes": "Public no-auth GET returning a single registered model's metadata and composition record by repository id; path-parameterized sibling of the already-tracked model list. Documented in the circuit repository's own OpenAPI 3.1 schema (path /models/{id}) with no security declared. Live-verified 2026-07-22: a real id taken from the live model list returns HTTP 200 application/json with the matching model record (metadata, composition, component slices). probe.enabled:false -- percent-encoded path template.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
+      "url": "https://repository.inferencelabs.com/models/%7Bid%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-2-dsperse-model-weights-by-digest",
+      "kind": "subnet-api",
+      "name": "DSperse circuit repository model weights by digest",
+      "notes": "Public no-auth GET streaming a model weights artifact addressed by its content digest. Documented in the circuit repository's own OpenAPI 3.1 schema (path /models/wb/{sha256}) with no security declared. Live-verified 2026-07-22: a real artifact digest taken from a live model record's composition returns HTTP 200 application/octet-stream streaming the weights file (~109 MB, transfer confirmed in progress and cut off locally). probe.enabled:false -- percent-encoded path template.",
+      "probe": {
+        "enabled": false,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rsnetworkinginc"
+      },
+      "source_urls": ["https://repository.inferencelabs.com/openapi.json"],
+      "url": "https://repository.inferencelabs.com/models/wb/%7Bsha256%7D"
     }
   ],
   "website_url": "https://subnet2.inferencelabs.com/"


### PR DESCRIPTION
## Summary

Closes #7018

Registers the 8 missing circuit-repository API paths for SN2 (DSperse) in `registry/subnets/dsperse.json`, completing the issue's "Additional surface(s) found during review (now in scope)" list. Same single-file, append-only pattern as the recently merged #7582, #7594, and #7551.

## What this adds (8 new surfaces)

Schema arithmetic (`https://repository.inferencelabs.com/openapi.json`, OpenAPI 3.1, re-fetched 2026-07-22): **11 total paths = 3 collection roots already registered (`/circuits`, `/components`, `/models`) + 8 missing paths** — matching the issue's itemized list exactly.

One fold to note: `/circuits/{id}/metrics` carries two operations — a GET read with no security declared, and a POST submit the schema marks `security: true`. The registry keys one surface per URL, so this lands as one surface tracking the public GET read, with the protected POST write route documented in that surface's `notes` (the same same-URL GET/POST fold used in merged #7582, where six such pairs each folded into one surface).

## Live verification (all 8 individually requested, 2026-07-22 ~06:45 UTC)

**Path-param routes verified with real values from the live collections (4):**
- `GET /components/{sha256}` → HTTP 200 `application/json` with the matching component record (name, proof_system, file listing), using a real digest taken from the live `/components` listing.
- `GET /components/{sha256}/files/{filename}` → HTTP 200 `application/octet-stream`, real file bytes (`circuit.bin`, ~6.7 MB).
- `GET /models/{id}` → HTTP 200 `application/json` with the matching model record (metadata, composition, component slices), using a real id from the live `/models` listing.
- `GET /models/wb/{sha256}` → HTTP 200 `application/octet-stream` streaming the weights artifact (~109 MB; transfer confirmed in progress, cut off locally), using a real artifact digest from a live model record's composition.
- (The real digest/id values deliberately do not appear in this PR or the diff; each is reproducible in one request from the corresponding live collection listing.)

**Path-param circuit routes (4) — no stored records exist to fetch** (`GET /circuits` live-returns `{"circuits":[]}`; the issue notes the same "no real circuit IDs on hand" limitation):
- `GET /circuits/{id}`, `GET /circuits/{id}/download`, `GET /circuits/{id}/metrics`, `GET /circuits/files/{circuitId}/{filename}`: a placeholder path value returns a clean **HTTP 400 `application/json` Zod validation error naming the exact path field** (`id` / `circuitId`) — proving live routing plus input validation on the same host and routing layer that serves the confirmed-live collection roots, and that these reads sit behind no access wall.
- `POST /circuits/{id}/metrics` (the folded write route) observed directly: bare POST → HTTP 503 `{"error":"Metrics submission not configured"}`.

**Original 5 verify-scope surfaces re-confirmed live (2026-07-22):** `sn2-api.inferencelabs.com/stats` → 200 JSON (`total_proofs`/`unique_miners`/`unique_validators`); `/openapi.json` → 200; `/circuits`, `/components`, `/models` → all 200 JSON.

## Schema/tooling notes

- Append-only: **+176/−0**, `surfaces[]` entries only; top-level `notes`/`curation` untouched (the existing "circuit/component/model list endpoints, all tracked" wording stays accurate — the list endpoints remain tracked; this adds the per-entity siblings).
- Path-param URLs use percent-encoded braces (`%7Bid%7D`, `%7Bsha256%7D`, `%7Bfilename%7D`) per the `url` `format:"uri"` schema check.
- `probe.enabled: false` on all 8 per the issue's own instruction (no stable canonical id to auto-probe); `probe.expect: "any"` on the three binary/file streams, `"json"` on the JSON reads.
- `provider: "inference-labs"` — matches the file's existing surfaces and the registered `registry/providers/inference-labs.json`.
- Validation run locally on this branch: `validate:surface` (2317 surfaces / 129 files), full `npm run build` + `npm run validate` (129 subnets, 3019 surfaces, 136 providers, 2037 candidates), `scan:public-safety`, `prettier --check`, and the existing `tests/dsperse-call-subnet-surface-verify.test.mjs` (3/3 passing) — all green. The regenerated `operational-surfaces.json` build artifact is deliberately not committed (single-file PR; the sync workflow regenerates it).
