### PR TITLE
fix(registry): reclassify ain's 18 surfaces to their actual auth mechanisms

### DIFF
--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -533,8 +533,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-results-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-results-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -559,8 +561,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-reveals-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-reveals-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -585,8 +589,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires both the x-user-hotkey and x-service-token headers together (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"; both are declared as required header parameters on this operation in the subnet's own OpenAPI spec). No bearer token alone is accepted.",
+        "location": "header",
+        "names": ["x-user-hotkey", "x-service-token"]
       },
       "auth_required": true,
       "authority": "community",
@@ -611,8 +617,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -637,8 +645,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -663,8 +673,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -689,8 +701,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-service-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-service-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -715,8 +729,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -741,8 +757,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -767,8 +785,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -793,8 +813,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -819,8 +841,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -845,8 +869,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-admin-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-admin-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -871,8 +897,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-results-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-results-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -897,8 +925,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-results-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-results-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -923,8 +953,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-results-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-results-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -949,8 +981,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-service-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-service-token"
       },
       "auth_required": true,
       "authority": "community",
@@ -975,8 +1009,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential header that is not fully documented by the subnet's own API schema. Contact the subnet operator for details."
+        "scheme": "api-key",
+        "scopes_note": "Requires a x-service-token header (confirmed live: an unauthenticated request returns HTTP 401 \"unauthorized\"). No bearer token or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "x-service-token"
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- Reclassifies all 18 auth-gated `ain.json` surfaces from `auth.scheme:"custom"` to their actual, precisely-typed mechanism.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.

## Why

ain (SN69, `api.heraldmedia.ai`) doesn't use one uniform scheme -- each route family gates behind its own distinct single-value header token, all declared as operation parameters in the subnet's own OpenAPI spec and confirmed live (`HTTP 401 {"detail":"unauthorized"}` when absent):

| Family | Header | Surfaces |
|---|---|---|
| `/admin/*` | `x-admin-token` | 9 |
| `/results`, `/validator/results`, `/api/v3/validator/*` | `x-results-token` | 4 |
| `/reveals` | `x-reveals-token` | 1 |
| `/contact`, `/users/upsert` | `x-service-token` | 3 |
| `/users/coverage` | `x-user-hotkey` **and** `x-service-token` together | 1 |

17 of these are single-value static tokens -> `auth.scheme:"api-key"`. The one route needing two headers together (`/users/coverage`) -> `auth.scheme:"signature"` (#7701/#7702, merged), `auth.names: ["x-user-hotkey", "x-service-token"]`.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/ain.json` -- passes (41 surfaces).
- [x] Deep-equal check: exactly 18 `auth` objects changed, zero drift on any other field.
- [x] `npx prettier --check registry/subnets/ain.json` -- clean.