### PR TITLE
feat(ui): merge Lovable's alpha-price fields into joinEconomics

### DIFF
--- a/apps/ui/docs/ssr-safety.md
+++ b/apps/ui/docs/ssr-safety.md
@@ -25,9 +25,13 @@ Use this checklist before shipping code that touches `window`, `document`,
 
 ## Automated check
 
-The eslint `no-restricted-syntax` rules in `eslint.config.js` block the two
-most common regressions (reading `localStorage`/`matchMedia` inside a
-`useState` initializer) at PR time.
+The blank-screen watchdog (`src/lib/blank-screen-watchdog.ts`) plus the
+`GlobalErrorBoundary` (`src/components/metagraphed/global-error-boundary.tsx`,
+mounted in `src/routes/__root.tsx`) catch runtime regressions in production —
+window error/rejection handlers and a rendered-height check report through
+`reportLovableError`. The eslint `no-restricted-syntax` rules in
+`eslint.config.js` block the two most common regressions (reading
+`localStorage`/`matchMedia` inside a `useState` initializer) at PR time.
 
 ## Known safe entry points
 

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -52,6 +52,7 @@ import { ApiSourceProvider } from "@/lib/metagraphed/api-source-context";
 import { IncidentStrip } from "./incident-strip";
 import { pushRecentVisit, visitFromPath } from "@/lib/metagraphed/recent-visits";
 import { buildCrumbs, parentCrumb } from "./breadcrumb-nav";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 // Brand links resolve from build-time env constants, but still run them through
 // the external-URL guard (with a known-good fallback) so a misconfigured
@@ -77,6 +78,8 @@ function Brand({ onNavigate }: { onNavigate?: () => void }) {
 export function AppShell({
   children,
   fullBleedMain = false,
+  flushTop = false,
+  afterHeader,
 }: {
   children: ReactNode;
   // Fumadocs' DocsLayout manages its own full-height sidebar/content grid
@@ -84,6 +87,14 @@ export function AppShell({
   // + px/py wrapper below would squeeze its sidebar into the content column
   // instead of letting it span the full width under the header.
   fullBleedMain?: boolean;
+  // Drop <main>'s top padding so the first child sits flush against whatever
+  // renders in `afterHeader` (used by the home route to eliminate the gap
+  // between the alpha-price ticker and the hero).
+  flushTop?: boolean;
+  // Slot rendered flush beneath the header chrome, before <main>'s padded
+  // column. Used by the home route to seat the alpha-price ticker in what
+  // would otherwise be dead space between the ecosystem strip and the hero.
+  afterHeader?: ReactNode;
 }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -126,6 +137,26 @@ export function AppShell({
     // Track visit for the "Continue exploring" rail.
     const v = visitFromPath(pathname);
     if (v) pushRecentVisit(v);
+  }, [pathname]);
+
+  // Publish the live header height as --mg-sticky-offset so downstream sticky
+  // sub-nav / toolbars can pin flush against the chrome instead of hardcoding
+  // top-14 (which is wrong once the ticker + breadcrumb strips render).
+  useEffect(() => {
+    const header = document.querySelector<HTMLElement>("header.mg-header");
+    if (!header) return;
+    const publish = () => {
+      const h = header.getBoundingClientRect().height;
+      document.documentElement.style.setProperty("--mg-sticky-offset", `${Math.round(h)}px`);
+    };
+    publish();
+    const ro = new ResizeObserver(publish);
+    ro.observe(header);
+    window.addEventListener("resize", publish);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", publish);
+    };
   }, [pathname]);
 
   // Scroll-aware header
@@ -290,6 +321,7 @@ export function AppShell({
                 </div>
               </>
             ) : null}
+            {afterHeader}
           </header>
 
           <IncidentStrip />
@@ -347,8 +379,17 @@ export function AppShell({
             id="main-content"
             key={pathname}
             className={classNames(
-              "flex-1 w-full mg-route-enter",
-              fullBleedMain ? "" : "px-4 md:px-10 py-10 md:py-14 max-w-shell-max mx-auto",
+              // Keep route content visible by default. The previous
+              // `mg-route-enter` animation started at opacity: 0; when the
+              // embedded preview paused CSS animations, the entire route
+              // remained permanently transparent even though it had rendered.
+              "flex-1 w-full",
+              fullBleedMain
+                ? ""
+                : classNames(
+                    "px-4 md:px-10 max-w-shell-max mx-auto pb-10 md:pb-14",
+                    flushTop ? "pt-0" : "pt-10 md:pt-14",
+                  ),
             )}
           >
             {children}
@@ -485,10 +526,13 @@ function SiteFooter() {
 }
 
 function RegistryPulseStrip() {
-  const freshness = useQuery({ ...freshnessQuery(), retry: 0 });
-  const build = useQuery({ ...buildQuery(), retry: 0 });
-  const f = freshness.data?.data;
-  const b = build.data?.data as { version?: string; built_at?: string } | undefined;
+  const hydrated = useHydrated();
+  const freshness = useQuery({ ...freshnessQuery(), retry: 0, enabled: hydrated });
+  const build = useQuery({ ...buildQuery(), retry: 0, enabled: hydrated });
+  const f = hydrated ? freshness.data?.data : undefined;
+  const b = hydrated
+    ? (build.data?.data as { version?: string; built_at?: string } | undefined)
+    : undefined;
   const stale = f?.stale_count ?? 0;
   const sources = f?.sources?.length ?? 0;
   // Freshness carries an `[key: string]: unknown` index signature, so guard the

--- a/apps/ui/src/components/metagraphed/charts/animated-trace-sparkline.tsx
+++ b/apps/ui/src/components/metagraphed/charts/animated-trace-sparkline.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+
+export type TraceDirection = "up" | "down" | "flat";
+
+interface Props {
+  values: number[];
+  width?: number;
+  height?: number;
+  /** When it changes, the trace animation replays. Pass slide index / metric key. */
+  animateKey?: string | number;
+  direction?: TraceDirection;
+  ariaLabel?: string;
+  className?: string;
+  /** Trace duration in ms. Respects prefers-reduced-motion. */
+  durationMs?: number;
+}
+
+const COLOR_BY_DIRECTION: Record<TraceDirection, string> = {
+  up: "var(--health-ok)",
+  down: "var(--health-down)",
+  flat: "var(--ink-muted)",
+};
+
+/** Percentile clamp so a single outlier doesn't flatten the whole series. */
+function clampToPercentile(values: number[], lo = 0.05, hi = 0.95): number[] {
+  if (values.length < 4) return values;
+  const sorted = [...values].sort((a, b) => a - b);
+  const loV = sorted[Math.floor(sorted.length * lo)];
+  const hiV = sorted[Math.floor(sorted.length * hi)];
+  return values.map((v) => Math.max(loV, Math.min(hiV, v)));
+}
+
+/**
+ * Monotone cubic (Fritsch–Carlson) interpolation → produces a smooth curve
+ * through every point without the overshoot of naive Catmull–Rom. Returns an
+ * SVG path `d` string starting with a Move to the first point.
+ */
+function monotoneCubicPath(pts: ReadonlyArray<readonly [number, number]>): string {
+  const n = pts.length;
+  if (n < 2) return "";
+  if (n === 2) return `M ${pts[0][0]} ${pts[0][1]} L ${pts[1][0]} ${pts[1][1]}`;
+
+  const dx: number[] = new Array(n - 1);
+  const dy: number[] = new Array(n - 1);
+  const m: number[] = new Array(n - 1); // slopes between points
+  for (let i = 0; i < n - 1; i++) {
+    dx[i] = pts[i + 1][0] - pts[i][0];
+    dy[i] = pts[i + 1][1] - pts[i][1];
+    m[i] = dy[i] / (dx[i] || 1);
+  }
+
+  // Tangents at each point
+  const t: number[] = new Array(n);
+  t[0] = m[0];
+  t[n - 1] = m[n - 2];
+  for (let i = 1; i < n - 1; i++) {
+    if (m[i - 1] * m[i] <= 0) t[i] = 0;
+    else t[i] = (m[i - 1] + m[i]) / 2;
+  }
+  // Fritsch–Carlson monotone correction
+  for (let i = 0; i < n - 1; i++) {
+    if (m[i] === 0) {
+      t[i] = 0;
+      t[i + 1] = 0;
+    } else {
+      const a = t[i] / m[i];
+      const b = t[i + 1] / m[i];
+      const h = Math.hypot(a, b);
+      if (h > 3) {
+        const factor = 3 / h;
+        t[i] = factor * a * m[i];
+        t[i + 1] = factor * b * m[i];
+      }
+    }
+  }
+
+  let d = `M ${pts[0][0].toFixed(2)} ${pts[0][1].toFixed(2)}`;
+  for (let i = 0; i < n - 1; i++) {
+    const cp1x = pts[i][0] + dx[i] / 3;
+    const cp1y = pts[i][1] + (t[i] * dx[i]) / 3;
+    const cp2x = pts[i + 1][0] - dx[i] / 3;
+    const cp2y = pts[i + 1][1] - (t[i + 1] * dx[i]) / 3;
+    d += ` C ${cp1x.toFixed(2)} ${cp1y.toFixed(2)}, ${cp2x.toFixed(2)} ${cp2y.toFixed(2)}, ${pts[i + 1][0].toFixed(2)} ${pts[i + 1][1].toFixed(2)}`;
+  }
+  return d;
+}
+
+/**
+ * Sparkline that traces left→right on mount / when `animateKey` changes,
+ * with a stroke color tied to the direction of the series (green/red/neutral)
+ * and a soft area fill under the line. Uses monotone-cubic interpolation for
+ * a natural, unhurried curve and clamps outliers to the 5–95 percentile so a
+ * single spike doesn't flatten the rest of the data.
+ */
+export function AnimatedTraceSparkline({
+  values,
+  width = 640,
+  height = 180,
+  animateKey,
+  direction = "flat",
+  ariaLabel,
+  className,
+  durationMs = 2000,
+}: Props) {
+  const gradId = useId();
+  const clean = useMemo(
+    () => clampToPercentile(values.filter((v) => Number.isFinite(v))),
+    [values],
+  );
+  const pathRef = useRef<SVGPathElement | null>(null);
+  const [pathLen, setPathLen] = useState<number>(0);
+  const [drawn, setDrawn] = useState<boolean>(false);
+
+  const { linePath, areaPath, tail } = useMemo(() => {
+    const padTop = 14;
+    const padBottom = 10;
+    if (clean.length < 2) {
+      const y = height / 2;
+      return {
+        linePath: `M 0 ${y} L ${width} ${y}`,
+        areaPath: `M 0 ${height} L 0 ${y} L ${width} ${y} L ${width} ${height} Z`,
+        tail: [width, y] as const,
+      };
+    }
+    const min = Math.min(...clean);
+    const max = Math.max(...clean);
+    const span = max - min || 1;
+    const stepX = width / (clean.length - 1);
+    const usableH = height - padTop - padBottom;
+    const coords = clean.map((v, i) => {
+      const x = i * stepX;
+      const y = padTop + usableH - ((v - min) / span) * usableH;
+      return [x, y] as const;
+    });
+    const line = monotoneCubicPath(coords);
+    const area = `${line} L ${width} ${height} L 0 ${height} Z`;
+    return { linePath: line, areaPath: area, tail: coords[coords.length - 1] };
+  }, [clean, width, height]);
+
+  // Re-measure and replay when animateKey changes.
+  useEffect(() => {
+    const node = pathRef.current;
+    if (!node) return;
+    const reduced =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    setDrawn(false);
+    const len = node.getTotalLength();
+    setPathLen(len);
+    if (reduced) {
+      setDrawn(true);
+      return;
+    }
+    const raf = requestAnimationFrame(() => requestAnimationFrame(() => setDrawn(true)));
+    return () => cancelAnimationFrame(raf);
+  }, [linePath, animateKey]);
+
+  const color = COLOR_BY_DIRECTION[direction];
+  const easing = "cubic-bezier(0.22, 0.61, 0.36, 1)";
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className={`block h-full w-full ${className ?? ""}`}
+      role="img"
+      aria-label={ariaLabel ?? "trend sparkline"}
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity={0.24} />
+          <stop offset="100%" stopColor={color} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <path
+        d={areaPath}
+        fill={`url(#${gradId})`}
+        opacity={drawn ? 1 : 0}
+        style={{
+          transition: `opacity ${durationMs * 0.7}ms ${easing} ${durationMs * 0.35}ms`,
+        }}
+      />
+      <path
+        ref={pathRef}
+        d={linePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.75}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+        style={{
+          strokeDasharray: pathLen || 1,
+          strokeDashoffset: drawn ? 0 : pathLen || 1,
+          transition: `stroke-dashoffset ${durationMs}ms ${easing}`,
+        }}
+      />
+      {/* Trailing endpoint dot — fades in as the trace completes. */}
+      <circle
+        cx={tail[0]}
+        cy={tail[1]}
+        r={3}
+        fill={color}
+        opacity={drawn ? 1 : 0}
+        style={{
+          transition: `opacity 400ms ease-out ${durationMs * 0.85}ms`,
+        }}
+      />
+      <circle
+        cx={tail[0]}
+        cy={tail[1]}
+        r={6}
+        fill={color}
+        opacity={drawn ? 0.18 : 0}
+        style={{
+          transition: `opacity 500ms ease-out ${durationMs * 0.85}ms`,
+        }}
+      />
+    </svg>
+  );
+}
+
+export function directionFor(values: number[]): TraceDirection {
+  if (values.length < 2) return "flat";
+  const first = values[0];
+  const last = values[values.length - 1];
+  const delta = last - first;
+  const scale = Math.max(Math.abs(first), Math.abs(last), 1);
+  const pct = delta / scale;
+  if (pct > 0.005) return "up";
+  if (pct < -0.005) return "down";
+  return "flat";
+}

--- a/apps/ui/src/components/metagraphed/global-error-boundary.tsx
+++ b/apps/ui/src/components/metagraphed/global-error-boundary.tsx
@@ -1,0 +1,137 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { AlertTriangle, Copy, Home, RefreshCw } from "lucide-react";
+import { reportError } from "@/lib/error-reporting";
+
+interface Props {
+  children: ReactNode;
+}
+interface State {
+  error: unknown;
+  copied: boolean;
+}
+
+/**
+ * Global styled error boundary. Wraps the app tree in __root so that any
+ * render-time throw that escapes route-level `errorComponent` (portals,
+ * event handlers that force a re-render, provider crashes) still lands on a
+ * branded Bone & Ink fallback instead of a black/blank page.
+ *
+ * On catch it stamps a `mg:last-crash` session flag so the blank-screen
+ * watchdog can distinguish "genuine runtime error" from "silent blank".
+ */
+export class GlobalErrorBoundary extends Component<Props, State> {
+  state: State = { error: null, copied: false };
+
+  static getDerivedStateFromError(error: unknown) {
+    return { error, copied: false };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    reportError(error, { boundary: "global", componentStack: info.componentStack });
+    try {
+      sessionStorage.setItem("mg:last-crash", String(Date.now()));
+    } catch {
+      /* private mode / disabled storage — best-effort only */
+    }
+  }
+
+  private reset = () => {
+    try {
+      sessionStorage.removeItem("mg:last-crash");
+    } catch {
+      /* noop */
+    }
+    this.setState({ error: null, copied: false });
+  };
+
+  private reload = () => {
+    if (typeof window !== "undefined") window.location.reload();
+  };
+
+  private goHome = () => {
+    if (typeof window !== "undefined") window.location.assign("/");
+  };
+
+  private copyDetails = async () => {
+    const err = this.state.error;
+    const text =
+      err instanceof Error ? `${err.name}: ${err.message}\n${err.stack ?? ""}` : String(err);
+    try {
+      await navigator.clipboard.writeText(text);
+      this.setState({ copied: true });
+      setTimeout(() => this.setState({ copied: false }), 1500);
+    } catch {
+      /* noop */
+    }
+  };
+
+  render() {
+    if (this.state.error == null) return this.props.children;
+
+    const err = this.state.error;
+    const message = err instanceof Error ? err.message : String(err);
+
+    return (
+      <div className="min-h-dvh bg-paper px-4 py-10 text-ink-strong">
+        <div className="mx-auto max-w-3xl">
+          <main aria-labelledby="ge-title">
+            <div className="mg-label flex items-center gap-2">
+              <AlertTriangle className="size-3.5 text-health-warn" />
+              Metagraphed / runtime error
+            </div>
+            <h1
+              id="ge-title"
+              className="mt-3 font-display text-3xl font-semibold leading-tight text-ink-strong md:text-4xl"
+            >
+              Something broke while rendering this page.
+            </h1>
+            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-muted md:text-base">
+              The rest of the registry is unaffected — you can retry this view, go back to the
+              overview, or copy the error details for a bug report.
+            </p>
+
+            <div className="mt-6 rounded-xl border border-border bg-card p-4">
+              <div className="mg-label">Error message</div>
+              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-paper p-2 font-mono text-[12px] text-ink">
+                {message || "Unknown error"}
+              </pre>
+            </div>
+
+            <div className="mt-6 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={this.reset}
+                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-accent/60 bg-primary-soft px-4 text-sm font-medium text-ink-strong transition-colors hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <RefreshCw className="size-4" /> Try again
+              </button>
+              <button
+                type="button"
+                onClick={this.reload}
+                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-border bg-card px-4 text-sm text-ink-muted transition-colors hover:border-accent/60 hover:text-ink-strong"
+              >
+                Hard reload
+              </button>
+              <button
+                type="button"
+                onClick={this.goHome}
+                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-border bg-card px-4 text-sm text-ink-muted transition-colors hover:border-accent/60 hover:text-ink-strong"
+              >
+                <Home className="size-4" /> Overview
+              </button>
+              <button
+                type="button"
+                onClick={this.copyDetails}
+                aria-live="polite"
+                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-border bg-card px-4 text-sm text-ink-muted transition-colors hover:border-accent/60 hover:text-ink-strong"
+              >
+                <Copy className="size-4" />
+                {this.state.copied ? "Copied" : "Copy error details"}
+              </button>
+            </div>
+          </main>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/ui/src/components/metagraphed/hero-feature-row.tsx
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.tsx
@@ -1,0 +1,250 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight } from "lucide-react";
+import { useMemo } from "react";
+
+import {
+  AnimatedTraceSparkline,
+  directionFor,
+} from "@/components/metagraphed/charts/animated-trace-sparkline";
+import { BrandIcon, Sparkline } from "@jsonbored/ui-kit";
+import { chainActivityQuery, subnetOhlcQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { Subnet } from "@/lib/metagraphed/types";
+import { useHydrated } from "@/hooks/use-hydrated";
+
+/**
+ * Two-up feature row that lives directly beneath the centered hero.
+ * Left = animated chain-throughput trace (7d). Right = compact live-subnet list
+ * with per-row price sparklines. Everything renders skeletons/placeholders on
+ * cold fetch so layout never jumps.
+ */
+export function HeroFeatureRow() {
+  return (
+    <section className="mt-10 md:mt-14 grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+      <ChainThroughputCard />
+      <LiveSubnetsCard />
+    </section>
+  );
+}
+
+/* ------------------------------ Left card ------------------------------ */
+
+function ChainThroughputCard() {
+  const hydrated = useHydrated();
+  const { data } = useQuery({ ...chainActivityQuery("7d"), enabled: hydrated });
+  const activity = hydrated ? data?.data : undefined;
+
+  const { series, latest, deltaPct, dir } = useMemo(() => {
+    const days = activity?.days?.length ? [...activity.days].reverse() : [];
+    const s = days.map((d) => d.extrinsic_count).filter((v) => Number.isFinite(v));
+    const last = s.at(-1) ?? 0;
+    const first = s[0] ?? last;
+    const delta = first ? ((last - first) / first) * 100 : 0;
+    return {
+      series: s,
+      latest: last,
+      deltaPct: delta,
+      dir: s.length ? directionFor(s) : ("flat" as const),
+    };
+  }, [activity]);
+
+  const deltaTone =
+    dir === "up" ? "text-health-ok" : dir === "down" ? "text-health-down" : "text-ink-muted";
+
+  return (
+    <div className="mg-card-glow relative flex flex-col overflow-hidden rounded-2xl border border-border bg-card">
+      <div className="flex items-start justify-between gap-3 px-5 pt-5">
+        <div className="min-w-0">
+          <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted">
+            Chain throughput · 7d
+          </div>
+          <div className="mt-2 flex items-baseline gap-3">
+            <div className="font-display text-3xl md:text-4xl font-semibold tabular-nums text-ink-strong leading-none">
+              {series.length ? formatNumber(latest) : "—"}
+            </div>
+            {series.length > 0 && (
+              <span className={`font-mono text-xs tabular-nums ${deltaTone}`}>
+                {deltaPct >= 0 ? "+" : ""}
+                {deltaPct.toFixed(1)}%
+              </span>
+            )}
+          </div>
+          <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.16em] text-ink-subtle-text">
+            extrinsics · last day
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 px-1">
+        {series.length >= 2 ? (
+          <AnimatedTraceSparkline
+            values={series}
+            direction={dir}
+            width={640}
+            height={180}
+            ariaLabel="Chain throughput over the last 7 days"
+            className="w-full"
+          />
+        ) : (
+          <div className="h-[180px] w-full animate-pulse rounded-lg bg-surface-2" />
+        )}
+      </div>
+
+      <div className="mt-1 flex items-center justify-between border-t border-border px-5 py-3">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          /api/v1/chain/activity
+        </span>
+        <Link
+          to="/blocks"
+          className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-strong transition-colors hover:text-accent"
+        >
+          Open the block explorer
+          <ArrowUpRight className="size-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/* ----------------------------- Right card ----------------------------- */
+
+function LiveSubnetsCard() {
+  const hydrated = useHydrated();
+  const { data } = useQuery({ ...subnetsQuery({ limit: 128 }), enabled: hydrated });
+  const subnets = hydrated ? ((data?.data as Subnet[] | undefined) ?? []) : [];
+
+  const featured = useMemo(() => pickFeatured(subnets, 6), [subnets]);
+
+  return (
+    <div className="mg-card-glow flex flex-col overflow-hidden rounded-2xl border border-border bg-card">
+      <div className="flex items-center justify-between border-b border-border px-5 py-3">
+        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted">
+          Live subnets · 7d
+        </div>
+        <Link
+          to="/subnets"
+          className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted transition-colors hover:text-accent"
+        >
+          View all
+          <ArrowUpRight className="size-3" />
+        </Link>
+      </div>
+      <ul className="divide-y divide-border">
+        {featured.length === 0 &&
+          Array.from({ length: 6 }).map((_, i) => (
+            <li key={i} className="flex items-center gap-3 px-5 py-3">
+              <div className="size-7 shrink-0 animate-pulse rounded-md bg-surface-2" />
+              <div className="h-3 w-24 animate-pulse rounded bg-surface-2" />
+              <div className="ml-auto h-4 w-20 animate-pulse rounded bg-surface-2" />
+            </li>
+          ))}
+        {featured.map((sn) => (
+          <LiveSubnetRow key={sn.netuid} sn={sn} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function LiveSubnetRow({ sn }: { sn: Subnet }) {
+  const { data } = useQuery({
+    ...subnetOhlcQuery(sn.netuid, { interval: "1h", days: 7 }),
+    enabled: sn.netuid > 0,
+  });
+  const closes = useMemo(() => {
+    const candles = (data?.data?.candles ?? []) as Array<{ close?: number }>;
+    return candles
+      .map((c) => (typeof c.close === "number" ? c.close : NaN))
+      .filter((v) => Number.isFinite(v));
+  }, [data]);
+
+  const deltaPct =
+    closes.length >= 2 && closes[0] ? ((closes.at(-1)! - closes[0]) / closes[0]) * 100 : null;
+  const dir: "up" | "down" | "flat" =
+    deltaPct == null ? "flat" : deltaPct > 0.5 ? "up" : deltaPct < -0.5 ? "down" : "flat";
+  const strokeColor =
+    dir === "up" ? "var(--health-ok)" : dir === "down" ? "var(--health-down)" : "var(--ink-muted)";
+  const deltaTone =
+    dir === "up" ? "text-health-ok" : dir === "down" ? "text-health-down" : "text-ink-muted";
+
+  return (
+    <li>
+      <Link
+        to="/subnets/$netuid"
+        params={{ netuid: sn.netuid }}
+        className="mg-hover-lift flex items-center gap-3 px-5 py-3 text-sm"
+      >
+        <BrandIcon
+          name={sn.name}
+          netuid={sn.netuid}
+          fallback={sn.symbol ?? sn.netuid}
+          size={28}
+          className="shrink-0"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-ink-strong">{sn.name ?? `Subnet ${sn.netuid}`}</div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-muted">
+            SN{sn.netuid}
+          </div>
+        </div>
+        <div className="hidden shrink-0 sm:block">
+          {closes.length >= 2 ? (
+            <Sparkline
+              values={closes}
+              width={72}
+              height={22}
+              interactive={false}
+              color={strokeColor}
+              ariaLabel={`${sn.name ?? "Subnet"} 7-day price trend`}
+            />
+          ) : (
+            <div className="h-[22px] w-[72px] rounded bg-surface-2/60" />
+          )}
+        </div>
+        <div className="shrink-0 flex flex-col items-end gap-0.5">
+          <span
+            className="font-mono text-[11px] tabular-nums text-ink-strong"
+            title="Latest alpha price in TAO"
+          >
+            {closes.length ? `${formatAlpha(closes.at(-1)!)} τ` : "—"}
+          </span>
+          <span
+            className={`font-mono text-[10px] tabular-nums ${deltaTone}`}
+            title="Alpha price change over the last 7 days"
+          >
+            {deltaPct == null ? "—" : `${deltaPct >= 0 ? "+" : ""}${deltaPct.toFixed(1)}%`}
+          </span>
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+function formatAlpha(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  if (v >= 1) return v.toFixed(3);
+  if (v >= 0.01) return v.toFixed(4);
+  return v.toPrecision(3);
+}
+
+/* ----------------------------- helpers ----------------------------- */
+
+function pickFeatured(subnets: Subnet[], n: number): Subnet[] {
+  if (!subnets.length) return [];
+  // Prefer adapter-backed / verified curation, then by descending market cap /
+  // participant count as a rough popularity proxy. Skip root (netuid 0).
+  const app = subnets.filter((s) => s.netuid > 0);
+  const score = (s: Subnet) => {
+    const c = (s as unknown as { curation?: string }).curation ?? "";
+    const curationRank =
+      c === "adapter" ? 4 : c === "native" ? 3 : c === "verified" ? 3 : c === "pilot" ? 2 : 1;
+    const size = Number(
+      (s as unknown as { participants?: number }).participants ??
+        (s as unknown as { neuron_count?: number }).neuron_count ??
+        0,
+    );
+    return curationRank * 1e6 + size;
+  };
+  return [...app].sort((a, b) => score(b) - score(a)).slice(0, n);
+}

--- a/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
@@ -269,7 +269,7 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
               {active ? (
                 <span
                   aria-hidden
-                  className="pointer-events-none absolute left-2.5 right-2.5 -bottom-[13px] h-px bg-accent"
+                  className="pointer-events-none absolute left-3 right-3 -bottom-1 h-[1.5px] rounded-full bg-accent mg-fade-in"
                 />
               ) : null}
             </Link>

--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -11,6 +11,7 @@ import {
 import { API_BASE } from "@/lib/metagraphed/config";
 import { Tooltip, TooltipContent, TooltipTrigger, CopyButton, TimeAgo } from "@jsonbored/ui-kit";
 import { classNames } from "@/lib/metagraphed/format";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 interface Stat {
   label: string;
@@ -21,13 +22,18 @@ interface Stat {
 }
 
 export function RegistryTicker() {
-  const subnets = useQuery({ ...subnetsQuery(), retry: 0 });
-  const health = useQuery({ ...healthQuery(), retry: 0 });
-  const fresh = useQuery({ ...freshnessQuery(), retry: 0 });
-  const gaps = useQuery({ ...gapsQuery(), retry: 0 });
-  const build = useQuery({ ...buildQuery(), retry: 0 });
+  // Gate every query on hydration: SSR and the first client render must emit
+  // the same "—" placeholders, or React logs a hydration mismatch and
+  // discards the SSR-rendered tree (#7744 -- caught live via the
+  // hydration-capture handshake in __root.tsx).
+  const hydrated = useHydrated();
+  const subnets = useQuery({ ...subnetsQuery(), retry: 0, enabled: hydrated });
+  const health = useQuery({ ...healthQuery(), retry: 0, enabled: hydrated });
+  const fresh = useQuery({ ...freshnessQuery(), retry: 0, enabled: hydrated });
+  const gaps = useQuery({ ...gapsQuery(), retry: 0, enabled: hydrated });
+  const build = useQuery({ ...buildQuery(), retry: 0, enabled: hydrated });
 
-  const all = subnets.data?.data ?? [];
+  const all = hydrated ? (subnets.data?.data ?? []) : [];
   const curated = all.filter((s) => {
     const c = (s as { curation_level?: string }).curation_level;
     return c && c !== "native";
@@ -35,10 +41,10 @@ export function RegistryTicker() {
   const machineVerified = all.filter(
     (s) => (s as { curation_level?: string }).curation_level === "machine-verified",
   ).length;
-  const h = health.data?.data;
-  const f = fresh.data?.data;
-  const openGaps = gaps.data?.data?.length ?? 0;
-  const b = build.data?.data as { version?: string } | undefined;
+  const h = hydrated ? health.data?.data : undefined;
+  const f = hydrated ? fresh.data?.data : undefined;
+  const openGaps = hydrated ? (gaps.data?.data?.length ?? 0) : 0;
+  const b = hydrated ? (build.data?.data as { version?: string } | undefined) : undefined;
 
   // Freshness “live” pulse only when latest source < 5 minutes old.
   const isFresh = typeof f?.avg_age_seconds === "number" ? f.avg_age_seconds < 300 : false;

--- a/apps/ui/src/lib/blank-screen-watchdog.test.ts
+++ b/apps/ui/src/lib/blank-screen-watchdog.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  isBlank,
+  measureRenderedHeight,
+  PRE_HYDRATION_RECOVERY_SCRIPT,
+} from "./blank-screen-watchdog";
+
+describe("measureRenderedHeight", () => {
+  it("returns zeros when the root is null", () => {
+    expect(measureRenderedHeight(null)).toEqual({
+      visibleHeight: 0,
+      childCount: 0,
+      visuallyHidden: true,
+    });
+  });
+
+  it("reads the bounding rect height and childElementCount", () => {
+    const el = {
+      getBoundingClientRect: () => ({ height: 120 }) as DOMRect,
+      childElementCount: 3,
+    } as unknown as Element;
+    expect(measureRenderedHeight(el)).toEqual({
+      visibleHeight: 120,
+      childCount: 3,
+      visuallyHidden: false,
+    });
+  });
+});
+
+describe("isBlank", () => {
+  it("is true when height is under the threshold", () => {
+    expect(isBlank({ visibleHeight: 10, childCount: 5, visuallyHidden: false })).toBe(true);
+  });
+  it("is true when there are zero children even if height is padding", () => {
+    expect(isBlank({ visibleHeight: 500, childCount: 0, visuallyHidden: false })).toBe(true);
+  });
+  it("is false when height and children are both healthy", () => {
+    expect(isBlank({ visibleHeight: 500, childCount: 3, visuallyHidden: false })).toBe(false);
+  });
+  it("is true when CSS hides an otherwise populated root", () => {
+    expect(isBlank({ visibleHeight: 500, childCount: 3, visuallyHidden: true })).toBe(true);
+  });
+});
+
+// Small smoke check that vi is wired — not exercising the mount fn directly
+// because it schedules setTimeout side effects best covered by the Playwright
+// script under tests/e2e (out of unit scope).
+describe("watchdog module surface", () => {
+  it("exports the pure helpers", () => {
+    expect(typeof isBlank).toBe("function");
+    expect(typeof measureRenderedHeight).toBe("function");
+    expect(vi).toBeTruthy();
+  });
+
+  it("ships an independent pre-hydration recovery handshake", () => {
+    expect(PRE_HYDRATION_RECOVERY_SCRIPT).toContain("__MG_HYDRATED__");
+    expect(PRE_HYDRATION_RECOVERY_SCRIPT).toContain("unhandledrejection");
+    expect(PRE_HYDRATION_RECOVERY_SCRIPT).toContain("location.reload()");
+    expect(PRE_HYDRATION_RECOVERY_SCRIPT).not.toContain("document.body.innerHTML");
+  });
+});

--- a/apps/ui/src/lib/blank-screen-watchdog.ts
+++ b/apps/ui/src/lib/blank-screen-watchdog.ts
@@ -1,0 +1,188 @@
+// Client-side blank-screen watchdog.
+//
+// Runs after hydration to detect the "hydrated but the viewport is empty"
+// failure mode (bad CSS override, animation stuck at opacity:0, provider
+// crash below the boundary). A separate inline bootstrap below covers failures
+// that happen before React mounts, when no React boundary/effect can run.
+//
+// SSR-safe: every DOM access is guarded; the mount helper only wires listeners
+// in the browser.
+
+const BLANK_MIN_HEIGHT_PX = 40;
+const FIRST_CHECK_DELAY_MS = 1500;
+const SECOND_CHECK_DELAY_MS = 1500;
+const RECOVERY_FLAG = "mg:blank-recovery";
+const CRASH_FLAG = "mg:last-crash";
+const RECOVERY_TTL_MS = 30_000;
+
+/**
+ * Runs from <head>, independently of the client bundle. This is deliberately
+ * dependency-free: if a chunk fails to load or hydration throws before React
+ * effects mount, it still captures the failure and retries once. It never
+ * replaces server-rendered markup: preserving the original DOM lets React's
+ * own error boundaries report the real failure instead of introducing a
+ * second hydration mismatch. React sets __MG_HYDRATED__ on mount.
+ */
+export const PRE_HYDRATION_RECOVERY_SCRIPT = `(() => {
+  var KEY = "${RECOVERY_FLAG}:boot";
+  var fatal = null;
+  function remember(value) {
+    fatal = value && (value.message || String(value));
+  }
+  addEventListener("error", function (event) {
+    remember(event.error || event.message || (event.target && event.target.src) || "Resource failed to load");
+  }, true);
+  addEventListener("unhandledrejection", function (event) { remember(event.reason); });
+  function inspect() {
+    if (window.__MG_HYDRATED__) {
+      try { sessionStorage.removeItem(KEY); } catch (_) {}
+      return;
+    }
+    var main = document.querySelector("main");
+    var mainStyle = main && getComputedStyle(main);
+    var bodyStyle = getComputedStyle(document.body);
+    var hidden = !mainStyle || mainStyle.display === "none" || mainStyle.visibility === "hidden" || Number(mainStyle.opacity) === 0 || bodyStyle.display === "none" || bodyStyle.visibility === "hidden" || Number(bodyStyle.opacity) === 0;
+    var blank = !main || main.getBoundingClientRect().height < 40 || !document.body.innerText.trim() || hidden;
+    if (!fatal && !blank) return;
+    setTimeout(function () {
+      if (window.__MG_HYDRATED__) return;
+      var confirmMain = document.querySelector("main");
+      var confirmStyle = confirmMain && getComputedStyle(confirmMain);
+      var confirmBlank = !confirmMain || confirmMain.getBoundingClientRect().height < 40 || !document.body.innerText.trim() || !confirmStyle || confirmStyle.display === "none" || confirmStyle.visibility === "hidden" || Number(confirmStyle.opacity) === 0;
+      if (!fatal && !confirmBlank) return;
+      var recent = 0;
+      try { recent = Number(sessionStorage.getItem(KEY) || 0); } catch (_) {}
+      if (recent && Date.now() - recent < ${RECOVERY_TTL_MS}) return;
+      try { sessionStorage.setItem(KEY, String(Date.now())); } catch (_) {}
+      location.reload();
+    }, 1500);
+  }
+  setTimeout(inspect, 8000);
+})();`;
+
+declare global {
+  interface Window {
+    __MG_HYDRATED__?: boolean;
+  }
+}
+
+export type BlankScreenMetrics = {
+  visibleHeight: number;
+  childCount: number;
+  visuallyHidden: boolean;
+};
+
+/** Pure measurement — accepts any element so it's unit-testable in jsdom. */
+export function measureRenderedHeight(root: Element | null): BlankScreenMetrics {
+  if (!root) return { visibleHeight: 0, childCount: 0, visuallyHidden: true };
+  const rect = root.getBoundingClientRect();
+  let visuallyHidden = false;
+  if (typeof window !== "undefined" && root instanceof HTMLElement) {
+    let current: HTMLElement | null = root;
+    while (current) {
+      const style = window.getComputedStyle(current);
+      if (
+        style.display === "none" ||
+        style.visibility === "hidden" ||
+        Number(style.opacity) === 0
+      ) {
+        visuallyHidden = true;
+        break;
+      }
+      current = current.parentElement;
+    }
+  }
+  return { visibleHeight: rect.height, childCount: root.childElementCount, visuallyHidden };
+}
+
+/** Pure predicate: is this measurement "blank"? */
+export function isBlank(m: BlankScreenMetrics): boolean {
+  return m.visibleHeight < BLANK_MIN_HEIGHT_PX || m.childCount === 0 || m.visuallyHidden;
+}
+
+function readRecentSessionFlag(key: string): boolean {
+  try {
+    const stored = Number(sessionStorage.getItem(key));
+    return Number.isFinite(stored) && stored > 0 && Date.now() - stored < RECOVERY_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+function writeSessionFlag(key: string, value: string) {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    /* noop */
+  }
+}
+
+function clearSessionFlag(key: string) {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    /* noop */
+  }
+}
+
+export type WatchdogOptions = {
+  onReport?: (metrics: BlankScreenMetrics) => void;
+};
+
+/** Mounts the watchdog. Returns a cleanup fn. Safe to call from useEffect. */
+export function mountBlankScreenWatchdog(opts: WatchdogOptions): () => void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return () => {};
+  }
+  // Avoid competing with a freshly rendered error boundary, but do not disable
+  // recovery for the rest of the browser session after one historical crash.
+  if (readRecentSessionFlag(CRASH_FLAG)) return () => {};
+
+  // Preview is where stale HMR frames and interrupted portals are most likely,
+  // so it needs the same protection as production. Keep an explicit opt-out
+  // for tests or unusual local debugging sessions.
+  const explicitlyDisabled =
+    (import.meta.env?.VITE_ENABLE_BLANK_WATCHDOG as string | undefined) === "0";
+  if (explicitlyDisabled) return () => {};
+
+  let cancelled = false;
+  const timers: ReturnType<typeof setTimeout>[] = [];
+
+  const measureRoot = () =>
+    document.querySelector("main") ?? document.getElementById("app-root") ?? document.body;
+
+  const runCheck = () => {
+    if (cancelled) return;
+    if (document.visibilityState !== "visible") return;
+
+    const first = measureRenderedHeight(measureRoot());
+    if (!isBlank(first)) {
+      clearSessionFlag(RECOVERY_FLAG);
+      return;
+    }
+
+    opts.onReport?.(first);
+
+    timers.push(
+      setTimeout(() => {
+        if (cancelled) return;
+        const second = measureRenderedHeight(measureRoot());
+        if (!isBlank(second)) {
+          clearSessionFlag(RECOVERY_FLAG);
+          return;
+        }
+        // Guarded single hard reload per session.
+        if (readRecentSessionFlag(RECOVERY_FLAG)) return;
+        writeSessionFlag(RECOVERY_FLAG, String(Date.now()));
+        window.location.reload();
+      }, SECOND_CHECK_DELAY_MS),
+    );
+  };
+
+  timers.push(setTimeout(runCheck, FIRST_CHECK_DELAY_MS));
+
+  return () => {
+    cancelled = true;
+    for (const t of timers) clearTimeout(t);
+  };
+}

--- a/apps/ui/src/lib/metagraphed/url-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.test.ts
@@ -158,4 +158,20 @@ describe("joinEconomics", () => {
     // No entry for netuid 2 → passes through unchanged, "—" in the cell.
     expect(out[1]).toBe(rows[1]);
   });
+
+  it("attaches optional subnet financial analytics from the same entry", () => {
+    const rows = [{ netuid: 1 }];
+    const out = joinEconomics(rows, {
+      1: {
+        alpha_price_tao: 0.0412,
+        total_stake_tao: 12_345,
+        alpha_market_cap_tao: 507,
+      },
+    });
+    expect(out[0]).toMatchObject({
+      alpha_price_tao: 0.0412,
+      total_stake_tao: 12_345,
+      alpha_market_cap_tao: 507,
+    });
+  });
 });

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -91,12 +91,12 @@ export function joinHealth<
 
 /**
  * #3364/#3363: join a list of rows with a per-netuid economics map, overlaying
- * the `registration_cost_tao` + `registration_allowed` + `emission_share`
- * fields so the /subnets table's Registration and Emission columns (and their
- * sort) can read them straight off the row. Mirrors `joinHealth`/the catalog
- * join: a row with no economics entry passes through unchanged (same
- * reference), so its cells render "—". Pure + allocation-light so callers can
- * memoize it.
+ * registration, emission, price, stake, and market-cap fields so the /subnets
+ * table's Registration and Emission columns (and their sort), plus the
+ * homepage's alpha-price ticker, can read them straight off the row. Mirrors
+ * `joinHealth`/the catalog join: a row with no economics entry passes through
+ * unchanged (same reference), so its cells render "—". Pure + allocation-light
+ * so callers can memoize it.
  */
 export function joinEconomics<
   T extends { netuid: number },
@@ -104,6 +104,9 @@ export function joinEconomics<
     registration_cost_tao?: number;
     registration_allowed?: boolean;
     emission_share?: number;
+    alpha_price_tao?: number;
+    total_stake_tao?: number;
+    alpha_market_cap_tao?: number;
   },
 >(
   rows: T[],
@@ -114,6 +117,9 @@ export function joinEconomics<
       registration_cost_tao?: number;
       registration_allowed?: boolean;
       emission_share?: number;
+      alpha_price_tao?: number;
+      total_stake_tao?: number;
+      alpha_market_cap_tao?: number;
     })
 > {
   return rows.map((s) => {
@@ -124,6 +130,9 @@ export function joinEconomics<
           registration_cost_tao: e.registration_cost_tao,
           registration_allowed: e.registration_allowed,
           emission_share: e.emission_share,
+          alpha_price_tao: e.alpha_price_tao,
+          total_stake_tao: e.total_stake_tao,
+          alpha_market_cap_tao: e.alpha_market_cap_tao,
         }
       : s;
   });

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -26,6 +26,11 @@ import { Toaster } from "@jsonbored/ui-kit";
 import { THEME_BOOTSTRAP_SCRIPT } from "@/lib/theme";
 import { DENSITY_BOOTSTRAP_SCRIPT } from "@/lib/density";
 import { HEALTH_PALETTE_BOOTSTRAP_SCRIPT } from "@/lib/health-palette";
+import { GlobalErrorBoundary } from "@/components/metagraphed/global-error-boundary";
+import {
+  mountBlankScreenWatchdog,
+  PRE_HYDRATION_RECOVERY_SCRIPT,
+} from "@/lib/blank-screen-watchdog";
 
 function NotFoundComponent() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
@@ -308,6 +313,7 @@ function RootShell({ children }: { children: ReactNode }) {
         <script dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP_SCRIPT }} />
         <script dangerouslySetInnerHTML={{ __html: DENSITY_BOOTSTRAP_SCRIPT }} />
         <script dangerouslySetInnerHTML={{ __html: HEALTH_PALETTE_BOOTSTRAP_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: PRE_HYDRATION_RECOVERY_SCRIPT }} />
         <HeadContent />
       </head>
       <body>
@@ -321,12 +327,41 @@ function RootShell({ children }: { children: ReactNode }) {
 function RootComponent() {
   const { queryClient } = Route.useRouteContext();
 
+  useEffect(() => {
+    // Handshake with the dependency-free <head> recovery script. This must be
+    // the first effect work so a successful mount cancels its startup timeout.
+    window.__MG_HYDRATED__ = true;
+    const onError = (e: ErrorEvent) => {
+      const err = e.error instanceof Error ? e.error : new Error(String(e.message ?? e));
+      console.error("[hydration-capture] window error:", err, err.stack);
+      reportLovableError(err, { boundary: "hydration_window_error" });
+    };
+    const onRejection = (e: PromiseRejectionEvent) => {
+      const err = e.reason instanceof Error ? e.reason : new Error(String(e.reason));
+      console.error("[hydration-capture] unhandled rejection:", err, err.stack);
+      reportLovableError(err, { boundary: "hydration_unhandled_rejection" });
+    };
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+    const cleanupWatchdog = mountBlankScreenWatchdog({
+      onReport: (m) => reportLovableError(new Error("blank_screen_detected"), { metrics: m }),
+    });
+    return () => {
+      window.__MG_HYDRATED__ = false;
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+      cleanupWatchdog();
+    };
+  }, [queryClient]);
+
   return (
     <QueryClientProvider client={queryClient}>
-      <RouteTransitionBar />
-      {/* Required: nested routes render here. Removing <Outlet /> breaks all child routes. */}
-      <Outlet />
-      <Toaster />
+      <GlobalErrorBoundary>
+        <RouteTransitionBar />
+        {/* Required: nested routes render here. Removing <Outlet /> breaks all child routes. */}
+        <Outlet />
+        <Toaster />
+      </GlobalErrorBoundary>
     </QueryClientProvider>
   );
 }

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -13,11 +13,9 @@ import {
   CurationChip,
   HealthPill,
   CopyableCode,
-  InfoTooltip,
   safeExternalUrl,
   ScrollReveal,
   Sparkline,
-  type SparklinePoint,
 } from "@jsonbored/ui-kit";
 import { SubnetPulseGrid } from "@/components/metagraphed/charts/subnet-pulse-grid";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
@@ -40,10 +38,11 @@ import { HeroSubnetChips } from "@/components/metagraphed/hero-subnet-chips";
 import { QuickActionsRow } from "@/components/metagraphed/quick-actions-row";
 import { RecentIdentityChanges } from "@/components/metagraphed/recent-identity-changes";
 import { ContinueExploring } from "@/components/metagraphed/continue-exploring";
+import { HeroFeatureRow } from "@/components/metagraphed/hero-feature-row";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 import {
   blocksQuery,
-  chainActivityQuery,
   coverageQuery,
   freshnessQuery,
   healthQuery,
@@ -79,20 +78,24 @@ function OverviewPage() {
   // until opened.
   const [showMore, setShowMore] = useState(false);
   return (
-    <AppShell>
+    <AppShell
+      flushTop
+      afterHeader={
+        // Seat the alpha-price marquee flush against the secondary ecosystem
+        // strip -- fills the gap that used to sit above the hero. Its bottom
+        // mint hairline doubles as the hero's top rule.
+        <QueryErrorBoundary fallback={() => null}>
+          <Suspense fallback={null}>
+            <SubnetPriceTicker />
+          </Suspense>
+        </QueryErrorBoundary>
+      }
+    >
       <HomeHero />
 
-      {/* #1124/#1302: hero discovery rail — alpha-price ticker, trending subnet
-          chips, and a "continue exploring" rail. Each renders null until it has
-          data, so they never clutter a cold first paint. */}
-      <QueryErrorBoundary fallback={() => null}>
-        <Suspense fallback={null}>
-          <SubnetPriceTicker />
-        </Suspense>
-      </QueryErrorBoundary>
-
-      {/* #6642: network-wide sentiment reading, surfaced as its own widget --
-          self-manages loading/error via useQuery (no Suspense needed). */}
+      {/* #6642: network-wide sentiment reading — full-width card with a real
+          gradient rail, ticks, and a numeric ratio. Self-manages loading/error
+          via useQuery (no Suspense needed). */}
       <QueryErrorBoundary fallback={() => null}>
         <NetworkMoodGauge />
       </QueryErrorBoundary>
@@ -352,201 +355,109 @@ function ChainHeadTip() {
   );
 }
 
+function openCommandPalette() {
+  if (typeof window === "undefined") return;
+  // The app shell listens on window for ⌘/Ctrl+K — dispatching a real
+  // KeyboardEvent triggers the same open path, no shell changes needed.
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "k", metaKey: true, ctrlKey: true, bubbles: true }),
+  );
+}
+
 function HomeHero() {
+  const hydrated = useHydrated();
+  const { data: subnetsData } = useQuery({
+    ...subnetsQuery({ limit: 128 }),
+    enabled: hydrated,
+  });
+  const subnetCount =
+    hydrated && Array.isArray(subnetsData?.data)
+      ? (subnetsData?.data as Subnet[]).filter((s) => s.netuid > 0).length
+      : 128;
+
   return (
-    <section className="mg-hero-slab relative overflow-hidden px-6 py-12 md:px-12 md:py-20">
-      <div className="relative z-10 grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,380px)] lg:items-center">
-        <div className="min-w-0 max-w-2xl">
-          <div className="mg-fade-in font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted inline-flex items-center gap-2">
-            <span className="mg-live-dot" />
-            Registry · Live · Read-only
-          </div>
-          <h1 className="mg-fade-in mg-fade-in-delay-1 mt-4 font-display text-4xl sm:text-5xl md:text-6xl font-semibold leading-[1.02] tracking-tight text-ink-strong">
-            The public-interface registry for <span className="text-accent">Bittensor</span>.
-          </h1>
-          <p className="mg-fade-in mg-fade-in-delay-2 mt-5 max-w-xl text-base text-ink-muted leading-relaxed">
-            A builder-facing index of subnet APIs, schemas, docs, endpoints, and providers — plus a
-            chain-direct block explorer for blocks, extrinsics, and events.
-          </p>
-          <div className="mg-fade-in mg-fade-in-delay-3 mt-7 flex flex-wrap items-center gap-3">
-            <Link
-              to="/subnets"
-              className="inline-flex items-center gap-1.5 rounded-full bg-accent px-5 py-2.5 text-sm font-medium text-accent-foreground hover:opacity-90 transition-opacity"
+    <section className="mg-hero-slab relative overflow-hidden px-4 py-14 sm:px-6 md:py-20">
+      <div className="relative z-10 mx-auto flex max-w-4xl flex-col items-center text-center">
+        <h1 className="mg-fade-in mt-2 font-display text-[30px] sm:text-[40px] md:text-[48px] font-semibold leading-[1.08] text-ink-strong">
+          <span className="block">Bittensor,</span>
+          <span className="block text-accent">de-mystified.</span>
+        </h1>
+        <p className="mg-fade-in mg-fade-in-delay-1 mt-5 max-w-xl text-base md:text-lg text-ink-muted leading-relaxed">
+          One search bar for every subnet, endpoint, and account — and yes, it&rsquo;s all a live
+          API.
+        </p>
+
+        {/* Unified search field: query trigger on the left, mint Search button flush right. */}
+        <div className="mg-fade-in mg-fade-in-delay-2 mt-8 w-full max-w-2xl">
+          <div className="mg-focus-ring flex items-stretch overflow-hidden rounded-2xl border border-border bg-card transition-colors focus-within:border-accent/60 hover:border-accent/40">
+            <button
+              type="button"
+              onClick={openCommandPalette}
+              aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
+              className="flex flex-1 items-center gap-3 px-4 py-3.5 text-left text-sm text-ink-muted transition-colors hover:text-ink"
             >
-              Browse subnets
-              <ArrowUpRight className="size-3.5" />
-            </Link>
-            <Link
-              to="/schemas"
-              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card/50 px-5 py-2.5 text-sm font-medium text-ink hover:border-accent/40 transition-colors"
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.75"
+                className="size-4 shrink-0 text-ink-muted"
+              >
+                <circle cx="11" cy="11" r="7" />
+                <path d="m20 20-3.5-3.5" strokeLinecap="round" />
+              </svg>
+              <span className="flex-1 truncate">
+                Search subnets, validators, endpoints, accounts…
+              </span>
+              <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+                ⌘K
+              </kbd>
+            </button>
+            <button
+              type="button"
+              onClick={openCommandPalette}
+              aria-label="Open search"
+              className="flex size-12 shrink-0 items-center justify-center border-l border-border bg-primary-soft text-accent-text transition-colors hover:bg-accent hover:text-accent-foreground sm:h-auto sm:w-auto sm:px-5"
             >
-              Read the API
-            </Link>
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.75"
+                className="size-4 sm:hidden"
+              >
+                <circle cx="11" cy="11" r="7" />
+                <path d="m20 20-3.5-3.5" strokeLinecap="round" />
+              </svg>
+              <span className="hidden text-sm font-medium sm:inline">Search</span>
+            </button>
           </div>
-          <ChainHeadTip />
         </div>
-        <div className="mg-fade-in mg-fade-in-delay-2 shrink-0">
-          <HeroKpis />
+
+        <div className="mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-col items-center gap-3 sm:flex-row sm:gap-4 text-[13px]">
+          <Link
+            to="/subnets"
+            className="mg-focus-ring inline-flex items-center gap-1.5 rounded-full bg-accent px-5 py-2 font-medium text-accent-foreground transition-opacity hover:opacity-90"
+          >
+            Explore all {subnetCount} subnets
+            <ArrowUpRight className="size-3.5" />
+          </Link>
+          <Link
+            to="/schemas"
+            className="mg-focus-ring inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-5 py-2 font-medium text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
+          >
+            Read the API
+          </Link>
         </div>
+        <ChainHeadTip />
+      </div>
+
+      <div className="relative z-10 mx-auto mt-10 max-w-6xl px-0 sm:px-2">
+        <HeroFeatureRow />
       </div>
     </section>
-  );
-}
-
-function HeroKpis() {
-  // #5312: freshness and health percentages live only in LivePerformance
-  // (homepage deep dive) — the global registry ticker already carries glance
-  // counts. The hero card keeps the subnet health map + chain-direct activity.
-  const activityResult = useQuery(chainActivityQuery("7d"));
-  const activity = activityResult.data?.data;
-  const activityChrono = activity?.days.length ? [...activity.days].reverse() : undefined;
-  const latestExtrinsics = activityChrono?.at(-1)?.extrinsic_count;
-  const activitySeries = activityChrono?.map((d) => d.extrinsic_count);
-  const activityPoints = activityChrono?.map((d) => ({ t: d.day, v: d.extrinsic_count }));
-
-  return (
-    <div className="mx-auto w-full max-w-[560px] rounded-xl border border-border bg-card/80 overflow-hidden lg:mx-0 lg:max-w-none">
-      {/* Caption strip */}
-      <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-surface/40">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted inline-flex items-center gap-2">
-          <span className="mg-live-dot" />
-          Registry pulse
-        </div>
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          live · 30s
-        </div>
-      </div>
-
-      {/* Subnet health map — visual only; active-subnet count is in the global ticker. */}
-      <div className="px-4 py-3.5 border-b border-border">
-        <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Subnet health map
-        </div>
-        <SubnetPulseGrid columns={16} />
-        <div className="mt-2.5 flex items-center gap-3 text-[10px] font-mono text-ink-muted">
-          <LegendDot tone="bg-health-ok" label="ok" />
-          <LegendDot tone="bg-health-warn" label="warn" />
-          <LegendDot tone="bg-health-down" label="down" />
-          <LegendDot tone="bg-ink-subtle/60" label="unknown" />
-        </div>
-      </div>
-
-      {/* Chain-direct activity — the only numeric hero stat; not in the ticker. */}
-      <div className="border-b border-border">
-        <HeroStatCell
-          label="Chain activity"
-          value={latestExtrinsics != null ? formatNumber(latestExtrinsics) : "—"}
-          phase={statPhase(activityResult)}
-          series={activitySeries}
-          points={activityPoints}
-          formatValue={(v) => formatNumber(v)}
-          seriesCaption="7d · daily"
-          tooltip="Extrinsics in the latest indexed day, chain-direct (not registry-derived). Source: /api/v1/chain/activity."
-        />
-      </div>
-
-      {/* Pilot chips */}
-      <div className="flex items-center gap-2 px-4 py-2.5 text-[11px] font-mono text-ink-muted">
-        <span className="uppercase tracking-[0.18em] text-[10px]">Pilots</span>
-        <span aria-hidden>▸</span>
-        <Link
-          to="/subnets/$netuid"
-          params={{ netuid: 7 }}
-          className="rounded-full border border-border bg-paper px-2 py-0.5 hover:text-accent hover:border-accent/40 transition-colors"
-        >
-          Allways · SN7
-        </Link>
-        <Link
-          to="/subnets/$netuid"
-          params={{ netuid: 74 }}
-          className="rounded-full border border-border bg-paper px-2 py-0.5 hover:text-accent hover:border-accent/40 transition-colors"
-        >
-          Gittensor · SN74
-        </Link>
-      </div>
-    </div>
-  );
-}
-
-function LegendDot({ tone, label }: { tone: string; label: string }) {
-  return (
-    <span className="inline-flex items-center gap-1">
-      <span className={`size-1.5 rounded-full ${tone}`} />
-      {label}
-    </span>
-  );
-}
-
-function HeroStatCell({
-  label,
-  value,
-  phase = "ready",
-  series,
-  points,
-  formatValue,
-  tooltip,
-  accent,
-  seriesCaption = "24h · hourly",
-}: {
-  label: string;
-  value: string;
-  /** Loading/error/ready phase of the cell's source query (#3964). */
-  phase?: StatPhase;
-  /** Real data series. When absent, no sparkline is rendered (no fabrication). */
-  series?: number[];
-  points?: SparklinePoint[];
-  formatValue?: (v: number) => string;
-  tooltip?: string;
-  accent?: boolean;
-  /** Cadence label under the sparkline; defaults to the freshness cell's 24h/hourly cadence. */
-  seriesCaption?: string;
-}) {
-  // Hide the sparkline unless the value settled successfully — a skeleton or
-  // error glyph replaces the number, so a stale series would misrepresent state.
-  const hasSeries = phase === "ready" && !!series && series.length > 1;
-  return (
-    <div className="px-4 py-3">
-      <div className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        <span>{label}</span>
-        {tooltip ? <InfoTooltip label={tooltip} /> : null}
-      </div>
-      <div
-        className={`mt-1 font-display text-xl font-semibold leading-none tabular-nums ${
-          accent ? "text-accent" : "text-ink-strong"
-        }`}
-      >
-        {phase === "pending" ? (
-          <Skeleton className="h-5 w-14" />
-        ) : phase === "error" ? (
-          <StatUnavailable />
-        ) : (
-          value
-        )}
-      </div>
-      {hasSeries ? (
-        <>
-          <div className="mt-2">
-            <Sparkline
-              values={series}
-              points={points}
-              formatValue={formatValue}
-              width={150}
-              height={20}
-              color={accent ? "var(--accent)" : "var(--ink-strong)"}
-              ariaLabel={label}
-            />
-          </div>
-          <div className="mt-1.5 flex items-center gap-1.5 text-[9px] font-mono uppercase tracking-[0.18em] text-ink-muted">
-            <span
-              aria-hidden
-              className="inline-block h-px w-3"
-              style={{ background: accent ? "var(--accent)" : "var(--ink-strong)" }}
-            />
-            <span>{seriesCaption}</span>
-          </div>
-        </>
-      ) : null}
-    </div>
   );
 }
 


### PR DESCRIPTION
## What changed

Fourth batch of the Lovable-redesign sync (#7741), stacked on #7770 (still open — this PR's diff will shrink to just the 2 files below once that merges).

`url-state.ts`'s `joinEconomics` diverged cleanly on both sides since the Lovable-sync baseline — not a conflict, a genuine merge:
- This repo independently added `registration_cost_tao` / `registration_allowed` / `emission_share`.
- The Lovable redesign independently added `alpha_price_tao` / `total_stake_tao` / `alpha_market_cap_tao` (feeds an "alpha price on live subnets" hero feature).

Both sets of fields now flow through the same join — neither side's addition is dropped. Ported the matching new test case from the Lovable source too.

**No action needed on `types.ts` / `queries.ts`** — confirmed via full diff against the Lovable source that this repo's data layer is strictly ahead (new leaderboard boards, domains, account-delegation graph, network parameters, idle-stake, subnet-lease, compare-validators — none of which exist in the Lovable copy). Porting Lovable's version of either file would be a straight regression.

## Test plan
- [x] `npx vitest run src/lib/metagraphed/url-state.test.ts` — 21/21 passing (added 1 new test)
- [x] `npx eslint` — 0 errors (1 pre-existing-pattern warning: the hex-color rule false-triggers on a `#3363` issue reference inside a test description string, not a real hex color — a known limitation of the rule as ported in #7756, not something to fix here)
- [x] `npx prettier --check` clean
- [x] `npm run typecheck --workspace=apps/ui` — 0 new errors

Closes #7745