### PR TITLE
fix(registry): SN46 Zipcode combined OpenAPI docs route (#7060)

### DIFF
--- a/registry/subnets/zipcode.json
+++ b/registry/subnets/zipcode.json
@@ -1155,6 +1155,31 @@
       },
       "source_urls": ["https://zipcode.ai/openapi.json"],
       "url": "https://zipcode.ai/api/v1/real_estate/evaluate/results/%7Bid%7D"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-46-zipcode-api-docs",
+      "kind": "subnet-api",
+      "name": "Zipcode combined OpenAPI docs",
+      "notes": "Public GET /api/docs on zipcode.ai — combined OpenAPI spec entry point from metagraphed#7060 additional scope (distinct from the openapi-kind sn-46-zipcode-openapi and sn-46-zipcode-dashboard-openapi surfaces). Live-verified 2026-07-21: HTTP 302 redirect to /openapi.json; following the redirect yields byte-identical content to sn-46-zipcode-openapi. Registered as its own callable route per JSONbored reopen — catalog everything the subnet exposes.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "andriypolanski"
+      },
+      "source_urls": [
+        "https://zipcode.ai/openapi.json",
+        "https://github.com/resi-labs-ai/RESI-models"
+      ],
+      "url": "https://zipcode.ai/api/docs"
     }
   ],
   "website_url": "https://zipcode.ai/"


### PR DESCRIPTION
## Summary

Closes [#7060](https://github.com/JSONbored/metagraphed/issues/7060) by appending the **one remaining surface** from the additional-scope section — `GET /api/docs` — that [#7481](https://github.com/JSONbored/metagraphed/pull/7481) deliberately skipped.

Closes #7060

## Why the issue was reopened (three times)

1. **First reopen** — test-only PR ([#7359](https://github.com/JSONbored/metagraphed/pull/7359)) closed #7060 without registry changes. JSONbored:

   > A verification test alone doesn't satisfy this issue — the registry file itself needs the actual surface entries added.

2. **Second reopen** — after [#7481](https://github.com/JSONbored/metagraphed/pull/7481) landed 35 surfaces, JSONbored confirmed **44 of 45** additional-scope items done; **one remains**:

   > `GET https://zipcode.ai/api/docs` — the combined OpenAPI spec endpoint, `probe.enabled:true`, `auth_required:false`

3. **Gardening pass** — noted #7481's great work but kept open for the same gap (`/api/docs`; the gardening comment references `/api/dashboard/docs` but that path is already registered as `sn-46-zipcode-dashboard-openapi` — the actual missing route is `/api/docs` per the issue body and reopen).

## Why #7481 skipped this (and why we register it anyway)

#7481 live-checked `/api/docs` and found HTTP **302 → `/openapi.json`** with byte-identical content to the already-registered `sn-46-zipcode-openapi`. Correctly concluded it isn't a distinct schema resource — but JSONbored's reopen explicitly wants the **callable route cataloged** anyway (same "register everything the subnet exposes" policy as other MCP-execute parity issues).

This PR registers it as `subnet-api` (not a third `openapi`-kind surface), distinct from the two existing openapi entries.

## How to implement without failing the gate

| Risk | Avoidance |
|---|---|
| Re-doing #7481's 35 surfaces | **One surface only** — append `/api/docs`, nothing else |
| Editing existing surfaces | Append-only (+25 lines, 0 deletions) |
| Duplicate URL | `/api/docs` is not registered; `/api/dashboard/docs` and `/openapi.json` left untouched |
| 302 redirect breaks JSON probe | `probe.expect: "any"` (redirect, not JSON body) |
| Partial scope claim | Matches JSONbored's exact remaining deliverable |

## What this PR adds

**1 new surface:**

- `sn-46-zipcode-api-docs` — `GET https://zipcode.ai/api/docs`, public, `probe.enabled:true`, `expect:any`
- Live note: 302 redirect to `/openapi.json` (same content as `sn-46-zipcode-openapi`)

## Checklist

- [x] Changes exactly one `registry/subnets/zipcode.json` file (**+25, 0 deletions**)
- [x] Append-only — no edits to existing surfaces
- [x] `validate:surface` — 44 surfaces, passed
- [x] `scan:public-safety` — passed
- [x] `tests/sn46-call-subnet-surface-verify.test.mjs` — 11/11

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] MCP smoke: `sn-46-zipcode-api-docs` (expect redirect/any), `sn-46-zipcode-openapi` (existing JSON schema)
