### PR TITLE
feat(api): add subnet_candidates GraphQL field for per-subnet candidates parity (#7641)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -538,6 +538,8 @@ export const SDL = `
     subnet_gaps(netuid: Int!): JSON
     "One subnet's curation evidence record — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry. Null when no evidence record has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_evidence MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/evidence."
     subnet_evidence(netuid: Int!): JSON
+    "One subnet's unpromoted candidate-surface queue — the baked per-subnet /metagraph/candidates/{netuid}.json artifact the REST route and get_subnet_candidates MCP tool read. Null when no candidate artifact has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim. Distinct from candidates(...) (the filterable network-wide candidate catalog). Mirrors GET /api/v1/subnets/{netuid}/candidates."
+    subnet_candidates(netuid: Int!): JSON
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
@@ -4266,6 +4268,7 @@ export const FIELD_COMPLEXITY = {
   subnet_event_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_gaps: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_evidence: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_candidates: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6790,6 +6793,19 @@ const rootValue = {
     // Same baked evidence artifact the REST route + get_subnet_evidence MCP
     // tool read; null when no record has been baked for this netuid.
     return loadArtifact(context, `/metagraph/evidence/${netuid}.json`);
+  },
+
+  async subnet_candidates({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same baked per-subnet candidates artifact the REST route +
+    // get_subnet_candidates MCP tool read (distinct from the network-wide
+    // candidates(...) catalog); null when no artifact has been baked for this
+    // netuid, matching subnet_gaps/subnet_evidence's cold-artifact convention.
+    return loadArtifact(context, `/metagraph/candidates/${netuid}.json`);
   },
 
   async subnet_health_incidents({ netuid, window }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -8626,6 +8626,39 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
   });
 });
 
+describe("graphql — subnet_candidates (#7641, baked per-subnet candidate artifact)", () => {
+  test("resolves the baked per-subnet candidates artifact", async () => {
+    const env = fixtureEnv({
+      "/metagraph/candidates/5.json": {
+        netuid: 5,
+        candidates: [{ id: "cand-1", kind: "subnet-api" }],
+      },
+    });
+    const { status, body } = await gql("{ subnet_candidates(netuid: 5) }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_candidates.netuid, 5);
+    assert.equal(body.data.subnet_candidates.candidates[0].kind, "subnet-api");
+  });
+
+  test("degrades to null when no candidate artifact is baked, never an error", async () => {
+    const { status, body } = await gql("{ subnet_candidates(netuid: 999) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_candidates, null);
+  });
+
+  test("a negative netuid is a GraphQL error", async () => {
+    const { body } = await gql("{ subnet_candidates(netuid: -1) }");
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+  });
+
+  test("is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_candidates, 5);
+  });
+});
+
 describe("graphql — subnet_performance_history (#6981, neuron_daily reward-distribution trend)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

GraphQL parity for `GET /api/v1/subnets/{netuid}/candidates`: a new `subnet_candidates(netuid: Int!): JSON` Query field reading the same baked `/metagraph/candidates/{netuid}.json` artifact the REST route and `get_subnet_candidates` MCP tool read — the exact `subnet_gaps`/`subnet_evidence` pattern the issue prescribes (`src/graphql.mjs` resolvers at the gaps/evidence block), no new loader invented.

Closes #7641.

## What changed (2 files)

- `src/graphql.mjs` — SDL field (docstring notes it mirrors the REST route and is **distinct from the network-wide `candidates(...)` catalog**, per the `gaps`/`subnet_gaps` disambiguation convention); resolver with the same `netuid` validation (`BAD_USER_INPUT` for non-integer/negative) and `loadArtifact` passthrough (null on a cold/absent artifact, never a GraphQL error); `FIELD_COMPLEXITY.subnet_candidates = RELATIONSHIP_FIELD_COMPLEXITY`.
- `tests/graphql.test.mjs` — populated artifact resolves; cold netuid degrades to null with no error; negative netuid is a GraphQL error; complexity weight pinned. 893 tests passing.

## Validation

- [x] `npx vitest run tests/graphql.test.mjs` — 893 passing
- [x] `node --check src/graphql.mjs` — clean
- [x] `eslint` + repo-pinned `prettier --check` (LF-normalized staged content) — clean
- [x] Gap verified real before implementing: `subnet_candidates` had zero occurrences in `src/graphql.mjs`
