### PR TITLE
fix(test): stop asserting SN38's evidence_action snapshot value

### DIFF
--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -2501,7 +2501,12 @@ test("enrichment guidance ignores maintainer-excluded candidate URLs", () => {
   const colosseum = queue.queue.find((entry) => entry.netuid === 38);
 
   assert(colosseum, "expected SN38 colosseum enrichment queue entry");
-  assert.equal(colosseum.evidence_action, "submit-new-evidence");
+  // evidence_action tracks the queue entry's lane (submit-new-evidence vs.
+  // maintainer-review-existing-evidence vs. ...) and legitimately changes as
+  // real evidence/candidates accumulate for this subnet -- not asserted here,
+  // this test only cares that the maintainer-excluded URL stays excluded
+  // regardless of what evidence_action currently is (same pattern as the
+  // sibling "ignores maintainer-excluded candidate IDs" test above).
   assert.equal(
     colosseum.sample_target_candidate_ids.includes(
       "sn-38-native-chain-website",


### PR DESCRIPTION
## Summary

`enrichment guidance ignores maintainer-excluded candidate URLs` asserted `colosseum.evidence_action === "submit-new-evidence"` — a snapshot of SN38's pre-#7672 state. `evidence_action` tracks the queue entry's `lane` (`enrichmentEvidenceAction` in `scripts/lib/enrichment-queue-artifacts.mjs`) and legitimately changes as real evidence accumulates for a subnet; it's now `maintainer-review-existing-evidence` since #7672 added 10 real surfaces for SN38.

This test's actual name/purpose is verifying a maintainer-excluded candidate URL (`sn-38-native-chain-website`) stays excluded from enrichment targets — not pinning `evidence_action` to a point-in-time value. The sibling test right above it (`ignores maintainer-excluded candidate IDs`, SN118) tests the identical exclusion behavior and never asserts `evidence_action` at all.

## What changed

Removed the brittle `evidence_action` assertion, replaced with a comment explaining why (so a future reader doesn't wonder if it was dropped by accident).

## Validation

- [x] Confirmed via a stash-and-rerun against clean `main` that this failure predates this fix entirely (caused by #7672, not a regression from any of my other in-flight work).
- [x] `npx vitest run tests/artifacts.test.mjs` — 23/23 passing.
- [x] `npm run lint` / `npm run format:check` — clean.