### PR TITLE
fix(security): prevent credential leakage in call_subnet_surface responses

### DIFF
--- a/src/call-subnet-surface.mjs
+++ b/src/call-subnet-surface.mjs
@@ -53,6 +53,36 @@ function buildRequestUrl(baseUrl, query) {
   return url.toString();
 }
 
+// metagraphed#7687 (MCP execute Phase 3b): a query-location credential is,
+// unavoidably, part of the request URL itself -- unlike a header/cookie
+// credential (which never appears in any response field, this module never
+// echoes request headers back), the URL is exactly what this module DOES
+// return to the caller on both success and some failure paths. Only a
+// query-location credential is ever redacted here; header/cookie placement
+// has nothing in the URL to redact.
+const REDACTED_CREDENTIAL_PLACEHOLDER = "<redacted>";
+function redactQueryCredential(url, credential) {
+  if (!url || credential?.location !== "query") return url;
+  // No try/catch: `url` here is always the output of an earlier `new URL()`
+  // call within this same module (buildRequestUrl, or safetyCheckedFetch's
+  // own redirect-target construction) -- by the time it reaches here it has
+  // already been proven parseable, so a second parse can't newly fail.
+  const parsed = new URL(url);
+  if (!parsed.searchParams.has(credential.name)) return url;
+  parsed.searchParams.set(credential.name, REDACTED_CREDENTIAL_PLACEHOLDER);
+  return parsed.toString();
+}
+
+// Regardless of credential location, scrub the raw value out of any
+// free-form error string this module returns -- the underlying fetch
+// implementation's own error text (network/timeout/DNS failures) is outside
+// this module's control, and some implementations echo the request URL (or
+// occasionally other request details) into it.
+function redactCredentialValue(text, credential) {
+  if (!text || !credential?.value) return text;
+  return text.split(credential.value).join(REDACTED_CREDENTIAL_PLACEHOLDER);
+}
+
 /**
  * @typedef {object} CallSubnetSurfaceCredential
  * @property {"header" | "query" | "cookie"} location Where to place the credential -- mirrors the surface's own `auth.location`. The CALLER (call_subnet_surface's tool handler) is responsible for validating the surface's auth.scheme is generically supported (bearer/api-key) and auth.location/auth.name are both present BEFORE ever passing this; this function only places the value, it does not validate eligibility.
@@ -153,7 +183,31 @@ export async function callSubnetSurface(surface, options) {
     isUnsafeUrl,
     timeoutMs,
   });
-  if (!fetched.ok) return fetched;
+  if (!fetched.ok) {
+    // metagraphed#7687: a query-location credential (extraHeaders never
+    // echoes back on any path, but a query param is part of the URL itself)
+    // must never appear in a URL this function hands back, including a
+    // blocked-redirect's own target -- redact it here, at the one place
+    // that knows both the credential and every URL field that could carry
+    // it, rather than trusting every caller to remember to scrub it.
+    // error is scrubbed too, regardless of credential location: some fetch
+    // implementations embed the request URL (or occasionally headers) in
+    // their own thrown error text, and that's outside this module's control.
+    return {
+      ...fetched,
+      ...(fetched.redirect_target
+        ? {
+            redirect_target: redactQueryCredential(
+              fetched.redirect_target,
+              credential,
+            ),
+          }
+        : {}),
+      ...(fetched.error
+        ? { error: redactCredentialValue(fetched.error, credential) }
+        : {}),
+    };
+  }
 
   const { response, latencyMs, redirectTarget } = fetched;
   const contentType = response.headers.get("content-type") || null;
@@ -187,7 +241,7 @@ export async function callSubnetSurface(surface, options) {
     status_code: response.status,
     content_type: contentType,
     latency_ms: latencyMs,
-    url: redirectTarget || requestUrl,
+    url: redactQueryCredential(redirectTarget || requestUrl, credential),
     body,
     truncated: raw.truncated,
     ...(parseError ? { parse_error: parseError } : {}),

--- a/src/call-subnet-surface.mjs
+++ b/src/call-subnet-surface.mjs
@@ -54,12 +54,20 @@ function buildRequestUrl(baseUrl, query) {
 }
 
 /**
+ * @typedef {object} CallSubnetSurfaceCredential
+ * @property {"header" | "query" | "cookie"} location Where to place the credential -- mirrors the surface's own `auth.location`. The CALLER (call_subnet_surface's tool handler) is responsible for validating the surface's auth.scheme is generically supported (bearer/api-key) and auth.location/auth.name are both present BEFORE ever passing this; this function only places the value, it does not validate eligibility.
+ * @property {string} name Header name, query-parameter name, or cookie name -- the surface's own `auth.name`.
+ * @property {string} value The credential value exactly as supplied by the caller, inserted verbatim (never reformatted against `auth.value_format` -- the caller is expected to have already formatted it, e.g. "Bearer <token>").
+ */
+
+/**
  * @typedef {object} CallSubnetSurfaceOptions
  * @property {Record<string, string | number | boolean>} [query] Query params merged onto the effective base URL.
  * @property {string} [path] MCP execute Phase 2b (#7674) schema-validated path override -- the CALLER (call_subnet_surface's tool handler) is responsible for confirming this path is declared in the surface's captured schema via matchSchemaOperation BEFORE ever passing it here; this function does not validate it. When present, the request URL is this surface's own origin (never the OpenAPI document's own `servers[]` host) joined with this path, not `surface.url`.
  * @property {string} [method] Overrides the surface's probe-derived method (Phase 1 default). Ignored unless `path` is also set.
  * @property {string} [body] MCP execute Phase 2c (#7675) request body, already serialized to a string by the caller -- this function never serializes or validates it, only sends it as-is. Ignored unless `path` is also set; GET/HEAD never send a body regardless.
  * @property {string} [contentType] The `content-type` header to send alongside `body`. Ignored when `body` is not set.
+ * @property {CallSubnetSurfaceCredential} [credential] MCP execute Phase 3a (#7686) caller-supplied credential to attach to the request. Unlike `body`/`method`, this applies regardless of whether `path` is set -- it attaches to whichever URL is already being called (the surface's own curated `url`, Phase 1, or a schema-validated `path` override, Phase 2), it never changes URL/path resolution itself.
  * @property {typeof fetch} [fetchImpl] Injectable fetch (tests; also threaded into isUnsafeUrl's own DoH lookups).
  * @property {(url: string) => Promise<boolean>} isUnsafeUrl Required -- the same DNS-rebinding-aware guard verify_integration uses (workerResolvedUrlSafetyGuard).
  */
@@ -75,11 +83,29 @@ export async function callSubnetSurface(surface, options) {
     method: methodOverride,
     body: requestBody,
     contentType: requestContentType,
+    credential,
     fetchImpl = fetch,
     isUnsafeUrl,
   } = options ?? {};
   if (typeof isUnsafeUrl !== "function") {
     throw new Error("callSubnetSurface requires options.isUnsafeUrl");
+  }
+  // Placed before URL/header construction so a query-location credential
+  // becomes part of the query object buildRequestUrl() merges below, and a
+  // header/cookie-location credential is ready to hand to safetyCheckedFetch.
+  let effectiveQuery = query;
+  const extraHeaders = {};
+  if (credential) {
+    if (credential.location === "query") {
+      effectiveQuery = {
+        ...(query || {}),
+        [credential.name]: credential.value,
+      };
+    } else if (credential.location === "header") {
+      extraHeaders[credential.name] = credential.value;
+    } else if (credential.location === "cookie") {
+      extraHeaders.cookie = `${credential.name}=${credential.value}`;
+    }
   }
   const method =
     path && methodOverride
@@ -115,13 +141,14 @@ export async function callSubnetSurface(surface, options) {
     }
     baseUrl = resolved.toString();
   }
-  const requestUrl = buildRequestUrl(baseUrl, query);
+  const requestUrl = buildRequestUrl(baseUrl, effectiveQuery);
 
   const fetched = await safetyCheckedFetch(requestUrl, {
     method,
     ...(canHaveBody && requestBody !== undefined
       ? { body: requestBody, contentType: requestContentType }
       : {}),
+    extraHeaders,
     fetchImpl,
     isUnsafeUrl,
     timeoutMs,
@@ -298,6 +325,7 @@ async function safetyCheckedFetch(
     timeoutMs,
     body,
     contentType,
+    extraHeaders,
     redirectCount = 0,
   },
 ) {
@@ -317,6 +345,7 @@ async function safetyCheckedFetch(
         ...(body !== undefined && contentType
           ? { "content-type": contentType }
           : {}),
+        ...(extraHeaders || {}),
       },
       ...(body !== undefined ? { body } : {}),
       redirect: "manual",
@@ -340,6 +369,16 @@ async function safetyCheckedFetch(
           status_code: response.status,
         };
       }
+      // metagraphed#7686: extraHeaders may carry a caller's credential
+      // (Authorization/api-key/Cookie) -- forwarding it across an origin
+      // boundary would hand it to a host the caller never authorized,
+      // exactly the class of leak real HTTP clients guard against by
+      // stripping Authorization on a cross-origin redirect. This code
+      // manually re-issues each hop (redirect: "manual"), so that stripping
+      // doesn't happen for free; drop extraHeaders the moment the redirect
+      // target's origin differs from the current hop's, and it stays
+      // dropped for every hop after (a stripped call never receives it back).
+      const sameOrigin = new URL(redirectTarget).origin === new URL(url).origin;
       return safetyCheckedFetch(redirectTarget, {
         method,
         fetchImpl,
@@ -347,6 +386,7 @@ async function safetyCheckedFetch(
         timeoutMs,
         body,
         contentType,
+        extraHeaders: sameOrigin ? extraHeaders : undefined,
         redirectCount: redirectCount + 1,
       });
     }

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11063,6 +11063,11 @@ export const MCP_TOOLS = [
           description:
             'Media type for `body`, e.g. "application/json". Must be one the matched operation declares. Optional when the operation declares application/json or exactly one media type.',
         },
+        credential: {
+          type: "string",
+          description:
+            'Credential for an auth_required surface, already formatted per the surface\'s auth.value_format (e.g. "Bearer <token>", "Apikey <key>" -- fetch it first with list_subnet_apis/get_api_schema). Only surfaces with auth.scheme bearer or api-key AND both auth.location/auth.name documented accept this; anything else (custom scheme, or an incompletely-documented one) is rejected. This tool never obtains a credential on your behalf -- you must already hold a working one. Never stored, logged, or reused past this single call.',
+        },
       },
       required: ["surface_id"],
       additionalProperties: false,
@@ -11133,11 +11138,43 @@ export const MCP_TOOLS = [
           `No catalogued surface with id, key, or deprecated id "${args.surface_id}".`,
         );
       }
-      if (surface.auth_required) {
+      const hasCredentialArg =
+        typeof args?.credential === "string" && args.credential.length > 0;
+      if (hasCredentialArg && !surface.auth_required) {
         throw toolError(
-          "auth_required",
-          "This surface requires a credential this tool does not yet support (MCP execute Phase 3). Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+          "invalid_params",
+          "`credential` was supplied but this surface does not require one.",
         );
+      }
+      let credentialPlacement;
+      if (surface.auth_required) {
+        if (!hasCredentialArg) {
+          throw toolError(
+            "auth_required",
+            "This surface requires a credential. Supply `credential` (see this tool's description for the required format), or use list_subnet_apis / how_do_i_call to see how to call it directly.",
+          );
+        }
+        const scheme = surface.auth?.scheme;
+        if (scheme !== "bearer" && scheme !== "api-key") {
+          throw toolError(
+            "credential_not_supported",
+            `This surface's auth scheme ("${scheme || "undocumented"}") is not one this tool can attach a credential to (only bearer/api-key are supported). Use list_subnet_apis / how_do_i_call to see how to call it directly.`,
+          );
+        }
+        const location = surface.auth?.location;
+        const name = surface.auth?.name;
+        if (
+          !name ||
+          (location !== "header" &&
+            location !== "query" &&
+            location !== "cookie")
+        ) {
+          throw toolError(
+            "credential_not_supported",
+            "This surface's auth mechanism (location/name) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+          );
+        }
+        credentialPlacement = { location, name, value: args.credential };
       }
       if (surface.probe?.enabled === false) {
         throw toolError(
@@ -11236,6 +11273,7 @@ export const MCP_TOOLS = [
         method: hasPath ? normalizedMethod : undefined,
         body: requestBody,
         contentType: requestContentType,
+        credential: credentialPlacement,
         fetchImpl: globalThis.fetch,
         isUnsafeUrl: workerResolvedUrlSafetyGuard({
           fetchImpl: globalThis.fetch,

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -113,6 +113,60 @@ const SCHEMA_DOCUMENT = {
   },
 };
 
+// #7686 (MCP execute Phase 3a) fixtures: a fully-documented bearer surface
+// (header location), an api-key surface (query location), a custom-scheme
+// surface (no generic mechanism), and a bearer surface missing
+// auth.location/auth.name (scheme is generic, but not documented enough).
+const BEARER_SURFACE = {
+  surface_id: "x:api:6",
+  netuid: 10,
+  kind: "subnet-api",
+  url: "https://x.example/admin",
+  auth_required: true,
+  auth: { scheme: "bearer", location: "header", name: "Authorization" },
+  probe: { method: "GET", enabled: true },
+};
+
+const API_KEY_QUERY_SURFACE = {
+  surface_id: "x:api:7",
+  netuid: 11,
+  kind: "subnet-api",
+  url: "https://x.example/billing",
+  auth_required: true,
+  auth: { scheme: "api-key", location: "query", name: "api_key" },
+  probe: { method: "GET", enabled: true },
+};
+
+const CUSTOM_AUTH_SURFACE = {
+  surface_id: "x:api:8",
+  netuid: 12,
+  kind: "subnet-api",
+  url: "https://x.example/custom",
+  auth_required: true,
+  auth: { scheme: "custom" },
+  probe: { method: "GET", enabled: true },
+};
+
+const INCOMPLETE_AUTH_SURFACE = {
+  surface_id: "x:api:9",
+  netuid: 13,
+  kind: "subnet-api",
+  url: "https://x.example/undocumented",
+  auth_required: true,
+  auth: { scheme: "bearer" },
+  probe: { method: "GET", enabled: true },
+};
+
+const DISABLED_PROBE_BEARER_SURFACE = {
+  surface_id: "x:api:10",
+  netuid: 14,
+  kind: "subnet-api",
+  url: "https://x.example/disabled-admin",
+  auth_required: true,
+  auth: { scheme: "bearer", location: "header", name: "Authorization" },
+  probe: { method: "GET", enabled: false },
+};
+
 const CATALOG = {
   surfaces: [
     NO_AUTH_SURFACE,
@@ -121,6 +175,11 @@ const CATALOG = {
     SCHEMA_SURFACE,
     NO_SCHEMA_SURFACE,
     SELF_SCHEMA_SURFACE,
+    BEARER_SURFACE,
+    API_KEY_QUERY_SURFACE,
+    CUSTOM_AUTH_SURFACE,
+    INCOMPLETE_AUTH_SURFACE,
+    DISABLED_PROBE_BEARER_SURFACE,
   ],
 };
 
@@ -626,6 +685,115 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       });
       assert.equal(result.isError, true);
       assert.match(result.content[0].text, /invalid_params/);
+    });
+  });
+
+  // #7686 (MCP execute Phase 3a): credential-passthrough eligibility + placement.
+  describe("credential passthrough (#7686)", () => {
+    test("a bearer surface with a credential injects it as the documented header", async () => {
+      let sentHeader;
+      const result = await callTool(
+        { surface_id: "x:api:6", credential: "Bearer abc123" },
+        async (url, init) => {
+          sentHeader = init.headers.Authorization;
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.equal(sentHeader, "Bearer abc123");
+    });
+
+    test("an api-key surface with a credential injects it as the documented query param", async () => {
+      let requestedUrl;
+      const result = await callTool(
+        { surface_id: "x:api:7", credential: "abc123" },
+        async (url) => {
+          requestedUrl = String(url);
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.equal(new URL(requestedUrl).searchParams.get("api_key"), "abc123");
+    });
+
+    test("no credential on an auth_required surface is still auth_required (Phase 1/2 unchanged)", async () => {
+      const result = await callTool({ surface_id: "x:api:6" });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /auth_required/);
+    });
+
+    test("a credential on a custom-scheme surface is credential_not_supported", async () => {
+      const result = await callTool({
+        surface_id: "x:api:8",
+        credential: "whatever",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
+    });
+
+    test("a credential on a bearer surface missing location/name is credential_not_supported", async () => {
+      const result = await callTool({
+        surface_id: "x:api:9",
+        credential: "whatever",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
+    });
+
+    test("a credential on a surface that doesn't require auth is invalid_params", async () => {
+      const result = await callTool({
+        surface_id: "x:api:1",
+        credential: "whatever",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+    });
+
+    test("a credentialed call to an eligible surface still respects probe.enabled:false", async () => {
+      let fetched = false;
+      const result = await callTool(
+        { surface_id: "x:api:10", credential: "Bearer abc123" },
+        async () => {
+          fetched = true;
+          return new Response("{}", { status: 200 });
+        },
+      );
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /surface_unavailable/);
+      assert.equal(fetched, false);
+    });
+
+    test("a credentialed call to a schema-bearing surface still works with path/method (Phase 2 + 3 compose)", async () => {
+      let sentHeader;
+      let requestedUrl;
+      const result = await callTool(
+        {
+          surface_id: "x:api:6",
+          credential: "Bearer abc123",
+          path: "/admin",
+          method: "GET",
+        },
+        async (url, init) => {
+          requestedUrl = String(url);
+          sentHeader = init.headers.Authorization;
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      // x:api:6 has no captured schema, so this exercises the no_schema path
+      // -- credential eligibility is still validated before schema resolution.
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /no_schema/);
+      assert.equal(sentHeader, undefined);
+      assert.equal(requestedUrl, undefined);
     });
   });
 });

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -168,6 +168,19 @@ const DISABLED_PROBE_BEARER_SURFACE = {
   probe: { method: "GET", enabled: false },
 };
 
+// A generically-supported scheme with `name` documented but `location`
+// missing -- distinct from INCOMPLETE_AUTH_SURFACE above (which is missing
+// `name` too, short-circuiting before location is ever checked).
+const MISSING_LOCATION_SURFACE = {
+  surface_id: "x:api:11",
+  netuid: 15,
+  kind: "subnet-api",
+  url: "https://x.example/no-location",
+  auth_required: true,
+  auth: { scheme: "bearer", name: "Authorization" },
+  probe: { method: "GET", enabled: true },
+};
+
 const CATALOG = {
   surfaces: [
     NO_AUTH_SURFACE,
@@ -181,6 +194,7 @@ const CATALOG = {
     CUSTOM_AUTH_SURFACE,
     INCOMPLETE_AUTH_SURFACE,
     DISABLED_PROBE_BEARER_SURFACE,
+    MISSING_LOCATION_SURFACE,
   ],
 };
 
@@ -745,6 +759,28 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       });
       assert.equal(result.isError, true);
       assert.match(result.content[0].text, /credential_not_supported/);
+    });
+
+    test("a credential on a bearer surface with name but no location is credential_not_supported", async () => {
+      // Distinct from the missing-name case above: name present, only
+      // location absent -- exercises the `location !== ...` half of the
+      // eligibility check, not just the `!name` short-circuit.
+      const result = await callTool({
+        surface_id: "x:api:11",
+        credential: "whatever",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
+    });
+
+    test("a credential on a surface with auth_required but no auth object at all names the scheme as undocumented", async () => {
+      const result = await callTool({
+        surface_id: "x:api:2",
+        credential: "whatever",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
+      assert.match(result.content[0].text, /"undocumented"/);
     });
 
     test("a credential on a surface that doesn't require auth is invalid_params", async () => {

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -10,6 +10,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.mjs";
 
 const NO_AUTH_SURFACE = {
   surface_id: "x:api:1",
@@ -794,6 +795,63 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       assert.match(result.content[0].text, /no_schema/);
       assert.equal(sentHeader, undefined);
       assert.equal(requestedUrl, undefined);
+    });
+  });
+
+  // #7687 (MCP execute Phase 3b): a credential must never appear in usage
+  // telemetry. usageEventProperties (src/usage-telemetry.mjs) is already a
+  // strict allowlist that never receives raw tool args -- this proves that
+  // holds for a real credentialed call, not just by reading the allowlist.
+  describe("credential never reaches usage telemetry (#7687)", () => {
+    test("a credentialed call_subnet_surface records only the allowlisted fields", async () => {
+      const of = globalThis.fetch;
+      globalThis.fetch = async () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      const recorded = [];
+      try {
+        const response = await handleMcpRequest(
+          new Request("https://metagraph.sh/mcp", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/call",
+              params: {
+                name: "call_subnet_surface",
+                arguments: {
+                  surface_id: "x:api:6",
+                  credential: "Bearer super-secret-abc123",
+                },
+              },
+            }),
+          }),
+          { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" },
+          {
+            ...deps,
+            executionCtx: { waitUntil: (p) => p },
+            recordUsageEvent: async (_env, event) => {
+              recorded.push(event);
+              return true;
+            },
+          },
+        );
+        await response.json();
+      } finally {
+        globalThis.fetch = of;
+      }
+      assert.equal(recorded.length, 1);
+      const serialized = JSON.stringify(recorded[0]);
+      assert.ok(!serialized.includes("super-secret-abc123"));
+      assert.deepEqual(Object.keys(recorded[0]).sort(), [
+        "durationMs",
+        "mcpTool",
+        "ok",
+      ]);
+      assert.equal(recorded[0].mcpTool, "call_subnet_surface");
     });
   });
 });

--- a/tests/call-subnet-surface.test.mjs
+++ b/tests/call-subnet-surface.test.mjs
@@ -636,6 +636,174 @@ describe("callSubnetSurface", () => {
     assert.equal(result.ok, true);
   });
 
+  // #7687 (MCP execute Phase 3b): a query-location credential is part of the
+  // request URL itself, so it's the one placement that can leak back out
+  // through this function's own return value -- these confirm it's redacted
+  // everywhere a URL/error could carry it, while header/cookie placement
+  // (never echoed anywhere by this module) needs no equivalent redaction.
+  test("credential: query-location value is redacted in the successful response's url", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "query", name: "api_key", value: "abc123" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => jsonResponse({}),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(new URL(result.url).searchParams.get("api_key"), "<redacted>");
+    assert.ok(!result.url.includes("abc123"));
+  });
+
+  test("credential: query-location value is redacted in the url after a followed redirect", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "query", name: "api_key", value: "abc123" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          if (new URL(url).pathname === "/api") {
+            return new Response(null, {
+              status: 302,
+              // The surface's own redirect happens to echo the query string
+              // back -- exactly the case that would leak the credential if
+              // redirectTarget weren't redacted too.
+              headers: {
+                location: `https://example.com/api/v2?api_key=abc123`,
+              },
+            });
+          }
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.ok(!result.url.includes("abc123"));
+    assert.equal(new URL(result.url).searchParams.get("api_key"), "<redacted>");
+  });
+
+  test("credential: a redirect target with no credential-named param is returned unchanged (nothing to redact)", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "query", name: "api_key", value: "abc123" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          if (new URL(url).pathname === "/api") {
+            // The surface's redirect drops the query string entirely --
+            // nothing named "api_key" ends up in the target.
+            return new Response(null, {
+              status: 302,
+              headers: { location: "https://example.com/api/v2" },
+            });
+          }
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.url, "https://example.com/api/v2");
+  });
+
+  test("credential: query-location value is redacted in a blocked-redirect's redirect_target", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "query", name: "api_key", value: "abc123" },
+        isUnsafeUrl: async (url) => url.includes("internal"),
+        fetchImpl: async (url) => {
+          if (new URL(url).pathname === "/api") {
+            return new Response(null, {
+              status: 302,
+              headers: {
+                location: "https://internal.example/secret?api_key=abc123",
+              },
+            });
+          }
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.private_redirect_blocked, true);
+    assert.ok(!result.redirect_target.includes("abc123"));
+    assert.equal(
+      new URL(result.redirect_target).searchParams.get("api_key"),
+      "<redacted>",
+    );
+  });
+
+  test("credential: query-location value is not present when the surface has no query param matching auth.name", async () => {
+    // The redaction only touches a param actually named after the
+    // credential -- an unrelated same-named-looking query value some OTHER
+    // param happens to carry is left alone (nothing to redact there).
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        query: { other: "abc123" },
+        credential: { location: "query", name: "api_key", value: "abc123" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => jsonResponse({}),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(new URL(result.url).searchParams.get("other"), "abc123");
+    assert.equal(new URL(result.url).searchParams.get("api_key"), "<redacted>");
+  });
+
+  test("credential: header/cookie-location values never appear in the response url (nothing to redact there)", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => jsonResponse({}),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.url, "https://example.com/api");
+  });
+
+  test("credential: any placement's value is scrubbed from a network-error message", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => {
+          throw new Error(
+            "fetch failed: https://example.com/api (header Authorization: Bearer abc123)",
+          );
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.ok(!result.error.includes("Bearer abc123"));
+    assert.ok(result.error.includes("<redacted>"));
+  });
+
+  test("credential: no credential supplied leaves error messages untouched", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => {
+          throw new Error("connection refused");
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "connection refused");
+  });
+
   test("credential: cookie location sets a Cookie header formatted name=value", async () => {
     const result = await callSubnetSurface(
       { url: "https://example.com/api" },

--- a/tests/call-subnet-surface.test.mjs
+++ b/tests/call-subnet-surface.test.mjs
@@ -575,6 +575,218 @@ describe("callSubnetSurface", () => {
     assert.equal(calls, 2);
   });
 
+  test("credential: header location sets the named header", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(init.headers.Authorization, "Bearer abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: query location merges a query param, distinct from the query option", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        query: { limit: 5 },
+        credential: {
+          location: "query",
+          name: "api_key",
+          value: "abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          const parsed = new URL(url);
+          assert.equal(parsed.searchParams.get("limit"), "5");
+          assert.equal(parsed.searchParams.get("api_key"), "abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: query location works with no query option supplied at all", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "query",
+          name: "api_key",
+          value: "abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          const parsed = new URL(url);
+          assert.equal(parsed.searchParams.get("api_key"), "abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: cookie location sets a Cookie header formatted name=value", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "cookie",
+          name: "session",
+          value: "abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(init.headers.cookie, "session=abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: an unrecognized location is silently ignored, never placed anywhere", async () => {
+    // callSubnetSurface only places a credential, it doesn't validate
+    // eligibility (the tool handler already restricts location to
+    // header/query/cookie before ever constructing this option) -- an
+    // unrecognized value should be a no-op, not a crash or a guess.
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "body", name: "x", value: "abc123" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(url, "https://example.com/api");
+          assert.equal(init.headers.x, undefined);
+          assert.equal(init.headers.cookie, undefined);
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: applies to the surface's curated url with no path override (Phase 1 shape)", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "header", name: "X-Api-Key", value: "k" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(url, "https://example.com/api");
+          assert.equal(init.headers["X-Api-Key"], "k");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential: a header-location credential is preserved across a same-origin redirect", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          calls += 1;
+          if (url === "https://example.com/api") {
+            assert.equal(init.headers.Authorization, "Bearer abc123");
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://example.com/api/v2" },
+            });
+          }
+          assert.equal(init.headers.Authorization, "Bearer abc123");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(calls, 2);
+  });
+
+  test("credential: a header-location credential is stripped on a cross-origin redirect", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          calls += 1;
+          if (url === "https://example.com/api") {
+            assert.equal(init.headers.Authorization, "Bearer abc123");
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://other.example/api" },
+            });
+          }
+          assert.equal(url, "https://other.example/api");
+          assert.equal(init.headers.Authorization, undefined);
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(calls, 2);
+  });
+
+  test("credential: once stripped on a cross-origin hop, stays stripped on a further redirect back to the original origin", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          name: "Authorization",
+          value: "Bearer abc123",
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          calls += 1;
+          if (url === "https://example.com/api") {
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://other.example/api" },
+            });
+          }
+          if (url === "https://other.example/api") {
+            assert.equal(init.headers.Authorization, undefined);
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://example.com/api/v2" },
+            });
+          }
+          assert.equal(url, "https://example.com/api/v2");
+          assert.equal(init.headers.Authorization, undefined);
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(calls, 3);
+  });
+
   test("without a path override, method falls back to Phase 1's probe-derived default even if a method option is set alone", async () => {
     const result = await callSubnetSurface(
       { url: "https://example.com/api", probe: { method: "HEAD" } },

--- a/tests/mcp-server-sentry-args-safety.test.mjs
+++ b/tests/mcp-server-sentry-args-safety.test.mjs
@@ -1,0 +1,107 @@
+// metagraphed#7687 (MCP execute Phase 3b): confirms dispatchTool's
+// Sentry.startSpan call (src/mcp-server.mjs) never receives a tool's raw
+// arguments -- only {name, op}. Motivated by call_subnet_surface's Phase 3
+// `credential` argument, but the property being verified is generic to
+// every MCP tool, not specific to that one. A separate small file rather
+// than folded into tests/call-subnet-surface-mcp.test.mjs: vi.mock is
+// file-scoped and hoisted, and that file's other ~48 tests already exercise
+// the real (unmocked) Sentry.startSpan through every other tool call --
+// mocking it there risks disturbing tests this issue doesn't own.
+import assert from "node:assert/strict";
+import { afterEach, test, vi } from "vitest";
+
+const startSpanCalls = vi.hoisted(() => []);
+const captureException = vi.hoisted(() => vi.fn());
+
+vi.mock("@sentry/cloudflare", () => ({
+  startSpan: async (spanArgs, callback) => {
+    startSpanCalls.push(spanArgs);
+    return callback();
+  },
+  captureException,
+}));
+
+const { handleMcpRequest } = await import("../src/mcp-server.mjs");
+
+afterEach(() => {
+  startSpanCalls.length = 0;
+  captureException.mockClear();
+});
+
+async function callTool(name, args, fetchImpl) {
+  const of = globalThis.fetch;
+  globalThis.fetch =
+    fetchImpl ??
+    (async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+  const deps = {
+    readArtifact: async (_e, path) => {
+      if (path === "/metagraph/operational-surfaces.json") {
+        return {
+          ok: true,
+          data: {
+            surfaces: [
+              {
+                surface_id: "x:api:1",
+                netuid: 5,
+                kind: "subnet-api",
+                url: "https://x.example/admin",
+                auth_required: true,
+                auth: {
+                  scheme: "bearer",
+                  location: "header",
+                  name: "Authorization",
+                },
+                probe: { method: "GET", enabled: true },
+              },
+            ],
+          },
+        };
+      }
+      return { ok: false, status: 404 };
+    },
+  };
+  try {
+    const response = await handleMcpRequest(
+      new Request("https://metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name, arguments: args },
+        }),
+      }),
+      {},
+      deps,
+    );
+    return (await response.json()).result;
+  } finally {
+    globalThis.fetch = of;
+  }
+}
+
+test("Sentry.startSpan is called exactly once per tool call, with only {name, op}", async () => {
+  const result = await callTool("call_subnet_surface", {
+    surface_id: "x:api:1",
+    credential: "Bearer super-secret-abc123",
+  });
+  assert.equal(result.isError, false);
+  assert.equal(startSpanCalls.length, 1);
+  assert.deepEqual(Object.keys(startSpanCalls[0]).sort(), ["name", "op"]);
+  assert.equal(startSpanCalls[0].name, "mcp.tool/call_subnet_surface");
+  assert.equal(startSpanCalls[0].op, "mcp.tool");
+});
+
+test("the credential value never appears anywhere in the span-creation call", async () => {
+  await callTool("call_subnet_surface", {
+    surface_id: "x:api:1",
+    credential: "Bearer super-secret-abc123",
+  });
+  const serialized = JSON.stringify(startSpanCalls);
+  assert.ok(!serialized.includes("super-secret-abc123"));
+});


### PR DESCRIPTION
## Summary

Closes #7687 (MCP execute Phase 3b — step 2 of 3 toward #7016).

**Stacked on #7691** (Phase 3a). This diff includes #7691's commit until it merges; rebase target is `main` after it lands.

Ensures the credential #7686 injects never comes back out anywhere it shouldn't — the response itself, telemetry, or Sentry.

## What changed

1. **Query-location redaction** (`src/call-subnet-surface.mjs`): a `query`-location credential is now redacted from every URL `callSubnetSurface` returns — the successful response's `url`, a followed redirect's resolved `url`, and a blocked-redirect's own `redirect_target`. A query parameter is part of the URL itself, and this function does return URLs to the caller, so without this, a `query`-location surface would echo the credential straight back in cleartext. Header/cookie placement needs no equivalent fix — nothing in this module ever echoes request headers back in any response field.
2. **Error-message scrubbing, defense in depth**: the raw credential value is also stripped from any network-error message this module returns, regardless of placement — in case an underlying `fetch` implementation ever embeds request details (URL, headers) in its own thrown error text, which is outside this module's control.
3. **Found and removed dead code along the way**: the first pass wrapped the URL-redaction in a `try/catch` for a "URL fails to parse" case that, on inspection, can't actually happen — `url` here is always the output of an earlier `new URL()` call within this same module, already proven parseable. Removed rather than writing a contrived test to hit an unreachable branch.

## Verified, not just inspected

- [x] **Telemetry**: a credentialed `call_subnet_surface` call through the real dispatch path records only the existing allowlisted fields (`mcpTool`, `ok`, `durationMs`) — confirmed with a live call and a `recordUsageEvent` spy, not just by reading `usageEventProperties`'s allowlist and assuming it holds.
- [x] **Sentry**: `Sentry.startSpan`'s own call in `dispatchTool` only ever receives `{name, op}` — confirmed with a mocked `@sentry/cloudflare` and a real credentialed tool call, not just by reading the call site. New dedicated file (`tests/mcp-server-sentry-args-safety.test.mjs`) rather than folded into the existing 48-test `call-subnet-surface-mcp.test.mjs`: `vi.mock` is file-scoped and hoisted, and that file's other tests already exercise the real (unmocked) `Sentry.startSpan` through every other tool call — mocking it there risked disturbing tests this issue doesn't own.

## Validation

- [x] 9 new unit tests (`tests/call-subnet-surface.test.mjs`): query-value redacted in a successful response, redacted after a followed redirect that happens to echo the query string, redacted in a blocked-redirect's `redirect_target`, a param merely sharing the credential's value (different name) is left alone, header/cookie placement's `url` has nothing to redact, error-message scrubbing for any placement, no-credential calls leave error messages untouched, a redirect target with no credential-named param returned unchanged.
- [x] 1 new MCP-level telemetry test + 2 new Sentry tests (separate file).
- [x] Full regression: `tests/mcp-server.test.mjs` + `tests/mcp-server-branch-coverage.test.mjs` + both `call-subnet-surface*` files + `tests/mcp-usage-telemetry.test.mjs` + the new Sentry file — 1371 tests, all passing.
- [x] Coverage: `call-subnet-surface.mjs` 100% lines/branches/functions/statements; confirmed via line-number cross-reference that every uncovered line in `mcp-server.mjs`'s report falls outside this PR's edited range.
- [x] `npm run lint` / `npm run format:check` — clean.