### PR TITLE
feat(api): add evm_address_mapping alias field for MCP-name parity (#7648)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -823,6 +823,8 @@ export const SDL = `
     randomness_status: NetworkRandomness
     "Live EVM (H160) -> Substrate (SS58) account-address mapping for a 20-byte 0x-prefixed hex address, resolved directly from chain via RPC (not the Postgres tier). ss58 is null when the address has no association or the RPC lookup fails, schema-stable, never a GraphQL error. Mirrors GET /api/v1/evm/address/{h160}."
     evm_address(h160: String!): EvmAddressMapping
+    "The get_evm_address_mapping-aligned name for evm_address, so the MCP tool name and this Query field line up. Structurally identical to evm_address -- same live RPC read, same validation, same schema-stable null on an unresolved mapping -- not a second lookup. Mirrors GET /api/v1/evm/address/{h160}."
+    evm_address_mapping(h160: String!): EvmAddressMapping
     "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
     sudo(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
   }
@@ -4367,6 +4369,7 @@ export const FIELD_COMPLEXITY = {
   network_randomness: LIVE_RPC_FIELD_COMPLEXITY,
   randomness_status: LIVE_RPC_FIELD_COMPLEXITY,
   evm_address: LIVE_RPC_FIELD_COMPLEXITY,
+  evm_address_mapping: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -4912,6 +4915,22 @@ async function listPage(
 // namespace. Constrain it to the safe slug charset the other id-bearing artifact
 // paths use; subnet(netuid) is Int-typed and needs no guard.
 const VALID_PROVIDER_ID = /^[A-Za-z0-9._:-]+$/;
+
+// Backs both evm_address and its get_evm_address_mapping-aligned alias
+// evm_address_mapping (#7648), so the two fields cannot drift apart. Same
+// H160_PATTERN validation the REST route + MCP get_evm_address_mapping use --
+// a malformed address is a GraphQL BAD_USER_INPUT error, not a card. The read
+// itself is live chain RPC, not the Postgres tier, reusing loadAddressMapping's
+// own KV cache/TTL, matching REST's /evm/address/{h160} handler exactly; ss58 is
+// null on an unresolved mapping (schema-stable), never a GraphQL error.
+function resolveEvmAddressMapping(h160, context) {
+  if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
+    throw new GraphQLError("h160 must be a 20-byte 0x-prefixed hex address.", {
+      extensions: { code: "BAD_USER_INPUT" },
+    });
+  }
+  return loadAddressMapping(context.env, h160);
+}
 
 const rootValue = {
   subnets(
@@ -10089,20 +10108,13 @@ const rootValue = {
     return rootValue.network_randomness(_args, context);
   },
   async evm_address({ h160 }, context) {
-    // Same H160_PATTERN validation the REST route + MCP get_evm_address_mapping
-    // use -- a malformed address is a GraphQL BAD_USER_INPUT error, not a card.
-    if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
-      throw new GraphQLError(
-        "h160 must be a 20-byte 0x-prefixed hex address.",
-        {
-          extensions: { code: "BAD_USER_INPUT" },
-        },
-      );
-    }
-    // Live chain RPC, not the Postgres tier -- reuses loadAddressMapping's own
-    // KV cache/TTL, matching REST's /evm/address/{h160} handler exactly. ss58 is
-    // null on an unresolved mapping (schema-stable), never a GraphQL error.
-    return loadAddressMapping(context.env, h160);
+    return resolveEvmAddressMapping(h160, context);
+  },
+  // Same resolver as evm_address, under the get_evm_address_mapping tool name so
+  // MCP and GraphQL agree; delegating rather than duplicating keeps the two
+  // fields from ever drifting apart.
+  async evm_address_mapping({ h160 }, context) {
+    return resolveEvmAddressMapping(h160, context);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -16513,6 +16513,82 @@ describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs
   });
 });
 
+describe("graphql — evm_address_mapping (#7648, get_evm_address_mapping name parity)", () => {
+  function kvEnv(payload) {
+    return { METAGRAPH_CONTROL: { get: async () => payload } };
+  }
+  const H160 = "0x1234567890abcdef1234567890abcdef12345678";
+
+  test("resolves the h160 -> ss58 mapping under the MCP tool name", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      h160: H160,
+      ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      queried_at: "2026-07-22T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ evm_address_mapping(h160: "${H160}") { schema_version h160 ss58 queried_at } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.evm_address_mapping;
+    assert.equal(r.schema_version, 1);
+    assert.equal(r.h160, H160);
+    assert.equal(r.ss58, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    assert.ok(r.queried_at);
+  });
+
+  test("an unresolved mapping resolves with null ss58, never a GraphQL error", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      h160: H160,
+      ss58: null,
+      queried_at: "2026-07-22T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ evm_address_mapping(h160: "${H160}") { h160 ss58 } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.evm_address_mapping.ss58, null);
+  });
+
+  test("a malformed h160 is a GraphQL BAD_USER_INPUT error, not a card", async () => {
+    const { body } = await gql(
+      '{ evm_address_mapping(h160: "not-an-address") { ss58 } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/h160/i.test(body.errors[0].message));
+    assert.equal(body.errors[0].extensions?.code, "BAD_USER_INPUT");
+    assert.equal(body.data?.evm_address_mapping ?? null, null);
+  });
+
+  test("returns the same payload as evm_address for the same address", async () => {
+    const payload = {
+      schema_version: 1,
+      h160: H160,
+      ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      queried_at: "2026-07-22T00:00:00.000Z",
+    };
+    const { body } = await gql(
+      `{ a: evm_address(h160: "${H160}") { schema_version h160 ss58 queried_at }
+         b: evm_address_mapping(h160: "${H160}") { schema_version h160 ss58 queried_at } }`,
+      kvEnv(payload),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.b, body.data.a);
+  });
+
+  test("evm_address_mapping is weighted exactly like evm_address", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.evm_address_mapping,
+      FIELD_COMPLEXITY.evm_address,
+    );
+  });
+});
+
 describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled.mjs)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/subnet-recycled.test.mjs.


### PR DESCRIPTION
## Summary

Closes #7648.

Adds `evm_address_mapping(h160: String!): EvmAddressMapping` — the `get_evm_address_mapping`-aligned field name the issue asks for — so the MCP tool name and the GraphQL Query field line up.

The capability already ships as **`evm_address`** ([`src/graphql.mjs`](../blob/main/src/graphql.mjs), same route, same validation), so this is a naming-parity alias, not a second implementation. Both fields now delegate to one shared `resolveEvmAddressMapping()` helper, so they cannot drift apart.

## Meets each requirement

| Issue requirement | How |
|---|---|
| Field on `type Query`, documented "Mirrors GET /api/v1/evm/address/{h160}." | SDL docstring also distinguishes it from `evm_address`, per the `subnet_gaps` vs `gaps` convention |
| Reuse the same live precompile call — do not re-implement | Both fields call the shared helper → `loadAddressMapping()`, with its own KV cache/TTL, unchanged |
| Malformed `h160` is `BAD_USER_INPUT` | Same `H160_PATTERN` check the REST route and MCP tool use |
| Unmapped address → schema-stable null, not an error | Returns the loader's payload verbatim; `ss58` is `null` |

**On the return type:** the issue proposes `JSON` "or a typed return if a natural type exists". `EvmAddressMapping` already types this exact payload (it's the existing field's return type), so the alias reuses it — keeping both fields structurally identical.

`FIELD_COMPLEXITY` weights the alias exactly like `evm_address`, so it can't be used to bypass the query-complexity budget.

## Tests (5, in `tests/graphql.test.mjs`)

The issue's three required cases — mapped address, unmapped address (null `ss58`, no error), malformed `h160` (`BAD_USER_INPUT`) — plus two that pin the aliasing itself:
- both fields return a `deepEqual` payload for the same address
- both carry the same complexity weight

## Validation

- `tests/graphql.test.mjs` — **915 passed**, run after rebasing onto latest `main`
- `tsc --noEmit` clean; `eslint .` clean; `npm run validate:docs` passes
- `tests/api-coverage.test.mjs` + `tests/docs-content-drift.test.mjs` — 291 passed
- **Patch coverage: 100%.** Coverage on `src/graphql.mjs` is 99.92% stmt / 99.74% branch, and the single uncovered line (6261, a pre-existing `throw err;`) is nowhere near this diff — my hunks are at 822, 4366, 4913 and 10089. This matters because the issue sets a 99% branch-counted `codecov/patch` bar.

## Scope

Exactly 2 files, `src/graphql.mjs` and `tests/graphql.test.mjs`. No registry files and no unrelated changes are bundled — #7671 was closed for exactly that.

## Test plan

- [ ] CI green (`checks`, `test`, `codecov/patch`)
- [ ] `{ evm_address_mapping(h160: "0x...") { ss58 } }` resolves identically to `evm_address`
