### PR TITLE
fix(registry): SN51 lium.io wire 5 live-verified API surfaces (#7064)

### DIFF
--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -323,6 +323,128 @@
       "public_safe": true,
       "source_urls": ["https://lium.io/api/openapi.json"],
       "url": "https://lium.io/api/watchtower/digest"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-executors",
+      "kind": "data-artifact",
+      "name": "Lium available executors",
+      "notes": "Lium available executors on the Lium Backend API (GET /executors), declared in the subnet's own OpenAPI spec at https://lium.io/api/openapi.json. Live-verified 2026-07-22: HTTP 200 application/json listing available executors with machine name and per-GPU pricing. Public, no-auth and fixed-URL, so its probe is enabled and it is callable through call_subnet_surface today.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://lium.io/api/openapi.json"],
+      "url": "https://lium.io/api/executors"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (a bearer scheme declared per-operation). Only the scheme and location are asserted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-51-lium-pods",
+      "kind": "subnet-api",
+      "name": "Lium pods collection",
+      "notes": "Lium pods collection on the Lium Backend API (GET /pods), declared in the subnet's own OpenAPI spec at https://lium.io/api/openapi.json. Live-verified 2026-07-22: HTTP 401 to an unauthenticated request, confirming the declared gate is real. Registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://lium.io/api/openapi.json"],
+      "url": "https://lium.io/api/pods"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-root",
+      "kind": "subnet-api",
+      "name": "Lium API service root",
+      "notes": "Lium API service root on the Lium Backend API (GET /), declared in the subnet's own OpenAPI spec at https://lium.io/api/openapi.json. Live-verified 2026-07-22: HTTP 200 application/json service banner (\"Hello world\"). Public, no-auth and fixed-URL, so its probe is enabled and it is callable through call_subnet_surface today.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://lium.io/api/openapi.json"],
+      "url": "https://lium.io/api/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-templates",
+      "kind": "data-artifact",
+      "name": "Lium pod templates",
+      "notes": "Lium pod templates on the Lium Backend API (GET, POST /templates), declared in the subnet's own OpenAPI spec at https://lium.io/api/openapi.json. Live-verified 2026-07-22: HTTP 200 application/json listing published pod templates (id, name, description). Public, no-auth and fixed-URL, so its probe is enabled and it is callable through call_subnet_surface today.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://lium.io/api/openapi.json"],
+      "url": "https://lium.io/api/templates"
+    },
+    {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (a bearer scheme declared per-operation). Only the scheme and location are asserted."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-51-lium-users-search",
+      "kind": "subnet-api",
+      "name": "Lium user search",
+      "notes": "Lium user search on the Lium Backend API (GET /users/search), declared in the subnet's own OpenAPI spec at https://lium.io/api/openapi.json. Live-verified 2026-07-22: HTTP 401 to an unauthenticated request, confirming the declared gate is real. Registered auth_required:true with probe.enabled:false (Phase 3).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "joaovictor91123"
+      },
+      "source_urls": ["https://lium.io/api/openapi.json"],
+      "url": "https://lium.io/api/users/search"
     }
   ],
   "source_repo": "https://github.com/Datura-ai/lium-io"


### PR DESCRIPTION
## Summary

Closes #7064.

Registers the **5 SN51 Lium Backend API surfaces I could directly verify** against the live host.

> **Replaces #7636** (closed), which added all 139 missing spec paths. That version broke two repo-wide artifact budgets — `endpoints.json 5093580 >= 5000000` and `surfaces.json 4177219 >= 4000000` — while every other open registry PR passed the same check, so the size was mine to fix. Its diff also carried upstream path segments that the registry review read as credential material. This scope resolves both.

## Every entry is live-verified (2026-07-22)

**3 public, no-auth, fixed-URL — probes enabled, callable through `call_subnet_surface` today:**

| request | result |
|---|---|
| `GET https://lium.io/api/` | **200** `application/json` — service banner |
| `GET https://lium.io/api/templates` | **200** `application/json` — published pod templates (id, name, description) |
| `GET https://lium.io/api/executors` | **200** `application/json` — available executors with machine names and per-GPU pricing |

**2 gated — confirming the spec's bearer scheme is real, not schema-only:**

| request | result |
|---|---|
| `GET https://lium.io/api/users/search` | **401** |
| `GET https://lium.io/api/pods` | **401** |

Both registered `auth_required: true`, `probe.enabled: false` (Phase 3), with an `auth{}` object recording **scheme + location only**.

## What this deliberately leaves out

The remaining ~134 spec paths are not included. They're mostly auth-gated routes I could only infer from the spec rather than observe, plus path-parameterised variants — and in aggregate they're what breached the artifact budgets. I'd rather register what's verified than inflate repo-wide artifacts with spec-only entries.

Two upstream paths (`/keys/{api_key_id}`, `/docker/authentication/{docker_credential_id}`) are also intentionally omitted: their URL segments trip the registry review's secret detector. In #7636 I kept them verbatim for accuracy, which is what closed that PR — dropping them entirely is cleaner than distorting the URL.

Audited every added `id`, `name`, `notes` **and `url`** for credential vocabulary: **zero** occurrences.

## Checklist

- [x] Changes exactly one `registry/subnets/lium-io.json` file (+122/−0, clean append)
- [x] Every added surface: `authority: community`, `review.state: community-submitted`, `public_safe: true`; no health/`verification` set by hand
- [x] `node scripts/validate-schemas.mjs` passed
- [x] `node scripts/validate-surface.mjs` passed (2321 surfaces / 129 files), **no `auth_required` advisories**
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs` + `tests/sn51-call-subnet-surface-verify.test.mjs` (30 passed)
- [x] `npm run scan:public-safety` — no lium findings
- [x] Surface ids asserted unique against the full manifest
- [x] `provider` uses the already-registered `lium` slug
- [x] No other open PR references #7064
- [x] Rebased on latest `main`

## Test plan

- [ ] Gittensory Gate + CI green (including the artifact budget check #7636 failed)
- [ ] `/templates` and `/executors` are good no-auth MCP smoke targets
