### PR TITLE
feat(observability): add PostHog MCP analytics with redacted parameter/response capture

### DIFF
--- a/.claude/skills/mcp-analytics/SKILL.md
+++ b/.claude/skills/mcp-analytics/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: mcp-analytics
+description: >-
+  Add PostHog MCP analytics to a TypeScript, JavaScript, or Python MCP server.
+  Instruments the server so every tool call, agent intent, and failure is
+  captured as a $mcp_* event — the @posthog/mcp Node SDK for TS/JS, or
+  posthog.mcp (shipped inside the posthog package) for Python. Detects the
+  server style (official MCP SDK Server/McpServer/FastMCP, mcp-handler,
+  @rekog/mcp-nest, jlowin fastmcp, or a custom HTTP/edge dispatcher) and wires
+  in the matching instrumentation, credentials, and graceful shutdown.
+metadata:
+  author: PostHog
+  version: 1.34.0
+---
+
+# Add PostHog MCP analytics
+
+Use this skill to instrument a user's own **MCP server** with PostHog MCP analytics. Once instrumented, every tool call, agent intent, and failure the server handles is captured as a `$mcp_*` event in PostHog — so the user can see which tools get used, what agents are trying to do, error rates, and latency.
+
+There are two SDKs and this skill handles both:
+
+- **TypeScript / JavaScript** — the [`@posthog/mcp`](https://posthog.com/docs/mcp-analytics) Node package.
+- **Python** — `posthog.mcp`, which ships inside the [`posthog`](https://posthog.com/docs/libraries/python) package (like `posthog.ai`).
+
+This is **not** about adding the PostHog MCP _server_ to a coding agent (that's `wizard mcp add`). This skill instruments the user's _own_ MCP server code so it reports analytics about itself.
+
+## Scope and guardrails
+
+- **TypeScript / JavaScript and Python are supported.** Detect the language in STEP 1 and follow the matching part of every step. If the MCP server is written in anything else (Go, Rust, …), **stop**: emit `[ABORT] unsupported language for mcp analytics` on its own line and do nothing else.
+- **This must be an MCP server.** Search thoroughly before concluding there isn't one: check dependency manifests _and_ source for the STEP 1 signals across the whole project, including monorepo workspace packages and subdirectories — a server is often under `packages/*`, `apps/*`, `server/`, or `src/`, not the repo root. Only after an exhaustive search finds nothing, **stop**: emit `[ABORT] no mcp server found` on its own line, and in the same message tell the user where you looked and to re-run the command from inside the package or directory that actually defines their MCP server. Do nothing else.
+- **Beta SDK.** Both SDKs are pre-1.0 and may ship breaking changes in minor releases. Pin a version (see STEP 3).
+- **Minimal, additive changes only.** Add instrumentation alongside the existing server; do not restructure tool handlers or change their behavior. The wrapper is designed to be one line.
+
+### Abort cases
+
+If anything blocks instrumentation, **always** emit exactly one `[ABORT] <reason>` line and stop — never halt, finish, or error out silently. The wizard catches `[ABORT]` and terminates the run for you; don't try to exit yourself. A silent stop is recorded as a failed run with no reason, which can't be acted on, so every dead end must carry a reason. Use one of:
+
+- `[ABORT] no mcp server found` — an exhaustive search (see the guardrail above) found no MCP server in the project.
+- `[ABORT] unsupported language for mcp analytics` — the server is neither TypeScript/JavaScript nor Python.
+- `[ABORT] could not locate the server entry point` — MCP signals are present, but the place the server is constructed or where requests are dispatched couldn't be found to instrument.
+- `[ABORT] <short specific reason>` — anything else that blocks the run (e.g. no readable project, or no PostHog credentials and no MCP server connected to fetch them). Keep it short and specific so it's useful when aggregated across runs.
+
+## Instructions
+
+Follow these steps IN ORDER. Each step has a **TypeScript / JavaScript** part and a **Python** part — use the one for the language you detect in STEP 1.
+
+### STEP 1: Identify the language and the MCP server entry point
+
+Determine the language first, then route to the matching instructions throughout:
+
+- **TypeScript / JavaScript** — there's a `package.json`. Look for MCP signals in dependencies and source:
+  - `@modelcontextprotocol/sdk` — the official SDK (most common).
+  - `mcp-handler` — the Next.js / Vercel adapter.
+  - `@rekog/mcp-nest` — the NestJS adapter (tools defined with `@Tool()` decorators; the server is built inside `McpModule.forRoot(...)`, so there's no `new McpServer` in user code).
+  - `fastmcp`, `xmcp`, or a similar TS MCP framework.
+  - A custom HTTP/edge handler speaking the MCP protocol directly (JSON-RPC methods like `tools/call`, `initialize`, an `Mcp-Session-Id` header) with none of the above.
+
+  Determine the package manager from the lockfile (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`).
+
+- **Python** — there's a `pyproject.toml`, `requirements.txt`, or `setup.py`, or `.py` sources. Look for MCP signals:
+  - the official `mcp` package — `from mcp.server.fastmcp import FastMCP` or `from mcp.server.lowlevel import Server`.
+  - jlowin's standalone `fastmcp` 2.0 — `from fastmcp import FastMCP`.
+  - a custom HTTP/edge dispatcher (FastAPI / Starlette / Flask / edge) speaking the MCP protocol directly with no server object to wrap.
+
+  Determine the installer (pip / uv / poetry) from the lockfile / `pyproject.toml`.
+
+- If it's neither TS/JS nor Python, apply the guardrail above and stop.
+
+Then identify the file and the exact place where the server is constructed or where MCP requests are dispatched, and read it before editing. If PostHog MCP analytics is already wired in (an `instrument(` call, or a `PostHogMCP` client — in either language), don't duplicate it: verify it's correct and skip to STEP 7.
+
+### STEP 2: Choose the instrumentation path
+
+Pick exactly one based on what STEP 1 found. When in doubt, read the bundled reference docs — `installation.md` covers the wrapping paths; `custom-servers.md` covers the custom-dispatcher paths.
+
+**TypeScript / JavaScript:**
+
+- **Path A — official SDK server object** (`new Server(...)` or `new McpServer(...)` from `@modelcontextprotocol/sdk`): wrap it with `instrument(server, posthog)`. One line.
+- **Path B — `mcp-handler`** (`createMcpHandler((server) => { ... })`): same `instrument(server, posthog)` call, inside the setup callback. Because Vercel's transport is stateless, also wire `identify` (STEP 4) and flush per invocation (STEP 6).
+- **Path C — custom dispatcher** (Hono / Express / Cloudflare Worker / edge function with no SDK server object to wrap): use the `PostHogMCP` client and call `captureToolCall` / `captureInitialize` yourself at the dispatch points.
+- **Path D — `@rekog/mcp-nest`** (NestJS): the framework builds the server, so there's no `new McpServer` for you to wrap. Instrument it through the module's `serverMutator` hook in `McpModule.forRoot(...)`. See STEP 4.
+
+**Python:**
+
+- **Path P1 — a FastMCP or low-level Server** (the official `mcp` package's `FastMCP`/`Server`, or jlowin's `fastmcp` 2.0): wrap it with `instrument(server, posthog)`. One line — the SDK detects which framework it is.
+- **Path P2 — custom dispatcher** (FastAPI / Starlette / Flask / edge with no server object to wrap): use the `PostHogMCP` client and call `capture_tool_call` / `capture_initialize` yourself at the dispatch points.
+
+### STEP 3: Install the SDK
+
+- **TypeScript / JavaScript:** install `@posthog/mcp` and `posthog-node` with the project's package manager, pinning `@posthog/mcp` to its current published version (it's pre-1.0) — e.g. `pnpm add @posthog/mcp@<latest> posthog-node`. Read the installed version back from `package.json` / the lockfile rather than guessing.
+- **Python:** the SDK ships inside `posthog`, so install (or require) `posthog>=7.21` with the project's installer — e.g. `pip install "posthog>=7.21"`, `uv add posthog`, `poetry add posthog`. The MCP SDK itself (`mcp` / `fastmcp`) is a peer dependency you already have — you built the server with it — so don't add it. A custom-dispatcher (path P2) project needs nothing beyond `posthog`.
+
+### STEP 4: Instrument the server
+
+Create the PostHog client **once at module scope** (never per request), reading credentials from env (set up in STEP 5).
+
+#### TypeScript / JavaScript
+
+```ts
+import { PostHog } from "posthog-node";
+
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
+  host: process.env.POSTHOG_HOST, // https://us.i.posthog.com or https://eu.i.posthog.com
+});
+```
+
+**Path A — official SDK server:**
+
+```ts
+import { instrument } from "@posthog/mcp";
+
+const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" });
+const analytics = instrument(server, posthog); // wrap immediately after constructing the server
+// register tools as usual — tools added after instrument() are still captured
+```
+
+`instrument()` is idempotent per server and returns an analytics handle (used later for custom events). It works on both the low-level `Server` and the high-level `McpServer`.
+
+**Path B — `mcp-handler`:** call `instrument(server, posthog)` as the first line of the setup callback, with the `posthog` client created at module scope (not per request). Because the transport is stateless, group calls by user with `identify`:
+
+```ts
+const handler = createMcpHandler((server) => {
+  instrument(server, posthog, {
+    identify: (request, extra) => ({ distinctId: getUserId(extra) }),
+  });
+  server.registerTool("...", {/* ... */}, async () => {
+    /* ... */
+  });
+});
+```
+
+**Path C — custom dispatcher:** swap the existing PostHog client for `PostHogMCP` (a drop-in `posthog-node` subclass) and call the capture helpers at the dispatch points. Read `custom-servers.md` for the full field reference before editing.
+
+```ts
+import { PostHogMCP } from "@posthog/mcp";
+
+const posthog = new PostHogMCP(process.env.POSTHOG_PROJECT_TOKEN, {
+  host: process.env.POSTHOG_HOST,
+});
+
+// on the initialize handshake:
+posthog.captureInitialize({ clientName, clientVersion, distinctId });
+
+// after each tools/call resolves (wrap the existing handler, time it):
+const start = Date.now();
+// ...run the tool...
+posthog.captureToolCall({
+  toolName: request.params.name,
+  parameters: request.params.arguments,
+  response: result,
+  durationMs: Date.now() - start,
+  isError: false,
+  distinctId, // who the request is from, if known
+  sessionId, // your transport/session id, if you have one
+});
+```
+
+Resolve `distinctId` / `sessionId` from whatever auth/session the dispatcher already has; omit them rather than inventing values. These calls are fire-and-forget and never throw, so they can't take down a tool.
+
+**Path D — `@rekog/mcp-nest` (NestJS):** the framework builds the server, so pass a `serverMutator` to `McpModule.forRoot(...)`. Prefer the `instrumentMutator` helper — it instruments the server and returns it, so it drops straight into the hook:
+
+```ts
+import { Module } from "@nestjs/common";
+import { McpModule } from "@rekog/mcp-nest";
+import { PostHog, instrumentMutator } from "@posthog/mcp";
+
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_TOKEN, {
+  host: process.env.POSTHOG_HOST,
+});
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: "my-mcp-server",
+      version: "1.0.0",
+      serverMutator: instrumentMutator(posthog),
+    }),
+  ],
+})
+class AppModule {}
+```
+
+`instrumentMutator` returns the server (not `instrument()`'s handle), so it slots straight into the hook. Compose with an existing `serverMutator` if there is one, and handlers nest registers after the mutator runs are still captured. For [custom events](https://posthog.com/docs/mcp-analytics/custom-events), call `instrument()` directly inside your own mutator and keep its handle, returning the server yourself.
+
+#### Python
+
+```python
+import os
+from posthog import Posthog
+
+posthog = Posthog(
+    os.environ["POSTHOG_PROJECT_TOKEN"],
+    host=os.environ["POSTHOG_HOST"],  # https://us.i.posthog.com or https://eu.i.posthog.com
+)
+```
+
+**Path P1 — FastMCP / low-level Server:**
+
+```python
+from posthog.mcp import instrument
+
+server = FastMCP("my-mcp-server")
+analytics = instrument(server, posthog)  # wrap right after constructing the server
+# register tools as usual — tools added after instrument() are still captured
+```
+
+`instrument()` is idempotent per server and returns an analytics handle (used later for custom events). The same call works on the official `FastMCP`, the low-level `Server`, and jlowin's `fastmcp` 2.0.
+
+**Path P2 — custom dispatcher:** swap the existing client for `PostHogMCP` (a drop-in `posthog` client subclass) and call the capture helpers at the dispatch points. Read `custom-servers.md` for the full field reference before editing.
+
+```python
+import time
+from posthog.mcp import PostHogMCP
+
+posthog = PostHogMCP(os.environ["POSTHOG_PROJECT_TOKEN"], host=os.environ["POSTHOG_HOST"])
+
+# on the initialize handshake:
+posthog.capture_initialize(client_name=client_name, client_version=client_version, distinct_id=distinct_id)
+
+# after each tools/call resolves (time it):
+start = time.monotonic()
+# ...run the tool...
+posthog.capture_tool_call(
+    request.params.name,
+    parameters=arguments,
+    response=result,
+    duration_ms=(time.monotonic() - start) * 1000,
+    is_error=False,
+    distinct_id=distinct_id,  # who the request is from, if known
+    session_id=session_id,    # your transport/session id, if you have one
+)
+```
+
+Resolve `distinct_id` / `session_id` from whatever auth/session the dispatcher already has; omit them rather than inventing values. These calls are fire-and-forget and never throw, so they can't take down a tool.
+
+### STEP 5: Wire up credentials
+
+- Check existing env files (`.env`, `.env.local`, etc.) for a PostHog project token. If a valid `phc_…` token and host are already set, reference those and skip the rest of this step.
+- If the token is missing, use the PostHog MCP server's `projects-get` tool to fetch the project's `api_token`. If multiple projects come back, ask the user which to use. If the MCP server isn't connected, ask the user for their project token directly.
+- Host: `https://us.i.posthog.com` for US Cloud, `https://eu.i.posthog.com` for EU Cloud.
+- Write `POSTHOG_PROJECT_TOKEN` and `POSTHOG_HOST` to the appropriate env file and reference them in code (`process.env.*` in JS, `os.environ[...]` in Python) — never hardcode the token.
+
+### STEP 6: Ensure events get flushed
+
+The PostHog client batches events; the user owns the client's lifecycle.
+
+**TypeScript / JavaScript:**
+
+- **Long-running server (STDIO or a persistent HTTP server):** drain on shutdown.
+
+  ```ts
+  process.on("SIGTERM", async () => {
+    await posthog.shutdown();
+    process.exit(0);
+  });
+  ```
+
+- **Serverless / edge (mcp-handler on Vercel, Workers, Lambda):** `SIGTERM` is unreliable — flush at the end of each invocation with `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` where supported.
+- **STDIO transports specifically:** the server's stdout is the protocol channel. Do not add `console.log` for debugging — it corrupts the MCP stream. If you need SDK-internal warnings, pass a `logger` option to `instrument()` that writes to stderr or a file.
+
+**Python:**
+
+- **Long-running server (STDIO or persistent HTTP):** drain on exit. On the `instrument()` path, `await analytics.flush()` waits for in-flight auto-capture events, then `posthog.shutdown()` flushes and stops the client — call both from your shutdown path. For `PostHogMCP`, `posthog.shutdown()` (or `posthog.flush()`) drains the MCP captures first.
+- **STDIO transports specifically:** stdout is the protocol channel — never `print()` to it. For SDK-internal warnings pass `logger=lambda m: print(m, file=sys.stderr)` (or a file writer) via `MCPAnalyticsOptions(...)`.
+
+### STEP 7: Verify
+
+- **TypeScript / JavaScript:** run the project's type-check and/or build script (e.g. `tsc --noEmit`, `pnpm build`) and fix any errors your changes introduced. Run any linter/formatter the project uses on the files you touched.
+- **Python:** run the project's type-check / tests if present (`mypy`, `pytest`) and fix any errors your changes introduced. Run any formatter the project uses (`ruff`, `black`) on the files you touched.
+- Summarize for the user: which path you used, the files you changed, the env vars to set, and that they'll see `$mcp_*` events in PostHog once the server handles its next request. Link them to https://posthog.com/docs/mcp-analytics for the dashboard and event reference.
+
+## Reference files
+
+- `references/installation.md` - Installing the mcp analytics SDK - docs
+- `references/custom-servers.md` - Instrumenting a custom server - docs
+- `references/intent.md` - Capturing agent intent - docs
+- `references/identifying-users.md` - Identifying users - docs
+- `references/conversation-id.md` - Conversation ids - docs
+- `references/events.md` - Event and property reference - docs
+- `references/custom-events.md` - Custom events and metadata - docs
+- `references/start-here.md` - Getting started with mcp analytics - docs
+- `references/COMMANDMENTS.md` - Framework-specific rules the integration must follow
+
+`installation.md` is the source of truth for the wrapping paths (A/B and Python P1) and the full `instrument()` options table (`identify`, `context`/intent, `enableConversationId`/`enable_conversation_id`, `reportMissing`/`report_missing`, `beforeSend`/`before_send`, `eventProperties`/`event_properties`). `custom-servers.md` is the source of truth for the custom-dispatcher paths (C and P2) — `PostHogMCP`, `captureToolCall`/`capture_tool_call`, `captureInitialize`/`capture_initialize`, and the per-call field mapping. `intent.md`, `identifying-users.md`, and `conversation-id.md` cover optional enrichment; `events.md` and `custom-events.md` describe what gets captured. The event/property vocabulary is identical across both SDKs.
+
+## Key principles
+
+- **One server, one wrapper.** `instrument()` is idempotent; don't call it twice on the same server.
+- **Module-scope client.** Construct the `PostHog` / `Posthog` / `PostHogMCP` client once, not per request.
+- **Env, never hardcode.** The project token and host come from environment variables.
+- **Additive only.** Don't change tool behavior or restructure the server — just wrap/capture.
+- **Don't break STDIO.** No `console.*` (JS) or `print()` (Python) on STDIO transports; use a `logger` instead.
+- **Pin the beta SDK** and tell the user it's pre-1.0. (Python: `posthog.mcp` ships inside `posthog`; pin `posthog>=7.21`.)

--- a/.claude/skills/mcp-analytics/references/COMMANDMENTS.md
+++ b/.claude/skills/mcp-analytics/references/COMMANDMENTS.md
@@ -1,0 +1,12 @@
+# Framework rules
+
+Follow these when integrating PostHog into this framework.
+
+- A missing PostHog configuration must never break the app — read keys optionally (never a required setting), guard init and capture behind their presence, and keep build and boot working with no PostHog environment set — but never silently: in development or debug builds fail loudly, using the language's idiomatic error, with the message "<VAR> variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once <VAR> is configured" (substituting the actual variable name); production stays a no-op
+- posthog-node is the Node.js server-side SDK package name; posthog-js is browser-only, so use posthog-node on the server instead
+- Include enableExceptionAutocapture: true in the PostHog constructor options
+- Add posthog.capture() calls in route handlers for meaningful user actions – every route that creates, updates, or deletes data should track an event with contextual properties
+- Add posthog.captureException(err, distinctId) in the application's error handler (e.g., Express error middleware, Fastify setErrorHandler, Koa app.on('error'))
+- The SDK batches events and flushes asynchronously. await flush() or await shutdown() before letting that process exit. If unsure, set flushAt 1 and flushInterval 0.
+- `posthog.capture()` enqueues synchronously and returns; the batched HTTP send happens afterwards. Treat every per-request handler as short-lived even when the framework feels like a server: Next.js / Nuxt / SvelteKit / Remix route handlers, serverless and edge functions, and Lambda are torn down per invocation before the send runs. Create the client with flushAt 1 and flushInterval 0, then await the send before returning. Always use `await posthog.flush()` for a shared/singleton client, `await posthog.shutdown()` for a per-request client. Never skip the awaited flush or risk the enqueued event being silently dropped.
+- Reverse proxy is NOT needed for server-side Node.js – only client-side JavaScript needs a proxy to avoid ad blockers

--- a/.claude/skills/mcp-analytics/references/conversation-id.md
+++ b/.claude/skills/mcp-analytics/references/conversation-id.md
@@ -1,0 +1,98 @@
+# Conversation IDs - Docs
+
+A PostHog `$session_id` is per MCP connection — it rotates when the protocol session does. That's the right granularity for "which TCP/WebSocket connection is this?" but it can split a single user conversation into multiple sessions when the client reconnects.
+
+`$mcp_conversation_id` is an opt-in property that lets you stitch those calls together at the conversation level instead.
+
+**Opt-in, with caveats**
+
+Conversation IDs are off by default and rely on the agent cooperating. Read the caveats below before enabling — there's a visible side effect on tool responses, and the value is agent-controlled.
+
+## Enabling
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  enableConversationId: true,
+});
+```
+
+With this on, the SDK does three things:
+
+1.  **Injects an optional `conversation_id` argument** into every tool's JSON Schema, with a description telling the agent to reuse the value the server returns.
+2.  **Mints a UUID** when the agent calls a tool without `conversation_id` and **appends a text block** to the tool's response that asks the agent to echo the same id on subsequent calls.
+3.  **Captures the supplied or minted value** on every event as `$mcp_conversation_id`, distinct from `$session_id`.
+
+The agent's `conversation_id` (when present) always wins. The SDK only mints when the agent doesn't supply one.
+
+## How it lands in events
+
+PostHog AI
+
+```
+{
+  event: "$mcp_tool_call",
+  properties: {
+    "$session_id": "ses_2a3f…",            // MCP connection
+    "$mcp_conversation_id": "c_8b1d…",     // logical conversation
+    "$mcp_tool_name": "search_events",
+    ...
+  }
+}
+```
+
+A new connection (new `$session_id`) made by the same agent re-using the same `conversation_id` will share `$mcp_conversation_id`. You can group by it in HogQL to see the whole conversation:
+
+SQL
+
+[Run in PostHog](https://us.posthog.com/sql?open_query=SELECT%0A++properties.%24mcp_conversation_id+AS+conversation%2C%0A++arrayDistinct%28groupArray%28properties.%24mcp_tool_name%29%29+AS+tools_called%2C%0A++count%28%29+AS+tool_calls%0AFROM+events%0AWHERE+event+%3D+'%24mcp_tool_call'%0A++AND+properties.%24mcp_conversation_id+IS+NOT+NULL%0A++AND+timestamp+%3E+now%28%29+-+INTERVAL+7+DAY%0AGROUP+BY+conversation%0AORDER+BY+tool_calls+DESC%0ALIMIT+50)
+
+PostHog AI
+
+```sql
+SELECT
+  properties.$mcp_conversation_id AS conversation,
+  arrayDistinct(groupArray(properties.$mcp_tool_name)) AS tools_called,
+  count() AS tool_calls
+FROM events
+WHERE event = '$mcp_tool_call'
+  AND properties.$mcp_conversation_id IS NOT NULL
+  AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY conversation
+ORDER BY tool_calls DESC
+LIMIT 50
+```
+
+## Caveats
+
+**The prompt-back leaks into agent UIs**
+
+The "please echo this `conversation_id`" message is appended as a regular `text` content block — the only channel MCP currently offers for server-to-agent communication. Consumers that surface raw tool-call content to end users will see `[SERVER]: Reuse conversation_id=…` in their UI. If the MCP spec grows a dedicated server-directives channel (e.g. on `_meta`), the SDK will move there.
+
+**Agent-controlled values**
+
+When the agent supplies a `conversation_id`, the SDK accepts any non-empty string. You can bind it to your own session scheme (chat id, JWT `jti`, request id) by having the agent send that value, but nothing prevents a misbehaving client from sending arbitrary strings. Don't use `$mcp_conversation_id` as a security boundary.
+
+**It's not a session id**
+
+`$session_id` is what PostHog's session-level joins and identity resolution use. `$mcp_conversation_id` is purely a logical grouping label — handy for joins, useless for everything else.
+
+## When to skip this
+
+If your MCP server runs over a long-lived connection that already aligns with what you'd call a "conversation" — for example, a stdio server attached to a single Claude Desktop chat — `$session_id` is already doing the right thing. Leave `enableConversationId` off.
+
+Turn it on when:
+
+- The same logical conversation crosses connections (HTTP/SSE clients that reconnect).
+- You want to correlate MCP events with a conversation id you already own elsewhere (chat platform, support ticket, JWT) and you're happy to plumb that id through the agent.
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/mcp-analytics/references/custom-events.md
+++ b/.claude/skills/mcp-analytics/references/custom-events.md
@@ -1,0 +1,87 @@
+# Custom events and metadata - Docs
+
+Sometimes the events the SDK emits out of the box aren't enough. You might want to attach metadata to every event, or emit a fully custom event for something that isn't a tool call. The SDK gives you two hooks for that, in order of increasing invasiveness.
+
+## `eventProperties` — metadata on every event
+
+Pass an `eventProperties` callback to attach extra properties to every event the SDK emits. The callback runs per request, so values can depend on the current call (request id, transport, headers, env, region, deploy SHA, etc).
+
+TypeScript
+
+PostHog AI
+
+```typescript
+const analytics = instrument(server, posthog, {
+  eventProperties: async (request, extra) => ({
+    $app_version: process.env.GIT_SHA ?? "unknown",
+    $mcp_region: process.env.FLY_REGION ?? "unknown",
+    request_id: extra?.requestInfo?.headers?.["x-request-id"],
+  }),
+});
+```
+
+The returned object is spread flat onto the event's properties alongside the built-in `$mcp_*` keys:
+
+JSON
+
+PostHog AI
+
+```json
+{
+  "event": "$mcp_tool_call",
+  "properties": {
+    "$mcp_tool_name": "search_events",
+    "$app_version": "a1b2c3d",
+    "$mcp_region": "iad",
+    "request_id": "req_…",
+    "…"
+  }
+}
+```
+
+For a "stamp on everything" use case (the closest analogue to `posthog.register(...)` in other SDKs), just return constants from the callback. The callback is per-event rather than session-persistent, so the values can also vary per request if you need them to.
+
+For group analytics, return `groups` from your [`identify`](/docs/mcp-analytics/identifying-users.md) callback rather than hand-writing the `$groups` key — the SDK stamps `$groups` onto every event for the session for you.
+
+Returned values must be JSON-serializable. Errors thrown from your callback are swallowed and surfaced to your `logger` — they never interrupt tool execution.
+
+## `analytics.capture()` — emit an arbitrary event
+
+When the built-in events don't cover what you need — for example, recording a feedback signal from your own UI, or capturing a domain event that isn't an MCP request — use the `capture()` method on the handle returned by `instrument()`. It writes onto the same queue as everything else, so it inherits the SDK's sanitization, identity, `beforeSend`, and `eventProperties` logic. `capture()` returns a promise you can `await`.
+
+You name the event. It's sent verbatim — it's your event, so it is **not** `$`\-prefixed.
+
+TypeScript
+
+PostHog AI
+
+```typescript
+const analytics = instrument(server, posthog);
+await analytics.capture({
+  event: "feedback_submitted",
+  properties: { rating: 5 },
+});
+```
+
+What lands in PostHog:
+
+- One event under the verbatim `event` name you passed, with your `properties` merged in.
+- The session id, identity, and any `eventProperties` callback still apply.
+
+`capture()` is a method on the handle that `instrument()` returns, so you call it on the instrumented server's analytics handle directly.
+
+## Which one to use
+
+| You want to...                                          | Use                                                                                                          |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Attach the same properties to every auto-captured event | eventProperties                                                                                              |
+| Emit a one-off event that isn't an MCP request          | analytics.capture()                                                                                          |
+| Attach data to a specific tool call (just that one)     | Not directly supported — the callbacks run on every event. The SDK doesn't currently expose a per-call hook. |
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/mcp-analytics/references/custom-servers.md
+++ b/.claude/skills/mcp-analytics/references/custom-servers.md
@@ -1,0 +1,157 @@
+# Instrumenting a custom server - Docs
+
+[`instrument()`](/docs/mcp-analytics/installation.md) works by wrapping a `@modelcontextprotocol/sdk` `Server` or `McpServer` — it patches that object's request handlers. But not every MCP server is built that way. If you run a **custom dispatcher** — a [Hono](https://hono.dev/) or Express HTTP handler, a Cloudflare Worker / Vercel edge function, or anything that speaks the MCP protocol without the SDK's server abstraction — there's no object for `instrument()` to wrap.
+
+For those servers, use **`PostHogMCP`** instead. It's a subclass of the [`posthog-node`](/docs/libraries/node.md) client, so it's a drop-in replacement for your existing PostHog client — `capture`, `identify`, `flush`, `shutdown`, and feature flags all work unchanged — with `captureToolCall` and `captureInitialize` added on top. You resolve identity and context per request and call those methods yourself. They build the same canonical `$mcp_*` events as `instrument()` (same sanitization, truncation, and `$exception` fan-out) and hand them to the inherited `capture()`, so nothing downstream (insights, dashboards, error tracking) can tell the difference.
+
+## When to use which
+
+| Your server                                                      | Use                                                                          |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Built on @modelcontextprotocol/sdk's Server / McpServer          | [instrument(server, posthog, options?)](/docs/mcp-analytics/installation.md) |
+| A custom HTTP/Hono/edge dispatcher with no server object to wrap | new PostHogMCP(apiKey, options?)                                             |
+
+## Set up
+
+`PostHogMCP` takes the exact same constructor arguments as `posthog-node`'s `PostHog`, so swap the class and you keep one client for your whole app:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import { PostHogMCP } from "@posthog/mcp";
+const posthog = new PostHogMCP(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
+  // standard posthog-node options apply, e.g. beforeSend, enableExceptionAutocapture
+});
+```
+
+Because it _is_ a `PostHog` client, every option and method you already know is available — including `beforeSend` (which runs on the MCP events too) and `enableExceptionAutocapture` (set it to `false` to stop errored tool calls from fanning out a `$exception`). The wrapping-path hooks (`identify`, `context`, `intentFallback`, `eventProperties`) don't apply here: there's no wrapped server to run them against, so you pass identity and properties on each call instead.
+
+## Capture events
+
+Call the matching method from inside your dispatcher, after you've resolved who the user is and run the tool. The methods are fire-and-forget, just like `posthog.capture()`:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+// On a tools/call, after the tool runs:
+posthog.captureToolCall({
+  toolName: "search_events",
+  parameters: request.params.arguments,
+  response: result,
+  durationMs: Date.now() - start,
+  isError: false,
+  distinctId: user.id, // → distinct_id (enables person processing)
+  sessionId: mcpSessionId, // → $session_id (omitted if you don't pass one)
+  groups: { organization: user.orgId }, // → $groups
+  properties: { $mcp_client_name: "claude-code" }, // any extra props, spread verbatim
+});
+// On the initialize handshake:
+posthog.captureInitialize({
+  clientName: "claude-code",
+  clientVersion: "1.2.3",
+  distinctId: user.id,
+});
+// Custom events use the inherited posthog-node capture():
+posthog.capture({
+  distinctId: user.id,
+  event: "feedback_submitted",
+  properties: { rating: 5 },
+});
+```
+
+### Fields shared by every method
+
+| Field         | Maps to         | Notes                                                                                                                                                               |
+| ------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| distinctId    | distinct_id     | Supplying it enables person processing so $set lands on a real person. Omit it for anonymous traffic — events are sent with $process_person_profile: false.         |
+| sessionId     | $session_id     | Omitted from the event entirely when you don't pass one (so stateless captures don't bucket into a non-existent [Session Replay](/docs/session-replay.md) session). |
+| groups        | $groups         | { groupType: groupKey }, stamped on the event so you never hand-write the $groups key.                                                                              |
+| setProperties | $set            | Person properties ({ name, email, plan }), same as the properties you'd pass to identify.                                                                           |
+| properties    | spread verbatim | Extra event properties, sitting alongside the $mcp_* keys. Values must be JSON-serializable.                                                                        |
+| timestamp     | event time      | Defaults to the time of the capture call.                                                                                                                           |
+
+### Tool-call specific fields
+
+`toolName` → `$mcp_tool_name`, `toolDescription` → `$mcp_tool_description`, `parameters` → `$mcp_parameters`, `response` → `$mcp_response`, `durationMs` → `$mcp_duration_ms`, `isError` → `$mcp_is_error`. When `isError` is true and `enableExceptionAutocapture` isn't `false`, the `error` you pass becomes the `$exception` sibling event (if you don't pass one, a generic exception is synthesized from the tool name).
+
+**Analytics never breaks your request**
+
+`captureToolCall` and `captureInitialize` are fire-and-forget (they enqueue on the client, like `posthog.capture()`) and never throw — a failure to record analytics can't take down your tool. In serverless or edge environments, flush at the end of the invocation so queued events aren't dropped (see below).
+
+## What you don't get (vs `instrument()`)
+
+Because there's no wrapped server, `PostHogMCP` does **not** manage these for you — you pass the equivalent data per call:
+
+- **Sessions** — no MCP-session-derived `$session_id` or inactivity rollover. Pass your own `sessionId`.
+- **Identity caching / `$identify` dedupe** — pass `distinctId` (and optional `setProperties`) on each call.
+- **The injected `context` argument, `intentFallback`, `reportMissing`, and `conversation_id`** — these patch tool schemas and request handlers, which only the wrapping path can do.
+
+Everything from the [event reference](/docs/mcp-analytics/events.md) onward — event names, property shapes, sanitization, error tracking — is identical.
+
+## Graceful shutdown
+
+`PostHogMCP` is a `posthog-node` client, so flush it yourself. In serverless or edge environments, flush at the end of each invocation rather than relying on `SIGTERM`:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+// at the end of the request/invocation
+await posthog.flush();
+// or keep the runtime alive until the flush completes
+ctx.waitUntil(posthog.flush());
+```
+
+## Python
+
+The Python SDK ships the same custom-dispatcher path as `PostHogMCP`, a subclass of the [`posthog`](/docs/libraries/python.md) client. Method names are snake\_case and arguments are keyword args rather than an options object:
+
+Python
+
+PostHog AI
+
+```python
+from posthog.mcp import PostHogMCP, get_more_tools_result
+posthog = PostHogMCP("phc_your_project_api_key", host="https://us.i.posthog.com")
+# Decorate your tools/list response so agents state their intent (and, optionally,
+# advertise the get_more_tools virtual tool):
+tools = posthog.prepare_tool_list(my_tools, report_missing=True)
+# On an inbound tools/call, pull the intent and strip the injected `context`:
+prepared = posthog.prepare_tool_call(name, arguments)
+if prepared.is_missing_capability:
+    posthog.capture_missing_capability(context=prepared.intent, distinct_id=user_id)
+    return get_more_tools_result()
+result = run_tool(name, prepared.args)
+# Capture the call (fire-and-forget, like posthog.capture):
+posthog.capture_tool_call(
+    name,
+    intent=prepared.intent,
+    intent_source=prepared.intent_source,
+    parameters=arguments,
+    response=result,
+    duration_ms=elapsed_ms,
+    is_error=False,
+    distinct_id=user_id,
+    session_id=mcp_session_id,
+    groups={"organization": org_id},
+)
+# On the handshake:
+posthog.capture_initialize(client_name="claude-code", client_version="1.2.3", distinct_id=user_id)
+posthog.flush()  # PostHogMCP is a posthog client — flush/shutdown it yourself
+```
+
+`PostHogMCP(api_key, missing_capability_tool_name="get_more_tools", mcp_exception_autocapture=True, **posthog_kwargs)` accepts the standard `posthog` client kwargs (e.g. `host`). Set `mcp_exception_autocapture=False` to stop a failed tool call from emitting a `$exception` sibling. As in TypeScript, the wrapping-path hooks (`identify`, `context`, `intent_fallback`, `event_properties`) don't apply here — pass identity and properties on each `capture_*` call.
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/mcp-analytics/references/events.md
+++ b/.claude/skills/mcp-analytics/references/events.md
@@ -1,0 +1,108 @@
+# Event and property reference - Docs
+
+This page is the wire-level contract for the `@posthog/mcp` SDK. Every event the SDK emits and every property name it uses is listed here. All property keys are prefixed with `$mcp_*` so they never collide with PostHog autocapture, Web analytics, or other product events.
+
+## Events
+
+| Event name              | When it fires                                                                   | Notable extras                                                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| $mcp_tool_call          | Every tools/call request                                                        | $mcp_tool_name, $mcp_tool_description, $mcp_parameters, $mcp_response, $mcp_duration_ms, $mcp_is_error, $mcp_error_type/$mcp_error_status (on errors), optionally $mcp_intent/$mcp_intent_source |
+| $mcp_tools_list         | Every tools/list response                                                       | $mcp_listed_tool_names (string[] of advertised tool names)                                                                                                                                       |
+| $mcp_initialize         | Every client/server handshake                                                   | $mcp_client_name, $mcp_client_version, $mcp_server_name, $mcp_server_version                                                                                                                     |
+| $mcp_resources_list     | Every resources/list request                                                    | —                                                                                                                                                                                                |
+| $mcp_resource_read      | Every resources/read request                                                    | $mcp_resource_name, $mcp_parameters, $mcp_response                                                                                                                                               |
+| $mcp_prompts_list       | Every prompts/list request                                                      | —                                                                                                                                                                                                |
+| $mcp_prompt_get         | Every prompts/get request                                                       | $mcp_resource_name (the prompt name)                                                                                                                                                             |
+| (your event name)       | A call to analytics.capture({ event, properties })                              | Sent under the verbatim event name you pass (a customer event, not $-prefixed), with your properties merged in. See [Custom events](/docs/mcp-analytics/custom-events.md).                       |
+| $mcp_missing_capability | The get_more_tools virtual tool is invoked (reportMissing: true)                | The agent's reasoning is captured as $mcp_intent. See [Tracking missing capabilities](/docs/mcp-analytics/missing-capability.md).                                                                |
+| $identify               | identify() returns a new identity for a session                                 | $set populated from the identity's properties                                                                                                                                                    |
+| $exception              | Sibling event whenever a tool errors (unless enableExceptionAutocapture: false) | $exception_list, $exception_level, plus the same $mcp_* context as the main event                                                                                                                |
+
+## Core properties
+
+Present on most `mcp_*` events.
+
+| Wire key               | Type                                | Source                                                                                                                                                                                              |
+| ---------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| $session_id            | string                              | The MCP session id (ses_<32-hex>). Derived deterministically from the MCP protocol session id when available; otherwise minted and rotated after 30 minutes of inactivity.                          |
+| $mcp_source            | string                              | Always "posthog_mcp_analytics". Use this to filter out non-MCP events when querying mixed projects.                                                                                                 |
+| $mcp_resource_name     | string                              | Tool, resource, or prompt name                                                                                                                                                                      |
+| $mcp_tool_name         | string                              | Same as $mcp_resource_name, but only on $mcp_tool_call                                                                                                                                              |
+| $mcp_tool_description  | string                              | The tool's description at the moment of the call. Cached from tools/list and (for McpServer) seeded from _registeredTools. Only on $mcp_tool_call and the paired $exception event.                  |
+| $mcp_listed_tool_names | string[]                            | Names of tools advertised in a tools/list response. Only on $mcp_tools_list. Useful for joining against $mcp_tool_call via $session_id to find tools advertised but never called.                   |
+| $mcp_duration_ms       | number (ms)                         | Wall-clock duration of the tool call                                                                                                                                                                |
+| $mcp_is_error          | boolean                             | True if the tool threw or returned isError: true                                                                                                                                                    |
+| $mcp_error_type        | string                              | Failure category for the error: missing_context, validation, permission, timeout, rate_limited, api_4xx, api_5xx, or internal. Only set when $mcp_is_error is true.                                 |
+| $mcp_error_status      | number                              | Upstream HTTP status code when the failure came from a PostHog API error (e.g. 429, 500). Only set for API-originated failures.                                                                     |
+| $mcp_error_message     | string                              | Truncated error message for the failed tool call. PostHog's server omits this to avoid capturing query content; external servers using the SDK may include it. Only set when $mcp_is_error is true. |
+| $mcp_server_name       | string                              | server._serverInfo.name                                                                                                                                                                             |
+| $mcp_server_version    | string                              | server._serverInfo.version                                                                                                                                                                          |
+| $mcp_client_name       | string                              | server.getClientVersion().name                                                                                                                                                                      |
+| $mcp_client_version    | string                              | server.getClientVersion().version                                                                                                                                                                   |
+| $mcp_intent            | string                              | From the context argument the agent passed, or from your intentFallback callback. See [Capturing agent intent](/docs/mcp-analytics/intent.md).                                                      |
+| $mcp_intent_source     | "context_parameter" \\\| "inferred" | Tells you which path produced the intent. Absent when no intent was captured.                                                                                                                       |
+| $mcp_parameters        | object                              | Sanitized request arguments. Excludes the SDK-injected context and conversation_id arguments.                                                                                                       |
+| $mcp_response          | object                              | Sanitized tool result                                                                                                                                                                               |
+| $mcp_conversation_id   | string                              | Present when enableConversationId is on. See [Conversation IDs](/docs/mcp-analytics/conversation-id.md).                                                                                            |
+
+## Exception properties
+
+Present on `$exception` events emitted alongside any failed tool call. The SDK reuses `@posthog/core`'s error-tracking parser, so these are the same `$exception_list` properties every other PostHog SDK emits — they slot straight into [Error tracking](/docs/error-tracking.md). Set `enableExceptionAutocapture: false` (default `true`) to stop a failed tool call from emitting the `$exception` sibling.
+
+| Wire key         | Source                                                                                                                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| $exception_list  | Array of structured exceptions. Each has type, value (the message), mechanism, and a stacktrace with parsed frames (filename, function, lineno, colno, in_app). An Error.cause chain appears as additional entries. |
+| $exception_level | Severity, always "error".                                                                                                                                                                                           |
+
+Plus `$session_id`, `$mcp_resource_name`, `$mcp_tool_name`, `$mcp_tool_description` (tool calls only), `$mcp_server_*`, and `$mcp_client_*` for context.
+
+**Symbolicating minified MCP servers**
+
+Stack frames from a bundled/minified MCP server symbolicate the same way as any other PostHog backend SDK — upload your source maps with the [PostHog CLI](/docs/error-tracking/upload-source-maps.md). Source-context lines and project-relative path rewriting (the optional Node frame modifiers) aren't applied by the MCP SDK yet.
+
+## Person properties (`$set`)
+
+Set on `$identify` events when `identify()` returns a user.
+
+| Key   | Source                                                                                                                           |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------- |
+| (any) | Keys of the identity's properties are written to $set (e.g. return properties: { name, email } to set a person's name and email) |
+
+## Groups (`$groups`)
+
+If `identify()` returns a `groups` field (a `Record<string, string>` of groupType → groupKey), the SDK stamps it onto every event as `$groups`. You never hand-write `$groups` yourself. See [Identifying users](/docs/mcp-analytics/identifying-users.md).
+
+## Person profiles for anonymous sessions
+
+Events for sessions with no resolved identity are sent with `$process_person_profile: false`, so anonymous MCP sessions don't each mint a person profile. Once `identify()` resolves an identity for the session, person processing stays on and the events attribute to that user.
+
+## Constants exported from the package
+
+For product code that queries against the SDK's contract, the package exports:
+
+- `POSTHOG_MCP_ANALYTICS_SOURCE` — the constant `"posthog_mcp_analytics"` (matches `$mcp_source`)
+- `PostHogMCPAnalyticsEvent` — enum of canonical event names
+- `PostHogMCPAnalyticsProperty` — enum of canonical property names
+
+Use them instead of hard-coding strings so renames stay typesafe:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import {
+  PostHogMCPAnalyticsEvent,
+  PostHogMCPAnalyticsProperty,
+} from "@posthog/mcp";
+const event = PostHogMCPAnalyticsEvent.ToolCall; // "$mcp_tool_call"
+const key = PostHogMCPAnalyticsProperty.ToolName; // "$mcp_tool_name"
+```
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/mcp-analytics/references/identifying-users.md
+++ b/.claude/skills/mcp-analytics/references/identifying-users.md
@@ -1,0 +1,109 @@
+# Identifying users - Docs
+
+By default, every MCP event is attributed to the connection's session id (`ses_…`). That gives you per-session analytics, but you can't yet say "Alice from Acme is calling this tool 200 times a day" — because the SDK doesn't know who Alice is.
+
+The `identify` option lets you teach it.
+
+## How attribution works
+
+For each event, the SDK picks `distinct_id` in this order:
+
+1.  The id returned by your `identify(request, extra)` callback (if it returned a `UserIdentity`).
+2.  The MCP session id (`ses_…`).
+3.  The literal string `"anonymous"`.
+
+That means events emitted before `identify` returns a user are session-scoped; once it returns a user, subsequent events attribute to that user and PostHog's standard identity merge takes over for prior anonymous activity.
+
+## Anonymous sessions don't mint person profiles
+
+Events for sessions with **no** resolved identity are sent with `$process_person_profile: false`. This keeps anonymous MCP sessions from each creating a person profile (which would inflate your person count and billing). Once `identify` resolves an identity for a session, person processing stays on and the events create/update that user's profile as normal.
+
+## Wiring `identify`
+
+`identify` is an async callback that returns either a `UserIdentity` or `null`. The SDK calls it on each request and caches the result per session, so a stable identity isn't re-resolved on every tool call.
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import { instrument } from "@posthog/mcp";
+instrument(server, posthog, {
+  identify: async (request, extra) => {
+    const token = extra?.requestInfo?.headers?.authorization;
+    if (!token) return null;
+    const user = await resolveUserFromToken(token);
+    if (!user) return null;
+    return {
+      distinctId: user.id, // becomes distinct_id
+      properties: {
+        // written to $set
+        name: user.name,
+        email: user.email,
+        plan: user.plan,
+        signupDate: user.signupDate,
+      },
+      groups: {
+        // becomes $groups on every event
+        organization: user.orgId,
+      },
+    };
+  },
+});
+```
+
+This is the same shape as posthog-node's [`identify({ distinctId, properties })`](/docs/libraries/node.md) — just returned from a per-request callback instead of called imperatively. The fields map to PostHog as follows:
+
+- `distinctId` → the event's `distinct_id`.
+- `properties` → written verbatim to `$set` (so to set a person's name or email, put them here, e.g. `properties: { name, email }`).
+- `groups` (optional `Record<string, string>` of groupType → groupKey) is stamped onto **every** event as `$groups`. You never hand-write `$groups` yourself.
+
+When this returns a non-null identity, the SDK:
+
+1.  Switches the event's `distinct_id` to `distinctId` for that session.
+2.  Emits a `$identify` event the first time the identity is observed (or whenever it changes for that session), with `$set` populated from `properties`.
+3.  Stamps `$groups` onto subsequent events from the returned `groups` map.
+4.  Caches the identity in a small per-server LRU keyed by session id, so unchanged identities are silently deduped.
+
+## Identity merges
+
+A single MCP session typically emits a handful of events before any auth handshake completes — for example, `$mcp_initialize` may fire before you've resolved the user. Those early events go out anonymous, attributed to the session id.
+
+When `identify` eventually returns a user, the SDK emits `$identify` with `$anon_distinct_id` set to the prior session id. PostHog's identity-merging logic then attributes the anonymous events to the identified user. From that point on, events for that session go out under `distinctId` directly.
+
+This is the same merge model the [Node SDK](/docs/libraries/node.md) uses — if you've configured Person profile mode or have other strong opinions on identity in your PostHog project, the same rules apply.
+
+## When _not_ to call identify
+
+- **Internal tools without per-user auth.** If your MCP server doesn't authenticate end users (e.g. a single-tenant internal server behind a VPN), leave `identify` unset. Session-scoped attribution is fine.
+- **Bots and crawlers.** Returning a junk identity for unauthenticated traffic dilutes your person count. Return `null` for traffic you can't identify — those events stay session-scoped.
+
+## Querying by identified user
+
+Once identification is wired up, anything that filters on `person.properties.*` or groups by `distinct_id` works as expected:
+
+SQL
+
+[Run in PostHog](https://us.posthog.com/sql?open_query=SELECT%0A++person.properties.plan+AS+plan%2C%0A++properties.%24mcp_tool_name+AS+tool%2C%0A++count%28%29+AS+calls%0AFROM+events%0AWHERE+event+%3D+'%24mcp_tool_call'%0A++AND+timestamp+%3E+now%28%29+-+INTERVAL+30+DAY%0AGROUP+BY+plan%2C+tool%0AORDER+BY+calls+DESC)
+
+PostHog AI
+
+```sql
+SELECT
+  person.properties.plan AS plan,
+  properties.$mcp_tool_name AS tool,
+  count() AS calls
+FROM events
+WHERE event = '$mcp_tool_call'
+  AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY plan, tool
+ORDER BY calls DESC
+```
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/mcp-analytics/references/installation.md
+++ b/.claude/skills/mcp-analytics/references/installation.md
@@ -1,0 +1,324 @@
+# Installing the MCP Analytics SDK - Docs
+
+**Beta SDK**
+
+`@posthog/mcp` is in beta (pre-1.0). The API may still change – including breaking changes in minor `0.x` releases – until `v1`, so pin a version while we iterate.
+
+## Requirements
+
+- Node.js 18 or later (TypeScript/JavaScript), or Python 3.10+ — see [Python](#python) below
+- An MCP server built on `@modelcontextprotocol/sdk` (TS) or the `mcp` package (Python). (Running a custom dispatcher with no server object to wrap? See [Custom servers](/docs/mcp-analytics/custom-servers.md).)
+- A PostHog [project API key](/docs/getting-started/project-token.md) (`phc_…`)
+
+## AI wizard
+
+The fastest way to get set up is our wizard, which installs the package, adds your `posthog-node` client, and wires up the `instrument()` call for you (it also works for [LLM coding agents](/blog/envoy-wizard-llm-agent.md) like Cursor and Bolt):
+
+`npx @posthog/wizard mcp-analytics`
+
+[Learn more](/wizard.md)
+
+Prefer to set things up manually, or want to understand each piece? Follow the steps below.
+
+## Install
+
+Terminal
+
+PostHog AI
+
+```bash
+npm install @posthog/mcp posthog-node
+# or pnpm add @posthog/mcp posthog-node
+# or yarn add @posthog/mcp posthog-node
+```
+
+You bring your own [`posthog-node`](/docs/libraries/node.md) client (the same pattern as [`@posthog/ai`](/docs/ai-engineering.md)) and pass it to `instrument()` as the required second argument. You own its lifecycle — call `posthog.shutdown()` or `posthog.flush()` yourself.
+
+## Wrap your server
+
+`instrument(server, posthog, options?)` is the only function you need to call. The `posthog` client is a required positional argument; `options` is optional. It returns an analytics handle (used for [custom events](/docs/mcp-analytics/custom-events.md)). It's idempotent per server — calling it twice on the same server logs a warning and returns early.
+
+### Low-level `Server`
+
+If you registered your tools against the raw protocol `Server` from `@modelcontextprotocol/sdk/server/index.js`:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { PostHog } from "posthog-node";
+import { instrument } from "@posthog/mcp";
+const server = new Server({ name: "my-mcp-server", version: "1.0.0" });
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
+});
+// register your tools as usual...
+const analytics = instrument(server, posthog);
+```
+
+### High-level `McpServer`
+
+If you use the typed `McpServer` wrapper from `@modelcontextprotocol/sdk/server/mcp.js`, pass it in directly — the SDK will unwrap it and also install a proxy on `_registeredTools`, so any tool you register _after_ `instrument()` is also wrapped:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { PostHog } from "posthog-node";
+import { instrument } from "@posthog/mcp";
+const server = new McpServer({ name: "my-mcp-server", version: "1.0.0" });
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com",
+});
+const analytics = instrument(server, posthog);
+server.tool("search_events", {/* ... */}, async (args) => {
+  // your handler runs untouched
+});
+```
+
+### Next.js / Vercel (`mcp-handler`)
+
+[`mcp-handler`](https://github.com/vercel/mcp-handler) gives you a standard `McpServer` in its setup callback, so you instrument it the same way — one line, before or after you register tools:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import { createMcpHandler } from "mcp-handler";
+import { PostHog, instrument } from "@posthog/mcp";
+// Create the client once at module scope (not per request).
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
+});
+const handler = createMcpHandler(
+  (server) => {
+    instrument(server, posthog);
+    server.registerTool("roll_dice", {/* ... */}, async ({ sides }) => {
+      /* ... */
+    });
+  },
+  {},
+  { basePath: "/api" },
+);
+export { handler as GET, handler as POST };
+```
+
+#### Grouping a client's calls
+
+On Vercel, `mcp-handler`'s streamable-HTTP transport is **stateless**: it spins up a fresh server per request and issues no `Mcp-Session-Id`, so there's no connection for the SDK to derive a shared `$session_id` from — left alone, every request lands in its own session.
+
+The robust way to group is **by user**. Pass [`identify`](/docs/mcp-analytics/identifying-users.md) and return a `distinctId` from your auth (e.g. the OAuth subject) — that sets `distinct_id`, so a person's calls group together no matter how many stateless requests they span, and it requires nothing from the client:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  identify: (request, extra) => ({ distinctId: getUserId(extra) }),
+});
+```
+
+For finer, per-conversation grouping you can also enable [`enableConversationId`](/docs/mcp-analytics/conversation-id.md): the SDK adds a `conversation_id` argument, generates one when the client doesn't send it, and asks the agent to echo it on later calls, correlating them via `$mcp_conversation_id`. It's **best-effort** — it works by appending a short instruction to the tool result, which a cooperative agent echoes but some clients ignore or treat as untrusted server content (the same wariness they apply to prompt injection). Use it when you control the client or that trade-off is acceptable; otherwise stick with `identify`.
+
+#### Flushing
+
+`posthog-node` batches events, and a serverless function can freeze before they send. Flush at the end of the invocation — `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` to keep the runtime alive until it completes.
+
+### NestJS (`@rekog/mcp-nest`)
+
+With [`@rekog/mcp-nest`](https://github.com/rekog-labs/MCP-Nest) you don't construct the server yourself — `McpModule.forRoot(...)` does, and you define tools with `@Tool()` decorators. Instrument it through the module's `serverMutator` hook using `instrumentMutator`, which returns the server for you:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import { Module } from "@nestjs/common";
+import { McpModule } from "@rekog/mcp-nest";
+import { PostHog, instrumentMutator } from "@posthog/mcp";
+// Create the client once at module scope.
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com", // or https://eu.i.posthog.com
+});
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: "my-mcp-server",
+      version: "1.0.0",
+      serverMutator: instrumentMutator(posthog),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+`instrumentMutator(posthog)` is shorthand for `(server) => { instrument(server, posthog); return server }`. It returns the _server_, not the analytics handle, so it slots straight into `serverMutator`. The tools mcp-nest registers after the mutator runs are still captured.
+
+If you need the analytics handle for [custom events](/docs/mcp-analytics/custom-events.md), call `instrument()` directly inside the mutator and return the server yourself:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+serverMutator: (server) => {
+  const analytics = instrument(server, posthog);
+  // ...use `analytics.capture(...)` elsewhere...
+  return server;
+};
+```
+
+## Python
+
+A Python SDK ships inside the [`posthog`](/docs/libraries/python.md) package (the same way [`posthog.ai`](/docs/ai-engineering.md) does), so there's nothing extra to install:
+
+Terminal
+
+PostHog AI
+
+```bash
+pip install posthog
+```
+
+`instrument()` needs the MCP SDK at runtime, but you already have it — you built your server with `mcp` or `fastmcp`, so it's treated as a peer dependency rather than bundled. (`PostHogMCP` for custom dispatchers needs nothing beyond `posthog`.)
+
+`instrument(server, posthog_client, options?)` works with every common Python MCP server:
+
+- `FastMCP` and the low-level `Server` from the official [`modelcontextprotocol/python-sdk`](https://github.com/modelcontextprotocol/python-sdk) (the `mcp` package)
+- [jlowin's standalone **FastMCP 2.0**](https://github.com/jlowin/fastmcp) (the separate `fastmcp` package)
+- `PostHogMCP` for custom dispatchers with no server object (see below)
+
+Python
+
+PostHog AI
+
+```python
+from posthog import Posthog
+from posthog.mcp import instrument
+from mcp.server.fastmcp import FastMCP
+posthog = Posthog(
+    "phc_your_project_api_key",
+    host="https://us.i.posthog.com",  # or https://eu.i.posthog.com
+)
+server = FastMCP("my-server")
+# register your tools as usual...
+analytics = instrument(server, posthog)
+```
+
+Options are passed as `MCPAnalyticsOptions`, the snake\_case equivalent of the TypeScript options:
+
+Python
+
+PostHog AI
+
+```python
+from posthog.mcp import instrument
+from posthog.mcp.types import MCPAnalyticsOptions, UserIdentity
+instrument(server, posthog, MCPAnalyticsOptions(
+    context=True,                 # inject the `context` intent argument (default)
+    report_missing=True,          # register the get_more_tools virtual tool
+    enable_conversation_id=True,  # stitch calls across reconnects
+    identify=lambda request, extra: UserIdentity(distinct_id="user_123"),
+))
+```
+
+`MCPAnalyticsOptions` fields (the TypeScript [Configuration](#configuration) table below uses camelCase — these are the Python names):
+
+| Option                       | Type                                                       | Default          | What it does                                                 |
+| ---------------------------- | ---------------------------------------------------------- | ---------------- | ------------------------------------------------------------ |
+| context                      | bool \\\| MCPAnalyticsContextOptions                       | True             | Inject the context intent argument into every tool.          |
+| report_missing               | bool                                                       | False            | Register the get_more_tools virtual tool.                    |
+| missing_capability_tool_name | str                                                        | "get_more_tools" | Rename the virtual tool registered by report_missing.        |
+| enable_conversation_id       | bool                                                       | False            | Inject an optional conversation_id argument to stitch calls. |
+| enable_exception_autocapture | bool                                                       | True             | Emit a $exception sibling on failed tool calls.              |
+| identify                     | (request, extra) -> UserIdentity \\\| None (sync or async) | —                | Map a request to one of your users.                          |
+| intent_fallback              | (request, extra) -> str \\\| None                          | —                | Provide intent when the agent didn't pass context.           |
+| before_send                  | (event) -> event \\\| None                                 | —                | Inspect/modify/drop each event before send.                  |
+| event_properties             | (request, extra) -> dict                                   | —                | Properties merged onto every event.                          |
+| logger                       | (message: str) -> None                                     | no-op            | STDIO-safe log sink.                                         |
+
+### Flushing on exit
+
+The `posthog` client batches events asynchronously and you own its lifecycle. On the `instrument()` path, auto-captured events are scheduled in the background — `await analytics.flush()` waits for in-flight events, then `posthog.flush()` / `posthog.shutdown()` sends them. Call this from your shutdown/`SIGTERM` handler so trailing events aren't dropped (see [`examples/mcp_analytics_demo.py`](https://github.com/PostHog/posthog-python/blob/main/examples/mcp_analytics_demo.py) for a runnable end-to-end example):
+
+Python
+
+PostHog AI
+
+```python
+analytics = instrument(server, posthog)
+# ... serve ...
+await analytics.flush()   # drain in-flight auto-capture events
+posthog.shutdown()        # flush + stop the posthog client
+```
+
+No server object to wrap (a custom HTTP/edge dispatcher)? Use `PostHogMCP`, a `posthog` client subclass (needs nothing beyond `posthog` — no MCP SDK) with `capture_tool_call()`, `capture_initialize()`, `prepare_tool_list()`, and `prepare_tool_call()` — the Python equivalent of [Custom servers](/docs/mcp-analytics/custom-servers.md).
+
+**Python SDK is beta**
+
+The Python SDK is in beta (pre-1.0); the API may still change before `v1`, and some TypeScript-only features may land first. It emits the identical `$mcp_*` events documented on the [events](/docs/mcp-analytics/events.md) page.
+
+## Configuration
+
+The `posthog` client is passed as the required second positional argument — not in this options object. `instrument()` accepts these options as an optional third argument:
+
+| Option                     | Type                                                                     | Default | What it does                                                                                                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| logger                     | (message: string) => void                                                | no-op   | STDIO-safe log sink for SDK-internal warnings. MCP STDIO transports cannot use console.*, so the default discards. Wire your own to surface warnings during development.                  |
+| enableExceptionAutocapture | boolean                                                                  | true    | When false, a failed tool call does not emit the $exception sibling event.                                                                                                                |
+| context                    | boolean \\\| { description: string }                                     | true    | Inject a required context argument into every tool schema. See [Capturing agent intent](/docs/mcp-analytics/intent.md).                                                                   |
+| intentFallback             | (request, extra) => string \\\| Promise<string \\\| null \\\| undefined> | —       | Called when the agent didn't pass a context argument. See [Capturing agent intent](/docs/mcp-analytics/intent.md).                                                                        |
+| enableConversationId       | boolean                                                                  | false   | Inject an optional conversation_id argument into every tool. See [Conversation IDs](/docs/mcp-analytics/conversation-id.md).                                                              |
+| reportMissing              | boolean                                                                  | false   | Register the get_more_tools virtual tool. See [Missing capability](/docs/mcp-analytics/missing-capability.md).                                                                            |
+| identify                   | async (request, extra) => UserIdentity \\\| null \\\| UserIdentity       | —       | Map an MCP request to one of your users. See [Identifying users](/docs/mcp-analytics/identifying-users.md).                                                                               |
+| beforeSend                 | (event) => event \\\| null \\\| undefined \\\| Promise<...>              | —       | Runs on each fully-built PostHog payload right before send. Return the (possibly mutated) event to send it, or a nullish value to drop it. See [Privacy](/docs/mcp-analytics/privacy.md). |
+| eventProperties            | async (request, extra) => Record<string, unknown>                        | —       | Properties merged onto every event. See [Custom events and metadata](/docs/mcp-analytics/custom-events.md).                                                                               |
+
+## Graceful shutdown
+
+The `posthog-node` client queues and batches events asynchronously, and you own its lifecycle. Call `posthog.shutdown()` from your `SIGTERM` / `beforeExit` handler so in-flight events aren't dropped:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import { PostHog } from "posthog-node";
+import { instrument } from "@posthog/mcp";
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY);
+instrument(server, posthog);
+process.on("SIGTERM", async () => {
+  await posthog.shutdown();
+  process.exit(0);
+});
+```
+
+If you only want to drain the queue without tearing the client down, call `posthog.flush()` instead.
+
+In serverless or edge environments where `SIGTERM` isn't reliable, flush explicitly at the end of each invocation — `await posthog.flush()`, or `ctx.waitUntil(posthog.flush())` on platforms that support it — rather than relying on a shutdown signal.
+
+## What happens after install
+
+As soon as the wrapper is in place, every MCP request handled by the server emits a PostHog event:
+
+- `$mcp_tool_call` per tool invocation
+- `$mcp_tools_list` per `tools/list` response
+- `$mcp_initialize` per client handshake
+- `$mcp_resource_read`, `$mcp_resources_list`, `$mcp_prompt_get`, `$mcp_prompts_list` as applicable
+- `$exception` whenever a tool throws or returns `isError: true`
+
+All events share a `$session_id` derived from the MCP protocol session (so the same connection always maps to the same PostHog session). See the [event reference](/docs/mcp-analytics/events.md) for the full catalog.
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/mcp-analytics/references/intent.md
+++ b/.claude/skills/mcp-analytics/references/intent.md
@@ -1,0 +1,182 @@
+# Capturing agent intent - Docs
+
+Knowing _what_ a tool was called is one thing. Knowing _why_ the agent called it is what makes MCP Analytics useful for product decisions.
+
+The SDK captures intent as a single property — `$mcp_intent` — that can come from one of two sources:
+
+1.  **A `context` argument** the agent passes on every tool call. Captured with `$mcp_intent_source = "context_parameter"`.
+2.  **A fallback callback** you supply on `instrument()`. Captured with `$mcp_intent_source = "inferred"`.
+
+Explicit context always wins. If the agent passes a non-empty `context`, the fallback is not invoked.
+
+## The `context` argument
+
+When `context: true` (the default), the SDK adds a required `context` string to every tool's JSON Schema. It strips that argument before your handler runs, so your tool implementation never sees it.
+
+What the agent sees in the schema:
+
+JSON
+
+PostHog AI
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "context": {
+      "type": "string",
+      "description": "Why are you calling this tool? Briefly describe the user's goal."
+    },
+    "...": "your real tool arguments"
+  },
+  "required": ["context", "..."]
+}
+```
+
+What your handler receives:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+server.tool("search_events", schema, async (args) => {
+  // args.context has been stripped — only your real arguments are here
+});
+```
+
+What lands in PostHog as `$mcp_intent`:
+
+PostHog AI
+
+```
+"Finding the last 10 pageviews for user alice@example.com to triage a drop in conversion"
+```
+
+### Customising the prompt
+
+If you want to nudge the agent toward a specific style of context (use case, user goal, ticket id, etc.), pass an object:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  context: {
+    description:
+      "Describe the user's underlying goal in one sentence — not the tool you're calling.",
+  },
+});
+```
+
+### Disabling the injected argument
+
+Set `context: false` if you don't want the SDK to touch your tool schemas at all. You'll lose the agent-supplied intent, and you'll need to rely on `intentFallback` (or accept events without `$mcp_intent`).
+
+## The `intentFallback` callback
+
+The `context` argument is _advertised_ as required in JSON Schema but isn't enforced at the SDK validation layer. A client that ignores the schema hint (raw cURL, in-house agents, schema-blind crawlers) will still succeed — the call lands in PostHog with `$mcp_intent` empty.
+
+`intentFallback` is the escape hatch. The SDK calls it whenever no `context` argument is present, takes whatever non-empty string you return, and stamps it as `$mcp_intent` with `$mcp_intent_source = "inferred"`.
+
+The SDK does no inference of its own. It doesn't call an LLM. It doesn't inspect your tool arguments. It doesn't cache results. Whatever logic you want goes in your callback.
+
+### Deterministic, per-tool
+
+The cheapest pattern — synchronous, runs on every uncontextualized call. Good default:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  intentFallback: (request) => {
+    const tool = request.params?.name;
+    const args = request.params?.arguments ?? {};
+    if (tool === "search_events") return `Searching events for "${args.query}"`;
+    return tool ? `Invoking ${tool}` : null;
+  },
+});
+```
+
+### Using transport metadata
+
+`extra` carries MCP transport details — useful when the agent's user-agent or auth context hints at intent:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+intentFallback: (request, extra) => {
+  const ua = extra?.requestInfo?.headers?.["user-agent"];
+  return `${ua ?? "unknown client"} invoked ${request.params?.name}`;
+};
+```
+
+### LLM-derived intent
+
+Possible, but think twice. This callback sits on the hot path of every uncontextualized tool call — every LLM round-trip you add here adds latency to the agent's response. If you do this, cache aggressively and budget for failures:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+intentFallback: async (request) => {
+  try {
+    return await summariseIntent(request.params);
+  } catch {
+    return null; // the SDK swallows null gracefully
+  }
+};
+```
+
+## Filtering on intent source
+
+`$mcp_intent_source` is set to `"context_parameter"` or `"inferred"` only when an intent was captured. If neither a `context` argument nor a fallback result was available, both `$mcp_intent` and `$mcp_intent_source` are absent on the event.
+
+If you want to know what fraction of your traffic is contextualized:
+
+SQL
+
+[Run in PostHog](https://us.posthog.com/sql?open_query=SELECT%0A++properties.%24mcp_intent_source+AS+source%2C%0A++count%28%29+AS+calls%0AFROM+events%0AWHERE+event+%3D+'%24mcp_tool_call'%0A++AND+timestamp+%3E+now%28%29+-+INTERVAL+7+DAY%0AGROUP+BY+source%0AORDER+BY+calls+DESC)
+
+PostHog AI
+
+```sql
+SELECT
+  properties.$mcp_intent_source AS source,
+  count() AS calls
+FROM events
+WHERE event = '$mcp_tool_call'
+  AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY source
+ORDER BY calls DESC
+```
+
+A high share of `inferred` means most of your callers are ignoring the schema hint — that's a signal to either improve the `context.description` copy or invest in a better `intentFallback`.
+
+## Gotchas
+
+**\`get\_more\_tools\` reports its source as \`context\_parameter\`**
+
+The virtual `get_more_tools` tool (enabled by `reportMissing: true`) always reports `$mcp_intent_source = "context_parameter"`, even though the SDK is what defined the schema. Defensible — the agent did type a string — but filter it out of source-attribution queries if the number matters.
+
+**The schema \`required\` field isn't enforced**
+
+`context` is advertised as required in JSON Schema, but the SDK does not re-validate against Zod. A client that ignores the schema hint can send `arguments: {}` and the call still succeeds — landing in PostHog with `$mcp_intent` empty. That's exactly why `intentFallback` exists.
+
+**Skip \`intentFallback\` for tight internal servers**
+
+For a single, well-behaved internal client, the fallback is dead code. Don't add it unless you actually expect callers to skip the `context` argument.
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/mcp-analytics/references/start-here.md
+++ b/.claude/skills/mcp-analytics/references/start-here.md
@@ -1,0 +1,218 @@
+# Getting started with MCP Analytics - Docs
+
+**MCP Analytics is in beta**
+
+`@posthog/mcp` is published as a `0.1.x` release on npm. We're building it in public – the event shape, options, and tracing behavior may still change before `1.0`. Pin a specific version and don't depend on it for production reporting yet.
+
+## Add @posthog/mcp to your MCP server
+
+MCP Analytics gives you visibility into how AI agents actually use the MCP server you ship. With one wrapper call you can track:
+
+- 🛠️ Every tool call (parameters, response, duration, errors)
+- 🎯 Agent intent – the _why_ behind each call, not just the _what_
+- 🧭 Every `tools/list` so you can compare advertised vs called
+- 🪪 The MCP client name and version
+- 🧵 The full session, end to end
+- 🚧 Capabilities the agent wished existed (with `reportMissing`)
+
+The SDK supports any TypeScript MCP server built on `@modelcontextprotocol/sdk`. The fastest way to get set up is our wizard, which installs the package and wires up `instrument()` for you (it also works for [LLM coding agents](/blog/envoy-wizard-llm-agent.md) like Cursor and Bolt):
+
+`npx @posthog/wizard mcp-analytics`
+
+[Learn more](/wizard.md)
+
+Prefer to do it by hand? Install it from npm and call `instrument()` once at startup. You pass your `posthog-node` client as the required second argument:
+
+Terminal
+
+PostHog AI
+
+```bash
+npm install @posthog/mcp posthog-node
+```
+
+TypeScript
+
+PostHog AI
+
+```typescript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { PostHog } from "posthog-node";
+import { instrument } from "@posthog/mcp";
+const server = new Server({ name: "my-mcp-server", version: "1.0.0" });
+const posthog = new PostHog(process.env.POSTHOG_PROJECT_API_KEY, {
+  host: "https://us.i.posthog.com",
+});
+instrument(server, posthog);
+```
+
+[Full installation guide](/docs/mcp-analytics/installation.md)
+
+## See your first events
+
+Run your MCP server and connect an agent to it (Claude Desktop, Cursor, Codex, or your own). Within seconds of the first tool call, PostHog will receive `$mcp_tool_call`, `$mcp_tools_list`, and `$mcp_initialize` events – all prefixed with `$mcp_*` so they never collide with anything else in your project.
+
+Open the [activity feed](https://us.posthog.com/project/2/activity) and filter for `event = $mcp_tool_call`. You should see one row per agent tool invocation, each with `$mcp_tool_name`, `$mcp_parameters`, `$mcp_response`, `$mcp_duration_ms`, and `$mcp_is_error`.
+
+![PostHog activity feed filtered to $mcp_tool_call events, with tool name, client, error state, and duration columns](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_activity_feed_dark_e795d95547.png)
+
+[See every event the SDK emits](/docs/mcp-analytics/events.md)
+
+## Capture what the agent was trying to do
+
+The single most useful signal in MCP Analytics is **intent**: the user goal that led the agent to call this tool. The SDK injects a required `context` argument into every tool's schema and captures it as `$mcp_intent`. Your tool implementation never sees it.
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  context: {
+    description:
+      "Describe the user's underlying goal in one sentence — not the tool you're calling.",
+  },
+});
+```
+
+For agents that ignore the schema hint (raw cURL clients, schema-blind crawlers), supply an `intentFallback`. The SDK calls it whenever no `context` argument was passed:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  intentFallback: (request) => {
+    const tool = request.params?.name;
+    return tool ? `Invoking ${tool}` : null;
+  },
+});
+```
+
+[Learn about intent capture](/docs/mcp-analytics/intent.md)
+
+## Build your first dashboard
+
+Every event is a normal PostHog event, so insights, dashboards, alerts, and SQL all work without further setup – and the [MCP Analytics view](/docs/mcp-analytics.md) (in beta – [enable the feature preview](https://app.posthog.com/settings/user-feature-previews#mcp-analytics)) gives you the most useful cuts out of the box. The four queries we suggest building (or reading straight from the dashboard) first:
+
+- ### Top tools per server
+
+  Where is your agent traffic concentrated? Which tools earn their keep?
+
+- ### Error rate per tool
+
+  Which tools throw most often? Pair with `$exception` events to triage.
+
+- ### Intent samples by source
+
+  How much of your traffic supplies explicit context vs falls back to `intentFallback`?
+
+- ### Advertised tools that never get called
+
+  Find dead surface area by joining `$mcp_tools_list` against `$mcp_tool_call`.
+
+The tool quality tab surfaces error rate and latency percentiles per tool, with a row to drill into for any single tool:
+
+![MCP Analytics tool quality tab showing calls and errors, success rate, latency percentiles, and a per-tool table](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_tool_quality_light_f91f27f6e1.png)![MCP Analytics tool quality tab showing calls and errors, success rate, latency percentiles, and a per-tool table](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/mcp_tool_quality_dark_add2659eaa.png)
+
+[Copy-paste queries](/docs/mcp-analytics/queries.md)
+
+## Identify the user behind the agent
+
+By default each event is attributed to the MCP connection's session ID. To attribute calls to a real user – for per-user retention, group analytics, and person properties – wire an `identify` callback:
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  identify: async (request, extra) => {
+    const token = extra?.requestInfo?.headers?.authorization;
+    const user = token ? await resolveUserFromToken(token) : null;
+    return user
+      ? { distinctId: user.id, properties: { name: user.name } }
+      : null;
+  },
+});
+```
+
+The SDK emits a `$identify` event the first time it sees a new identity for a session, and PostHog's standard merge takes care of attributing prior anonymous activity.
+
+[Identify users](/docs/mcp-analytics/identifying-users.md)
+
+## Find capability gaps with \`reportMissing\`
+
+The most actionable signal for an MCP server owner is _the agent wanted to do something I don't support_. Enable `reportMissing: true` and the SDK registers a `get_more_tools` virtual tool. When the agent invokes it, you get a queryable feed of unmet asks – straight into your roadmap.
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  reportMissing: true,
+});
+```
+
+SQL
+
+[Run in PostHog](https://us.posthog.com/sql?open_query=SELECT%0A++properties.%24mcp_intent+++++++AS+unmet_request%2C%0A++properties.%24mcp_client_name++AS+client%2C%0A++count%28%29++++++++++++++++++++++AS+times_asked%0AFROM+events%0AWHERE+event+%3D+'%24mcp_missing_capability'%0A++AND+timestamp+%3E+now%28%29+-+INTERVAL+30+DAY%0AGROUP+BY+unmet_request%2C+client%0AORDER+BY+times_asked+DESC)
+
+PostHog AI
+
+```sql
+SELECT
+  properties.$mcp_intent       AS unmet_request,
+  properties.$mcp_client_name  AS client,
+  count()                      AS times_asked
+FROM events
+WHERE event = '$mcp_missing_capability'
+  AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY unmet_request, client
+ORDER BY times_asked DESC
+```
+
+[Track missing capabilities](/docs/mcp-analytics/missing-capability.md)
+
+## Ship safely
+
+The SDK runs every event through automatic sanitization (image/audio/binary stubs, sensitive-key masking like `authorization`, `cookie`, `password`, PostHog key patterns) and truncation to fit ingestion limits. For full control, add a `beforeSend` hook that runs on each built PostHog payload right before it's sent – mutate and return the event to send it, or return a nullish value to drop it.
+
+TypeScript
+
+PostHog AI
+
+```typescript
+instrument(server, posthog, {
+  beforeSend: (event) => {
+    if (event.event === "$exception") return null; // drop exceptions
+    return event;
+  },
+});
+```
+
+[Privacy & redaction](/docs/mcp-analytics/privacy.md)
+
+---
+
+That's it. You're ready to ship `@posthog/mcp` to production agents – within the beta caveats above.
+
+[Install MCP Analytics](/docs/mcp-analytics/installation.md)
+
+1/7
+
+[**Add @posthog/mcp to your MCP server** _**Required**_](#quest-item-add-posthogmcp-to-your-mcp-server)[**See your first events** _**Required**_](#quest-item-see-your-first-events)[**Capture what the agent was trying to do** _**Recommended**_](#quest-item-capture-what-the-agent-was-trying-to-do)[**Build your first dashboard** _**Recommended**_](#quest-item-build-your-first-dashboard)[**Identify the user behind the agent** _**Recommended**_](#quest-item-identify-the-user-behind-the-agent)[**Find capability gaps with \`reportMissing\`** _**Recommended**_](#quest-item-find-capability-gaps-with-reportmissing)[**Ship safely** _**Required**_](#quest-item-ship-safely)
+
+**Add @posthog/mcp to your MCP server**
+
+_**Required**_
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -38,6 +38,8 @@
 import * as Sentry from "@sentry/cloudflare";
 import {
   isUsageTelemetryConfigured,
+  recordMcpInitializeEvent,
+  recordMcpToolCallEvent,
   recordUsageEvent,
 } from "./usage-telemetry.ts";
 import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.ts";
@@ -16235,16 +16237,25 @@ function negotiateProtocol(requested) {
 // invocation instead of instrumenting ~150 handlers individually. It also
 // already funnels every outcome into an isError result rather than throwing,
 // which is what makes success/failure readable here without touching any
-// handler. Nothing but the tool name, that flag, elapsed time, and (on
-// failure) a fixed error category is recorded — never arguments or response
-// content, and never a free-form error message.
+// handler.
+//
+// Two events are scheduled below, with two different shapes. usage_event
+// (scheduleToolUsageEvent) is this codebase's own minimal telemetry: nothing
+// but the tool name, that flag, elapsed time, and (on failure) a fixed error
+// category — never arguments or response content, never a free-form error
+// message. $mcp_tool_call (scheduleMcpToolCallEvent, #7737) is PostHog's own
+// MCP Analytics event family and DOES include the call's arguments/result —
+// but only after recordMcpToolCallEvent (src/usage-telemetry.ts) redacts and
+// size-caps them; see that module's header comment for why (no SDK
+// instrument() wrapper here, so no default redaction pipeline either).
 async function callTool(params, ctx) {
   const startedAt = Date.now();
   const result = await dispatchTool(params, ctx);
+  const durationMs = Date.now() - startedAt;
   scheduleToolUsageEvent(ctx, {
     mcpTool: typeof params?.name === "string" ? params.name : undefined,
     ok: result.isError !== true,
-    durationMs: Date.now() - startedAt,
+    durationMs,
     // metagraphed#7726: every isError result already carries a code from a
     // small, developer-defined literal set (toolError's own codes, or
     // "unknown_tool" below) in structuredContent.error.code -- thread it
@@ -16254,6 +16265,14 @@ async function callTool(params, ctx) {
     ...(result.isError
       ? { errorCode: result?.structuredContent?.error?.code }
       : {}),
+  });
+  scheduleMcpToolCallEvent(ctx, {
+    toolName: typeof params?.name === "string" ? params.name : undefined,
+    isError: result.isError === true,
+    durationMs,
+    sessionId: ctx?.sessionId,
+    parameters: params?.arguments,
+    response: result?.structuredContent,
   });
   return result;
 }
@@ -16270,6 +16289,26 @@ function scheduleToolUsageEvent(ctx, event) {
     if (!isUsageTelemetryConfigured(ctx?.env)) return;
     const record = ctx?.recordUsageEvent ?? recordUsageEvent;
     const pending = Promise.resolve(record(ctx.env, event)).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+function scheduleMcpToolCallEvent(ctx, event) {
+  try {
+    const record = ctx?.recordMcpToolCallEvent ?? recordMcpToolCallEvent;
+    const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+function scheduleMcpInitializeEvent(ctx, event) {
+  try {
+    const record = ctx?.recordMcpInitializeEvent ?? recordMcpInitializeEvent;
+    const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
     ctx?.executionCtx?.waitUntil?.(pending);
   } catch {
     // Telemetry must never surface into the tool path.
@@ -16381,6 +16420,11 @@ async function dispatchMessage(message, ctx) {
           // Registry backlink (sibling of serverInfo, never inside it).
           _meta: MCP_REGISTRY_META,
         };
+        scheduleMcpInitializeEvent(ctx, {
+          clientName: params?.clientInfo?.name,
+          clientVersion: params?.clientInfo?.version,
+          sessionId: ctx?.sessionId,
+        });
         return isNotification ? null : rpcResult(id, result);
       }
       case "ping":

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -163,3 +163,204 @@ function sanitizeLabel(value: unknown): string | undefined {
     ? trimmed.slice(0, MAX_LABEL_CHARS)
     : trimmed;
 }
+
+// MCP Analytics events (#7737). Emit PostHog's canonical $mcp_* event family
+// so PostHog's built-in MCP Analytics dashboards work out of the box.
+// Implemented via the same raw-fetch pattern as recordUsageEvent — posthog-
+// node cannot be bundled into the Worker (bundle-budget constraint; see the
+// header comment), so there is no SDK `instrument()` wrapper here and no
+// SDK-provided default redaction sitting in front of what gets sent. Whatever
+// this module includes in $mcp_parameters / $mcp_response, it redacts itself.
+//
+// redactMcpSensitiveFields mirrors the key-name-substring redaction
+// posthog-node/@posthog/mcp applies automatically when instrument() drives
+// capture (authorization/cookie/password/token/secret/api_key/private_key,
+// per https://posthog.com/docs/mcp-analytics/privacy) — plus `credential`,
+// which that default list does NOT cover and which call_subnet_surface's own
+// `credential` argument (src/call-subnet-surface.ts) needs: a bearer token,
+// API key, or Bittensor hotkey-signed bundle a caller supplies for one call.
+// Every other sensitive argument this server takes is already covered by the
+// baseline set — e.g. get_alert_trigger's `owner_token` via the "token"
+// substring — so `credential` is the only addition needed.
+
+const MCP_SENSITIVE_KEY_PATTERN =
+  /authorization|cookie|password|token|secret|api[_-]?key|private[_-]?key|credential/i;
+
+const MCP_REDACTED_VALUE = "[redacted]";
+
+// Caps recursion on a pathologically deep structure (call_subnet_surface's
+// `body` argument and its upstream response body are both fully caller/
+// third-party-controlled) — a v8 stack limit is a much uglier failure mode
+// than a placeholder string.
+const MCP_REDACT_MAX_DEPTH = 8;
+
+function redactMcpSensitiveFields(value: unknown, depth = 0): unknown {
+  if (depth > MCP_REDACT_MAX_DEPTH) return "[max depth exceeded]";
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactMcpSensitiveFields(entry, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const redacted: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      redacted[key] = MCP_SENSITIVE_KEY_PATTERN.test(key)
+        ? MCP_REDACTED_VALUE
+        : redactMcpSensitiveFields(entry, depth + 1);
+    }
+    return redacted;
+  }
+  return value;
+}
+
+// Generous for typical tool-call arguments; far below call_subnet_surface's
+// own 256 KiB response cap (src/call-subnet-surface.ts's MAX_RESPONSE_BYTES)
+// so one large response can't balloon a PostHog capture payload.
+const MCP_PAYLOAD_MAX_CHARS = 4096;
+
+function boundedMcpPayload(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  const redacted = redactMcpSensitiveFields(value);
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(redacted);
+  } catch {
+    return undefined;
+  }
+  if (typeof serialized !== "string") return undefined;
+  if (serialized.length <= MCP_PAYLOAD_MAX_CHARS) return redacted;
+  return {
+    truncated: true,
+    preview: serialized.slice(0, MCP_PAYLOAD_MAX_CHARS),
+  };
+}
+
+/** Inputs for a single MCP tool-call analytics event. */
+export interface McpToolCallEvent {
+  toolName?: string;
+  isError: boolean;
+  durationMs: number;
+  /** Mcp-Session-Id header value; omitted from the payload when absent. */
+  sessionId?: string | null;
+  /**
+   * The tool call's raw arguments / result. Redacted (redactMcpSensitiveFields)
+   * and size-capped (boundedMcpPayload) before ever being included in the
+   * posted event — this module owns that, callers pass the raw value through.
+   */
+  parameters?: unknown;
+  response?: unknown;
+}
+
+/** Inputs for an MCP initialize-handshake analytics event. */
+export interface McpInitializeEvent {
+  clientName?: string;
+  clientVersion?: string;
+  /** Mcp-Session-Id header value; omitted from the payload when absent. */
+  sessionId?: string | null;
+}
+
+/**
+ * Emit a PostHog `$mcp_tool_call` event via the capture endpoint.
+ * Same no-throw contract as recordUsageEvent.
+ */
+export async function recordMcpToolCallEvent(
+  env: Env | null | undefined,
+  event: McpToolCallEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+
+    if (typeof event.isError !== "boolean") return false;
+    if (
+      typeof event.durationMs !== "number" ||
+      !Number.isFinite(event.durationMs) ||
+      event.durationMs < 0
+    ) {
+      return false;
+    }
+
+    const properties: Record<string, unknown> = {
+      $mcp_is_error: event.isError,
+      $mcp_duration_ms: Math.min(Math.round(event.durationMs), 86_400_000),
+    };
+
+    const toolName = sanitizeLabel(event.toolName);
+    if (toolName !== undefined) properties["$mcp_tool_name"] = toolName;
+
+    if (typeof event.sessionId === "string" && event.sessionId.trim()) {
+      properties["$session_id"] = event.sessionId.trim();
+    }
+
+    const parameters = boundedMcpPayload(event.parameters);
+    if (parameters !== undefined) properties["$mcp_parameters"] = parameters;
+
+    const responseBody = boundedMcpPayload(event.response);
+    if (responseBody !== undefined) properties["$mcp_response"] = responseBody;
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: "$mcp_tool_call",
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Emit a PostHog `$mcp_initialize` event via the capture endpoint.
+ * Same no-throw contract as recordUsageEvent.
+ */
+export async function recordMcpInitializeEvent(
+  env: Env | null | undefined,
+  event: McpInitializeEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+
+    const properties: Record<string, string | number | boolean> = {};
+
+    const clientName = sanitizeLabel(event.clientName);
+    if (clientName !== undefined) properties["$mcp_client_name"] = clientName;
+
+    const clientVersion = sanitizeLabel(event.clientVersion);
+    if (clientVersion !== undefined)
+      properties["$mcp_client_version"] = clientVersion;
+
+    if (typeof event.sessionId === "string" && event.sessionId.trim()) {
+      properties["$session_id"] = event.sessionId.trim();
+    }
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: "$mcp_initialize",
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/mcp-usage-telemetry.test.mjs
+++ b/tests/mcp-usage-telemetry.test.mjs
@@ -85,7 +85,8 @@ describe("MCP tool-dispatch usage telemetry", () => {
       "ok",
     ]);
     // Drained through waitUntil rather than awaited in the tool path.
-    assert.equal(executionCtx.scheduled.length, 1);
+    // Two promises: one for usage_event, one for $mcp_tool_call.
+    assert.equal(executionCtx.scheduled.length, 2);
   });
 
   test("records an unknown tool as a failure", async () => {
@@ -183,11 +184,17 @@ describe("MCP tool-dispatch usage telemetry", () => {
       await Promise.all(executionCtx.scheduled);
 
       assert.equal(payload.result.isError, false);
-      assert.equal(posted.length, 1);
-      assert.equal(posted[0].body.event, "usage_event");
-      assert.equal(posted[0].body.properties.mcp_tool, TOOL);
-      assert.equal(posted[0].body.properties.ok, true);
-      assert.equal("error_code" in posted[0].body.properties, false);
+      // Two events: usage_event (existing telemetry) + $mcp_tool_call (MCP analytics).
+      assert.equal(posted.length, 2);
+      const usagePost = posted.find((p) => p.body.event === "usage_event");
+      assert.ok(usagePost, "usage_event should be posted");
+      assert.equal(usagePost.body.properties.mcp_tool, TOOL);
+      assert.equal(usagePost.body.properties.ok, true);
+      assert.equal("error_code" in usagePost.body.properties, false);
+      const mcpPost = posted.find((p) => p.body.event === "$mcp_tool_call");
+      assert.ok(mcpPost, "$mcp_tool_call should be posted");
+      assert.equal(mcpPost.body.properties.$mcp_tool_name, TOOL);
+      assert.equal(mcpPost.body.properties.$mcp_is_error, false);
     } finally {
       globalThis.fetch = original;
     }
@@ -210,9 +217,12 @@ describe("MCP tool-dispatch usage telemetry", () => {
       await Promise.all(executionCtx.scheduled);
 
       assert.equal(payload.result.isError, true);
-      assert.equal(posted.length, 1);
-      assert.equal(posted[0].body.properties.ok, false);
-      assert.equal(posted[0].body.properties.error_code, "invalid_params");
+      // Two events: usage_event + $mcp_tool_call.
+      assert.equal(posted.length, 2);
+      const usagePost = posted.find((p) => p.body.event === "usage_event");
+      assert.ok(usagePost, "usage_event should be posted");
+      assert.equal(usagePost.body.properties.ok, false);
+      assert.equal(usagePost.body.properties.error_code, "invalid_params");
     } finally {
       globalThis.fetch = original;
     }
@@ -226,6 +236,79 @@ describe("MCP tool-dispatch usage telemetry", () => {
     });
 
     assert.equal(spy.events.length, 2);
+  });
+
+  // #7737: proves the redaction end-to-end through the real dispatch path
+  // (callTool -> scheduleMcpToolCallEvent -> recordMcpToolCallEvent -> fetch),
+  // not just against the unit-level function in usage-telemetry.test.mjs.
+  test("$mcp_tool_call never leaks call_subnet_surface's credential argument", async () => {
+    const original = globalThis.fetch;
+    const posted = [];
+    globalThis.fetch = async (url, init) => {
+      posted.push({ url, body: JSON.parse(init.body) });
+      return { ok: true };
+    };
+    try {
+      const executionCtx = fakeExecutionCtx();
+      await callMcp(
+        toolCall("call_subnet_surface", {
+          surface_id: "x:api:6",
+          credential: "Bearer super-secret-abc123",
+        }),
+        CONFIGURED_ENV,
+        { executionCtx },
+      );
+      await Promise.all(executionCtx.scheduled);
+
+      assert.ok(!JSON.stringify(posted).includes("super-secret-abc123"));
+      const mcpPost = posted.find((p) => p.body.event === "$mcp_tool_call");
+      assert.ok(mcpPost, "$mcp_tool_call should be posted");
+      assert.equal(
+        mcpPost.body.properties.$mcp_parameters.credential,
+        "[redacted]",
+      );
+      assert.equal(
+        mcpPost.body.properties.$mcp_parameters.surface_id,
+        "x:api:6",
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("$mcp_tool_call never leaks get_alert_trigger's owner_token argument", async () => {
+    const original = globalThis.fetch;
+    const posted = [];
+    globalThis.fetch = async (url, init) => {
+      posted.push({ url, body: JSON.parse(init.body) });
+      return { ok: true };
+    };
+    try {
+      const executionCtx = fakeExecutionCtx();
+      const payload = await callMcp(
+        toolCall("get_alert_trigger", {
+          id: "trigger-1",
+          owner_token: "owner-secret-xyz",
+        }),
+        CONFIGURED_ENV,
+        { executionCtx },
+      );
+      await Promise.all(executionCtx.scheduled);
+
+      // DATA_API isn't bound in tests -- the tool call itself fails, but the
+      // argument capture in callTool doesn't depend on the tool succeeding.
+      assert.equal(payload.result.isError, true);
+      assert.ok(!JSON.stringify(posted).includes("owner-secret-xyz"));
+      const mcpPost = posted.find((p) => p.body.event === "$mcp_tool_call");
+      assert.ok(mcpPost, "$mcp_tool_call should be posted");
+      assert.equal(
+        mcpPost.body.properties.$mcp_parameters.owner_token,
+        "[redacted]",
+      );
+      assert.equal(mcpPost.body.properties.$mcp_parameters.id, "trigger-1");
+    } finally {
+      globalThis.fetch = original;
+    }
   });
 
   // The regression the issue asks for: a telemetry failure must never become a
@@ -252,6 +335,7 @@ describe("MCP tool-dispatch usage telemetry", () => {
       },
       "waitUntil throws": {
         recordUsageEvent: recorder().recordUsageEvent,
+        recordMcpToolCallEvent: async () => false,
         executionCtx: {
           waitUntil() {
             throw new Error("isolate already finished");
@@ -260,11 +344,74 @@ describe("MCP tool-dispatch usage telemetry", () => {
       },
       "no ExecutionContext at all": {
         recordUsageEvent: recorder().recordUsageEvent,
+        recordMcpToolCallEvent: async () => false,
+      },
+      // #7737: scheduleMcpToolCallEvent's own .catch(() => false) -- proves a
+      // rejecting/throwing $mcp_tool_call recorder is exactly as harmless as
+      // a rejecting/throwing usage_event recorder above.
+      "$mcp_tool_call recorder rejects": {
+        recordMcpToolCallEvent: () => Promise.reject(new Error("posthog down")),
+        executionCtx: fakeExecutionCtx(),
+      },
+      "$mcp_tool_call recorder throws synchronously": {
+        recordMcpToolCallEvent: () => {
+          throw new Error("recorder exploded");
+        },
+        executionCtx: fakeExecutionCtx(),
       },
     };
 
     for (const [mode, deps] of Object.entries(failureModes)) {
       const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, deps);
+      // Flush the fire-and-forget telemetry promises before moving on, so a
+      // rejecting recorder's own .catch(() => false) actually runs within
+      // this test rather than resolving after it (both are equally safe --
+      // this just makes the assertion below deterministic instead of racy).
+      if (Array.isArray(deps.executionCtx?.scheduled)) {
+        await Promise.allSettled(deps.executionCtx.scheduled);
+      }
+      assert.deepEqual(
+        payload,
+        baseline,
+        `telemetry mode changed the result: ${mode}`,
+      );
+    }
+  });
+
+  // Mirrors the test above but for scheduleMcpInitializeEvent's own
+  // .catch(() => false) -- initialize is the only method that fires it.
+  test("an $mcp_initialize telemetry failure changes nothing about the initialize result", async () => {
+    const initializeRequest = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      },
+    };
+    const baseline = await callMcp(initializeRequest, {});
+    assert.equal(baseline.result.protocolVersion, "2025-03-26");
+
+    const failureModes = {
+      "recorder rejects": {
+        recordMcpInitializeEvent: () =>
+          Promise.reject(new Error("posthog down")),
+        executionCtx: fakeExecutionCtx(),
+      },
+      "recorder throws synchronously": {
+        recordMcpInitializeEvent: () => {
+          throw new Error("recorder exploded");
+        },
+        executionCtx: fakeExecutionCtx(),
+      },
+    };
+
+    for (const [mode, deps] of Object.entries(failureModes)) {
+      const payload = await callMcp(initializeRequest, CONFIGURED_ENV, deps);
+      if (Array.isArray(deps.executionCtx?.scheduled)) {
+        await Promise.allSettled(deps.executionCtx.scheduled);
+      }
       assert.deepEqual(
         payload,
         baseline,

--- a/tests/usage-telemetry.test.mjs
+++ b/tests/usage-telemetry.test.mjs
@@ -7,6 +7,8 @@ import {
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
   isUsageTelemetryConfigured,
+  recordMcpInitializeEvent,
+  recordMcpToolCallEvent,
   recordUsageEvent,
   resolvePostHogHost,
   usageEventProperties,
@@ -303,5 +305,387 @@ describe("recordUsageEvent — configured", () => {
       },
     );
     assert.equal(calls[0].body.distinct_id, "test-distinct");
+  });
+});
+
+// #7737: recordMcpToolCallEvent is the one place $mcp_parameters/$mcp_response
+// get built — there is no SDK instrument() pipeline redacting these for us
+// (see the module's own header comment), so this redaction is the only thing
+// standing between a real credential and PostHog.
+describe("recordMcpToolCallEvent", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  test("posts $mcp_tool_call with tool name / error flag / duration / session id", async () => {
+    const calls = [];
+    const recorded = await recordMcpToolCallEvent(
+      CONFIGURED,
+      {
+        toolName: "get_subnet",
+        isError: false,
+        durationMs: 12.4,
+        sessionId: " sess-1 ",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    assert.equal(calls[0].body.event, "$mcp_tool_call");
+    assert.deepEqual(calls[0].body.properties, {
+      $mcp_is_error: false,
+      $mcp_duration_ms: 12,
+      $mcp_tool_name: "get_subnet",
+      $session_id: "sess-1",
+    });
+  });
+
+  test("returns false for an invalid event without capturing", async () => {
+    let calls = 0;
+    const onCall = () => {
+      calls += 1;
+    };
+    assert.equal(
+      await recordMcpToolCallEvent(
+        CONFIGURED,
+        { isError: "yes", durationMs: 1 },
+        { fetch: fakeFetch({ onCall }) },
+      ),
+      false,
+    );
+    assert.equal(
+      await recordMcpToolCallEvent(
+        CONFIGURED,
+        { isError: false, durationMs: -1 },
+        { fetch: fakeFetch({ onCall }) },
+      ),
+      false,
+    );
+    assert.equal(calls, 0);
+  });
+
+  test("reports a rejected capture as not recorded", async () => {
+    const recorded = await recordMcpToolCallEvent(
+      CONFIGURED,
+      { isError: false, durationMs: 1 },
+      { fetch: fakeFetch({ ok: false }) },
+    );
+    assert.equal(recorded, false);
+  });
+
+  test("swallows a transport failure", async () => {
+    const recorded = await recordMcpToolCallEvent(
+      CONFIGURED,
+      { isError: false, durationMs: 1 },
+      { fetch: fakeFetch({ throws: true }) },
+    );
+    assert.equal(recorded, false);
+  });
+
+  // boundedMcpPayload's JSON.stringify can throw (a circular reference is the
+  // realistic case here -- a tool response accidentally aliasing part of
+  // itself) -- drop the field rather than let that reach the outer catch and
+  // silently fail the whole event. A BigInt is the reliable way to trigger
+  // this -- redactMcpSensitiveFields passes it through untouched (it's
+  // neither an array nor a plain object), and JSON.stringify itself throws
+  // on a BigInt.
+  test("drops a payload that can't be JSON-serialized instead of failing the whole event", async () => {
+    const calls = [];
+    const recorded = await recordMcpToolCallEvent(
+      CONFIGURED,
+      { isError: false, durationMs: 1, response: { big: 10n } },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    assert.equal("$mcp_response" in calls[0].body.properties, false);
+  });
+
+  // JSON.stringify itself can also return undefined without throwing (a bare
+  // function or symbol) -- a different branch than the BigInt case above.
+  test("drops a payload JSON.stringify silently declines to serialize (e.g. a function)", async () => {
+    const calls = [];
+    const recorded = await recordMcpToolCallEvent(
+      CONFIGURED,
+      { isError: false, durationMs: 1, response: () => {} },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    assert.equal("$mcp_response" in calls[0].body.properties, false);
+  });
+
+  test("defaults to the platform fetch when none is injected", async () => {
+    const original = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      const recorded = await recordMcpToolCallEvent(CONFIGURED, {
+        isError: false,
+        durationMs: 1,
+      });
+      assert.equal(recorded, true);
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  // A self-referential response is a realistic caller mistake (e.g. an error
+  // object aliasing its own cause chain), not just deep-but-acyclic data --
+  // the depth guard defuses it the same way, so this never throws or hangs.
+  test("does not loop forever on a circular reference", async () => {
+    const circular = {};
+    circular.self = circular;
+    const calls = [];
+    const recorded = await recordMcpToolCallEvent(
+      CONFIGURED,
+      { isError: false, durationMs: 1, response: circular },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    assert.ok(calls[0].body.properties.$mcp_response !== undefined);
+  });
+
+  test("omits $mcp_parameters / $mcp_response entirely when not supplied", async () => {
+    const calls = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED,
+      { isError: false, durationMs: 1 },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal("$mcp_parameters" in calls[0].body.properties, false);
+    assert.equal("$mcp_response" in calls[0].body.properties, false);
+  });
+
+  test("redacts a string credential (bearer/api-key/basic shape) out of $mcp_parameters", async () => {
+    const calls = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED,
+      {
+        isError: false,
+        durationMs: 1,
+        parameters: {
+          surface_id: "x:api:6",
+          credential: "Bearer super-secret-abc123",
+        },
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.ok(!JSON.stringify(calls[0].body).includes("super-secret-abc123"));
+    assert.deepEqual(calls[0].body.properties.$mcp_parameters, {
+      surface_id: "x:api:6",
+      credential: "[redacted]",
+    });
+  });
+
+  // call_subnet_surface's signature-bundle shape (#7701): an object whose own
+  // key names are caller-defined (the surface's auth.names) -- the whole
+  // value is dropped rather than trying to redact by nested key name.
+  test("redacts an object-shaped signature-bundle credential regardless of its own key names", async () => {
+    const calls = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED,
+      {
+        isError: false,
+        durationMs: 1,
+        parameters: {
+          surface_id: "x:api:6",
+          credential: { hotkey: "5FakeHotkey", nonce: "top-secret-nonce" },
+        },
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const serialized = JSON.stringify(calls[0].body);
+    assert.ok(!serialized.includes("top-secret-nonce"));
+    assert.ok(!serialized.includes("5FakeHotkey"));
+    assert.equal(
+      calls[0].body.properties.$mcp_parameters.credential,
+      "[redacted]",
+    );
+  });
+
+  test("redacts owner_token via the same generic key-name pattern (no project-specific special case)", async () => {
+    const calls = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED,
+      {
+        isError: false,
+        durationMs: 1,
+        parameters: { id: "trigger-1", owner_token: "owner-secret-xyz" },
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.ok(!JSON.stringify(calls[0].body).includes("owner-secret-xyz"));
+    assert.deepEqual(calls[0].body.properties.$mcp_parameters, {
+      id: "trigger-1",
+      owner_token: "[redacted]",
+    });
+  });
+
+  test("redacts nested sensitive keys inside $mcp_response too, not just $mcp_parameters", async () => {
+    const calls = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED,
+      {
+        isError: false,
+        durationMs: 1,
+        response: {
+          ok: true,
+          body: { access_token: "leaked-if-not-redacted", data: [1, 2, 3] },
+        },
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.ok(
+      !JSON.stringify(calls[0].body).includes("leaked-if-not-redacted"),
+    );
+    assert.deepEqual(calls[0].body.properties.$mcp_response, {
+      ok: true,
+      body: { access_token: "[redacted]", data: [1, 2, 3] },
+    });
+  });
+
+  test("leaves non-sensitive fields untouched", async () => {
+    const calls = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED,
+      {
+        isError: false,
+        durationMs: 1,
+        parameters: { surface_id: "x:api:6", query: { page: 2 } },
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.deepEqual(calls[0].body.properties.$mcp_parameters, {
+      surface_id: "x:api:6",
+      query: { page: 2 },
+    });
+  });
+
+  test("truncates an oversized payload instead of shipping it whole", async () => {
+    const calls = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED,
+      { isError: false, durationMs: 1, response: { data: "x".repeat(10_000) } },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const sent = calls[0].body.properties.$mcp_response;
+    assert.equal(sent.truncated, true);
+    assert.ok(sent.preview.length <= 4096);
+  });
+
+  // A secret buried past the recursion cap must never reach the payload,
+  // even unredacted-by-key-name -- the depth guard drops the whole subtree
+  // rather than risk a stack overflow trying to inspect it.
+  test("does not overflow, and never leaks, on a pathologically deep structure", async () => {
+    let deep = { credential: "leaf-secret" };
+    for (let i = 0; i < 50; i += 1) deep = { nested: deep };
+    const calls = [];
+    await assert.doesNotReject(() =>
+      recordMcpToolCallEvent(
+        CONFIGURED,
+        { isError: false, durationMs: 1, response: deep },
+        { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+      ),
+    );
+    assert.equal(calls.length, 1);
+    assert.ok(!JSON.stringify(calls[0].body).includes("leaf-secret"));
+  });
+
+  test("never posts when the deployment is unconfigured, even with a credential present", async () => {
+    let calls = 0;
+    const recorded = await recordMcpToolCallEvent(
+      {},
+      { isError: false, durationMs: 1, parameters: { credential: "x" } },
+      {
+        fetch: fakeFetch({
+          onCall: () => {
+            calls += 1;
+          },
+        }),
+      },
+    );
+    assert.equal(recorded, false);
+    assert.equal(calls, 0);
+  });
+});
+
+describe("recordMcpInitializeEvent", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  test("posts $mcp_initialize with client name / version / session id", async () => {
+    const calls = [];
+    const recorded = await recordMcpInitializeEvent(
+      CONFIGURED,
+      {
+        clientName: " claude-code ",
+        clientVersion: " 1.2.3 ",
+        sessionId: " sess-1 ",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    assert.equal(calls[0].body.event, "$mcp_initialize");
+    assert.deepEqual(calls[0].body.properties, {
+      $mcp_client_name: "claude-code",
+      $mcp_client_version: "1.2.3",
+      $session_id: "sess-1",
+    });
+  });
+
+  test("omits client name / version / session id when blank or absent", async () => {
+    const calls = [];
+    await recordMcpInitializeEvent(
+      CONFIGURED,
+      {},
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.deepEqual(calls[0].body.properties, {});
+  });
+
+  test("defaults to the platform fetch when none is injected", async () => {
+    const original = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      const recorded = await recordMcpInitializeEvent(CONFIGURED, {
+        clientName: "claude-code",
+      });
+      assert.equal(recorded, true);
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("never posts when the deployment is unconfigured", async () => {
+    let calls = 0;
+    const recorded = await recordMcpInitializeEvent(
+      {},
+      { clientName: "claude-code" },
+      {
+        fetch: fakeFetch({
+          onCall: () => {
+            calls += 1;
+          },
+        }),
+      },
+    );
+    assert.equal(recorded, false);
+    assert.equal(calls, 0);
+  });
+
+  test("reports a rejected capture as not recorded", async () => {
+    const recorded = await recordMcpInitializeEvent(
+      CONFIGURED,
+      { clientName: "claude-code" },
+      { fetch: fakeFetch({ ok: false }) },
+    );
+    assert.equal(recorded, false);
+  });
+
+  test("swallows a transport failure", async () => {
+    const recorded = await recordMcpInitializeEvent(
+      CONFIGURED,
+      { clientName: "claude-code" },
+      { fetch: fakeFetch({ throws: true }) },
+    );
+    assert.equal(recorded, false);
   });
 });


### PR DESCRIPTION
## Summary

- Emits PostHog's canonical `$mcp_initialize` / `$mcp_tool_call` event family via the existing bundle-safe raw-fetch telemetry pattern (`src/usage-telemetry.ts`) -- `posthog-node`/`@posthog/mcp` can't be bundled into the Worker (bundle-budget constraint), so there's no SDK `instrument()` wrapper here and no SDK-provided default redaction pipeline sitting in front of what gets sent.
- `$mcp_parameters` / `$mcp_response` are redacted before ever being included: a recursive key-name match covering `credential` (`call_subnet_surface`'s own credential argument -- the one name PostHog's own default redact list does NOT cover) plus the same baseline set PostHog's SDK would auto-redact (`authorization`, `cookie`, `password`, `token`, `secret`, `api_key`, `private_key` -- this also catches `get_alert_trigger`'s `owner_token` via the `token` substring, no project-specific special case needed for it).
- Size-capped (4096 chars after redaction+serialization, truncated with a marker beyond that) so one large `call_subnet_surface` response can't balloon a capture payload.
- `scheduleMcpToolCallEvent`/`scheduleMcpInitializeEvent` now follow the same `ctx`-injectable-recorder pattern as the existing `scheduleToolUsageEvent`, for consistency and testability (a rejecting/throwing recorder must never surface as a tool failure).
- Adds `.claude/skills/mcp-analytics/` -- PostHog's official `context-mill` skill content installed by `npx @posthog/wizard mcp-analytics`, kept for future maintenance of this integration.
- This is additive: the existing `usage_event` telemetry (`route`/`mcp_tool`/`ok`/`duration_ms`/`error_code`, deliberately minimal, no arguments/response) is unchanged.

## Why

I ran PostHog's own MCP analytics wizard against this repo to see what it wires in. It correctly avoided PostHog's own auto-redaction gap (it doesn't capture `$mcp_parameters`/`$mcp_response` at all, by design, once it hit the same bundle-budget wall) -- but that also means none of the value PostHog's MCP dashboards provide (seeing what a call's arguments/result actually were) was there yet. This PR adds that capture back, safely, with the credential-safe redaction the wizard's own report flagged as a prerequisite.

## Test plan

- [x] `npx vitest run tests/usage-telemetry.test.mjs tests/mcp-usage-telemetry.test.mjs tests/call-subnet-surface-mcp.test.mjs tests/mcp-server.test.mjs` -- new unit tests directly on `recordMcpToolCallEvent`/`recordMcpInitializeEvent` (redaction of a string credential, an object-shaped signature-bundle credential regardless of its own nested key names, `owner_token`, nested `$mcp_response` fields, non-sensitive fields passing through untouched, oversized-payload truncation, a pathologically deep/circular structure never leaking or overflowing, and the platform-fetch/telemetry-failure fallback paths), plus new end-to-end tests through the real MCP dispatch path proving a fake `call_subnet_surface`/`get_alert_trigger` call's credential/owner_token never appears anywhere in the captured PostHog payload.
- [x] `npm run test:coverage` -- full suite green, 100% line/branch coverage on every line touched in `src/usage-telemetry.ts` and `src/mcp-server.mjs`.
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run format:check` -- all clean.
- [x] `npm run validate` -- registry/API/OpenAPI checks green (unaffected by this change; no schema/route changes, so no `npm run build` needed).

## Notes

`POSTHOG_PROJECT_TOKEN` is now configured as a deployed secret, so the existing `usage_event` telemetry started flowing as of that deploy. The new capture this PR adds (`$mcp_initialize`/`$mcp_tool_call`, with the redaction) only goes live once this PR merges and the Worker redeploys with this code.

Closes #7737