### PR TITLE
fix(observability): capture AI-route failures to Sentry in workers/api.mjs

### DIFF
--- a/tests/api-ai-routes-sentry.test.mjs
+++ b/tests/api-ai-routes-sentry.test.mjs
@@ -1,0 +1,100 @@
+// metagraphed#7731: confirms captureAiRouteError (workers/api.mjs) actually
+// reaches Sentry for a genuine AI-backend failure on /api/v1/search/semantic
+// and /api/v1/ask, and stays silent for an expected, caller-fixable input
+// rejection (the `aiInput` branch). A separate small file rather than folded
+// into tests/ai-search.test.mjs: vi.mock is file-scoped and hoisted, and that
+// file's other ~80 tests already exercise these same routes through the real
+// (unmocked) Sentry no-op path -- mocking it there risks disturbing tests
+// this issue doesn't own. Mirrors tests/mcp-server-sentry-args-safety.test.mjs's
+// same rationale for src/mcp-server.mjs.
+import assert from "node:assert/strict";
+import { afterEach, test, vi } from "vitest";
+
+const captureException = vi.hoisted(() => vi.fn());
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException,
+}));
+
+const { handleRequest } = await import("../workers/api.mjs");
+const { createLocalArtifactEnv } = await import("../scripts/lib.ts");
+
+afterEach(() => {
+  captureException.mockClear();
+});
+
+const SEMANTIC_URL = "https://api.metagraph.sh/api/v1/search/semantic";
+const ASK_URL = "https://api.metagraph.sh/api/v1/ask";
+
+function stubAi(run) {
+  return { run };
+}
+
+function aiWorkerEnv(overrides = {}) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ENABLE_AI: "true",
+    AI: stubAi(() => Promise.resolve({ response: "ok" })),
+    VECTORIZE: {
+      query: () => Promise.resolve({ matches: [] }),
+      upsert: () => Promise.resolve({ count: 0 }),
+      deleteByIds: () => Promise.resolve({ count: 0 }),
+    },
+    ...overrides,
+  };
+}
+
+test("a semantic-search backend failure reaches Sentry, tagged by route", async () => {
+  const env = aiWorkerEnv({
+    AI: stubAi(() => Promise.reject(new Error("model down"))),
+  });
+  const res = await handleRequest(new Request(`${SEMANTIC_URL}?q=x`), env, {});
+  assert.equal(res.status, 502);
+  assert.equal((await res.json()).error.code, "ai_error");
+  assert.equal(captureException.mock.calls.length, 1);
+  const [capturedError, context] = captureException.mock.calls[0];
+  assert.equal(capturedError.message, "model down");
+  assert.deepEqual(context, { tags: { route: "semantic_search" } });
+});
+
+test("an ask backend failure reaches Sentry, tagged by route", async () => {
+  const env = aiWorkerEnv({
+    AI: stubAi(() => Promise.reject(new Error("model down"))),
+  });
+  const res = await handleRequest(
+    new Request(ASK_URL, {
+      method: "POST",
+      body: JSON.stringify({ question: "x" }),
+    }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 502);
+  assert.equal(captureException.mock.calls.length, 1);
+  const [capturedError, context] = captureException.mock.calls[0];
+  assert.equal(capturedError.message, "model down");
+  assert.deepEqual(context, { tags: { route: "ask" } });
+});
+
+test("a caller-input rejection (aiInput) on either route never reaches Sentry", async () => {
+  const env = aiWorkerEnv();
+  const semanticRes = await handleRequest(
+    new Request(`${SEMANTIC_URL}?q=x&type=bogus`),
+    env,
+    {},
+  );
+  assert.equal(semanticRes.status, 400);
+  const askRes = await handleRequest(
+    new Request(ASK_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ question: "which?", type: "bogus" }),
+    }),
+    env,
+    {},
+  );
+  assert.equal(askRes.status, 400);
+  // Expected, caller-fixable input errors -- not exceptional, must never
+  // count as a Sentry-worthy fault.
+  assert.equal(captureException.mock.calls.length, 0);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/cloudflare";
 import {
   API_QUERY_COLLECTIONS,
   API_ROUTES,
@@ -4766,6 +4767,20 @@ async function handleEventsRequest(request, env) {
 
 // --- AI search / ask (semantic + RAG) --------------------------------------
 
+// metagraphed#7731: this Worker's own equivalent of data-api.mjs's
+// captureDataApiError (#6769) -- a caught error converted to a clean
+// errorResponse() here never reaches Sentry via api.sentry.ts's withSentry()
+// wrap, since that only instruments genuinely UNCAUGHT exceptions. The AI
+// routes below are the only two places in this file that catch a real
+// (non-caller-input) failure and swallow it into a clean 502; every other
+// catch block either handles an expected condition inline or re-throws to
+// the top-level wrap. Sentry.captureException is a safe no-op with no
+// active client (confirmed live, same as captureDataApiError's own note),
+// which is every test importing this raw handler directly.
+function captureAiRouteError(error, route) {
+  Sentry.captureException(error, { tags: { route } });
+}
+
 function aiUnavailableResponse() {
   return errorResponse(
     "ai_unavailable",
@@ -4867,6 +4882,7 @@ async function handleSemanticSearchRequest(request, env, url) {
     logEvent(env, "error", "semantic_search_failed", {
       message: error?.message,
     });
+    captureAiRouteError(error, "semantic_search");
     return errorResponse(
       "ai_error",
       "Semantic search failed. Please retry shortly.",
@@ -4932,6 +4948,7 @@ async function handleAskRequest(request, env) {
       return errorResponse("invalid_request", error.message, 400);
     }
     logEvent(env, "error", "ask_failed", { message: error?.message });
+    captureAiRouteError(error, "ask");
     return errorResponse(
       "ai_error",
       "The answer service failed. Please retry shortly.",


### PR DESCRIPTION
## Summary

- Adds `captureAiRouteError(error, route)` to `workers/api.mjs`, mirroring `data-api.mjs`'s own `captureDataApiError` helper (#6769).
- Calls it in both AI routes' (`handleSemanticSearchRequest`, `handleAskRequest`) genuine-internal-failure branches -- not the separate `error?.aiInput` caller-input branch, which is expected/handled, not exceptional.

## Why

Auditing Sentry error-visibility coverage across the REST/GraphQL Worker (after building MCP's error_code telemetry, #7726) found a gap structurally identical to one `data-api.mjs` already fixed once: a caught error converted into a clean `errorResponse()` never reaches Sentry, since `api.sentry.ts`'s `withSentry()` wrap only instruments genuinely *uncaught* exceptions.

Confirmed via a full scan of the file (comment false-positives excluded): `workers/api.mjs` has exactly 3 real `try/catch` blocks. One safely re-throws to the top-level wrap; the other two -- the AI routes -- catch a genuine internal failure and swallow it into a clean 502 with only `logEvent()` (Wrangler-log-only, not Sentry) for visibility. The file had zero Sentry import and zero manual capture anywhere before this.

`workers/data-api.mjs` needed no changes -- audited the same way: every one of its 27 real catch blocks either calls `captureDataApiError` directly or funnels into an outer catch that does. `workers/registry-sync-api.ts` not yet audited, flagged as a possible follow-up.

Closes #7731.

## Test plan

- [x] New dedicated `tests/api-ai-routes-sentry.test.mjs` (separate from the large shared `tests/ai-search.test.mjs`, matching `tests/mcp-server-sentry-args-safety.test.mjs`'s own established rationale for why `vi.mock` needs its own file) -- 3 tests: both routes' genuine failures reach Sentry tagged by route, and a caller-input rejection on either route does not.
- [x] `npx vitest run tests/api-ai-routes-sentry.test.mjs tests/ai-search.test.mjs tests/data-api.test.mjs` -- 612 tests, all passing.
- [x] Full repo suite: `npm test` -- 475 files, 11,328 tests, all passing.
- [x] Coverage: 100% on every changed line.
- [x] `npx tsc --noEmit`, `node scripts/scan-public-safety.mjs`, `npx prettier --check` -- all clean.