### PR TITLE
fix(registry): SN3 Templar wire the 6 in-scope public Grafana read surfaces

### DIFF
--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -223,6 +223,138 @@
         "https://github.com/one-covenant/templar"
       ],
       "url": "https://raw.githubusercontent.com/one-covenant/templar/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-grafana-org",
+      "kind": "subnet-api",
+      "name": "Templar Grafana current org",
+      "notes": "Public no-auth GET /api/org on grafana.tplr.ai returning the current organization record. Declared in the already-registered Grafana OpenAPI 3 schema on this host. The instance serves viewer-level reads without sign-in (admin-scoped reads such as /api/admin/settings correctly return HTTP 403), matching the already-tracked no-auth /api/health surface on the same host. Live-verified 2026-07-22: HTTP 200 application/json (org name 'Templar AI').",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://grafana.tplr.ai/public/openapi3.json"],
+      "url": "https://grafana.tplr.ai/api/org"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-grafana-search",
+      "kind": "subnet-api",
+      "name": "Templar Grafana dashboard search",
+      "notes": "Public no-auth GET /api/search on grafana.tplr.ai returning the dashboard/folder search listing (includes the Crusades folder and the eval-metrics dashboard already tracked as a dashboard surface). Declared in the already-registered Grafana OpenAPI 3 schema on this host. The instance serves viewer-level reads without sign-in (admin-scoped reads such as /api/admin/settings correctly return HTTP 403), matching the already-tracked no-auth /api/health surface on the same host. Live-verified 2026-07-22: HTTP 200 application/json array of dashboard/folder entries.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://grafana.tplr.ai/public/openapi3.json"],
+      "url": "https://grafana.tplr.ai/api/search"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-grafana-datasources",
+      "kind": "subnet-api",
+      "name": "Templar Grafana datasource list",
+      "notes": "Public no-auth GET /api/datasources on grafana.tplr.ai returning the configured datasource list (names/types, e.g. InfluxDB). Declared in the already-registered Grafana OpenAPI 3 schema on this host. The instance serves viewer-level reads without sign-in (admin-scoped reads such as /api/admin/settings correctly return HTTP 403), matching the already-tracked no-auth /api/health surface on the same host. Live-verified 2026-07-22: HTTP 200 application/json array of datasource records.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://grafana.tplr.ai/public/openapi3.json"],
+      "url": "https://grafana.tplr.ai/api/datasources"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-grafana-plugins",
+      "kind": "subnet-api",
+      "name": "Templar Grafana plugin list",
+      "notes": "Public no-auth GET /api/plugins on grafana.tplr.ai returning the installed plugin list. Declared in the already-registered Grafana OpenAPI 3 schema on this host. The instance serves viewer-level reads without sign-in (admin-scoped reads such as /api/admin/settings correctly return HTTP 403), matching the already-tracked no-auth /api/health surface on the same host. Live-verified 2026-07-22: HTTP 200 application/json array of plugin records.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://grafana.tplr.ai/public/openapi3.json"],
+      "url": "https://grafana.tplr.ai/api/plugins"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-grafana-frontend-settings",
+      "kind": "subnet-api",
+      "name": "Templar Grafana frontend settings",
+      "notes": "Public no-auth GET /api/frontend/settings on grafana.tplr.ai returning the frontend bootstrap configuration (default datasource, feature flags, panel metadata). Declared in the already-registered Grafana OpenAPI 3 schema on this host. The instance serves viewer-level reads without sign-in (admin-scoped reads such as /api/admin/settings correctly return HTTP 403), matching the already-tracked no-auth /api/health surface on the same host. Live-verified 2026-07-22: HTTP 200 application/json.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://grafana.tplr.ai/public/openapi3.json"],
+      "url": "https://grafana.tplr.ai/api/frontend/settings"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-3-templar-grafana-dashboard-by-uid",
+      "kind": "subnet-api",
+      "name": "Templar Grafana eval-metrics dashboard model",
+      "notes": "Public no-auth GET returning the JSON model of the eval-metrics dashboard (uid taken from the already-registered sn-3-templar-grafana dashboard surface's URL on this host), the same dashboard that doubles as the Crusades tournament leaderboard. Declared in the already-registered Grafana OpenAPI 3 schema (path /api/dashboards/uid/{uid}). The instance serves viewer-level reads without sign-in (admin-scoped reads such as /api/admin/settings correctly return HTTP 403), matching the already-tracked no-auth /api/health surface on the same host. Live-verified 2026-07-22: HTTP 200 application/json with the dashboard model and read-only meta flags. probe.enabled:false per the issue's instruction, matching the registry's path-param-lookup convention even though this uid is fixed and known.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://grafana.tplr.ai/public/openapi3.json"],
+      "url": "https://grafana.tplr.ai/api/dashboards/uid/ceia6bwlwn8qof"
     }
   ],
   "website_url": "https://www.tplr.ai/"


### PR DESCRIPTION
## Summary

Closes #7019

Registers the 6 in-scope public Grafana read endpoints for SN3 (Templar) in `registry/subnets/templar.json`, completing the issue's "Additional surface(s) found during review (now in scope)" list. Same single-file, append-only pattern as the recently merged #7582, #7594, and #7551.

## Scope (exactly the issue's 6 itemized endpoints)

The issue's in-scope instruction is explicit: "register at minimum the 6 confirmed-live endpoints above with `auth_required: false` (`probe.enabled: true` for org/search/datasources/plugins/frontend-settings; `probe.enabled: false` for the dashboard-by-uid lookup)" — and it explicitly declines exhaustive enumeration of the remaining ~200 paths ("Given the schema has 208 total paths and this is a generic third-party monitoring tool's API rather than Templar-specific business logic, not enumerating exhaustively"). This PR registers exactly those 6, with exactly that prescribed config. No wider sweep of the generic Grafana surface is claimed or attempted, per the issue's own scoping.

## What this adds (6 new surfaces)

- `sn-3-templar-grafana-org` — `GET /api/org` (probe enabled)
- `sn-3-templar-grafana-search` — `GET /api/search` (probe enabled)
- `sn-3-templar-grafana-datasources` — `GET /api/datasources` (probe enabled)
- `sn-3-templar-grafana-plugins` — `GET /api/plugins` (probe enabled)
- `sn-3-templar-grafana-frontend-settings` — `GET /api/frontend/settings` (probe enabled)
- `sn-3-templar-grafana-dashboard-by-uid` — `GET /api/dashboards/uid/ceia6bwlwn8qof` (probe disabled per the issue's instruction, matching the registry's path-param-lookup convention; the uid is the one already embedded in the registered `sn-3-templar-grafana` dashboard surface's URL, so no new identifier is introduced)

## Live verification (all 6 individually requested, 2026-07-22 ~06:50 UTC)

- `GET /api/org` → HTTP 200 `application/json` (org record, name "Templar AI")
- `GET /api/search` → HTTP 200 JSON array (includes the Crusades folder and the already-tracked eval-metrics dashboard)
- `GET /api/datasources` → HTTP 200 JSON array (InfluxDB et al.)
- `GET /api/plugins` → HTTP 200 JSON array (installed plugin records)
- `GET /api/frontend/settings` → HTTP 200 JSON (default datasource, feature flags)
- `GET /api/dashboards/uid/ceia6bwlwn8qof` → HTTP 200 JSON dashboard model with read-only meta flags (`canSave`/`canEdit`/`canAdmin` all false)
- Boundary check, matching the issue's own observation: `GET /api/admin/settings` → HTTP 403 — confirming the instance serves viewer-level reads only, not admin scope.
- Original 2 verify-scope surfaces re-confirmed live: `GET /api/health` → 200 (`database: ok`); `GET /public/openapi3.json` → 200 (the registered schema).

## Schema/tooling notes

- Append-only: **+132/−0**, `surfaces[]` entries only; top-level `notes`/`curation`/`gap_notes` untouched.
- `auth_required: false` on all 6, exactly as the issue prescribes; `probe.expect: "json"`, `method: GET`, 10s timeout, matching the sibling `sn-3-templar-health` surface's shape.
- `provider: "one-covenant"` — matches every existing surface in the file and the registered `registry/providers/one-covenant.json`.
- `source_urls` point at the already-registered Grafana OpenAPI 3 schema on the same host.
- Validation run locally on this branch: `validate:surface` (2315 surfaces / 129 files), full `npm run build` + `npm run validate` (129 subnets, 3017 surfaces, 136 providers, 2037 candidates), `scan:public-safety`, `prettier --check`, and the existing `tests/templar-call-subnet-surface-verify.test.mjs` (3/3 passing) — all green. The regenerated `operational-surfaces.json` build artifact is deliberately not committed (single-file PR; the sync workflow regenerates it).
