### PR TITLE
fix(registry): reclassify oro's 50 admin/miner/validator surfaces to signature

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -500,9 +500,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -527,9 +528,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -554,9 +556,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -581,9 +584,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -608,9 +612,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -635,9 +640,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -662,9 +668,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -689,9 +696,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -716,9 +724,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -743,9 +752,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -770,9 +780,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -797,9 +808,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -824,9 +836,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -851,9 +864,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -878,9 +892,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -905,9 +920,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -932,9 +948,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -959,9 +976,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -986,9 +1004,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1013,9 +1032,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1040,9 +1060,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1067,9 +1088,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1094,9 +1116,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1121,9 +1144,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1148,9 +1172,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1175,9 +1200,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1202,9 +1228,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1229,9 +1256,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1256,9 +1284,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1283,9 +1312,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1310,9 +1340,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1337,9 +1368,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1445,9 +1477,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1472,9 +1505,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1499,9 +1533,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1526,9 +1561,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1553,9 +1589,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1580,9 +1617,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1607,9 +1645,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1634,9 +1673,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1661,9 +1701,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1688,9 +1729,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -1715,9 +1757,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -2012,9 +2055,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -2039,9 +2083,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -2066,9 +2111,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -2093,9 +2139,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -2120,9 +2167,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -2147,9 +2195,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",
@@ -2174,9 +2223,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
+        "scheme": "signature",
         "location": "header",
-        "scopes_note": "Requires a signed request using a custom header set; no static API key or bearer token is accepted. Contact the subnet operator for signing details."
+        "names": ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"],
+        "scopes_note": "Requires a hotkey-signed request: the X-Hotkey, X-Timestamp, X-Nonce, and X-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the exact header names are named directly in the API's own 401 response). No static API key or bearer token is accepted."
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- Reclassifies 50 of `oro.json`'s auth-gated surfaces (the `/v1/admin/*`, `/v1/miner/*`, and `/v1/validator/*` families) from `auth.scheme:"custom"` to `auth.scheme:"signature"`, with `auth.names: ["X-Hotkey", "X-Timestamp", "X-Nonce", "X-Signature"]`.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.
- Deliberately does **not** touch the 13 remaining `scheme:"custom"` surfaces under `/v1/public/*` and `/v1/auth/*` -- see below.

## Why

Live-verified 2026-07-22: oro (SN15, `api.oroagents.com`)'s admin/miner/validator route families all reject an unauthenticated request with the same explicit error naming every required header: `{"detail":"Missing required authentication headers: X-Hotkey, X-Timestamp, X-Nonce, X-Signature"}`. Confirmed consistent across many distinct endpoints spanning all three families. `auth.scheme:"custom"` had no generic mechanism for this; `auth.scheme:"signature"` (#7701/#7702, merged) is exactly this shape.

## Why the other 13 surfaces are excluded

While verifying this, I found the existing prose's claim of a subnet-wide "global signed-request middleware" doesn't hold for two other route families still carrying `scheme:"custom"`:

- `/v1/public/*` (10 surfaces): a live `POST /v1/public/waitlist` with a valid body succeeded (`{"success":true}`) with **zero** auth headers, and `GET /v1/public/agent-versions/{valid-uuid}` returned a clean business-logic 404, not an auth error. These look genuinely public, contradicting their current `auth_required:true`.
- `/v1/auth/*` (3 surfaces): a login/session flow -- `POST /v1/auth/logout` unauthenticated returns `{"detail":"Missing Authorization header"}`, a different (bearer-style) scheme entirely, and `challenge`/`session` are the flow's own entry points.

Both need their own careful, per-route re-verification (which auth_required/scheme is actually correct) rather than a guess folded into this PR -- flagged as a follow-up task.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/oro.json` -- passes (83 surfaces).
- [x] Deep-equal check: exactly 50 `auth` objects changed, zero drift on any other field (including the 13 untouched surfaces).
- [x] `npx prettier --check registry/subnets/oro.json` -- clean.