### PR TITLE
fix(registry): reclassify iota's 13 surfaces to auth.scheme signature

### DIFF
--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -212,8 +212,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -241,8 +247,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -270,8 +282,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -299,8 +317,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -328,8 +352,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -357,8 +387,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -386,8 +422,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -415,8 +457,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -444,8 +492,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -473,8 +527,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -502,8 +562,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -531,8 +597,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -560,8 +632,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a Bittensor Epistula-protocol signed request proving control of a registered hotkey; no static API key or bearer token is accepted."
+        "scheme": "signature",
+        "scopes_note": "Requires an Epistula-protocol signed request: the Epistula-Timestamp, Epistula-Signed-By, and Epistula-Request-Signature headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own EpistulaError messages progress through SS58-format, timestamp-freshness, and signature-hex-format checks as each header is supplied correctly). No static API key or bearer token is accepted.",
+        "location": "header",
+        "names": [
+          "Epistula-Timestamp",
+          "Epistula-Signed-By",
+          "Epistula-Request-Signature"
+        ]
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- Reclassifies all 13 auth-gated `iota.json` surfaces from `auth.scheme:"custom"` to `auth.scheme:"signature"`, with `auth.names: ["Epistula-Timestamp", "Epistula-Signed-By", "Epistula-Request-Signature"]`.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.

## Why

iota (SN9, `iota.api.macrocosmos.ai`) uses the canonical Epistula protocol. The exact header names are already declared as parameters in the subnet's own OpenAPI spec. Live-verified 2026-07-22 with a 4-stage error progression proving each header is actively checked, not just declared:

1. No/invalid `Epistula-Signed-By` -> `EpistulaError: Invalid SS58 address`
2. Valid-format SS58 + a stale `Epistula-Timestamp` -> `EpistulaError: Request is too stale`
3. Fresh timestamp + malformed `Epistula-Request-Signature` -> `EpistulaError: Invalid hex string: OddLength`
4. Fresh timestamp + **no** signature header at all -> a different message (`Expected hex string`) confirming the header is read, not defaulted

The OpenAPI spec also declares 4 other headers (`X-Request-Id`, `X-Spec-Version`, `X-Is-Mounted`, `X-Host-Version`) with sensible server-side defaults -- these are excluded from `auth.names` since they aren't part of the credential itself.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/iota.json` -- passes (22 surfaces).
- [x] Deep-equal check: exactly 13 `auth` objects changed, zero drift on any other field.
- [x] `npx prettier --check registry/subnets/iota.json` -- clean.