### PR TITLE
feat(registry): add SN7 Allways minimum-compute data-artifact

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -950,6 +950,24 @@
       },
       "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/treasury/churn"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-7-allways-data-artifact",
+      "kind": "data-artifact",
+      "name": "Allways minimum compute requirements",
+      "notes": "Public no-auth min_compute.yml committed at the root of Allways' official SN7 source repository (entrius/allways, the registered SN7 source-repo) — the machine-readable minimum hardware specification (CPU cores/speed, RAM, storage, OS, Python version, GPU requirement) for running an Allways miner or validator. Live-verified 2026-07-22: HTTP 200, YAML.",
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "philluiz2323"
+      },
+      "source_urls": [
+        "https://github.com/entrius/allways/blob/0f30f597642f573b37953799a616cb04de5cba7a/min_compute.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/entrius/allways/0f30f597642f573b37953799a616cb04de5cba7a/min_compute.yml"
     }
   ],
   "website_url": "https://all-ways.io/"


### PR DESCRIPTION
## Summary

Adds the public data-artifact SN7 (Allways) was missing (#7609): the subnet's **`min_compute.yml`** — the machine-readable minimum hardware specification (CPU cores/speed, RAM, storage, OS, Python version, GPU requirement) for running an Allways miner or validator.

- **url:** `https://raw.githubusercontent.com/entrius/allways/0f30f597642f573b37953799a616cb04de5cba7a/min_compute.yml`
- **source_url:** the same file in the subnet's **official registered source repo** (`entrius/allways`, already SN7's `source-repo` surface), pinned to an immutable commit SHA.

**Live-verified 2026-07-22:** HTTP 200, YAML, no auth. The same standard `min_compute.yml` data-artifact already registered for other subnets (e.g. SN43 Graphite, SN87 Luminar).

## Scope

One file, append-only: `registry/subnets/allways.json` — a single `data-artifact` surface with `authority: community`, `review.state: community-submitted`, `public_safe: true`, `auth_required: false`. Validated with `npm run validate:surface` + `npm run scan:public-safety` (both pass).

Closes #7609