### PR TITLE
fix(registry): reclassify adtao's 7 surfaces to auth.scheme signature

### DIFF
--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -249,8 +249,10 @@
       "auth_required": true,
       "authority": "community",
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a per-miner identity header; not a bearer token. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Miner-Hotkey, X-Miner-Nonce, and X-Miner-Signature headers proving control of a registered hotkey (declared in the subnet's own OpenAPI spec; live-verified 2026-07-22 -- an unauthenticated request's HTTP 422 names X-Miner-Hotkey as missing). No bearer token or API key is accepted.",
+        "location": "header",
+        "names": ["X-Miner-Hotkey", "X-Miner-Nonce", "X-Miner-Signature"]
       },
       "id": "sn-21-adtao-episodes",
       "kind": "subnet-api",
@@ -278,8 +280,10 @@
       "auth_required": true,
       "authority": "community",
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a per-miner identity header; not a bearer token. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Miner-Hotkey, X-Miner-Nonce, and X-Miner-Signature headers proving control of a registered hotkey (declared in the subnet's own OpenAPI spec; live-verified 2026-07-22 -- an unauthenticated request's HTTP 422 names X-Miner-Hotkey as missing). No bearer token or API key is accepted.",
+        "location": "header",
+        "names": ["X-Miner-Hotkey", "X-Miner-Nonce", "X-Miner-Signature"]
       },
       "id": "sn-21-adtao-episode-detail",
       "kind": "subnet-api",
@@ -307,8 +311,10 @@
       "auth_required": true,
       "authority": "community",
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a per-miner identity header; not a bearer token. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Miner-Hotkey, X-Miner-Nonce, and X-Miner-Signature headers proving control of a registered hotkey (declared in the subnet's own OpenAPI spec; live-verified 2026-07-22 -- an unauthenticated request's HTTP 422 names X-Miner-Hotkey as missing). No bearer token or API key is accepted.",
+        "location": "header",
+        "names": ["X-Miner-Hotkey", "X-Miner-Nonce", "X-Miner-Signature"]
       },
       "id": "sn-21-adtao-episodes-batch",
       "kind": "subnet-api",
@@ -336,8 +342,10 @@
       "auth_required": true,
       "authority": "community",
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a per-miner identity header; not a bearer token. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Miner-Hotkey, X-Miner-Nonce, and X-Miner-Signature headers proving control of a registered hotkey (declared in the subnet's own OpenAPI spec; live-verified 2026-07-22 -- an unauthenticated request's HTTP 422 names X-Miner-Hotkey as missing). No bearer token or API key is accepted.",
+        "location": "header",
+        "names": ["X-Miner-Hotkey", "X-Miner-Nonce", "X-Miner-Signature"]
       },
       "id": "sn-21-adtao-my-predictions",
       "kind": "subnet-api",
@@ -365,8 +373,10 @@
       "auth_required": true,
       "authority": "community",
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a per-miner identity header; not a bearer token. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Miner-Hotkey, X-Miner-Nonce, and X-Miner-Signature headers proving control of a registered hotkey (declared in the subnet's own OpenAPI spec; live-verified 2026-07-22 -- an unauthenticated request's HTTP 422 names X-Miner-Hotkey as missing). No bearer token or API key is accepted.",
+        "location": "header",
+        "names": ["X-Miner-Hotkey", "X-Miner-Nonce", "X-Miner-Signature"]
       },
       "id": "sn-21-adtao-training-episodes-api",
       "kind": "subnet-api",
@@ -394,8 +404,10 @@
       "auth_required": true,
       "authority": "community",
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a per-miner identity header; not a bearer token. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Miner-Hotkey, X-Miner-Nonce, and X-Miner-Signature headers proving control of a registered hotkey (declared in the subnet's own OpenAPI spec; live-verified 2026-07-22 -- an unauthenticated request's HTTP 422 names X-Miner-Hotkey as missing). No bearer token or API key is accepted.",
+        "location": "header",
+        "names": ["X-Miner-Hotkey", "X-Miner-Nonce", "X-Miner-Signature"]
       },
       "id": "sn-21-adtao-training-summary",
       "kind": "subnet-api",
@@ -423,8 +435,10 @@
       "auth_required": true,
       "authority": "community",
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a per-miner identity header; not a bearer token. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Miner-Hotkey, X-Miner-Nonce, and X-Miner-Signature headers proving control of a registered hotkey (declared in the subnet's own OpenAPI spec; live-verified 2026-07-22 -- an unauthenticated request's HTTP 422 names X-Miner-Hotkey as missing). No bearer token or API key is accepted.",
+        "location": "header",
+        "names": ["X-Miner-Hotkey", "X-Miner-Nonce", "X-Miner-Signature"]
       },
       "id": "sn-21-adtao-registration-status",
       "kind": "subnet-api",

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -276,6 +276,21 @@ const patterns = [
     // is.
     regex:
       /\b(?:private|secret|wallet|validator|miner)[\s-]+hotkey\b|\bhotkey[\s_-]+(?:path|private[\s_-]?key|seed[\s_-]?phrase|seed|mnemonic)\b/i,
+    // A real HTTP custom-header name, e.g. "X-Validator-Hotkey" or
+    // "X-Miner-Hotkey" (confirmed live 2026-07-22 against swarm124.com's and
+    // adtao.io's own APIs, and stored verbatim in registry/subnets/*.json's
+    // auth.names since that's the literal header the tool must send) -- this
+    // is the hyphenated sibling of the already-exempted `<role>_hotkey`
+    // snake_case field name above, just spelled the way HTTP header names
+    // conventionally are. Deliberately case-SENSITIVE and requires the
+    // leading "X-" + capitalized-word shape, unlike the case-insensitive main
+    // regex: that's what distinguishes "this is a real header identifier"
+    // from suspicious prose using the same words -- lowercase or
+    // space-joined "x-validator-hotkey"/"validator hotkey" still trips the
+    // rule untouched. Only "Hotkey" as the header's final segment is
+    // exempted; "X-Validator-Seed-Phrase" or similar would still match the
+    // main regex's other alternatives.
+    allow: /\bX-[A-Z][A-Za-z]*-Hotkey\b/g,
     soft: true,
   },
 ];

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -681,6 +681,52 @@ describe("captured-fixture body scan", () => {
       );
     }
   });
+
+  test("does not flag a real X-Role-Hotkey HTTP header name", async () => {
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "X-Validator-Hotkey",
+        "X-Miner-Hotkey",
+        "Requires the X-Validator-Hotkey and X-Validator-Signature headers.",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_PUBLIC_FILE),
+      false,
+      `a real X-Role-Hotkey header name must not trip sensitive hotkey wording; got:\n${output}`,
+    );
+  });
+
+  test("still flags validator/miner hotkey prose alongside a real header name on other lines", async () => {
+    // The allowlist strips only the exact "X-Role-Hotkey" shape -- lowercase
+    // or space-joined wording using the same words, even on an adjacent line
+    // in the same file, must still trip the rule untouched.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "X-Validator-Hotkey",
+        "share your validator hotkey with us",
+        "x-validator-hotkey",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.ok(
+      !output.includes(`${TEST_PUBLIC_FILE}:1: sensitive hotkey wording`),
+      `line 1 (real header name) must not be flagged; got:\n${output}`,
+    );
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:2: sensitive hotkey wording`),
+      `line 2 (space-joined prose) should still be flagged; got:\n${output}`,
+    );
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:3: sensitive hotkey wording`),
+      `line 3 (lowercase header-shaped text) should still be flagged; got:\n${output}`,
+    );
+  });
 });
 
 // scripts/, deploy/, and apps/indexer-rs/ joined targetRoots in the same PR


### PR DESCRIPTION
## Summary

- Reclassifies all 7 auth-gated `adtao.json` surfaces from `auth.scheme:"custom"` to `auth.scheme:"signature"`, with `auth.names: ["X-Miner-Hotkey", "X-Miner-Nonce", "X-Miner-Signature"]`.
- Only the `auth` object changes on each surface -- verified by a deep-equal diff against every other field.

## Why

Every adtao (SN21, `validator.adtao.io`) auth-gated surface requires `X-Miner-Hotkey`, `X-Miner-Nonce`, and `X-Miner-Signature` headers -- declared as operation parameters in the subnet's own OpenAPI spec and confirmed live: an unauthenticated request's `HTTP 422` names `X-Miner-Hotkey` as missing.

**Depends on #7713** (public-safety scanner allowlist for the `X-Miner-Hotkey` header shape) -- based on that branch since the real header name otherwise trips the scanner's pre-push hook as a false positive. Merge #7713 first.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/adtao.json` -- passes (16 surfaces).
- [x] Deep-equal check: exactly 7 `auth` objects changed, zero drift on any other field.
- [x] `node scripts/scan-public-safety.mjs` -- clean (with #7713's fix).
- [x] `npx prettier --check registry/subnets/adtao.json` -- clean.