### PR TITLE
fix(registry): register SN124 Swarm signed validator API surfaces (#7132)

### DIFF
--- a/registry/subnets/swarm.json
+++ b/registry/subnets/swarm.json
@@ -187,6 +187,238 @@
         "https://github.com/swarm-subnet/swarm/blob/main/docs/king_of_the_hill.md"
       ],
       "url": "https://api.swarm124.com/kings/diagnostics"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request HMAC-style validator signature headers derived from the caller's wallet (signed request headers), per swarm/validator/backend_api.py _sign_request/_get_signed/_post_signed. Not a simple bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py",
+        "https://github.com/JSONbored/metagraphed/issues/7132"
+      ],
+      "id": "sn-124-swarm-validators-next-task",
+      "kind": "subnet-api",
+      "name": "Swarm validators next-task (signed)",
+      "url": "https://api.swarm124.com/validators/next-task",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "notes": "Auth-gated GET /validators/next-task on api.swarm124.com — long-poll for the next authorized evaluation task. Called via _get_signed in swarm/validator/backend_api.py (HMAC signed-request headers). Registered per metagraphed#7132 remaining deliverable with auth_required:true, probe.enabled:false. Live-verified 2026-07-22: unsigned GET returns HTTP 426 {\"detail\":\"validator_code_version_below_minimum\"} (non-2xx gate; matches the issue's own live-verified 426 observation)."
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request HMAC-style validator signature headers derived from the caller's wallet (signed request headers), per swarm/validator/backend_api.py _sign_request/_get_signed/_post_signed. Not a simple bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py",
+        "https://github.com/JSONbored/metagraphed/issues/7132"
+      ],
+      "id": "sn-124-swarm-validators-sync",
+      "kind": "subnet-api",
+      "name": "Swarm validators sync (signed)",
+      "url": "https://api.swarm124.com/validators/sync",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "notes": "Auth-gated GET /validators/sync on api.swarm124.com — current weights + re-eval queue + authoritative benchmark epoch. Called via _get_signed in swarm/validator/backend_api.py. Registered per metagraphed#7132 remaining deliverable with auth_required:true, probe.enabled:false. Live-verified 2026-07-22: unsigned GET returns HTTP 422 listing missing X-Validator-* signature headers (Hotkey/Signature/Nonce/Timestamp; matches the issue's own live-verified 422 observation)."
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request HMAC-style validator signature headers derived from the caller's wallet (signed request headers), per swarm/validator/backend_api.py _sign_request/_get_signed/_post_signed. Not a simple bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py",
+        "https://github.com/JSONbored/metagraphed/issues/7132"
+      ],
+      "id": "sn-124-swarm-validators-events",
+      "kind": "sse",
+      "name": "Swarm validators events SSE (signed)",
+      "url": "https://api.swarm124.com/validators/events",
+      "probe": {
+        "enabled": false,
+        "expect": "sse",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "notes": "Auth-gated GET /validators/events SSE stream on api.swarm124.com — server-sent events for validator runtime updates. Called via signed stream in swarm/validator/backend_api.py events() (Accept: text/event-stream + signed-request headers). Registered per metagraphed#7132 remaining deliverable with auth_required:true, probe.enabled:false, kind:sse. Live-verified 2026-07-22: unsigned GET returns HTTP 422 requiring the X-Validator-* signature headers (same signed-header gate as sync; SSE body not exercised without credentials)."
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request HMAC-style validator signature headers derived from the caller's wallet (signed request headers), per swarm/validator/backend_api.py _sign_request/_get_signed/_post_signed. Not a simple bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py",
+        "https://github.com/JSONbored/metagraphed/issues/7132"
+      ],
+      "id": "sn-124-swarm-validators-seed-scores",
+      "kind": "subnet-api",
+      "name": "Swarm validators seed-scores POST (signed)",
+      "url": "https://api.swarm124.com/validators/seed-scores",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "notes": "Auth-gated POST /validators/seed-scores on api.swarm124.com — stream/submit per-seed scores for the active task. Called via _post_signed in swarm/validator/backend_api.py. probe.method stays GET (schema enum GET/HEAD/JSON-RPC/WSS-RPC only) with probe.enabled:false so the probe never fires; the real method is POST, documented here and in the surface id/name. Registered per metagraphed#7132 remaining deliverable with auth_required:true. Live-verified 2026-07-22: unsigned POST returns HTTP 426 {\"detail\":\"validator_code_version_below_minimum\"}."
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request HMAC-style validator signature headers derived from the caller's wallet (signed request headers), per swarm/validator/backend_api.py _sign_request/_get_signed/_post_signed. Not a simple bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py",
+        "https://github.com/JSONbored/metagraphed/issues/7132"
+      ],
+      "id": "sn-124-swarm-validators-heartbeat",
+      "kind": "subnet-api",
+      "name": "Swarm validators heartbeat POST (signed)",
+      "url": "https://api.swarm124.com/validators/heartbeat",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "notes": "Auth-gated POST /validators/heartbeat on api.swarm124.com. Called via _post_signed in swarm/validator/backend_api.py. probe.method stays GET (schema enum) with probe.enabled:false; real method is POST. Registered per metagraphed#7132 remaining deliverable with auth_required:true. Live-verified 2026-07-22: unsigned POST returns HTTP 422 requiring X-Validator-* signature headers."
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request HMAC-style validator signature headers derived from the caller's wallet (signed request headers), per swarm/validator/backend_api.py _sign_request/_get_signed/_post_signed. Not a simple bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py",
+        "https://github.com/JSONbored/metagraphed/issues/7132"
+      ],
+      "id": "sn-124-swarm-validators-epoch-publish",
+      "kind": "subnet-api",
+      "name": "Swarm validators epoch publish POST (signed)",
+      "url": "https://api.swarm124.com/validators/epoch/publish",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "notes": "Auth-gated POST /validators/epoch/publish on api.swarm124.com — publish epoch seeds. Called via _post_signed in swarm/validator/backend_api.py publish_epoch_seeds(). probe.method stays GET (schema enum) with probe.enabled:false; real method is POST. Registered per metagraphed#7132 remaining deliverable with auth_required:true. Live-verified 2026-07-22: unsigned POST returns HTTP 422 requiring X-Validator-* signature headers."
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request HMAC-style validator signature headers derived from the caller's wallet (signed request headers), per swarm/validator/backend_api.py _sign_request/_get_signed/_post_signed. Not a simple bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py",
+        "https://github.com/JSONbored/metagraphed/issues/7132"
+      ],
+      "id": "sn-124-swarm-validators-task-result",
+      "kind": "subnet-api",
+      "name": "Swarm validators task result POST (signed)",
+      "url": "https://api.swarm124.com/validators/tasks/%7Bid%7D/result",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "notes": "Auth-gated POST /validators/tasks/{id}/result on api.swarm124.com — submit the aggregated task result. Called via _post_signed in swarm/validator/backend_api.py submit_task_result(). Path-param URL uses percent-encoded braces (%7Bid%7D) so the url format:uri schema check passes. probe.method stays GET (schema enum) with probe.enabled:false; real method is POST. Registered per metagraphed#7132 remaining deliverable with auth_required:true. Live-verified 2026-07-22 with placeholder id: unsigned POST returns HTTP 426 {\"detail\":\"validator_code_version_below_minimum\"}."
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request HMAC-style validator signature headers derived from the caller's wallet (signed request headers), per swarm/validator/backend_api.py _sign_request/_get_signed/_post_signed. Not a simple bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "wondercreatemaster"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py",
+        "https://github.com/JSONbored/metagraphed/issues/7132"
+      ],
+      "id": "sn-124-swarm-validators-private-artifact",
+      "kind": "subnet-api",
+      "name": "Swarm validators private model artifact (signed)",
+      "url": "https://api.swarm124.com/validators/models/%7Bmodel_hash%7D/private-artifact",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "notes": "Auth-gated GET /validators/models/{model_hash}/private-artifact on api.swarm124.com — fetch a miner's private model artifact for evaluation. Called via signed GET in swarm/validator/backend_api.py fetch_private_artifact(). Path-param URL uses percent-encoded braces (%7Bmodel_hash%7D) so the url format:uri schema check passes. Registered per metagraphed#7132 remaining deliverable with auth_required:true, probe.enabled:false. Live-verified 2026-07-22 with placeholder hash: unsigned GET returns HTTP 426 {\"detail\":\"validator_code_version_below_private_minimum\"}."
     }
   ],
   "website_url": "https://swarm124.com/"


### PR DESCRIPTION
## Summary

Closes #7132.

Fresh PR replacing closed #7655 (one-shot gate closed it after a follow-up commit). Complete fix in **one commit**.

Implements the **maintainer reopen deliverable** (2026-07-21): originals are already correct — register the eight signed-header-gated `/validators/*` routes on `api.swarm124.com` in `registry/subnets/swarm.json`, nothing else.

Does **not** touch `kings/diagnostics` or other existing surfaces.

## Surfaces added (8)

All `auth_required: true`, `probe.enabled: false`, `auth.scheme: custom` (HMAC signed-request headers per `swarm/validator/backend_api.py`). Live-verified **2026-07-22** with unsigned requests:

| surface_id | method / path | unsigned result |
|---|---|---|
| `sn-124-swarm-validators-next-task` | GET `/validators/next-task` | **426** `validator_code_version_below_minimum` |
| `sn-124-swarm-validators-sync` | GET `/validators/sync` | **422** missing `X-Validator-*` headers |
| `sn-124-swarm-validators-events` | GET `/validators/events` (kind: `sse`) | **422** missing `X-Validator-*` headers |
| `sn-124-swarm-validators-seed-scores` | POST `/validators/seed-scores` | **426** `validator_code_version_below_minimum` |
| `sn-124-swarm-validators-heartbeat` | POST `/validators/heartbeat` | **422** missing `X-Validator-*` headers |
| `sn-124-swarm-validators-epoch-publish` | POST `/validators/epoch/publish` | **422** missing `X-Validator-*` headers |
| `sn-124-swarm-validators-task-result` | POST `/validators/tasks/{id}/result` | **426** (placeholder id) |
| `sn-124-swarm-validators-private-artifact` | GET `/validators/models/{model_hash}/private-artifact` | **426** `validator_code_version_below_private_minimum` |

Path-param URLs use percent-encoded braces (`%7Bid%7D`, `%7Bmodel_hash%7D`). POST routes keep `probe.method: GET` (schema enum) with `probe.enabled: false`; real method is documented in notes/id.

## Originals (no change — confirmed still live)

| surface | result |
|---|---|
| `sn-124-swarm-health` | 200 `{"status":"healthy"}` |
| `sn-124-swarm-leaderboard-api` | 200 JSON leaderboard |
| `sn-124-swarm-data-artifact` (`/kings/active`) | 200 JSON kings window |

## Validation

- [x] Exactly one file changed: `registry/subnets/swarm.json` (append-only `surfaces[]`, +232/−0)
- [x] `npm run validate:surface -- registry/subnets/swarm.json` — 15 surfaces, passed
- [x] `npm run scan:public-safety` — passed
- [x] `npx prettier --check registry/subnets/swarm.json`

## Checklist

- [x] Linked open issue with `Closes #7132`
- [x] Every status claim traces to a live request made 2026-07-22
- [x] Single commit — no follow-up pushes
