### PR TITLE
fix(smoke): pass required hotkeys param for /api/v1/compare/validators

### DIFF
--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -504,6 +504,14 @@ export function apiRouteUrl(routePath, date, options = {}) {
     // stake-quote requires `amount` — a bare GET is a correct 400
     // invalid_amount, not a route failure (same #1682 class as compare above).
     url.searchParams.set("amount", "1");
+  } else if (routePath === "/api/v1/compare/validators") {
+    // compare/validators requires `hotkeys` — a bare GET is a 400 invalid_query
+    // (same #1682 class as compare/stake-quote above). Alice's address is the
+    // same known-good SS58 already substituted for {ss58}/{hotkey} above.
+    url.searchParams.set(
+      "hotkeys",
+      "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+    );
   } else if (
     [
       "/api/v1/surfaces",

--- a/tests/smoke-route-substitution.test.mjs
+++ b/tests/smoke-route-substitution.test.mjs
@@ -25,6 +25,19 @@ describe("smoke route substitution", () => {
     });
   }
 
+  // REGRESSION: /api/v1/compare/validators requires `hotkeys` -- a bare GET is
+  // a 400 invalid_query, not a route failure (same #1682 class as
+  // /api/v1/compare's `netuids` and stake-quote's `amount`, confirmed live
+  // against production: the smoke step failed with "hotkeys is required" until
+  // this special-case was added).
+  test("/api/v1/compare/validators URL includes a hotkeys query param", () => {
+    const url = new URL(apiRouteUrl("/api/v1/compare/validators", sampleDate));
+    assert.ok(
+      url.searchParams.get("hotkeys"),
+      "expected apiRouteUrl to set a hotkeys query param for /api/v1/compare/validators",
+    );
+  });
+
   test("fixture detail live smoke is included when a surface id is available", () => {
     assert.equal(
       liveSmokeApiRoutes(null).some((route) => route.id === "fixture-detail"),


### PR DESCRIPTION
## Summary
- The publish pipeline's post-publish `smoke:live` check was failing on `/api/v1/compare/validators: expected HTTP 200` / `400 !== 200`, blocking the "Publish Cloudflare Backend" workflow's success status on an otherwise-fully-successful publish (artifacts uploaded, KV pointer updated).
- Root cause: `/api/v1/compare/validators` requires a `hotkeys` query param, and the smoke test's URL builder never special-cased it -- the same "#1682 class" of bug the script's own comments already document for `/api/v1/compare` (`netuids`) and stake-quote (`amount`), just missed when this newer route was added.
- Confirmed directly against production: the endpoint itself is healthy (200, valid response) once `hotkeys` is supplied -- this was purely a smoke-test gap, not a live API regression.

## What Changed
- `scripts/smoke-live-api.mjs`: `apiRouteUrl` now sets `hotkeys` to the same known-good Alice SS58 address already used elsewhere in the script for `/api/v1/compare/validators`.
- `tests/smoke-route-substitution.test.mjs`: added a regression test asserting the generated URL includes a `hotkeys` param.

## Registry Safety
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A -- no API surface change, test-only fix.)
- **No linked issue**: found while investigating a publish-pipeline smoke-test failure surfaced during METAGRAPHED-6/9 verification, not a tracked GitHub issue. Submitting directly as the maintainer.

## Validation
- [x] `npx eslint scripts/smoke-live-api.mjs tests/smoke-route-substitution.test.mjs` -- clean.
- [x] `npx prettier --check` on both files -- clean.
- [x] `npx vitest run tests/smoke-route-substitution.test.mjs` -- 181/181 passing.
- [x] Verified live: `curl https://api.metagraph.sh/api/v1/compare/validators?hotkeys=...` returns 200 with a valid response envelope.