### PR TITLE
feat(ui): account page delegation graph + entity labels

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-delegation.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-delegation.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountChildrenQuery, accountParentsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 addresses (ss58PathSegment rejects malformed input).
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+function resolveWith(data: unknown, url: string): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url,
+  });
+}
+
+async function runChildren(ss58: string) {
+  const opts = accountChildrenQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+async function runParents(ss58: string) {
+  const opts = accountParentsQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountChildrenQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the children route and reads the per-entry `child` counterpart field", async () => {
+    resolveWith(
+      {
+        schema_version: 1,
+        account: ALICE,
+        subnets: [
+          {
+            netuid: 3,
+            entries: [{ child: BOB, proportion: "9223372036854775808", proportion_fraction: 0.5 }],
+          },
+        ],
+        queried_at: "2026-07-21T00:00:00.000Z",
+      },
+      `/api/v1/accounts/${ALICE}/children`,
+    );
+    const res = await runChildren(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/children`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data.account).toBe(ALICE);
+    expect(res.data.queried_at).toBe("2026-07-21T00:00:00.000Z");
+    expect(res.data.subnets).toEqual([
+      {
+        netuid: 3,
+        entries: [
+          { counterpart: BOB, proportion: "9223372036854775808", proportion_fraction: 0.5 },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves `subnets: null` (live RPC failed) as a distinct tri-state, not []", async () => {
+    resolveWith(
+      { schema_version: 1, account: ALICE, subnets: null, queried_at: null },
+      `/api/v1/accounts/${ALICE}/children`,
+    );
+    const res = await runChildren(ALICE);
+    expect(res.data.subnets).toBeNull();
+  });
+
+  it("drops subnets with no netuid, entries with no counterpart, and coerces junk fractions to null", async () => {
+    resolveWith(
+      {
+        account: ALICE,
+        subnets: [
+          { netuid: "nope", entries: [{ child: BOB, proportion_fraction: 1 }] },
+          {
+            netuid: 7,
+            entries: [
+              { proportion_fraction: 1 },
+              { child: BOB, proportion: 123, proportion_fraction: "junk" },
+            ],
+          },
+          { netuid: 9, entries: [{ proportion_fraction: 1 }] },
+        ],
+      },
+      `/api/v1/accounts/${ALICE}/children`,
+    );
+    const res = await runChildren(ALICE);
+    expect(res.data.subnets).toEqual([
+      {
+        netuid: 7,
+        entries: [{ counterpart: BOB, proportion: null, proportion_fraction: null }],
+      },
+    ]);
+  });
+
+  it("degrades a cold / unknown account to an empty subnet list (never throws)", async () => {
+    for (const raw of [{}, null, { subnets: "not-an-array" }]) {
+      resolveWith(raw, `/api/v1/accounts/${ALICE}/children`);
+      const res = await runChildren(ALICE);
+      expect(res.data.account).toBe(ALICE);
+      expect(res.data.subnets).toEqual([]);
+    }
+  });
+});
+
+describe("accountParentsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the parents route and reads the per-entry `parent` counterpart field", async () => {
+    resolveWith(
+      {
+        account: ALICE,
+        subnets: [{ netuid: 1, entries: [{ parent: BOB, proportion_fraction: 0.25 }] }],
+      },
+      `/api/v1/accounts/${ALICE}/parents`,
+    );
+    const res = await runParents(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/parents`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data.subnets).toEqual([
+      { netuid: 1, entries: [{ counterpart: BOB, proportion: null, proportion_fraction: 0.25 }] },
+    ]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
@@ -88,10 +88,7 @@ describe("accountEntitiesQuery", () => {
     resolveWith({
       ss58: ALICE,
       labels: [{ source_urls: ["https://ok", 42, null] }],
-      ownership_ties: [
-        { netuid: "junk", role: "gained_ownership", block_number: "junk" },
-        {},
-      ],
+      ownership_ties: [{ netuid: "junk", role: "gained_ownership", block_number: "junk" }, {}],
     });
     const res = await runQuery(ALICE);
     expect(res.data.labels).toEqual([

--- a/apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountEntitiesQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 address (ss58PathSegment rejects malformed input).
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${ALICE}/entities`,
+  });
+}
+
+async function runQuery(ss58: string) {
+  const opts = accountEntitiesQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountEntitiesQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the entities route and passes through labels + ownership ties", async () => {
+    resolveWith({
+      ss58: ALICE,
+      labels: [
+        {
+          name: "Foundation",
+          category: "foundation",
+          notes: "core dev",
+          source_urls: ["https://example.com/a", "https://example.com/b"],
+        },
+      ],
+      ownership_tie_count: 2,
+      ownership_ties: [
+        {
+          netuid: 5,
+          role: "gained_ownership",
+          block_number: 1000,
+          observed_at: "2026-07-20T00:00:00.000Z",
+        },
+        { netuid: 6, role: "lost_ownership", block_number: 900, observed_at: null },
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/entities`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data.ss58).toBe(ALICE);
+    expect(res.data.labels).toEqual([
+      {
+        name: "Foundation",
+        category: "foundation",
+        notes: "core dev",
+        source_urls: ["https://example.com/a", "https://example.com/b"],
+      },
+    ]);
+    expect(res.data.ownership_tie_count).toBe(2);
+    expect(res.data.ownership_ties).toEqual([
+      {
+        netuid: 5,
+        role: "gained_ownership",
+        block_number: 1000,
+        observed_at: "2026-07-20T00:00:00.000Z",
+      },
+      { netuid: 6, role: "lost_ownership", block_number: 900, observed_at: null },
+    ]);
+  });
+
+  it("nulls missing label/tie fields, drops non-string source URLs and empty ties, and never NaNs", async () => {
+    resolveWith({
+      ss58: ALICE,
+      labels: [{ source_urls: ["https://ok", 42, null] }],
+      ownership_ties: [
+        { netuid: "junk", role: "gained_ownership", block_number: "junk" },
+        {},
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(res.data.labels).toEqual([
+      { name: null, category: null, notes: null, source_urls: ["https://ok"] },
+    ]);
+    expect(res.data.ownership_ties).toEqual([
+      { netuid: null, role: "gained_ownership", block_number: null, observed_at: null },
+    ]);
+    expect(res.data.ownership_tie_count).toBe(1);
+  });
+
+  it("degrades a cold / unknown account to empty labels + ties (never throws)", async () => {
+    for (const raw of [{}, null, { labels: "x", ownership_ties: 3 }]) {
+      resolveWith(raw);
+      const res = await runQuery(ALICE);
+      expect(res.data.ss58).toBe(ALICE);
+      expect(res.data.labels).toEqual([]);
+      expect(res.data.ownership_ties).toEqual([]);
+      expect(res.data.ownership_tie_count).toBe(0);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -47,6 +47,11 @@ import type {
   AccountEvent,
   AccountEventsPage,
   AccountCounterparties,
+  AccountDelegationGraph,
+  AccountDelegationSubnet,
+  AccountEntities,
+  AccountEntityLabel,
+  AccountOwnershipTie,
   AccountCounterparty,
   AccountStakeFlow,
   AccountStakeFlowSubnet,
@@ -2788,6 +2793,142 @@ export const accountCounterpartiesQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountCounterparties>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #6723: live child/parent-hotkey delegation graph — the counterpart hotkeys
+// this account delegates stake-weight to (children) or receives it from
+// (parents), per subnet. Shared normalizer for both /accounts/{ss58}/children
+// and /parents, which differ only in the per-entry counterpart field name
+// ("child" vs "parent"). Preserves the backend's `subnets: null` tri-state (live
+// RPC failed) distinctly from `subnets: []` (genuinely no delegations) so the UI
+// can render "temporarily unavailable" separately from a cold wallet.
+function normalizeDelegationSubnets(
+  raw: unknown,
+  counterpartKey: "child" | "parent",
+): AccountDelegationSubnet[] | null {
+  if (raw === null) return null;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((subnet) => {
+    if (!isRecord(subnet)) return [];
+    const netuid = firstFiniteNumber(subnet.netuid);
+    if (netuid == null) return [];
+    const entries = Array.isArray(subnet.entries)
+      ? subnet.entries.flatMap((entry) => {
+          if (!isRecord(entry)) return [];
+          const counterpart = firstString(entry[counterpartKey]);
+          if (!counterpart) return [];
+          return [
+            {
+              counterpart,
+              proportion: firstString(entry.proportion) ?? null,
+              proportion_fraction: firstFiniteNumber(entry.proportion_fraction) ?? null,
+            },
+          ];
+        })
+      : [];
+    // Drop a subnet that lost every entry to malformed rows — an empty
+    // entries[] would render as a blank group with no edges.
+    if (entries.length === 0) return [];
+    return [{ netuid, entries }];
+  });
+}
+
+function delegationGraphQuery(
+  ss58: string,
+  route: "children" | "parents",
+  counterpartKey: "child" | "parent",
+) {
+  return queryOptions({
+    queryKey: k(`account-${route}`, ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/${route}`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          account: firstString(d.account) ?? ss58,
+          subnets: normalizeDelegationSubnets(d.subnets, counterpartKey),
+          queried_at: firstString(d.queried_at) ?? null,
+        } as AccountDelegationGraph,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountDelegationGraph>;
+    },
+    staleTime: STALE_MED,
+  });
+}
+
+export const accountChildrenQuery = (ss58: string) =>
+  delegationGraphQuery(ss58, "children", "child");
+
+export const accountParentsQuery = (ss58: string) =>
+  delegationGraphQuery(ss58, "parents", "parent");
+
+// #6740: community entity labels + subnet-ownership ties for one address, from
+// /api/v1/accounts/{ss58}/entities. Structured-object response with two arrays;
+// both degrade to [] on a cold/unknown address (never throws).
+function normalizeEntityLabel(raw: unknown): AccountEntityLabel | null {
+  if (!isRecord(raw)) return null;
+  return {
+    name: firstString(raw.name) ?? null,
+    category: firstString(raw.category) ?? null,
+    notes: firstString(raw.notes) ?? null,
+    source_urls: Array.isArray(raw.source_urls)
+      ? raw.source_urls.flatMap((u) => {
+          const s = firstString(u);
+          return s ? [s] : [];
+        })
+      : [],
+  };
+}
+
+function normalizeOwnershipTie(raw: unknown): AccountOwnershipTie | null {
+  if (!isRecord(raw)) return null;
+  const role = firstString(raw.role);
+  const netuid = firstFiniteNumber(raw.netuid);
+  const block = firstFiniteNumber(raw.block_number);
+  if (role == null && netuid == null && block == null) return null;
+  return {
+    netuid: netuid ?? null,
+    role: role ?? null,
+    block_number: block ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+  };
+}
+
+export const accountEntitiesQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-entities", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/entities`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const labels = Array.isArray(d.labels)
+        ? d.labels.flatMap((row) => {
+            const l = normalizeEntityLabel(row);
+            return l ? [l] : [];
+          })
+        : [];
+      const ownershipTies = Array.isArray(d.ownership_ties)
+        ? d.ownership_ties.flatMap((row) => {
+            const t = normalizeOwnershipTie(row);
+            return t ? [t] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          labels,
+          ownership_tie_count: firstFiniteNumber(d.ownership_tie_count) ?? ownershipTies.length,
+          ownership_ties: ownershipTies,
+        } as AccountEntities,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountEntities>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1381,6 +1381,67 @@ export interface AccountCounterparties {
   counterparties: AccountCounterparty[];
   [key: string]: unknown;
 }
+
+/**
+ * One edge in the live child/parent-hotkey delegation graph
+ * (/accounts/{ss58}/children | /parents, #6723) — the counterpart hotkey and
+ * the proportion of stake-weight this edge carries on a given subnet.
+ */
+export interface AccountDelegationEdge {
+  /** The child (children route) or parent (parents route) hotkey ss58. */
+  counterpart: string;
+  /** Raw u64 proportion as a decimal string (0..u64::MAX ≙ 0..100%). */
+  proportion: string | null;
+  /** The same proportion as a 0..1 fraction. */
+  proportion_fraction: number | null;
+}
+/** One subnet's delegation edges in the child/parent-hotkey graph. */
+export interface AccountDelegationSubnet {
+  netuid: number;
+  entries: AccountDelegationEdge[];
+}
+/**
+ * #6723: /accounts/{ss58}/children | /parents — this account's live stake-weight
+ * delegation graph, per subnet. `subnets` is `null` (not `[]`) when the live RPC
+ * failed, so callers can distinguish "temporarily unavailable" from "genuinely
+ * none" — matching src/child-hotkey-delegation.mjs's tri-state contract.
+ */
+export interface AccountDelegationGraph {
+  account: string;
+  subnets: AccountDelegationSubnet[] | null;
+  queried_at: string | null;
+  [key: string]: unknown;
+}
+/** One community-contributed entity label in /accounts/{ss58}/entities (#6740). */
+export interface AccountEntityLabel {
+  name: string | null;
+  category: string | null;
+  notes: string | null;
+  source_urls: string[];
+}
+/**
+ * One subnet-ownership tie in /accounts/{ss58}/entities — a SubnetOwnerChanged
+ * transfer this address was on either side of.
+ */
+export interface AccountOwnershipTie {
+  netuid: number | null;
+  /** "gained_ownership" when this address became owner, else "lost_ownership". */
+  role: string | null;
+  block_number: number | null;
+  observed_at: string | null;
+}
+/**
+ * #6740: /accounts/{ss58}/entities — this address's community labels plus every
+ * subnet-ownership tie via the SubnetOwnerChanged chain-events stream.
+ */
+export interface AccountEntities {
+  ss58: string;
+  labels: AccountEntityLabel[];
+  ownership_tie_count: number;
+  ownership_ties: AccountOwnershipTie[];
+  [key: string]: unknown;
+}
+
 /** One per-subnet stake/unstake flow row in /accounts/{ss58}/stake-flow. */
 export interface AccountStakeFlowSubnet {
   netuid: number;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -17,10 +17,12 @@ import {
   Github,
   Globe,
   MessageCircle,
+  Network,
   Radar,
   RefreshCw,
   Rows3,
   Scale,
+  Tag,
   Unplug,
   UserMinus,
   UserPlus,
@@ -49,7 +51,10 @@ import { AccountHistoryChart } from "@/components/metagraphed/account-history-ch
 import { AccountPositionHistoryChart } from "@/components/metagraphed/account-position-history-chart";
 import {
   accountAxonRemovalsQuery,
+  accountChildrenQuery,
   accountCounterpartiesQuery,
+  accountEntitiesQuery,
+  accountParentsQuery,
   accountStakeFlowQuery,
   accountPortfolioQuery,
   accountStakeMovesQuery,
@@ -77,6 +82,10 @@ import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
 import { entityNotFoundMeta } from "@/lib/metagraphed/entity-not-found-meta";
 import type {
   AccountCounterparty,
+  AccountDelegationGraph,
+  AccountDelegationSubnet,
+  AccountEntityLabel,
+  AccountOwnershipTie,
   AccountStakeFlowSubnet,
   AccountRegistration,
   AccountSummary,
@@ -399,6 +408,12 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       {/* #3340: the aggregated fund-flow view over the same transfer data. */}
       <AccountCounterpartiesSection ss58={ss58} />
 
+      {/* #6723: live child/parent-hotkey stake-weight delegation graph. */}
+      <AccountDelegationSection ss58={ss58} />
+
+      {/* #6740: community entity labels + subnet-ownership ties. */}
+      <AccountEntitiesSection ss58={ss58} />
+
       {/* #6432: deliberately NOT "← All accounts" like the other detail pages'
           back-links. /accounts is a lookup form, not an index -- there is no
           list of every chain account to go back to -- so the label names what
@@ -427,6 +442,9 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
             { label: "counterparties", path: `/api/v1/accounts/${sourceRef}/counterparties` },
+            { label: "children", path: `/api/v1/accounts/${sourceRef}/children` },
+            { label: "parents", path: `/api/v1/accounts/${sourceRef}/parents` },
+            { label: "entities", path: `/api/v1/accounts/${sourceRef}/entities` },
             { label: "stake-flow", path: `/api/v1/accounts/${sourceRef}/stake-flow` },
             { label: "serving", path: `/api/v1/accounts/${sourceRef}/serving` },
             { label: "prometheus", path: `/api/v1/accounts/${sourceRef}/prometheus` },
@@ -442,6 +460,9 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
           `/api/v1/accounts/${sourceRef}/counterparties`,
+          `/api/v1/accounts/${sourceRef}/children`,
+          `/api/v1/accounts/${sourceRef}/parents`,
+          `/api/v1/accounts/${sourceRef}/entities`,
           `/api/v1/accounts/${sourceRef}/stake-flow`,
           `/api/v1/accounts/${sourceRef}/serving`,
           `/api/v1/accounts/${sourceRef}/prometheus`,
@@ -1061,6 +1082,423 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
         <p className="mt-3 font-mono text-[10px] text-ink-muted">
           Showing the {rows.length} highest-volume of {formatNumber(parties.length)} counterparties.
         </p>
+      ) : null}
+    </SectionAnchor>
+  );
+}
+
+// A u64 proportion is delivered as a 0..1 fraction; show it as a compact percent.
+function fmtProportionPct(f: number | null): string {
+  if (f == null || !Number.isFinite(f)) return "—";
+  return `${(f * 100).toFixed(1)}%`;
+}
+
+type DelegationRow = {
+  netuid: number;
+  counterpart: string;
+  proportion_fraction: number | null;
+};
+
+function flattenDelegation(subnets: AccountDelegationSubnet[] | null): DelegationRow[] {
+  if (!Array.isArray(subnets)) return [];
+  const rows: DelegationRow[] = [];
+  for (const subnet of subnets) {
+    for (const entry of subnet.entries) {
+      rows.push({
+        netuid: subnet.netuid,
+        counterpart: entry.counterpart,
+        proportion_fraction: entry.proportion_fraction,
+      });
+    }
+  }
+  return rows.sort((a, b) => a.netuid - b.netuid || a.counterpart.localeCompare(b.counterpart));
+}
+
+type DelegationStatus =
+  | { kind: "pending" }
+  | { kind: "empty" }
+  | {
+      kind: "ready";
+      childRows: DelegationRow[];
+      parentRows: DelegationRow[];
+      childUnavailable: boolean;
+      parentUnavailable: boolean;
+    };
+
+// Single status derivation so the section body only branches once
+// (closed-PR feedback: overlapping pending/empty checks were hard to trace).
+function deriveDelegationStatus(
+  childrenResult: { isPending: boolean; isError: boolean },
+  parentsResult: { isPending: boolean; isError: boolean },
+  childrenData: AccountDelegationGraph | undefined,
+  parentsData: AccountDelegationGraph | undefined,
+): DelegationStatus {
+  if (
+    (childrenResult.isPending && !childrenData) ||
+    (parentsResult.isPending && !parentsData)
+  ) {
+    return { kind: "pending" };
+  }
+  const childRows = flattenDelegation(childrenData?.subnets ?? null);
+  const parentRows = flattenDelegation(parentsData?.subnets ?? null);
+  // HTTP error OR `subnets: null` = live RPC didn't answer for that side.
+  const childUnavailable = childrenResult.isError || childrenData?.subnets === null;
+  const parentUnavailable = parentsResult.isError || parentsData?.subnets === null;
+  if (
+    !childUnavailable &&
+    !parentUnavailable &&
+    childRows.length === 0 &&
+    parentRows.length === 0
+  ) {
+    return { kind: "empty" };
+  }
+  return { kind: "ready", childRows, parentRows, childUnavailable, parentUnavailable };
+}
+
+/**
+ * Visual edge list — proportion bar + compact SN/hotkey row.
+ * Avoids multi-word table headers that wrap on mobile (#7226/#7263 closes).
+ */
+function DelegationEdgeList({
+  ss58,
+  rows,
+}: {
+  ss58: string;
+  rows: DelegationRow[];
+}) {
+  return (
+    <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border/80 bg-card/95">
+      {rows.map((r, i) => {
+        const pct =
+          r.proportion_fraction != null && Number.isFinite(r.proportion_fraction)
+            ? Math.max(0, Math.min(1, r.proportion_fraction))
+            : null;
+        return (
+          <div
+            key={`${r.netuid}-${r.counterpart}-${i}`}
+            className="flex items-center gap-3 px-4 py-3"
+          >
+            <Link
+              to="/subnets/$netuid"
+              params={{ netuid: r.netuid }}
+              className="shrink-0 whitespace-nowrap font-mono text-[11px] text-ink hover:text-accent hover:underline"
+            >
+              SN{r.netuid}
+            </Link>
+            <div className="min-w-0 flex-1 truncate font-mono text-[11px] text-ink-muted" title={r.counterpart}>
+              {r.counterpart !== ss58 ? (
+                <Link
+                  to="/accounts/$ss58"
+                  params={{ ss58: r.counterpart }}
+                  className="hover:text-accent hover:underline"
+                >
+                  {shortHash(r.counterpart)}
+                </Link>
+              ) : (
+                (shortHash(r.counterpart) ?? "—")
+              )}
+            </div>
+            <div className="flex w-28 shrink-0 items-center gap-2">
+              <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-surface">
+                <div
+                  className="h-full rounded-full bg-accent"
+                  style={{ width: `${pct == null ? 0 : pct * 100}%` }}
+                />
+              </div>
+              <span className="w-11 whitespace-nowrap text-right font-mono text-[11px] tabular-nums text-ink">
+                {fmtProportionPct(r.proportion_fraction)}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function DelegationSide({
+  label,
+  ss58,
+  rows,
+  unavailable,
+  error,
+  onRetry,
+  emptyTitle,
+  emptyDescription,
+  unavailableTitle,
+}: {
+  label: string;
+  ss58: string;
+  rows: DelegationRow[];
+  unavailable: boolean;
+  error: unknown;
+  onRetry: () => void;
+  emptyTitle: string;
+  emptyDescription: string;
+  unavailableTitle: string;
+}) {
+  return (
+    <div>
+      <h3 className="mb-2 whitespace-nowrap font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+        {label}
+      </h3>
+      {unavailable ? (
+        <TableState
+          variant="error"
+          title={unavailableTitle}
+          description="Live RPC didn't respond — the rest of the page is unaffected."
+          error={error}
+          onRetry={onRetry}
+        />
+      ) : rows.length === 0 ? (
+        <TableState variant="empty" title={emptyTitle} description={emptyDescription} />
+      ) : (
+        <DelegationEdgeList ss58={ss58} rows={rows} />
+      )}
+    </div>
+  );
+}
+
+// #6723 (child-hotkey epic #6721): live stake-weight delegation graph.
+// Soft-hides for cold wallets; preserves null-vs-[] tri-state per side.
+function AccountDelegationSection({ ss58 }: { ss58: string }) {
+  const childrenResult = useQuery(accountChildrenQuery(ss58));
+  const parentsResult = useQuery(accountParentsQuery(ss58));
+  const childrenData = childrenResult.data?.data;
+  const parentsData = parentsResult.data?.data;
+  const status = deriveDelegationStatus(
+    childrenResult,
+    parentsResult,
+    childrenData,
+    parentsData,
+  );
+
+  if (status.kind === "pending") {
+    return <AccountFeedSectionSkeleton id="delegation" title="Delegation" />;
+  }
+  if (status.kind === "empty") return null;
+
+  const { childRows, parentRows, childUnavailable, parentUnavailable } = status;
+  const edgeCount = childRows.length + parentRows.length;
+
+  return (
+    <SectionAnchor
+      id="delegation"
+      title="Delegation"
+      tone="accent"
+      info="Live child/parent-hotkey stake-weight edges from /api/v1/accounts/{ss58}/children and /parents (ChildKeys/ParentKeys, KV-cached). Each row is one edge and its share on that subnet."
+      right={
+        edgeCount > 0 ? (
+          <SectionBadge tone="accent">{formatNumber(edgeCount)} edges</SectionBadge>
+        ) : null
+      }
+    >
+      <div className="mb-4 grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={Network}
+          eyebrow="Children"
+          tone="accent"
+          value={childUnavailable ? "—" : formatNumber(childRows.length)}
+          hint="delegated to"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Parents"
+          value={parentUnavailable ? "—" : formatNumber(parentRows.length)}
+          hint="delegating in"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Boxes}
+          eyebrow="Subnets"
+          value={formatNumber(new Set([...childRows, ...parentRows].map((r) => r.netuid)).size)}
+          hint="with an edge"
+          className={KPI_TILE}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <DelegationSide
+          label="Children"
+          ss58={ss58}
+          rows={childRows}
+          unavailable={childUnavailable}
+          error={childrenResult.error}
+          onRetry={() => void childrenResult.refetch()}
+          emptyTitle="No children"
+          emptyDescription="This account delegates stake-weight to no child hotkeys."
+          unavailableTitle="Children unavailable"
+        />
+        <DelegationSide
+          label="Parents"
+          ss58={ss58}
+          rows={parentRows}
+          unavailable={parentUnavailable}
+          error={parentsResult.error}
+          onRetry={() => void parentsResult.refetch()}
+          emptyTitle="No parents"
+          emptyDescription="No parent hotkeys delegate stake-weight to this account."
+          unavailableTitle="Parents unavailable"
+        />
+      </div>
+    </SectionAnchor>
+  );
+}
+
+function ownershipRoleLabel(role: string | null): string {
+  if (role === "gained_ownership") return "Gained";
+  if (role === "lost_ownership") return "Lost";
+  return "—";
+}
+
+function EntityLabelCard({ label }: { label: AccountEntityLabel }) {
+  return (
+    <div className={KPI_TILE}>
+      <div className="flex flex-wrap items-center gap-2">
+        <Tag className="h-3.5 w-3.5 shrink-0 text-accent" />
+        <span className="min-w-0 truncate font-semibold text-ink">
+          {label.name ?? "Unnamed"}
+        </span>
+        {label.category ? (
+          <span className="shrink-0 whitespace-nowrap rounded border border-border/70 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-ink-muted">
+            {label.category}
+          </span>
+        ) : null}
+      </div>
+      {label.notes ? <p className="mt-2 text-[12px] text-ink-muted">{label.notes}</p> : null}
+      {label.source_urls.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-3">
+          {label.source_urls.map((url, i) => (
+            <ExternalLink
+              key={`${url}-${i}`}
+              href={url}
+              className="font-mono text-[10px] text-accent-text hover:underline"
+            >
+              source{label.source_urls.length > 1 ? ` ${i + 1}` : ""}
+            </ExternalLink>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// #6740: community entity labels + SubnetOwnerChanged ownership ties.
+// Soft-hides when both lists are empty.
+function AccountEntitiesSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountEntitiesQuery(ss58));
+  const e = result.data?.data;
+
+  if (result.isPending && !e) {
+    return <AccountFeedSectionSkeleton id="entities" title="Entity" />;
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor id="entities" title="Entity" tone="accent">
+        <TableState
+          variant="error"
+          title="Couldn't load entity labels"
+          description="The entity-labels tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+  const labels: AccountEntityLabel[] = e?.labels ?? [];
+  const ties: AccountOwnershipTie[] = e?.ownership_ties ?? [];
+  if (!e || (labels.length === 0 && ties.length === 0)) return null;
+
+  return (
+    <SectionAnchor
+      id="entities"
+      title="Entity"
+      tone="accent"
+      info="Community labels and subnet-ownership ties from /api/v1/accounts/{ss58}/entities. Ownership ties are automatic SubnetOwnerChanged transfers only (not genesis ownership)."
+      right={
+        <SectionBadge tone="accent">
+          {formatNumber(labels.length + ties.length)}
+        </SectionBadge>
+      }
+    >
+      {labels.length > 0 ? (
+        <div className="mb-6 grid gap-4 sm:grid-cols-2">
+          {labels.map((label, i) => (
+            <EntityLabelCard key={`${label.name ?? "label"}-${i}`} label={label} />
+          ))}
+        </div>
+      ) : null}
+
+      {ties.length > 0 ? (
+        <>
+          <h3 className="mb-2 whitespace-nowrap font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Ownership
+          </h3>
+          <DataPanel>
+            <table className="w-full text-left text-sm">
+              <thead className="bg-surface/50">
+                <tr>
+                  <th className={`${TH} whitespace-nowrap`}>SN</th>
+                  <th className={`${TH} whitespace-nowrap`}>Role</th>
+                  <th className={`${TH} whitespace-nowrap text-right`}>Block</th>
+                  <th className={`${TH} whitespace-nowrap text-right`}>When</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {ties.map((tie, i) => (
+                  <tr
+                    key={`${tie.netuid}-${tie.block_number}-${i}`}
+                    className="hover:bg-surface/30"
+                  >
+                    <td className="whitespace-nowrap px-5 py-4 font-mono text-[12px]">
+                      {tie.netuid != null ? (
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: tie.netuid }}
+                          className="text-ink hover:text-accent hover:underline"
+                        >
+                          SN{tie.netuid}
+                        </Link>
+                      ) : (
+                        <span className="text-ink-muted">—</span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-5 py-4 text-[11px]">
+                      <span
+                        className={
+                          tie.role === "gained_ownership"
+                            ? "text-health-ok"
+                            : tie.role === "lost_ownership"
+                              ? "text-health-warn-text"
+                              : "text-ink-muted"
+                        }
+                      >
+                        {ownershipRoleLabel(tie.role)}
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-5 py-4 text-right font-mono text-[12px]">
+                      {tie.block_number != null ? (
+                        <Link
+                          to="/blocks/$ref"
+                          params={{ ref: String(tie.block_number) }}
+                          className="text-ink hover:text-accent hover:underline"
+                        >
+                          #{formatNumber(tie.block_number)}
+                        </Link>
+                      ) : (
+                        <span className="text-ink-muted">—</span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-5 py-4 text-right font-mono text-[11px] text-ink-muted">
+                      {tie.observed_at ? <TimeAgo at={tie.observed_at} /> : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </DataPanel>
+        </>
       ) : null}
     </SectionAnchor>
   );

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1133,10 +1133,7 @@ function deriveDelegationStatus(
   childrenData: AccountDelegationGraph | undefined,
   parentsData: AccountDelegationGraph | undefined,
 ): DelegationStatus {
-  if (
-    (childrenResult.isPending && !childrenData) ||
-    (parentsResult.isPending && !parentsData)
-  ) {
+  if ((childrenResult.isPending && !childrenData) || (parentsResult.isPending && !parentsData)) {
     return { kind: "pending" };
   }
   const childRows = flattenDelegation(childrenData?.subnets ?? null);
@@ -1159,13 +1156,7 @@ function deriveDelegationStatus(
  * Visual edge list — proportion bar + compact SN/hotkey row.
  * Avoids multi-word table headers that wrap on mobile (#7226/#7263 closes).
  */
-function DelegationEdgeList({
-  ss58,
-  rows,
-}: {
-  ss58: string;
-  rows: DelegationRow[];
-}) {
+function DelegationEdgeList({ ss58, rows }: { ss58: string; rows: DelegationRow[] }) {
   return (
     <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border/80 bg-card/95">
       {rows.map((r, i) => {
@@ -1185,7 +1176,10 @@ function DelegationEdgeList({
             >
               SN{r.netuid}
             </Link>
-            <div className="min-w-0 flex-1 truncate font-mono text-[11px] text-ink-muted" title={r.counterpart}>
+            <div
+              className="min-w-0 flex-1 truncate font-mono text-[11px] text-ink-muted"
+              title={r.counterpart}
+            >
               {r.counterpart !== ss58 ? (
                 <Link
                   to="/accounts/$ss58"
@@ -1266,12 +1260,7 @@ function AccountDelegationSection({ ss58 }: { ss58: string }) {
   const parentsResult = useQuery(accountParentsQuery(ss58));
   const childrenData = childrenResult.data?.data;
   const parentsData = parentsResult.data?.data;
-  const status = deriveDelegationStatus(
-    childrenResult,
-    parentsResult,
-    childrenData,
-    parentsData,
-  );
+  const status = deriveDelegationStatus(childrenResult, parentsResult, childrenData, parentsData);
 
   if (status.kind === "pending") {
     return <AccountFeedSectionSkeleton id="delegation" title="Delegation" />;
@@ -1357,9 +1346,7 @@ function EntityLabelCard({ label }: { label: AccountEntityLabel }) {
     <div className={KPI_TILE}>
       <div className="flex flex-wrap items-center gap-2">
         <Tag className="h-3.5 w-3.5 shrink-0 text-accent" />
-        <span className="min-w-0 truncate font-semibold text-ink">
-          {label.name ?? "Unnamed"}
-        </span>
+        <span className="min-w-0 truncate font-semibold text-ink">{label.name ?? "Unnamed"}</span>
         {label.category ? (
           <span className="shrink-0 whitespace-nowrap rounded border border-border/70 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-ink-muted">
             {label.category}
@@ -1416,11 +1403,7 @@ function AccountEntitiesSection({ ss58 }: { ss58: string }) {
       title="Entity"
       tone="accent"
       info="Community labels and subnet-ownership ties from /api/v1/accounts/{ss58}/entities. Ownership ties are automatic SubnetOwnerChanged transfers only (not genesis ownership)."
-      right={
-        <SectionBadge tone="accent">
-          {formatNumber(labels.length + ties.length)}
-        </SectionBadge>
-      }
+      right={<SectionBadge tone="accent">{formatNumber(labels.length + ties.length)}</SectionBadge>}
     >
       {labels.length > 0 ? (
         <div className="mb-6 grid gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary

Wires two already-shipped account sub-resources onto the account detail page, following `AccountCounterpartiesSection`:

- **Delegation** — live child/parent-hotkey stake-weight edges from `GET /api/v1/accounts/{ss58}/children` + `/parents` (#6723 / epic #6721)
- **Entity** — community labels + `SubnetOwnerChanged` ownership ties from `GET /api/v1/accounts/{ss58}/entities` (#6737 / #6740)

Closes #6999.

## What changed

- `apps/ui/src/lib/metagraphed/types.ts` — `AccountDelegation*` + `AccountEntity*` types
- `apps/ui/src/lib/metagraphed/queries.ts` — `accountChildrenQuery`, `accountParentsQuery`, `accountEntitiesQuery` (preserve `subnets: null` vs `[]`)
- `apps/ui/src/routes/accounts.$ss58.tsx` — `AccountDelegationSection` + `AccountEntitiesSection` after counterparties; endpoints added to Call this endpoint / footer
- Unit tests: `queries.account-delegation.test.ts`, `queries.account-entities.test.ts`

## Design (vs closed attempts #7149 / #7226 / #7258 / #7263)

- Short titles (**Delegation** / **Entity**); long copy lives in the `info` tooltip — no wrapping subtitle
- Compact edge-count badge; proportion-bar edge rows instead of multi-word table headers that wrap on mobile
- Soft-hide when both sides empty (counterparties pattern); per-side unavailable state when `subnets` is `null`
- Design-system tokens only (`KPI_TILE` / `TH` / `StatTile` / `SectionAnchor` / `SectionBadge`)

## Screenshots

Fixed-viewport `page.screenshot` (Mobile 375×812 · Tablet 768×1024 · Desktop 1280×800), themes forced via `mg-theme`. Account `5Fh1YDPcJ2Bs6JHfE5Ck1gCwvPxgkK32ZpHy94oy9XKMEyh9` has a live delegation graph. **Before** scrolls to `#counterparties` (section did not exist yet); **after** scrolls to `#delegation`.

Entity soft-hides on this address (no labels / ownership ties); label + ties paths are covered by `queries.account-entities.test.ts`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/wondercreatemaster/metagraphed/screenshots/6999/6999-delegation-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

```sh
npm run format:check --workspace=apps/ui
npx eslint apps/ui/src/routes/accounts.\$ss58.tsx apps/ui/src/lib/metagraphed/queries.ts apps/ui/src/lib/metagraphed/types.ts apps/ui/src/lib/metagraphed/queries.account-delegation.test.ts apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui -- queries.account-delegation queries.account-entities
```

All green locally (8/8 unit tests; prettier clean; typecheck clean after workspace package builds).

