### PR TITLE
feat(telemetry): categorize MCP tool-call failures with an error_code property (#7726)

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -16240,10 +16240,20 @@ function negotiateProtocol(requested) {
 async function callTool(params, ctx) {
   const startedAt = Date.now();
   const result = await dispatchTool(params, ctx);
+  // #7726: thread the failure's categorized code (already present on every
+  // toolError-produced result, plus the unknown_tool branch below) into the
+  // usage event -- always one of the fixed literal codes, never caller
+  // content -- so PostHog can show WHY a call failed, not just that it did.
+  const errorCode =
+    result.isError === true &&
+    typeof result.structuredContent?.error?.code === "string"
+      ? result.structuredContent.error.code
+      : undefined;
   scheduleToolUsageEvent(ctx, {
     mcpTool: typeof params?.name === "string" ? params.name : undefined,
     ok: result.isError !== true,
     durationMs: Date.now() - startedAt,
+    ...(errorCode !== undefined ? { errorCode } : {}),
   });
   return result;
 }
@@ -16272,6 +16282,15 @@ async function dispatchTool(params, ctx) {
   if (!tool) {
     return {
       content: [{ type: "text", text: `Unknown tool: ${String(name)}` }],
+      // #7726: the one failure branch that doesn't go through toolError still
+      // carries a stable machine-readable code, so every failure category is
+      // represented in structuredContent.error and usage telemetry alike.
+      structuredContent: {
+        error: {
+          code: "unknown_tool",
+          message: `Unknown tool: ${String(name)}`,
+        },
+      },
       isError: true,
     };
   }

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -35,12 +35,16 @@ export const USAGE_EVENT_NAME = "usage_event";
 const MAX_LABEL_CHARS = 256;
 
 /** REST/GraphQL route path (no query string / bodies) or MCP tool name (no
- * arguments / response content); ok/durationMs describe the outcome. */
+ * arguments / response content); ok/durationMs describe the outcome.
+ * errorCode is the failure's categorized toolError code (one of the fixed
+ * literal codes like invalid_params / rate_limited — never caller-derived
+ * content), present only for failed calls (#7726). */
 export interface UsageEvent {
   route?: string;
   mcpTool?: string;
   ok: boolean;
   durationMs: number;
+  errorCode?: string;
 }
 
 /** Public capture endpoint, appended to the resolved PostHog host. */
@@ -89,6 +93,12 @@ export function usageEventProperties(
 
   const mcpTool = sanitizeLabel(event.mcpTool);
   if (mcpTool !== undefined) properties.mcp_tool = mcpTool;
+
+  // #7726: categorized failure code (PostHog object_adjective naming), same
+  // privacy-preserving cap as the other labels; omitted entirely when absent
+  // so the successful-call event shape is unchanged.
+  const errorCode = sanitizeLabel(event.errorCode);
+  if (errorCode !== undefined) properties.error_code = errorCode;
 
   return properties;
 }

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -1436,5 +1436,58 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       ]);
       assert.equal(recorded[0].mcpTool, "call_subnet_surface");
     });
+
+    // #7726: the same holds for a FAILING credentialed call — error_code is
+    // always one of the fixed literal toolError codes (mirrored verbatim from
+    // structuredContent.error.code), never caller-derived content, so it can
+    // never become a vector for leaking credential data.
+    test("a failing credentialed call records a fixed literal errorCode, never credential data", async () => {
+      const recorded = [];
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "call_subnet_surface",
+              arguments: {
+                surface_id: "no-such-surface-id",
+                credential: "Bearer super-secret-abc123",
+              },
+            },
+          }),
+        }),
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" },
+        {
+          ...deps,
+          executionCtx: { waitUntil: (p) => p },
+          recordUsageEvent: async (_env, event) => {
+            recorded.push(event);
+            return true;
+          },
+        },
+      );
+      const payload = await response.json();
+      assert.equal(payload.result.isError, true);
+      assert.equal(recorded.length, 1);
+      const serialized = JSON.stringify(recorded[0]);
+      assert.ok(!serialized.includes("super-secret-abc123"));
+      assert.deepEqual(Object.keys(recorded[0]).sort(), [
+        "durationMs",
+        "errorCode",
+        "mcpTool",
+        "ok",
+      ]);
+      assert.equal(recorded[0].ok, false);
+      assert.equal(
+        recorded[0].errorCode,
+        payload.result.structuredContent.error.code,
+      );
+      // A fixed literal category, not free-form text.
+      assert.match(recorded[0].errorCode, /^[a-z_]+$/);
+    });
   });
 });

--- a/tests/mcp-usage-telemetry.test.mjs
+++ b/tests/mcp-usage-telemetry.test.mjs
@@ -103,6 +103,10 @@ describe("MCP tool-dispatch usage telemetry", () => {
     assert.equal(spy.events.length, 1);
     assert.equal(spy.events[0].event.mcpTool, "no_such_tool_at_all");
     assert.equal(spy.events[0].event.ok, false);
+    // #7726: the unknown-tool branch carries its own stable code, in both the
+    // structuredContent contract and the usage event.
+    assert.equal(payload.result.structuredContent.error.code, "unknown_tool");
+    assert.equal(spy.events[0].event.errorCode, "unknown_tool");
   });
 
   test("records a failing tool as a failure", async () => {
@@ -120,6 +124,25 @@ describe("MCP tool-dispatch usage telemetry", () => {
     assert.equal(payload.result.isError, true);
     assert.equal(spy.events.length, 1);
     assert.equal(spy.events[0].event.ok, false);
+    // #7726: the toolError's categorized code is threaded into the event,
+    // matching the machine-readable structuredContent contract exactly.
+    assert.equal(
+      spy.events[0].event.errorCode,
+      payload.result.structuredContent.error.code,
+    );
+    assert.equal(spy.events[0].event.errorCode, "invalid_params");
+  });
+
+  test("a successful call carries no errorCode at all (#7726)", async () => {
+    const spy = recorder();
+    const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, {
+      executionCtx: fakeExecutionCtx(),
+      recordUsageEvent: spy.recordUsageEvent,
+    });
+
+    assert.equal(payload.result.isError, false);
+    assert.equal(spy.events.length, 1);
+    assert.equal("errorCode" in spy.events[0].event, false);
   });
 
   test("does no telemetry work when the deployment is unconfigured", async () => {

--- a/tests/usage-telemetry.test.mjs
+++ b/tests/usage-telemetry.test.mjs
@@ -105,6 +105,42 @@ describe("usageEventProperties", () => {
       86_400_000,
     );
   });
+
+  // #7726: categorized failure code, same cap as the other labels, omitted
+  // entirely when absent so the successful-call event shape is unchanged.
+  test("adds error_code only when present, capped like the other labels", () => {
+    assert.deepEqual(
+      usageEventProperties({
+        mcpTool: "get_subnet",
+        ok: false,
+        durationMs: 5,
+        errorCode: " invalid_params ",
+      }),
+      {
+        mcp_tool: "get_subnet",
+        ok: false,
+        duration_ms: 5,
+        error_code: "invalid_params",
+      },
+    );
+    assert.equal(
+      "error_code" in usageEventProperties({ ok: true, durationMs: 5 }),
+      false,
+    );
+    assert.equal(
+      "error_code" in
+        usageEventProperties({ ok: false, durationMs: 5, errorCode: "   " }),
+      false,
+    );
+    assert.equal(
+      usageEventProperties({
+        ok: false,
+        durationMs: 5,
+        errorCode: "e".repeat(300),
+      }).error_code,
+      "e".repeat(256),
+    );
+  });
 });
 
 describe("resolvePostHogHost", () => {


### PR DESCRIPTION
## Summary

Implements #7726 exactly as scoped: every failed MCP `tools/call` now records its categorized `error_code` in the PostHog usage event — always one of the fixed literal `toolError` codes, never caller-derived content — so aggregate analytics can show *why* calls fail, not just that they did.

Closes #7726.

## What changed (2 source files + 3 test files)

- **`src/usage-telemetry.ts`** — optional `errorCode?: string` on `UsageEvent`; `usageEventProperties()` adds a snake_case `error_code` (PostHog `object_adjective` convention) **only when present**, through the same 256-char privacy cap (`sanitizeLabel`) as the other labels — the successful-call event shape is byte-for-byte unchanged.
- **`src/mcp-server.mjs`** — `callTool` (the single `tools/call` chokepoint) mirrors `result.structuredContent.error.code` into the usage event when `isError`. The **unknown-tool early return** — the one failure branch that bypasses `toolError` — now carries its own `structuredContent.error.code: "unknown_tool"`, so every failure category is represented in the machine-readable contract and telemetry alike (the internal-error catch already carried `internal_error`).
- **Tests** (all three files the issue names):
  - `tests/usage-telemetry.test.mjs` — `error_code` presence, trim/cap at 256, omission for successful/blank/absent.
  - `tests/mcp-usage-telemetry.test.mjs` — a failing tool threads `invalid_params` matching `structuredContent.error.code` exactly; the unknown-tool branch records `unknown_tool` in both places; a successful call carries **no** `errorCode` key at all.
  - `tests/call-subnet-surface-mcp.test.mjs` — the #7687 credential regression extended to a **failing** credentialed call: the recorded event's serialized form contains no credential material, its key set is exactly `{durationMs, errorCode, mcpTool, ok}`, and `errorCode` mirrors the fixed literal code (`/^[a-z_]+$/`) — proving `error_code` cannot become a credential-leak vector.

## Out of scope (per the issue)

REST/GraphQL route events and Sentry are untouched.

## Validation

- [x] `npx vitest run` on the three named test files — **100 passing**
- [x] `npx vitest run tests/mcp-server.test.mjs` — **1189 passing** (callTool/dispatchTool consumers unaffected)
- [x] `node scripts/validate-mcp.mjs` — passed (200 tools, full lifecycle)
- [x] `node --check src/mcp-server.mjs`; `eslint` + repo-pinned `prettier --check` (LF-staged, per-extension parser) — clean
