### PR TITLE
fix(registry): reclassify bitsota's 2 surfaces to their actual auth mechanisms

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -509,9 +509,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "api-key",
         "location": "header",
-        "scopes_note": "Requires a hotkey-signed request (X-Hotkey, X-Timestamp, X-Signature headers); administrative routes additionally accept an X-Admin-Token. No static API key or bearer token is accepted for standard use."
+        "name": "X-Admin-Token",
+        "scopes_note": "Requires an X-Admin-Token header (confirmed live: an unauthenticated request returns HTTP 401 \"invalid admin token\"). No bearer token or hotkey-signed request is accepted for this route."
       },
       "auth_required": true,
       "authority": "community",
@@ -536,9 +537,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a hotkey-signed request (X-Hotkey, X-Timestamp, X-Signature headers); administrative routes additionally accept an X-Admin-Token. No static API key or bearer token is accepted for standard use."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, and X-Signature headers proving control of a registered hotkey. No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- `sn-94-bitsota-reward-policy`: `auth.scheme` from `"custom"` to `"api-key"`, `auth.name: "X-Admin-Token"`.
- `sn-94-bitsota-submissions`: `auth.scheme` from `"custom"` to `"signature"` (#7702), `auth.names: ["X-Hotkey", "X-Timestamp", "X-Signature"]`.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.

## Why

bitsota's own `openapi.json` and a live request against each route show these two surfaces use genuinely **different** auth mechanisms, which the existing prose (from #7697) had incorrectly conflated into one combined description ("hotkey-signed... administrative routes additionally accept an X-Admin-Token"):

- `reward-policy` (GET/PUT `/api/v1/reward-policy`) declares only an `X-Admin-Token` header parameter in its own spec, and an unauthenticated request returns `HTTP 401 {"detail":"invalid admin token"}` -- a single-value credential, not a signature bundle.
- `submissions` (GET/POST `/api/v1/submissions`) declares `X-Hotkey`, `X-Timestamp`, and `X-Signature` header parameters -- a genuine Bittensor hotkey-signed request.

`auth.scheme:"custom"` had no generic mechanism for either. Now that #7702 shipped both single-value (`api-key`) and multi-value (`signature`) credential passthrough, both are correctly and precisely typed.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/bitsota.json` -- passes (42 surfaces).
- [x] Deep-equal check: exactly the 2 intended `auth` objects changed, zero drift on any other field.
- [x] `npx prettier --check registry/subnets/bitsota.json` -- clean.