### PR TITLE
fix(registry): SN112 minotaur app-management read surfaces (4 missing)

### DIFF
--- a/registry/subnets/minotaur.json
+++ b/registry/subnets/minotaur.json
@@ -184,6 +184,110 @@
         "https://github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md"
       ],
       "url": "https://api.minotaursubnet.com/v1/apps/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-112-minotaur-app-status",
+      "kind": "subnet-api",
+      "name": "minotaur app deployment status",
+      "notes": "GET /v1/apps/{app_id}/status -- per-app + per-chain deployment status (the deploy-poll target), listed in the official app-management doc's Reads table. Live-verified 2026-07-22 (~08:25 UTC) with a real app_id taken from the already-registered /v1/apps/ list: HTTP 200 JSON returning the app record + status, no credential required. Path-parameterized (percent-encoded template), so probe.enabled:false per the linked issue's own instruction.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": [
+        "https://raw.githubusercontent.com/subnet112/minotaur_subnet/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/%7Bapp_id%7D/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-112-minotaur-app-auth-nonce",
+      "kind": "subnet-api",
+      "name": "minotaur app auth-nonce read",
+      "notes": "GET /v1/apps/{app_id}/auth-nonce (optional deployer query param) -- issues the next single-use nonce used to sign app-management writes; necessarily callable without a credential, per the official doc and the linked issue. Live-verified 2026-07-22 (~08:25 UTC) with a real app_id: HTTP 200 JSON {app_id, deployer, next_nonce} both bare (defaults to the app's registered deployer) and with an explicit placeholder deployer query value. Path-parameterized, probe.enabled:false per the linked issue's instruction.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": [
+        "https://raw.githubusercontent.com/subnet112/minotaur_subnet/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/%7Bapp_id%7D/auth-nonce"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Grouped under the signature-gated App-management auth class in the official app-management API doc's auth-model table (a publicly documented scheme, verifiable without holding any credential); live-verified rejected unauthenticated (HTTP 403) 2026-07-22 (~08:25 UTC)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-112-minotaur-app-admin-state",
+      "kind": "subnet-api",
+      "name": "minotaur app operator state (auth-gated)",
+      "notes": "GET /v1/apps/{app_id}/admin-state -- full operator view (store record, live per-chain config, fee-settlement balances, registry status), listed in the official doc's Reads table under its signature-gated App-management auth class. Live-verified 2026-07-22 (~08:25 UTC) with a real app_id: HTTP 403 JSON rejected unauthenticated -- auth-gated in practice, exactly as the linked issue's own live test found. Registered auth_required:true, probe.enabled:false per the issue's instruction.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": [
+        "https://raw.githubusercontent.com/subnet112/minotaur_subnet/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/%7Bapp_id%7D/admin-state"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Grouped under the signature-gated App-management auth class in the official app-management API doc's auth-model table (a publicly documented scheme, verifiable without holding any credential); live-verified rejected unauthenticated (HTTP 403) 2026-07-22 (~08:25 UTC)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-112-minotaur-app-registry-calldata",
+      "kind": "subnet-api",
+      "name": "minotaur app registry calldata (auth-gated)",
+      "notes": "GET /v1/apps/{app_id}/deployments/{chain_id}/registry-calldata -- prepared transaction calldata for external signing, documented in the same signature-gated auth class as admin-state (deadline-bound reads). Live-verified 2026-07-22 (~08:25 UTC) with a real app_id and a real chain_id from the already-registered /v1/chains surface: HTTP 403 JSON rejected unauthenticated (stronger than the linked issue's own evidence, which did not spot-verify this route). Registered auth_required:true, probe.enabled:false per the issue's instruction.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": [
+        "https://raw.githubusercontent.com/subnet112/minotaur_subnet/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/%7Bapp_id%7D/deployments/%7Bchain_id%7D/registry-calldata"
     }
   ],
   "source_repo": "https://github.com/subnet112/minotaur_subnet",


### PR DESCRIPTION
## Summary

Closes #7123

Registers the 4 app-management read routes from the issue's "Additional surface(s) found during review (now in scope)" section — same pattern as #7582 (SN69), #7594 (SN120), #7603 (SN3), and #7605 (SN127): single-file, append-only edit to `registry/subnets/minotaur.json`, every claim traced to a live request made today.

## Scope

Exactly the issue's itemized 4 routes (the official app-management doc's Reads table beyond the already-registered `/v1/apps/` and `/v1/chains`), registered with exactly the config the issue prescribes for each (`{app_id}` templates, `probe.enabled:false`, per-route `auth_required`):

1. `GET /v1/apps/{app_id}/status` — `auth_required:false`
2. `GET /v1/apps/{app_id}/auth-nonce` (optional `deployer` query param) — `auth_required:false`
3. `GET /v1/apps/{app_id}/admin-state` — `auth_required:true`
4. `GET /v1/apps/{app_id}/deployments/{chain_id}/registry-calldata` — `auth_required:true`

## Live verification (2026-07-22, ~08:24-08:27 UTC)

All checks used a **real `app_id` returned by the already-registered `/v1/apps/` list** (real identifier values kept out of the diff and this body; templates only):

- **Original scope re-verified**: `/health` → HTTP 200 JSON (`status: ok`, service + benchmark fields); `/v1/apps/` → HTTP 200 JSON app list; `/v1/chains` → HTTP 200 JSON chain list.
- **status** → HTTP 200 JSON returning the app record + status, no credential required — matches the issue's finding.
- **auth-nonce** → HTTP 200 JSON `{app_id, deployer, next_nonce}`, verified both bare (defaults to the app's registered deployer) and with an explicit placeholder `deployer` query value — slightly stronger than the issue's single check.
- **admin-state** → HTTP 403 rejected unauthenticated — confirms the issue's key correction (auth-gated in practice despite the doc grouping it under "Reads").
- **registry-calldata** → HTTP 403 rejected unauthenticated, using a real `chain_id` from the already-registered `/v1/chains` surface — **stronger than the issue's own evidence** (the issue could not spot-verify this route); its documented auth class is confirmed enforced live.

## Note on the existing `gap_notes`

The issue itself observes the manifest's existing gap_note ("genuinely public reads... status, admin-state, auth-nonce") is now only 2/3 accurate — `admin-state` is auth-gated in practice. Per the append-only convention for community surface PRs, top-level `notes`/`curation.gap_notes` are deliberately left untouched; the issue body's own live test supersedes that note, and this PR registers `admin-state` with the verified `auth_required:true` config rather than the note's older "public" characterization. Flagged here in prose only.

## Schema/tooling notes

- Append-only: `+104/−0`, `surfaces[]` only; no top-level metadata touched.
- Path-parameterized URLs use percent-encoded braces (`%7B...%7D`) per the `format:"uri"` schema check; templates only, no real values.
- `auth` objects are minimal `{scheme, scopes_note}` (no credential formats or literals), matching the shape merged in #7582; the auth class is publicly documented in the official app-management doc's auth-model table, verifiable without holding any credential.
- `provider: "minotaur"` matches the file's existing surfaces and `registry/providers/minotaur.json`.
- `source_urls` point at the official app-management doc the issue cites (verified live, HTTP 200).
- The regenerated `public/metagraph/operational-surfaces.json` build artifact is deliberately reverted (CI regenerates it).

## Validation

- `npm run validate:surface` — 2320 surfaces / 129 subnet files, passing
- full `npm run build` + `npm run validate` — 129 subnets, 3022 surfaces, 136 providers, passing
- `node scripts/scan-public-safety.mjs` — passing
- `npx prettier --check registry/subnets/minotaur.json` — clean
- `npx vitest run tests/minotaur-call-subnet-surface-verify.test.mjs tests/sn112-call-subnet-surface-verify.test.mjs` — 27/27 passing
