### PR TITLE
feat(api): add global_incidents alias field for MCP-name parity (#7643)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -657,6 +657,8 @@ export const SDL = `
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
     "Global endpoint-incident ledger over a 7d/30d window; degrades to a schema-stable empty ledger (never a GraphQL error) on a cold/retired health tier. Mirrors GET /api/v1/incidents."
     incidents(window: String): GlobalIncidents!
+    "The get_global_incidents-aligned name for the same global downtime-incident ledger (#7643): identical 7d/30d window validation, tier fallback, and cold-tier degradation as incidents — a thin alias so MCP tool names and GraphQL fields line up. Distinct from endpoint_incidents (the active endpoint failure/degradation feed, GET /api/v1/endpoint-incidents): this is the historical incident ledger. Returns the typed GlobalIncidents envelope rather than the issue's literal JSON suggestion, matching incidents. Mirrors GET /api/v1/incidents."
+    global_incidents(window: String): GlobalIncidents!
     "Recent-extrinsic feed (newest first), optionally filtered. Mirrors GET /api/v1/extrinsics."
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "Paginated all-events feed (newest first) from the Postgres-backed all-events tier: each event's block, event index, pallet, method, decoded args, phase, and emitting extrinsic index. Filter by pallet/method/block/extrinsic; page with limit (1-200, default 50) and the opaque keyset cursor (or legacy before=block_number). An invalid filter combo is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty feed, never a GraphQL error. Distinct from Subscription.chainEvents (live WebSocket firehose). Mirrors GET /api/v1/chain-events."
@@ -4305,6 +4307,7 @@ export const FIELD_COMPLEXITY = {
   subnet_profile: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
+  global_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   runtime: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6440,6 +6443,15 @@ const rootValue = {
       summary: data.summary ?? null,
       surfaces: data.surfaces ?? [],
     };
+  },
+
+  // #7643: the get_global_incidents-aligned name for the same downtime-incident
+  // ledger -- a thin delegate so MCP tool names and GraphQL fields line up.
+  // Identical window validation (7d/30d -> BAD_USER_INPUT), Postgres-tier ->
+  // retired-D1 fallback, and schema-stable cold-tier degradation; nothing
+  // re-derived. Distinct from endpoint_incidents (the active endpoint feed).
+  async global_incidents({ window }, context) {
+    return rootValue.incidents({ window }, context);
   },
 
   search({ limit, cursor }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6796,6 +6796,118 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
   });
 });
 
+describe("graphql — global_incidents (#7643, get_global_incidents-aligned alias)", () => {
+  // Fresh Response per fetch so incidents + global_incidents can each consume
+  // their own Postgres-tier body when queried side by side.
+  function dataApi(payload) {
+    return { fetch: async () => Response.json(payload) };
+  }
+  const emptyHealthDb = {
+    prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }),
+  };
+
+  test("serves the same ledger as incidents through the delegate, incident rows included", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi({
+        schema_version: 1,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00.000Z",
+        source: "postgres",
+        summary: {
+          incident_count: 1,
+          active_count: 1,
+          by_status: { down: 1 },
+        },
+        surfaces: [
+          {
+            id: "inc-1",
+            endpoint_id: "ep-1",
+            state: "down",
+            severity: "high",
+            status: "down",
+            netuid: 5,
+            provider: "acme",
+          },
+        ],
+      }),
+    };
+    // Two sequential queries against the same env (side by side would exceed
+    // the complexity budget -- both fields carry the fan-out weight); dataApi
+    // serves each resolver a fresh Response, so the envelopes must be identical.
+    const selection = `{
+        schema_version window observed_at source summary
+        surfaces { id endpoint_id state severity status netuid provider }
+      }`;
+    const { status, body } = await gql(
+      `{ global_incidents(window: "30d") ${selection} }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const alias = body.data.global_incidents;
+    assert.equal(alias.window, "30d");
+    assert.equal(alias.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(alias.summary.incident_count, 1);
+    assert.equal(alias.surfaces.length, 1);
+    assert.equal(alias.surfaces[0].id, "inc-1");
+    assert.equal(alias.surfaces[0].netuid, 5);
+    const canonical = await gql(
+      `{ incidents(window: "30d") ${selection} }`,
+      env,
+    );
+    assert.equal(canonical.status, 200);
+    assert.equal(canonical.body.errors, undefined);
+    // Alias equivalence: the identical envelope from the same env.
+    assert.deepEqual(alias, canonical.body.data.incidents);
+  });
+
+  test("cold store: falls back to the D1 ledger, schema-stable empty, never null", async () => {
+    const { status, body } = await gql(
+      "{ global_incidents { schema_version window surfaces { id } } }",
+      { METAGRAPH_HEALTH_DB: emptyHealthDb },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.global_incidents.schema_version, 1);
+    assert.equal(body.data.global_incidents.window, "7d");
+    assert.deepEqual(body.data.global_incidents.surfaces, []);
+  });
+
+  test("an unsupported window is the same BAD_USER_INPUT error incidents raises", async () => {
+    const { body } = await gql(
+      '{ global_incidents(window: "99d") { schema_version } }',
+      { METAGRAPH_HEALTH_DB: emptyHealthDb },
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.equal(body.errors[0].extensions?.code, "BAD_USER_INPUT");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.global_incidents ?? null, null);
+  });
+
+  test("is priced identically to incidents", () => {
+    assert.equal(FIELD_COMPLEXITY.global_incidents, FIELD_COMPLEXITY.incidents);
+  });
+
+  test("has the identical GraphQL signature as incidents (args + return type)", async () => {
+    const { status, body } = await gql(
+      `{ __type(name: "Query") { fields {
+          name
+          args { name type { kind name ofType { kind name } } }
+          type { kind name ofType { kind name } }
+        } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const fields = body.data.__type.fields;
+    const canonical = fields.find((f) => f.name === "incidents");
+    const alias = fields.find((f) => f.name === "global_incidents");
+    assert.ok(canonical && alias, "both fields present in the schema");
+    assert.deepEqual(alias.args, canonical.args);
+    assert.deepEqual(alias.type, canonical.type);
+  });
+});
+
 describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

- Adds a `global_incidents(window: String): GlobalIncidents!` Query field to `src/graphql.mjs` — the `get_global_incidents`-aligned name for the cross-subnet downtime-incident ledger, so the MCP tool name and the GraphQL field line up. Mirrors `GET /api/v1/incidents`.
- The resolver is a thin delegate to the existing `incidents` resolver: identical 7d/30d window validation (`BAD_USER_INPUT` on an unsupported window), the same Postgres-tier → retired-D1 `loadGlobalIncidentsLedger` fallback, and the same schema-stable cold-tier degradation. Nothing re-derived, per the issue's constraint.
- The SDL docstring explicitly distinguishes it from `endpoint_incidents` (the active endpoint failure/degradation feed, `GET /api/v1/endpoint-incidents`) — the same disambiguation convention as `subnet_gaps` vs `gaps` — and states the intentional shape decision: it returns the existing typed `GlobalIncidents` envelope rather than the issue's literal `JSON` suggestion, matching the canonical field.

## What Changed

- `src/graphql.mjs` (+12): the `global_incidents` SDL field + docstring, a `FIELD_COMPLEXITY` entry priced identically to `incidents`, and the delegating resolver.
- `tests/graphql.test.mjs` (+112): five tests — a 30d window with incident rows asserting alias equivalence (`assert.deepEqual` against `incidents` on the same env), the cold-store D1 fallback (schema-stable empty, never null), an unsupported window (`BAD_USER_INPUT`), identical complexity pricing, and a schema-introspection assertion that `global_incidents` and `incidents` keep identical arg + return-type signatures, guarding future divergence.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check` (components run individually: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run validate:docs` — all green; `pipeline:check` not run)
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [ ] `npm run validate:api` (not run locally — live-RPC check, exercised in CI; this diff adds no API route)
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [ ] `npm run worker:test` (not run locally)
- [ ] `npm run test:coverage` (full-suite coverage not run locally; `vitest run tests/graphql.test.mjs` — 906/906 passing, and the patch's only executable path is the 3-line branchless delegate covered by three of the new tests)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

`npm run build` was also run (green), with the deploy-owned `public/metagraph/r2-manifest.json` / `schemas/index.json` / `operational-surfaces.json` reverted against `upstream/main` per the contribution guide — the diff is exactly the two files above.

## Template Used

- Backend/code change

Closes #7643
