### PR TITLE
fix(registry): reclassify minos's 9 surfaces to auth.scheme signature

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -135,8 +135,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",
@@ -163,8 +165,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",
@@ -191,8 +195,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the validator_hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["validator_hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",
@@ -219,8 +225,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the validator_hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["validator_hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",
@@ -247,8 +255,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the validator_hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["validator_hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",
@@ -275,8 +285,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the validator_hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["validator_hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",
@@ -303,8 +315,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the validator_hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["validator_hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",
@@ -331,8 +345,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the validator_hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["validator_hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",
@@ -359,8 +375,10 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a hotkey-signed request body (registered subnet identity, timestamp, and signature); no static API key exists. See the subnet's own documentation for the signing format."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the validator_hotkey, timestamp, signature fields merged into the POST body, proving control of a registered hotkey (documented in the official minos_subnet README; live-verified 2026-07-22 -- an unsigned request's HTTP 422 lists exactly these fields as missing). No static API token exists. Calling this via path+method credential passthrough requires a captured schema for this subnet, not yet registered.",
+        "location": "body",
+        "names": ["validator_hotkey", "timestamp", "signature"]
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- Reclassifies all 9 auth-gated `minos.json` surfaces from `auth.scheme:"custom"` to `auth.scheme:"signature"`, `auth.location:"body"`.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.

## Why

Documented in the official minos_subnet README and live-verified 2026-07-22: every minos (SN107, `api.theminos.ai`) surface requires a hotkey-signed request as flat top-level JSON body fields (not headers). An unsigned request's `HTTP 422` directly lists the exact required field names per operation:

- `round-status`, `submit-config`: `hotkey`, `timestamp`, `signature`
- the other 7 operations: `validator_hotkey`, `timestamp`, `signature`

Some operations (e.g. `submit-score`, `submit-weight-history`) also require unrelated semantic payload fields (`round_id`, `miner_hotkey`, `entries`) in the same body -- those are left alone; only the credential fields go in `auth.names`.

**Note:** calling these via the tool's `path`+`method` credential passthrough requires a captured OpenAPI schema for this subnet, which isn't registered yet. This PR is a data-accuracy fix (the `auth` object now correctly describes the mechanism), not a claim the mechanism is end-to-end callable today.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/minos.json` -- passes (14 surfaces).
- [x] Deep-equal check: exactly 9 `auth` objects changed, zero drift on any other field.
- [x] `npx prettier --check registry/subnets/minos.json` -- clean.