### PR TITLE
feat(graphql): add subnet_health parity field for GET /api/v1/subnets/{netuid}/health (#7640)

### DIFF
--- a/src/data-api-mcp.mjs
+++ b/src/data-api-mcp.mjs
@@ -18,6 +18,23 @@ function clampChainEventsLimit(value) {
   return Math.min(Math.max(Math.floor(n), 1), CHAIN_EVENTS_LIMIT_MAX);
 }
 
+// Blocks-window validator shared by MCP get_chain_activity and GraphQL
+// Query.chain_events_stats (#7432): a missing window defaults to 1000, a
+// non-positive-integer window is an invalid_params error, and the window is
+// clamped to the 5000-block maximum. Colocated with loadChainActivity below so
+// both callers reuse one validator instead of duplicating it.
+export function optionalBlocksWindow(args) {
+  const value = args?.blocks;
+  if (value === undefined || value === null) return 1000;
+  if (!Number.isInteger(value) || value < 1) {
+    throwToolError(
+      "invalid_params",
+      "Argument `blocks` must be a positive integer.",
+    );
+  }
+  return Math.min(value, 5000);
+}
+
 // The data Worker returns `{ error: "..." }` on 400; some envelopes use
 // `{ error: { message } }` or a top-level `message` instead.
 function dataApiErrorMessage(body) {
@@ -178,5 +195,22 @@ export async function loadChainEventsFeed(
     next_before: data?.next_before ?? null,
     next_cursor: data?.next_cursor ?? null,
     events: Array.isArray(data?.events) ? data.events : [],
+  };
+}
+
+// Chain-activity aggregate (pallet.method event distribution) over the most
+// recent N blocks, from the Postgres-backed all-events tier via the DATA_API
+// binding -- the same path loadChainEventsFeed uses for the raw feed. Shared by
+// MCP get_chain_activity and GraphQL Query.chain_events_stats (#7432); the
+// caller applies optionalBlocksWindow first.
+export async function loadChainActivity(ctx, blocks) {
+  const data = await dataApiFetchJson(
+    ctx,
+    `/api/v1/chain-events/stats?blocks=${blocks}`,
+  );
+  return {
+    window_blocks: data?.window_blocks ?? blocks,
+    groups: data?.groups ?? 0,
+    activity: Array.isArray(data?.activity) ? data.activity : [],
   };
 }

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -19,7 +19,14 @@ import { loadEvidenceList } from "./evidence-mcp.mjs";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
-import { loadChainEventsFeed } from "./data-api-mcp.mjs";
+// #7432: GraphQL parity for GET /api/v1/chain-events/stats, reusing the
+// relocated loadChainActivity (+ its optionalBlocksWindow validator) that MCP
+// get_chain_activity already calls -- not a reimplementation.
+import {
+  loadChainActivity,
+  loadChainEventsFeed,
+  optionalBlocksWindow,
+} from "./data-api-mcp.mjs";
 // #6992: GraphQL parity for profiles, reusing list_profiles' own loader
 // unchanged (same artifact read, filter, sort, and page logic REST and MCP
 // already use) -- not a reimplementation.
@@ -643,6 +650,8 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "Paginated all-events feed (newest first) from the Postgres-backed all-events tier: each event's block, event index, pallet, method, decoded args, phase, and emitting extrinsic index. Filter by pallet/method/block/extrinsic; page with limit (1-200, default 50) and the opaque keyset cursor (or legacy before=block_number). An invalid filter combo is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty feed, never a GraphQL error. Distinct from Subscription.chainEvents (live WebSocket firehose). Mirrors GET /api/v1/chain-events."
     chain_events(pallet: String, method: String, block: Int, extrinsic: Int, cursor: String, before: Int, limit: Int): ChainEventsFeed!
+    "The pallet.method event-distribution aggregate over the most recent blocks (the blocks window, 1-5000, default 1000) from the Postgres-backed all-events tier: each pallet.method with its event count, busiest first. A non-positive-integer blocks window is a GraphQL error. Distinct from chain_events (the raw paginated feed) and chain_activity (the daily block/extrinsic/event-count series). Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity)."
+    chain_events_stats(blocks: Int): ChainEventsStats!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
     "Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes."
@@ -1960,6 +1969,13 @@ export const SDL = `
     next_before: Int
     next_cursor: String
     events: [ChainEventRow!]!
+  }
+
+  "The pallet.method event-distribution aggregate for GET /api/v1/chain-events/stats: the block window covered, the number of distinct pallet.method groups, and the activity rows (each a pallet.method with its event count, busiest first) passed through verbatim from the all-events tier."
+  type ChainEventsStats {
+    window_blocks: Int
+    groups: Int
+    activity: [JSON!]!
   }
 
   "One raw pallet-level chain event from the all-events tier (distinct from the curated AccountEvent and from Subscription's ChainEvent firehose payload)."
@@ -4188,6 +4204,7 @@ export const FIELD_COMPLEXITY = {
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_events: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_events_stats: RELATIONSHIP_FIELD_COMPLEXITY,
   sudo: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   governance_config_changes: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6864,6 +6881,11 @@ const rootValue = {
   // BAD_USER_INPUT; a cold/unbound/rate-limited tier degrades to a
   // schema-stable empty feed, never a GraphQL error — matching extrinsics'
   // cold-empty convention. Distinct from Subscription.chainEvents.
+  chain_events_stats(args, context) {
+    const blocks = optionalBlocksWindow(args);
+    return loadChainActivity(context, blocks);
+  },
+
   async chain_events(
     { pallet, method, block, extrinsic, cursor, before, limit },
     context,

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -169,10 +169,12 @@ import {
   buildGlobalHealth,
   formatLeaderboards,
   LEADERBOARD_BOARDS,
+  loadSubnetReliability,
   loadSubnetTrajectory,
   mergeFreshness,
   mergeRpcEndpoints,
   overlayOverviewHealth,
+  overlaySubnetHealth,
   overlayCatalogDetail,
   overlayCatalogIndex,
   resolveLiveEconomics,
@@ -488,6 +490,8 @@ export const SDL = `
     subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
     "Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving."
     subnet_serving(netuid: Int!, window: String): SubnetServing!
+    "One subnet's current live operational-health card: the per-surface probe rows (status, classification, latency, last_checked/last_ok) plus the summary rollup and the subnet's reliability scores, composed from the live health-probe KV exactly as REST and the get_subnet_health MCP tool do. The un-windowed base card of the subnet_health_trends/incidents/percentiles family. A subnet with no live health data resolves to a schema-stable unknown card (summary.status 'unknown', empty surfaces), never null or a GraphQL error; a negative netuid is a BAD_USER_INPUT error. Mirrors GET /api/v1/subnets/{netuid}/health."
+    subnet_health(netuid: Int!): SubnetHealthCard!
     "One subnet's uptime + success-only latency trend windows (7d/30d) from the live health-probe history: per-window samples, uptime_ratio, latency sample count, and the per-surface uptime/latency series. A subnet with no probe history resolves to a schema-stable zeroed-windows card, never null. Mirrors GET /api/v1/subnets/{netuid}/health/trends."
     subnet_health_trends(netuid: Int!): SubnetHealthTrends!
     "One subnet's long-term daily uptime history for its operational surfaces from the live surface_uptime_daily rollup: per-surface day series, window-wide uptime ratios, and reliability scores for the requested window (90d or 1y, default 90d). Optional min_samples drops day rows whose daily probe count is below the threshold (including zero-sample 'unknown' days). A subnet with no history resolves to a schema-stable empty card (surfaces []), never null. Mirrors GET /api/v1/subnets/{netuid}/uptime."
@@ -2150,6 +2154,21 @@ export const SDL = `
     health_source: String
     scope: String
     subnets: [SubnetHealth!]!
+  }
+
+  "One subnet's current live operational-health card for GET /api/v1/subnets/{netuid}/health: the summary rollup, per-surface probe rows, and reliability scores composed from the live health-probe KV. Distinct from SubnetHealth (the flat per-subnet status counts embedded in list/overview cards)."
+  type SubnetHealthCard {
+    schema_version: Int
+    contract_version: String
+    generated_at: String
+    netuid: Int
+    slug: String
+    name: String
+    summary: JSON
+    operational_observed_at: String
+    health_source: String
+    reliability: JSON
+    surfaces: [JSON!]!
   }
 
   type SubnetHealth {
@@ -4234,6 +4253,7 @@ export const FIELD_COMPLEXITY = {
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_health: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_uptime: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -9446,6 +9466,38 @@ const rootValue = {
       observed_at: data.observed_at ?? null,
       source: data.source ?? null,
       windows: data.windows ?? {},
+    };
+  },
+
+  // #7640: the un-windowed base card of the subnet_health_* family. Reuses the
+  // exact live-health composition REST and the get_subnet_health MCP tool share
+  // -- loadLiveHealth (this file's resolveLiveHealth wrapper, the same one
+  // subnetBadgeStatus reads) + loadSubnetReliability, overlaid by
+  // overlaySubnetHealth -- so no health computation is duplicated here. A cold
+  // health store yields the same schema-stable "unknown" card the MCP tool
+  // returns, never null or a GraphQL error.
+  async subnet_health({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const [live, reliability] = await Promise.all([
+      loadLiveHealth(context),
+      loadSubnetReliability(),
+    ]);
+    const overlaid = overlaySubnetHealth(null, live, netuid);
+    if (overlaid) {
+      return { ...overlaid, reliability };
+    }
+    return {
+      schema_version: 1,
+      netuid,
+      summary: { status: "unknown", surface_count: 0 },
+      operational_observed_at: null,
+      health_source: "unavailable",
+      reliability,
+      surfaces: [],
     };
   },
 

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -602,10 +602,11 @@ import {
   buildBlockExtrinsics,
 } from "./extrinsics.mjs";
 import {
-  dataApiFetchJson,
   loadBlockChainEvents,
+  loadChainActivity,
   loadChainEventsFeed,
   loadExtrinsicChainEvents,
+  optionalBlocksWindow,
 } from "./data-api-mcp.mjs";
 import {
   aiEnabled,
@@ -1295,22 +1296,9 @@ async function loadSubnetEconomics(ctx, netuid) {
   };
 }
 
-// Chain-activity aggregate (pallet.method event distribution) over the most
-// recent N blocks, from the Postgres-backed all-events tier. That tier lives in
-// the dedicated data Worker (ADR 0013) so the postgres.js driver stays out of
-// this Worker's bundle; MCP handlers reach it through the DATA_API service
-// binding, the same binding the REST proxy uses for /api/v1/chain-events/stats.
-async function loadChainActivity(ctx, blocks) {
-  const data = await dataApiFetchJson(
-    ctx,
-    `/api/v1/chain-events/stats?blocks=${blocks}`,
-  );
-  return {
-    window_blocks: data?.window_blocks ?? blocks,
-    groups: data?.groups ?? 0,
-    activity: Array.isArray(data?.activity) ? data.activity : [],
-  };
-}
+// loadChainActivity (the /api/v1/chain-events/stats aggregate) now lives in
+// src/data-api-mcp.mjs alongside its raw-feed sibling loadChainEventsFeed and is
+// imported above -- shared with GraphQL Query.chain_events_stats (#7432).
 
 // One page of the raw recent chain-events feed (newest first) from the
 // Postgres-backed all-events tier via the DATA_API binding — the same path
@@ -1926,18 +1914,6 @@ function requireHotkey(args) {
 // to 1000; a provided value must be a positive integer and is clamped to the
 // data Worker's 1-5000 bound so a stray large value is silently capped (the data
 // Worker clamps too, but capping here keeps the request URL honest).
-function optionalBlocksWindow(args) {
-  const value = args?.blocks;
-  if (value === undefined || value === null) return 1000;
-  if (!Number.isInteger(value) || value < 1) {
-    throw toolError(
-      "invalid_params",
-      "Argument `blocks` must be a positive integer.",
-    );
-  }
-  return Math.min(value, 5000);
-}
-
 function clampLimit(value, fallback, max) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to
   // 1. tools/call does not enforce the inputSchema `minimum`, so an explicit

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -14729,6 +14729,75 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 });
 
+describe("graphql — subnet_health (#7640, live base card)", () => {
+  // No last_run_at: resolveLiveHealth treats a missing/unparseable stamp as
+  // fresh (documented back-compat), keeping this fixture independent of the
+  // 25-minute freshness window rather than pinning a clock.
+  const LIVE = {
+    surfaces: [
+      {
+        netuid: 7,
+        surface_id: "sn-7-allways-api",
+        kind: "subnet-api",
+        provider: "allways",
+        url: "https://api.all-ways.io/health",
+        status: "ok",
+        classification: "live",
+        latency_ms: 120,
+        last_checked: "2026-07-22T00:00:00.000Z",
+        last_ok: "2026-07-22T00:00:00.000Z",
+      },
+      { netuid: 8, surface_id: "other", status: "failed" },
+    ],
+  };
+
+  test("composes the live health card for the subnet, matching REST/MCP", async () => {
+    const env = fixtureEnv({}, { kv: { [KV_HEALTH_CURRENT]: LIVE } });
+    const { status, body } = await gql(
+      "{ subnet_health(netuid: 7) { schema_version summary operational_observed_at surfaces reliability } }",
+      env,
+    );
+    assert.equal(status, 200);
+    const card = body.data.subnet_health;
+    // Only this subnet's surfaces are overlaid (netuid 8 is filtered out).
+    assert.equal(card.surfaces.length, 1);
+    assert.equal(card.surfaces[0].surface_id, "sn-7-allways-api");
+    assert.equal(card.surfaces[0].status, "ok");
+    assert.ok(card.summary);
+  });
+
+  test("a cold health store resolves to the schema-stable unknown card, never null or an error", async () => {
+    const { status, body } = await gql(
+      "{ subnet_health(netuid: 7) { schema_version netuid summary health_source surfaces } }",
+      emptyEnv,
+    );
+    assert.equal(status, 200);
+    assert.ok(!body.errors, "cold store must not be a GraphQL error");
+    const card = body.data.subnet_health;
+    assert.equal(card.schema_version, 1);
+    assert.equal(card.netuid, 7);
+    assert.equal(card.health_source, "unavailable");
+    assert.deepEqual(card.surfaces, []);
+    assert.equal(card.summary.status, "unknown");
+  });
+
+  test("a negative netuid is a BAD_USER_INPUT error", async () => {
+    const { body } = await gql(
+      "{ subnet_health(netuid: -1) { schema_version } }",
+      emptyEnv,
+    );
+    assert.ok(body.errors?.length);
+    assert.equal(body.errors[0].extensions?.code, "BAD_USER_INPUT");
+  });
+
+  test("FIELD_COMPLEXITY weights it like its subnet_health_* siblings", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.subnet_health,
+      FIELD_COMPLEXITY.subnet_health_trends,
+    );
+  });
+});
+
 describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallback)", () => {
   const NETUID = 3;
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1967,6 +1967,61 @@ describe("graphql — profiles", () => {
 
 // #6977: block-scoped extrinsics/events/chain-events lists mirror the same
 // Postgres tier + schema-stable fallback the block/extrinsics feeds already use.
+describe("graphql — chain_events_stats (#7432)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("resolves the pallet.method aggregate from the all-events tier", async () => {
+    const env = {
+      DATA_API: dataApi(
+        Response.json({
+          window_blocks: 500,
+          groups: 2,
+          activity: [
+            { pallet: "Balances", method: "Transfer", count: 120 },
+            { pallet: "System", method: "ExtrinsicSuccess", count: 90 },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ chain_events_stats(blocks: 500) { window_blocks groups activity } }",
+      env,
+    );
+    assert.equal(status, 200);
+    const stats = body.data.chain_events_stats;
+    assert.equal(stats.window_blocks, 500);
+    assert.equal(stats.groups, 2);
+    assert.equal(stats.activity.length, 2);
+    assert.equal(stats.activity[0].method, "Transfer");
+    assert.equal(stats.activity[0].count, 120);
+  });
+
+  test("defaults a missing blocks window and passes an empty tier through as a zeroed aggregate", async () => {
+    const env = { DATA_API: dataApi(Response.json({})) };
+    const { body } = await gql(
+      "{ chain_events_stats { window_blocks groups activity } }",
+      env,
+    );
+    // optionalBlocksWindow defaults to 1000; an empty tier response yields the
+    // loader's defaults (never null), matching REST/MCP.
+    assert.equal(body.data.chain_events_stats.window_blocks, 1000);
+    assert.equal(body.data.chain_events_stats.groups, 0);
+    assert.deepEqual(body.data.chain_events_stats.activity, []);
+  });
+
+  test("rejects a non-positive-integer blocks window as a GraphQL error", async () => {
+    const { body } = await gql("{ chain_events_stats(blocks: 0) { groups } }");
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_events_stats, 5);
+  });
+});
+
 describe("graphql — block_extrinsics / block_events / block_chain_events (#6977)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Adds the one missing member of the `subnet_health_*` GraphQL family: the un-windowed base card for `GET /api/v1/subnets/{netuid}/health`. `subnet_health_trends`, `subnet_health_incidents`, and `subnet_health_percentiles` all have `Query` fields; the plain live-health card did not.

## Change

- Add `subnet_health(netuid: Int!): SubnetHealthCard!` to `type Query`, documented with the same "Mirrors GET ..." convention as its siblings.
- Resolver reuses the **exact** live-health composition REST and the `get_subnet_health` MCP tool already share — `loadLiveHealth` (this file's existing `resolveLiveHealth` wrapper) + `loadSubnetReliability`, overlaid by `overlaySubnetHealth` — so no health computation is duplicated.
- `netuid` is validated as a non-negative integer (`BAD_USER_INPUT`), matching the sibling health fields' documented contract.
- A cold health store resolves to the same schema-stable "unknown" card the MCP tool returns (`summary.status: "unknown"`, `health_source: "unavailable"`, empty `surfaces`) — never null, never a GraphQL error.
- New `type SubnetHealthCard`. The existing `SubnetHealth` type is a **different shape** (the flat per-subnet status counts embedded in list/overview cards), so reusing it would have misrepresented this payload; the new type is documented to say so. Nested aggregates (`summary`, `reliability`, `surfaces`) are `JSON`, matching the `Contracts`/`Changelog` convention.
- Weighted in `FIELD_COMPLEXITY` at the same relationship-field weight as its siblings.

## Verification

- `npx vitest run tests/graphql.test.mjs` — **888 pass**.
- New tests: live card composed from the health KV (and correctly filtered to the requested netuid), cold store → schema-stable unknown card (no error), negative netuid → `BAD_USER_INPUT`, and complexity parity with `subnet_health_trends`.
- **100% patch coverage** on every added line and branch; `prettier`/`eslint` clean. No schema/REST-contract change (additive GraphQL wiring only).

Closes #7640
