### PR TITLE
fix(registry): SN127 Astrid full API parity (1 missing surface)

### DIFF
--- a/registry/subnets/astrid.json
+++ b/registry/subnets/astrid.json
@@ -134,6 +134,30 @@
       "public_safe": true,
       "source_urls": ["https://github.com/astridintelligence/sn-127"],
       "url": "https://github.com/astridintelligence/sn-127"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-127-astrid-execution-presence",
+      "kind": "subnet-api",
+      "name": "Astrid Arena execution presence",
+      "notes": "Public no-auth GET returning execution presence records (participantId plus executionTime, with total/limit/offset pagination fields) for an SN127 Astrid Arena competition, per the official validator client (src/core/arena/api.ts, fetchExecutionPresence) — a plain fetch like the sibling completed-competitions call. Requires a participantIds query parameter (comma-joined list; optional limit/offset/after for pagination) in addition to the competitionId path parameter. Live-verified 2026-07-22: without the query parameter the route returns HTTP 400 JSON naming participantIds as required (confirms live validation, not auth); with participant ids taken from the completed-competitions surface already in this manifest it returns HTTP 200 JSON presence records. probe.enabled:false since the probe pipeline has no per-surface injection for the required query parameter.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "astrid",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": [
+        "https://github.com/astridintelligence/sn-127/blob/master/src/core/arena/api.ts"
+      ],
+      "url": "https://arena-api.astrid.global/public/competitions/%7BcompetitionId%7D/executions/presence"
     }
   ],
   "source_repo": "https://github.com/astridintelligence/sn-127",


### PR DESCRIPTION
## Summary

Closes #7135

Registers the single "Additional surface(s) found during review (now in scope)" endpoint for SN127 (Astrid) in `registry/subnets/astrid.json`: the Astrid Arena execution-presence route. Same single-file, append-only pattern as the recently merged #7582, #7594, and #7603.

## Scope (exactly the issue's 1 itemized endpoint)

The issue's additional-scope section itemizes exactly one route — `GET /public/competitions/{competitionId}/executions/presence` — and prescribes the registration shape outright: "register with the `{competitionId}` template, `probe.enabled:false`, noting the required `participantIds` query param in the surface notes." This PR does exactly that, nothing wider. Arithmetic: the official validator client (`src/core/arena/api.ts`, the file the issue and the manifest both cite) documents three Arena data routes; two are already registered (completed-competitions as the subnet-api surface, wallet-activity as the data-artifact surface); this adds the one missing = 1 new surface, full parity with the documented client surface.

## What this adds (1 new surface)

- `sn-127-astrid-execution-presence` — `GET /public/competitions/%7BcompetitionId%7D/executions/presence` (subnet-api, `auth_required: false`, probe disabled per the issue's instruction; the required `participantIds` query parameter is documented in the surface notes exactly as the issue prescribes)

## Live verification (2026-07-22 ~07:41 UTC)

The issue left this route "Not spot-verified live" because it needs real participant ids; this PR closes that gap — every claim below traces back to a request actually made:

- `GET /public/competitions/{competitionId}/executions/presence` with a real competitionId (the one already embedded in the registered wallet-activity surface's URL — no new identifier introduced) and **no query parameters** → HTTP 400 `application/json`: "participantIds query parameter is required" — a clean validation error confirming live validation, not auth, exactly matching the issue's description of the route.
- Same URL with `participantIds` set to real participant ids taken from the public completed-competitions response (comma-joined, two ids, plus `limit=2`) → HTTP 200 `application/json`: `executions` records (each carrying `participantId` and `executionTime`) plus `total`/`limit`/`offset` pagination fields — matching the client's `fetchExecutionPresence` exactly. The real id values are deliberately not reproduced here or in the diff.
- Original 1 verify-scope surface re-confirmed live the same session: `GET /public/arena/completed-competitions` → HTTP 200 JSON (this surface is already pinned end-to-end by the merged #7270/#7436 verify tests, which still pass on this branch).

## Schema/tooling notes

- Append-only: **+24/−0**, one `surfaces[]` entry only; top-level `notes`/`curation`/`gap_notes` untouched (maintainer-owned). One prose flag for the maintainer rather than an edit: `curation.gap_notes` currently carries the old-policy line that this route "requires a participantIds query parameter and is not promotable" — the linked issue's own additional-scope section supersedes that conclusion ("Under the current policy this is exactly the callable-today case the tool's `query` argument exists for"), so that line is left for maintainer discretion per the append-only convention.
- Percent-encoded braces in the URL template (`%7BcompetitionId%7D`) per the `url` `format:"uri"` schema requirement, matching the registry's path-param convention.
- `probe.enabled:false` (the route requires a query parameter the probe pipeline cannot inject), `expect:"json"`, `method:"GET"`, 10s timeout — the same disabled-probe shape as the merged required-query surfaces in #7582.
- `provider: "astrid"` — matches every existing surface in the file and the registered `registry/providers/astrid.json`.
- `source_urls` point at the official validator client file the issue itself cites.
- Validation run locally on this branch: `validate:surface` (2316 surfaces / 129 files), full `npm run build` + `npm run validate` (129 subnets, 3018 surfaces, 136 providers, 2037 candidates), `scan:public-safety`, `prettier --check`, and the existing `tests/astrid-call-subnet-surface-verify.test.mjs` (15/15 passing) — all green. The regenerated `operational-surfaces.json` build artifact is deliberately not committed (single-file PR; the sync workflow regenerates it).
