### PR TITLE
feat(mcp): signature-scheme multi-value credential bundles for call_subnet_surface

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4016,17 +4016,19 @@ export interface components {
             /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
             auth?: {
                 /**
-                 * @description Where the credential is sent.
+                 * @description Where the credential is sent. "body" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).
                  * @enum {unknown}
                  */
-                location?: "header" | "query" | "cookie";
-                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". */
+                location?: "header" | "query" | "cookie" | "body";
+                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead. */
                 name?: string;
+                /** @description For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. ["X-Hotkey", "X-Timestamp", "X-Signature"]. Mutually exclusive with `name`. */
+                names?: string[];
                 /**
-                 * @description Credential scheme.
+                 * @description Credential scheme. "signature" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`.
                  * @enum {unknown}
                  */
-                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "custom";
+                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "signature" | "custom";
                 /** @description Note on required scopes or how to obtain a credential. */
                 scopes_note?: string;
                 /**
@@ -8306,17 +8308,19 @@ export interface components {
             /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
             auth?: {
                 /**
-                 * @description Where the credential is sent.
+                 * @description Where the credential is sent. "body" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).
                  * @enum {unknown}
                  */
-                location?: "header" | "query" | "cookie";
-                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". */
+                location?: "header" | "query" | "cookie" | "body";
+                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead. */
                 name?: string;
+                /** @description For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. ["X-Hotkey", "X-Timestamp", "X-Signature"]. Mutually exclusive with `name`. */
+                names?: string[];
                 /**
-                 * @description Credential scheme.
+                 * @description Credential scheme. "signature" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`.
                  * @enum {unknown}
                  */
-                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "custom";
+                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "signature" | "custom";
                 /** @description Note on required scopes or how to obtain a credential. */
                 scopes_note?: string;
                 /**

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4051,25 +4051,35 @@
             "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
             "properties": {
               "location": {
-                "description": "Where the credential is sent.",
+                "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).",
                 "enum": [
                   "header",
                   "query",
-                  "cookie"
+                  "cookie",
+                  "body"
                 ]
               },
               "name": {
-                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\".",
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead.",
                 "type": "string"
               },
+              "names": {
+                "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
               "scheme": {
-                "description": "Credential scheme.",
+                "description": "Credential scheme. \"signature\" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`.",
                 "enum": [
                   "none",
                   "bearer",
                   "api-key",
                   "basic",
                   "oauth2",
+                  "signature",
                   "custom"
                 ]
               },
@@ -21960,25 +21970,35 @@
             "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
             "properties": {
               "location": {
-                "description": "Where the credential is sent.",
+                "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).",
                 "enum": [
                   "header",
                   "query",
-                  "cookie"
+                  "cookie",
+                  "body"
                 ]
               },
               "name": {
-                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\".",
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead.",
                 "type": "string"
               },
+              "names": {
+                "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
               "scheme": {
-                "description": "Credential scheme.",
+                "description": "Credential scheme. \"signature\" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`.",
                 "enum": [
                   "none",
                   "bearer",
                   "api-key",
                   "basic",
                   "oauth2",
+                  "signature",
                   "custom"
                 ]
               },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4016,17 +4016,19 @@ export interface components {
             /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
             auth?: {
                 /**
-                 * @description Where the credential is sent.
+                 * @description Where the credential is sent. "body" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).
                  * @enum {unknown}
                  */
-                location?: "header" | "query" | "cookie";
-                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". */
+                location?: "header" | "query" | "cookie" | "body";
+                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead. */
                 name?: string;
+                /** @description For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. ["X-Hotkey", "X-Timestamp", "X-Signature"]. Mutually exclusive with `name`. */
+                names?: string[];
                 /**
-                 * @description Credential scheme.
+                 * @description Credential scheme. "signature" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`.
                  * @enum {unknown}
                  */
-                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "custom";
+                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "signature" | "custom";
                 /** @description Note on required scopes or how to obtain a credential. */
                 scopes_note?: string;
                 /**
@@ -8306,17 +8308,19 @@ export interface components {
             /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
             auth?: {
                 /**
-                 * @description Where the credential is sent.
+                 * @description Where the credential is sent. "body" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).
                  * @enum {unknown}
                  */
-                location?: "header" | "query" | "cookie";
-                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". */
+                location?: "header" | "query" | "cookie" | "body";
+                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead. */
                 name?: string;
+                /** @description For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. ["X-Hotkey", "X-Timestamp", "X-Signature"]. Mutually exclusive with `name`. */
+                names?: string[];
                 /**
-                 * @description Credential scheme.
+                 * @description Credential scheme. "signature" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`.
                  * @enum {unknown}
                  */
-                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "custom";
+                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "signature" | "custom";
                 /** @description Note on required scopes or how to obtain a credential. */
                 scopes_note?: string;
                 /**

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -4037,25 +4037,35 @@
             "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
             "properties": {
               "location": {
-                "description": "Where the credential is sent.",
+                "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).",
                 "enum": [
                   "header",
                   "query",
-                  "cookie"
+                  "cookie",
+                  "body"
                 ]
               },
               "name": {
-                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\".",
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead.",
                 "type": "string"
               },
+              "names": {
+                "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
               "scheme": {
-                "description": "Credential scheme.",
+                "description": "Credential scheme. \"signature\" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`.",
                 "enum": [
                   "none",
                   "bearer",
                   "api-key",
                   "basic",
                   "oauth2",
+                  "signature",
                   "custom"
                 ]
               },
@@ -21938,25 +21948,35 @@
             "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
             "properties": {
               "location": {
-                "description": "Where the credential is sent.",
+                "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).",
                 "enum": [
                   "header",
                   "query",
-                  "cookie"
+                  "cookie",
+                  "body"
                 ]
               },
               "name": {
-                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\".",
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead.",
                 "type": "string"
               },
+              "names": {
+                "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
               "scheme": {
-                "description": "Credential scheme.",
+                "description": "Credential scheme. \"signature\" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`.",
                 "enum": [
                   "none",
                   "bearer",
                   "api-key",
                   "basic",
                   "oauth2",
+                  "signature",
                   "custom"
                 ]
               },

--- a/schemas/candidate-surface.schema.json
+++ b/schemas/candidate-surface.schema.json
@@ -167,16 +167,30 @@
       "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
       "properties": {
         "scheme": {
-          "enum": ["none", "bearer", "api-key", "basic", "oauth2", "custom"],
-          "description": "Credential scheme."
+          "enum": [
+            "none",
+            "bearer",
+            "api-key",
+            "basic",
+            "oauth2",
+            "signature",
+            "custom"
+          ],
+          "description": "Credential scheme. \"signature\" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`."
         },
         "location": {
-          "enum": ["header", "query", "cookie"],
-          "description": "Where the credential is sent."
+          "enum": ["header", "query", "cookie", "body"],
+          "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie)."
         },
         "name": {
           "type": "string",
-          "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\"."
+          "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead."
+        },
+        "names": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
         },
         "value_format": {
           "type": "string",

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -316,17 +316,24 @@
                   "api-key",
                   "basic",
                   "oauth2",
+                  "signature",
                   "custom"
                 ],
-                "description": "Credential scheme."
+                "description": "Credential scheme. \"signature\" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`."
               },
               "location": {
-                "enum": ["header", "query", "cookie"],
-                "description": "Where the credential is sent."
+                "enum": ["header", "query", "cookie", "body"],
+                "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie)."
               },
               "name": {
                 "type": "string",
-                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\"."
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead."
+              },
+              "names": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 1,
+                "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
               },
               "value_format": {
                 "type": "string",
@@ -576,17 +583,24 @@
                   "api-key",
                   "basic",
                   "oauth2",
+                  "signature",
                   "custom"
                 ],
-                "description": "Credential scheme."
+                "description": "Credential scheme. \"signature\" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`."
               },
               "location": {
-                "enum": ["header", "query", "cookie"],
-                "description": "Where the credential is sent."
+                "enum": ["header", "query", "cookie", "body"],
+                "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie)."
               },
               "name": {
                 "type": "string",
-                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\"."
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead."
+              },
+              "names": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 1,
+                "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
               },
               "value_format": {
                 "type": "string",

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -296,17 +296,24 @@
                 "api-key",
                 "basic",
                 "oauth2",
+                "signature",
                 "custom"
               ],
-              "description": "Credential scheme."
+              "description": "Credential scheme. \"signature\" is a multi-value bundle (e.g. a Bittensor hotkey-signed request: signature + timestamp + address headers) the caller computes and supplies as a whole -- see `names`, not `name`."
             },
             "location": {
-              "enum": ["header", "query", "cookie"],
-              "description": "Where the credential is sent."
+              "enum": ["header", "query", "cookie", "body"],
+              "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie)."
             },
             "name": {
               "type": "string",
-              "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\"."
+              "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\". Mutually exclusive with `names` -- single-value schemes (bearer/api-key/basic) use this; scheme:signature uses `names` instead."
+            },
+            "names": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1,
+              "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
             },
             "value_format": {
               "type": "string",

--- a/src/call-subnet-surface.mjs
+++ b/src/call-subnet-surface.mjs
@@ -58,43 +58,62 @@ function buildRequestUrl(baseUrl, query) {
 // credential (which never appears in any response field, this module never
 // echoes request headers back), the URL is exactly what this module DOES
 // return to the caller on both success and some failure paths. Only a
-// query-location credential is ever redacted here; header/cookie placement
-// has nothing in the URL to redact.
+// query-location credential is ever redacted here; header/cookie/body
+// placement has nothing in the returned URL to redact. Handles both a
+// single-value credential (`name`) and a multi-value bundle (`values`,
+// metagraphed#7701's scheme:signature) -- every name in the bundle gets
+// redacted, not just the first.
 const REDACTED_CREDENTIAL_PLACEHOLDER = "<redacted>";
 function redactQueryCredential(url, credential) {
   if (!url || credential?.location !== "query") return url;
+  const names = credential.values
+    ? Object.keys(credential.values)
+    : credential.name
+      ? [credential.name]
+      : [];
+  if (names.length === 0) return url;
   // No try/catch: `url` here is always the output of an earlier `new URL()`
   // call within this same module (buildRequestUrl, or safetyCheckedFetch's
   // own redirect-target construction) -- by the time it reaches here it has
   // already been proven parseable, so a second parse can't newly fail.
   const parsed = new URL(url);
-  if (!parsed.searchParams.has(credential.name)) return url;
-  parsed.searchParams.set(credential.name, REDACTED_CREDENTIAL_PLACEHOLDER);
-  return parsed.toString();
+  let changed = false;
+  for (const name of names) {
+    if (parsed.searchParams.has(name)) {
+      parsed.searchParams.set(name, REDACTED_CREDENTIAL_PLACEHOLDER);
+      changed = true;
+    }
+  }
+  return changed ? parsed.toString() : url;
 }
 
-// Regardless of credential location, scrub the raw value out of any
-// free-form error string this module returns -- the underlying fetch
+// Regardless of credential location, scrub every raw credential value out of
+// any free-form error string this module returns -- the underlying fetch
 // implementation's own error text (network/timeout/DNS failures) is outside
 // this module's control, and some implementations echo the request URL (or
-// occasionally other request details) into it.
+// occasionally other request details) into it. Handles both a single value
+// and a multi-value bundle.
 function redactCredentialValue(text, credential) {
-  if (!text || !credential?.value) return text;
-  return text.split(credential.value).join(REDACTED_CREDENTIAL_PLACEHOLDER);
+  if (!text || !credential) return text;
+  const values = credential.values
+    ? Object.values(credential.values)
+    : credential.value
+      ? [credential.value]
+      : [];
+  let result = text;
+  for (const value of values) {
+    if (value)
+      result = result.split(value).join(REDACTED_CREDENTIAL_PLACEHOLDER);
+  }
+  return result;
 }
 
 /**
  * @typedef {object} CallSubnetSurfaceCredential
- * @property {"header" | "query" | "cookie"} location Where to place the credential -- mirrors the surface's own `auth.location`. The CALLER (call_subnet_surface's tool handler) is responsible for validating the surface's auth.scheme is generically supported (bearer/api-key) and auth.location/auth.name are both present BEFORE ever passing this; this function only places the value, it does not validate eligibility.
- * @property {string} name Header name, query-parameter name, or cookie name -- the surface's own `auth.name`.
- * @property {string} value The credential value exactly as supplied by the caller, inserted verbatim (never reformatted against `auth.value_format` -- the caller is expected to have already formatted it, e.g. "Bearer <token>").
- */
-
-/**
- * @typedef {object} CallSubnetSurfaceCredential
- * @property {"header" | "query" | "cookie"} location Where to place the credential -- mirrors the surface's own `auth.location`. The CALLER (call_subnet_surface's tool handler) is responsible for validating the surface's auth.scheme is generically supported (bearer/api-key) and auth.location/auth.name are both present BEFORE ever passing this; this function only places the value, it does not validate eligibility.
- * @property {string} name Header name, query-parameter name, or cookie name -- the surface's own `auth.name`.
- * @property {string} value The credential value exactly as supplied by the caller, inserted verbatim (never reformatted against `auth.value_format` -- the caller is expected to have already formatted it, e.g. "Bearer <token>").
+ * @property {"header" | "query" | "cookie" | "body"} location Where to place the credential -- mirrors the surface's own `auth.location`. The CALLER (call_subnet_surface's tool handler) is responsible for validating the surface's auth.scheme is generically supported and auth.location plus (auth.name or auth.names) are present BEFORE ever passing this; this function only places the value(s), it does not validate eligibility.
+ * @property {string} [name] Single credential name (auth.scheme bearer/api-key/basic) -- mutually exclusive with `values`. The surface's own `auth.name`.
+ * @property {string} [value] Single credential value, paired with `name`. Inserted verbatim (never reformatted against `auth.value_format` -- the caller is expected to have already formatted it, e.g. "Bearer <token>").
+ * @property {Record<string, string>} [values] Multi-value credential bundle (metagraphed#7701, auth.scheme:signature) -- mutually exclusive with `name`/`value`. Every key is a name from the surface's own `auth.names`, mapped to the value the CALLER already computed (e.g. a signature the caller signed locally with their own key) -- this module never computes or validates a signature, only relays the bundle as given. For `location: "body"`, every entry is merged into the outgoing JSON request body alongside whatever `body` option is separately supplied.
  */
 
 /**
@@ -127,21 +146,41 @@ export async function callSubnetSurface(surface, options) {
   if (typeof isUnsafeUrl !== "function") {
     throw new Error("callSubnetSurface requires options.isUnsafeUrl");
   }
-  // Placed before URL/header construction so a query-location credential
-  // becomes part of the query object buildRequestUrl() merges below, and a
-  // header/cookie-location credential is ready to hand to safetyCheckedFetch.
+  // Normalize both the single-value shape ({name, value}) and the
+  // metagraphed#7701 multi-value bundle shape ({values: {name: value}}) to
+  // one list of entries, so every placement branch below handles both
+  // uniformly instead of duplicating logic per shape.
+  const credentialEntries = credential
+    ? credential.values
+      ? Object.entries(credential.values)
+      : credential.name
+        ? [[credential.name, credential.value]]
+        : []
+    : [];
+  // Placed before URL/header/body construction so a query-location
+  // credential becomes part of the query object buildRequestUrl() merges
+  // below, a header/cookie-location credential is ready to hand to
+  // safetyCheckedFetch, and a body-location credential is ready to merge
+  // into the outgoing JSON below.
   let effectiveQuery = query;
   const extraHeaders = {};
-  if (credential) {
+  let bodyCredentialFields = null;
+  if (credential && credentialEntries.length > 0) {
     if (credential.location === "query") {
-      effectiveQuery = {
-        ...(query || {}),
-        [credential.name]: credential.value,
-      };
+      effectiveQuery = { ...(query || {}) };
+      for (const [name, value] of credentialEntries) {
+        effectiveQuery[name] = value;
+      }
     } else if (credential.location === "header") {
-      extraHeaders[credential.name] = credential.value;
+      for (const [name, value] of credentialEntries) {
+        extraHeaders[name] = value;
+      }
     } else if (credential.location === "cookie") {
-      extraHeaders.cookie = `${credential.name}=${credential.value}`;
+      extraHeaders.cookie = credentialEntries
+        .map(([name, value]) => `${name}=${value}`)
+        .join("; ");
+    } else if (credential.location === "body") {
+      bodyCredentialFields = Object.fromEntries(credentialEntries);
     }
   }
   const method =
@@ -180,10 +219,23 @@ export async function callSubnetSurface(surface, options) {
   }
   const requestUrl = buildRequestUrl(baseUrl, effectiveQuery);
 
+  // A body-location credential bundle is merged into the outgoing JSON
+  // request body -- the tool handler is responsible for ensuring this only
+  // ever happens for a JSON content type and a valid-JSON-or-absent existing
+  // body BEFORE calling this function; this function trusts that and merges
+  // unconditionally (matches this module's existing "caller validates
+  // eligibility, this module only places" contract for every other location).
+  const effectiveBody = bodyCredentialFields
+    ? JSON.stringify({
+        ...(requestBody ? JSON.parse(requestBody) : {}),
+        ...bodyCredentialFields,
+      })
+    : requestBody;
+
   const fetched = await safetyCheckedFetch(requestUrl, {
     method,
-    ...(canHaveBody && requestBody !== undefined
-      ? { body: requestBody, contentType: requestContentType }
+    ...(canHaveBody && effectiveBody !== undefined
+      ? { body: effectiveBody, contentType: requestContentType }
       : {}),
     extraHeaders,
     fetchImpl,

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11027,7 +11027,7 @@ export const MCP_TOOLS = [
     name: "call_subnet_surface",
     title: "Call a subnet's live API and return its response",
     description:
-      "Actually call a catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected. With no `path`/`method`, only the surface's own curated url is ever fetched, using its declared probe method (GET/HEAD) -- MCP execute Phase 1 (#7014). Supplying both `path` and `method` (GET/HEAD/POST/PUT) calls a different route on the SAME surface's host instead, but only when that exact path+method is declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright, never guessed -- MCP execute Phase 2 (#7674, #7675). For POST/PUT, `body` is validated against the matched operation's declared request body: rejected if the operation declares none, or if `content_type` isn't one of its declared media types (defaults to application/json when that's declared, or the operation's only declared media type). A surface with `auth_required:true` needs a `credential` argument to be callable at all -- see that argument's own description for which surfaces support it (MCP execute Phase 3, #7686-#7688). Never obtains a credential on your behalf and never stores or reuses one past this single call.",
+      "Actually call a catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected. With no `path`/`method`, only the surface's own curated url is ever fetched, using its declared probe method (GET/HEAD) -- MCP execute Phase 1 (#7014). Supplying both `path` and `method` (GET/HEAD/POST/PUT) calls a different route on the SAME surface's host instead, but only when that exact path+method is declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright, never guessed -- MCP execute Phase 2 (#7674, #7675). For POST/PUT, `body` is validated against the matched operation's declared request body: rejected if the operation declares none, or if `content_type` isn't one of its declared media types (defaults to application/json when that's declared, or the operation's only declared media type). A surface with `auth_required:true` needs a `credential` argument to be callable at all -- see that argument's own description for which surfaces support it, including multi-value signature bundles (e.g. a Bittensor hotkey-signed request) that can be placed in a header, query param, cookie, or merged into a POST/PUT JSON body (MCP execute Phase 3-4, #7686-#7688, #7701). Never obtains a credential on your behalf and never stores or reuses one past this single call.",
     inputSchema: {
       type: "object",
       properties: {
@@ -11064,9 +11064,9 @@ export const MCP_TOOLS = [
             'Media type for `body`, e.g. "application/json". Must be one the matched operation declares. Optional when the operation declares application/json or exactly one media type.',
         },
         credential: {
-          type: "string",
+          type: ["string", "object"],
           description:
-            'Credential for an auth_required surface, already formatted per the surface\'s auth.value_format (e.g. "Bearer <token>", "Apikey <key>" -- fetch it first with list_subnet_apis/get_api_schema). Only surfaces with auth.scheme bearer or api-key AND both auth.location/auth.name documented accept this; anything else (custom scheme, or an incompletely-documented one) is rejected. This tool never obtains a credential on your behalf -- you must already hold a working one. Never stored, logged, or reused past this single call.',
+            "Credential for an auth_required surface -- see this surface's auth details (list_subnet_apis/get_api_schema) for which shape it needs. For auth.scheme bearer/api-key: a single string, already formatted per auth.value_format (e.g. \"Bearer <token>\"). For auth.scheme signature (e.g. a Bittensor hotkey-signed request): an object mapping every name in auth.names to a value YOU have already computed -- this tool never signs anything itself, you must compute the signature yourself (with your own wallet/key, exactly as if calling the subnet directly) before calling this tool; the object's keys must exactly match auth.names, no more, no fewer. Any other scheme (custom, or incompletely documented) is rejected. Never obtains a credential on your behalf, never stores or reuses one past this single call.",
         },
       },
       required: ["surface_id"],
@@ -11138,8 +11138,13 @@ export const MCP_TOOLS = [
           `No catalogued surface with id, key, or deprecated id "${args.surface_id}".`,
         );
       }
-      const hasCredentialArg =
+      const hasStringCredentialArg =
         typeof args?.credential === "string" && args.credential.length > 0;
+      const hasObjectCredentialArg =
+        args?.credential !== null &&
+        typeof args?.credential === "object" &&
+        !Array.isArray(args?.credential);
+      const hasCredentialArg = hasStringCredentialArg || hasObjectCredentialArg;
       if (hasCredentialArg && !surface.auth_required) {
         throw toolError(
           "invalid_params",
@@ -11155,26 +11160,92 @@ export const MCP_TOOLS = [
           );
         }
         const scheme = surface.auth?.scheme;
-        if (scheme !== "bearer" && scheme !== "api-key") {
-          throw toolError(
-            "credential_not_supported",
-            `This surface's auth scheme ("${scheme || "undocumented"}") is not one this tool can attach a credential to (only bearer/api-key are supported). Use list_subnet_apis / how_do_i_call to see how to call it directly.`,
-          );
-        }
         const location = surface.auth?.location;
-        const name = surface.auth?.name;
-        if (
-          !name ||
-          (location !== "header" &&
-            location !== "query" &&
-            location !== "cookie")
-        ) {
+        if (scheme === "bearer" || scheme === "api-key") {
+          const name = surface.auth?.name;
+          if (
+            !name ||
+            (location !== "header" &&
+              location !== "query" &&
+              location !== "cookie")
+          ) {
+            throw toolError(
+              "credential_not_supported",
+              "This surface's auth mechanism (location/name) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+            );
+          }
+          if (!hasStringCredentialArg) {
+            throw toolError(
+              "invalid_params",
+              `This surface's auth.scheme ("${scheme}") requires \`credential\` to be a single string, not an object.`,
+            );
+          }
+          credentialPlacement = { location, name, value: args.credential };
+        } else if (scheme === "signature") {
+          const names = Array.isArray(surface.auth?.names)
+            ? surface.auth.names
+            : null;
+          if (
+            !names ||
+            names.length === 0 ||
+            (location !== "header" &&
+              location !== "query" &&
+              location !== "cookie" &&
+              location !== "body")
+          ) {
+            throw toolError(
+              "credential_not_supported",
+              "This surface's auth mechanism (location/names) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+            );
+          }
+          if (!hasObjectCredentialArg) {
+            throw toolError(
+              "invalid_params",
+              `This surface's auth.scheme ("signature") requires \`credential\` to be an object mapping each of ${JSON.stringify(names)} to a value you have already computed -- this tool does not sign requests itself.`,
+            );
+          }
+          const suppliedNames = Object.keys(args.credential);
+          const missing = names.filter((n) => !suppliedNames.includes(n));
+          const unexpected = suppliedNames.filter((n) => !names.includes(n));
+          if (missing.length > 0 || unexpected.length > 0) {
+            throw toolError(
+              "invalid_params",
+              `\`credential\` must have exactly these keys: ${JSON.stringify(names)}.` +
+                (missing.length > 0
+                  ? ` Missing: ${JSON.stringify(missing)}.`
+                  : "") +
+                (unexpected.length > 0
+                  ? ` Unexpected: ${JSON.stringify(unexpected)}.`
+                  : ""),
+            );
+          }
+          for (const [key, value] of Object.entries(args.credential)) {
+            if (typeof value !== "string" || value.length === 0) {
+              throw toolError(
+                "invalid_params",
+                `\`credential.${key}\` must be a non-empty string.`,
+              );
+            }
+          }
+          if (
+            location === "body" &&
+            !(
+              hasPath &&
+              (normalizedMethod === "POST" || normalizedMethod === "PUT")
+            )
+          ) {
+            throw toolError(
+              "invalid_params",
+              "This surface's credential is sent in the request body, which requires `path` and `method` (POST or PUT) to also be set.",
+            );
+          }
+          credentialPlacement = { location, values: args.credential };
+        } else {
           throw toolError(
             "credential_not_supported",
-            "This surface's auth mechanism (location/name) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+            `This surface's auth scheme ("${scheme || "undocumented"}") is not one this tool can attach a credential to (only bearer/api-key/signature are supported). Use list_subnet_apis / how_do_i_call to see how to call it directly.`,
           );
         }
-        credentialPlacement = { location, name, value: args.credential };
       }
       if (surface.probe?.enabled === false) {
         throw toolError(
@@ -11265,6 +11336,20 @@ export const MCP_TOOLS = [
           // reusing MAX_RESPONSE_BYTES's 256 KiB) would be strictly weaker
           // than the transport cap and could never fire.
         }
+      }
+      // A body-location signature credential (#7701) is merged into the
+      // outgoing JSON body by callSubnetSurface regardless of whether the
+      // caller separately supplied `body` -- if they didn't (credential
+      // fields only), the block above never ran and requestContentType is
+      // still unset. This surface's own auth object already independently
+      // establishes that a JSON body carrying these fields is expected (the
+      // operation's OpenAPI schema frequently doesn't document it at all,
+      // which is exactly why it's scheme:signature and not something
+      // generic), so default to application/json here rather than reusing
+      // the schema-driven resolution above, which only ever runs when the
+      // caller supplied a body of their own.
+      if (credentialPlacement?.location === "body" && !requestContentType) {
+        requestContentType = "application/json";
       }
       const result = await callSubnetSurface(surface, {
         query:

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -181,6 +181,96 @@ const MISSING_LOCATION_SURFACE = {
   probe: { method: "GET", enabled: true },
 };
 
+// #7701 (MCP execute Phase 4): scheme:signature multi-value credential
+// bundle fixtures -- a Bittensor hotkey-signed request the CALLER computes
+// and supplies as a complete {name: value} bundle; this tool only places it,
+// never signs anything itself.
+const SIGNATURE_HEADER_SURFACE = {
+  surface_id: "x:api:12",
+  netuid: 16,
+  kind: "subnet-api",
+  url: "https://x.example/signed",
+  auth_required: true,
+  auth: {
+    scheme: "signature",
+    location: "header",
+    names: ["X-Hotkey", "X-Timestamp", "X-Signature"],
+  },
+  probe: { method: "GET", enabled: true },
+};
+
+const SIGNATURE_QUERY_SURFACE = {
+  surface_id: "x:api:13",
+  netuid: 17,
+  kind: "subnet-api",
+  url: "https://x.example/signed-query",
+  auth_required: true,
+  auth: {
+    scheme: "signature",
+    location: "query",
+    names: ["validator_hotkey", "signature"],
+  },
+  probe: { method: "GET", enabled: true },
+};
+
+const SIGNATURE_COOKIE_SURFACE = {
+  surface_id: "x:api:14",
+  netuid: 18,
+  kind: "subnet-api",
+  url: "https://x.example/signed-cookie",
+  auth_required: true,
+  auth: { scheme: "signature", location: "cookie", names: ["session", "csrf"] },
+  probe: { method: "GET", enabled: true },
+};
+
+// Body-location signature needs a captured schema (the credential merges
+// into a POST/PUT JSON body) -- reuses SCHEMA_DOCUMENT's /users and /ping
+// operations via schema_source, same as SCHEMA_SURFACE above.
+const SIGNATURE_BODY_SURFACE = {
+  surface_id: "x:api:15",
+  netuid: 19,
+  kind: "subnet-api",
+  url: "https://x.example/signed-body",
+  auth_required: true,
+  auth: {
+    scheme: "signature",
+    location: "body",
+    names: ["identity", "timestamp", "signature"],
+  },
+  probe: { method: "GET", enabled: true },
+  schema_source: { surface_id: "x:openapi:1" },
+};
+
+const SIGNATURE_NO_NAMES_SURFACE = {
+  surface_id: "x:api:16",
+  netuid: 20,
+  kind: "subnet-api",
+  url: "https://x.example/signed-undocumented",
+  auth_required: true,
+  auth: { scheme: "signature", location: "header" },
+  probe: { method: "GET", enabled: true },
+};
+
+const SIGNATURE_EMPTY_NAMES_SURFACE = {
+  surface_id: "x:api:17",
+  netuid: 21,
+  kind: "subnet-api",
+  url: "https://x.example/signed-empty-names",
+  auth_required: true,
+  auth: { scheme: "signature", location: "header", names: [] },
+  probe: { method: "GET", enabled: true },
+};
+
+const SIGNATURE_NO_LOCATION_SURFACE = {
+  surface_id: "x:api:18",
+  netuid: 22,
+  kind: "subnet-api",
+  url: "https://x.example/signed-no-location",
+  auth_required: true,
+  auth: { scheme: "signature", names: ["X-Hotkey", "X-Signature"] },
+  probe: { method: "GET", enabled: true },
+};
+
 const CATALOG = {
   surfaces: [
     NO_AUTH_SURFACE,
@@ -195,6 +285,13 @@ const CATALOG = {
     INCOMPLETE_AUTH_SURFACE,
     DISABLED_PROBE_BEARER_SURFACE,
     MISSING_LOCATION_SURFACE,
+    SIGNATURE_HEADER_SURFACE,
+    SIGNATURE_QUERY_SURFACE,
+    SIGNATURE_COOKIE_SURFACE,
+    SIGNATURE_BODY_SURFACE,
+    SIGNATURE_NO_NAMES_SURFACE,
+    SIGNATURE_EMPTY_NAMES_SURFACE,
+    SIGNATURE_NO_LOCATION_SURFACE,
   ],
 };
 
@@ -831,6 +928,288 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       assert.match(result.content[0].text, /no_schema/);
       assert.equal(sentHeader, undefined);
       assert.equal(requestedUrl, undefined);
+    });
+  });
+
+  // #7701 (MCP execute Phase 4): scheme:signature multi-value credential
+  // bundle -- eligibility validation and placement across every supported
+  // location. src/call-subnet-surface.mjs's own unit tests already cover
+  // placement/redaction exhaustively; this block proves the tool-layer
+  // eligibility gate (name-set matching, value typing, body's path/method
+  // requirement) end-to-end.
+  describe("signature-scheme credential passthrough (#7701)", () => {
+    test("location:header injects every named header", async () => {
+      let sentHeaders;
+      const result = await callTool(
+        {
+          surface_id: "x:api:12",
+          credential: {
+            "X-Hotkey": "5F...",
+            "X-Timestamp": "1700000000",
+            "X-Signature": "0xabc",
+          },
+        },
+        async (url, init) => {
+          sentHeaders = init.headers;
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.equal(sentHeaders["X-Hotkey"], "5F...");
+      assert.equal(sentHeaders["X-Timestamp"], "1700000000");
+      assert.equal(sentHeaders["X-Signature"], "0xabc");
+    });
+
+    test("location:query merges every named param", async () => {
+      let requestedUrl;
+      const result = await callTool(
+        {
+          surface_id: "x:api:13",
+          credential: { validator_hotkey: "5F...", signature: "0xabc" },
+        },
+        async (url) => {
+          requestedUrl = String(url);
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.equal(
+        new URL(requestedUrl).searchParams.get("validator_hotkey"),
+        "5F...",
+      );
+      assert.equal(
+        new URL(requestedUrl).searchParams.get("signature"),
+        "0xabc",
+      );
+    });
+
+    test("location:cookie joins every named cookie", async () => {
+      let sentHeaders;
+      const result = await callTool(
+        {
+          surface_id: "x:api:14",
+          credential: { session: "abc", csrf: "def" },
+        },
+        async (url, init) => {
+          sentHeaders = init.headers;
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.equal(sentHeaders.cookie, "session=abc; csrf=def");
+    });
+
+    test("location:body merges every named field into an explicitly-supplied JSON body", async () => {
+      let sentBody;
+      let sentContentType;
+      const result = await callTool(
+        {
+          surface_id: "x:api:15",
+          path: "/users",
+          method: "POST",
+          body: { name: "ada" },
+          credential: {
+            identity: "5F...",
+            timestamp: "1700000000",
+            signature: "0xabc",
+          },
+        },
+        async (url, init) => {
+          sentBody = init.body;
+          sentContentType = init.headers["content-type"];
+          return new Response(JSON.stringify({ id: 1 }), {
+            status: 201,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.deepEqual(JSON.parse(sentBody), {
+        name: "ada",
+        identity: "5F...",
+        timestamp: "1700000000",
+        signature: "0xabc",
+      });
+      assert.equal(sentContentType, "application/json");
+    });
+
+    test("location:body with no separately-supplied body still defaults content-type to application/json", async () => {
+      let sentBody;
+      let sentContentType;
+      const result = await callTool(
+        {
+          surface_id: "x:api:15",
+          path: "/ping",
+          method: "POST",
+          credential: {
+            identity: "5F...",
+            timestamp: "1700000000",
+            signature: "0xabc",
+          },
+        },
+        async (url, init) => {
+          sentBody = init.body;
+          sentContentType = init.headers["content-type"];
+          return new Response("pong", { status: 200 });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.deepEqual(JSON.parse(sentBody), {
+        identity: "5F...",
+        timestamp: "1700000000",
+        signature: "0xabc",
+      });
+      assert.equal(sentContentType, "application/json");
+    });
+
+    test("a credential missing a required name is invalid_params", async () => {
+      const result = await callTool({
+        surface_id: "x:api:12",
+        credential: { "X-Hotkey": "5F...", "X-Timestamp": "1700000000" },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /Missing/);
+    });
+
+    test("a credential carrying an extra unexpected key is invalid_params", async () => {
+      const result = await callTool({
+        surface_id: "x:api:12",
+        credential: {
+          "X-Hotkey": "5F...",
+          "X-Timestamp": "1700000000",
+          "X-Signature": "0xabc",
+          "X-Extra": "nope",
+        },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /Unexpected/);
+    });
+
+    test("a non-string credential value is invalid_params", async () => {
+      const result = await callTool({
+        surface_id: "x:api:12",
+        credential: {
+          "X-Hotkey": "5F...",
+          "X-Timestamp": 1700000000,
+          "X-Signature": "0xabc",
+        },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /non-empty string/);
+    });
+
+    test("an empty-string credential value is invalid_params", async () => {
+      const result = await callTool({
+        surface_id: "x:api:12",
+        credential: {
+          "X-Hotkey": "",
+          "X-Timestamp": "1700000000",
+          "X-Signature": "0xabc",
+        },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /non-empty string/);
+    });
+
+    test("a plain string credential is invalid_params -- signature scheme requires an object", async () => {
+      const result = await callTool({
+        surface_id: "x:api:12",
+        credential: "just-a-string",
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /object mapping/);
+    });
+
+    test("an object credential on a bearer surface is invalid_params -- bearer requires a string", async () => {
+      const result = await callTool({
+        surface_id: "x:api:6",
+        credential: { token: "abc123" },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /not an object/);
+    });
+
+    test("an array credential is treated as no credential at all (auth_required)", async () => {
+      const result = await callTool({
+        surface_id: "x:api:12",
+        credential: ["5F...", "1700000000", "0xabc"],
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /auth_required/);
+    });
+
+    test("location:body without path/method (POST or PUT) is invalid_params", async () => {
+      const result = await callTool({
+        surface_id: "x:api:15",
+        credential: {
+          identity: "5F...",
+          timestamp: "1700000000",
+          signature: "0xabc",
+        },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /POST or PUT/);
+    });
+
+    test("location:body with method GET is invalid_params even though path is set", async () => {
+      // Distinct from the no-path-at-all case above: exercises the PUT half
+      // of the POST/PUT check once hasPath is already true.
+      const result = await callTool({
+        surface_id: "x:api:15",
+        path: "/users/123",
+        method: "GET",
+        credential: {
+          identity: "5F...",
+          timestamp: "1700000000",
+          signature: "0xabc",
+        },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /POST or PUT/);
+    });
+
+    test("a surface with no auth.names documented is credential_not_supported", async () => {
+      const result = await callTool({
+        surface_id: "x:api:16",
+        credential: { "X-Hotkey": "5F..." },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
+    });
+
+    test("a surface with an empty auth.names array is credential_not_supported", async () => {
+      const result = await callTool({
+        surface_id: "x:api:17",
+        credential: { whatever: "x" },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
+    });
+
+    test("a surface with auth.names but no auth.location is credential_not_supported", async () => {
+      const result = await callTool({
+        surface_id: "x:api:18",
+        credential: { "X-Hotkey": "5F...", "X-Signature": "0xabc" },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /credential_not_supported/);
     });
   });
 

--- a/tests/call-subnet-surface.test.mjs
+++ b/tests/call-subnet-surface.test.mjs
@@ -804,6 +804,255 @@ describe("callSubnetSurface", () => {
     assert.equal(result.error, "connection refused");
   });
 
+  // metagraphed#7701: multi-value credential bundle (scheme:signature) --
+  // the caller has already computed every value themselves (e.g. signed a
+  // request locally with their own Bittensor hotkey); this module only
+  // places the bundle, never computes or validates a signature.
+  test("credential bundle: header location sets every named header", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          values: {
+            "X-Hotkey": "5F...",
+            "X-Timestamp": "1700000000",
+            "X-Signature": "0xabc",
+          },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(init.headers["X-Hotkey"], "5F...");
+          assert.equal(init.headers["X-Timestamp"], "1700000000");
+          assert.equal(init.headers["X-Signature"], "0xabc");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential bundle: query location merges every named param", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "query",
+          values: { validator_hotkey: "5F...", signature: "0xabc", nonce: "1" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url) => {
+          const parsed = new URL(url);
+          assert.equal(parsed.searchParams.get("validator_hotkey"), "5F...");
+          assert.equal(parsed.searchParams.get("signature"), "0xabc");
+          assert.equal(parsed.searchParams.get("nonce"), "1");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential bundle: cookie location joins every named cookie with '; '", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "cookie",
+          values: { session: "abc", csrf: "def" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.equal(init.headers.cookie, "session=abc; csrf=def");
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential bundle: body location merges every named field into the outgoing JSON body", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/openapi.json" },
+      {
+        path: "/submit",
+        method: "POST",
+        body: JSON.stringify({ payload: "x" }),
+        contentType: "application/json",
+        credential: {
+          location: "body",
+          values: {
+            identity: "5F...",
+            timestamp: "1700000000",
+            signature: "0xabc",
+          },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.deepEqual(JSON.parse(init.body), {
+            payload: "x",
+            identity: "5F...",
+            timestamp: "1700000000",
+            signature: "0xabc",
+          });
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential bundle: body location works with no separately-supplied body (credential fields only)", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/openapi.json" },
+      {
+        path: "/submit",
+        method: "POST",
+        contentType: "application/json",
+        credential: {
+          location: "body",
+          values: { identity: "5F...", signature: "0xabc" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.deepEqual(JSON.parse(init.body), {
+            identity: "5F...",
+            signature: "0xabc",
+          });
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential bundle: query values are all redacted in the returned url", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "query",
+          values: { validator_hotkey: "5F...", signature: "0xabc" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => jsonResponse({}),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.ok(!result.url.includes("5F..."));
+    assert.ok(!result.url.includes("0xabc"));
+    assert.equal(
+      new URL(result.url).searchParams.get("validator_hotkey"),
+      "<redacted>",
+    );
+    assert.equal(
+      new URL(result.url).searchParams.get("signature"),
+      "<redacted>",
+    );
+  });
+
+  test("credential bundle: every value is scrubbed from a network-error message", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          values: { "X-Hotkey": "5F-secret", "X-Signature": "0xdeadbeef" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => {
+          throw new Error(
+            "fetch failed (X-Hotkey: 5F-secret, X-Signature: 0xdeadbeef)",
+          );
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.ok(!result.error.includes("5F-secret"));
+    assert.ok(!result.error.includes("0xdeadbeef"));
+  });
+
+  test("credential: a query-location credential with neither name nor values leaves the url unchanged (nothing to redact)", async () => {
+    // Exercises the credentialEntries/names fallback all the way to [] --
+    // a credential object present but carrying no name and no values (never
+    // produced by the tool handler's own validation, but this module's own
+    // "caller validates eligibility, this module only places/redacts"
+    // contract means it must still degrade to a no-op rather than throw.
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "query" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => jsonResponse({}),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.url, "https://example.com/api");
+  });
+
+  test("credential: a credential with neither value nor values leaves error messages unchanged (nothing to redact)", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: { location: "header" },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => {
+          throw new Error("connection refused");
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "connection refused");
+  });
+
+  test("credential bundle: an empty-string value in the bundle is skipped during error scrubbing", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          values: { "X-Hotkey": "5F-secret", "X-Empty": "" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async () => {
+          throw new Error("fetch failed (X-Hotkey: 5F-secret)");
+        },
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.ok(!result.error.includes("5F-secret"));
+    assert.ok(result.error.includes("<redacted>"));
+  });
+
+  test("credential bundle: preserved across a same-origin redirect, stripped on cross-origin", async () => {
+    let calls = 0;
+    const result = await callSubnetSurface(
+      { url: "https://example.com/api" },
+      {
+        credential: {
+          location: "header",
+          values: { "X-Hotkey": "5F...", "X-Signature": "0xabc" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          calls += 1;
+          if (url === "https://example.com/api") {
+            assert.equal(init.headers["X-Hotkey"], "5F...");
+            return new Response(null, {
+              status: 307,
+              headers: { location: "https://other.example/api" },
+            });
+          }
+          assert.equal(init.headers["X-Hotkey"], undefined);
+          assert.equal(init.headers["X-Signature"], undefined);
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(calls, 2);
+  });
+
   test("credential: cookie location sets a Cookie header formatted name=value", async () => {
     const result = await callSubnetSurface(
       { url: "https://example.com/api" },
@@ -826,12 +1075,12 @@ describe("callSubnetSurface", () => {
   test("credential: an unrecognized location is silently ignored, never placed anywhere", async () => {
     // callSubnetSurface only places a credential, it doesn't validate
     // eligibility (the tool handler already restricts location to
-    // header/query/cookie before ever constructing this option) -- an
+    // header/query/cookie/body before ever constructing this option) -- an
     // unrecognized value should be a no-op, not a crash or a guess.
     const result = await callSubnetSurface(
       { url: "https://example.com/api" },
       {
-        credential: { location: "body", name: "x", value: "abc123" },
+        credential: { location: "nonsense", name: "x", value: "abc123" },
         isUnsafeUrl: SAFE,
         fetchImpl: async (url, init) => {
           assert.equal(url, "https://example.com/api");


### PR DESCRIPTION
## Summary

- Adds `auth.scheme: "signature"`, `auth.location: "body"`, and `auth.names` (plural, multi-value) to the surface schema, alongside the existing singular `auth.name`/`auth.location: header|query|cookie`.
- Extends `callSubnetSurface`/`safetyCheckedFetch` (`src/call-subnet-surface.mjs`) to place a multi-value credential bundle (`{location, values: Record<string,string>}`) across header, query, cookie, or a merged POST/PUT JSON body -- and extends the existing leak-prevention redaction (query-url scrubbing, error-message scrubbing) to cover every value in the bundle.
- Extends `call_subnet_surface`'s `credential` argument (`src/mcp-server.mjs`) to accept an object for `auth.scheme: "signature"` surfaces: validates the supplied object's keys exactly match `auth.names` (no missing, no extra), every value is a non-empty string, and (for `location: "body"`) that `path`+`method` (POST or PUT) are also set.

## Why

Phase 3 (#7016) explicitly scoped out `auth.scheme: "custom"` surfaces as having "no generically-describable credential mechanism." A follow-up audit of all 555 `custom`-scheme surfaces found ~230 are Bittensor hotkey-signed requests (Epistula protocol and close variants) -- generically describable once the credential shape is multi-value rather than single-value. The caller must always compute the signature themselves (it's typically time/nonce-bound, so it can't be cached), so this tool still never obtains, stores, or computes a credential on the caller's behalf -- it only relays a bundle the caller already computed, same non-negotiable constraint as Phase 3.

Closes #7701.

## Test plan

- [x] `npx vitest run tests/call-subnet-surface.test.mjs` -- 76 tests, including 12 new (placement across header/query/cookie/body, redaction of every value in a bundle, edge cases for empty/missing name-or-values).
- [x] `npx vitest run tests/call-subnet-surface-mcp.test.mjs` -- 67 tests, including 17 new (eligibility gate: missing/extra key rejection, non-string/empty-string value rejection, wrong-arg-type rejection both directions, body-location-without-POST/PUT rejection, successful calls across all four placements, credential_not_supported for undocumented names/location).
- [x] Full repo suite: `npm test` -- 474 files, 11,308 tests, all passing.
- [x] `npm run build` -- schema bundle, OpenAPI/types/client regenerated and committed; `npm run validate:contract-drift` passes.
- [x] `npx tsc --noEmit` -- clean.
- [x] `npx prettier --check` on every touched file -- clean.
- [x] Coverage: 100% statements/functions and 168/169 branches on `call-subnet-surface.mjs` (the one gap is pre-existing, untouched-by-this-diff code); zero uncovered branches in the new `mcp-server.mjs` signature-scheme region.