### PR TITLE
fix(registry): reclassify tensorusd's schema surface to auth.scheme basic

### DIFF
--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -186,8 +186,11 @@
     },
     {
       "auth": {
-        "scheme": "custom",
-        "scopes_note": "The exact credential mechanism is not publicly documented by the subnet; this endpoint requires authentication to access."
+        "scheme": "basic",
+        "scopes_note": "Requires HTTP Basic Authentication (live-verified 2026-07-22: an unauthenticated request returns HTTP 401 with a \"WWW-Authenticate: Basic\" challenge header). No bearer token, API key, or hotkey-signed request is accepted for this route.",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Basic <base64(username:password)>"
       },
       "auth_required": true,
       "authority": "community",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11066,7 +11066,7 @@ export const MCP_TOOLS = [
         credential: {
           type: ["string", "object"],
           description:
-            "Credential for an auth_required surface -- see this surface's auth details (list_subnet_apis/get_api_schema) for which shape it needs. For auth.scheme bearer/api-key: a single string, already formatted per auth.value_format (e.g. \"Bearer <token>\"). For auth.scheme signature (e.g. a Bittensor hotkey-signed request): an object mapping every name in auth.names to a value YOU have already computed -- this tool never signs anything itself, you must compute the signature yourself (with your own wallet/key, exactly as if calling the subnet directly) before calling this tool; the object's keys must exactly match auth.names, no more, no fewer. Any other scheme (custom, or incompletely documented) is rejected. Never obtains a credential on your behalf, never stores or reuses one past this single call.",
+            'Credential for an auth_required surface -- see this surface\'s auth details (list_subnet_apis/get_api_schema) for which shape it needs. For auth.scheme bearer/api-key/basic: a single string, already formatted per auth.value_format (e.g. "Bearer <token>" or "Basic <base64(username:password)>"). For auth.scheme signature (e.g. a Bittensor hotkey-signed request): an object mapping every name in auth.names to a value YOU have already computed -- this tool never signs anything itself, you must compute the signature yourself (with your own wallet/key, exactly as if calling the subnet directly) before calling this tool; the object\'s keys must exactly match auth.names, no more, no fewer. Any other scheme (custom, oauth2, or incompletely documented) is rejected. Never obtains a credential on your behalf, never stores or reuses one past this single call.',
         },
       },
       required: ["surface_id"],
@@ -11161,7 +11161,7 @@ export const MCP_TOOLS = [
         }
         const scheme = surface.auth?.scheme;
         const location = surface.auth?.location;
-        if (scheme === "bearer" || scheme === "api-key") {
+        if (scheme === "bearer" || scheme === "api-key" || scheme === "basic") {
           const name = surface.auth?.name;
           if (
             !name ||
@@ -11266,7 +11266,7 @@ export const MCP_TOOLS = [
         } else {
           throw toolError(
             "credential_not_supported",
-            `This surface's auth scheme ("${scheme || "undocumented"}") is not one this tool can attach a credential to (only bearer/api-key/signature are supported). Use list_subnet_apis / how_do_i_call to see how to call it directly.`,
+            `This surface's auth scheme ("${scheme || "undocumented"}") is not one this tool can attach a credential to (only bearer/api-key/basic/signature are supported). Use list_subnet_apis / how_do_i_call to see how to call it directly.`,
           );
         }
       }

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -138,6 +138,24 @@ const API_KEY_QUERY_SURFACE = {
   probe: { method: "GET", enabled: true },
 };
 
+// #7722: auth.scheme:"basic" -- plain HTTP Basic Auth, same single-value
+// shape as bearer/api-key (a pre-computed opaque string), just a different
+// value_format convention.
+const BASIC_AUTH_SURFACE = {
+  surface_id: "x:api:21",
+  netuid: 25,
+  kind: "subnet-api",
+  url: "https://x.example/basic-gated",
+  auth_required: true,
+  auth: {
+    scheme: "basic",
+    location: "header",
+    name: "Authorization",
+    value_format: "Basic <base64(username:password)>",
+  },
+  probe: { method: "GET", enabled: true },
+};
+
 const CUSTOM_AUTH_SURFACE = {
   surface_id: "x:api:8",
   netuid: 12,
@@ -319,6 +337,7 @@ const CATALOG = {
     SELF_SCHEMA_SURFACE,
     BEARER_SURFACE,
     API_KEY_QUERY_SURFACE,
+    BASIC_AUTH_SURFACE,
     CUSTOM_AUTH_SURFACE,
     INCOMPLETE_AUTH_SURFACE,
     DISABLED_PROBE_BEARER_SURFACE,
@@ -872,6 +891,35 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       );
       assert.equal(result.isError, false);
       assert.equal(new URL(requestedUrl).searchParams.get("api_key"), "abc123");
+    });
+
+    test("a basic-auth surface with a credential injects it as the documented header (#7722)", async () => {
+      let sentHeader;
+      const result = await callTool(
+        {
+          surface_id: "x:api:21",
+          credential: "Basic dXNlcjpwYXNz",
+        },
+        async (url, init) => {
+          sentHeader = init.headers.Authorization;
+          return new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      );
+      assert.equal(result.isError, false);
+      assert.equal(sentHeader, "Basic dXNlcjpwYXNz");
+    });
+
+    test("an object credential on a basic-auth surface is invalid_params -- basic requires a string", async () => {
+      const result = await callTool({
+        surface_id: "x:api:21",
+        credential: { user: "u", pass: "p" },
+      });
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /invalid_params/);
+      assert.match(result.content[0].text, /not an object/);
     });
 
     test("no credential on an auth_required surface is still auth_required (Phase 1/2 unchanged)", async () => {


### PR DESCRIPTION
## Summary

- Reclassifies `sn-113-tensorusd-api-openapi` from `auth.scheme:"custom"` to `auth.scheme:"basic"`, `auth.location:"header"`, `auth.name:"Authorization"`, `auth.value_format:"Basic <base64(username:password)>"`.
- Only the `auth` object changes -- verified by a deep-equal diff against every other field.

## Why

Live-verified 2026-07-22: `GET https://api.tensorusd.com/api/openapi.json` returns `HTTP 401` with a `WWW-Authenticate: Basic` response header -- plain HTTP Basic Authentication, not an undocumented custom scheme.

**Depends on #7723** (wires up `auth.scheme:"basic"` credential passthrough, which was previously schema-only) -- based on that branch. Merge #7723 first.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/tensorusd.json` -- passes (8 surfaces).
- [x] Deep-equal check: exactly 1 `auth` object changed, zero drift on any other field.
- [x] `node scripts/scan-public-safety.mjs` -- clean.
- [x] `npx prettier --check registry/subnets/tensorusd.json` -- clean.