### PR TITLE
feat(api): add saved_query GraphQL field for the curated saved-query library (#7642)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -235,6 +235,9 @@ import {
   labelsForSs58,
 } from "./entity-labels.mjs";
 import { loadSudoKey } from "./sudo-key.mjs";
+// #7642: saved_query reuses the same maintainer-curated template executor the
+// GET /api/v1/queries/{id} route and run_saved_query MCP tool already share.
+import { runSavedQuery } from "./saved-queries.mjs";
 import { loadNetworkParameters } from "./network-parameters.mjs";
 import { loadRandomnessStatus } from "./randomness.mjs";
 import { loadAddressMapping, H160_PATTERN } from "./address-mapping.mjs";
@@ -504,6 +507,8 @@ export const SDL = `
     curation: JSON
     "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state and page with limit/cursor, exactly like the REST route. Resolves to {items,total,next_cursor} as opaque JSON. Mirrors GET /api/v1/candidates."
     candidates(netuid: Int, kind: String, provider: String, state: String, limit: Int, cursor: String): JSON
+    "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}."
+    saved_query(id: String!, params: JSON): JSON
     "The recorded response fixtures for registered surfaces, used to replay/verify a surface without calling it. Null when no fixture index has been baked in this environment. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
     fixtures: JSON
     "The agent-callable service catalog: without a netuid, the global index of subnets exposing callable services; with one, that subnet's full per-service catalog. Both are overlaid with live health exactly as REST composes them. Null when the catalog has not been baked. Opaque JSON, matching the get_agent_catalog MCP/REST shape. Mirrors GET /api/v1/agent-catalog."
@@ -4248,6 +4253,7 @@ export const FIELD_COMPLEXITY = {
   agent_resources: RELATIONSHIP_FIELD_COMPLEXITY,
   curation: RELATIONSHIP_FIELD_COMPLEXITY,
   candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  saved_query: RELATIONSHIP_FIELD_COMPLEXITY,
   fixtures: RELATIONSHIP_FIELD_COMPLEXITY,
   agent_catalog: RELATIONSHIP_FIELD_COMPLEXITY,
   freshness: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6205,6 +6211,28 @@ const rootValue = {
     // Degrades to null when cold instead of erroring, matching every other
     // artifact-backed resolver here.
     return loadArtifact(context, "/metagraph/registry-summary.json");
+  },
+
+  async saved_query({ id, params }, context) {
+    // #7642: the same maintainer-curated template executor the REST route and
+    // run_saved_query MCP tool share (src/saved-queries.mjs) -- template
+    // lookup, param coercion/validation, and execution are all its. Its
+    // not_found (unknown id) and invalid_params toolErrors map to
+    // BAD_USER_INPUT, matching this file's invalid-argument convention; any
+    // other executor failure surfaces as a normal GraphQL error.
+    try {
+      return await runSavedQuery(context.env, id, params ?? {});
+    } catch (err) {
+      if (
+        err?.toolError &&
+        (err.code === "not_found" || err.code === "invalid_params")
+      ) {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      throw err;
+    }
   },
 
   source_health(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -16634,6 +16634,44 @@ describe("graphql — registry_leaderboards (#5661, shared composer + REST-match
   });
 });
 
+describe("graphql — saved_query (#7642, curated saved-query templates)", () => {
+  test("runs a template through the shared executor and returns the {query_id, params, data} envelope", async () => {
+    const { status, body } = await gql(
+      `{ saved_query(id: "subnet-leaderboard", params: { limit: 5 }) }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const result = body.data.saved_query;
+    assert.equal(result.query_id, "subnet-leaderboard");
+    assert.equal(result.params.limit, 5);
+    assert.ok(result.data, "expected the executed template's data payload");
+  });
+
+  test("an unknown id is BAD_USER_INPUT listing the valid template ids", async () => {
+    const { status, body } = await gql(
+      `{ saved_query(id: "no-such-template") }`,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.match(body.errors[0].message, /no-such-template/);
+    assert.match(body.errors[0].message, /subnet-leaderboard/);
+    assert.equal(body.data?.saved_query ?? null, null);
+  });
+
+  test("an unknown param is BAD_USER_INPUT, not a silent default", async () => {
+    const { status, body } = await gql(
+      `{ saved_query(id: "subnet-leaderboard", params: { not_a_real_param: 1 }) }`,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.match(body.errors[0].message, /not_a_real_param/);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(FIELD_COMPLEXITY.saved_query, FIELD_COMPLEXITY.candidates);
+  });
+});
+
 describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => {
   const HP_FIELDS =
     "kappa_ratio immunity_period tempo registration_allowed min_burn_tao bonds_moving_avg_raw liquid_alpha_enabled min_childkey_take_ratio";


### PR DESCRIPTION
## Summary

GraphQL parity for the curated saved-query library: `saved_query(id: String!, params: JSON): JSON`, executing the same maintainer-curated templates `GET /api/v1/queries/{id}` and the `run_saved_query` MCP tool already run — closing the one REST+MCP surface with zero GraphQL exposure (#7642's framing).

Closes #7642.

## What changed (2 files)

- `src/graphql.mjs` — SDL field (JSON-passthrough opaque convention per the issue's `registry_summary`/`curation` precedent, "Mirrors GET /api/v1/queries/{id}"); resolver calling the **shared executor** `runSavedQuery` from `src/saved-queries.mjs` (the same module the REST handler and MCP tool import — template lookup, param coercion/validation, and execution all reused, nothing duplicated); its `not_found` (unknown id, message lists valid template ids) and `invalid_params` toolErrors map to **BAD_USER_INPUT**, any other executor failure surfaces as a normal GraphQL error; `FIELD_COMPLEXITY.saved_query = RELATIONSHIP_FIELD_COMPLEXITY`.
- `tests/graphql.test.mjs` — a template run end-to-end through `POST /graphql` with a `params` object literal (`subnet-leaderboard`, `{limit: 5}` → the `{query_id, params, data}` envelope); unknown id → BAD_USER_INPUT listing valid ids; unknown param → BAD_USER_INPUT; complexity weight pinned. 893 tests passing.

## Validation

- [x] `npx vitest run tests/graphql.test.mjs` — 893 passing
- [x] `node --check src/graphql.mjs` — clean
- [x] `eslint` + repo-pinned `prettier --check` (LF-normalized staged content) — clean
- [x] Gap verified real before implementing: no `saved_query`/`/queries/` functionality existed anywhere in `src/graphql.mjs` (checked by field name AND by loader/route, after finding #7649's `randomness_status` already shipped as `network_randomness`)
