### PR TITLE
feat(graphql): add validators list cursor pagination (#7644)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -245,7 +245,6 @@ import { loadRandomnessStatus } from "./randomness.mjs";
 import { loadAddressMapping, H160_PATTERN } from "./address-mapping.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
-  GLOBAL_VALIDATOR_LIMIT_DEFAULT,
   GLOBAL_VALIDATOR_LIMIT_MAX,
   GLOBAL_VALIDATOR_SORTS,
   buildGlobalValidators,
@@ -683,8 +682,8 @@ export const SDL = `
     blocks_summary: BlocksSummary!
     "Site-wide runtime spec-version transition timeline: the earliest known block at each distinct spec_version observed (ascending), the current spec_version, and where coverage starts. The empty shape (transition_count 0, current_spec_version null) is schema-stable, never a GraphQL error, when the store has no reading yet. Mirrors GET /api/v1/runtime."
     runtime: RuntimeVersionHistory!
-    "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Mirrors GET /api/v1/validators."
-    validators(sort: String, limit: Int): ValidatorList!
+    "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Paginate with limit/cursor like providers. Mirrors GET /api/v1/validators."
+    validators(sort: String, limit: Int, cursor: String): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
     validator(hotkey: String!): Validator
     "One validator's nominator leaderboard over a 7d/30d/90d window (default 30d): every coldkey that staked to or unstaked from this hotkey in the window, with its staked/unstaked/net/gross TAO, event count, and last-activity time, ranked by sort (net_staked | gross_staked | last_activity, default net_staked). An unsupported window/sort is a GraphQL error, not a silently substituted default; a hotkey with no nominators resolves to a schema-stable empty list, never null and never a GraphQL error. Mirrors GET /api/v1/validators/{hotkey}/nominators."
@@ -3382,6 +3381,7 @@ export const SDL = `
   type ValidatorList {
     items: [Validator!]!
     total: Int!
+    next_cursor: String
     sort: String!
     captured_at: String
     block_number: Int
@@ -7286,7 +7286,7 @@ const rootValue = {
     return loadBlockChainEvents(context, blockNumber);
   },
 
-  async validators({ sort, limit }, context) {
+  async validators({ sort, limit, cursor }, context) {
     const requestedSort = sort ?? DEFAULT_GLOBAL_VALIDATOR_SORT;
     if (!GLOBAL_VALIDATOR_SORTS.includes(requestedSort)) {
       throw new GraphQLError(
@@ -7294,13 +7294,11 @@ const rootValue = {
         { extensions: { code: "BAD_USER_INPUT" } },
       );
     }
-    const safeLimit = clampLimit(limit, {
-      defaultLimit: GLOBAL_VALIDATOR_LIMIT_DEFAULT,
-      maxLimit: GLOBAL_VALIDATOR_LIMIT_MAX,
-    });
+    // Same leaderboard computation REST/MCP use; fetch the max REST window once,
+    // then paginate in-process like providers/economics (cursor keyed by hotkey).
     const params = new URLSearchParams();
     params.set("sort", requestedSort);
-    params.set("limit", String(safeLimit));
+    params.set("limit", String(GLOBAL_VALIDATOR_LIMIT_MAX));
     const data = overlayFeaturedValidators(
       (await tryPostgresTier(
         context.env,
@@ -7309,12 +7307,20 @@ const rootValue = {
       )) ??
         buildGlobalValidators([], {
           sort: requestedSort,
-          limit: safeLimit,
+          limit: GLOBAL_VALIDATOR_LIMIT_MAX,
         }),
     );
+    const nodes = (data.validators || []).map(validatorNode);
+    const { page, total, nextCursor } = paginate(
+      nodes,
+      limit,
+      cursor,
+      (v) => v.hotkey,
+    );
     return {
-      items: (data.validators || []).map(validatorNode),
-      total: data.validator_count ?? 0,
+      items: page,
+      total: data.validator_count ?? total,
+      next_cursor: nextCursor,
       sort: data.sort ?? requestedSort,
       captured_at: data.captured_at ?? null,
       block_number: data.block_number ?? null,

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3813,7 +3813,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     assert.deepEqual(item.subnets, [{ netuid: 1, uid: 5, stake_tao: 1000 }]);
   });
 
-  test("validators: sort and limit args are forwarded as query params to the Postgres tier", async () => {
+  test("validators: sort is forwarded to the Postgres tier; limit is always the REST max window", async () => {
     let capturedUrl;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
@@ -3823,7 +3823,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
           return Response.json({
             schema_version: 1,
             sort: "uid_count",
-            limit: 5,
+            limit: 100,
             captured_at: null,
             block_number: null,
             validator_count: 0,
@@ -3835,10 +3835,10 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     await gql('{ validators(sort: "uid_count", limit: 5) { total } }', env);
     assert.equal(capturedUrl.pathname, "/api/v1/validators");
     assert.equal(capturedUrl.searchParams.get("sort"), "uid_count");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
   });
 
-  test("validators: an omitted limit forwards the default limit to the Postgres tier", async () => {
+  test("validators: an omitted GraphQL limit still fetches the REST max window from the Postgres tier", async () => {
     let capturedUrl;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
@@ -3848,7 +3848,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
           return Response.json({
             schema_version: 1,
             sort: "subnet_count",
-            limit: 20,
+            limit: 100,
             captured_at: null,
             block_number: null,
             validator_count: 0,
@@ -3859,7 +3859,54 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     };
     await gql("{ validators { total } }", env);
     assert.equal(capturedUrl.searchParams.get("sort"), "subnet_count");
-    assert.equal(capturedUrl.searchParams.get("limit"), "20");
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+  });
+
+  test("validators: paginate with a hotkey cursor", async () => {
+    const payload = {
+      schema_version: 1,
+      sort: "subnet_count",
+      limit: 100,
+      captured_at: null,
+      block_number: null,
+      validator_count: 2,
+      validators: [
+        {
+          hotkey: "5Alpha",
+          featured: false,
+          subnet_count: 2,
+          subnets: [],
+        },
+        {
+          hotkey: "5Beta",
+          featured: false,
+          subnet_count: 1,
+          subnets: [],
+        },
+      ],
+    };
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => Response.json(payload),
+      },
+    };
+    const first = await gql(
+      "{ validators(limit: 1) { items { hotkey } total next_cursor } }",
+      env,
+    );
+    assert.equal(first.status, 200);
+    assert.equal(first.body.data.validators.total, 2);
+    assert.equal(first.body.data.validators.items[0].hotkey, "5Alpha");
+    assert.equal(first.body.data.validators.next_cursor, "5Alpha");
+
+    const second = await gql(
+      '{ validators(limit: 1, cursor: "5Alpha") { items { hotkey } next_cursor } }',
+      env,
+    );
+    assert.equal(second.status, 200);
+    assert.equal(second.body.data.validators.items[0].hotkey, "5Beta");
+    assert.equal(second.body.data.validators.next_cursor, null);
   });
 
   test("validators: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {


### PR DESCRIPTION
## Summary

Completes GraphQL parity for `GET /api/v1/validators` by adding **cursor pagination** to the existing `validators` Query field, matching the `providers(limit, cursor)` / `provider(id)` pattern the issue prescribes.

Closes #7644

## Context

- **REST:** `GET /api/v1/validators` — network-wide validator/operator leaderboard (sort + limit, max 100).
- **MCP:** `list_global_validators` — same computation.
- **GraphQL (before this PR):** `Query.validators(sort, limit)` landed in [#5616](https://github.com/JSONbored/metagraphed/pull/5616) (#5573) but had **no `cursor` arg** and **no `next_cursor`** on `ValidatorList`, so clients could not page the leaderboard the way `providers` does.

This issue was filed to close that gap explicitly: mirror `providers(limit, cursor)` in `src/graphql.mjs`, reuse the shared leaderboard loader, reject bad `sort` as `BAD_USER_INPUT`, and cover pagination in tests.

## How similar issues merged

| PR | Issue | Pattern |
|---|---|---|
| [#5616](https://github.com/JSONbored/metagraphed/pull/5616) | #5573 | Initial `validators`/`validator` SDL + resolvers via `tryPostgresTier` + `buildGlobalValidators` fallback; tests for sort, limit forwarding, `BAD_USER_INPUT`, cold store |
| [#7651](https://github.com/JSONbored/metagraphed/pull/7651) | #7641 | Minimal GraphQL parity PR: SDL field + resolver + focused tests in `tests/graphql.test.mjs`; 2 files only |
| `providers` resolver | — | `listPage` / `paginate` with `limit`, `cursor`, `next_cursor` keyed by entity id |

This PR follows the **#7651 minimal-diff** shape applied to **#5616's existing validators field**: extend SDL + resolver + tests; no REST/OpenAPI contract change.

## What changed (2 files)

### `src/graphql.mjs`

- SDL: `validators(sort, limit, cursor)` — docstring notes pagination like `providers`.
- `ValidatorList`: add `next_cursor: String`.
- Resolver:
  - Always fetches the REST max window (`limit=100`) from Postgres tier / cold fallback (same data REST/MCP use).
  - Applies client-side `paginate(..., cursor, hotkey => hotkey)` over the normalized nodes — same approach as `economics` (REST has no server-side cursor).
  - Returns `next_cursor` and uses `data.validator_count ?? total` for `total`.
  - Invalid `sort` still throws `BAD_USER_INPUT` before tier fetch.

### `tests/graphql.test.mjs`

- Update Postgres-tier forwarding tests: GraphQL `limit` is now a **page size**, not forwarded to REST; tier always receives `limit=100`.
- Add **cursor pagination** test (hotkey-keyed, two-page walk).
- All existing validators tests retained (default sort, explicit sort, `BAD_USER_INPUT`, cold/malformed fallback, detail drill-in).

## Validation

- [x] `npx vitest run tests/graphql.test.mjs` — 911 passing
- [x] `node --check src/graphql.mjs` — clean
- [ ] `npm run validate:contract-drift` (GraphQL-only; no REST/OpenAPI drift expected)
- [ ] Gittensory Gate + CI green

## Test plan

- [ ] `{ validators { items { hotkey } total sort } }` — default sort, cold store empty page
- [ ] `{ validators(sort: "total_stake", limit: 5) { items { hotkey } total next_cursor } }` — explicit sort + page size
- [ ] `{ validators(sort: "not_a_real_sort") { total } }` — `BAD_USER_INPUT`, tier not called
- [ ] `{ validators(limit: 1) { next_cursor } }` then `{ validators(limit: 1, cursor: "<hotkey>") { items { hotkey } next_cursor } }` — cursor walk
