### PR TITLE
fix(registry): reclassify minotaur's 2 surfaces to auth.scheme signature

### DIFF
--- a/registry/subnets/minotaur.json
+++ b/registry/subnets/minotaur.json
@@ -235,8 +235,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request per the subnet's documented App-management auth model; not a static API key or bearer token."
+        "scheme": "signature",
+        "scopes_note": "Requires an EIP-712 wallet-signed request: the X-App-Auth-Signer, X-App-Auth-Signature, and X-App-Auth-Deadline headers, documented in the subnet's own official app-management API reference (docs/api/app-management.md) -- reads (this route among them) are deadline-bound only, unlike writes which additionally need a single-use X-App-Auth-Nonce. The signature must be an EIP-712 signature from an allowed signer (the app's own deployer or an operator admin address) over a paramsHash binding this request's specific parameters -- computing it is the caller's own responsibility. Live-verified 2026-07-22: an unauthenticated request returns HTTP 403. No admin key or bearer token is accepted for this route.",
+        "location": "header",
+        "names": [
+          "X-App-Auth-Signer",
+          "X-App-Auth-Signature",
+          "X-App-Auth-Deadline"
+        ]
       },
       "auth_required": true,
       "authority": "community",
@@ -263,8 +269,14 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "Requires a signed request per the subnet's documented App-management auth model; not a static API key or bearer token."
+        "scheme": "signature",
+        "scopes_note": "Requires an EIP-712 wallet-signed request: the X-App-Auth-Signer, X-App-Auth-Signature, and X-App-Auth-Deadline headers, documented in the subnet's own official app-management API reference (docs/api/app-management.md) -- reads (this route among them) are deadline-bound only, unlike writes which additionally need a single-use X-App-Auth-Nonce. The signature must be an EIP-712 signature from an allowed signer (the app's own deployer or an operator admin address) over a paramsHash binding this request's specific parameters -- computing it is the caller's own responsibility. Live-verified 2026-07-22: an unauthenticated request returns HTTP 403. No admin key or bearer token is accepted for this route.",
+        "location": "header",
+        "names": [
+          "X-App-Auth-Signer",
+          "X-App-Auth-Signature",
+          "X-App-Auth-Deadline"
+        ]
       },
       "auth_required": true,
       "authority": "community",


### PR DESCRIPTION
## Summary

- Reclassifies both `minotaur.json` app-management surfaces (`admin-state`, `registry-calldata`) from `auth.scheme:"custom"` to `auth.scheme:"signature"`, with `auth.names: ["X-App-Auth-Signer", "X-App-Auth-Signature", "X-App-Auth-Deadline"]`.
- Only the `auth` object changes per surface -- verified by a deep-equal diff against every other field.

## Why

Minotaur's own official API reference ([`docs/api/app-management.md`](https://github.com/subnet112/minotaur_subnet/blob/main/docs/api/app-management.md)) documents the exact "Wallet-signature headers (app-management endpoints)" and explicitly notes: **"reads (`admin-state`, `registry-calldata`) are deadline-bound only"** -- unlike writes, which additionally need a single-use `X-App-Auth-Nonce`. Both of these registered surfaces are GET reads, matching exactly.

The signature is an EIP-712 signature over a `paramsHash` binding the request's specific parameters, from an allowed signer (the app's own deployer or an operator admin address) -- computing it correctly is the caller's own responsibility, same as every other signature-scheme surface; this tool never signs anything itself.

Live-verified 2026-07-22 (already recorded in this file's own notes from the original investigation): an unauthenticated request returns `HTTP 403`.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/minotaur.json` -- passes (11 surfaces).
- [x] Deep-equal check: exactly 2 `auth` objects changed, zero drift on any other field.
- [x] `node scripts/scan-public-safety.mjs` -- clean.
- [x] `npx prettier --check registry/subnets/minotaur.json` -- clean.