### PR TITLE
fix(api): rewrite counterparties OR-query as indexed UNION ALL; raise stale artifact budgets

### DIFF
--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -2,8 +2,20 @@ export const ARTIFACT_SIZE_BUDGETS = [
   budget("candidates.json", 4_500_000, 8_000_000),
   budget("review-queue.json", 4_500_000, 8_000_000),
   budget("verification/latest.json", 3_000_000, 5_000_000),
-  budget("surfaces.json", 1_500_000, 4_000_000),
-  budget("endpoints.json", 2_500_000, 5_000_000),
+  // METAGRAPHED-9/A (#stale-publish-pipeline): the registry's organic growth (new
+  // subnets/providers/endpoints from ongoing contributor PRs) pushed both actual
+  // sizes past the old fail_bytes ceiling (endpoints.json 5,271,281 >= 5,000,000;
+  // surfaces.json 4,020,869 >= 4,000,000), hard-failing publish-cloudflare.yml's
+  // validate:artifact-budgets step on every run since ~2026-07-17 -- the whole
+  // publish (R2 artifacts + the KV `latest` pointer) never reaches its upload
+  // step, so the live site kept serving that stale run indefinitely (this budget
+  // check has no partial-failure path; one over-budget artifact blocks every
+  // artifact). Raised with real headroom above current size, not just enough to
+  // clear it today, so ongoing registry growth doesn't reopen the same outage in
+  // a few weeks; still bounded well below "no budget at all" so a genuinely
+  // runaway artifact (a bug, not organic growth) still fails loudly.
+  budget("surfaces.json", 2_500_000, 6_000_000),
+  budget("endpoints.json", 4_000_000, 7_500_000),
   budget("providers/*/endpoints.json", 1_000_000, 3_000_000),
   budget("evidence-ledger.json", 1_000_000, 3_000_000),
   budget("health/history/*.json", 650_000, 1_250_000),

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4580,7 +4580,13 @@ test("GET /api/v1/accounts/:ss58/counterparties?counterparty= returns the relati
   });
   expect(body.relationship.counterparty).toBe("5Cold");
   expect(body.relationship.transfer_count).toBe(1);
-  expect(queryText()).toContain("(hotkey = ");
+  // METAGRAPHED-6/5: UNION ALL of two single-column-indexed legs, not a single
+  // `(hotkey = ? OR ...)` predicate neither idx_ae_kind_hotkey_observed nor
+  // idx_ae_kind_coldkey_observed can drive -- see the route's own comment.
+  const text = queryText();
+  expect(text).toContain("hotkey = ");
+  expect(text).toContain("UNION ALL");
+  expect(text).toContain("IS DISTINCT FROM");
 });
 
 test("GET /api/v1/accounts/:ss58/counterparties?counterparty= with no matching transfers returns an empty counterparties array", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -7712,15 +7712,35 @@ export default {
             100,
           );
           if (counterparty) {
-            // ORDER BY leads with observed_at (same chunk-exclusion fix as
-            // the /api/v1/extrinsics list route) -- not selected, since
-            // buildCounterpartyRelationship only reads the columns above,
-            // but a valid ORDER BY key doesn't need to be in the SELECT list.
+            // METAGRAPHED-6/5: rewritten as a UNION ALL of two single-column-indexed
+            // legs instead of one `((hotkey=? AND coldkey=?) OR (hotkey=? AND
+            // coldkey=?))` predicate. account_events is a 10M-rows/week compressed
+            // TimescaleDB hypertable (#4832/#4869) -- neither idx_ae_kind_hotkey_observed
+            // nor idx_ae_kind_coldkey_observed can drive a single scan across an OR of
+            // two independently-valued hotkey/coldkey pairs, so Postgres fell back to a
+            // cross-chunk scan + sort that timed out under load (statement_timeout
+            // cancellations, "canceling statement due to statement timeout"). Each leg
+            // here filters on ONE indexed `hotkey = <literal>` value (idx_ae_kind_hotkey_
+            // observed covers event_kind+hotkey+observed_at, INCLUDE amount_tao), with
+            // coldkey/observed_at ORDER BY + LIMIT applied inside the leg so the index
+            // scan itself is bounded, not a residual filter over the whole table. The
+            // trailing `${ss58} IS DISTINCT FROM ${counterparty}` guard (NULL-safe,
+            // unlike !=) skips leg 2 entirely when querying an account's relationship
+            // with itself, where both legs would otherwise resolve to the identical
+            // predicate and UNION ALL would double-count every matching row.
             const rows = await sql`
-            SELECT hotkey, coldkey, amount_tao, block_number, event_index
-            FROM account_events
-            WHERE event_kind = 'Transfer'
-              AND ((hotkey = ${ss58} AND coldkey = ${counterparty}) OR (hotkey = ${counterparty} AND coldkey = ${ss58}))
+            SELECT hotkey, coldkey, amount_tao, block_number, event_index FROM (
+              (SELECT hotkey, coldkey, amount_tao, block_number, event_index, observed_at
+               FROM account_events
+               WHERE event_kind = 'Transfer' AND hotkey = ${ss58} AND coldkey = ${counterparty}
+               ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP})
+              UNION ALL
+              (SELECT hotkey, coldkey, amount_tao, block_number, event_index, observed_at
+               FROM account_events
+               WHERE event_kind = 'Transfer' AND hotkey = ${counterparty} AND coldkey = ${ss58}
+                 AND ${ss58} IS DISTINCT FROM ${counterparty}
+               ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP})
+            ) combined
             ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP}`;
             const relationship = buildCounterpartyRelationship(
               rows,
@@ -7753,12 +7773,27 @@ export default {
               relationship,
             });
           }
-          // ORDER BY leads with observed_at, same reasoning as the
-          // counterparty-drilldown query above.
+          // METAGRAPHED-6/5: same UNION ALL rewrite as the counterparty-drilldown query
+          // above, for the same reason -- `(hotkey = ? OR coldkey = ?)` can't use either
+          // idx_ae_kind_hotkey_observed or idx_ae_kind_coldkey_observed, and this is the
+          // route the timing-out production traffic actually hit (a crawler repeatedly
+          // listing ALL counterparties for many addresses with no ?counterparty= filter).
+          // `hotkey IS DISTINCT FROM ss58` (NULL-safe) on the coldkey = ss58 leg
+          // excludes the one row shape (a genuine self-transfer, hotkey = coldkey =
+          // ss58) the hotkey = ss58 leg already caught, so UNION ALL can never
+          // double-count it.
           const rows = await sql`
-          SELECT hotkey, coldkey, amount_tao, block_number, event_index
-          FROM account_events
-          WHERE event_kind = 'Transfer' AND (hotkey = ${ss58} OR coldkey = ${ss58})
+          SELECT hotkey, coldkey, amount_tao, block_number, event_index FROM (
+            (SELECT hotkey, coldkey, amount_tao, block_number, event_index, observed_at
+             FROM account_events
+             WHERE event_kind = 'Transfer' AND hotkey = ${ss58}
+             ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP})
+            UNION ALL
+            (SELECT hotkey, coldkey, amount_tao, block_number, event_index, observed_at
+             FROM account_events
+             WHERE event_kind = 'Transfer' AND coldkey = ${ss58} AND hotkey IS DISTINCT FROM ${ss58}
+             ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP})
+          ) combined
           ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT ${COUNTERPARTIES_SCAN_CAP}`;
           return json(buildCounterparties(rows, ss58, { limit }));
         }


### PR DESCRIPTION
## Summary

- Counterparties routes (drilldown + list-all) timed out under crawler traffic because their `(hotkey = ? OR coldkey = ?)` predicate can't use either single-column index; rewritten as a UNION ALL of two indexed legs.
- Publish pipeline's artifact size budgets had no headroom for organic registry growth, hard-failing `validate:artifact-budgets` and blocking every publish (R2 artifacts + KV `latest` pointer) since the ceiling was first crossed.

## What Changed

- `workers/data-api.mjs`: both counterparties queries rewritten as `UNION ALL` of two single-column-indexed legs (`idx_ae_kind_hotkey_observed` / `idx_ae_kind_coldkey_observed`), each with its own `ORDER BY` + `LIMIT` pushed inside so the index can drive the scan. A NULL-safe `IS DISTINCT FROM` on the second leg prevents double-counting a genuine self-transfer row.
- `tests/data-api.test.mjs`: updated the query-shape assertion to check for the `UNION ALL` + `IS DISTINCT FROM` structure.
- `scripts/artifact-budgets.mjs`: raised `surfaces.json` and `endpoints.json` budgets with real headroom above current size (verified against today's actual `validate:artifact-budgets` output — both now `warn`, not `fail`).

Root-caused and validated against a real local TimescaleDB instance (`docker compose up -d postgres` + `EXPLAIN`), not just static reasoning — confirmed the OR-predicate can't use either existing index and that the UNION ALL rewrite produces the expected per-leg index scan.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no API surface change, same response shape/ordering.)
- **No linked issue**: found via Sentry (METAGRAPHED-6/5, METAGRAPHED-9/A), not a tracked GitHub issue. Submitting directly as the maintainer, same as recent loopover maintainer PRs.

## Validation

- [x] `npm run check` — blocked by an environment issue unrelated to this diff: ESLint's `tsconfigRootDir` auto-detection is confused by sibling `.claude/worktrees/*` checkouts from other concurrent sessions on this machine. Ran the 3 changed files through `eslint`/`prettier --check` directly instead — clean, exit 0.
- [x] `npm run typecheck` — clean (this surfaced a stale/missing `@cloudflare/workers-types` install unrelated to this diff, fixed locally; both changed `.mjs` files are `checkJs: false` anyway).
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets` — `endpoints.json` now warns (4.86MB) instead of failing.
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage` — 473/473 files, 11159/11159 tests passing; `data-api.mjs` 96.94%/96.22%/97.74%/97.2% (stmt/branch/fn/line).
- [x] `npm run scan:public-safety`
- [x] `git diff --check`