### PR TITLE
fix(lint): ignore .claude/** in root eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,12 @@ export default tseslint.config(
       "packages/*/node_modules/**",
       "packages/*/dist/**",
       "packages/*/src/metagraphed-*.ts",
+      // Isolated agent worktrees live under .claude/worktrees/** — each is a
+      // full nested checkout that can be mid-edit or on a different branch
+      // entirely, so a plain `eslint .` recursive scan picks it up and can
+      // fail on files that don't exist yet in that worktree's working tree.
+      // Not application source; never meant to be linted from the root config.
+      ".claude/**",
       // apps/ui has its own eslint.config.js scoped to its own React/TS setup —
       // this repo's root config has no TSX/JSX parser wired in and would just
       // error on syntax it can't parse, not meaningfully lint it.


### PR DESCRIPTION
## Summary

Isolated agent worktrees live under `.claude/worktrees/**` — each is a full nested git checkout that can be mid-edit or on a different branch entirely. A plain `eslint .` recursive scan from the root config picks these up and can fail on files that don't exist yet in that worktree's working tree, even though none of it is application source. `.claude/**` wasn't in the root config's `ignores` array.

## What changed

Added `.claude/**` to `eslint.config.mjs`'s `ignores` array, alongside the existing `node_modules/**`, `packages/*/dist/**`, etc. entries.

## Verification

- [x] `npm run lint` — clean
- [x] Not a CI-visible bug (CI checks out a clean tree with no `.claude/worktrees/**`) — this is a local-development-experience fix for any contributor/maintainer running `npm run lint` with an active worktree present