### PR TITLE
fix(graphql): harden validator detail zeroed-card fallback (#7645)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -4772,6 +4772,24 @@ function validatorNode(validator) {
   };
 }
 
+// buildValidatorDetail always returns a full-shaped object (rows=[] yields a
+// zeroed aggregate), but a malformed Postgres-tier response body degrades to
+// `{}` -- merged here with the cold-safe base the same way accountSummaryNode
+// normalizes a bad upstream body into the schema-stable zero card.
+function validatorDetailNode(data, hotkey) {
+  const base = buildValidatorDetail([], hotkey);
+  const raw = data && typeof data === "object" ? data : {};
+  return validatorNode({
+    ...base,
+    ...raw,
+    hotkey:
+      typeof raw.hotkey === "string" && raw.hotkey.length > 0
+        ? raw.hotkey
+        : hotkey,
+    subnets: Array.isArray(raw.subnets) ? raw.subnets : base.subnets,
+  });
+}
+
 // buildAccountSummary always returns a full-shaped object (a cold/absent store
 // still yields a zeroed summary, never a partial one), but a malformed
 // Postgres-tier response body degrades to `{}` -- normalized here the same way
@@ -7398,16 +7416,15 @@ const rootValue = {
   },
 
   async validator({ hotkey }, context) {
-    const data =
-      (await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/validators/${encodeURIComponent(hotkey)}`,
-        ),
-        "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildValidatorDetail([], hotkey);
-    return validatorNode(data);
+    const data = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(
+        context,
+        `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+      ),
+      "METAGRAPH_NEURONS_SOURCE",
+    );
+    return validatorDetailNode(data, hotkey);
   },
 
   async validator_history({ hotkey, window }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3964,6 +3964,28 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     ]);
   });
 
+  test("validator: a malformed Postgres-tier body degrades to a schema-stable zeroed aggregate", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      '{ validator(hotkey: "5NoRows") { hotkey featured subnet_count total_stake_tao captured_at block_number subnets { netuid } } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.validator, {
+      hotkey: "5NoRows",
+      featured: false,
+      subnet_count: 0,
+      total_stake_tao: 0,
+      captured_at: null,
+      block_number: null,
+      subnets: [],
+    });
+  });
+
   test("validators / validator are weighted as fan-out fields", () => {
     assert.equal(FIELD_COMPLEXITY.validators, 5);
     assert.equal(FIELD_COMPLEXITY.validator, 5);


### PR DESCRIPTION
## Summary

Hardens GraphQL parity for `GET /api/v1/validators/{hotkey}` by ensuring `Query.validator(hotkey)` always resolves to a **schema-stable zeroed aggregate** — even when the Postgres tier returns a malformed body — matching the `provider(id)` drill-in convention and MCP `get_validator_detail` contract.

Closes #7645

## Context

- **REST:** `GET /api/v1/validators/{hotkey}` — one validator's cross-subnet aggregate.
- **MCP:** `get_validator_detail` — same loader (`tryPostgresTier` + `buildValidatorDetail` fallback).
- **GraphQL (already on main):** `Query.validator(hotkey: String!): Validator` landed in [#5616](https://github.com/JSONbored/metagraphed/pull/5616) (#5573) with Postgres-tier resolution and tests for populated + empty hotkeys.

Issue #7645 was filed as a sibling to #7644 (`validators` list). The field and core tests already existed; this PR closes the remaining gap: **malformed upstream bodies** previously surfaced as `Cannot return null for non-nullable field Validator.hotkey` instead of the documented zeroed card.

## How similar issues merged

| PR | Issue | Pattern |
|---|---|---|
| [#5616](https://github.com/JSONbored/metagraphed/pull/5616) | #5573 | Initial `validator(hotkey)` SDL + resolver via shared neurons tier; zeroed aggregate for absent hotkey |
| [#7651](https://github.com/JSONbored/metagraphed/pull/7651) | #7641 | Minimal hardening PR on an existing field: focused fix + test in `tests/graphql.test.mjs` |
| `account(ss58)` | — | `accountSummaryNode` merges malformed `{}` Postgres bodies with `buildAccountSummary` cold-safe base |

## What changed (2 files)

### `src/graphql.mjs`

- Add `validatorDetailNode(data, hotkey)` — merges Postgres-tier payload (or `{}` / null) with `buildValidatorDetail([], hotkey)` base, same technique as `accountSummaryNode`.
- `validator` resolver now returns `validatorDetailNode(data, hotkey)` instead of bare `validatorNode(data)`.

### `tests/graphql.test.mjs`

- Add **malformed Postgres-tier body** test: `{}` response degrades to zeroed aggregate (never GraphQL error, never null).
- Existing tests retained: absent hotkey zero card, Postgres-tier detail with `captured_at`/`block_number` normalization, `FIELD_COMPLEXITY` pin.

## Validation

- [x] `npx vitest run tests/graphql.test.mjs` — 916 passing
- [x] `node --check src/graphql.mjs` — clean
- [ ] `npm run validate:contract-drift` (GraphQL-only; no REST/OpenAPI drift expected)
- [ ] Gittensory Gate + CI green

## Test plan

- [ ] `{ validator(hotkey: "5NoRows") { hotkey subnet_count subnets { netuid } } }` — cold store / absent hotkey → zeroed aggregate
- [ ] `{ validator(hotkey: "5Validator") { hotkey subnet_count subnets { netuid stake_tao } } }` — Postgres tier populates detail
- [ ] Same query with Postgres returning `{}` → zeroed aggregate, no GraphQL errors
