### PR TITLE
feat(observability): GraphQL Sentry capture, error_code, and ok-semantics fix

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -6,6 +6,7 @@ import {
   specifiedRules,
   validate,
 } from "graphql";
+import * as Sentry from "@sentry/cloudflare";
 import { readArtifact, readHealthKv } from "../workers/storage.ts";
 // #6986: GraphQL parity for source-snapshots, reusing list_source_snapshots'
 // own loader unchanged (same artifact read, filter, sort, and page logic REST
@@ -10146,10 +10147,19 @@ const rootValue = {
 const GRAPHQL_CONTENT_TYPE = "application/graphql-response+json";
 const SDL_CONTENT_TYPE = "application/graphql; charset=utf-8";
 
-const graphqlError = (message, status = 400, extraHeaders = {}) =>
+// metagraphed#7734: `code` mirrors errorResponse()'s own x-metagraph-error-code
+// convention (workers/http.ts, #7733) so withUsageTelemetry can categorize a
+// GraphQL transport-level rejection the same way it already does for every
+// REST route -- this file had no such header at all before. Required (every
+// call site below already has one), not optional -- no path should ever
+// produce an error response with no category.
+const graphqlError = (message, status, code, extraHeaders = {}) =>
   new Response(JSON.stringify({ errors: [{ message }] }), {
     status,
-    headers: graphqlHeaders(extraHeaders),
+    headers: graphqlHeaders({
+      "x-metagraph-error-code": code,
+      ...extraHeaders,
+    }),
   });
 
 const graphqlHeaders = (extra = {}) => ({
@@ -10167,12 +10177,20 @@ async function readLimitedJson(request) {
     const length = Number(declaredLength);
     if (!Number.isFinite(length) || length < 0) {
       return {
-        error: graphqlError("Invalid Content-Length header."),
+        error: graphqlError(
+          "Invalid Content-Length header.",
+          400,
+          "graphql_invalid_json",
+        ),
       };
     }
     if (length > GRAPHQL_MAX_BODY_BYTES) {
       return {
-        error: graphqlError("GraphQL request body is too large.", 413),
+        error: graphqlError(
+          "GraphQL request body is too large.",
+          413,
+          "graphql_payload_too_large",
+        ),
       };
     }
   }
@@ -10193,7 +10211,11 @@ async function readLimitedJson(request) {
       if (total > GRAPHQL_MAX_BODY_BYTES) {
         await reader.cancel();
         return {
-          error: graphqlError("GraphQL request body is too large.", 413),
+          error: graphqlError(
+            "GraphQL request body is too large.",
+            413,
+            "graphql_payload_too_large",
+          ),
         };
       }
       chunks.push(value);
@@ -10213,7 +10235,11 @@ async function readLimitedJson(request) {
     return { value: JSON.parse(new TextDecoder().decode(bytes)) };
   } catch {
     return {
-      error: graphqlError("Request body must be valid JSON."),
+      error: graphqlError(
+        "Request body must be valid JSON.",
+        400,
+        "graphql_invalid_json",
+      ),
     };
   }
 }
@@ -10248,7 +10274,10 @@ export async function handleGraphQLRequest(request, env) {
       }),
       {
         status: 405,
-        headers: graphqlHeaders({ allow: "GET, POST" }),
+        headers: graphqlHeaders({
+          allow: "GET, POST",
+          "x-metagraph-error-code": "graphql_bad_method",
+        }),
       },
     );
   }
@@ -10262,12 +10291,21 @@ export async function handleGraphQLRequest(request, env) {
       JSON.stringify({
         errors: [{ message: "Missing required field: query." }],
       }),
-      { status: 400, headers: graphqlHeaders() },
+      {
+        status: 400,
+        headers: graphqlHeaders({
+          "x-metagraph-error-code": "graphql_missing_query",
+        }),
+      },
     );
   }
 
   if (utf8ByteLength(query) > GRAPHQL_MAX_QUERY_BYTES) {
-    return graphqlError("GraphQL query is too large.", 413);
+    return graphqlError(
+      "GraphQL query is too large.",
+      413,
+      "graphql_payload_too_large",
+    );
   }
 
   let document;
@@ -10276,7 +10314,12 @@ export async function handleGraphQLRequest(request, env) {
   } catch (err) {
     return new Response(
       JSON.stringify({ errors: [{ message: err.message }] }),
-      { status: 400, headers: graphqlHeaders() },
+      {
+        status: 400,
+        headers: graphqlHeaders({
+          "x-metagraph-error-code": "graphql_parse_error",
+        }),
+      },
     );
   }
 
@@ -10293,7 +10336,12 @@ export async function handleGraphQLRequest(request, env) {
           extensions: e.extensions,
         })),
       }),
-      { status: 400, headers: graphqlHeaders() },
+      {
+        status: 400,
+        headers: graphqlHeaders({
+          "x-metagraph-error-code": "graphql_validation_error",
+        }),
+      },
     );
   }
 
@@ -10306,6 +10354,34 @@ export async function handleGraphQLRequest(request, env) {
     operationName: operationName ?? undefined,
   });
 
+  // metagraphed#7734: execute() catches every resolver throw into
+  // result.errors rather than letting it propagate -- api.sentry.ts's
+  // withSentry() (uncaught exceptions only) never sees any of these, so this
+  // is the only place a genuine resolver fault can reach Sentry at all. A
+  // deliberately-thrown `new GraphQLError(...)` (validation, "netuid must be
+  // non-negative", etc. -- expected, caller-fixable, the GraphQL analogue of
+  // a REST 4xx) is NOT the same as a resolver's raw Error wrapping a real
+  // backend failure -- both get an `originalError`, so presence alone can't
+  // tell them apart (confirmed directly against graphql-js's own execute(),
+  // not assumed). The one reliable signal: a deliberate throw's
+  // originalError is ITSELF a GraphQLError instance; a wrapped raw
+  // exception's is not.
+  const genuineFaults =
+    result.errors?.filter(
+      (e) => e.originalError && !(e.originalError instanceof GraphQLError),
+    ) ?? [];
+  for (const fault of genuineFaults) {
+    Sentry.captureException(fault.originalError, {
+      tags: { route: "graphql" },
+    });
+  }
+  const errorCode =
+    genuineFaults.length > 0
+      ? "graphql_execution_error"
+      : result.errors?.length
+        ? "graphql_field_error"
+        : undefined;
+
   return new Response(JSON.stringify(result), {
     status: 200,
     headers: graphqlHeaders({
@@ -10315,6 +10391,7 @@ export async function handleGraphQLRequest(request, env) {
         ? "no-store"
         : "public, max-age=60, stale-while-revalidate=300",
       vary: "Accept-Encoding",
+      ...(errorCode ? { "x-metagraph-error-code": errorCode } : {}),
     }),
   });
 }

--- a/tests/graphql-sentry-and-error-code.test.mjs
+++ b/tests/graphql-sentry-and-error-code.test.mjs
@@ -1,0 +1,204 @@
+// metagraphed#7734: confirms src/graphql.mjs's genuine-fault discriminator
+// (a resolver's raw Error, wrapped by execute() into result.errors, vs a
+// deliberately-thrown `new GraphQLError(...)` -- expected, caller-fixable
+// validation, the GraphQL analogue of a REST 4xx) actually reaches Sentry
+// only for the former, and that the x-metagraph-error-code response header
+// is set correctly across every transport- and execution-level error path.
+// A separate small file rather than folded into tests/graphql.test.mjs
+// (20k lines, ~900 tests): vi.mock is file-scoped and hoisted, and that
+// file's own tests already exercise these same paths through the real
+// (unmocked) Sentry no-op -- mocking it there risks disturbing tests this
+// issue doesn't own. Mirrors tests/mcp-server-sentry-args-safety.test.mjs's
+// and tests/api-ai-routes-sentry.test.mjs's own identical rationale.
+import assert from "node:assert/strict";
+import { afterEach, test, vi } from "vitest";
+
+const captureException = vi.hoisted(() => vi.fn());
+const resolveLiveEconomics = vi.hoisted(() => vi.fn());
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException,
+}));
+
+// loadEconomics (src/graphql.mjs) awaits resolveLiveEconomics with no
+// try/catch, and Query.economics awaits loadEconomics the same way -- a
+// rejection here propagates uncaught all the way to execute(), the exact
+// genuine-fault shape this file needs to trigger on demand. Every other
+// export of health-serving.ts passes through unmocked (importOriginal),
+// so no other resolver's behavior changes.
+vi.mock("../src/health-serving.ts", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, resolveLiveEconomics };
+});
+
+const {
+  handleGraphQLRequest,
+  GRAPHQL_MAX_BODY_BYTES,
+  GRAPHQL_MAX_QUERY_BYTES,
+} = await import("../src/graphql.mjs");
+
+afterEach(() => {
+  captureException.mockClear();
+  resolveLiveEconomics.mockReset();
+});
+
+const emptyEnv = {};
+
+async function gql(query, env = emptyEnv) {
+  const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+  const res = await handleGraphQLRequest(req, env);
+  return { res, body: await res.json() };
+}
+
+test("a resolver's genuine exception reaches Sentry and is tagged graphql_execution_error", async () => {
+  resolveLiveEconomics.mockRejectedValue(new Error("hyperdrive unavailable"));
+  const { res, body } = await gql("{ economics { total } }");
+
+  assert.equal(res.status, 200); // spec-mandated: errors ride a 200
+  assert.equal(
+    res.headers.get("x-metagraph-error-code"),
+    "graphql_execution_error",
+  );
+  assert.ok(body.errors?.length >= 1);
+
+  assert.equal(captureException.mock.calls.length, 1);
+  const [capturedError, context] = captureException.mock.calls[0];
+  assert.equal(capturedError.message, "hyperdrive unavailable");
+  assert.deepEqual(context, { tags: { route: "graphql" } });
+});
+
+test("a deliberate GraphQLError (bad user input) never reaches Sentry, tagged graphql_field_error", async () => {
+  const { res, body } = await gql(
+    "{ subnet_identity_history(netuid: -1) { __typename } }",
+  );
+
+  assert.equal(res.status, 200);
+  assert.equal(
+    res.headers.get("x-metagraph-error-code"),
+    "graphql_field_error",
+  );
+  assert.ok(body.errors?.[0]?.message.includes("non-negative"));
+  assert.equal(captureException.mock.calls.length, 0);
+});
+
+test("a clean success carries no error-code header and is not captured", async () => {
+  const { res, body } = await gql("{ __typename }");
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("x-metagraph-error-code"), null);
+  assert.equal(body.errors, undefined);
+  assert.equal(captureException.mock.calls.length, 0);
+});
+
+test("every transport-level rejection carries its own error code, none reach Sentry", async () => {
+  const cases = [
+    {
+      name: "bad method",
+      req: () =>
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "PUT",
+        }),
+      status: 405,
+      code: "graphql_bad_method",
+    },
+    {
+      name: "invalid Content-Length",
+      req: () =>
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "content-length": "not-a-number",
+          },
+          body: JSON.stringify({ query: "{ __typename }" }),
+        }),
+      status: 400,
+      code: "graphql_invalid_json",
+    },
+    {
+      name: "declared-too-large body",
+      req: () =>
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "content-length": String(GRAPHQL_MAX_BODY_BYTES + 1),
+          },
+          body: JSON.stringify({ query: "{ __typename }" }),
+        }),
+      status: 413,
+      code: "graphql_payload_too_large",
+    },
+    {
+      name: "invalid JSON body",
+      req: () =>
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "not json",
+        }),
+      status: 400,
+      code: "graphql_invalid_json",
+    },
+    {
+      name: "missing query field",
+      req: () =>
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({}),
+        }),
+      status: 400,
+      code: "graphql_missing_query",
+    },
+    {
+      name: "oversized query",
+      req: () =>
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            query: `# ${"x".repeat(GRAPHQL_MAX_QUERY_BYTES)}\n{ __typename }`,
+          }),
+        }),
+      status: 413,
+      code: "graphql_payload_too_large",
+    },
+    {
+      name: "parse error",
+      req: () =>
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ query: "{ not valid graphql {" }),
+        }),
+      status: 400,
+      code: "graphql_parse_error",
+    },
+    {
+      name: "schema validation error",
+      req: () =>
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ query: "{ this_field_does_not_exist }" }),
+        }),
+      status: 400,
+      code: "graphql_validation_error",
+    },
+  ];
+
+  for (const { name, req, status, code } of cases) {
+    const res = await handleGraphQLRequest(req(), emptyEnv);
+    assert.equal(res.status, status, `${name}: status`);
+    assert.equal(
+      res.headers.get("x-metagraph-error-code"),
+      code,
+      `${name}: error code`,
+    );
+  }
+  assert.equal(captureException.mock.calls.length, 0);
+});

--- a/tests/request-usage-telemetry.test.mjs
+++ b/tests/request-usage-telemetry.test.mjs
@@ -243,6 +243,60 @@ describe("withUsageTelemetry", () => {
     assert.equal("errorCode" in uncoded.events[0].event, false);
   });
 
+  // metagraphed#7734: GraphQL execution errors are a spec-mandated 200 with
+  // a populated `errors` array (src/graphql.mjs) -- status alone can't tell
+  // that apart from a real success, so this one code is a narrow, explicit
+  // exception to the status<500 rule. Every other error code (including a
+  // GraphQL transport-level one like graphql_bad_method) keeps the existing
+  // status-based ok, proving the exception is scoped to exactly one code.
+  test("graphql_execution_error flips ok to false even at HTTP 200; no other code does", async () => {
+    const executionError = recorder();
+    await withUsageTelemetry(
+      req("/api/v1/graphql"),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "x-metagraph-error-code": "graphql_execution_error" },
+        }),
+      executionError,
+    );
+    assert.equal(executionError.events[0].event.ok, false);
+    assert.equal(
+      executionError.events[0].event.errorCode,
+      "graphql_execution_error",
+    );
+
+    const fieldError = recorder();
+    await withUsageTelemetry(
+      req("/api/v1/graphql"),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "x-metagraph-error-code": "graphql_field_error" },
+        }),
+      fieldError,
+    );
+    assert.equal(fieldError.events[0].event.ok, true);
+
+    const transportError = recorder();
+    await withUsageTelemetry(
+      req("/api/v1/graphql"),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () =>
+        new Response("nope", {
+          status: 405,
+          headers: { "x-metagraph-error-code": "graphql_bad_method" },
+        }),
+      transportError,
+    );
+    assert.equal(transportError.events[0].event.ok, true);
+  });
+
   test("does not record a subscription upgrade as a request", async () => {
     const spy = recorder();
     const response = await withUsageTelemetry(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -584,6 +584,17 @@ export async function withUsageTelemetry(request, env, ctx, handle, deps = {}) {
     // only 5xx (and a thrown handler, which leaves ok false) is a failure.
     ok = response.status < 500;
     errorCode = response.headers.get("x-metagraph-error-code") ?? undefined;
+    // metagraphed#7734: GraphQL execution errors are a spec-mandated 200
+    // with a populated `errors` array (src/graphql.mjs) -- status alone
+    // can't distinguish that from a real success, so this one code (set
+    // only when execute() surfaced a genuine resolver fault, never a
+    // deliberate/expected GraphQLError -- see graphql.mjs's own
+    // genuineFaults comment) is a narrow, explicit exception to the
+    // status-based rule above. Every other route/code keeps the existing
+    // status<500 semantics untouched.
+    if (errorCode === "graphql_execution_error") {
+      ok = false;
+    }
     return response;
   } finally {
     scheduleUsageEvent(env, ctx, record, {


### PR DESCRIPTION
## Summary
- GraphQL execution errors are a spec-mandated HTTP 200 with a populated `errors` array (`execute()`, graphql-js), so status code alone can't distinguish a genuine resolver fault from success. Both PostHog usage telemetry and Sentry had zero visibility into this failure class.
- `src/graphql.mjs`: a resolver's genuine exception is now captured to Sentry (`tags: {route: "graphql"}`), discriminated from a deliberate/expected `GraphQLError` via `error.originalError instanceof GraphQLError`. Every transport- and execution-level error path now sets an `x-metagraph-error-code` response header (`graphql_bad_method`, `graphql_invalid_json`, `graphql_payload_too_large`, `graphql_missing_query`, `graphql_parse_error`, `graphql_validation_error`, `graphql_execution_error`, `graphql_field_error`).
- `workers/api.mjs`: `graphql_execution_error` flips `ok:false` in usage telemetry even though the HTTP status is 200; every other code keeps the existing `status<500` semantics untouched.

## Why
Extends the same error-code granularity already shipped for MCP (#7728) and REST (#7735) to GraphQL, the one surface where HTTP status alone is structurally insufficient to detect failure.

Closes #7734

## Test plan
- [x] New `tests/graphql-sentry-and-error-code.test.mjs`: genuine exception → Sentry captured + `graphql_execution_error`; deliberate `GraphQLError` → not captured + `graphql_field_error`; clean success → no header/capture; 8-case table covering every transport-level error code, none reaching Sentry
- [x] Extended `tests/request-usage-telemetry.test.mjs`: `graphql_execution_error` flips `ok:false`, `graphql_field_error`/`graphql_bad_method` leave `ok:true`
- [x] `tests/graphql.test.mjs` (919 tests) unaffected
- [x] Full suite green pre-push (474 files, 11328 tests)