### PR TITLE
fix(registry): reclassify bitsec's 11 surfaces to auth.scheme bearer

### DIFF
--- a/registry/subnets/bitsec.json
+++ b/registry/subnets/bitsec.json
@@ -497,8 +497,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -523,8 +526,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -549,8 +555,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -575,8 +584,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -601,8 +613,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -627,8 +642,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -653,8 +671,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -679,8 +700,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -705,8 +729,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -731,8 +758,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",
@@ -757,8 +787,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a credential in the authorization header; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "bearer",
+        "scopes_note": "Requires a Bearer token in the Authorization header (confirmed live: a well-formed \"Bearer <token>\" progresses past the missing-header check to an invalid-token-format error). No hotkey-signed request or API key is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- Reclassifies all 11 auth-gated `bitsec.json` surfaces from `auth.scheme:"custom"` to `auth.scheme:"bearer"`, `auth.name: "Authorization"`, `auth.value_format: "Bearer <token>"`.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.

## Why

Every bitsec (SN60, `bitsec.ai`) auth-gated surface declares exactly one header parameter (`authorization`) in its own OpenAPI spec -- a single-value credential, not a signature bundle. Live-verified 2026-07-22 the expected format is a standard Bearer token:

- A raw token with no `Bearer ` prefix -> `{"detail":"Missing or invalid Authorization header"}`
- A well-formed `Bearer <token>` -> `{"detail":"Invalid token format"}` -- a different, more specific error, proving the server recognized the prefix and moved on to validating the token itself.

`auth.scheme:"custom"` had no generic mechanism for this; standard `bearer` (already supported since Phase 3) is the correct, precise type.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/bitsec.json` -- passes (34 surfaces).
- [x] Deep-equal check: exactly 11 `auth` objects changed, zero drift on any other field.
- [x] `npx prettier --check registry/subnets/bitsec.json` -- clean.