### PR TITLE
fix(registry): SN112 Minotaur wire 4 in-scope app-management API surfaces

### DIFF
--- a/registry/subnets/minotaur.json
+++ b/registry/subnets/minotaur.json
@@ -116,9 +116,7 @@
       },
       "provider": "minotaur",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/subnet112/minotaur_subnet"
-      ],
+      "source_urls": ["https://github.com/subnet112/minotaur_subnet"],
       "url": "https://minotaursubnet.com/"
     },
     {
@@ -136,9 +134,7 @@
       },
       "provider": "minotaur",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/subnet112/minotaur_subnet"
-      ],
+      "source_urls": ["https://github.com/subnet112/minotaur_subnet"],
       "url": "https://github.com/subnet112/minotaur_subnet"
     },
     {

--- a/registry/subnets/minotaur.json
+++ b/registry/subnets/minotaur.json
@@ -82,7 +82,7 @@
       "id": "sn-112-minotaur-app-dashboard",
       "kind": "dashboard",
       "name": "Minotaur App dashboard",
-      "notes": "Public no-auth Minotaur App web dashboard for SN112 (intent signing + quorum settlement), served on the official minotaursubnet.com domain (same host as the registered api.minotaursubnet.com health surface) and linked from the official docs at docs.minotaursubnet.com. Document title 'Minotaur App — Sign intents. Settle through quorum.'; wallet actions require signing but the dashboard itself loads without auth (verified HTTP 200).",
+      "notes": "Public no-auth Minotaur App web dashboard for SN112 (intent signing + quorum settlement), served on the official minotaursubnet.com domain (same host as the registered api.minotaursubnet.com health surface) and linked from the official docs at docs.minotaursubnet.com. Document title 'Minotaur App \u2014 Sign intents. Settle through quorum.'; wallet actions require signing but the dashboard itself loads without auth (verified HTTP 200).",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -116,7 +116,9 @@
       },
       "provider": "minotaur",
       "public_safe": true,
-      "source_urls": ["https://github.com/subnet112/minotaur_subnet"],
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet"
+      ],
       "url": "https://minotaursubnet.com/"
     },
     {
@@ -134,7 +136,9 @@
       },
       "provider": "minotaur",
       "public_safe": true,
-      "source_urls": ["https://github.com/subnet112/minotaur_subnet"],
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet"
+      ],
       "url": "https://github.com/subnet112/minotaur_subnet"
     },
     {
@@ -184,6 +188,110 @@
         "https://github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md"
       ],
       "url": "https://api.minotaursubnet.com/v1/apps/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-112-minotaur-app-status",
+      "kind": "subnet-api",
+      "name": "Minotaur app deployment status",
+      "notes": "GET /v1/apps/{app_id}/status on api.minotaursubnet.com \u2014 per-app + per-chain deployment status (the deploy-poll target). Path-parameterized on {app_id}; no auth required despite the doc grouping reads under the app-management auth class. Live-verified 2026-07-22: GET /v1/apps/app_0867cdd4effd/status \u2192 HTTP 200 JSON (app record with status field). Register with {app_id} template, auth_required:false, probe.enabled:false (path-param).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/%7Bapp_id%7D/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-112-minotaur-app-auth-nonce",
+      "kind": "subnet-api",
+      "name": "Minotaur app wallet-auth nonce",
+      "notes": "GET /v1/apps/{app_id}/auth-nonce on api.minotaursubnet.com \u2014 issues the next single-use nonce for signing wallet-auth writes; necessarily unauthenticated (pre-auth bootstrap step). Accepts optional deployer query param. Live-verified 2026-07-22: GET /v1/apps/app_0867cdd4effd/auth-nonce?deployer=0x...dEaD \u2192 HTTP 200 JSON {\"app_id\":\"...\",\"deployer\":\"...\",\"next_nonce\":1}. probe.enabled:false (path-param URL; also requires deployer query param for meaningful data).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/%7Bapp_id%7D/auth-nonce"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Documented as requiring an admin key or wallet signature (wallet-auth class). Live-verified 2026-07-22: unauthenticated GET \u2192 HTTP 403 {\"detail\":\"Unauthorized: admin key or wallet signature required\"}. No static bearer token; credential format is a signed request per the app-management auth scheme documented in the official API doc."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-112-minotaur-app-admin-state",
+      "kind": "subnet-api",
+      "name": "Minotaur app admin/operator state (auth-gated)",
+      "notes": "GET /v1/apps/{app_id}/admin-state on api.minotaursubnet.com \u2014 full operator view (store record, live per-chain config, fee-settlement balances, AppRegistry status). Requires admin key or wallet signature (wallet-auth class). Live-verified 2026-07-22: unauthenticated GET /v1/apps/app_0867cdd4effd/admin-state \u2192 HTTP 403 {\"detail\":\"Unauthorized: admin key or wallet signature required\"}. probe.enabled:false.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/%7Bapp_id%7D/admin-state"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Same wallet-auth class as admin-state \u2014 admin key or wallet signature required. Live-verified 2026-07-22: unauthenticated GET \u2192 HTTP 403 (same auth gate). No static bearer token; credential format is a signed request per the app-management auth scheme documented in the official API doc."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-112-minotaur-app-registry-calldata",
+      "kind": "subnet-api",
+      "name": "Minotaur app on-chain registry calldata (auth-gated)",
+      "notes": "GET /v1/apps/{app_id}/deployments/{chain_id}/registry-calldata on api.minotaursubnet.com \u2014 prepared registerApp/revokeApp calldata for external signing, deadline-bound. Requires admin key or wallet signature (same wallet-auth class as admin-state). Live-verified 2026-07-22: unauthenticated GET \u2192 HTTP 403 (same auth gate). Not spot-verified with valid credentials; registered per the official API doc and confirmed live at the route level. probe.enabled:false (path-param on both {app_id} and {chain_id}).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/%7Bapp_id%7D/deployments/%7Bchain_id%7D/registry-calldata"
     }
   ],
   "source_repo": "https://github.com/subnet112/minotaur_subnet",


### PR DESCRIPTION
## Summary

Registers the 4 in-scope app-management API surfaces for SN112 (Minotaur) in `registry/subnets/minotaur.json`, completing the issue's "Additional surface(s) found during review (now in scope)" list. Same single-file, append-only pattern as the recently merged #7603 and #7605.

## Scope (exactly the issue's 4 itemized routes)

The issue diffed `docs/api/app-management.md` against the 7 registered surfaces and found 4 path-parameterized routes not yet registered. This PR adds exactly those 4, with exactly the auth and probe config the issue prescribes.

## What this adds (4 new surfaces)

- `sn-112-minotaur-app-status` — `GET /v1/apps/%7Bapp_id%7D/status` (subnet-api, `auth_required:false`, probe disabled; path-param)
- `sn-112-minotaur-app-auth-nonce` — `GET /v1/apps/%7Bapp_id%7D/auth-nonce` (subnet-api, `auth_required:false`, probe disabled; accepts `deployer` query param)
- `sn-112-minotaur-app-admin-state` — `GET /v1/apps/%7Bapp_id%7D/admin-state` (subnet-api, `auth_required:true`, custom wallet-auth scheme, probe disabled)
- `sn-112-minotaur-app-registry-calldata` — `GET /v1/apps/%7Bapp_id%7D/deployments/%7Bchain_id%7D/registry-calldata` (subnet-api, `auth_required:true`, custom wallet-auth scheme, probe disabled)

## Live verification (2026-07-22 ~13:00 UTC)

All 4 routes individually requested against `app_0867cdd4effd` (obtained from the already-registered `sn-112-minotaur-apps-list` surface, `GET /v1/apps/`):

- `GET /v1/apps/app_0867cdd4effd/status` → **HTTP 200** `application/json` (app record with status field — no auth required, confirming the issue's finding that this route's auth model differs from what the doc implies)
- `GET /v1/apps/app_0867cdd4effd/auth-nonce?deployer=0x...dEaD` → **HTTP 200** `{"app_id":"app_0867cdd4effd","deployer":"0x...dEaD","next_nonce":1}` (no auth required — pre-auth bootstrap step)
- `GET /v1/apps/app_0867cdd4effd/admin-state` → **HTTP 403** `{"detail":"Unauthorized: admin key or wallet signature required"}` (auth-gated, custom wallet-auth class)
- `GET /v1/apps/app_0867cdd4effd/deployments/1/registry-calldata` → **HTTP 403** (same auth gate — route live, credentials not held)

Results match the issue's own live-test observations exactly.

## Schema/tooling notes

- Append-only: **+4 surfaces, +111 lines**; top-level `notes`/`curation`/`gap_notes` untouched (maintainer-owned).
- Source URL: `github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md` — same doc already cited by the existing `sn-112-minotaur-chains` and `sn-112-minotaur-apps-list` surfaces.

## Validation

```
npm run validate:surface -- registry/subnets/minotaur.json
# Surface validation passed: 11 surface(s) across 1 subnet file(s).

npm run scan:public-safety
# Public-safety scan passed.
```

Closes #7123