### PR TITLE
feat(mcp): body-envelope credential placement for nested signed-request wrappers

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4015,6 +4015,13 @@ export interface components {
         CandidateSurface: {
             /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
             auth?: {
+                /** @description For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {"payload": {...}, "sig": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default). */
+                body_envelope?: {
+                    /** @description Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. "sig". */
+                    credential_key: string;
+                    /** @description Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. "payload". */
+                    payload_key: string;
+                };
                 /**
                  * @description Where the credential is sent. "body" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).
                  * @enum {unknown}
@@ -8307,6 +8314,13 @@ export interface components {
         Surface: {
             /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
             auth?: {
+                /** @description For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {"payload": {...}, "sig": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default). */
+                body_envelope?: {
+                    /** @description Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. "sig". */
+                    credential_key: string;
+                    /** @description Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. "payload". */
+                    payload_key: string;
+                };
                 /**
                  * @description Where the credential is sent. "body" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).
                  * @enum {unknown}

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4050,6 +4050,27 @@
             "additionalProperties": false,
             "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
             "properties": {
+              "body_envelope": {
+                "additionalProperties": false,
+                "description": "For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {\"payload\": {...}, \"sig\": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default).",
+                "properties": {
+                  "credential_key": {
+                    "description": "Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. \"sig\".",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "payload_key": {
+                    "description": "Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. \"payload\".",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "payload_key",
+                  "credential_key"
+                ],
+                "type": "object"
+              },
               "location": {
                 "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).",
                 "enum": [
@@ -21969,6 +21990,27 @@
             "additionalProperties": false,
             "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
             "properties": {
+              "body_envelope": {
+                "additionalProperties": false,
+                "description": "For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {\"payload\": {...}, \"sig\": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default).",
+                "properties": {
+                  "credential_key": {
+                    "description": "Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. \"sig\".",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "payload_key": {
+                    "description": "Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. \"payload\".",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "payload_key",
+                  "credential_key"
+                ],
+                "type": "object"
+              },
               "location": {
                 "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).",
                 "enum": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4015,6 +4015,13 @@ export interface components {
         CandidateSurface: {
             /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
             auth?: {
+                /** @description For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {"payload": {...}, "sig": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default). */
+                body_envelope?: {
+                    /** @description Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. "sig". */
+                    credential_key: string;
+                    /** @description Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. "payload". */
+                    payload_key: string;
+                };
                 /**
                  * @description Where the credential is sent. "body" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).
                  * @enum {unknown}
@@ -8307,6 +8314,13 @@ export interface components {
         Surface: {
             /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
             auth?: {
+                /** @description For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {"payload": {...}, "sig": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default). */
+                body_envelope?: {
+                    /** @description Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. "sig". */
+                    credential_key: string;
+                    /** @description Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. "payload". */
+                    payload_key: string;
+                };
                 /**
                  * @description Where the credential is sent. "body" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).
                  * @enum {unknown}

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -4036,6 +4036,27 @@
             "additionalProperties": false,
             "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
             "properties": {
+              "body_envelope": {
+                "additionalProperties": false,
+                "description": "For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {\"payload\": {...}, \"sig\": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default).",
+                "properties": {
+                  "credential_key": {
+                    "description": "Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. \"sig\".",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "payload_key": {
+                    "description": "Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. \"payload\".",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "payload_key",
+                  "credential_key"
+                ],
+                "type": "object"
+              },
               "location": {
                 "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).",
                 "enum": [
@@ -21947,6 +21968,27 @@
             "additionalProperties": false,
             "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
             "properties": {
+              "body_envelope": {
+                "additionalProperties": false,
+                "description": "For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {\"payload\": {...}, \"sig\": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default).",
+                "properties": {
+                  "credential_key": {
+                    "description": "Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. \"sig\".",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "payload_key": {
+                    "description": "Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. \"payload\".",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "payload_key",
+                  "credential_key"
+                ],
+                "type": "object"
+              },
               "location": {
                 "description": "Where the credential is sent. \"body\" only applies to scheme:signature (the values are merged into the outgoing JSON request body, not sent as headers/query/cookie).",
                 "enum": [

--- a/schemas/candidate-surface.schema.json
+++ b/schemas/candidate-surface.schema.json
@@ -192,6 +192,24 @@
           "minItems": 1,
           "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
         },
+        "body_envelope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["payload_key", "credential_key"],
+          "description": "For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {\"payload\": {...}, \"sig\": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default).",
+          "properties": {
+            "payload_key": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. \"payload\"."
+            },
+            "credential_key": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. \"sig\"."
+            }
+          }
+        },
         "value_format": {
           "type": "string",
           "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret."

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -335,6 +335,24 @@
                 "minItems": 1,
                 "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
               },
+              "body_envelope": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["payload_key", "credential_key"],
+                "description": "For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {\"payload\": {...}, \"sig\": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default).",
+                "properties": {
+                  "payload_key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. \"payload\"."
+                  },
+                  "credential_key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. \"sig\"."
+                  }
+                }
+              },
               "value_format": {
                 "type": "string",
                 "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret."
@@ -601,6 +619,24 @@
                 "items": { "type": "string" },
                 "minItems": 1,
                 "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
+              },
+              "body_envelope": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["payload_key", "credential_key"],
+                "description": "For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {\"payload\": {...}, \"sig\": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default).",
+                "properties": {
+                  "payload_key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. \"payload\"."
+                  },
+                  "credential_key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. \"sig\"."
+                  }
+                }
               },
               "value_format": {
                 "type": "string",

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -315,6 +315,24 @@
               "minItems": 1,
               "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
             },
+            "body_envelope": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["payload_key", "credential_key"],
+              "description": "For scheme:signature, location:body only: set when the target API wraps the credential in its own nested object alongside the semantic request payload (e.g. {\"payload\": {...}, \"sig\": {...}}) instead of flat-merging the credential's fields into the top-level body. `names` still lists the credential bundle's own field names (nested under `credential_key`), unaffected by this wrapper shape. Omit entirely for a flat top-level merge (the default).",
+              "properties": {
+                "payload_key": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Top-level body key the caller-supplied semantic payload (the `body` argument, or {} when absent) is wrapped under, e.g. \"payload\"."
+                },
+                "credential_key": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Top-level body key the credential bundle (every name/value pair from `names`) is nested under, e.g. \"sig\"."
+                }
+              }
+            },
             "value_format": {
               "type": "string",
               "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret."

--- a/src/call-subnet-surface.ts
+++ b/src/call-subnet-surface.ts
@@ -80,8 +80,16 @@ export interface CallSubnetSurfaceCredential {
   // key) -- this module never computes or validates a signature, only
   // relays the bundle as given. For `location: "body"`, every entry is
   // merged into the outgoing JSON request body alongside whatever `body`
-  // option is separately supplied.
+  // option is separately supplied -- unless `bodyEnvelope` is also set.
   values?: Record<string, string>;
+  // `location: "body"` only (metagraphed#7716, auth.body_envelope): when the
+  // target API wraps the credential in its own nested object alongside the
+  // semantic payload (e.g. `{"payload": {...}, "sig": {...}}`) instead of
+  // flat-merging, this describes that wrapper shape. When set, the outgoing
+  // body becomes `{[payloadKey]: <body arg, or {} when absent>,
+  // [credentialKey]: <every values entry, as its own nested object>}`
+  // instead of a flat merge.
+  bodyEnvelope?: { payloadKey: string; credentialKey: string };
 }
 
 // metagraphed#7687 (MCP execute Phase 3b): a query-location credential is,
@@ -308,11 +316,22 @@ export async function callSubnetSurface(
   // body BEFORE calling this function; this function trusts that and merges
   // unconditionally (matches this module's existing "caller validates
   // eligibility, this module only places" contract for every other location).
+  // metagraphed#7716: when the target API wraps the credential in its own
+  // nested object alongside the semantic payload (auth.body_envelope) rather
+  // than flat-merging, build that shape instead of spreading bodyCredentialFields
+  // across the top level.
   const effectiveBody = bodyCredentialFields
-    ? JSON.stringify({
-        ...(requestBody ? JSON.parse(requestBody) : {}),
-        ...bodyCredentialFields,
-      })
+    ? credential?.bodyEnvelope
+      ? JSON.stringify({
+          [credential.bodyEnvelope.payloadKey]: requestBody
+            ? JSON.parse(requestBody)
+            : {},
+          [credential.bodyEnvelope.credentialKey]: bodyCredentialFields,
+        })
+      : JSON.stringify({
+          ...(requestBody ? JSON.parse(requestBody) : {}),
+          ...bodyCredentialFields,
+        })
     : requestBody;
 
   const fetched = await safetyCheckedFetch(requestUrl, {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11239,7 +11239,30 @@ export const MCP_TOOLS = [
               "This surface's credential is sent in the request body, which requires `path` and `method` (POST or PUT) to also be set.",
             );
           }
-          credentialPlacement = { location, values: args.credential };
+          // metagraphed#7716: some APIs wrap the credential in its own
+          // nested object alongside the semantic payload (e.g.
+          // {"payload": {...}, "sig": {...}}) rather than a flat top-level
+          // merge -- auth.body_envelope, curated registry data, describes
+          // that shape. Only meaningful for location:"body"; malformed or
+          // absent falls back to the existing flat-merge behavior.
+          const envelope = surface.auth?.body_envelope;
+          const bodyEnvelope =
+            location === "body" &&
+            envelope &&
+            typeof envelope.payload_key === "string" &&
+            envelope.payload_key.length > 0 &&
+            typeof envelope.credential_key === "string" &&
+            envelope.credential_key.length > 0
+              ? {
+                  payloadKey: envelope.payload_key,
+                  credentialKey: envelope.credential_key,
+                }
+              : undefined;
+          credentialPlacement = {
+            location,
+            values: args.credential,
+            ...(bodyEnvelope ? { bodyEnvelope } : {}),
+          };
         } else {
           throw toolError(
             "credential_not_supported",

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -241,6 +241,44 @@ const SIGNATURE_BODY_SURFACE = {
   schema_source: { surface_id: "x:openapi:1" },
 };
 
+// metagraphed#7716: body-envelope credential placement -- the credential
+// nests under its own key alongside the semantic payload, instead of a flat
+// top-level merge.
+const SIGNATURE_BODY_ENVELOPE_SURFACE = {
+  surface_id: "x:api:19",
+  netuid: 23,
+  kind: "subnet-api",
+  url: "https://x.example/signed-envelope",
+  auth_required: true,
+  auth: {
+    scheme: "signature",
+    location: "body",
+    names: ["signer_ss58", "nonce", "signature"],
+    body_envelope: { payload_key: "payload", credential_key: "sig" },
+  },
+  probe: { method: "GET", enabled: true },
+  schema_source: { surface_id: "x:openapi:1" },
+};
+
+// A malformed body_envelope (missing credential_key) -- must fall back to
+// the existing flat-merge behavior rather than crash or silently drop the
+// credential.
+const SIGNATURE_MALFORMED_ENVELOPE_SURFACE = {
+  surface_id: "x:api:20",
+  netuid: 24,
+  kind: "subnet-api",
+  url: "https://x.example/signed-malformed-envelope",
+  auth_required: true,
+  auth: {
+    scheme: "signature",
+    location: "body",
+    names: ["identity", "timestamp", "signature"],
+    body_envelope: { payload_key: "payload" },
+  },
+  probe: { method: "GET", enabled: true },
+  schema_source: { surface_id: "x:openapi:1" },
+};
+
 const SIGNATURE_NO_NAMES_SURFACE = {
   surface_id: "x:api:16",
   netuid: 20,
@@ -289,6 +327,8 @@ const CATALOG = {
     SIGNATURE_QUERY_SURFACE,
     SIGNATURE_COOKIE_SURFACE,
     SIGNATURE_BODY_SURFACE,
+    SIGNATURE_BODY_ENVELOPE_SURFACE,
+    SIGNATURE_MALFORMED_ENVELOPE_SURFACE,
     SIGNATURE_NO_NAMES_SURFACE,
     SIGNATURE_EMPTY_NAMES_SURFACE,
     SIGNATURE_NO_LOCATION_SURFACE,
@@ -1183,6 +1223,86 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       assert.equal(result.isError, true);
       assert.match(result.content[0].text, /invalid_params/);
       assert.match(result.content[0].text, /POST or PUT/);
+    });
+
+    test("location:body with auth.body_envelope nests the credential under its own key", async () => {
+      let sentBody;
+      const result = await callTool(
+        {
+          surface_id: "x:api:19",
+          path: "/users",
+          method: "POST",
+          body: { name: "ada" },
+          credential: {
+            signer_ss58: "5F...",
+            nonce: "abc123",
+            signature: "0xabc",
+          },
+        },
+        async (url, init) => {
+          sentBody = init.body;
+          return new Response(JSON.stringify({ id: 1 }), {
+            status: 201,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.deepEqual(JSON.parse(sentBody), {
+        payload: { name: "ada" },
+        sig: { signer_ss58: "5F...", nonce: "abc123", signature: "0xabc" },
+      });
+    });
+
+    test("location:body with auth.body_envelope defaults the payload key to {} with no separately-supplied body", async () => {
+      let sentBody;
+      const result = await callTool(
+        {
+          surface_id: "x:api:19",
+          path: "/ping",
+          method: "POST",
+          credential: {
+            signer_ss58: "5F...",
+            nonce: "abc123",
+            signature: "0xabc",
+          },
+        },
+        async (url, init) => {
+          sentBody = init.body;
+          return new Response("pong", { status: 200 });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.deepEqual(JSON.parse(sentBody), {
+        payload: {},
+        sig: { signer_ss58: "5F...", nonce: "abc123", signature: "0xabc" },
+      });
+    });
+
+    test("a malformed auth.body_envelope (missing credential_key) falls back to a flat top-level merge", async () => {
+      let sentBody;
+      const result = await callTool(
+        {
+          surface_id: "x:api:20",
+          path: "/ping",
+          method: "POST",
+          credential: {
+            identity: "5F...",
+            timestamp: "1700000000",
+            signature: "0xabc",
+          },
+        },
+        async (url, init) => {
+          sentBody = init.body;
+          return new Response("pong", { status: 200 });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.deepEqual(JSON.parse(sentBody), {
+        identity: "5F...",
+        timestamp: "1700000000",
+        signature: "0xabc",
+      });
     });
 
     test("a surface with no auth.names documented is credential_not_supported", async () => {

--- a/tests/call-subnet-surface.test.mjs
+++ b/tests/call-subnet-surface.test.mjs
@@ -926,6 +926,68 @@ describe("callSubnetSurface", () => {
     assert.equal(result.ok, true);
   });
 
+  // metagraphed#7716: body-envelope credential placement -- some APIs wrap
+  // the credential in its own nested object alongside the semantic payload
+  // (e.g. soma's {"payload": {...}, "sig": {...}}) instead of a flat merge.
+  test("credential bundle: body envelope nests the credential under its own key, alongside the supplied payload", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/openapi.json" },
+      {
+        path: "/miner/openrouter-key/add",
+        method: "POST",
+        body: JSON.stringify({ api_key: "sk-..." }),
+        contentType: "application/json",
+        credential: {
+          location: "body",
+          values: {
+            signer_ss58: "5F...",
+            nonce: "abc123",
+            signature: "0xabc",
+          },
+          bodyEnvelope: { payloadKey: "payload", credentialKey: "sig" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.deepEqual(JSON.parse(init.body), {
+            payload: { api_key: "sk-..." },
+            sig: {
+              signer_ss58: "5F...",
+              nonce: "abc123",
+              signature: "0xabc",
+            },
+          });
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
+  test("credential bundle: body envelope defaults the payload key to {} with no separately-supplied body", async () => {
+    const result = await callSubnetSurface(
+      { url: "https://example.com/openapi.json" },
+      {
+        path: "/miner/openrouter-key/delete",
+        method: "POST",
+        contentType: "application/json",
+        credential: {
+          location: "body",
+          values: { signer_ss58: "5F...", nonce: "abc", signature: "0xabc" },
+          bodyEnvelope: { payloadKey: "payload", credentialKey: "sig" },
+        },
+        isUnsafeUrl: SAFE,
+        fetchImpl: async (url, init) => {
+          assert.deepEqual(JSON.parse(init.body), {
+            payload: {},
+            sig: { signer_ss58: "5F...", nonce: "abc", signature: "0xabc" },
+          });
+          return jsonResponse({});
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+  });
+
   test("credential bundle: query values are all redacted in the returned url", async () => {
     const result = await callSubnetSurface(
       { url: "https://example.com/api" },


### PR DESCRIPTION
## Summary

- Adds an optional `auth.body_envelope: {payload_key, credential_key}` to the surface schema, valid alongside `auth.scheme:"signature"` + `auth.location:"body"`.
- When set, `callSubnetSurface` builds `{[payload_key]: <body arg, or {} when absent>, [credential_key]: <the credential bundle, as its own nested object>}` instead of the existing flat top-level merge.
- `auth.names` is unaffected -- it still lists the credential bundle's own field names, independent of the wrapper shape.
- A malformed `body_envelope` (missing either key) falls back to the existing flat-merge behavior rather than crashing.

## Why

Auditing `auth.scheme:"custom"` surfaces for signature-scheme reclassification found soma (SN114)'s `/miner/openrouter-key/*` surfaces use a genuinely different body shape than Phase 4's flat merge: the target API's own OpenAPI spec (`SignedEnvelope_dict_`) declares the request body as a nested envelope --

```json
{
  "payload": { ...semantic request data... },
  "sig": { "signer_ss58": "...", "nonce": "...", "signature": "..." }
}
```

Forcing this through the existing flat merge would silently produce a wrong, incompatible request body (credential fields landing as flat top-level siblings of `payload` instead of nested under `sig`).

Closes #7716.

## Test plan

- [x] `npx vitest run tests/call-subnet-surface.test.mjs` -- 78 tests, including 2 new (envelope with a supplied body, envelope defaulting the payload to `{}`).
- [x] `npx vitest run tests/call-subnet-surface-mcp.test.mjs` -- 70 tests, including 3 new (envelope nesting end-to-end, envelope defaulting, malformed-envelope fallback).
- [x] Full repo suite: `npm test` -- 474 files, 11,317 tests, all passing.
- [x] `npm run build` -- schema bundle, OpenAPI/types/client regenerated and committed; `npm run validate:contract-drift` passes.
- [x] `node scripts/scan-public-safety.mjs` -- clean.
- [x] `npx prettier --check` on every touched file -- clean.
- [x] Coverage: 100% statements, 99.4%+ branches on both `call-subnet-surface.mjs` and the new `mcp-server.mjs` region (zero gaps in new code; the one remaining gap on each file is the same pre-existing, untouched branch flagged in prior PRs).