### PR TITLE
fix(registry): reclassify swarm's 8 surfaces to auth.scheme signature

### DIFF
--- a/registry/subnets/swarm.json
+++ b/registry/subnets/swarm.json
@@ -190,8 +190,15 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request using custom headers; not a bearer token or API key. Contact the subnet operator for signing details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Nonce, and X-Validator-Timestamp headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own 422 response names all four as missing). Also requires a separate X-Code-Version header (a client-version gate, not part of the credential itself) -- calls without it are rejected with HTTP 426 before the credential is even checked. No bearer token or API key is accepted.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Nonce",
+          "X-Validator-Timestamp"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -218,8 +225,15 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request using custom headers; not a bearer token or API key. Contact the subnet operator for signing details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Nonce, and X-Validator-Timestamp headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own 422 response names all four as missing). Also requires a separate X-Code-Version header (a client-version gate, not part of the credential itself) -- calls without it are rejected with HTTP 426 before the credential is even checked. No bearer token or API key is accepted.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Nonce",
+          "X-Validator-Timestamp"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -246,8 +260,15 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request using custom headers; not a bearer token or API key. Contact the subnet operator for signing details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Nonce, and X-Validator-Timestamp headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own 422 response names all four as missing). Also requires a separate X-Code-Version header (a client-version gate, not part of the credential itself) -- calls without it are rejected with HTTP 426 before the credential is even checked. No bearer token or API key is accepted.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Nonce",
+          "X-Validator-Timestamp"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -274,8 +295,15 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request using custom headers; not a bearer token or API key. Contact the subnet operator for signing details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Nonce, and X-Validator-Timestamp headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own 422 response names all four as missing). Also requires a separate X-Code-Version header (a client-version gate, not part of the credential itself) -- calls without it are rejected with HTTP 426 before the credential is even checked. No bearer token or API key is accepted.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Nonce",
+          "X-Validator-Timestamp"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -302,8 +330,15 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request using custom headers; not a bearer token or API key. Contact the subnet operator for signing details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Nonce, and X-Validator-Timestamp headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own 422 response names all four as missing). Also requires a separate X-Code-Version header (a client-version gate, not part of the credential itself) -- calls without it are rejected with HTTP 426 before the credential is even checked. No bearer token or API key is accepted.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Nonce",
+          "X-Validator-Timestamp"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -330,8 +365,15 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request using custom headers; not a bearer token or API key. Contact the subnet operator for signing details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Nonce, and X-Validator-Timestamp headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own 422 response names all four as missing). Also requires a separate X-Code-Version header (a client-version gate, not part of the credential itself) -- calls without it are rejected with HTTP 426 before the credential is even checked. No bearer token or API key is accepted.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Nonce",
+          "X-Validator-Timestamp"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -358,8 +400,15 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request using custom headers; not a bearer token or API key. Contact the subnet operator for signing details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Nonce, and X-Validator-Timestamp headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own 422 response names all four as missing). Also requires a separate X-Code-Version header (a client-version gate, not part of the credential itself) -- calls without it are rejected with HTTP 426 before the credential is even checked. No bearer token or API key is accepted.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Nonce",
+          "X-Validator-Timestamp"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -386,8 +435,15 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request using custom headers; not a bearer token or API key. Contact the subnet operator for signing details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Nonce, and X-Validator-Timestamp headers proving control of a registered hotkey (live-verified 2026-07-22: the API's own 422 response names all four as missing). Also requires a separate X-Code-Version header (a client-version gate, not part of the credential itself) -- calls without it are rejected with HTTP 426 before the credential is even checked. No bearer token or API key is accepted.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Nonce",
+          "X-Validator-Timestamp"
+        ]
       },
       "auth_required": true,
       "authority": "community",

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -276,6 +276,21 @@ const patterns = [
     // is.
     regex:
       /\b(?:private|secret|wallet|validator|miner)[\s-]+hotkey\b|\bhotkey[\s_-]+(?:path|private[\s_-]?key|seed[\s_-]?phrase|seed|mnemonic)\b/i,
+    // A real HTTP custom-header name, e.g. "X-Validator-Hotkey" or
+    // "X-Miner-Hotkey" (confirmed live 2026-07-22 against swarm124.com's and
+    // adtao.io's own APIs, and stored verbatim in registry/subnets/*.json's
+    // auth.names since that's the literal header the tool must send) -- this
+    // is the hyphenated sibling of the already-exempted `<role>_hotkey`
+    // snake_case field name above, just spelled the way HTTP header names
+    // conventionally are. Deliberately case-SENSITIVE and requires the
+    // leading "X-" + capitalized-word shape, unlike the case-insensitive main
+    // regex: that's what distinguishes "this is a real header identifier"
+    // from suspicious prose using the same words -- lowercase or
+    // space-joined "x-validator-hotkey"/"validator hotkey" still trips the
+    // rule untouched. Only "Hotkey" as the header's final segment is
+    // exempted; "X-Validator-Seed-Phrase" or similar would still match the
+    // main regex's other alternatives.
+    allow: /\bX-[A-Z][A-Za-z]*-Hotkey\b/g,
     soft: true,
   },
 ];

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -681,6 +681,52 @@ describe("captured-fixture body scan", () => {
       );
     }
   });
+
+  test("does not flag a real X-Role-Hotkey HTTP header name", async () => {
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "X-Validator-Hotkey",
+        "X-Miner-Hotkey",
+        "Requires the X-Validator-Hotkey and X-Validator-Signature headers.",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_PUBLIC_FILE),
+      false,
+      `a real X-Role-Hotkey header name must not trip sensitive hotkey wording; got:\n${output}`,
+    );
+  });
+
+  test("still flags validator/miner hotkey prose alongside a real header name on other lines", async () => {
+    // The allowlist strips only the exact "X-Role-Hotkey" shape -- lowercase
+    // or space-joined wording using the same words, even on an adjacent line
+    // in the same file, must still trip the rule untouched.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "X-Validator-Hotkey",
+        "share your validator hotkey with us",
+        "x-validator-hotkey",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.ok(
+      !output.includes(`${TEST_PUBLIC_FILE}:1: sensitive hotkey wording`),
+      `line 1 (real header name) must not be flagged; got:\n${output}`,
+    );
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:2: sensitive hotkey wording`),
+      `line 2 (space-joined prose) should still be flagged; got:\n${output}`,
+    );
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:3: sensitive hotkey wording`),
+      `line 3 (lowercase header-shaped text) should still be flagged; got:\n${output}`,
+    );
+  });
 });
 
 // scripts/, deploy/, and apps/indexer-rs/ joined targetRoots in the same PR


### PR DESCRIPTION
## Summary

- Reclassifies all 8 auth-gated `swarm.json` surfaces from `auth.scheme:"custom"` to `auth.scheme:"signature"`, with `auth.names: ["X-Validator-Hotkey", "X-Validator-Signature", "X-Validator-Nonce", "X-Validator-Timestamp"]`.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.

## Why

Live-verified 2026-07-22: swarm (SN124, `api.swarm124.com`) rejects unauthenticated requests with `HTTP 426` (a client-version gate requiring a separate `X-Code-Version` header), then once past that, `HTTP 422` naming all four required credential headers directly. Confirmed consistent across 5 distinct endpoints (`next-task`, `heartbeat`, `epoch/publish`, `sync`, `events`).

`X-Code-Version` is documented in `scopes_note` but deliberately excluded from `auth.names` -- it's a version gate, not part of the credential itself.

**Depends on #7713** (public-safety scanner allowlist for the `X-Validator-Hotkey` header shape) -- based on that branch since the real header name otherwise trips the scanner's pre-push hook as a false positive. Merge #7713 first.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/swarm.json` -- passes (15 surfaces).
- [x] Deep-equal check: exactly 8 `auth` objects changed, zero drift on any other field.
- [x] `node scripts/scan-public-safety.mjs` -- clean (with #7713's fix).
- [x] `npx prettier --check registry/subnets/swarm.json` -- clean.