### PR TITLE
fix(scan): allow a real X-Role-Hotkey HTTP header name in public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -276,6 +276,21 @@ const patterns = [
     // is.
     regex:
       /\b(?:private|secret|wallet|validator|miner)[\s-]+hotkey\b|\bhotkey[\s_-]+(?:path|private[\s_-]?key|seed[\s_-]?phrase|seed|mnemonic)\b/i,
+    // A real HTTP custom-header name, e.g. "X-Validator-Hotkey" or
+    // "X-Miner-Hotkey" (confirmed live 2026-07-22 against swarm124.com's and
+    // adtao.io's own APIs, and stored verbatim in registry/subnets/*.json's
+    // auth.names since that's the literal header the tool must send) -- this
+    // is the hyphenated sibling of the already-exempted `<role>_hotkey`
+    // snake_case field name above, just spelled the way HTTP header names
+    // conventionally are. Deliberately case-SENSITIVE and requires the
+    // leading "X-" + capitalized-word shape, unlike the case-insensitive main
+    // regex: that's what distinguishes "this is a real header identifier"
+    // from suspicious prose using the same words -- lowercase or
+    // space-joined "x-validator-hotkey"/"validator hotkey" still trips the
+    // rule untouched. Only "Hotkey" as the header's final segment is
+    // exempted; "X-Validator-Seed-Phrase" or similar would still match the
+    // main regex's other alternatives.
+    allow: /\bX-[A-Z][A-Za-z]*-Hotkey\b/g,
     soft: true,
   },
 ];

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -681,6 +681,52 @@ describe("captured-fixture body scan", () => {
       );
     }
   });
+
+  test("does not flag a real X-Role-Hotkey HTTP header name", async () => {
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "X-Validator-Hotkey",
+        "X-Miner-Hotkey",
+        "Requires the X-Validator-Hotkey and X-Validator-Signature headers.",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_PUBLIC_FILE),
+      false,
+      `a real X-Role-Hotkey header name must not trip sensitive hotkey wording; got:\n${output}`,
+    );
+  });
+
+  test("still flags validator/miner hotkey prose alongside a real header name on other lines", async () => {
+    // The allowlist strips only the exact "X-Role-Hotkey" shape -- lowercase
+    // or space-joined wording using the same words, even on an adjacent line
+    // in the same file, must still trip the rule untouched.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "X-Validator-Hotkey",
+        "share your validator hotkey with us",
+        "x-validator-hotkey",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.ok(
+      !output.includes(`${TEST_PUBLIC_FILE}:1: sensitive hotkey wording`),
+      `line 1 (real header name) must not be flagged; got:\n${output}`,
+    );
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:2: sensitive hotkey wording`),
+      `line 2 (space-joined prose) should still be flagged; got:\n${output}`,
+    );
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:3: sensitive hotkey wording`),
+      `line 3 (lowercase header-shaped text) should still be flagged; got:\n${output}`,
+    );
+  });
 });
 
 // scripts/, deploy/, and apps/indexer-rs/ joined targetRoots in the same PR


### PR DESCRIPTION
## Summary

- Adds a narrow, case-sensitive `allow` exemption to `scan-public-safety.mjs`'s "sensitive hotkey wording" rule for the `X-<Role>-Hotkey` HTTP header-name shape (e.g. `X-Validator-Hotkey`, `X-Miner-Hotkey`).
- Adds two tests proving both directions: the real header-name shape is exempted, but lowercase or space-joined prose using the same words still trips the rule.

## Why

The rule already exempts `<role>_hotkey` (snake_case, e.g. `validator_hotkey`) as common, benign Bittensor API field naming, but not the hyphenated form that's the standard convention for an HTTP custom header name. Two subnets' own live APIs use exactly this: swarm124.com's `X-Validator-Hotkey`/`X-Validator-Signature`/`X-Validator-Nonce`/`X-Validator-Timestamp` and adtao.io's `X-Miner-Hotkey`/`X-Miner-Nonce`/`X-Miner-Signature`, both confirmed via real 401/422 responses naming them directly. Committing the literal header name into a registry surface's `auth.names` (functionally required -- it's what `call_subnet_surface` actually sends) tripped the rule as a false positive, blocking two otherwise-correct, evidence-backed registry PRs.

The exemption is deliberately narrow: case-sensitive, requires the leading `X-` + capitalized-word shape. `x-validator-hotkey` (lowercase) or `validator hotkey` (space-joined prose) still trip the rule untouched -- this doesn't weaken detection of real suspicious wording.

## Test plan

- [x] `npx vitest run tests/public-safety.test.mjs` -- 46/46 passing (2 new).
- [x] `node scripts/scan-public-safety.mjs` on the current tree -- clean.
- [x] `npx prettier --check` -- clean.