### PR TITLE
feat(registry): enrich SN7 Allways — add public data artifact (llms.txt)

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -950,6 +950,28 @@
       },
       "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/treasury/churn"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-7-allways-data-artifact",
+      "kind": "data-artifact",
+      "name": "Allways llms.txt agent quickstart",
+      "notes": "Public no-auth machine-readable llms.txt served at all-ways.io/llms.txt for SN7 Allways -- an agent/LLM-facing Markdown quickstart for the subnet's on-chain orderbook for native cross-asset swaps, with a resource table pointing at the live dashboard, the HTTP API + Swagger already registered here, the docs site, and the source repo; content begins '# Allways -- Agent Quickstart'. Distinct path from the registered website surface on the same host; the file self-references https://all-ways.io/llms.txt as its canonical raw location and notes a testnet mirror at test.all-ways.io/llms.txt.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "tryeverything24"
+      },
+      "source_urls": ["https://all-ways.io/"],
+      "url": "https://all-ways.io/llms.txt"
     }
   ],
   "website_url": "https://all-ways.io/"


### PR DESCRIPTION
## Summary

Closes #7609

Adds the one surface kind the live enrichment queue lists as missing for SN7 (`missing_kinds: ["data-artifact"]` per `GET https://api.metagraph.sh/api/v1/review/enrichment-targets`): the subnet's official public `llms.txt` agent quickstart. Registered exactly as the issue's own `surface:add` command writes it (`authority: "community"`, `review.state: "community-submitted"`), plus the descriptive `name`/`notes`/`probe` block in the same shape as the two llms.txt data-artifact entries already in the registry (`sn-95-actual-llms-txt`, `sn-121-sundae-bar-llms-txt`).

## What this adds (1 new surface)

- `sn-7-allways-data-artifact` — kind `data-artifact`, `https://all-ways.io/llms.txt`, provider `allways` (registered), `auth_required: false`, `public_safe: true`, probe `GET` / expect `any` / 10000 ms.

## Live verification (2026-07-22 ~11:03 UTC)

- `GET https://all-ways.io/llms.txt` → HTTP 200, `content-type: text/plain`, 22,027 bytes, 306 lines; content begins `# Allways — Agent Quickstart`.
- Ownership proof: the file is served from the same host as the subnet's registered official website surface, and the document's own resource table lists `https://all-ways.io/llms.txt` as its canonical raw location (testnet mirror at `test.all-ways.io/llms.txt`). It cross-links the already-registered mainnet Swagger, docs site, and source repo.
- The URL is distinct from every URL already registered in `registry/subnets/allways.json` (a URL maps to one kind; the earlier same-URL data-artifact duplicate was removed by the #6472 dedupe, and the live queue still lists `data-artifact` as SN7's one missing kind).

## Schema/tooling notes

- Generated with the issue's own command: `npm run surface:add -- --netuid 7 --kind data-artifact --url https://all-ways.io/llms.txt --source-url https://all-ways.io/ --provider allways --submitted-by tryeverything24 --write`.
- Append-only, one file: +22/−0 on `registry/subnets/allways.json`; no generated artifacts included; top-level `notes`/`curation`/`gap_notes` untouched.
- Local gates all green: `npm run build` + `npm run validate` (129 subnets / 129 overlays / 3019 surfaces / 136 providers OK), `node scripts/scan-public-safety.mjs` passed, `npx prettier --check` on the changed file passed; generated `dist/metagraph-r2/metagraph/surfaces.json` measures 3,989,047 bytes, under the 4,000,000-byte artifact budget.
