### PR TITLE
fix(registry): reclassify beam's epoch-summary surface to auth.scheme signature

### DIFF
--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -404,8 +404,16 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires validator signature headers; the exact format is not fully documented by the subnet. Contact the subnet operator for details."
+        "scheme": "signature",
+        "scopes_note": "Requires a hotkey-signed request: the X-Validator-Hotkey, X-Validator-Signature, X-Validator-Timestamp, X-Validator-Nonce, and X-Validator-Action headers proving control of a registered hotkey -- X-Validator-Action must be the exact literal string \"epoch_summary\" for this route, since it's part of the signed message. Confirmed live 2026-07-22: supplying all five moves the error from \"missing validator signature headers\" to a signature-byte-length check. No bearer token or API key is accepted, despite this API's own OpenAPI spec declaring an unused x-api-key scheme.",
+        "location": "header",
+        "names": [
+          "X-Validator-Hotkey",
+          "X-Validator-Signature",
+          "X-Validator-Timestamp",
+          "X-Validator-Nonce",
+          "X-Validator-Action"
+        ]
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- Reclassifies `sn-105-beam-validator-epoch-summary-latest-epoch` from `auth.scheme:"custom"` to `auth.scheme:"signature"`, with `auth.names: ["X-Validator-Hotkey", "X-Validator-Signature", "X-Validator-Timestamp", "X-Validator-Nonce", "X-Validator-Action"]`.
- Only the `auth` object changes -- verified by a deep-equal diff against every other field.

## Why

Beam's own public GitHub repo ([Beam-Network/beam](https://github.com/Beam-Network/beam), `neurons/validator/clients/subnet_core_client.py`) shows `GET /Validator/epoch-summary/latest-epoch` authenticates via `build_signed_auth_headers()`: the five headers above, with `X-Validator-Action` baked into the signed message as the literal string `"epoch_summary"` for this specific route.

Live-verified 2026-07-22: supplying all five (with a dummy signature) moves the error from `{"error":"missing validator signature headers"}` to `{"message":"Invalid signature length, expected [64..66] bytes, found 4"}` -- confirming the header set is complete and correctly named, despite this API's own OpenAPI spec declaring an unused `x-api-key` scheme that doesn't actually gate anything.

**Deliberately not touching the sibling `sn-105-beam-validators-weights-epoch` surface** -- the source repo's client only calls a different route (`POST /validators/weights/proof`), so the correct `X-Validator-Action` value for the `GET /validators/weights/{epoch}` route isn't confirmed by any available evidence. Left as `"custom"` rather than guess.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/beam.json` -- passes (31 surfaces).
- [x] Deep-equal check: exactly 1 `auth` object changed, zero drift on any other field.
- [x] `node scripts/scan-public-safety.mjs` -- clean.
- [x] `npx prettier --check registry/subnets/beam.json` -- clean.