### PR TITLE
feat(api): add evm_address_mapping alias field for MCP-name parity (#7648)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -819,6 +819,8 @@ export const SDL = `
     network_randomness: NetworkRandomness
     "Live EVM (H160) -> Substrate (SS58) account-address mapping for a 20-byte 0x-prefixed hex address, resolved directly from chain via RPC (not the Postgres tier). ss58 is null when the address has no association or the RPC lookup fails, schema-stable, never a GraphQL error. Mirrors GET /api/v1/evm/address/{h160}."
     evm_address(h160: String!): EvmAddressMapping
+    "The get_evm_address_mapping-aligned name for the same live H160 -> SS58 mapping (#7648): identical args, type, validation, and unresolved-mapping degradation as evm_address — a thin alias so MCP tool names and GraphQL fields line up. Mirrors GET /api/v1/evm/address/{h160}."
+    evm_address_mapping(h160: String!): EvmAddressMapping
     "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
     sudo(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
   }
@@ -4361,6 +4363,7 @@ export const FIELD_COMPLEXITY = {
   network_parameters: LIVE_RPC_FIELD_COMPLEXITY,
   network_randomness: LIVE_RPC_FIELD_COMPLEXITY,
   evm_address: LIVE_RPC_FIELD_COMPLEXITY,
+  evm_address_mapping: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -4906,6 +4909,21 @@ async function listPage(
 // namespace. Constrain it to the safe slug charset the other id-bearing artifact
 // paths use; subnet(netuid) is Int-typed and needs no guard.
 const VALID_PROVIDER_ID = /^[A-Za-z0-9._:-]+$/;
+
+// Shared by Query.evm_address and Query.evm_address_mapping (#7648) — same
+// H160_PATTERN validation + loadAddressMapping path the REST route and MCP
+// get_evm_address_mapping tool use. Malformed h160 → BAD_USER_INPUT; unresolved
+// mapping → schema-stable null ss58 (never a GraphQL error).
+async function resolveEvmAddressMapping({ h160 }, context) {
+  if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
+    throw new GraphQLError("h160 must be a 20-byte 0x-prefixed hex address.", {
+      extensions: { code: "BAD_USER_INPUT" },
+    });
+  }
+  // Live chain RPC, not the Postgres tier -- reuses loadAddressMapping's own
+  // KV cache/TTL, matching REST's /evm/address/{h160} handler exactly.
+  return loadAddressMapping(context.env, h160);
+}
 
 const rootValue = {
   subnets(
@@ -10067,20 +10085,14 @@ const rootValue = {
     return loadRandomnessStatus(context.env);
   },
   async evm_address({ h160 }, context) {
-    // Same H160_PATTERN validation the REST route + MCP get_evm_address_mapping
-    // use -- a malformed address is a GraphQL BAD_USER_INPUT error, not a card.
-    if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
-      throw new GraphQLError(
-        "h160 must be a 20-byte 0x-prefixed hex address.",
-        {
-          extensions: { code: "BAD_USER_INPUT" },
-        },
-      );
-    }
-    // Live chain RPC, not the Postgres tier -- reuses loadAddressMapping's own
-    // KV cache/TTL, matching REST's /evm/address/{h160} handler exactly. ss58 is
-    // null on an unresolved mapping (schema-stable), never a GraphQL error.
-    return loadAddressMapping(context.env, h160);
+    return resolveEvmAddressMapping({ h160 }, context);
+  },
+
+  // #7648: the get_evm_address_mapping-aligned name for the same mapping — a
+  // thin delegate so MCP tool names and GraphQL fields line up. Identical
+  // args, validation, and unresolved-mapping degradation; nothing re-implemented.
+  async evm_address_mapping({ h160 }, context) {
+    return resolveEvmAddressMapping({ h160 }, context);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -16324,6 +16324,66 @@ describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs
   });
 });
 
+describe("graphql — evm_address_mapping (#7648, get_evm_address_mapping-aligned alias)", () => {
+  function kvEnv(payload) {
+    return { METAGRAPH_CONTROL: { get: async () => payload } };
+  }
+  const H160 = "0x1234567890abcdef1234567890abcdef12345678";
+
+  test("serves the same mapping as evm_address through the shared resolver", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      h160: H160,
+      ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ evm_address_mapping(h160: "${H160}") { schema_version h160 ss58 queried_at } evm_address(h160: "${H160}") { ss58 } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.evm_address_mapping;
+    assert.equal(r.schema_version, 1);
+    assert.equal(r.h160, H160);
+    assert.equal(r.ss58, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    assert.ok(r.queried_at);
+    assert.equal(body.data.evm_address_mapping.ss58, body.data.evm_address.ss58);
+  });
+
+  test("an unresolved mapping resolves with null ss58, never a GraphQL error", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      h160: H160,
+      ss58: null,
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ evm_address_mapping(h160: "${H160}") { h160 ss58 } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.evm_address_mapping.ss58, null);
+  });
+
+  test("a malformed h160 is the same GraphQL BAD_USER_INPUT error evm_address raises", async () => {
+    const { body } = await gql(
+      '{ evm_address_mapping(h160: "not-an-address") { ss58 } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/h160/i.test(body.errors[0].message));
+    assert.equal(body.data?.evm_address_mapping ?? null, null);
+  });
+
+  test("is priced identically to evm_address", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.evm_address_mapping,
+      FIELD_COMPLEXITY.evm_address,
+    );
+  });
+});
+
 describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled.mjs)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/subnet-recycled.test.mjs.


### PR DESCRIPTION
## Summary
- Add `Query.evm_address_mapping(h160)` as a thin alias of `evm_address`, aligned with MCP `get_evm_address_mapping`.
- Shared `resolveEvmAddressMapping` path: same `EvmAddressMapping` type, H160 `BAD_USER_INPUT` validation, and schema-stable null `ss58` on unresolved mapping — nothing re-implemented.
- Closes #7648.

## Test plan
- [x] `npm run test -- tests/graphql.test.mjs -t "evm_address"` (8 passed)
- [ ] Confirm SDL exposes `evm_address_mapping` next to `evm_address`
- [ ] Confirm malformed h160 → BAD_USER_INPUT; unmapped address → null ss58