### PR TITLE
feat(observability): thread x-metagraph-error-code into REST usage telemetry

### DIFF
--- a/tests/request-usage-telemetry.test.mjs
+++ b/tests/request-usage-telemetry.test.mjs
@@ -181,6 +181,68 @@ describe("withUsageTelemetry", () => {
     assert.equal(broken.events[0].event.ok, false);
   });
 
+  // metagraphed#7733: threads errorResponse()'s own x-metagraph-error-code
+  // header into usage telemetry -- the same established code every REST
+  // route handler already sets, not a new taxonomy, and does not change the
+  // ok:true-for-4xx semantics the test above locks in.
+  test("threads x-metagraph-error-code into errorCode, without changing the ok/4xx semantics", async () => {
+    const spy = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () =>
+        new Response("nope", {
+          status: 400,
+          headers: { "x-metagraph-error-code": "invalid_query" },
+        }),
+      spy,
+    );
+    assert.equal(spy.events[0].event.ok, true);
+    assert.equal(spy.events[0].event.errorCode, "invalid_query");
+  });
+
+  test("threads errorCode for a 5xx too, alongside ok:false", async () => {
+    const spy = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () =>
+        new Response("boom", {
+          status: 502,
+          headers: { "x-metagraph-error-code": "data_query_failed" },
+        }),
+      spy,
+    );
+    assert.equal(spy.events[0].event.ok, false);
+    assert.equal(spy.events[0].event.errorCode, "data_query_failed");
+  });
+
+  test("omits errorCode entirely when the response carries no error-code header", async () => {
+    const success = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("ok", { status: 200 }),
+      success,
+    );
+    assert.equal("errorCode" in success.events[0].event, false);
+
+    // A route that predates the x-metagraph-error-code convention (or a
+    // plain non-JSON error) must not surface a stale/empty errorCode either.
+    const uncoded = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("nope", { status: 404 }),
+      uncoded,
+    );
+    assert.equal("errorCode" in uncoded.events[0].event, false);
+  });
+
   test("does not record a subscription upgrade as a request", async () => {
     const spy = recorder();
     const response = await withUsageTelemetry(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -570,17 +570,26 @@ export async function withUsageTelemetry(request, env, ctx, handle, deps = {}) {
 
   const startedAt = Date.now();
   let ok = false;
+  // metagraphed#7733: errorResponse() (workers/http.ts) already sets this on
+  // every REST error -- the same established code (invalid_query,
+  // method_not_allowed, ai_error, ...) every route handler already uses, not
+  // a new taxonomy. Undefined for a success response or one that predates
+  // this convention, same "omitted, not just falsy" contract as MCP's
+  // errorCode (#7726).
+  let errorCode;
   try {
     const response = await handle();
     // 4xx is a route correctly rejecting a bad request, not a broken route;
     // only 5xx (and a thrown handler, which leaves ok false) is a failure.
     ok = response.status < 500;
+    errorCode = response.headers.get("x-metagraph-error-code") ?? undefined;
     return response;
   } finally {
     scheduleUsageEvent(env, ctx, record, {
       route,
       ok,
       durationMs: Date.now() - startedAt,
+      ...(errorCode ? { errorCode } : {}),
     });
   }
 }


### PR DESCRIPTION
## Summary

- `withUsageTelemetry` now reads the existing `x-metagraph-error-code` response header (already set by `errorResponse()`, `workers/http.ts`, on every REST error) and threads it into `UsageEvent.errorCode` -- the same shared field already added for MCP (#7726).
- Present only for a response carrying the header; omitted entirely (not just falsy) otherwise.
- Deliberately does **not** change the existing `ok = status < 500` semantics (documented as "a 4xx is the route correctly rejecting a bad request, not a broken route") -- purely additive granularity.

## Why

`errorResponse()` already sets this header on every REST API error -- it's the established, existing error taxonomy across the whole REST surface (`invalid_query`, `invalid_request`, `method_not_allowed`, `payload_too_large`, `invalid_json`, `ai_error`, etc.), used consistently by every route handler already. `withUsageTelemetry` ignored it entirely, so PostHog could show *that* a REST route returned non-2xx, but not *which* of these established categories it was.

Closes #7733.

## Test plan

- [x] `npx vitest run tests/request-usage-telemetry.test.mjs` -- 22 tests, including 4 new: threading a 4xx code (ok stays true), a 5xx code (ok false), and omission for both a clean success and a response with no error-code header.
- [x] `npx vitest run tests/request-usage-telemetry.test.mjs tests/api-coverage.test.mjs` -- 305 tests, all passing.
- [x] Coverage: 100% on every changed line.
- [x] `npx tsc --noEmit`, `node scripts/scan-public-safety.mjs`, `npx prettier --check` -- all clean.