### PR TITLE
fix(auth): restore anonymous access to /mcp, broken since GitHub OAuth

### DIFF
--- a/src/github-oauth.mjs
+++ b/src/github-oauth.mjs
@@ -45,6 +45,11 @@ const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_API_URL = "https://api.github.com/user";
 
+// Single source of truth for the OAuth-gated API route, shared by
+// buildOAuthProviderOptions' apiRoute and isAnonymousMcpRequest below so the
+// two can never drift apart.
+const MCP_API_ROUTE = "/mcp";
+
 // Mirrors wallet-auth.mjs's WALLET_CHALLENGE_TTL_SECONDS: long enough for a
 // human to complete a GitHub login popup, short enough that an intercepted
 // nonce is worthless soon after.
@@ -77,12 +82,22 @@ export const UNUSED_DEFAULT_HANDLER = {
  */
 export function buildOAuthProviderOptions(defaultHandler) {
   return {
-    apiRoute: "/mcp",
+    apiRoute: MCP_API_ROUTE,
     // Authenticated /mcp gets identical behavior to anonymous /mcp today --
     // this only makes a validated GitHub identity available via ctx.props
-    // for future use (metagraphed#7151's stated scope). Anonymous/IP-rate-
-    // limited access is unaffected: a request with no/invalid token falls
-    // through to defaultHandler below, same as every other route.
+    // for future use (metagraphed#7151's stated scope). apiHandler only ever
+    // runs once OAuthProvider itself has already accepted a valid Bearer
+    // token, so it's a pure pass-through to defaultHandler; it is NOT what
+    // keeps anonymous /mcp working -- see isAnonymousMcpRequest below for why
+    // that guard has to live at the entrypoint, one layer
+    // OUTSIDE OAuthProvider.fetch() entirely, and this comment's own former
+    // claim ("a request with no/invalid token falls through to defaultHandler
+    // below") for the incident that guard fixes: OAuthProvider's
+    // apiRoute/apiHandler machinery unconditionally 401s a request with no
+    // Bearer token BEFORE apiHandler is ever reached (confirmed directly
+    // against node_modules/@cloudflare/workers-oauth-provider/dist/
+    // oauth-provider.js, not just its .d.ts) -- there is no library-level
+    // "authenticate if present, else fall through" option.
     apiHandler: {
       fetch: (request, env, ctx) => defaultHandler.fetch(request, env, ctx),
     },
@@ -95,6 +110,27 @@ export function buildOAuthProviderOptions(defaultHandler) {
       resource_name: "metagraphed",
     },
   };
+}
+
+/**
+ * True when `request` targets the OAuth-gated /mcp route with no Bearer
+ * Authorization header -- the one case @cloudflare/workers-oauth-provider's
+ * apiRoute/apiHandler machinery cannot serve anonymously (see
+ * buildOAuthProviderOptions' apiHandler comment for the confirmed library
+ * behavior). The real entrypoint (workers/api.sentry.ts) routes a true result
+ * DIRECTLY to the plain handler, bypassing oauthProvider.fetch() entirely, so
+ * an anonymous MCP client gets byte-identical behavior to before GitHub OAuth
+ * (metagraphed#7151) was added. Every other path -- /authorize, /oauth/token,
+ * /oauth/register, OAuthProvider's own discovery endpoints, and /mcp WITH a
+ * Bearer token -- still needs the real oauthProvider.fetch() dispatch, so
+ * this stays narrowly scoped to exactly the one route/no-token combination,
+ * not a blanket "no Authorization header" bypass.
+ */
+export function isAnonymousMcpRequest(request) {
+  return (
+    new URL(request.url).pathname === MCP_API_ROUTE &&
+    !request.headers.get("Authorization")?.startsWith("Bearer ")
+  );
 }
 
 // Real production helpers resolver -- lazy-imports the package so no test

--- a/tests/github-oauth.test.mjs
+++ b/tests/github-oauth.test.mjs
@@ -4,6 +4,7 @@ import {
   buildOAuthProviderOptions,
   handleAuthorizeRequest,
   handleGithubOAuthCallback,
+  isAnonymousMcpRequest,
   OAUTH_PENDING_TTL_SECONDS,
   UNUSED_DEFAULT_HANDLER,
 } from "../src/github-oauth.mjs";
@@ -99,6 +100,53 @@ describe("buildOAuthProviderOptions", () => {
     const response = await options.apiHandler.fetch("req", "env", "ctx");
     assert.equal(await response.text(), "delegated");
     assert.deepEqual(calls, [["req", "env", "ctx"]]);
+  });
+});
+
+// REGRESSION: @cloudflare/workers-oauth-provider's apiRoute/apiHandler
+// machinery unconditionally 401s a /mcp request with no Bearer token BEFORE
+// apiHandler is ever reached -- confirmed directly against
+// node_modules/@cloudflare/workers-oauth-provider/dist/oauth-provider.js.
+// This silently broke every anonymous MCP client since GitHub OAuth (#7151)
+// shipped; isAnonymousMcpRequest is what the real entrypoint
+// (workers/api.sentry.ts) uses to bypass oauthProvider.fetch() entirely for
+// exactly this one case, restoring the pre-#7151 anonymous behavior.
+describe("isAnonymousMcpRequest", () => {
+  test("true for /mcp with no Authorization header at all", () => {
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+    });
+    assert.equal(isAnonymousMcpRequest(request), true);
+  });
+
+  test("true for /mcp with a non-Bearer Authorization header", () => {
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { Authorization: "Basic dXNlcjpwYXNz" },
+    });
+    assert.equal(isAnonymousMcpRequest(request), true);
+  });
+
+  test("false for /mcp with a Bearer token -- still needs the real OAuth dispatch", () => {
+    const request = new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { Authorization: "Bearer real-token" },
+    });
+    assert.equal(isAnonymousMcpRequest(request), false);
+  });
+
+  test("false for a non-/mcp path with no Authorization header -- the OAuth flow's own endpoints must never bypass oauthProvider", () => {
+    const request = new Request(
+      "https://api.metagraph.sh/authorize?client_id=x",
+    );
+    assert.equal(isAnonymousMcpRequest(request), false);
+  });
+
+  test("false for /oauth/token with no Authorization header", () => {
+    const request = new Request("https://api.metagraph.sh/oauth/token", {
+      method: "POST",
+    });
+    assert.equal(isAnonymousMcpRequest(request), false);
   });
 });
 

--- a/workers/api.sentry.ts
+++ b/workers/api.sentry.ts
@@ -42,7 +42,10 @@
 import { withSentry } from "@sentry/cloudflare";
 import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
 import handler from "./api.mjs";
-import { buildOAuthProviderOptions } from "../src/github-oauth.mjs";
+import {
+  buildOAuthProviderOptions,
+  isAnonymousMcpRequest,
+} from "../src/github-oauth.mjs";
 // wrangler.jsonc's "main" now points at THIS file, so wrangler looks for
 // every Durable Object binding's class as a named export from here, not
 // from api.mjs -- confirmed by a real `wrangler deploy --dry-run` failure
@@ -58,10 +61,23 @@ export {
 // GitHub OAuth (metagraphed#7151): OAuthProvider owns top-level fetch
 // dispatch (its own /oauth/token + /oauth/register endpoints, plus routing
 // /mcp to apiHandler with ctx.props populated when a valid Bearer token is
-// present, falling through to defaultHandler -- the real, unmodified
-// `handler` -- for everything else, INCLUDING /mcp with no/invalid token).
-// Anonymous/IP-rate-limited access is therefore completely unaffected; see
-// src/github-oauth.mjs's own header for the full flow.
+// present). A BARE /mcp request with no Bearer token is routed to the real,
+// unmodified `handler` directly, bypassing oauthProvider.fetch() entirely --
+// isAnonymousMcpRequest below, NOT anything inside OAuthProvider's own
+// apiRoute/apiHandler machinery, is what keeps anonymous/IP-rate-limited
+// access to /mcp working. This was a real production regression (silently
+// 401ing every anonymous MCP client since #7151) until this explicit bypass
+// was added: @cloudflare/workers-oauth-provider's apiRoute/apiHandler
+// mechanism unconditionally requires a valid Bearer token and 401s BEFORE
+// apiHandler is ever reached -- there is no library-level "authenticate if
+// present, else fall through to defaultHandler" option (confirmed against
+// node_modules/@cloudflare/workers-oauth-provider/dist/oauth-provider.js
+// directly, not just its .d.ts); see src/github-oauth.mjs's
+// buildOAuthProviderOptions/isAnonymousMcpRequest comments for the full
+// story. Every other path -- /authorize, /oauth/token, /oauth/register,
+// OAuthProvider's own discovery endpoints, and /mcp WITH a Bearer token --
+// still needs the real oauthProvider.fetch() dispatch, so this bypass stays
+// scoped to exactly the one route/no-token combination.
 //
 // OAuthProvider instances expose ONLY .fetch(), not .scheduled() -- this
 // Worker has four live cron triggers (wrangler.jsonc "triggers.crons": the
@@ -75,7 +91,9 @@ export {
 const oauthProvider = new OAuthProvider(buildOAuthProviderOptions(handler));
 const handlerWithOAuth = {
   fetch: (request: Request, env: Env, ctx: ExecutionContext) =>
-    oauthProvider.fetch(request, env, ctx),
+    isAnonymousMcpRequest(request)
+      ? handler.fetch(request, env, ctx)
+      : oauthProvider.fetch(request, env, ctx),
   // Discards handleScheduled's (api.mjs, not yet converted) return value --
   // it returns diagnostic objects for its own test suite's benefit; the real
   // Workers runtime ignores scheduled()'s return value, and ExportedHandler's


### PR DESCRIPTION
## Summary

**Production regression, confirmed live**: every anonymous MCP client hitting `POST https://api.metagraph.sh/mcp` has been getting a 401 (`invalid_token: Missing or invalid access token`) since GitHub OAuth (#7151) shipped. The `/.well-known/mcp/server-card.json` discovery doc still describes this as a fully public, anonymous-access developer tool -- the actual endpoint has quietly stopped honoring that.

## Root cause

`@cloudflare/workers-oauth-provider`'s `apiRoute`/`apiHandler` machinery unconditionally rejects any request to a configured `apiRoute` that has no `Bearer` `Authorization` header, returning its **own** 401 `invalid_token` response before `apiHandler` is ever reached (confirmed directly against `node_modules/@cloudflare/workers-oauth-provider/dist/oauth-provider.js`, not just its `.d.ts` -- there is no library-level "authenticate if present, else fall through" option).

`src/github-oauth.mjs`'s `apiHandler.fetch` is coded to just forward straight to `defaultHandler`, and the surrounding comments explicitly claimed *"a request with no/invalid token falls through to defaultHandler... Anonymous/IP-rate-limited access is therefore completely unaffected"* -- that was simply wrong for how this library actually behaves. `apiHandler` only ever runs once the library's own Bearer-token gate has already passed.

This was masked in the publish pipeline's `smoke:live` check because an earlier, unrelated failure (`/api/v1/compare/validators` missing its required `hotkeys` param -- fixed separately in #7682) always threw first and the script never got far enough to exercise the MCP checks at all.

## Fix

- `src/github-oauth.mjs`: new `isAnonymousMcpRequest(request)` -- true only for the exact `/mcp` route with no Bearer token. Corrected the now-inaccurate `apiHandler` comment to describe the library's real behavior.
- `workers/api.sentry.ts`: the real entrypoint now checks `isAnonymousMcpRequest` before dispatching, routing that one case directly to the plain `handler.fetch()` and bypassing `oauthProvider.fetch()` entirely -- restoring pre-#7151 anonymous behavior byte-for-byte. Every other path (`/authorize`, `/oauth/token`, `/oauth/register`, OAuthProvider's own discovery endpoints, and `/mcp` **with** a Bearer token) is unaffected and still routes through the real OAuth dispatch.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A -- routing/auth fix only, no response-shape change.)
- **No linked issue**: found while verifying #7682 unblocked the publish smoke test further than before, not a tracked GitHub issue. Submitting directly as the maintainer.

## Validation
- [x] `npx eslint` / `npx prettier --check` on all 3 changed files -- clean.
- [x] `npm run typecheck` -- clean.
- [x] `npx vitest run tests/github-oauth.test.mjs` -- 29/29 passing, 100% stmt/branch/fn/line coverage on `src/github-oauth.mjs`.
- [x] `npm run scan:public-safety` / `npm run worker:test` -- clean.
- [x] `npm run test:coverage` -- 11230/11236 tests passing; the 6 failures are all pre-existing, unrelated timeouts in `tests/public-safety.test.mjs` (confirmed as environmental sandbox load, not a regression: all 44 tests in that file pass cleanly re-run in isolation).