### PR TITLE
feat(observability): PostHog-native $mcp_* analytics with credential-safe redaction (#7737)

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -38,6 +38,7 @@
 import * as Sentry from "@sentry/cloudflare";
 import {
   isUsageTelemetryConfigured,
+  recordMcpAnalyticsEvent,
   recordUsageEvent,
 } from "./usage-telemetry.ts";
 import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.ts";
@@ -16255,7 +16256,42 @@ async function callTool(params, ctx) {
       ? { errorCode: result?.structuredContent?.error?.code }
       : {}),
   });
+  // metagraphed#7737: PostHog-native $mcp_tool_call alongside the coarse
+  // usage_event. Arguments and structured response are handed over RAW --
+  // recordMcpAnalyticsEvent owns the recursive credential redaction and size
+  // cap, so there is exactly one scrubbing pipeline to audit rather than one
+  // per call site.
+  scheduleMcpAnalyticsEvent(ctx, {
+    type: "tool_call",
+    toolName: typeof params?.name === "string" ? params.name : undefined,
+    ok: result.isError !== true,
+    durationMs: Date.now() - startedAt,
+    parameters: params?.arguments,
+    response: result?.structuredContent,
+    ...(result.isError
+      ? { errorCode: result?.structuredContent?.error?.code }
+      : {}),
+  });
   return result;
+}
+
+/**
+ * Hand a PostHog-native $mcp_* analytics event to the recorder without ever
+ * blocking or failing the request path (metagraphed#7737). Mirrors
+ * scheduleToolUsageEvent, including the injectable-recorder seam for tests.
+ *
+ * @param {object} ctx
+ * @param {object} event
+ */
+function scheduleMcpAnalyticsEvent(ctx, event) {
+  try {
+    if (!isUsageTelemetryConfigured(ctx?.env)) return;
+    const record = ctx?.recordMcpAnalyticsEvent ?? recordMcpAnalyticsEvent;
+    const pending = Promise.resolve(record(ctx.env, event)).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
 }
 
 /**
@@ -16381,6 +16417,13 @@ async function dispatchMessage(message, ctx) {
           // Registry backlink (sibling of serverInfo, never inside it).
           _meta: MCP_REGISTRY_META,
         };
+        // metagraphed#7737: $mcp_initialize with the (redacted, capped)
+        // handshake params -- client name/version is what the analytics
+        // family exists to segment on.
+        scheduleMcpAnalyticsEvent(ctx, {
+          type: "initialize",
+          parameters: params,
+        });
         return isNotification ? null : rpcResult(id, result);
       }
       case "ping":
@@ -16474,6 +16517,7 @@ function buildContext(request, env, deps) {
     // keeps working. Used solely to drain usage telemetry (#6031).
     executionCtx: deps.executionCtx,
     recordUsageEvent: deps.recordUsageEvent,
+    recordMcpAnalyticsEvent: deps.recordMcpAnalyticsEvent,
   };
 }
 

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -155,6 +155,191 @@ export function resolvePostHogHost(env: Env | null | undefined): string {
     : DEFAULT_POSTHOG_HOST;
 }
 
+// --- PostHog native MCP analytics (#7737) -----------------------------------
+//
+// The `$mcp_*` event family PostHog's MCP Analytics wizard instruments,
+// hand-rolled through the same raw-fetch capture path as `usage_event` above
+// (the `posthog-node`/`@posthog/mcp` SDK wrapper is ruled out by the bundle
+// budget -- see the header comment). Because there is no SDK-provided
+// redaction pipeline in front of `$mcp_parameters`/`$mcp_response` on this
+// path, this module owns one: recursive key-name-based redaction that must
+// run before anything is serialized into a capture.
+
+/** PostHog-native MCP lifecycle event names owned by this wrapper. */
+export const MCP_INITIALIZE_EVENT_NAME = "$mcp_initialize";
+export const MCP_TOOL_CALL_EVENT_NAME = "$mcp_tool_call";
+
+/** Placeholder every redacted value is replaced with. */
+export const REDACTED_PLACEHOLDER = "[REDACTED]";
+
+// Key names whose values must never leave this server in an analytics
+// payload: the credential-bearing tool arguments this codebase itself defines
+// (`credential`, `owner_token`) plus the baseline set PostHog's own SDK
+// auto-redacts. Matched case-insensitively as substrings so wrappers like
+// `Authorization`, `session_cookie`, or `refresh_token` are covered too --
+// over-redacting an analytics capture is always safe, leaking never is.
+const REDACTED_KEY_NAMES = [
+  "credential",
+  "owner_token",
+  "authorization",
+  "cookie",
+  "password",
+  "token",
+  "secret",
+  "api_key",
+  "private_key",
+];
+
+// Bound the serialized parameter/response captures. 4 KiB keeps the whole
+// capture request comfortably small while retaining enough of a payload to
+// be diagnostically useful.
+const MAX_CAPTURE_JSON_CHARS = 4096;
+
+// Fail closed past this nesting depth: anything deeper is replaced with the
+// placeholder rather than passed through unexamined.
+const MAX_REDACTION_DEPTH = 8;
+
+function isRedactedKey(key: string): boolean {
+  const lowered = key.toLowerCase();
+  return REDACTED_KEY_NAMES.some((name) => lowered.includes(name));
+}
+
+/**
+ * Recursively replace the values of sensitive-named keys with
+ * REDACTED_PLACEHOLDER. Arrays are walked element-wise; primitives pass
+ * through; anything nested beyond MAX_REDACTION_DEPTH is redacted wholesale
+ * (fail closed) instead of being emitted unexamined.
+ */
+export function redactAnalyticsValue(value: unknown, depth = 0): unknown {
+  if (depth >= MAX_REDACTION_DEPTH) return REDACTED_PLACEHOLDER;
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactAnalyticsValue(entry, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = isRedactedKey(key)
+        ? REDACTED_PLACEHOLDER
+        : redactAnalyticsValue(entry, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Redact, serialize, and size-cap a `$mcp_parameters`/`$mcp_response`
+ * capture. Returns undefined when there is nothing to capture or the value
+ * cannot be serialized (cycles, exotic objects) -- dropping a capture is
+ * always preferable to failing or leaking.
+ */
+export function redactedCaptureJson(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  try {
+    const json = JSON.stringify(redactAnalyticsValue(value));
+    if (typeof json !== "string") return undefined;
+    return json.length > MAX_CAPTURE_JSON_CHARS
+      ? json.slice(0, MAX_CAPTURE_JSON_CHARS)
+      : json;
+  } catch {
+    return undefined;
+  }
+}
+
+/** One PostHog-native MCP analytics event (#7737). `parameters`/`response`
+ * are the RAW values -- redaction and capping happen inside this module, so
+ * no caller ever has to remember to pre-scrub them. */
+export interface McpAnalyticsEvent {
+  type: "initialize" | "tool_call";
+  toolName?: string;
+  parameters?: unknown;
+  response?: unknown;
+  ok?: boolean;
+  durationMs?: number;
+  /** Same fixed-literal-code contract as UsageEvent.errorCode (#7726). */
+  errorCode?: string;
+}
+
+/**
+ * Build the properties for one `$mcp_*` capture, or null when the event is
+ * malformed. Every free-form field is redacted/capped here -- nothing
+ * reaches the capture body unscrubbed.
+ */
+export function mcpAnalyticsProperties(
+  event: McpAnalyticsEvent | null | undefined,
+): Record<string, string | number | boolean> | null {
+  if (!event || typeof event !== "object") return null;
+  if (event.type !== "initialize" && event.type !== "tool_call") return null;
+
+  const properties: Record<string, string | number | boolean> = {};
+
+  const toolName = sanitizeLabel(event.toolName);
+  if (toolName !== undefined) properties.$mcp_tool_name = toolName;
+
+  if (typeof event.ok === "boolean") properties.ok = event.ok;
+
+  if (
+    typeof event.durationMs === "number" &&
+    Number.isFinite(event.durationMs) &&
+    event.durationMs >= 0
+  ) {
+    properties.duration_ms = Math.min(Math.round(event.durationMs), 86_400_000);
+  }
+
+  const errorCode = sanitizeLabel(event.errorCode);
+  if (errorCode !== undefined) properties.error_code = errorCode;
+
+  const parameters = redactedCaptureJson(event.parameters);
+  if (parameters !== undefined) properties.$mcp_parameters = parameters;
+
+  const response = redactedCaptureJson(event.response);
+  if (response !== undefined) properties.$mcp_response = response;
+
+  return properties;
+}
+
+/**
+ * Record one PostHog-native MCP analytics event through the same raw-fetch
+ * capture path as recordUsageEvent. Same contract: resolves without
+ * throwing, returns whether a capture was handed to PostHog, safe no-op when
+ * the deployment is unconfigured.
+ */
+export async function recordMcpAnalyticsEvent(
+  env: Env | null | undefined,
+  event: McpAnalyticsEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+
+    const properties = mcpAnalyticsProperties(event);
+    if (!properties) return false;
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event:
+            event.type === "initialize"
+              ? MCP_INITIALIZE_EVENT_NAME
+              : MCP_TOOL_CALL_EVENT_NAME,
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    // Telemetry must never surface into the request/tool path.
+    return false;
+  }
+}
+
 function sanitizeLabel(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();

--- a/tests/call-subnet-surface-mcp.test.mjs
+++ b/tests/call-subnet-surface-mcp.test.mjs
@@ -1485,5 +1485,73 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       assert.equal(recorded[0].ok, false);
       assert.equal(recorded[0].errorCode, "invalid_params");
     });
+
+    // metagraphed#7737: the $mcp_tool_call analytics capture DOES carry
+    // parameters -- so this exercises the real redaction pipeline end-to-end
+    // (no injected analytics recorder), asserting on the exact bytes handed
+    // to the capture transport: the credential value must be gone and the
+    // non-sensitive fields must survive.
+    test("the $mcp_tool_call capture redacts the credential end-to-end", async () => {
+      const of = globalThis.fetch;
+      const captured = [];
+      globalThis.fetch = async (url, init) => {
+        if (String(url).includes("posthog.com")) {
+          captured.push(JSON.parse(init.body));
+          return { ok: true };
+        }
+        // The surface's own outbound call.
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      };
+      const scheduled = [];
+      try {
+        const response = await handleMcpRequest(
+          new Request("https://metagraph.sh/mcp", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/call",
+              params: {
+                name: "call_subnet_surface",
+                arguments: {
+                  surface_id: "x:api:6",
+                  credential: "Bearer super-secret-abc123",
+                },
+              },
+            }),
+          }),
+          { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" },
+          {
+            ...deps,
+            executionCtx: { waitUntil: (p) => scheduled.push(p) },
+            // Keep the coarse usage_event on its injected spy so the only
+            // real capture on the wire is the $mcp_tool_call under test.
+            recordUsageEvent: async () => true,
+          },
+        );
+        await response.json();
+        await Promise.all(scheduled);
+      } finally {
+        globalThis.fetch = of;
+      }
+
+      assert.equal(captured.length, 1);
+      const capture = captured[0];
+      assert.equal(capture.event, "$mcp_tool_call");
+      assert.equal(capture.properties.$mcp_tool_name, "call_subnet_surface");
+      const serialized = JSON.stringify(capture);
+      assert.ok(!serialized.includes("super-secret-abc123"));
+      assert.ok(
+        capture.properties.$mcp_parameters.includes(
+          '"credential":"[REDACTED]"',
+        ),
+      );
+      // Redaction is surgical: the non-sensitive argument survives.
+      assert.ok(capture.properties.$mcp_parameters.includes("x:api:6"));
+    });
   });
 });

--- a/tests/mcp-usage-telemetry.test.mjs
+++ b/tests/mcp-usage-telemetry.test.mjs
@@ -84,8 +84,9 @@ describe("MCP tool-dispatch usage telemetry", () => {
       "mcpTool",
       "ok",
     ]);
-    // Drained through waitUntil rather than awaited in the tool path.
-    assert.equal(executionCtx.scheduled.length, 1);
+    // Drained through waitUntil rather than awaited in the tool path -- one
+    // usage_event plus one $mcp_tool_call (metagraphed#7737).
+    assert.equal(executionCtx.scheduled.length, 2);
   });
 
   test("records an unknown tool as a failure", async () => {
@@ -183,11 +184,13 @@ describe("MCP tool-dispatch usage telemetry", () => {
       await Promise.all(executionCtx.scheduled);
 
       assert.equal(payload.result.isError, false);
-      assert.equal(posted.length, 1);
-      assert.equal(posted[0].body.event, "usage_event");
-      assert.equal(posted[0].body.properties.mcp_tool, TOOL);
-      assert.equal(posted[0].body.properties.ok, true);
-      assert.equal("error_code" in posted[0].body.properties, false);
+      // usage_event plus its $mcp_tool_call sibling (metagraphed#7737).
+      assert.equal(posted.length, 2);
+      const usage = posted.find((c) => c.body.event === "usage_event");
+      assert.ok(usage);
+      assert.equal(usage.body.properties.mcp_tool, TOOL);
+      assert.equal(usage.body.properties.ok, true);
+      assert.equal("error_code" in usage.body.properties, false);
     } finally {
       globalThis.fetch = original;
     }
@@ -210,9 +213,12 @@ describe("MCP tool-dispatch usage telemetry", () => {
       await Promise.all(executionCtx.scheduled);
 
       assert.equal(payload.result.isError, true);
-      assert.equal(posted.length, 1);
-      assert.equal(posted[0].body.properties.ok, false);
-      assert.equal(posted[0].body.properties.error_code, "invalid_params");
+      // usage_event plus its $mcp_tool_call sibling (metagraphed#7737).
+      assert.equal(posted.length, 2);
+      const usage = posted.find((c) => c.body.event === "usage_event");
+      assert.ok(usage);
+      assert.equal(usage.body.properties.ok, false);
+      assert.equal(usage.body.properties.error_code, "invalid_params");
     } finally {
       globalThis.fetch = original;
     }
@@ -271,5 +277,112 @@ describe("MCP tool-dispatch usage telemetry", () => {
         `telemetry mode changed the result: ${mode}`,
       );
     }
+  });
+});
+
+// metagraphed#7737: the PostHog-native $mcp_* analytics family, recorded
+// through its own injectable seam. The recorder receives RAW parameters and
+// response -- redaction/capping is recordMcpAnalyticsEvent's job (unit-tested
+// in usage-telemetry.test.mjs); what matters here is that dispatch hands the
+// analytics pipeline exactly one complete event per lifecycle point.
+describe("PostHog-native MCP analytics ($mcp_*)", () => {
+  function analyticsRecorder() {
+    const events = [];
+    return {
+      events,
+      recordMcpAnalyticsEvent(env, event) {
+        events.push({ env, event });
+        return true;
+      },
+    };
+  }
+
+  test("initialize records one $mcp_initialize event with the handshake params", async () => {
+    const spy = analyticsRecorder();
+    const payload = await callMcp(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          clientInfo: { name: "vitest", version: "1.0.0" },
+        },
+      },
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordMcpAnalyticsEvent: spy.recordMcpAnalyticsEvent,
+      },
+    );
+
+    assert.ok(payload.result.serverInfo);
+    assert.equal(spy.events.length, 1);
+    const { env, event } = spy.events[0];
+    assert.equal(env, CONFIGURED_ENV);
+    assert.equal(event.type, "initialize");
+    assert.equal(event.parameters.clientInfo.name, "vitest");
+  });
+
+  test("a tool call records one $mcp_tool_call with raw args and response for central redaction", async () => {
+    const spy = analyticsRecorder();
+    const executionCtx = fakeExecutionCtx();
+    const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, {
+      executionCtx,
+      recordMcpAnalyticsEvent: spy.recordMcpAnalyticsEvent,
+    });
+
+    assert.equal(payload.result.isError, false);
+    assert.equal(spy.events.length, 1);
+    const { event } = spy.events[0];
+    assert.equal(event.type, "tool_call");
+    assert.equal(event.toolName, TOOL);
+    assert.equal(event.ok, true);
+    assert.ok(event.durationMs >= 0);
+    assert.deepEqual(event.parameters, {});
+    assert.deepEqual(event.response, payload.result.structuredContent);
+    assert.equal("errorCode" in event, false);
+  });
+
+  test("a failing tool call carries the same fixed literal errorCode", async () => {
+    const spy = analyticsRecorder();
+    const payload = await callMcp(
+      toolCall("get_subnet", { netuid: "not-a-netuid" }),
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordMcpAnalyticsEvent: spy.recordMcpAnalyticsEvent,
+      },
+    );
+
+    assert.equal(payload.result.isError, true);
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0].event.ok, false);
+    assert.equal(spy.events[0].event.errorCode, "invalid_params");
+  });
+
+  test("does no analytics work when the deployment is unconfigured", async () => {
+    const spy = analyticsRecorder();
+    await callMcp(
+      toolCall(TOOL),
+      {},
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordMcpAnalyticsEvent: spy.recordMcpAnalyticsEvent,
+      },
+    );
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("an analytics recorder failure changes nothing about the tool result", async () => {
+    const baseline = await callMcp(toolCall(TOOL), {});
+    const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, {
+      executionCtx: fakeExecutionCtx(),
+      recordUsageEvent: recorder().recordUsageEvent,
+      recordMcpAnalyticsEvent: () => {
+        throw new Error("analytics exploded");
+      },
+    });
+    assert.deepEqual(payload, baseline);
   });
 });

--- a/tests/usage-telemetry.test.mjs
+++ b/tests/usage-telemetry.test.mjs
@@ -1,13 +1,20 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  MCP_INITIALIZE_EVENT_NAME,
+  MCP_TOOL_CALL_EVENT_NAME,
   POSTHOG_CAPTURE_PATH,
   POSTHOG_HOST_ENV,
   POSTHOG_PROJECT_TOKEN_ENV,
+  REDACTED_PLACEHOLDER,
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
   isUsageTelemetryConfigured,
+  mcpAnalyticsProperties,
+  recordMcpAnalyticsEvent,
   recordUsageEvent,
+  redactAnalyticsValue,
+  redactedCaptureJson,
   resolvePostHogHost,
   usageEventProperties,
 } from "../src/usage-telemetry.ts";
@@ -303,5 +310,184 @@ describe("recordUsageEvent — configured", () => {
       },
     );
     assert.equal(calls[0].body.distinct_id, "test-distinct");
+  });
+});
+
+// --- PostHog native MCP analytics (#7737) -----------------------------------
+
+describe("redactAnalyticsValue", () => {
+  test("redacts every sensitive key name recursively, keeps safe siblings", () => {
+    const redacted = redactAnalyticsValue({
+      surface_id: "x:api:6",
+      credential: "Bearer super-secret-abc123",
+      owner_token: "ot_secret",
+      nested: {
+        Authorization: "Basic xyz",
+        session_cookie: "sid=1",
+        password: "hunter2",
+        refresh_token: "rt_1",
+        client_secret: "cs_1",
+        api_key: "ak_1",
+        private_key: "pk_1",
+        timeout_ms: 500,
+      },
+    });
+    assert.deepEqual(redacted, {
+      surface_id: "x:api:6",
+      credential: REDACTED_PLACEHOLDER,
+      owner_token: REDACTED_PLACEHOLDER,
+      nested: {
+        Authorization: REDACTED_PLACEHOLDER,
+        session_cookie: REDACTED_PLACEHOLDER,
+        password: REDACTED_PLACEHOLDER,
+        refresh_token: REDACTED_PLACEHOLDER,
+        client_secret: REDACTED_PLACEHOLDER,
+        api_key: REDACTED_PLACEHOLDER,
+        private_key: REDACTED_PLACEHOLDER,
+        timeout_ms: 500,
+      },
+    });
+  });
+
+  test("walks arrays element-wise and passes primitives through", () => {
+    assert.deepEqual(
+      redactAnalyticsValue([{ token: "t" }, "plain", 7, null, true]),
+      [{ token: REDACTED_PLACEHOLDER }, "plain", 7, null, true],
+    );
+    assert.equal(redactAnalyticsValue("just a string"), "just a string");
+    assert.equal(redactAnalyticsValue(null), null);
+  });
+
+  test("fails closed past the depth cap instead of passing values through", () => {
+    let deep = { credential: "leaf-secret" };
+    for (let i = 0; i < 12; i += 1) deep = { wrap: deep };
+    const serialized = JSON.stringify(redactAnalyticsValue(deep));
+    assert.ok(!serialized.includes("leaf-secret"));
+    assert.ok(serialized.includes(REDACTED_PLACEHOLDER));
+  });
+});
+
+describe("redactedCaptureJson", () => {
+  test("serializes the redacted value and caps it at 4096 chars", () => {
+    const json = redactedCaptureJson({ credential: "s", note: "n" });
+    assert.equal(json, `{"credential":"${REDACTED_PLACEHOLDER}","note":"n"}`);
+    const capped = redactedCaptureJson({ big: "x".repeat(10_000) });
+    assert.equal(capped.length, 4096);
+  });
+
+  test("returns undefined for undefined and for unserializable values", () => {
+    assert.equal(redactedCaptureJson(undefined), undefined);
+    // JSON.stringify throws on BigInt -- the capture is dropped, not thrown.
+    assert.equal(redactedCaptureJson({ big: 1n }), undefined);
+  });
+
+  test("a cyclic value is terminated by the depth cap, never thrown on", () => {
+    const cyclic = { credential: "loop-secret" };
+    cyclic.self = cyclic;
+    const json = redactedCaptureJson(cyclic);
+    assert.equal(typeof json, "string");
+    assert.ok(!json.includes("loop-secret"));
+    assert.ok(json.includes(REDACTED_PLACEHOLDER));
+  });
+});
+
+describe("mcpAnalyticsProperties", () => {
+  test("builds a fully-scrubbed $mcp_tool_call property set", () => {
+    const properties = mcpAnalyticsProperties({
+      type: "tool_call",
+      toolName: " call_subnet_surface ",
+      ok: false,
+      durationMs: 12.6,
+      errorCode: "invalid_params",
+      parameters: { surface_id: "x:api:6", credential: "sekrit" },
+      response: { error: { code: "invalid_params" } },
+    });
+    assert.deepEqual(properties, {
+      $mcp_tool_name: "call_subnet_surface",
+      ok: false,
+      duration_ms: 13,
+      error_code: "invalid_params",
+      $mcp_parameters: `{"surface_id":"x:api:6","credential":"${REDACTED_PLACEHOLDER}"}`,
+      $mcp_response: '{"error":{"code":"invalid_params"}}',
+    });
+  });
+
+  test("returns null for a malformed or unknown-type event", () => {
+    assert.equal(mcpAnalyticsProperties(null), null);
+    assert.equal(mcpAnalyticsProperties({}), null);
+    assert.equal(mcpAnalyticsProperties({ type: "no_such_type" }), null);
+  });
+
+  test("omits everything optional that is absent", () => {
+    assert.deepEqual(mcpAnalyticsProperties({ type: "initialize" }), {});
+  });
+});
+
+describe("recordMcpAnalyticsEvent", () => {
+  test("posts one $mcp_tool_call capture with redacted parameters", async () => {
+    const calls = [];
+    const recorded = await recordMcpAnalyticsEvent(
+      { [POSTHOG_PROJECT_TOKEN_ENV]: " phc_token " },
+      {
+        type: "tool_call",
+        toolName: "call_subnet_surface",
+        ok: true,
+        durationMs: 42,
+        parameters: { credential: "Bearer super-secret-abc123" },
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+
+    assert.equal(recorded, true);
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0].url,
+      `https://us.i.posthog.com${POSTHOG_CAPTURE_PATH}`,
+    );
+    assert.equal(calls[0].body.event, MCP_TOOL_CALL_EVENT_NAME);
+    assert.equal(calls[0].body.api_key, "phc_token");
+    assert.equal(calls[0].body.distinct_id, USAGE_EVENT_DISTINCT_ID);
+    const serialized = JSON.stringify(calls[0].body);
+    assert.ok(!serialized.includes("super-secret-abc123"));
+    assert.ok(
+      calls[0].body.properties.$mcp_parameters.includes(REDACTED_PLACEHOLDER),
+    );
+  });
+
+  test("names the initialize capture $mcp_initialize", async () => {
+    const calls = [];
+    await recordMcpAnalyticsEvent(
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+      { type: "initialize", parameters: { clientInfo: { name: "vitest" } } },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(calls[0].body.event, MCP_INITIALIZE_EVENT_NAME);
+  });
+
+  test("is a safe no-op when unconfigured, and swallows transport failures", async () => {
+    let calls = 0;
+    assert.equal(
+      await recordMcpAnalyticsEvent(
+        {},
+        { type: "initialize" },
+        {
+          fetch: fakeFetch({
+            onCall: () => {
+              calls += 1;
+            },
+          }),
+        },
+      ),
+      false,
+    );
+    assert.equal(calls, 0);
+    assert.equal(
+      await recordMcpAnalyticsEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+        { type: "initialize" },
+        { fetch: fakeFetch({ throws: true }) },
+      ),
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Implements #7737: the PostHog-native `$mcp_initialize` / `$mcp_tool_call` event family, hand-rolled through the **same raw-fetch capture path `usage_event` already uses** (zero Worker bundle cost — the `posthog-node`/`@posthog/mcp` SDK path is ruled out by the bundle budget, per `src/usage-telemetry.ts`'s header) — plus the redaction pipeline the SDK would otherwise have provided, sitting in front of every `$mcp_parameters`/`$mcp_response` capture.

Closes #7737.

## What changed

**`src/usage-telemetry.ts`** — the analytics family lives beside the existing wrapper so there is exactly **one scrubbing pipeline to audit**:
- `redactAnalyticsValue()` — recursive key-name-based redaction covering `credential` / `owner_token` plus the baseline set PostHog's own SDK auto-redacts (`authorization`, `cookie`, `password`, `token`, `secret`, `api_key`, `private_key`). Matched case-insensitively as **substrings**, so `Authorization`, `session_cookie`, `refresh_token`, `client_secret` are covered too — over-redacting analytics is always safe, leaking never is. **Fail-closed depth cap**: anything nested past 8 levels (including cycles) becomes `[REDACTED]` rather than passing through unexamined.
- `redactedCaptureJson()` — redact → serialize → cap at 4 KiB; unserializable values drop the capture, never throw.
- `mcpAnalyticsProperties()` / `recordMcpAnalyticsEvent()` — same contract as `recordUsageEvent` (never throws, safe no-op when unconfigured, injectable fetch/distinct_id), emitting `$mcp_tool_name`, `ok`, `duration_ms`, `error_code` (#7726 fixed-literal contract), `$mcp_parameters`, `$mcp_response`.

**`src/mcp-server.mjs`** — `initialize` schedules `$mcp_initialize` with the (redacted, capped) handshake params; `callTool` schedules `$mcp_tool_call` alongside the existing coarse `usage_event`, handing arguments/structured response over **raw** so redaction happens centrally, not per call site. `scheduleMcpAnalyticsEvent` mirrors `scheduleToolUsageEvent` exactly, including the injectable-recorder test seam and never-blocks/never-throws posture.

**Tests** (the deliverable the issue names — a credentialed call never leaks the raw secret anywhere in the captured payload):
- `tests/call-subnet-surface-mcp.test.mjs` — **end-to-end through the real pipeline** (no injected recorder): a `call_subnet_surface` call with `credential: "Bearer super-secret-abc123"` produces exactly one `$mcp_tool_call` on the capture wire whose serialized body **never contains the secret**, carries `"credential":"[REDACTED]"`, and still carries the non-sensitive `surface_id` (redaction is surgical, not wholesale).
- `tests/usage-telemetry.test.mjs` — every baseline key redacted recursively; arrays; depth-cap fail-closed; cyclic values terminated (never thrown on); 4 KiB cap; BigInt → dropped capture; `$mcp_initialize`/`$mcp_tool_call` wire format, unconfigured no-op, transport-failure swallowing.
- `tests/mcp-usage-telemetry.test.mjs` — dispatch records one `$mcp_initialize` per handshake and one `$mcp_tool_call` per tool call (errorCode parity with #7726 on failures, absent on success); unconfigured deployments do zero analytics work; an exploding analytics recorder changes nothing about the tool result; existing wire-format tests updated for the second capture now sharing the drain.

## Out of scope (per the issue)

Enabling capture in the PostHog dashboard, and the SDK path itself.

## Validation

- [x] `npx vitest run` on the three touched test files — **119 passing**
- [x] `npx vitest run tests/mcp-server.test.mjs` — **1189 passing**
- [x] `node scripts/validate-mcp.ts` — passed (200 tools, full lifecycle)
- [x] `node --check src/mcp-server.mjs`; `eslint` 0 errors; repo-pinned `prettier --check` clean on staged LF content (typescript parser for the .ts)
