### PR TITLE
feat(api): add GraphQL evm_address_mapping field mirroring GET /api/v1/evm/address/{h160}

### DIFF
--- a/registry/subnets/vocence.json
+++ b/registry/subnets/vocence.json
@@ -38,9 +38,7 @@
       "provider": "vocence",
       "public_safe": true,
       "source_urls": ["https://www.vocence.ai/"],
-      "source_urls": [
-        "https://www.vocence.ai/"
-      ],
+      "source_urls": ["https://www.vocence.ai/"],
       "url": "https://www.vocence.ai/"
     },
     {
@@ -59,9 +57,7 @@
       "provider": "vocence",
       "public_safe": true,
       "source_urls": ["https://github.com/vocence-78/vocence"],
-      "source_urls": [
-        "https://github.com/vocence-78/vocence"
-      ],
+      "source_urls": ["https://github.com/vocence-78/vocence"],
       "url": "https://github.com/vocence-78/vocence"
     },
     {
@@ -167,9 +163,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/account"
     },
     {
@@ -198,9 +192,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/account/keys"
     },
     {
@@ -229,9 +221,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/account/keys/%7Bkey_id%7D/revoke"
     },
     {
@@ -260,9 +250,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/account/usage"
     },
     {
@@ -291,9 +279,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agent-tools"
     },
     {
@@ -322,9 +308,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agent-tools/%7Btool_id%7D"
     },
     {
@@ -353,9 +337,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents"
     },
     {
@@ -384,9 +366,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/architect/chat"
     },
     {
@@ -415,9 +395,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/draft"
     },
     {
@@ -446,9 +424,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/models"
     },
     {
@@ -477,9 +453,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/templates"
     },
     {
@@ -508,9 +482,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/templates/%7Btemplate_id%7D"
     },
     {
@@ -539,9 +511,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/tools/builtin"
     },
     {
@@ -570,9 +540,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D"
     },
     {
@@ -601,9 +569,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/calls"
     },
     {
@@ -632,9 +598,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/calls/%7Bsession_id%7D/recording"
     },
     {
@@ -663,9 +627,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/calls/%7Bsession_id%7D/transcript"
     },
     {
@@ -694,9 +656,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/embed-tokens"
     },
     {
@@ -725,9 +685,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/embed-tokens/%7Btoken_id%7D"
     },
     {
@@ -756,9 +714,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/markdown"
     },
     {
@@ -787,9 +743,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/pdf"
     },
     {
@@ -818,9 +772,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/sitemap"
     },
     {
@@ -849,9 +801,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/text"
     },
     {
@@ -880,9 +830,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/ingest/url"
     },
     {
@@ -911,9 +859,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/jobs/%7Bjob_id%7D"
     },
     {
@@ -942,9 +888,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/sources"
     },
     {
@@ -973,9 +917,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/knowledge/sources/%7Bsource_id%7D"
     },
     {
@@ -1004,9 +946,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/runs"
     },
     {
@@ -1035,9 +975,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/runs/%7Brun_id%7D"
     },
     {
@@ -1066,9 +1004,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/runs/%7Brun_id%7D/cancel"
     },
     {
@@ -1097,9 +1033,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/tools"
     },
     {
@@ -1128,9 +1062,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/agents/%7Bagent_id%7D/tools/%7Btool_id%7D"
     },
     {
@@ -1159,9 +1091,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/audio/noise-remover"
     },
     {
@@ -1190,9 +1120,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/feedback"
     },
     {
@@ -1221,9 +1149,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/stt/transcribe"
     },
     {
@@ -1252,9 +1178,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/tts/generate"
     },
     {
@@ -1283,9 +1207,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/tts/speak"
     },
     {
@@ -1314,9 +1236,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/voice/clone"
     },
     {
@@ -1345,9 +1265,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/voice/clone/save"
     },
     {
@@ -1376,9 +1294,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/voice/design/preview"
     },
     {
@@ -1407,9 +1323,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/voice/design/save"
     },
     {
@@ -1438,9 +1352,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/voices"
     },
     {
@@ -1469,9 +1381,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/voices/builtin"
     },
     {
@@ -1500,9 +1410,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/voices/%7Bvoice_id%7D"
     },
     {
@@ -1531,9 +1439,7 @@
         "state": "community-submitted",
         "submitted_by": "joaovictor91123"
       },
-      "source_urls": [
-        "https://api.vocence.ai/openapi.json"
-      ],
+      "source_urls": ["https://api.vocence.ai/openapi.json"],
       "url": "https://api.vocence.ai/v1/voices/%7Bvoice_id%7D/speak"
     }
   ],

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -819,6 +819,8 @@ export const SDL = `
     network_randomness: NetworkRandomness
     "Live EVM (H160) -> Substrate (SS58) account-address mapping for a 20-byte 0x-prefixed hex address, resolved directly from chain via RPC (not the Postgres tier). ss58 is null when the address has no association or the RPC lookup fails, schema-stable, never a GraphQL error. Mirrors GET /api/v1/evm/address/{h160}."
     evm_address(h160: String!): EvmAddressMapping
+    "Live EVM (H160) -> Substrate (SS58) account-address mapping for a 20-byte 0x-prefixed hex address, resolved directly from chain via RPC (not the Postgres tier). ss58 is null when the address has no association or the RPC lookup fails, schema-stable, never a GraphQL error. Alias of evm_address that matches the get_evm_address_mapping MCP tool name. Mirrors GET /api/v1/evm/address/{h160}."
+    evm_address_mapping(h160: String!): EvmAddressMapping
     "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
     sudo(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
   }
@@ -4361,6 +4363,7 @@ export const FIELD_COMPLEXITY = {
   network_parameters: LIVE_RPC_FIELD_COMPLEXITY,
   network_randomness: LIVE_RPC_FIELD_COMPLEXITY,
   evm_address: LIVE_RPC_FIELD_COMPLEXITY,
+  evm_address_mapping: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -4906,6 +4909,21 @@ async function listPage(
 // namespace. Constrain it to the safe slug charset the other id-bearing artifact
 // paths use; subnet(netuid) is Int-typed and needs no guard.
 const VALID_PROVIDER_ID = /^[A-Za-z0-9._:-]+$/;
+
+// Shared by Query.evm_address and Query.evm_address_mapping (#7648) — same
+// H160_PATTERN validation + loadAddressMapping path the REST route and MCP
+// get_evm_address_mapping tool use. Malformed h160 → BAD_USER_INPUT; unresolved
+// mapping → schema-stable null ss58 (never a GraphQL error).
+async function resolveEvmAddressMapping({ h160 }, context) {
+  if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
+    throw new GraphQLError("h160 must be a 20-byte 0x-prefixed hex address.", {
+      extensions: { code: "BAD_USER_INPUT" },
+    });
+  }
+  // Live chain RPC, not the Postgres tier -- reuses loadAddressMapping's own
+  // KV cache/TTL, matching REST's /evm/address/{h160} handler exactly.
+  return loadAddressMapping(context.env, h160);
+}
 
 const rootValue = {
   subnets(
@@ -10067,20 +10085,11 @@ const rootValue = {
     return loadRandomnessStatus(context.env);
   },
   async evm_address({ h160 }, context) {
-    // Same H160_PATTERN validation the REST route + MCP get_evm_address_mapping
-    // use -- a malformed address is a GraphQL BAD_USER_INPUT error, not a card.
-    if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
-      throw new GraphQLError(
-        "h160 must be a 20-byte 0x-prefixed hex address.",
-        {
-          extensions: { code: "BAD_USER_INPUT" },
-        },
-      );
-    }
-    // Live chain RPC, not the Postgres tier -- reuses loadAddressMapping's own
-    // KV cache/TTL, matching REST's /evm/address/{h160} handler exactly. ss58 is
-    // null on an unresolved mapping (schema-stable), never a GraphQL error.
-    return loadAddressMapping(context.env, h160);
+    return resolveEvmAddressMapping({ h160 }, context);
+  },
+  // #7648 — MCP/REST naming alias for evm_address; same live precompile path.
+  async evm_address_mapping({ h160 }, context) {
+    return resolveEvmAddressMapping({ h160 }, context);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -16324,6 +16324,65 @@ describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs
   });
 });
 
+describe("graphql — evm_address_mapping (#7648, MCP/REST naming alias)", () => {
+  function kvEnv(payload) {
+    return { METAGRAPH_CONTROL: { get: async () => payload } };
+  }
+  const H160 = "0x1234567890abcdef1234567890abcdef12345678";
+
+  test("resolves a mapped address via the shared loadAddressMapping path", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      h160: H160,
+      ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ evm_address_mapping(h160: "${H160}") { schema_version h160 ss58 queried_at } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.evm_address_mapping;
+    assert.equal(r.schema_version, 1);
+    assert.equal(r.h160, H160);
+    assert.equal(r.ss58, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    assert.ok(r.queried_at);
+  });
+
+  test("an unmapped address resolves with null ss58, never a GraphQL error", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      h160: H160,
+      ss58: null,
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ evm_address_mapping(h160: "${H160}") { h160 ss58 } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.evm_address_mapping.ss58, null);
+  });
+
+  test("a malformed h160 is BAD_USER_INPUT", async () => {
+    const { body } = await gql(
+      '{ evm_address_mapping(h160: "not-an-address") { ss58 } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+    assert.equal(body.data?.evm_address_mapping ?? null, null);
+  });
+
+  test("evm_address_mapping is weighted as a live-RPC field", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.evm_address_mapping,
+      FIELD_COMPLEXITY.evm_address,
+    );
+  });
+});
+
 describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled.mjs)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/subnet-recycled.test.mjs.


### PR DESCRIPTION
## Summary

Closes #7648.

Adds `evm_address_mapping(h160: String!): EvmAddressMapping` on `Query`, documented **"Mirrors GET /api/v1/evm/address/{h160}."**

The live H160→SS58 lookup already existed as `evm_address` (same REST + MCP path). This PR adds the MCP-aligned field name as a thin alias that reuses a shared `resolveEvmAddressMapping` helper → `loadAddressMapping` from `src/address-mapping.mjs` (no re-implemented precompile call).

## Behavior

- Malformed `h160` → GraphQL `BAD_USER_INPUT`
- Unmapped / RPC-miss → schema-stable `{ ss58: null }`, not an error
- Complexity: `LIVE_RPC_FIELD_COMPLEXITY` (same as `evm_address`)

## Validation

- [x] `npx vitest run tests/graphql.test.mjs -t "evm_address"` — 8 passed
- [x] `npx prettier --check src/graphql.mjs tests/graphql.test.mjs`