### PR TITLE
feat(api): add randomness_status alias field with RPC-failure coverage (#7649)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -819,6 +819,8 @@ export const SDL = `
     network_parameters: NetworkParameters
     "Live drand randomness-beacon status read directly from chain via RPC (not the Postgres tier): the newest and oldest stored beacon rounds and the span between them. Each field is independently null on its own RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/network/randomness."
     network_randomness: NetworkRandomness
+    "The get_randomness_status-aligned name for the same live drand beacon snapshot (#7649): identical loader, KV cache, and independently-null RPC-failure behavior as network_randomness — a thin alias so MCP tool names and GraphQL fields line up. Returns the typed NetworkRandomness envelope rather than the issue's literal JSON suggestion, matching network_randomness. Mirrors GET /api/v1/network/randomness."
+    randomness_status: NetworkRandomness
     "Live EVM (H160) -> Substrate (SS58) account-address mapping for a 20-byte 0x-prefixed hex address, resolved directly from chain via RPC (not the Postgres tier). ss58 is null when the address has no association or the RPC lookup fails, schema-stable, never a GraphQL error. Mirrors GET /api/v1/evm/address/{h160}."
     evm_address(h160: String!): EvmAddressMapping
     "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
@@ -4363,6 +4365,7 @@ export const FIELD_COMPLEXITY = {
   sudo_key: LIVE_RPC_FIELD_COMPLEXITY,
   network_parameters: LIVE_RPC_FIELD_COMPLEXITY,
   network_randomness: LIVE_RPC_FIELD_COMPLEXITY,
+  randomness_status: LIVE_RPC_FIELD_COMPLEXITY,
   evm_address: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
@@ -10077,6 +10080,13 @@ const rootValue = {
     // Each round field stays independently null on RPC failure (schema-stable),
     // never a GraphQL error; schema_version/queried_at are always set.
     return loadRandomnessStatus(context.env);
+  },
+  // #7649: the get_randomness_status-aligned name for the same beacon snapshot
+  // -- a thin delegate so MCP tool names and GraphQL fields line up. Identical
+  // loader, KV cache/TTL, and independently-null RPC-failure behavior; nothing
+  // re-implemented.
+  async randomness_status(_args, context) {
+    return rootValue.network_randomness(_args, context);
   },
   async evm_address({ h160 }, context) {
     // Same H160_PATTERN validation the REST route + MCP get_evm_address_mapping

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -16377,6 +16377,83 @@ describe("graphql — network_randomness (#6990, live chain RPC via randomness.m
   });
 });
 
+describe("graphql — randomness_status (#7649, get_randomness_status-aligned alias)", () => {
+  function kvEnv(payload) {
+    return { METAGRAPH_CONTROL: { get: async () => payload } };
+  }
+
+  test("a successful live read serves the same beacon snapshot as network_randomness", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      last_stored_round: 1200,
+      oldest_stored_round: 900,
+      stored_round_span: 301,
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ randomness_status { schema_version last_stored_round oldest_stored_round stored_round_span queried_at }
+         network_randomness { schema_version last_stored_round oldest_stored_round stored_round_span queried_at } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const alias = body.data.randomness_status;
+    assert.equal(alias.schema_version, 1);
+    assert.equal(alias.last_stored_round, 1200);
+    assert.equal(alias.oldest_stored_round, 900);
+    assert.equal(alias.stored_round_span, 301);
+    assert.equal(alias.queried_at, "2026-07-20T00:00:00.000Z");
+    // Alias equivalence: the identical envelope from the same env.
+    assert.deepEqual(alias, body.data.network_randomness);
+  });
+
+  test("RPC failure: null rounds resolve as the same schema-stable card, never a GraphQL error", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      last_stored_round: null,
+      oldest_stored_round: null,
+      stored_round_span: null,
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      "{ randomness_status { last_stored_round oldest_stored_round stored_round_span queried_at } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.randomness_status;
+    assert.equal(r.last_stored_round, null);
+    assert.equal(r.oldest_stored_round, null);
+    assert.equal(r.stored_round_span, null);
+    assert.ok(r.queried_at);
+  });
+
+  test("is priced identically to network_randomness", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.randomness_status,
+      FIELD_COMPLEXITY.network_randomness,
+    );
+  });
+
+  test("has the identical GraphQL signature as network_randomness (args + return type)", async () => {
+    const { status, body } = await gql(
+      `{ __type(name: "Query") { fields {
+          name
+          args { name type { kind name ofType { kind name } } }
+          type { kind name ofType { kind name } }
+        } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const fields = body.data.__type.fields;
+    const canonical = fields.find((f) => f.name === "network_randomness");
+    const alias = fields.find((f) => f.name === "randomness_status");
+    assert.ok(canonical && alias, "both fields present in the schema");
+    assert.deepEqual(alias.args, canonical.args);
+    assert.deepEqual(alias.type, canonical.type);
+  });
+});
+
 describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs)", () => {
   function kvEnv(payload) {
     return { METAGRAPH_CONTROL: { get: async () => payload } };


### PR DESCRIPTION
## Summary

- Adds a `randomness_status: NetworkRandomness` Query field to `src/graphql.mjs` — the `get_randomness_status`-aligned name for the live drand beacon snapshot, so the MCP tool name and the GraphQL field line up. Mirrors `GET /api/v1/network/randomness`.
- The resolver is a thin delegate to the existing `network_randomness` resolver: identical `loadRandomnessStatus` loader, KV cache/TTL, and independently-null RPC-failure behavior. Nothing re-implemented, per the issue's constraint.
- The SDL docstring states the intentional shape decision: it returns the existing typed `NetworkRandomness` envelope rather than the issue's literal `JSON` suggestion, matching the canonical field.
- This completes what #7678 was closed for: the issue's Deliverables checklist requires **both** test scenarios, and this PR covers the RPC-failure/null case that PR was missing — modeled directly on the existing `network_randomness` null-rounds test, per the closing review's pointer.

## What Changed

- `src/graphql.mjs` (+10): the `randomness_status` SDL field + docstring, a `FIELD_COMPLEXITY` entry priced identically to `network_randomness` (`LIVE_RPC_FIELD_COMPLEXITY`), and the delegating resolver.
- `tests/graphql.test.mjs` (+77): four tests — a successful live read asserting alias equivalence (`assert.deepEqual` against `network_randomness` on the same env), **the RPC-failure case (all round fields null) resolving as the schema-stable card, never a GraphQL error**, identical complexity pricing, and a schema-introspection assertion that `randomness_status` and `network_randomness` keep identical arg + return-type signatures, guarding future divergence.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check` (components run individually: `npm run lint`, `npm run format:check`, `npm run typecheck` — all green; `pipeline:check` not run)
- [x] `npm run validate`
- [ ] `npm run validate:api` (not run locally — live-RPC check, exercised in CI; this diff adds no API route)
- [ ] `npm run test:coverage` (full-suite coverage not run locally; `vitest run tests/graphql.test.mjs` — 910/910 passing, and the patch's only executable path is the branchless delegate covered by two of the new tests — same shape as #7689, which passed `codecov/patch`)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

`npm run build` was also run (green), with the deploy-owned `public/metagraph/r2-manifest.json` / `schemas/index.json` / `operational-surfaces.json` reverted against `upstream/main` per the contribution guide — the diff is exactly the two files above.

## Template Used

- Backend/code change

Closes #7649
