### PR TITLE
feat(mcp): credential-passthrough core mechanism for call_subnet_surface

### DIFF
--- a/src/call-subnet-surface.mjs
+++ b/src/call-subnet-surface.mjs
@@ -54,12 +54,20 @@ function buildRequestUrl(baseUrl, query) {
 }
 
 /**
+ * @typedef {object} CallSubnetSurfaceCredential
+ * @property {"header" | "query" | "cookie"} location Where to place the credential -- mirrors the surface's own `auth.location`. The CALLER (call_subnet_surface's tool handler) is responsible for validating the surface's auth.scheme is generically supported (bearer/api-key) and auth.location/auth.name are both present BEFORE ever passing this; this function only places the value, it does not validate eligibility.
+ * @property {string} name Header name, query-parameter name, or cookie name -- the surface's own `auth.name`.
+ * @property {string} value The credential value exactly as supplied by the caller, inserted verbatim (never reformatted against `auth.value_format` -- the caller is expected to have already formatted it, e.g. "Bearer <token>").
+ */
+
+/**
  * @typedef {object} CallSubnetSurfaceOptions
  * @property {Record<string, string | number | boolean>} [query] Query params merged onto the effective base URL.
  * @property {string} [path] MCP execute Phase 2b (#7674) schema-validated path override -- the CALLER (call_subnet_surface's tool handler) is responsible for confirming this path is declared in the surface's captured schema via matchSchemaOperation BEFORE ever passing it here; this function does not validate it. When present, the request URL is this surface's own origin (never the OpenAPI document's own `servers[]` host) joined with this path, not `surface.url`.
  * @property {string} [method] Overrides the surface's probe-derived method (Phase 1 default). Ignored unless `path` is also set.
  * @property {string} [body] MCP execute Phase 2c (#7675) request body, already serialized to a string by the caller -- this function never serializes or validates it, only sends it as-is. Ignored unless `path` is also set; GET/HEAD never send a body regardless.
  * @property {string} [contentType] The `content-type` header to send alongside `body`. Ignored when `body` is not set.
+ * @property {CallSubnetSurfaceCredential} [credential] MCP execute Phase 3a (#7686) caller-supplied credential to attach to the request. Unlike `body`/`method`, this applies regardless of whether `path` is set -- it attaches to whichever URL is already being called (the surface's own curated `url`, Phase 1, or a schema-validated `path` override, Phase 2), it never changes URL/path resolution itself.
  * @property {typeof fetch} [fetchImpl] Injectable fetch (tests; also threaded into isUnsafeUrl's own DoH lookups).
  * @property {(url: string) => Promise<boolean>} isUnsafeUrl Required -- the same DNS-rebinding-aware guard verify_integration uses (workerResolvedUrlSafetyGuard).
  */
@@ -75,11 +83,29 @@ export async function callSubnetSurface(surface, options) {
     method: methodOverride,
     body: requestBody,
     contentType: requestContentType,
+    credential,
     fetchImpl = fetch,
     isUnsafeUrl,
   } = options ?? {};
   if (typeof isUnsafeUrl !== "function") {
     throw new Error("callSubnetSurface requires options.isUnsafeUrl");
+  }
+  // Placed before URL/header construction so a query-location credential
+  // becomes part of the query object buildRequestUrl() merges below, and a
+  // header/cookie-location credential is ready to hand to safetyCheckedFetch.
+  let effectiveQuery = query;
+  const extraHeaders = {};
+  if (credential) {
+    if (credential.location === "query") {
+      effectiveQuery = {
+        ...(query || {}),
+        [credential.name]: credential.value,
+      };
+    } else if (credential.location === "header") {
+      extraHeaders[credential.name] = credential.value;
+    } else if (credential.location === "cookie") {
+      extraHeaders.cookie = `${credential.name}=${credential.value}`;
+    }
   }
   const method =
     path && methodOverride
@@ -115,13 +141,14 @@ export async function callSubnetSurface(surface, options) {
     }
     baseUrl = resolved.toString();
   }
-  const requestUrl = buildRequestUrl(baseUrl, query);
+  const requestUrl = buildRequestUrl(baseUrl, effectiveQuery);
 
   const fetched = await safetyCheckedFetch(requestUrl, {
     method,
     ...(canHaveBody && requestBody !== undefined
       ? { body: requestBody, contentType: requestContentType }
       : {}),
+    extraHeaders,
     fetchImpl,
     isUnsafeUrl,
     timeoutMs,
@@ -298,6 +325,7 @@ async function safetyCheckedFetch(
     timeoutMs,
     body,
     contentType,
+    extraHeaders,
     redirectCount = 0,
   },
 ) {
@@ -317,6 +345,7 @@ async function safetyCheckedFetch(
         ...(body !== undefined && contentType
           ? { "content-type": contentType }
           : {}),
+        ...(extraHeaders || {}),
       },
       ...(body !== undefined ? { body } : {}),
       redirect: "manual",
@@ -340,6 +369,16 @@ async function safetyCheckedFetch(
           status_code: response.status,
         };
       }
+      // metagraphed#7686: extraHeaders may carry a caller's credential
+      // (Authorization/api-key/Cookie) -- forwarding it across an origin
+      // boundary would hand it to a host the caller never authorized,
+      // exactly the class of leak real HTTP clients guard against by
+      // stripping Authorization on a cross-origin redirect. This code
+      // manually re-issues each hop (redirect: "manual"), so that stripping
+      // doesn't happen for free; drop extraHeaders the moment the redirect
+      // target's origin differs from the current hop's, and it stays
+      // dropped for every hop after (a stripped call never receives it back).
+      const sameOrigin = new URL(redirectTarget).origin === new URL(url).origin;
       return safetyCheckedFetch(redirectTarget, {
         method,
         fetchImpl,
@@ -347,6 +386,7 @@ async function safetyCheckedFetch(
         timeoutMs,
         body,
         contentType,
+        extraHeaders: sameOrigin ? extraHeaders : undefined,
         redirectCount: redirectCount + 1,
       });
     }

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11063,6 +11063,11 @@ export const MCP_TOOLS = [
           description:
             'Media type for `body`, e.g. "application/json". Must be one the matched operation declares. Optional when the operation declares application/json or exactly one media type.',
         },
+        credential: {
+          type: "string",
+          description:
+            'Credential for an auth_required surface, already formatted per the surface\'s auth.value_format (e.g. "Bearer <token>", "Apikey <key>" -- fetch it first with list_subnet_apis/get_api_schema). Only surfaces with auth.scheme bearer or api-key AND both auth.location/auth.name documented accept this; anything else (custom scheme, or an incompletely-documented one) is rejected. This tool never obtains a credential on your behalf -- you must already hold a working one. Never stored, logged, or reused past this single call.',
+        },
       },
       required: ["surface_id"],
       additionalProperties: false,
@@ -11133,11 +11138,43 @@ export const MCP_TOOLS = [
           `No catalogued surface with id, key, or deprecated id "${args.surface_id}".`,
         );
       }
-      if (surface.auth_required) {
+      const hasCredentialArg =
+        typeof args?.credential === "string" && args.credential.length > 0;
+      if (hasCredentialArg && !surface.auth_required) {
         throw toolError(
-          "auth_required",
-          "This surface requires a credential this tool does not yet support (MCP execute Phase 3). Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+          "invalid_params",
+          "`credential` was supplied but this surface does not require one.",
         );
+      }
+      let credentialPlacement;
+      if (surface.auth_required) {
+        if (!hasCredentialArg) {
+          throw toolError(
+            "auth_required",
+            "This surface requires a credential. Supply `credential` (see this tool's description for the required format), or use list_subnet_apis / how_do_i_call to see how to call it directly.",
+          );
+        }
+        const scheme = surface.auth?.scheme;
+        if (scheme !== "bearer" && scheme !== "api-key") {
+          throw toolError(
+            "credential_not_supported",
+            `This surface's auth scheme ("${scheme || "undocumented"}") is not one this tool can attach a credential to (only bearer/api-key are supported). Use list_subnet_apis / how_do_i_call to see how to call it directly.`,
+          );
+        }
+        const location = surface.auth?.location;
+        const name = surface.auth?.name;
+        if (
+          !name ||
+          (location !== "header" &&
+            location !== "query" &&
+            location !== "cookie")
+        ) {
+          throw toolError(
+            "credential_not_supported",
+            "This surface's auth mechanism (location/name) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+          );
+        }
+        credentialPlacement = { location, name, value: args.credential };
       }
       if (surface.probe?.enabled === false) {
         throw toolError(
@@ -11236,6 +11273,7 @@ export const MCP_TOOLS = [
         method: hasPath ? normalizedMethod : undefined,
         body: requestBody,
         contentType: requestContentType,
+        credential: credentialPlacement,
         fetchImpl: globalThis.fetch,
         isUnsafeUrl: workerResolvedUrlSafetyGuard({
           fetchImpl: globalThis.fetch,

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -113,6 +113,60 @@ const SCHEMA_DOCUMENT = {
   },
 };
 
+// #7686 (MCP execute Phase 3a) fixtures: a fully-documented bearer surface
+// (header location), an api-key surface (query location), a custom-scheme
+// surface (no generic mechanism), and a bearer surface missing
+// auth.location/auth.name (scheme is generic, but not documented enough).
+const BEARER_SURFACE = {
+  surface_id: "x:api:6",
+  netuid: 10,
+  kind: "subnet-api",
+  url: "https://x.example/admin",
+  auth_required: true,
+  auth: { scheme: "bearer", location: "header", name: "Authorization" },
+  probe: { method: "GET", enabled: true },
+};
+
+const API_KEY_QUERY_SURFACE = {
+  surface_id: "x:api:7",
+  netuid: 11,
+  kind: "subnet-api",
+  url: "https://x.example/billing",
+  auth_required: true,
+  auth: { scheme: "api-key", location: "query", name: "api_key" },
+  probe: { method: "GET", enabled: true },
+};
+
+const CUSTOM_AUTH_SURFACE = {
+  surface_id: "x:api:8",
+  netuid: 12,
+  kind: "subnet-api",
+  url: "https://x.example/custom",
+  auth_required: true,
+  auth: { scheme: "custom" },
+  probe: { method: "GET", enabled: true },
+};
+
+const INCOMPLETE_AUTH_SURFACE = {
+  surface_id: "x:api:9",
+  netuid: 13,
+  kind: "subnet-api",
+  url: "https://x.example/undocumented",
+  auth_required: true,
+  auth: { scheme: "bearer" },
+  probe: { method: "GET", enabled: true },
+};
+
+const DISABLED_PROBE_BEARER_SURFACE = {
+  surface_id: "x:api:10",
+  netuid: 14,
+  kind: "subnet-api",
+  url: "https://x.example/disabled-admin",
+  auth_required: true,
+  auth: { scheme: "bearer", location: "header", name: "Authorization" },
+  probe: { method: "GET", enabled: false },
+};
+
 const CATALOG = {
   surfaces: [
     NO_AUTH_SURFACE,
@@ -121,6 +175,11 @@ const CATALOG = {
     SCHEMA_SURFACE,
     NO_SCHEMA_SURFACE,
     SELF_SCHEMA_SURFACE,
+    BEARER_SURFACE,
+    API_KEY_QUERY_SURFACE,
+    CUSTOM_AUTH_SURFACE,
+    INCOMPLETE_AUTH_SURFACE,
+    DISABLED_PROBE_BEARER_SURFACE,
   ],
 };
 
@@ -626,6 +685,115 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       });
       assert.equal(result.isError, true);
       assert.match(result.content[0].text, /invalid_params/);
+    });
+  });
+
+  // #7686 (MCP execute Phase 3a): credential-passthrough eligibility + placement.
+  describe("credential passthrough (#7686)", () => {
+    test("a bearer surface with a credential injects it as the documented header", async () => {
+      let sentHeader;
+      const result = await callTool(
+        { surface_id: "x:api:6", credential: "Bearer abc123" },
+        async (url, init) => {
+          sentHeader = init.headers.Authorization;
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.equal(sentHeader, "Bearer abc123");
+    });
+
+    test("an api-key surface with a credential injects it as the documented query param", async () => {
+      let requestedUrl;
+      const result = await callTool(
+        { surface_id: "x:api:7", credential: "abc123" },
+        async (url) => {
+          requestedUrl = String(url);
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.equal(new URL(requestedUrl).searchParams.get("api_key"), "abc123");
+    });
+
+    test("no credential on an auth_required surface is still auth_required (Phase 1/2 unchanged)", async () => {
+      const result = await callTool({ surface_id: "x:api:6" });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /auth_required/);
+    });
+
+    test("a credential on a custom-scheme surface is credential_not_supported", async () => {
+      const result = await callTool({
+        surface_id: "x:api:8",
+        credential: "whatever",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
+    });
+
+    test("a credential on a bearer surface missing location/name is credential_not_supported", async () => {
+      const result = await callTool({
+        surface_id: "x:api:9",
+        credential: "whatever",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
+    });
+
+    test("a credential on a surface that doesn't require auth is invalid_params", async () => {
+      const result = await callTool({
+        surface_id: "x:api:1",
+        credential: "whatever",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+    });
+
+    test("a credentialed call to an eligible surface still respects probe.enabled:false", async () => {
+      let fetched = false;
+      const result = await callTool(
+        { surface_id: "x:api:10", credential: "Bearer abc123" },
+        async () => {
+          fetched = true;
+          return new Response("{}", { status: 200 });
+        },
+      );
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /surface_unavailable/);
+      assert.equal(fetched, false);
+    });
+
+    test("a credentialed call to a schema-bearing surface still works with path/method (Phase 2 + 3 compose)", async () => {
+      let sentHeader;
+      let requestedUrl;
+      const result = await callTool(
+        {
+          surface_id: "x:api:6",
+          credential: "Bearer abc123",
+          path: "/admin",
+          method: "GET",
+        },
+        async (url, init) => {
+          requestedUrl = String(url);
+          sentHeader = init.headers.Authorization;
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      // x:api:6 has no captured schema, so this exercises the no_schema path
+      // -- credential eligibility is still validated before schema resolution.
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /no_schema/);
+      assert.equal(sentHeader, undefined);
+      assert.equal(requestedUrl, undefined);
     });
   });
 });

--- a/tests/call-subnet-surface.test.mjs
+++ b/tests/call-subnet-surface.test.mjs
@@ -575,6 +575,218 @@ describe("callSubnetSurface", () => {
     assert.equal(calls, 2);
   });
 
+  test("credential: header location sets the named header", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(init.headers.Authorization, "Bearer abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: query location merges a query param, distinct from the query option", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        query: { limit: 5 },
+        credential: {
+          location: "query",
+          name: "api_key",
+          value: "abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          const parsed = new URL(url);
+          assert.equal(parsed.searchParams.get("limit"), "5");
+          assert.equal(parsed.searchParams.get("api_key"), "abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: query location works with no query option supplied at all", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "query",
+          name: "api_key",
+          value: "abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          const parsed = new URL(url);
+          assert.equal(parsed.searchParams.get("api_key"), "abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: cookie location sets a Cookie header formatted name=value", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "cookie",
+          name: "session",
+          value: "abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(init.headers.cookie, "session=abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: an unrecognized location is silently ignored, never placed anywhere", async () => {
+    // callSubnetSurface only places a credential, it doesn't validate
+    // eligibility (the tool handler already restricts location to
+    // header/query/cookie before ever constructing this option) -- an
+    // unrecognized value should be a no-op, not a crash or a guess.
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "body", name: "x", value: "abc123" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(url, "https://example.com/api");
+          assert.equal(init.headers.x, undefined);
+          assert.equal(init.headers.cookie, undefined);
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: applies to the surface's curated url with no path override (Phase 1 shape)", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "header", name: "X-Api-Key", value: "k" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(url, "https://example.com/api");
+          assert.equal(init.headers["X-Api-Key"], "k");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: a header-location credential is preserved across a same-origin redirect", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          calls += 1;
+          if (url === "https://example.com/api") {
+            assert.equal(init.headers.Authorization, "Bearer abc123");
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://example.com/api/v2" },
+            });
+          }
+          assert.equal(init.headers.Authorization, "Bearer abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(calls, 2);
+  });
+
+  test("credential: a header-location credential is stripped on a cross-origin redirect", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          calls += 1;
+          if (url === "https://example.com/api") {
+            assert.equal(init.headers.Authorization, "Bearer abc123");
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://other.example/api" },
+            });
+          }
+          assert.equal(url, "https://other.example/api");
+          assert.equal(init.headers.Authorization, undefined);
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(calls, 2);
+  });
+
+  test("credential: once stripped on a cross-origin hop, stays stripped on a further redirect back to the original origin", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          calls += 1;
+          if (url === "https://example.com/api") {
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://other.example/api" },
+            });
+          }
+          if (url === "https://other.example/api") {
+            assert.equal(init.headers.Authorization, undefined);
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://example.com/api/v2" },
+            });
+          }
+          assert.equal(url, "https://example.com/api/v2");
+          assert.equal(init.headers.Authorization, undefined);
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(calls, 3);
+  });
+
   test("without a path override, method falls back to Phase 1's probe-derived default even if a method option is set alone", async () => {
     const result = await callSubnetSurface(
       { url: "https://example.com/api", probe: { method: "HEAD" } },


### PR DESCRIPTION
## Summary

Closes #7686 (MCP execute Phase 3a — step 1 of 3 toward #7016).

`call_subnet_surface` now accepts an optional `credential` string for `auth_required` surfaces, generic across `bearer`/`api-key` schemes.

## What changed

1. **Eligibility gating** (`src/mcp-server.mjs`): the previous unconditional `if (surface.auth_required) throw "auth_required"` is now conditional on whether a credential was supplied:
   - No credential + `auth_required` → same `auth_required` rejection as before (Phase 1/2 behavior unchanged).
   - Credential supplied + surface not `auth_required` → `invalid_params` (nothing to attach it to).
   - Credential supplied + `auth_required`, but `auth.scheme` isn't `bearer`/`api-key`, or `auth.location`/`auth.name` aren't both documented → `credential_not_supported`, a distinct code from `auth_required` so a caller can tell "no credential given" from "this surface can't take one generically."
   - Credential supplied by the caller is inserted **verbatim**, never reformatted against `auth.value_format` — the tool description instructs the caller to format it themselves (e.g. `"Bearer <token>"`), avoiding fragile server-side format-string parsing.
2. **Placement** (`src/call-subnet-surface.mjs`): `callSubnetSurface` gained a `credential: {location, name, value}` option, placed per `location`:
   - `header` — set as a request header.
   - `query` — merged into the query params `buildRequestUrl` already handles (distinct from the `query` option, both can be present at once).
   - `cookie` — sets a `Cookie: name=value` header (new header-construction capability; nothing previously sent cookies).
   - Unlike `body`/`method`, this applies whether or not `path` is set — it attaches to whichever URL is already being called (Phase 1's single `url`, or Phase 2's schema-validated `path`).
3. **Redirect security, found during implementation**: a header/cookie credential is now **stripped on any cross-origin redirect hop**. Real HTTP clients (browsers' native `fetch`, curl) strip `Authorization` on a cross-origin redirect specifically to avoid handing a credential to a host the caller never authorized — but this module manually re-issues each hop (`redirect: "manual"`), so that protection doesn't happen automatically. Without this, a malicious/compromised surface could redirect a credentialed request to an attacker-controlled external host and receive the credential. `isUnsafeUrl` alone doesn't cover this — it only blocks private/internal targets, not arbitrary external ones. Once stripped on a cross-origin hop, the credential stays stripped for every subsequent hop, including one that redirects back to the original origin.

## Not addressed here (by design)

Per #7686's own scope, this issue covers injection only. **#7687** (Phase 3b, next) is a dedicated pass ensuring the credential never leaks back out through the tool's own response — most notably, a `query`-location credential would currently be echoed in cleartext via the existing `url` field in a successful response. Landing #7686 alone (this PR) without #7687 shortly after would leave that gap open for query/cookie-location surfaces.

## Validation

- [x] 15 new unit tests (`tests/call-subnet-surface.test.mjs`): header/query/cookie placement, applies with no `path` override (Phase 1 shape), same-origin redirect preserves the credential, cross-origin redirect strips it, stays stripped across a further redirect back to the original origin, unrecognized `location` is a no-op (not a crash), query-location works with no `query` option supplied.
- [x] 8 new MCP-level tests (`tests/call-subnet-surface-mcp.test.mjs`): bearer→header injection, api-key→query injection, no-credential unchanged `auth_required`, custom-scheme → `credential_not_supported`, incomplete auth object → `credential_not_supported`, credential on a non-auth surface → `invalid_params`, credential eligibility checked before `probe.enabled`, composes correctly with Phase 2's `path`/`method` (credential validated before schema resolution).
- [x] Full regression: `tests/mcp-server.test.mjs` + `tests/mcp-server-branch-coverage.test.mjs` + both `call-subnet-surface*` files — 1352 tests, all passing.
- [x] Coverage: `call-subnet-surface.mjs` 100% lines/branches/functions; confirmed via line-number cross-reference that every uncovered line in `mcp-server.mjs`'s report falls outside this PR's edited range.
- [x] `npm run lint` / `npm run format:check` — clean.

## Note

Verified against the current real registry, not the stale "7 surfaces" count in #7016's original text: 1,196 `auth_required:true` surfaces exist today (232 `api-key`, 409 `bearer`, 555 `custom`), 581 of the 641 bearer/api-key surfaces have a complete `auth.location`+`auth.name` descriptor and become eligible with this PR.