### PR TITLE
build(typescript): Phase 4 batch 7 complete (108/109 scripts/ files) — convert to .ts

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -68,11 +68,11 @@ import {
   buildCoverageDepthArtifact,
   subnetIntegrationReadiness,
   summarizeAgentReadinessBlockers,
-} from "./lib/build-readiness.mjs";
+} from "./lib/build-readiness.ts";
 import {
   buildEnrichmentQueueArtifacts,
   directSubmissionKindsForProfile,
-} from "./lib/enrichment-queue-artifacts.mjs";
+} from "./lib/enrichment-queue-artifacts.ts";
 import {
   API_ROUTES,
   CONTRACT_VERSION,

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -2710,7 +2710,7 @@ export {
   buildEndpointResourceArtifact,
   buildEndpointPoolArtifact,
   buildEndpointIncidentArtifact,
-} from "./lib/endpoint-artifacts.mjs";
+} from "./lib/endpoint-artifacts.ts";
 
 // The two terminal trust-tier "ceiling" levels. The CurationLevel enum documents
 // a "maintainer-reviewed / adapter-backed ceiling" (schemas/api-components), so a

--- a/scripts/lib/build-readiness.ts
+++ b/scripts/lib/build-readiness.ts
@@ -6,12 +6,21 @@
 // and unit-tested in tests/build-readiness.test.mjs.
 import { OPERATIONAL_SURFACE_KINDS } from "../../src/health-probe-core.ts";
 
+// Subnets, surfaces, services, and derived readiness rows are untrusted dynamic
+// JSON, read only for artifact derivation -- never trusted for control flow.
+// Mirrors the readJson/readArtifactJson precedent in scripts/lib.ts.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
 export const READINESS_VERSION = 2;
 
-function countBy(items, keyOrFn) {
+function countBy(
+  items: Row[],
+  keyOrFn: string | ((item: Row) => string),
+): Record<string, number> {
   return Object.fromEntries(
     Object.entries(
-      items.reduce((accumulator, item) => {
+      items.reduce((accumulator: Record<string, number>, item) => {
         const key =
           typeof keyOrFn === "function" ? keyOrFn(item) : item[keyOrFn];
         accumulator[key] = (accumulator[key] || 0) + 1;
@@ -30,13 +39,22 @@ function countBy(items, keyOrFn) {
 // #356: a categorical readiness gradient that turns the API-less long tail into
 // a ranked curation pipeline instead of a single 0-15 cliff. Derived purely from
 // components (not the numeric score) so the tier stays stable if weights move.
-export function readinessTier(components) {
+export function readinessTier(components: Row): string {
   if (components.has_callable_api) return "buildable";
   if (components.has_candidate_api || components.has_public_docs)
     return "emerging";
   if (components.has_source_repo || components.active_lifecycle)
     return "identity-only";
   return "dormant";
+}
+
+interface SubnetIntegrationReadinessOptions {
+  services: Row[];
+  lifecycle: unknown;
+  completenessScore: unknown;
+  sourceRepo: unknown;
+  docsUrl: unknown;
+  candidates: Row[] | null | undefined;
 }
 
 export function subnetIntegrationReadiness({
@@ -46,7 +64,7 @@ export function subnetIntegrationReadiness({
   sourceRepo,
   docsUrl,
   candidates,
-}) {
+}: SubnetIntegrationReadinessOptions): Row {
   const callable = services.filter((service) => service.eligibility.callable);
   const components = {
     has_callable_api: services.length > 0,
@@ -58,7 +76,7 @@ export function subnetIntegrationReadiness({
       ),
     callable_now: callable.length > 0,
     active_lifecycle: lifecycle === "active",
-    profile_complete: (completenessScore ?? 0) >= 70,
+    profile_complete: (Number(completenessScore) || 0) >= 70,
     // #356: low-weight, NON-API signals so the ~99 API-less subnets stop
     // cliffing at one score and rank as a curation pipeline. has_public_docs is
     // any docs link (distinct from `documented`, which needs a verified schema);
@@ -66,7 +84,7 @@ export function subnetIntegrationReadiness({
     has_source_repo: Boolean(sourceRepo),
     has_public_docs: Boolean(docsUrl),
     has_candidate_api: (candidates ?? []).some((candidate) =>
-      OPERATIONAL_SURFACE_KINDS.includes(candidate.kind),
+      (OPERATIONAL_SURFACE_KINDS as string[]).includes(candidate.kind),
     ),
   };
   const score = Math.min(
@@ -91,17 +109,31 @@ export function subnetIntegrationReadiness({
   };
 }
 
+interface BuildAgentReadinessOptions {
+  subnet: Row;
+  profile: Row | null | undefined;
+  services: Row[];
+  readiness: Row | null | undefined;
+  callableCount: number;
+}
+
 export function buildAgentReadiness({
   subnet,
   profile,
   services,
   readiness,
   callableCount,
-}) {
-  const components = readiness?.components || {};
+}: BuildAgentReadinessOptions): Row {
+  const components: Row = readiness?.components || {};
   const subnetType = profile?.subnet_type || subnet.subnet_type || null;
-  const blockers = [];
-  const add = (code, severity, message, field, nextAction) => {
+  const blockers: Row[] = [];
+  const add = (
+    code: string,
+    severity: string,
+    message: string,
+    field: string,
+    nextAction: string,
+  ): void => {
     blockers.push({
       code,
       severity,
@@ -233,17 +265,17 @@ export function buildAgentReadiness({
     blocker_level: blockerLevel,
     blockers,
     missing_fields: [
-      ...new Set(
+      ...new Set<string>(
         blockers
           .filter((blocker) => blocker.severity === "missing-data")
-          .map((blocker) => blocker.field),
+          .map((blocker): string => blocker.field),
       ),
     ].sort(),
   };
 }
 
-export function summarizeAgentReadinessBlockers(blockedSubnets) {
-  const blockers = blockedSubnets.flatMap(
+export function summarizeAgentReadinessBlockers(blockedSubnets: Row[]): Row {
+  const blockers: Row[] = blockedSubnets.flatMap(
     (subnet) => subnet.agent_readiness?.blockers || [],
   );
   return {
@@ -271,13 +303,25 @@ export const COVERAGE_DEPTH_WEIGHTS = {
   profile_completeness: 10,
 };
 export const COVERAGE_DEPTH_QUEUE_LIMIT = 100;
-export const COVERAGE_DEPTH_SEVERITY_RANK = {
+export const COVERAGE_DEPTH_SEVERITY_RANK: Record<string, number> = {
   hard: 0,
   "needs-review": 1,
   "missing-data": 2,
 };
 
-export function coverageDepthTier({ agentReadiness, dimensions, gaps, score }) {
+interface CoverageDepthTierOptions {
+  agentReadiness: Row | null | undefined;
+  dimensions: Row;
+  gaps: Row[];
+  score: number;
+}
+
+export function coverageDepthTier({
+  agentReadiness,
+  dimensions,
+  gaps,
+  score,
+}: CoverageDepthTierOptions): string {
   if (agentReadiness?.blocker_level === "hard-blocked") {
     return "hard-blocked";
   }
@@ -304,13 +348,17 @@ export function coverageDepthTier({ agentReadiness, dimensions, gaps, score }) {
   return "missing-interface";
 }
 
-export function addCoverageDepthGap(gaps, seenCodes, gap) {
+export function addCoverageDepthGap(
+  gaps: Row[],
+  seenCodes: Set<string>,
+  gap: Row,
+): void {
   if (seenCodes.has(gap.code)) return;
   seenCodes.add(gap.code);
   gaps.push(gap);
 }
 
-export function sortCoverageDepthGaps(gaps) {
+export function sortCoverageDepthGaps(gaps: Row[]): Row[] {
   return [...gaps].sort((a, b) => {
     const severityDelta =
       (COVERAGE_DEPTH_SEVERITY_RANK[a.severity] ?? 9) -
@@ -320,11 +368,17 @@ export function sortCoverageDepthGaps(gaps) {
   });
 }
 
+interface ScoreCoverageDepthDimensionsOptions {
+  dimensions: Row;
+  agentReadiness: Row | null | undefined;
+  completenessScore: unknown;
+}
+
 export function scoreCoverageDepthDimensions({
   dimensions,
   agentReadiness,
   completenessScore,
-}) {
+}: ScoreCoverageDepthDimensionsOptions): number {
   const callableCoverage =
     dimensions.callable_service_count > 0
       ? 1
@@ -337,7 +391,7 @@ export function scoreCoverageDepthDimensions({
       : 0;
   const explicitFixtureAbsenceCount = Object.values(
     dimensions.fixture_status_counts,
-  ).reduce((sum, count) => sum + count, 0);
+  ).reduce((sum: number, count) => sum + (count as number), 0);
   const fixtureCoverage =
     dimensions.callable_service_count > 0
       ? dimensions.fixture_available_count > 0
@@ -380,12 +434,20 @@ export function scoreCoverageDepthDimensions({
   );
 }
 
-export function coverageDepthPriorityScore({ row, gaps }) {
+interface CoverageDepthPriorityScoreOptions {
+  row: Row;
+  gaps: Row[];
+}
+
+export function coverageDepthPriorityScore({
+  row,
+  gaps,
+}: CoverageDepthPriorityScoreOptions): number {
   const actionableGaps = gaps.filter((gap) => gap.severity !== "hard");
   if (row.subnet_type === "root" || actionableGaps.length === 0) {
     return 0;
   }
-  const severityWeight = actionableGaps.reduce((sum, gap) => {
+  const severityWeight = actionableGaps.reduce((sum: number, gap) => {
     if (gap.severity === "needs-review") return sum + 18;
     return sum + 12;
   }, 0);
@@ -411,6 +473,19 @@ export function coverageDepthPriorityScore({ row, gaps }) {
   );
 }
 
+interface BuildCoverageDepthArtifactOptions {
+  subnets: Row[];
+  profileByNetuid: Map<unknown, Row | null | undefined>;
+  surfacesByNetuid: Map<unknown, Row[]>;
+  servicesByNetuid: Map<unknown, Row[]>;
+  candidatesByNetuid: Map<unknown, Row[]>;
+  readinessByNetuid: Map<unknown, Row>;
+  agentReadinessByNetuid: Map<unknown, Row>;
+  examplesByNetuid: Map<unknown, Row[]>;
+  generatedAt: string;
+  contractVersion: string;
+}
+
 export function buildCoverageDepthArtifact({
   subnets,
   profileByNetuid,
@@ -422,16 +497,17 @@ export function buildCoverageDepthArtifact({
   examplesByNetuid,
   generatedAt,
   contractVersion,
-}) {
-  const rows = subnets
+}: BuildCoverageDepthArtifactOptions): Row {
+  const rows: Row[] = subnets
     .map((subnet) => {
       const profile = profileByNetuid.get(subnet.netuid) || null;
-      const subnetSurfaces = surfacesByNetuid.get(subnet.netuid) || [];
-      const services = servicesByNetuid.get(subnet.netuid) || [];
+      const subnetSurfaces: Row[] = surfacesByNetuid.get(subnet.netuid) || [];
+      const services: Row[] = servicesByNetuid.get(subnet.netuid) || [];
       const callableServices = services.filter(
         (service) => service.eligibility?.callable,
       );
-      const candidatesForSubnet = candidatesByNetuid.get(subnet.netuid) || [];
+      const candidatesForSubnet: Row[] =
+        candidatesByNetuid.get(subnet.netuid) || [];
       const agentReadiness = agentReadinessByNetuid.get(subnet.netuid) || {
         status: "blocked",
         blocker_level: "missing-data",
@@ -441,7 +517,7 @@ export function buildCoverageDepthArtifact({
       const readiness = readinessByNetuid.get(subnet.netuid) || {
         score: 0,
       };
-      const examples = examplesByNetuid.get(subnet.netuid) || [];
+      const examples: Row[] = examplesByNetuid.get(subnet.netuid) || [];
       const sdkCount = subnetSurfaces.filter(
         (surface) => surface.kind === "sdk",
       ).length;
@@ -449,7 +525,7 @@ export function buildCoverageDepthArtifact({
         callableServices,
         (service) => service.fixture_status?.status || "missing",
       );
-      const dimensions = {
+      const dimensions: Row = {
         surface_count: subnetSurfaces.length,
         official_surface_count: subnetSurfaces.filter(
           (surface) => surface.authority === "official",
@@ -463,7 +539,9 @@ export function buildCoverageDepthArtifact({
         service_count: services.length,
         callable_service_count: callableServices.length,
         service_kinds: [
-          ...new Set(callableServices.map((service) => service.kind)),
+          ...new Set<string>(
+            callableServices.map((service): string => service.kind),
+          ),
         ].sort(),
         schema_service_count: callableServices.filter(
           (service) => service.schema_artifact,
@@ -479,7 +557,7 @@ export function buildCoverageDepthArtifact({
         sdk_count: sdkCount,
         candidate_count: candidatesForSubnet.length,
         candidate_operational_count: candidatesForSubnet.filter((candidate) =>
-          OPERATIONAL_SURFACE_KINDS.includes(candidate.kind),
+          (OPERATIONAL_SURFACE_KINDS as string[]).includes(candidate.kind),
         ).length,
         data_artifact_count: callableServices.filter(
           (service) => service.kind === "data-artifact",
@@ -492,8 +570,8 @@ export function buildCoverageDepthArtifact({
         agentReadiness,
         completenessScore: profile?.completeness_score,
       });
-      const gaps = [];
-      const seenGapCodes = new Set();
+      const gaps: Row[] = [];
+      const seenGapCodes = new Set<string>();
       for (const blocker of agentReadiness.blockers || []) {
         addCoverageDepthGap(gaps, seenGapCodes, blocker);
       }
@@ -557,7 +635,7 @@ export function buildCoverageDepthArtifact({
         });
       }
       const sortedGaps = sortCoverageDepthGaps(gaps);
-      const row = {
+      const row: Row = {
         netuid: subnet.netuid,
         slug: subnet.slug,
         name: subnet.name,
@@ -604,7 +682,8 @@ export function buildCoverageDepthArtifact({
     .slice(0, COVERAGE_DEPTH_QUEUE_LIMIT)
     .map((row, index) => {
       const primaryGap =
-        row.top_gaps.find((gap) => gap.severity !== "hard") || row.top_gaps[0];
+        row.top_gaps.find((gap: Row) => gap.severity !== "hard") ||
+        row.top_gaps[0];
       return {
         rank: index + 1,
         netuid: row.netuid,
@@ -619,7 +698,7 @@ export function buildCoverageDepthArtifact({
           row.recommended_next_action || primaryGap.next_action,
       };
     });
-  const allTopGaps = rows.flatMap((row) => row.top_gaps);
+  const allTopGaps: Row[] = rows.flatMap((row) => row.top_gaps);
   return {
     schema_version: 1,
     contract_version: contractVersion,

--- a/scripts/lib/endpoint-artifacts.ts
+++ b/scripts/lib/endpoint-artifacts.ts
@@ -12,15 +12,32 @@
 // (inside buildEndpointResourceArtifact), never during module evaluation.
 import { surfaceStableKey } from "../lib.ts";
 
+// Surfaces, probe health, and derived endpoint/pool/incident rows are untrusted
+// dynamic JSON, read only for artifact derivation -- never trusted for control
+// flow. Mirrors the readJson/readArtifactJson precedent in lib.ts.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+interface BuildRpcEndpointArtifactOptions {
+  surfaces: Row[];
+  healthSurfaces?: Row[];
+  generatedAt: string;
+  contractVersion: string;
+  source: string;
+}
+
 export function buildRpcEndpointArtifact({
   surfaces,
   healthSurfaces = [],
   generatedAt,
   contractVersion,
   source,
-}) {
-  const healthBySurface = new Map(
-    healthSurfaces.map((surface) => [surface.surface_id, surface]),
+}: BuildRpcEndpointArtifactOptions): Row {
+  const healthBySurface = new Map<string, Row>(
+    healthSurfaces.map((surface): [string, Row] => [
+      surface.surface_id,
+      surface,
+    ]),
   );
   const endpoints = surfaces
     .filter((surface) =>
@@ -88,15 +105,26 @@ export function buildRpcEndpointArtifact({
   };
 }
 
+interface BuildEndpointResourceArtifactOptions {
+  surfaces: Row[];
+  healthSurfaces?: Row[];
+  generatedAt: string;
+  contractVersion: string;
+  source: string;
+}
+
 export function buildEndpointResourceArtifact({
   surfaces,
   healthSurfaces = [],
   generatedAt,
   contractVersion,
   source,
-}) {
-  const healthBySurface = new Map(
-    healthSurfaces.map((surface) => [surface.surface_id, surface]),
+}: BuildEndpointResourceArtifactOptions): Row {
+  const healthBySurface = new Map<string, Row>(
+    healthSurfaces.map((surface): [string, Row] => [
+      surface.surface_id,
+      surface,
+    ]),
   );
   const endpoints = surfaces.map((surface) => {
     const surfaceKey = surface.key || surfaceStableKey(surface);
@@ -204,31 +232,42 @@ export function buildEndpointResourceArtifact({
   };
 }
 
+interface BuildEndpointPoolArtifactOptions {
+  generatedAt: string;
+  contractVersion: string;
+  rpcArtifact?: Row | null;
+  endpointArtifact?: Row | null;
+  // Static, non-default-network base-layer RPC endpoints (e.g. testnet). These
+  // are NOT probe-derived: they carry static pool_eligible/score so /rpc/v1/{net}
+  // can route immediately, with the proxy's in-isolate breaker + failover handling
+  // liveness. Shape matches the mapped `endpoints` below (see test-base-endpoints).
+  testnetEndpoints?: Row[];
+}
+
 export function buildEndpointPoolArtifact({
   generatedAt,
   contractVersion,
   rpcArtifact = null,
   endpointArtifact = null,
-  // Static, non-default-network base-layer RPC endpoints (e.g. testnet). These
-  // are NOT probe-derived: they carry static pool_eligible/score so /rpc/v1/{net}
-  // can route immediately, with the proxy's in-isolate breaker + failover handling
-  // liveness. Shape matches the mapped `endpoints` below (see test-base-endpoints).
   testnetEndpoints = [],
-}) {
-  const sourceArtifact = endpointArtifact || rpcArtifact || { endpoints: [] };
-  const endpoints = (sourceArtifact.endpoints || []).map((endpoint) => {
-    const scoreBreakdown = endpointScoreBreakdown(endpoint);
-    const poolEligibility = endpointPoolEligibility(endpoint);
-    return {
-      ...endpoint,
-      score: scoreBreakdown.score,
-      score_reasons: endpoint.score_reasons || scoreBreakdown.reasons,
-      pool_eligible: poolEligibility.eligible,
-      pool_eligibility_reasons:
-        endpoint.pool_eligibility_reasons || poolEligibility.reasons,
-      unsafe_methods_blocked: true,
-    };
-  });
+}: BuildEndpointPoolArtifactOptions): Row {
+  const sourceArtifact: Row = endpointArtifact ||
+    rpcArtifact || { endpoints: [] };
+  const endpoints: Row[] = (sourceArtifact.endpoints || []).map(
+    (endpoint: Row) => {
+      const scoreBreakdown = endpointScoreBreakdown(endpoint);
+      const poolEligibility = endpointPoolEligibility(endpoint);
+      return {
+        ...endpoint,
+        score: scoreBreakdown.score,
+        score_reasons: endpoint.score_reasons || scoreBreakdown.reasons,
+        pool_eligible: poolEligibility.eligible,
+        pool_eligibility_reasons:
+          endpoint.pool_eligibility_reasons || poolEligibility.reasons,
+        unsafe_methods_blocked: true,
+      };
+    },
+  );
 
   return {
     schema_version: 1,
@@ -294,7 +333,7 @@ export function buildEndpointPoolArtifact({
   };
 }
 
-function endpointPool(id, kind, endpoints) {
+function endpointPool(id: string, kind: string, endpoints: Row[]): Row {
   const poolEndpoints = endpoints
     .filter((endpoint) => kind === "archive" || endpoint.kind === kind)
     .sort(
@@ -350,12 +389,18 @@ const CALLABLE_ENDPOINT_KINDS = new Set([
   "data-artifact",
 ]);
 
+interface BuildEndpointIncidentArtifactOptions {
+  endpointArtifact?: Row | null;
+  generatedAt: string;
+  contractVersion: string;
+}
+
 export function buildEndpointIncidentArtifact({
   endpointArtifact,
   generatedAt,
   contractVersion,
-}) {
-  const endpoints = endpointArtifact?.endpoints || [];
+}: BuildEndpointIncidentArtifactOptions): Row {
+  const endpoints: Row[] = endpointArtifact?.endpoints || [];
   const incidents = endpoints
     .filter((endpoint) => CALLABLE_ENDPOINT_KINDS.has(endpoint.kind))
     .filter((endpoint) => endpoint.monitoring_status === "monitored")
@@ -426,7 +471,7 @@ export function buildEndpointIncidentArtifact({
   };
 }
 
-function endpointLayer(kind) {
+function endpointLayer(kind: string): string {
   if (isBaseLayerEndpoint(kind) || kind === "archive") {
     return "bittensor-base";
   }
@@ -443,7 +488,21 @@ function endpointLayer(kind) {
   return "docs-provider";
 }
 
-function endpointHealthMetadata({ health, monitored }) {
+interface EndpointHealthMetadata {
+  observed_at: string | null;
+  health_source: string;
+  health_stale: boolean;
+  last_checked: string | null;
+  last_ok: string | null;
+}
+
+function endpointHealthMetadata({
+  health,
+  monitored,
+}: {
+  health: Row;
+  monitored: boolean;
+}): EndpointHealthMetadata {
   if (!monitored) {
     return {
       observed_at: null,
@@ -466,11 +525,11 @@ function endpointHealthMetadata({ health, monitored }) {
   };
 }
 
-function isBaseLayerEndpoint(kind) {
+function isBaseLayerEndpoint(kind: string): boolean {
   return ["subtensor-rpc", "subtensor-wss"].includes(kind);
 }
 
-function endpointMonitoringPolicy(surface) {
+function endpointMonitoringPolicy(surface: Row): Row {
   if (!surface.probe) {
     return {
       enabled: false,
@@ -488,7 +547,15 @@ function endpointMonitoringPolicy(surface) {
   };
 }
 
-function endpointPublicationState({ monitored, poolEligible, surface }) {
+function endpointPublicationState({
+  monitored,
+  poolEligible,
+  surface,
+}: {
+  monitored: boolean;
+  poolEligible: boolean;
+  surface: Row;
+}): string {
   if (surface.public_safe !== true) {
     return "disabled";
   }
@@ -501,10 +568,15 @@ function endpointPublicationState({ monitored, poolEligible, surface }) {
   return "verified";
 }
 
-function endpointScoreBreakdown(endpoint) {
+interface ScoreBreakdown {
+  score: number;
+  reasons: Array<{ reason: string; points: number }>;
+}
+
+function endpointScoreBreakdown(endpoint: Row): ScoreBreakdown {
   let score = 0;
-  const reasons = [];
-  function add(reason, points) {
+  const reasons: Array<{ reason: string; points: number }> = [];
+  function add(reason: string, points: number): void {
     score += points;
     reasons.push({ reason, points });
   }
@@ -537,8 +609,13 @@ function endpointScoreBreakdown(endpoint) {
   };
 }
 
-function endpointPoolEligibility(endpoint) {
-  const reasons = [];
+interface PoolEligibility {
+  eligible: boolean;
+  reasons: string[];
+}
+
+function endpointPoolEligibility(endpoint: Row): PoolEligibility {
+  const reasons: string[] = [];
   if (!isBaseLayerEndpoint(endpoint.kind)) {
     reasons.push("not-bittensor-base-layer");
   }
@@ -557,8 +634,8 @@ function endpointPoolEligibility(endpoint) {
   };
 }
 
-function endpointProviderScores(endpoints) {
-  const providers = new Map();
+function endpointProviderScores(endpoints: Row[]): Row[] {
+  const providers = new Map<string, Row>();
   for (const endpoint of endpoints) {
     const provider = endpoint.provider || "unknown";
     const row = providers.get(provider) || {
@@ -584,10 +661,15 @@ function endpointProviderScores(endpoints) {
   }
 
   return [...providers.values()]
-    .map((row) => {
-      const publicRow = { ...row };
+    .map((row): Row => {
+      const publicRow: Row = { ...row };
       delete publicRow.score_total;
       return {
+        // The object spread of a Record<string, any> drops its index
+        // signature, so the literal below would otherwise type as just
+        // {average_score, operational_score} -- annotate the callback return
+        // as Row (this function's declared return element type) to keep
+        // publicRow's fields visible to the .sort() below.
         ...publicRow,
         average_score: row.endpoint_count
           ? Math.round(row.score_total / row.endpoint_count)
@@ -614,14 +696,17 @@ function endpointProviderScores(endpoints) {
     );
 }
 
-function severityRank(severity) {
-  return { critical: 3, warning: 2, info: 1 }[severity] || 0;
+function severityRank(severity: string): number {
+  return ({ critical: 3, warning: 2, info: 1 } as Row)[severity] || 0;
 }
 
-function countRecord(items, keyFn) {
+function countRecord(
+  items: Row[],
+  keyFn: (item: Row) => string,
+): Record<string, number> {
   return Object.fromEntries(
     Object.entries(
-      items.reduce((accumulator, item) => {
+      items.reduce((accumulator: Record<string, number>, item) => {
         const key = keyFn(item) || "unknown";
         accumulator[key] = (accumulator[key] || 0) + 1;
         return accumulator;

--- a/scripts/lib/enrichment-queue-artifacts.ts
+++ b/scripts/lib/enrichment-queue-artifacts.ts
@@ -5,10 +5,20 @@
 // build-artifacts.mjs originals. Imported directly by scripts/build-artifacts.mjs.
 import { normalizePublicUrl, slugify } from "../lib.ts";
 
-function countBy(items, keyOrFn) {
+// Candidates, profiles, review/verification rows, and derived queue/evidence/
+// target entries are untrusted dynamic JSON, read only for artifact derivation
+// -- never trusted for control flow. Mirrors the readJson/readArtifactJson
+// precedent in scripts/lib.ts.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+function countBy(
+  items: Row[],
+  keyOrFn: string | ((item: Row) => string),
+): Record<string, number> {
   return Object.fromEntries(
     Object.entries(
-      items.reduce((accumulator, item) => {
+      items.reduce((accumulator: Record<string, number>, item) => {
         const key =
           typeof keyOrFn === "function" ? keyOrFn(item) : item[keyOrFn];
         accumulator[key] = (accumulator[key] || 0) + 1;
@@ -18,8 +28,11 @@ function countBy(items, keyOrFn) {
   );
 }
 
-function groupBy(items, key) {
-  const groups = new Map();
+function groupBy(
+  items: Row[],
+  key: string | ((item: Row) => unknown),
+): Map<unknown, Row[]> {
+  const groups = new Map<unknown, Row[]>();
   for (const item of items) {
     const groupKey = typeof key === "function" ? key(item) : item[key];
     const group = groups.get(groupKey) || [];
@@ -29,8 +42,25 @@ function groupBy(items, key) {
   return groups;
 }
 
-function groupByNetuid(items) {
+function groupByNetuid(items: Row[]): Map<unknown, Row[]> {
   return groupBy(items, "netuid");
+}
+
+interface BuildEnrichmentQueueArtifactsOptions {
+  candidates: Row[];
+  curationReview: Row;
+  profiles: Row[];
+  reviewProfiles: Row[];
+  subnets: Row[];
+  verification: Row;
+  contractVersion: string;
+  generatedAt: string;
+}
+
+interface BuildEnrichmentQueueArtifactsResult {
+  evidenceArtifact: Row;
+  queueArtifact: Row;
+  targetArtifact: Row;
 }
 
 export function buildEnrichmentQueueArtifacts({
@@ -42,44 +72,47 @@ export function buildEnrichmentQueueArtifacts({
   verification,
   contractVersion,
   generatedAt,
-}) {
-  const verificationByCandidate = new Map(
-    (verification.results || []).map((result) => [result.candidate_id, result]),
+}: BuildEnrichmentQueueArtifactsOptions): BuildEnrichmentQueueArtifactsResult {
+  const verificationByCandidate = new Map<unknown, Row>(
+    (verification.results || []).map((result: Row) => [
+      result.candidate_id,
+      result,
+    ]),
   );
-  const reviewProfileByNetuid = new Map(
+  const reviewProfileByNetuid = new Map<unknown, Row>(
     reviewProfiles.map((profile) => [profile.netuid, profile]),
   );
-  const gapPriorityByNetuid = new Map(
-    (curationReview.gap_priorities || []).map((priority) => [
+  const gapPriorityByNetuid = new Map<unknown, Row>(
+    (curationReview.gap_priorities || []).map((priority: Row) => [
       priority.netuid,
       priority,
     ]),
   );
-  const adapterCandidateByNetuid = new Map(
-    (curationReview.adapter_candidates || []).map((candidate) => [
+  const adapterCandidateByNetuid = new Map<unknown, Row>(
+    (curationReview.adapter_candidates || []).map((candidate: Row) => [
       candidate.netuid,
       candidate,
     ]),
   );
-  const excludedCandidateIdsByNetuid = new Map(
+  const excludedCandidateIdsByNetuid = new Map<unknown, Set<unknown>>(
     subnets.map((subnet) => [
       subnet.netuid,
       new Set(subnet.baseline_excluded_surface_ids || []),
     ]),
   );
-  const excludedCandidateUrlsByNetuid = new Map(
+  const excludedCandidateUrlsByNetuid = new Map<unknown, Set<string>>(
     subnets.map((subnet) => [
       subnet.netuid,
-      new Set(
+      new Set<string>(
         (subnet.baseline_excluded_surface_urls || [])
-          .map((url) => normalizePublicUrl(url))
+          .map((url: string) => normalizePublicUrl(url))
           .filter(Boolean),
       ),
     ]),
   );
   const candidatesByNetuid = groupByNetuid(candidates);
 
-  const fullQueue = profiles
+  const fullQueue: Row[] = profiles
     .map((profile) =>
       enrichmentQueueEntry({
         adapterCandidate: adapterCandidateByNetuid.get(profile.netuid),
@@ -103,7 +136,7 @@ export function buildEnrichmentQueueArtifacts({
   const queue = fullQueue.map(compactEnrichmentQueueEntry);
   const evidenceEntries = fullQueue.map(enrichmentEvidenceEntry);
 
-  const queueArtifact = {
+  const queueArtifact: Row = {
     schema_version: 1,
     contract_version: contractVersion,
     generated_at: generatedAt,
@@ -137,7 +170,7 @@ export function buildEnrichmentQueueArtifacts({
     },
     queue,
   };
-  const evidenceArtifact = {
+  const evidenceArtifact: Row = {
     schema_version: 1,
     contract_version: contractVersion,
     generated_at: generatedAt,
@@ -168,26 +201,39 @@ export function buildEnrichmentQueueArtifacts({
   return { evidenceArtifact, queueArtifact, targetArtifact };
 }
 
+interface EnrichmentCandidatesForSubnetOptions {
+  excludedIds: Set<unknown> | undefined;
+  excludedUrls: Set<string> | undefined;
+  subnetCandidates: Row[];
+}
+
 function enrichmentCandidatesForSubnet({
   excludedIds,
   excludedUrls,
   subnetCandidates,
-}) {
+}: EnrichmentCandidatesForSubnetOptions): Row[] {
   const hasExcludedIds = excludedIds && excludedIds.size > 0;
   const hasExcludedUrls = excludedUrls && excludedUrls.size > 0;
   if (!hasExcludedIds && !hasExcludedUrls) {
     return subnetCandidates;
   }
   return subnetCandidates.filter((candidate) => {
-    if (hasExcludedIds && excludedIds.has(candidate.id)) {
+    if (hasExcludedIds && excludedIds?.has(candidate.id)) {
       return false;
     }
     if (!hasExcludedUrls) {
       return true;
     }
     const candidateUrl = normalizePublicUrl(candidate.url);
-    return !candidateUrl || !excludedUrls.has(candidateUrl);
+    return !candidateUrl || !excludedUrls?.has(candidateUrl);
   });
+}
+
+interface BuildEnrichmentTargetsArtifactOptions {
+  evidenceEntries: Row[];
+  queue: Row[];
+  contractVersion: string;
+  generatedAt: string;
 }
 
 function buildEnrichmentTargetsArtifact({
@@ -195,11 +241,11 @@ function buildEnrichmentTargetsArtifact({
   queue,
   contractVersion,
   generatedAt,
-}) {
-  const evidenceByNetuid = new Map(
+}: BuildEnrichmentTargetsArtifactOptions): Row {
+  const evidenceByNetuid = new Map<unknown, Row>(
     evidenceEntries.map((entry) => [entry.netuid, entry]),
   );
-  const targets = queue
+  const targets: Row[] = queue
     .flatMap((entry) =>
       enrichmentTargetsForEntry({
         entry,
@@ -248,9 +294,15 @@ function buildEnrichmentTargetsArtifact({
   };
 }
 
-function enrichmentTargetsForEntry({ entry, evidenceEntry }) {
+function enrichmentTargetsForEntry({
+  entry,
+  evidenceEntry,
+}: {
+  entry: Row;
+  evidenceEntry: Row | undefined;
+}): Row[] {
   if (entry.lane === "direct-submission") {
-    return entry.direct_submission_kinds.map((kind) =>
+    return entry.direct_submission_kinds.map((kind: string) =>
       surfaceCandidateTarget({ entry, evidenceEntry, kind }),
     );
   }
@@ -275,8 +327,16 @@ function enrichmentTargetsForEntry({ entry, evidenceEntry }) {
   ];
 }
 
-function surfaceCandidateTarget({ entry, evidenceEntry, kind }) {
-  const candidateEvidence = evidenceEntry?.candidate_evidence_by_kind?.[
+function surfaceCandidateTarget({
+  entry,
+  evidenceEntry,
+  kind,
+}: {
+  entry: Row;
+  evidenceEntry: Row | undefined;
+  kind: string;
+}): Row {
+  const candidateEvidence: Row = evidenceEntry?.candidate_evidence_by_kind?.[
     kind
   ] || {
     candidate_count: 0,
@@ -320,7 +380,7 @@ function surfaceCandidateTarget({ entry, evidenceEntry, kind }) {
   };
 }
 
-function surfaceEvidenceAction(candidateEvidence) {
+function surfaceEvidenceAction(candidateEvidence: Row | undefined): string {
   if (!candidateEvidence || candidateEvidence.candidate_count === 0) {
     return "submit-new-evidence";
   }
@@ -333,8 +393,14 @@ function surfaceEvidenceAction(candidateEvidence) {
   return "verify-existing-evidence";
 }
 
-function nonSurfaceEnrichmentTarget({ entry, targetType }) {
-  const routeByType = {
+function nonSurfaceEnrichmentTarget({
+  entry,
+  targetType,
+}: {
+  entry: Row;
+  targetType: string;
+}): Row {
+  const routeByType: Record<string, string> = {
     "adapter-review": "adapter-request",
     "maintainer-review": "maintainer-review",
     "monitoring-followup": "status-report",
@@ -370,7 +436,7 @@ function nonSurfaceEnrichmentTarget({ entry, targetType }) {
   };
 }
 
-function enrichmentTargetQueueContext(entry) {
+function enrichmentTargetQueueContext(entry: Row): Row {
   return {
     adapter_score: entry.adapter_score,
     candidate_count: entry.candidate_count,
@@ -389,7 +455,7 @@ function enrichmentTargetQueueContext(entry) {
   };
 }
 
-function enrichmentTargetGroups(targets) {
+function enrichmentTargetGroups(targets: Row[]): Row[] {
   return [...groupBy(targets, "target_type").entries()]
     .flatMap(([targetType, rows]) => {
       const byKind = groupBy(rows, (row) => row.kind || targetType);
@@ -416,22 +482,26 @@ function enrichmentTargetGroups(targets) {
     })
     .sort(
       (a, b) =>
-        a.target_type.localeCompare(b.target_type) ||
+        String(a.target_type).localeCompare(String(b.target_type)) ||
         String(a.kind || "").localeCompare(String(b.kind || "")),
     );
 }
 
-function enrichmentTargetId(entry, targetType, kind) {
+function enrichmentTargetId(
+  entry: Row,
+  targetType: string,
+  kind: string | null,
+): string {
   return [`sn-${entry.netuid}`, targetType, kind || entry.lane]
     .map(slugify)
     .join("-");
 }
 
-function candidateCommandTemplate(netuid, kind) {
+function candidateCommandTemplate(netuid: unknown, kind: string): string {
   return `npm run surface:add -- --netuid ${netuid} --kind ${kind} --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write`;
 }
 
-function surfaceTargetAction(evidenceAction) {
+function surfaceTargetAction(evidenceAction: string): string {
   if (evidenceAction === "replace-stale-evidence") {
     return "replace-stale-candidate";
   }
@@ -444,7 +514,10 @@ function surfaceTargetAction(evidenceAction) {
   return "submit-new-candidate";
 }
 
-function contributionPromptForKind(kind, evidenceAction) {
+function contributionPromptForKind(
+  kind: string,
+  evidenceAction: string,
+): string {
   const verb =
     evidenceAction === "replace-stale-evidence"
       ? "Replace stale or failed"
@@ -454,7 +527,7 @@ function contributionPromptForKind(kind, evidenceAction) {
   return `${verb} official public ${kind} evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.`;
 }
 
-function contributionPromptForTargetType(targetType) {
+function contributionPromptForTargetType(targetType: string): string {
   if (targetType === "adapter-review") {
     return "Review whether the existing public API/schema/data surfaces justify a subnet-specific adapter. Adapter requests route to manual review.";
   }
@@ -464,7 +537,7 @@ function contributionPromptForTargetType(targetType) {
   return "Review probe-derived status or request a re-probe. Contributor reports never set observed health directly.";
 }
 
-function sourceRequirementsForKind(kind) {
+function sourceRequirementsForKind(kind: string): string[] {
   if (["website", "docs", "source-repo"].includes(kind)) {
     return [
       "Prefer an official project/team source.",
@@ -486,7 +559,7 @@ function sourceRequirementsForKind(kind) {
   ];
 }
 
-function sourceRequirementsForTargetType(targetType) {
+function sourceRequirementsForTargetType(targetType: string): string[] {
   if (targetType === "adapter-review") {
     return [
       "Existing public API/schema/data evidence should be stable enough to normalize.",
@@ -505,7 +578,7 @@ function sourceRequirementsForTargetType(targetType) {
   ];
 }
 
-function compactEnrichmentQueueEntry(entry) {
+function compactEnrichmentQueueEntry(entry: Row): Row {
   const { candidate_evidence_by_kind: evidenceByKind, ...compact } = entry;
   return {
     ...compact,
@@ -513,7 +586,7 @@ function compactEnrichmentQueueEntry(entry) {
   };
 }
 
-function enrichmentEvidenceEntry(entry) {
+function enrichmentEvidenceEntry(entry: Row): Row {
   return {
     candidate_evidence_by_kind: entry.candidate_evidence_by_kind,
     candidate_evidence_summary: summarizeCandidateEvidence(
@@ -530,9 +603,9 @@ function enrichmentEvidenceEntry(entry) {
   };
 }
 
-function summarizeCandidateEvidence(evidenceByKind) {
+function summarizeCandidateEvidence(evidenceByKind: Row | undefined): Row {
   const entries = Object.entries(evidenceByKind || {});
-  const summary = {
+  const summary: Row = {
     candidate_count: 0,
     kinds_with_candidates: [],
     live_kinds: [],
@@ -544,7 +617,7 @@ function summarizeCandidateEvidence(evidenceByKind) {
     unverified_kinds: [],
   };
 
-  for (const [kind, evidence] of entries) {
+  for (const [kind, evidence] of entries as [string, Row][]) {
     summary.candidate_count += evidence.candidate_count || 0;
     summary.live_or_redirected_count += evidence.live_or_redirected_count || 0;
     summary.reviewable_count += evidence.reviewable_count || 0;
@@ -571,6 +644,15 @@ function summarizeCandidateEvidence(evidenceByKind) {
   return summary;
 }
 
+interface EnrichmentQueueEntryOptions {
+  adapterCandidate: Row | undefined;
+  gapPriority: Row | undefined;
+  profile: Row;
+  reviewProfile: Row | undefined;
+  subnetCandidates: Row[];
+  verificationByCandidate: Map<unknown, Row>;
+}
+
 function enrichmentQueueEntry({
   adapterCandidate,
   gapPriority,
@@ -578,7 +660,7 @@ function enrichmentQueueEntry({
   reviewProfile,
   subnetCandidates,
   verificationByCandidate,
-}) {
+}: EnrichmentQueueEntryOptions): Row {
   const missingRequired = profile.completeness.missing_required || [];
   const missingOperational = profile.completeness.missing_operational || [];
   const missingKinds = [
@@ -688,12 +770,19 @@ function enrichmentQueueEntry({
   };
 }
 
+interface CandidateEvidenceByKindForQueueOptions {
+  directSubmissionKinds: string[];
+  missingKinds: string[];
+  subnetCandidates: Row[];
+  verificationByCandidate: Map<unknown, Row>;
+}
+
 function candidateEvidenceByKindForQueue({
   directSubmissionKinds,
   missingKinds,
   subnetCandidates,
   verificationByCandidate,
-}) {
+}: CandidateEvidenceByKindForQueueOptions): Row {
   const relevantKinds = [
     ...new Set([...missingKinds, ...directSubmissionKinds]),
   ].sort();
@@ -755,13 +844,21 @@ function candidateEvidenceByKindForQueue({
   );
 }
 
+interface SampleCandidateIdsForQueueOptions {
+  candidateClasses?: string[] | null;
+  directSubmissionKinds: string[];
+  missingKinds: string[];
+  subnetCandidates: Row[];
+  verificationByCandidate: Map<unknown, Row>;
+}
+
 function sampleCandidateIdsForQueue({
   candidateClasses = null,
   directSubmissionKinds,
   missingKinds,
   subnetCandidates,
   verificationByCandidate,
-}) {
+}: SampleCandidateIdsForQueueOptions): string[] {
   const relevantKinds = new Set(
     directSubmissionKinds.length > 0 ? directSubmissionKinds : missingKinds,
   );
@@ -788,7 +885,10 @@ function sampleCandidateIdsForQueue({
     .slice(0, 5);
 }
 
-function candidateQueueClassification(candidate, verificationByCandidate) {
+function candidateQueueClassification(
+  candidate: Row,
+  verificationByCandidate: Map<unknown, Row>,
+): string {
   return (
     verificationByCandidate.get(candidate.id)?.classification ||
     candidate.verification?.classification ||
@@ -797,12 +897,15 @@ function candidateQueueClassification(candidate, verificationByCandidate) {
   );
 }
 
-function candidateQueuePriority(candidate, verificationByCandidate) {
+function candidateQueuePriority(
+  candidate: Row,
+  verificationByCandidate: Map<unknown, Row>,
+): number {
   const classification = candidateQueueClassification(
     candidate,
     verificationByCandidate,
   );
-  const weights = {
+  const weights: Record<string, number> = {
     live: 0,
     redirected: 1,
     verified: 2,
@@ -821,11 +924,17 @@ function candidateQueuePriority(candidate, verificationByCandidate) {
   return weights[classification] ?? 20;
 }
 
+interface EnrichmentEvidenceActionOptions {
+  candidateEvidenceByKind: Row;
+  directSubmissionKinds: string[];
+  lane: string;
+}
+
 function enrichmentEvidenceAction({
   candidateEvidenceByKind,
   directSubmissionKinds,
   lane,
-}) {
+}: EnrichmentEvidenceActionOptions): string {
   if (["adapter-candidate", "maintainer-review"].includes(lane)) {
     return "maintainer-review-existing-evidence";
   }
@@ -863,14 +972,15 @@ function enrichmentEvidenceAction({
   return "submit-new-evidence";
 }
 
-function staleCandidateCount(candidateEvidenceByKind) {
+function staleCandidateCount(candidateEvidenceByKind: Row): number {
   return Object.values(candidateEvidenceByKind).reduce(
-    (sum, evidence) => sum + (evidence.stale_or_failed_count || 0),
+    (sum: number, evidence) =>
+      sum + ((evidence as Row).stale_or_failed_count || 0),
     0,
   );
 }
 
-export function directSubmissionKindsForProfile(profile) {
+export function directSubmissionKindsForProfile(profile: Row): string[] {
   const missingRequired = new Set(profile.completeness.missing_required || []);
   const identityTargets = ["docs", "website", "source-repo"].filter((kind) =>
     missingRequired.has(kind),
@@ -890,9 +1000,9 @@ export function directSubmissionKindsForProfile(profile) {
     return operationalTargets;
   }
 
-  const hasApiLikeEvidence = profile.operational_interface_kinds.some((kind) =>
-    ["openapi", "subnet-api"].includes(kind),
-  );
+  const hasApiLikeEvidence = (
+    profile.operational_interface_kinds as string[]
+  ).some((kind) => ["openapi", "subnet-api"].includes(kind));
   if (!hasApiLikeEvidence) {
     return operationalTargets.filter((kind) =>
       ["openapi", "subnet-api"].includes(kind),
@@ -902,7 +1012,17 @@ export function directSubmissionKindsForProfile(profile) {
   return [];
 }
 
-function enrichmentLane({ adapterCandidate, directSubmissionKinds, profile }) {
+interface EnrichmentLaneOptions {
+  adapterCandidate: Row | undefined;
+  directSubmissionKinds: string[];
+  profile: Row;
+}
+
+function enrichmentLane({
+  adapterCandidate,
+  directSubmissionKinds,
+  profile,
+}: EnrichmentLaneOptions): string {
   if (directSubmissionKinds.length > 0) {
     return "direct-submission";
   }
@@ -918,12 +1038,18 @@ function enrichmentLane({ adapterCandidate, directSubmissionKinds, profile }) {
   return "baseline-monitoring";
 }
 
+interface EnrichmentReasonCodesOptions {
+  adapterCandidate: Row | undefined;
+  directSubmissionKinds: string[];
+  profile: Row;
+}
+
 function enrichmentReasonCodes({
   adapterCandidate,
   directSubmissionKinds,
   profile,
-}) {
-  const reasons = [];
+}: EnrichmentReasonCodesOptions): string[] {
+  const reasons: string[] = [];
   if (profile.profile_level === "directory-only") {
     reasons.push("directory-only-profile");
   }
@@ -939,7 +1065,10 @@ function enrichmentReasonCodes({
   return [...new Set(reasons)].sort();
 }
 
-function enrichmentContributionHint(lane, directSubmissionKinds) {
+function enrichmentContributionHint(
+  lane: string,
+  directSubmissionKinds: string[],
+): string {
   if (lane === "direct-submission") {
     const kinds = directSubmissionKinds.join(", ");
     return `Submit one official public ${kinds || "interface"} candidate with npm run surface:add.`;
@@ -956,13 +1085,21 @@ function enrichmentContributionHint(lane, directSubmissionKinds) {
   return "No immediate enrichment action; keep monitoring for drift and new public interfaces.";
 }
 
+interface EnrichmentRecommendedActionOptions {
+  adapterCandidate: Row | undefined;
+  directSubmissionKinds: string[];
+  lane: string;
+  profile: Row;
+  reviewProfile: Row | undefined;
+}
+
 function enrichmentRecommendedAction({
   adapterCandidate,
   directSubmissionKinds,
   lane,
   profile,
   reviewProfile,
-}) {
+}: EnrichmentRecommendedActionOptions): string {
   if (lane === "direct-submission") {
     if (
       directSubmissionKinds.some((kind) =>
@@ -980,7 +1117,7 @@ function enrichmentRecommendedAction({
     );
   }
   if (lane === "adapter-candidate") {
-    const kinds = (adapterCandidate.operational_kinds || []).join(", ");
+    const kinds = (adapterCandidate?.operational_kinds || []).join(", ");
     return `evaluate adapter support for ${kinds || "operational surfaces"}`;
   }
   if (profile.operational_interface_count > 0) {
@@ -989,10 +1126,10 @@ function enrichmentRecommendedAction({
   return "profile is baseline-complete; monitor for new public interfaces";
 }
 
-function countDirectSubmissionKinds(queue) {
+function countDirectSubmissionKinds(queue: Row[]): Record<string, number> {
   return Object.fromEntries(
     Object.entries(
-      queue.reduce((accumulator, entry) => {
+      queue.reduce((accumulator: Record<string, number>, entry) => {
         for (const kind of entry.direct_submission_kinds || []) {
           accumulator[kind] = (accumulator[kind] || 0) + 1;
         }

--- a/scripts/probes-smoke.ts
+++ b/scripts/probes-smoke.ts
@@ -27,20 +27,6 @@ import { CONTRACT_VERSION } from "../src/contracts.mjs";
 
 type Row = Record<string, unknown>;
 
-// buildRpcEndpointArtifact/buildEndpointResourceArtifact's untyped .mjs default
-// param (healthSurfaces = []) locks TS's cross-file inference to never[], and
-// buildEndpointPoolArtifact's (rpcArtifact = null, endpointArtifact = null)
-// locks to null | undefined; cast until Phase 4 Batch 7 converts
-// scripts/lib/endpoint-artifacts.mjs.
-const typedBuildRpcEndpointArtifact = buildRpcEndpointArtifact as unknown as (
-  options: Row,
-) => Row;
-const typedBuildEndpointResourceArtifact =
-  buildEndpointResourceArtifact as unknown as (options: Row) => Row;
-const typedBuildEndpointPoolArtifact = buildEndpointPoolArtifact as unknown as (
-  options: Row,
-) => Row;
-
 const contractVersion = CONTRACT_VERSION;
 const subnets: Row[] = await loadSubnets();
 const providers: Row[] = await loadProviders();
@@ -136,16 +122,16 @@ const artifact = buildHealthArtifacts(results, {
 });
 
 if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
-  const rpcEndpointArtifact = typedBuildRpcEndpointArtifact({
+  const rpcEndpointArtifact = buildRpcEndpointArtifact({
     surfaces: allSurfaces,
-    healthSurfaces: artifact.latest.surfaces,
+    healthSurfaces: artifact.latest.surfaces as Row[],
     generatedAt: buildTimestamp(),
     contractVersion,
     source: "live-smoke-probe",
   });
-  const endpointResourceArtifact = typedBuildEndpointResourceArtifact({
+  const endpointResourceArtifact = buildEndpointResourceArtifact({
     surfaces: allSurfaces,
-    healthSurfaces: artifact.latest.surfaces,
+    healthSurfaces: artifact.latest.surfaces as Row[],
     generatedAt: buildTimestamp(),
     contractVersion,
     source: "live-smoke-probe",
@@ -178,7 +164,7 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
   );
   await writeJson(
     artifactOutputPath("rpc/pools.json"),
-    typedBuildEndpointPoolArtifact({
+    buildEndpointPoolArtifact({
       generatedAt: buildTimestamp(),
       contractVersion,
       rpcArtifact: rpcEndpointArtifact,
@@ -186,7 +172,7 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
   );
   await writeJson(
     artifactOutputPath("endpoint-pools.json"),
-    typedBuildEndpointPoolArtifact({
+    buildEndpointPoolArtifact({
       generatedAt: buildTimestamp(),
       contractVersion,
       endpointArtifact: endpointResourceArtifact,

--- a/tests/build-readiness.test.mjs
+++ b/tests/build-readiness.test.mjs
@@ -17,7 +17,7 @@ import {
   scoreCoverageDepthDimensions,
   coverageDepthPriorityScore,
   buildCoverageDepthArtifact,
-} from "../scripts/lib/build-readiness.mjs";
+} from "../scripts/lib/build-readiness.ts";
 
 // --- test helpers -----------------------------------------------------------
 

--- a/tests/endpoint-artifacts.test.mjs
+++ b/tests/endpoint-artifacts.test.mjs
@@ -5,7 +5,7 @@ import {
   buildEndpointResourceArtifact,
   buildEndpointPoolArtifact,
   buildEndpointIncidentArtifact,
-} from "../scripts/lib/endpoint-artifacts.mjs";
+} from "../scripts/lib/endpoint-artifacts.ts";
 
 const GENERATED_AT = "2026-06-25T00:00:00.000Z";
 const CONTRACT = "test-contract";

--- a/tests/enrichment-queue-artifacts.test.mjs
+++ b/tests/enrichment-queue-artifacts.test.mjs
@@ -3,7 +3,7 @@ import { describe, test } from "vitest";
 import {
   buildEnrichmentQueueArtifacts,
   directSubmissionKindsForProfile,
-} from "../scripts/lib/enrichment-queue-artifacts.mjs";
+} from "../scripts/lib/enrichment-queue-artifacts.ts";
 
 const GENERATED_AT = "2026-06-25T00:00:00.000Z";
 const CONTRACT = "test-contract";


### PR DESCRIPTION
Part of #7510. Completes Phase 4 batch 7 (`scripts/lib/`, 11/11 files) after #7730 converted the first 8.

Converts the final 3 batch-7 files to `.ts`, with real types (`Row = Record<string, any>` only where an untyped upstream `.mjs`/live-JSON boundary makes `unknown` pure friction, each with a justified `eslint-disable-next-line` comment mirroring the `readJson`/`readArtifactJson` precedent in `scripts/lib.ts`):

- `endpoint-artifacts.ts` (631 lines) — RPC-endpoint / endpoint-resource / pool / incident artifact derivation from surfaces + probe health
- `build-readiness.ts` (659 lines) — build-time integration-readiness + coverage-depth scoring
- `enrichment-queue-artifacts.ts` (1003 lines) — enrichment queue / evidence / targets artifact derivation

Every exported function is fully typed on its params and return; internal helpers use `Row`/`Row[]` for dynamic artifact shapes and real primitive types (`string`, `number`, `boolean`, `Set`, `Map`) everywhere else.

**Cross-references updated:** `scripts/lib.ts`'s re-export path for `endpoint-artifacts`; `scripts/build-artifacts.mjs`'s two import paths for `build-readiness` and `enrichment-queue-artifacts`; the three files' own `tests/*.test.mjs` import specifiers. `vitest.config.mjs`'s coverage-include glob already used `.{mjs,ts}` per file, so it needed no change. No workflow, docs, or `apps/ui/` references existed for any of the three filenames.

**Removes a resolved cast workaround:** `scripts/probes-smoke.ts` was calling `buildRpcEndpointArtifact`/`buildEndpointResourceArtifact`/`buildEndpointPoolArtifact` through `as unknown as` wrapper functions with a comment pointing at this exact conversion. Removed the wrappers now that the real functions are typed, and fixed the two call sites that then surfaced a real gap: `artifact.latest.surfaces` is `unknown` under `probes-smoke.ts`'s own `Row = Record<string, unknown>` alias, so it needs an explicit `as Row[]` cast at the call site now that the parameter is genuinely typed instead of erased by the old wrapper.

**A new TS quirk, distinct from the two documented in #7730:** spreading a `Record<string, any>`-typed object into an object literal (`{...publicRow, average_score, ...}`) drops the index signature entirely — the inferred type keeps only the literal's own new keys, not `publicRow`'s. Confirmed with a minimal repro under `--strict`. Fixed in `endpointProviderScores` (`endpoint-artifacts.ts`) by annotating the `.map()` callback's return type as `Row` so the later `.sort()` on `a.provider`/`b.provider` still typechecks.

**Repository-state correction:** while sweeping for cross-references, `scripts/` + `scripts/lib/` currently has 108 of 109 files already converted to `.ts` — every top-level `scripts/*.mjs` file besides the deliberately-deferred `build-artifacts.mjs` was already converted (verified via `git ls-tree` at each prior batch merge: batches 1-3 converted 56, batches 4-6 converted the remaining 41 top-level files, not just the ~44 its title implied). This PR's 3 files were the last of `scripts/lib/`. So Phase 4 for `scripts/`+`scripts/lib/` is now complete pending only `build-artifacts.mjs`, which stays deferred to its own dedicated PR per the standing plan.

Verified: `npm run typecheck` clean, `npm run lint` clean, a full-repo `npx prettier --check .` clean (the only warnings were in the gitignored `apps/indexer-rs/target/` Rust build cache, unrelated to this change), the three files' dedicated unit suites green (9 + 76 + 9 = 94 tests), the full `npx vitest run` suite green with no regressions, and a live `npm run build` end-to-end run — including the real `build-artifacts` step that imports all three converted modules — completed successfully with only the expected deploy-owned-artifact auto-revert (`r2-manifest.json`, `schemas/index.json`).
