### PR TITLE
fix(registry): reclassify alpharidge-ai's 20 surfaces to auth.scheme signature

### DIFF
--- a/registry/subnets/alpharidge-ai.json
+++ b/registry/subnets/alpharidge-ai.json
@@ -278,8 +278,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -305,8 +311,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -332,8 +344,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -359,8 +377,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -386,8 +410,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -413,8 +443,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -440,8 +476,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -467,8 +509,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -494,8 +542,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -521,8 +575,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -548,8 +608,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -575,8 +641,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -602,8 +674,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -629,8 +707,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -656,8 +740,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -683,8 +773,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -710,8 +806,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -737,8 +839,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -764,8 +872,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",
@@ -791,8 +905,14 @@
     {
       "auth": {
         "location": "header",
-        "scheme": "custom",
-        "scopes_note": "Requires a custom SS58-signature scheme: X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted."
+        "names": [
+          "X-Auth-SS58Address",
+          "X-Auth-Signature",
+          "X-Auth-Message",
+          "X-Auth-Timestamp"
+        ],
+        "scheme": "signature",
+        "scopes_note": "Requires a signed request: supply the X-Auth-SS58Address, X-Auth-Signature, X-Auth-Message, and X-Auth-Timestamp headers proving control of a registered hotkey. No static API key or bearer token is accepted -- each request must be signed fresh."
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- Reclassifies all 20 auth-gated `alpharidge-ai.json` surfaces from `auth.scheme:"custom"` to `auth.scheme:"signature"` (#7702, merged), with `auth.names: ["X-Auth-SS58Address", "X-Auth-Signature", "X-Auth-Message", "X-Auth-Timestamp"]`.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.

## Why

Live-verified 2026-07-21 (already documented in #7697's `scopes_note` prose): every one of these surfaces rejects an unauthenticated request naming the identical four required headers -- a Bittensor hotkey-signed request (SS58-signature scheme), not a bearer token or API key. `auth.scheme:"custom"` has no generic credential mechanism, so `call_subnet_surface` could never call these on a caller's behalf. `auth.scheme:"signature"` (#7701/#7702) is exactly this shape, now merged to `main`.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/alpharidge-ai.json` -- passes (43 surfaces).
- [x] Deep-equal check: exactly 20 `auth` objects changed, zero drift on any other field across all 43 surfaces.
- [x] `npx prettier --check registry/subnets/alpharidge-ai.json` -- clean.