### PR TITLE
fix(registry): register SN124 Swarm signed validator API surfaces (#7132)

### DIFF
--- a/registry/subnets/swarm.json
+++ b/registry/subnets/swarm.json
@@ -187,6 +187,230 @@
         "https://github.com/swarm-subnet/swarm/blob/main/docs/king_of_the_hill.md"
       ],
       "url": "https://api.swarm124.com/kings/diagnostics"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request signed headers via swarm/validator/backend_api.py (_sign_request / _get_signed / _post_signed). Not a bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-124-swarm-validators-next-task",
+      "kind": "subnet-api",
+      "name": "Swarm validators next-task",
+      "notes": "Auth-gated GET /validators/next-task on api.swarm124.com — long-poll for the next authorized evaluation task. Called via _get_signed in the official swarm/validator/backend_api.py client. Registered per metagraphed#7132 remaining deliverable with auth_required:true, probe.enabled:false. Live-verified 2026-07-22: unsigned GET returns HTTP 426 (non-2xx gate; matches the issue's own live-verified 426 observation).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/validators/next-task"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request signed headers via swarm/validator/backend_api.py (_sign_request / _get_signed / _post_signed). Not a bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-124-swarm-validators-sync",
+      "kind": "subnet-api",
+      "name": "Swarm validators sync",
+      "notes": "Auth-gated GET /validators/sync on api.swarm124.com — current weights, re-eval queue, and authoritative benchmark epoch. Called via _get_signed in the official swarm/validator/backend_api.py client. Registered per metagraphed#7132 remaining deliverable with auth_required:true, probe.enabled:false. Live-verified 2026-07-22: unsigned GET returns HTTP 422 (non-2xx gate; matches the issue's own live-verified 422 observation).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/validators/sync"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request signed headers via swarm/validator/backend_api.py (_sign_request / _get_signed / _post_signed). Not a bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-124-swarm-validators-events",
+      "kind": "sse",
+      "name": "Swarm validators events stream",
+      "notes": "Auth-gated GET /validators/events on api.swarm124.com — server-sent events stream for validator backend updates. Called via signed GET in the official swarm/validator/backend_api.py client (same signed-header gate as sync/next-task). Registered kind:sse per metagraphed#7132 remaining deliverable with auth_required:true, probe.enabled:false. Live-verified 2026-07-22: unsigned GET returns HTTP 422 (non-2xx gate).",
+      "probe": {
+        "enabled": false,
+        "expect": "sse",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/validators/events"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request signed headers via swarm/validator/backend_api.py (_sign_request / _get_signed / _post_signed). Not a bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-124-swarm-validators-seed-scores",
+      "kind": "subnet-api",
+      "name": "Swarm validators seed-scores",
+      "notes": "Auth-gated POST /validators/seed-scores on api.swarm124.com — stream per-seed scores for the active task. Called via _post_signed in the official swarm/validator/backend_api.py client. POST-only — probe.method stays GET with probe.enabled:false (schema probe methods are GET/HEAD/JSON-RPC/WSS-RPC only). Registered per metagraphed#7132 remaining deliverable with auth_required:true. Live-verified 2026-07-22: unsigned POST returns HTTP 426 (non-2xx gate).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/validators/seed-scores"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request signed headers via swarm/validator/backend_api.py (_sign_request / _get_signed / _post_signed). Not a bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-124-swarm-validators-heartbeat",
+      "kind": "subnet-api",
+      "name": "Swarm validators heartbeat",
+      "notes": "Auth-gated POST /validators/heartbeat on api.swarm124.com. Called via _post_signed in the official swarm/validator/backend_api.py client. POST-only — probe.method stays GET with probe.enabled:false (schema probe methods are GET/HEAD/JSON-RPC/WSS-RPC only). Registered per metagraphed#7132 remaining deliverable with auth_required:true. Live-verified 2026-07-22: unsigned POST returns HTTP 422 (non-2xx gate).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/validators/heartbeat"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request signed headers via swarm/validator/backend_api.py (_sign_request / _get_signed / _post_signed). Not a bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-124-swarm-validators-epoch-publish",
+      "kind": "subnet-api",
+      "name": "Swarm validators epoch publish",
+      "notes": "Auth-gated POST /validators/epoch/publish on api.swarm124.com. Called via _post_signed in the official swarm/validator/backend_api.py client. POST-only — probe.method stays GET with probe.enabled:false (schema probe methods are GET/HEAD/JSON-RPC/WSS-RPC only). Registered per metagraphed#7132 remaining deliverable with auth_required:true. Live-verified 2026-07-22: unsigned POST returns HTTP 422 (non-2xx gate).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/validators/epoch/publish"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request signed headers via swarm/validator/backend_api.py (_sign_request / _get_signed / _post_signed). Not a bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-124-swarm-validators-task-result",
+      "kind": "subnet-api",
+      "name": "Swarm validators task result",
+      "notes": "Auth-gated POST /validators/tasks/{id}/result on api.swarm124.com — submit aggregated task result. Called via _post_signed in the official swarm/validator/backend_api.py client. Path-param template uses URI-encoded braces (%7B...%7D) for schema uri format. POST-only — probe.method stays GET with probe.enabled:false (schema probe methods are GET/HEAD/JSON-RPC/WSS-RPC only). Registered per metagraphed#7132 remaining deliverable with auth_required:true. Live-verified 2026-07-22 with placeholder id: unsigned POST returns HTTP 426 (non-2xx gate).",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/validators/tasks/%7Bid%7D/result"
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Requires per-request signed headers via swarm/validator/backend_api.py (_sign_request / _get_signed / _post_signed). Not a bearer/API-key scheme."
+      },
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-124-swarm-validators-private-artifact",
+      "kind": "subnet-api",
+      "name": "Swarm validators private model artifact",
+      "notes": "Auth-gated GET /validators/models/{model_hash}/private-artifact on api.swarm124.com — fetch a miner private model artifact for evaluation. Called via _get_signed in the official swarm/validator/backend_api.py client. Path-param template uses URI-encoded braces (%7B...%7D) for schema uri format. Registered per metagraphed#7132 remaining deliverable with auth_required:true, probe.enabled:false. Live-verified 2026-07-22 with placeholder hash: unsigned GET returns HTTP 426 (non-2xx gate).",
+      "probe": {
+        "enabled": false,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "swarm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": [
+        "https://github.com/swarm-subnet/swarm/blob/main/swarm/validator/backend_api.py"
+      ],
+      "url": "https://api.swarm124.com/validators/models/%7Bmodel_hash%7D/private-artifact"
     }
   ],
   "website_url": "https://swarm124.com/"


### PR DESCRIPTION
## Summary

Closes #7132.

Originals (health, kings/active, leaderboard, kings/diagnostics) already match reality — no changes there.

Registers the 8 remaining signed-header validator surfaces from the issue's "Additional surface(s)" / latest status comment, append-only on `registry/subnets/swarm.json`.

## What this adds (8 surfaces)

All on `https://api.swarm124.com`, `provider: swarm`, `authority: community`, `auth_required: true`, `probe.enabled: false`, source: `swarm/validator/backend_api.py`.

| id | kind | method · path | Live-verified 2026-07-22 (unsigned) |
| --- | --- | --- | --- |
| `sn-124-swarm-validators-next-task` | subnet-api | GET `/validators/next-task` | HTTP 426 |
| `sn-124-swarm-validators-sync` | subnet-api | GET `/validators/sync` | HTTP 422 |
| `sn-124-swarm-validators-events` | sse | GET `/validators/events` | HTTP 422 |
| `sn-124-swarm-validators-seed-scores` | subnet-api | POST `/validators/seed-scores` | HTTP 426 |
| `sn-124-swarm-validators-heartbeat` | subnet-api | POST `/validators/heartbeat` | HTTP 422 |
| `sn-124-swarm-validators-epoch-publish` | subnet-api | POST `/validators/epoch/publish` | HTTP 422 |
| `sn-124-swarm-validators-task-result` | subnet-api | POST `/validators/tasks/{id}/result` | HTTP 426 |
| `sn-124-swarm-validators-private-artifact` | subnet-api | GET `/validators/models/{model_hash}/private-artifact` | HTTP 426 |

Path-param URLs use `%7B...%7D`. POST-only routes keep `probe.method: GET` with `enabled: false` (probe enum is GET/HEAD/JSON-RPC/WSS-RPC only).

## Registry Safety

- [x] Links open issue `Closes #7132`
- [x] Exactly one file: `registry/subnets/swarm.json` (append-only)
- [x] No secrets / PATs / private URLs; no generated artifacts
- [x] Does not re-title existing surfaces by `kind`

## Validation

- [x] `npm run validate:surface -- registry/subnets/swarm.json`
- [x] `npx prettier --write registry/subnets/swarm.json`