### PR TITLE
feat(registry): wire SN113 TensorUSD auth-gated backend schema endpoint

### DIFF
--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -183,6 +183,32 @@
         "https://github.com/TensorUSD/subnet/blob/main/README.md"
       ],
       "url": "https://agent-api.tensorusd.com/health"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "The /api/openapi.json path returns HTTP 401 unauthenticated, confirming a real gated schema endpoint; the required credential/header format is not documented (the schema itself is unreadable without it)."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-113-tensorusd-api-openapi",
+      "kind": "subnet-api",
+      "name": "TensorUSD SN113 backend API schema endpoint (auth-gated)",
+      "notes": "GET /api/openapi.json on api.tensorusd.com is a real, auth-gated backend OpenAPI schema endpoint -- distinct from the bare /openapi.json (404, already recorded in the existing gap_notes). It requires credentials to read, so the schema itself could not be captured (registered as subnet-api rather than openapi, since openapi-kind surfaces require a machine-readable schema). Live-verified 2026-07-22: GET https://api.tensorusd.com/api/openapi.json -> HTTP 401 (empty body); GET https://api.tensorusd.com/openapi.json -> HTTP 404 (confirms the distinct path). Registered with probe.enabled:false since it is not anonymously callable; worth re-probing with an API key to unlock full endpoint discovery.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorusd",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "lourincedaging0-commits"
+      },
+      "source_urls": ["https://api.tensorusd.com/api/openapi.json"],
+      "url": "https://api.tensorusd.com/api/openapi.json"
     }
   ],
   "website_url": "https://tensorusd.com/"


### PR DESCRIPTION
Closes #7124

## Verified the two listed surfaces (both already match reality)
Live-verified 2026-07-22:
- `sn-113-tensorusd-subnet-api` — GET https://api.tensorusd.com/health -> HTTP 200 JSON (healthy, db connected). Config already correct (no-auth GET json). No change needed.
- `sn-113-tensorusd-agent-api-health` — GET https://agent-api.tensorusd.com/health -> HTTP 200 JSON (`{"success":true,"data":{"status":"ok","env":"prod"}}`). Config already correct. No change needed.

## Wired the newly-discovered surface (the issue's "Additional surface(s) found during review — now in scope" section)
Added one surface to `registry/subnets/tensorusd.json`:
- `sn-113-tensorusd-api-openapi` — `GET https://api.tensorusd.com/api/openapi.json`, the backend OpenAPI schema endpoint. Live-verified 2026-07-22: returns **HTTP 401** (empty body) unauthenticated — a real, existing, auth-gated schema endpoint, **distinct from the bare `/openapi.json` which is 404** (also verified). Registered with `auth_required:true` and `probe.enabled:false` per the issue, since it is not anonymously callable.

Registered as `kind: subnet-api` (not `openapi`): the registry schema requires `openapi`-kind surfaces to reference a **machine-readable** schema (`validate.mjs`: "openapi surfaces must reference a machine-readable schema"), and this schema is gated/unreadable without a credential. The auth-gated shape mirrors the existing `sn-69-ain-api-validator-results` precedent (auth-gated endpoint, `probe.enabled:false`, custom `auth` block).

Every claim above traces to a request I made. One file, one added surface. Local gates: `validate:surface` passes (2317 surfaces / 129 files), `node scripts/validate.mjs` adds no new issues vs main, prettier clean, README catalog up to date.
