### PR TITLE
feat(observability): add PostHog native MCP analytics with credential-safe redaction (#7737)

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -38,6 +38,8 @@
 import * as Sentry from "@sentry/cloudflare";
 import {
   isUsageTelemetryConfigured,
+  recordMcpInitializeEvent,
+  recordMcpToolCallEvent,
   recordUsageEvent,
 } from "./usage-telemetry.ts";
 import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.ts";
@@ -16235,25 +16237,44 @@ function negotiateProtocol(requested) {
 // invocation instead of instrumenting ~150 handlers individually. It also
 // already funnels every outcome into an isError result rather than throwing,
 // which is what makes success/failure readable here without touching any
-// handler. Nothing but the tool name, that flag, elapsed time, and (on
-// failure) a fixed error category is recorded — never arguments or response
-// content, and never a free-form error message.
+// handler. The legacy `usage_event` still carries only the tool name, ok flag,
+// elapsed time, and (on failure) a fixed error category — never raw arguments
+// or response content. Native PostHog MCP analytics (#7737) additionally emit
+// a `$mcp_tool_call` with redacted/size-capped `$mcp_parameters`/`$mcp_response`.
 async function callTool(params, ctx) {
   const startedAt = Date.now();
   const result = await dispatchTool(params, ctx);
+  const durationMs = Date.now() - startedAt;
+  const toolName = typeof params?.name === "string" ? params.name : undefined;
+  const errorCode = result.isError
+    ? result?.structuredContent?.error?.code
+    : undefined;
   scheduleToolUsageEvent(ctx, {
-    mcpTool: typeof params?.name === "string" ? params.name : undefined,
+    mcpTool: toolName,
     ok: result.isError !== true,
-    durationMs: Date.now() - startedAt,
+    durationMs,
     // metagraphed#7726: every isError result already carries a code from a
     // small, developer-defined literal set (toolError's own codes, or
     // "unknown_tool" below) in structuredContent.error.code -- thread it
     // through so analytics can break failures down by cause, not just count
     // them. Omitted entirely on success (no `errorCode` key at all), same as
     // `route`/`mcpTool` being omitted when absent.
-    ...(result.isError
-      ? { errorCode: result?.structuredContent?.error?.code }
-      : {}),
+    ...(errorCode !== undefined ? { errorCode } : {}),
+  });
+  // #7737: native `$mcp_tool_call` (redacted params/response) for PostHog MCP
+  // Analytics — distinct from the allowlisted usage_event above.
+  scheduleMcpToolCallAnalytics(ctx, {
+    toolName: toolName ?? "unknown",
+    toolDescription:
+      typeof toolName === "string"
+        ? TOOLS_BY_NAME.get(toolName)?.description
+        : undefined,
+    parameters: params?.arguments ?? {},
+    response: result,
+    durationMs,
+    isError: result.isError === true,
+    errorType: typeof errorCode === "string" ? errorCode : undefined,
+    sessionId: ctx?.sessionId,
   });
   return result;
 }
@@ -16273,6 +16294,42 @@ function scheduleToolUsageEvent(ctx, event) {
     ctx?.executionCtx?.waitUntil?.(pending);
   } catch {
     // Telemetry must never surface into the tool path.
+  }
+}
+
+/**
+ * Hand a native `$mcp_tool_call` analytics event to the recorder without ever
+ * blocking or failing the tool response (#7737).
+ *
+ * @param {object} ctx
+ * @param {object} event
+ */
+function scheduleMcpToolCallAnalytics(ctx, event) {
+  try {
+    if (!isUsageTelemetryConfigured(ctx?.env)) return;
+    const record = ctx?.recordMcpToolCallEvent ?? recordMcpToolCallEvent;
+    const pending = Promise.resolve(record(ctx.env, event)).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+/**
+ * Hand a native `$mcp_initialize` analytics event to the recorder without ever
+ * blocking or failing the handshake (#7737).
+ *
+ * @param {object} ctx
+ * @param {object} event
+ */
+function scheduleMcpInitializeAnalytics(ctx, event) {
+  try {
+    if (!isUsageTelemetryConfigured(ctx?.env)) return;
+    const record = ctx?.recordMcpInitializeEvent ?? recordMcpInitializeEvent;
+    const pending = Promise.resolve(record(ctx.env, event)).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the initialize path.
   }
 }
 
@@ -16381,6 +16438,14 @@ async function dispatchMessage(message, ctx) {
           // Registry backlink (sibling of serverInfo, never inside it).
           _meta: MCP_REGISTRY_META,
         };
+        // #7737: native `$mcp_initialize` for PostHog MCP Analytics.
+        scheduleMcpInitializeAnalytics(ctx, {
+          clientName: params?.clientInfo?.name,
+          clientVersion: params?.clientInfo?.version,
+          serverName: MCP_SERVER_INFO.name,
+          serverVersion: MCP_SERVER_INFO.version,
+          sessionId: ctx?.sessionId,
+        });
         return isNotification ? null : rpcResult(id, result);
       }
       case "ping":
@@ -16471,9 +16536,12 @@ function buildContext(request, env, deps) {
     readHealthKv: deps.readHealthKv,
     // The Worker's ExecutionContext, when the caller has one to give: only the
     // real fetch entry does, so it stays optional and every direct-call test
-    // keeps working. Used solely to drain usage telemetry (#6031).
+    // keeps working. Used to drain usage telemetry (#6031) and native MCP
+    // analytics (#7737).
     executionCtx: deps.executionCtx,
     recordUsageEvent: deps.recordUsageEvent,
+    recordMcpToolCallEvent: deps.recordMcpToolCallEvent,
+    recordMcpInitializeEvent: deps.recordMcpInitializeEvent,
   };
 }
 

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -163,3 +163,278 @@ function sanitizeLabel(value: unknown): string | undefined {
     ? trimmed.slice(0, MAX_LABEL_CHARS)
     : trimmed;
 }
+
+// ─── PostHog native MCP analytics (#7737) ───────────────────────────────────
+//
+// Hand-rolled `$mcp_*` events (same raw-fetch capture as recordUsageEvent).
+// posthog-node / @posthog/mcp cannot ship in this Worker (bundle budget —
+// see header comment), so there is no SDK redaction pipeline in front of
+// `$mcp_parameters` / `$mcp_response`. Whatever we put on the wire is what
+// PostHog stores; credential-bearing tool args (call_subnet_surface) must
+// never leave this process unredacted.
+
+/** Canonical PostHog MCP handshake event. */
+export const MCP_INITIALIZE_EVENT = "$mcp_initialize";
+
+/** Canonical PostHog MCP tools/call event. */
+export const MCP_TOOL_CALL_EVENT = "$mcp_tool_call";
+
+/** Placeholder substituted for any sensitive-key value. */
+export const MCP_REDACTED_PLACEHOLDER = "[redacted]";
+
+/**
+ * Key names (lower-snake) whose values are always replaced before capture.
+ * Covers call_subnet_surface's `credential`, alert owner tokens, and the
+ * baseline set PostHog's own MCP SDK auto-redacts.
+ */
+export const MCP_SENSITIVE_KEYS = Object.freeze(
+  new Set([
+    "credential",
+    "owner_token",
+    "authorization",
+    "cookie",
+    "password",
+    "token",
+    "secret",
+    "api_key",
+    "private_key",
+  ]),
+);
+
+// Size caps loosely mirror PostHog SDK truncation (depth/breadth/string) so a
+// single tool response cannot blow the capture body. Tuned for Worker cost,
+// not byte-identical to the SDK.
+const MCP_MAX_DEPTH = 10;
+const MCP_MAX_BREADTH = 100;
+const MCP_MAX_STRING_CHARS = 8_192;
+const MCP_MAX_SERIALIZED_CHARS = 32_768;
+
+export interface McpInitializeAnalytics {
+  clientName?: string;
+  clientVersion?: string;
+  serverName: string;
+  serverVersion: string;
+  sessionId?: string | null;
+}
+
+export interface McpToolCallAnalytics {
+  toolName: string;
+  toolDescription?: string;
+  parameters?: unknown;
+  response?: unknown;
+  durationMs: number;
+  isError: boolean;
+  errorType?: string;
+  sessionId?: string | null;
+}
+
+export interface RecordMcpAnalyticsDeps {
+  fetch?: typeof fetch;
+  distinctId?: string;
+}
+
+/** True when `key` is a sensitive MCP analytics key (case-insensitive). */
+export function isSensitiveMcpKey(key: unknown): boolean {
+  if (typeof key !== "string") return false;
+  return MCP_SENSITIVE_KEYS.has(key.trim().toLowerCase());
+}
+
+/**
+ * Recursively redact sensitive-key values and size-cap the result for safe
+ * inclusion in `$mcp_parameters` / `$mcp_response`. Never throws.
+ */
+export function sanitizeMcpPayload(value: unknown, depth = 0): unknown {
+  try {
+    if (depth > MCP_MAX_DEPTH) return "[truncated:max_depth]";
+    if (value === null || value === undefined) return value;
+    if (typeof value === "string") {
+      return value.length > MCP_MAX_STRING_CHARS
+        ? `${value.slice(0, MCP_MAX_STRING_CHARS)}…[truncated]`
+        : value;
+    }
+    if (typeof value === "boolean") return value;
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? value : String(value);
+    }
+    if (typeof value !== "object") return String(value);
+
+    if (Array.isArray(value)) {
+      const items = value
+        .slice(0, MCP_MAX_BREADTH)
+        .map((item) => sanitizeMcpPayload(item, depth + 1));
+      if (value.length > MCP_MAX_BREADTH) {
+        items.push(`[truncated:${value.length - MCP_MAX_BREADTH}_more]`);
+      }
+      return items;
+    }
+
+    const out: Record<string, unknown> = {};
+    const entries = Object.entries(value as Record<string, unknown>);
+    let count = 0;
+    for (const [key, child] of entries) {
+      if (count >= MCP_MAX_BREADTH) {
+        out["…"] = `[truncated:${entries.length - MCP_MAX_BREADTH}_more]`;
+        break;
+      }
+      count += 1;
+      out[key] = isSensitiveMcpKey(key)
+        ? MCP_REDACTED_PLACEHOLDER
+        : sanitizeMcpPayload(child, depth + 1);
+    }
+    return out;
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+/**
+ * Sanitize then enforce a total serialized-size budget. Prefer this over
+ * sanitizeMcpPayload alone when building `$mcp_parameters` / `$mcp_response`.
+ */
+export function captureSafeMcpPayload(value: unknown): unknown {
+  const sanitized = sanitizeMcpPayload(value);
+  try {
+    const serialized = JSON.stringify(sanitized);
+    if (
+      typeof serialized === "string" &&
+      serialized.length > MCP_MAX_SERIALIZED_CHARS
+    ) {
+      return {
+        truncated: true,
+        preview: `${serialized.slice(0, MCP_MAX_SERIALIZED_CHARS)}…[truncated]`,
+      };
+    }
+  } catch {
+    return "[unserializable]";
+  }
+  return sanitized;
+}
+
+/** Allowlisted `$mcp_initialize` properties, or null when too malformed. */
+export function mcpInitializeProperties(
+  event: McpInitializeAnalytics | null | undefined,
+): Record<string, unknown> | null {
+  if (!event || typeof event !== "object") return null;
+  const serverName = sanitizeLabel(event.serverName);
+  const serverVersion = sanitizeLabel(event.serverVersion);
+  if (!serverName || !serverVersion) return null;
+
+  const properties: Record<string, unknown> = {
+    $mcp_server_name: serverName,
+    $mcp_server_version: serverVersion,
+    // Anonymous Worker sessions must not mint a person profile per handshake.
+    $process_person_profile: false,
+  };
+
+  const clientName = sanitizeLabel(event.clientName);
+  if (clientName !== undefined) properties.$mcp_client_name = clientName;
+  const clientVersion = sanitizeLabel(event.clientVersion);
+  if (clientVersion !== undefined) {
+    properties.$mcp_client_version = clientVersion;
+  }
+  const sessionId = sanitizeLabel(event.sessionId ?? undefined);
+  if (sessionId !== undefined) properties.$session_id = sessionId;
+
+  return properties;
+}
+
+/** Allowlisted `$mcp_tool_call` properties, or null when too malformed. */
+export function mcpToolCallProperties(
+  event: McpToolCallAnalytics | null | undefined,
+): Record<string, unknown> | null {
+  if (!event || typeof event !== "object") return null;
+  const toolName = sanitizeLabel(event.toolName);
+  if (!toolName) return null;
+  if (typeof event.isError !== "boolean") return null;
+  if (
+    typeof event.durationMs !== "number" ||
+    !Number.isFinite(event.durationMs) ||
+    event.durationMs < 0
+  ) {
+    return null;
+  }
+
+  const properties: Record<string, unknown> = {
+    $mcp_tool_name: toolName,
+    $mcp_duration_ms: Math.min(Math.round(event.durationMs), 86_400_000),
+    $mcp_is_error: event.isError,
+    $mcp_parameters: captureSafeMcpPayload(event.parameters ?? {}),
+    $mcp_response: captureSafeMcpPayload(event.response ?? null),
+    $process_person_profile: false,
+  };
+
+  const description = sanitizeLabel(event.toolDescription);
+  if (description !== undefined) properties.$mcp_tool_description = description;
+
+  if (event.isError) {
+    const errorType = sanitizeLabel(event.errorType);
+    if (errorType !== undefined) properties.$mcp_error_type = errorType;
+  }
+
+  const sessionId = sanitizeLabel(event.sessionId ?? undefined);
+  if (sessionId !== undefined) properties.$session_id = sessionId;
+
+  return properties;
+}
+
+/**
+ * Post one native `$mcp_*` analytics event. Same safe no-op / never-throw
+ * contract as recordUsageEvent.
+ */
+export async function recordMcpAnalyticsEvent(
+  env: Env | null | undefined,
+  eventName: typeof MCP_INITIALIZE_EVENT | typeof MCP_TOOL_CALL_EVENT,
+  properties: Record<string, unknown>,
+  deps: RecordMcpAnalyticsDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+    if (
+      eventName !== MCP_INITIALIZE_EVENT &&
+      eventName !== MCP_TOOL_CALL_EVENT
+    ) {
+      return false;
+    }
+    if (!properties || typeof properties !== "object") return false;
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: eventName,
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Convenience: build + post `$mcp_initialize`. */
+export async function recordMcpInitializeEvent(
+  env: Env | null | undefined,
+  event: McpInitializeAnalytics,
+  deps: RecordMcpAnalyticsDeps = {},
+): Promise<boolean> {
+  const properties = mcpInitializeProperties(event);
+  if (!properties) return false;
+  return recordMcpAnalyticsEvent(env, MCP_INITIALIZE_EVENT, properties, deps);
+}
+
+/** Convenience: build + post `$mcp_tool_call` with redacted payloads. */
+export async function recordMcpToolCallEvent(
+  env: Env | null | undefined,
+  event: McpToolCallAnalytics,
+  deps: RecordMcpAnalyticsDeps = {},
+): Promise<boolean> {
+  const properties = mcpToolCallProperties(event);
+  if (!properties) return false;
+  return recordMcpAnalyticsEvent(env, MCP_TOOL_CALL_EVENT, properties, deps);
+}

--- a/tests/mcp-usage-telemetry.test.mjs
+++ b/tests/mcp-usage-telemetry.test.mjs
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+import {
+  MCP_INITIALIZE_EVENT,
+  MCP_REDACTED_PLACEHOLDER,
+  MCP_TOOL_CALL_EVENT,
+  POSTHOG_PROJECT_TOKEN_ENV,
+  mcpToolCallProperties,
+} from "../src/usage-telemetry.ts";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 
 const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
 const TOOL = "get_contracts";
+const SECRET = "Bearer FAKESECRET_w1x2y3z4a5b6c7d8e9f0";
 
 // Collects what each tools/call hands the recorder, plus what it hands
 // waitUntil, without going anywhere near PostHog.
@@ -13,7 +20,22 @@ function recorder({ result = true } = {}) {
   return {
     events,
     recordUsageEvent(env, event) {
-      events.push({ env, event });
+      events.push({ kind: "usage_event", env, event });
+      return typeof result === "function" ? result() : result;
+    },
+  };
+}
+
+function mcpAnalyticsRecorder({ result = true } = {}) {
+  const events = [];
+  return {
+    events,
+    recordMcpToolCallEvent(env, event) {
+      events.push({ kind: MCP_TOOL_CALL_EVENT, env, event });
+      return typeof result === "function" ? result() : result;
+    },
+    recordMcpInitializeEvent(env, event) {
+      events.push({ kind: MCP_INITIALIZE_EVENT, env, event });
       return typeof result === "function" ? result() : result;
     },
   };
@@ -85,7 +107,8 @@ describe("MCP tool-dispatch usage telemetry", () => {
       "ok",
     ]);
     // Drained through waitUntil rather than awaited in the tool path.
-    assert.equal(executionCtx.scheduled.length, 1);
+    // usage_event + $mcp_tool_call each schedule one waitUntil.
+    assert.equal(executionCtx.scheduled.length, 2);
   });
 
   test("records an unknown tool as a failure", async () => {
@@ -139,36 +162,43 @@ describe("MCP tool-dispatch usage telemetry", () => {
 
   test("does no telemetry work when the deployment is unconfigured", async () => {
     const spy = recorder();
+    const mcpSpy = mcpAnalyticsRecorder();
     const payload = await callMcp(
       toolCall(TOOL),
       {},
       {
         executionCtx: fakeExecutionCtx(),
         recordUsageEvent: spy.recordUsageEvent,
+        recordMcpToolCallEvent: mcpSpy.recordMcpToolCallEvent,
       },
     );
 
     assert.equal(payload.result.isError, false);
     assert.deepEqual(spy.events, []);
+    assert.deepEqual(mcpSpy.events, []);
   });
 
   test("does not record tools/list — only tool invocations", async () => {
     const spy = recorder();
+    const mcpSpy = mcpAnalyticsRecorder();
     await callMcp(
       { jsonrpc: "2.0", id: 1, method: "tools/list" },
       CONFIGURED_ENV,
       {
         executionCtx: fakeExecutionCtx(),
         recordUsageEvent: spy.recordUsageEvent,
+        recordMcpToolCallEvent: mcpSpy.recordMcpToolCallEvent,
       },
     );
 
     assert.deepEqual(spy.events, []);
+    assert.deepEqual(mcpSpy.events, []);
   });
 
   test("falls back to the real recorder when none is injected", async () => {
     // Exercises the default path end-to-end: no injected recorder, so the
-    // module's own recordUsageEvent runs and posts through the platform fetch.
+    // module's own recordUsageEvent / recordMcpToolCallEvent run and post
+    // through the platform fetch.
     const original = globalThis.fetch;
     const posted = [];
     globalThis.fetch = async (url, init) => {
@@ -183,11 +213,21 @@ describe("MCP tool-dispatch usage telemetry", () => {
       await Promise.all(executionCtx.scheduled);
 
       assert.equal(payload.result.isError, false);
-      assert.equal(posted.length, 1);
-      assert.equal(posted[0].body.event, "usage_event");
-      assert.equal(posted[0].body.properties.mcp_tool, TOOL);
-      assert.equal(posted[0].body.properties.ok, true);
-      assert.equal("error_code" in posted[0].body.properties, false);
+      assert.equal(posted.length, 2);
+      const byEvent = Object.fromEntries(
+        posted.map((p) => [p.body.event, p.body]),
+      );
+      assert.equal(byEvent.usage_event.properties.mcp_tool, TOOL);
+      assert.equal(byEvent.usage_event.properties.ok, true);
+      assert.equal("error_code" in byEvent.usage_event.properties, false);
+      assert.equal(
+        byEvent[MCP_TOOL_CALL_EVENT].properties.$mcp_tool_name,
+        TOOL,
+      );
+      assert.equal(
+        byEvent[MCP_TOOL_CALL_EVENT].properties.$mcp_is_error,
+        false,
+      );
     } finally {
       globalThis.fetch = original;
     }
@@ -210,9 +250,12 @@ describe("MCP tool-dispatch usage telemetry", () => {
       await Promise.all(executionCtx.scheduled);
 
       assert.equal(payload.result.isError, true);
-      assert.equal(posted.length, 1);
-      assert.equal(posted[0].body.properties.ok, false);
-      assert.equal(posted[0].body.properties.error_code, "invalid_params");
+      const usage = posted.find((p) => p.body.event === "usage_event");
+      assert.equal(usage.body.properties.ok, false);
+      assert.equal(usage.body.properties.error_code, "invalid_params");
+      const mcp = posted.find((p) => p.body.event === MCP_TOOL_CALL_EVENT);
+      assert.equal(mcp.body.properties.$mcp_is_error, true);
+      assert.equal(mcp.body.properties.$mcp_error_type, "invalid_params");
     } finally {
       globalThis.fetch = original;
     }
@@ -240,6 +283,9 @@ describe("MCP tool-dispatch usage telemetry", () => {
         recordUsageEvent: recorder({
           result: () => Promise.reject(new Error("posthog down")),
         }).recordUsageEvent,
+        recordMcpToolCallEvent: mcpAnalyticsRecorder({
+          result: () => Promise.reject(new Error("posthog down")),
+        }).recordMcpToolCallEvent,
         executionCtx: fakeExecutionCtx(),
       },
       "recorder throws synchronously": {
@@ -248,10 +294,16 @@ describe("MCP tool-dispatch usage telemetry", () => {
             throw new Error("recorder exploded");
           },
         }).recordUsageEvent,
+        recordMcpToolCallEvent: mcpAnalyticsRecorder({
+          result: () => {
+            throw new Error("recorder exploded");
+          },
+        }).recordMcpToolCallEvent,
         executionCtx: fakeExecutionCtx(),
       },
       "waitUntil throws": {
         recordUsageEvent: recorder().recordUsageEvent,
+        recordMcpToolCallEvent: mcpAnalyticsRecorder().recordMcpToolCallEvent,
         executionCtx: {
           waitUntil() {
             throw new Error("isolate already finished");
@@ -260,6 +312,7 @@ describe("MCP tool-dispatch usage telemetry", () => {
       },
       "no ExecutionContext at all": {
         recordUsageEvent: recorder().recordUsageEvent,
+        recordMcpToolCallEvent: mcpAnalyticsRecorder().recordMcpToolCallEvent,
       },
     };
 
@@ -271,5 +324,114 @@ describe("MCP tool-dispatch usage telemetry", () => {
         `telemetry mode changed the result: ${mode}`,
       );
     }
+  });
+});
+
+describe("MCP native PostHog analytics (#7737)", () => {
+  test("initialize emits $mcp_initialize with client/server identity", async () => {
+    const spy = mcpAnalyticsRecorder();
+    const executionCtx = fakeExecutionCtx();
+    await callMcp(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "cursor", version: "1.2.3" },
+        },
+      },
+      CONFIGURED_ENV,
+      {
+        executionCtx,
+        recordMcpInitializeEvent: spy.recordMcpInitializeEvent,
+      },
+    );
+
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0].kind, MCP_INITIALIZE_EVENT);
+    assert.equal(spy.events[0].event.clientName, "cursor");
+    assert.equal(spy.events[0].event.clientVersion, "1.2.3");
+    assert.equal(spy.events[0].event.serverName, "metagraphed");
+    assert.equal(typeof spy.events[0].event.serverVersion, "string");
+    assert.equal(executionCtx.scheduled.length, 1);
+  });
+
+  test("a credentialed call_subnet_surface never leaks the raw secret on the wire", async () => {
+    const original = globalThis.fetch;
+    const posted = [];
+    globalThis.fetch = async (_url, init) => {
+      // Capture analytics posts; also satisfy any outbound surface call.
+      if (typeof init?.body === "string") {
+        try {
+          posted.push(JSON.parse(init.body));
+        } catch {
+          posted.push({ raw: init.body });
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: async () => "{}",
+      };
+    };
+    try {
+      const executionCtx = fakeExecutionCtx();
+      await callMcp(
+        toolCall("call_subnet_surface", {
+          surface_id: "does-not-exist",
+          credential: {
+            name: "Authorization",
+            value: SECRET,
+            location: "header",
+          },
+        }),
+        CONFIGURED_ENV,
+        { executionCtx },
+      );
+      await Promise.all(executionCtx.scheduled);
+
+      const mcpCall = posted.find((p) => p.event === MCP_TOOL_CALL_EVENT);
+      assert.ok(mcpCall, "expected a $mcp_tool_call capture");
+      assert.equal(
+        mcpCall.properties.$mcp_parameters.credential,
+        MCP_REDACTED_PLACEHOLDER,
+      );
+      const wire = JSON.stringify(posted);
+      assert.equal(wire.includes(SECRET), false);
+      assert.equal(wire.includes("sk-live-credential-must-never-leak"), false);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("scheduled tool-call analytics redact credentials before capture properties", () => {
+    // The scheduler hands the raw args object to recordMcpToolCallEvent; the
+    // property builder is the redaction boundary that must never leak.
+    const props = mcpToolCallProperties({
+      toolName: "call_subnet_surface",
+      parameters: {
+        surface_id: "x:api:1",
+        credential: {
+          name: "Authorization",
+          value: SECRET,
+          location: "header",
+        },
+        owner_token: "owner-secret-value",
+      },
+      response: {
+        isError: true,
+        structuredContent: { error: { code: "not_found" } },
+      },
+      durationMs: 4,
+      isError: true,
+      errorType: "not_found",
+    });
+    assert.equal(props.$mcp_parameters.credential, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(props.$mcp_parameters.owner_token, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(JSON.stringify(props).includes(SECRET), false);
+    assert.equal(JSON.stringify(props).includes("owner-secret-value"), false);
   });
 });

--- a/tests/usage-telemetry.test.mjs
+++ b/tests/usage-telemetry.test.mjs
@@ -1,14 +1,25 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  MCP_INITIALIZE_EVENT,
+  MCP_REDACTED_PLACEHOLDER,
+  MCP_TOOL_CALL_EVENT,
   POSTHOG_CAPTURE_PATH,
   POSTHOG_HOST_ENV,
   POSTHOG_PROJECT_TOKEN_ENV,
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
+  captureSafeMcpPayload,
+  isSensitiveMcpKey,
   isUsageTelemetryConfigured,
+  mcpInitializeProperties,
+  mcpToolCallProperties,
+  recordMcpAnalyticsEvent,
+  recordMcpInitializeEvent,
+  recordMcpToolCallEvent,
   recordUsageEvent,
   resolvePostHogHost,
+  sanitizeMcpPayload,
   usageEventProperties,
 } from "../src/usage-telemetry.ts";
 
@@ -303,5 +314,401 @@ describe("recordUsageEvent — configured", () => {
       },
     );
     assert.equal(calls[0].body.distinct_id, "test-distinct");
+  });
+});
+
+describe("sanitizeMcpPayload / captureSafeMcpPayload (#7737)", () => {
+  test("isSensitiveMcpKey matches the issue's key set case-insensitively", () => {
+    assert.equal(isSensitiveMcpKey("credential"), true);
+    assert.equal(isSensitiveMcpKey("Owner_Token"), true);
+    assert.equal(isSensitiveMcpKey("AUTHORIZATION"), true);
+    assert.equal(isSensitiveMcpKey("api_key"), true);
+    assert.equal(isSensitiveMcpKey("private_key"), true);
+    assert.equal(isSensitiveMcpKey("surface_id"), false);
+    assert.equal(isSensitiveMcpKey(null), false);
+  });
+
+  test("redacts sensitive keys recursively without descending into them", () => {
+    const out = sanitizeMcpPayload({
+      surface_id: "x:api:1",
+      credential: {
+        name: "Authorization",
+        value: "Bearer super-secret-token-value",
+        location: "header",
+      },
+      nested: {
+        owner_token: "owner-secret",
+        password: "hunter2",
+        cookie: "sid=abc",
+        token: "tok",
+        secret: "shh",
+        api_key: "ak",
+        private_key: "pk",
+        authorization: "Basic xxx",
+        safe: "ok",
+      },
+    });
+    assert.equal(out.surface_id, "x:api:1");
+    assert.equal(out.credential, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.owner_token, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.password, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.cookie, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.token, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.secret, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.api_key, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.private_key, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.authorization, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(out.nested.safe, "ok");
+    // Raw secret must not appear anywhere in the sanitized tree.
+    assert.equal(
+      JSON.stringify(out).includes("super-secret-token-value"),
+      false,
+    );
+    assert.equal(JSON.stringify(out).includes("owner-secret"), false);
+    assert.equal(JSON.stringify(out).includes("hunter2"), false);
+  });
+
+  test("truncates overlong strings and deep trees", () => {
+    const long = "y".repeat(9_000);
+    assert.match(sanitizeMcpPayload(long), /\[truncated\]$/);
+
+    let deep = { leaf: "ok" };
+    for (let i = 0; i < 20; i += 1) deep = { child: deep };
+    const capped = sanitizeMcpPayload(deep);
+    assert.match(JSON.stringify(capped), /max_depth/);
+  });
+
+  test("truncates array and object breadth, and stringifies exotic values", () => {
+    const wideArray = Array.from({ length: 105 }, (_, i) => i);
+    const arrayOut = sanitizeMcpPayload(wideArray);
+    assert.equal(arrayOut.length, 101);
+    assert.match(arrayOut[100], /_more\]$/);
+
+    const wideObject = Object.fromEntries(
+      Array.from({ length: 105 }, (_, i) => [`k${i}`, i]),
+    );
+    const objectOut = sanitizeMcpPayload(wideObject);
+    assert.equal(objectOut["…"].includes("_more"), true);
+    assert.equal(Object.keys(objectOut).length, 101);
+
+    assert.equal(sanitizeMcpPayload(Number.POSITIVE_INFINITY), "Infinity");
+    assert.equal(sanitizeMcpPayload(undefined), undefined);
+    assert.equal(sanitizeMcpPayload(null), null);
+    assert.equal(sanitizeMcpPayload(true), true);
+    assert.equal(sanitizeMcpPayload(123n), "123");
+  });
+
+  test("sanitizeMcpPayload returns unserializable when walking throws", () => {
+    const evil = {};
+    Object.defineProperty(evil, "x", {
+      enumerable: true,
+      get() {
+        throw new Error("boom");
+      },
+    });
+    assert.equal(sanitizeMcpPayload(evil), "[unserializable]");
+  });
+
+  test("captureSafeMcpPayload collapses an oversized serialized body", () => {
+    // 100 breadth-capped strings near the per-string cap exceed the total
+    // serialized budget even after sanitizeMcpPayload runs.
+    const huge = {
+      rows: Array.from({ length: 100 }, () => "x".repeat(8_000)),
+    };
+    const out = captureSafeMcpPayload(huge);
+    assert.equal(out.truncated, true);
+    assert.equal(typeof out.preview, "string");
+  });
+
+  test("captureSafeMcpPayload returns unserializable when JSON.stringify throws", () => {
+    const cyclic = {};
+    cyclic.self = cyclic;
+    // sanitizeMcpPayload walks plain objects and will recurse into the cycle
+    // until max_depth, so build a value whose sanitized form still throws:
+    // BigInt is preserved only via String() path; use a toJSON bomb instead.
+    const bomb = {
+      toJSON() {
+        throw new Error("nope");
+      },
+    };
+    // sanitize copies enumerable own props; toJSON isn't copied as a value
+    // that JSON.stringify will call unless we keep the object identity. Force
+    // the catch by stubbing JSON.stringify once.
+    const original = JSON.stringify;
+    JSON.stringify = () => {
+      throw new Error("stringify failed");
+    };
+    try {
+      assert.equal(captureSafeMcpPayload({ a: 1 }), "[unserializable]");
+    } finally {
+      JSON.stringify = original;
+    }
+    assert.equal(typeof cyclic.self, "object");
+    assert.equal(typeof bomb.toJSON, "function");
+  });
+});
+
+describe("mcpInitializeProperties / mcpToolCallProperties (#7737)", () => {
+  test("mcpInitializeProperties requires server identity", () => {
+    assert.equal(mcpInitializeProperties(null), null);
+    assert.equal(mcpInitializeProperties({ serverName: "x" }), null);
+    assert.deepEqual(
+      mcpInitializeProperties({
+        clientName: " cursor ",
+        clientVersion: "1.0",
+        serverName: "metagraphed",
+        serverVersion: "1.2.3",
+        sessionId: "sess-1",
+      }),
+      {
+        $mcp_server_name: "metagraphed",
+        $mcp_server_version: "1.2.3",
+        $mcp_client_name: "cursor",
+        $mcp_client_version: "1.0",
+        $session_id: "sess-1",
+        $process_person_profile: false,
+      },
+    );
+  });
+
+  test("mcpToolCallProperties redacts credentials in parameters and response", () => {
+    const props = mcpToolCallProperties({
+      toolName: "call_subnet_surface",
+      toolDescription: "Execute a registered surface",
+      parameters: {
+        surface_id: "x:api:1",
+        credential: { value: "Bearer leak-me-now" },
+      },
+      response: {
+        isError: false,
+        structuredContent: { ok: true, echo: { password: "nope" } },
+      },
+      durationMs: 12.4,
+      isError: false,
+    });
+    assert.equal(props.$mcp_tool_name, "call_subnet_surface");
+    assert.equal(props.$mcp_is_error, false);
+    assert.equal(props.$mcp_duration_ms, 12);
+    assert.equal(props.$mcp_parameters.credential, MCP_REDACTED_PLACEHOLDER);
+    assert.equal(props.$mcp_parameters.surface_id, "x:api:1");
+    assert.equal(
+      props.$mcp_response.structuredContent.echo.password,
+      MCP_REDACTED_PLACEHOLDER,
+    );
+    const wire = JSON.stringify(props);
+    assert.equal(wire.includes("leak-me-now"), false);
+    assert.equal(wire.includes("Bearer"), false);
+    assert.equal(wire.includes("nope"), false);
+    assert.equal("$mcp_error_type" in props, false);
+  });
+
+  test("mcpToolCallProperties rejects malformed events", () => {
+    assert.equal(mcpToolCallProperties(null), null);
+    assert.equal(
+      mcpToolCallProperties({ toolName: "   ", durationMs: 1, isError: false }),
+      null,
+    );
+    assert.equal(mcpToolCallProperties({ toolName: "x", durationMs: 1 }), null);
+    assert.equal(
+      mcpToolCallProperties({
+        toolName: "x",
+        durationMs: Number.NaN,
+        isError: false,
+      }),
+      null,
+    );
+    assert.equal(
+      mcpToolCallProperties({
+        toolName: "x",
+        durationMs: -1,
+        isError: false,
+      }),
+      null,
+    );
+  });
+
+  test("mcpToolCallProperties omits blank error types and optional fields", () => {
+    const props = mcpToolCallProperties({
+      toolName: "get_subnet",
+      durationMs: 2,
+      isError: true,
+      errorType: "   ",
+    });
+    assert.equal(props.$mcp_is_error, true);
+    assert.equal("$mcp_error_type" in props, false);
+    assert.equal("$mcp_tool_description" in props, false);
+    assert.equal("$session_id" in props, false);
+    assert.deepEqual(props.$mcp_parameters, {});
+    assert.equal(props.$mcp_response, null);
+  });
+
+  test("mcpToolCallProperties includes error type only on failures", () => {
+    const props = mcpToolCallProperties({
+      toolName: "get_subnet",
+      parameters: {},
+      response: { isError: true },
+      durationMs: 1,
+      isError: true,
+      errorType: "invalid_params",
+      sessionId: "sess-9",
+      toolDescription: "Get one subnet",
+    });
+    assert.equal(props.$mcp_error_type, "invalid_params");
+    assert.equal(props.$session_id, "sess-9");
+    assert.equal(props.$mcp_tool_description, "Get one subnet");
+  });
+});
+
+describe("recordMcpAnalyticsEvent (#7737)", () => {
+  test("posts $mcp_initialize and $mcp_tool_call with redacted properties", async () => {
+    const calls = [];
+    const env = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+    const fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+
+    assert.equal(
+      await recordMcpInitializeEvent(
+        env,
+        {
+          serverName: "metagraphed",
+          serverVersion: "9.9.9",
+          clientName: "test",
+        },
+        { fetch },
+      ),
+      true,
+    );
+    assert.equal(
+      await recordMcpToolCallEvent(
+        env,
+        {
+          toolName: "call_subnet_surface",
+          parameters: { credential: "SECRET_VALUE_XYZ" },
+          response: { ok: true },
+          durationMs: 3,
+          isError: false,
+        },
+        { fetch },
+      ),
+      true,
+    );
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].body.event, MCP_INITIALIZE_EVENT);
+    assert.equal(calls[1].body.event, MCP_TOOL_CALL_EVENT);
+    assert.equal(
+      calls[1].body.properties.$mcp_parameters.credential,
+      MCP_REDACTED_PLACEHOLDER,
+    );
+    assert.equal(
+      JSON.stringify(calls[1].body).includes("SECRET_VALUE_XYZ"),
+      false,
+    );
+  });
+
+  test("rejects unknown event names, bad properties, and unconfigured env", async () => {
+    let calls = 0;
+    const fetch = fakeFetch({
+      onCall: () => {
+        calls += 1;
+      },
+    });
+    assert.equal(
+      await recordMcpAnalyticsEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc" },
+        "$mcp_tools_list",
+        { a: 1 },
+        { fetch },
+      ),
+      false,
+    );
+    assert.equal(
+      await recordMcpAnalyticsEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc" },
+        MCP_TOOL_CALL_EVENT,
+        null,
+        { fetch },
+      ),
+      false,
+    );
+    assert.equal(
+      await recordMcpToolCallEvent(
+        {},
+        {
+          toolName: "x",
+          durationMs: 1,
+          isError: false,
+        },
+        { fetch },
+      ),
+      false,
+    );
+    assert.equal(
+      await recordMcpToolCallEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc" },
+        { toolName: "x", durationMs: -5, isError: false },
+        { fetch },
+      ),
+      false,
+    );
+    assert.equal(calls, 0);
+  });
+
+  test("swallows transport failures and rejected captures", async () => {
+    assert.equal(
+      await recordMcpInitializeEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc" },
+        { serverName: "metagraphed", serverVersion: "1" },
+        { fetch: fakeFetch({ throws: true }) },
+      ),
+      false,
+    );
+    assert.equal(
+      await recordMcpInitializeEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc" },
+        { serverName: "metagraphed", serverVersion: "1" },
+        { fetch: fakeFetch({ ok: false }) },
+      ),
+      false,
+    );
+  });
+
+  test("defaults to platform fetch and honors distinctId", async () => {
+    const original = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      assert.equal(
+        await recordMcpInitializeEvent(
+          { [POSTHOG_PROJECT_TOKEN_ENV]: "phc" },
+          { serverName: "metagraphed", serverVersion: "1" },
+          { distinctId: "mcp-distinct" },
+        ),
+        true,
+      );
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].body.distinct_id, "mcp-distinct");
+      assert.equal(calls[0].body.event, MCP_INITIALIZE_EVENT);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("recordMcpInitializeEvent returns false when identity is blank", async () => {
+    let calls = 0;
+    assert.equal(
+      await recordMcpInitializeEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc" },
+        { serverName: "  ", serverVersion: "1" },
+        {
+          fetch: fakeFetch({
+            onCall: () => {
+              calls += 1;
+            },
+          }),
+        },
+      ),
+      false,
+    );
+    assert.equal(calls, 0);
   });
 });


### PR DESCRIPTION
## Summary

- Hand-roll PostHog native `$mcp_initialize` / `$mcp_tool_call` events through the existing raw-fetch usage-telemetry path (zero Worker bundle cost — `posthog-node` / `@posthog/mcp` ruled out by the script-size budget).
- Recursive key-name redaction + size caps on `$mcp_parameters` / `$mcp_response`, covering `credential`, `owner_token`, and PostHog SDK baseline keys (`authorization`, `cookie`, `password`, `token`, `secret`, `api_key`, `private_key`).
- Wire emit points into MCP `initialize` and `callTool`; keep the existing allowlisted `usage_event` path unchanged.

Closes #7737.

## What Changed

- `src/usage-telemetry.ts` — `sanitizeMcpPayload` / `captureSafeMcpPayload`, `$mcp_*` property builders, `recordMcpInitializeEvent` / `recordMcpToolCallEvent`.
- `src/mcp-server.mjs` — schedule `$mcp_initialize` on handshake and `$mcp_tool_call` (redacted args/result) alongside the existing usage event.
- `tests/usage-telemetry.test.mjs`, `tests/mcp-usage-telemetry.test.mjs` — redaction, size caps, initialize/tool-call wiring, and a credentialed `call_subnet_surface` wire-leak regression.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7737`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `npx vitest run tests/usage-telemetry.test.mjs tests/mcp-usage-telemetry.test.mjs` — 48 passing
- [x] `npx vitest run … --coverage.include=src/usage-telemetry.ts` — 100% stmts/branches/funcs/lines on that module
- [x] `npx vitest run tests/call-subnet-surface-mcp.test.mjs tests/mcp-server-sentry-args-safety.test.mjs` — 75 passing
- [x] `npx tsc --noEmit`
- [x] `npx eslint` + `npx prettier --check` on touched files
- [x] `git diff --check`