### PR TITLE
feat(ui): wire blocks/ enrichment components into blocks routes

### DIFF
--- a/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
@@ -47,43 +47,32 @@ export function AuthorSharePanel({ rows }: { rows: Block[] }) {
           const share = total > 0 ? (count / total) * 100 : 0;
           const pct = Math.max(3, Math.round((count / max) * 100));
           const heavy = share >= 20;
+          const filterByAuthor = () =>
+            navigate({
+              search: (prev: Record<string, unknown>) => ({ ...prev, author, offset: 0 }) as never,
+              resetScroll: false,
+            });
           return (
             <li key={author}>
-              <button
-                type="button"
-                onClick={() =>
-                  navigate({
-                    search: (prev: Record<string, unknown>) =>
-                      ({ ...prev, author, offset: 0 }) as never,
-                    resetScroll: false,
-                  })
-                }
-                className="mg-focus-ring group grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-2 text-left transition-colors hover:bg-surface/40 -mx-2 px-2 rounded"
-                title="Filter by this author"
-              >
+              {/* AccountAddress renders its own <a>/<button> (account link + copy
+                  button), so it can't sit inside a "filter by author" button/link
+                  without invalid HTML nesting (button-in-button breaks hydration).
+                  It's its own row; the bar + count below are the filter trigger. */}
+              <div className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-2 -mx-2 px-2 rounded">
                 <div className="min-w-0">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <AccountAddress
-                      ss58={author}
-                      compact
-                      keep={6}
-                      fallback={<span className="text-ink-muted">—</span>}
-                    />
-                  </div>
-                  <div
-                    aria-hidden
-                    className="mt-1.5 h-[3px] w-full overflow-hidden rounded-full bg-border/60"
-                  >
-                    <div
-                      className={classNames(
-                        "h-full rounded-full transition-[width]",
-                        heavy ? "bg-health-warn/80" : "bg-accent/70",
-                      )}
-                      style={{ width: `${pct}%` }}
-                    />
-                  </div>
+                  <AccountAddress
+                    ss58={author}
+                    compact
+                    keep={6}
+                    fallback={<span className="text-ink-muted">—</span>}
+                  />
                 </div>
-                <div className="shrink-0 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                <button
+                  type="button"
+                  onClick={filterByAuthor}
+                  className="mg-focus-ring shrink-0 text-right font-mono text-[11px] tabular-nums text-ink-strong"
+                  title="Filter by this author"
+                >
                   <div>{formatNumber(count)}</div>
                   <div
                     className={classNames(
@@ -93,6 +82,25 @@ export function AuthorSharePanel({ rows }: { rows: Block[] }) {
                   >
                     {share.toFixed(1)}%
                   </div>
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={filterByAuthor}
+                className="mg-focus-ring group -mt-1 block w-full text-left"
+                title="Filter by this author"
+              >
+                <div
+                  aria-hidden
+                  className="h-[3px] w-full overflow-hidden rounded-full bg-border/60 group-hover:opacity-80"
+                >
+                  <div
+                    className={classNames(
+                      "h-full rounded-full transition-[width]",
+                      heavy ? "bg-health-warn/80" : "bg-accent/70",
+                    )}
+                    style={{ width: `${pct}%` }}
+                  />
                 </div>
               </button>
             </li>

--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -41,12 +41,11 @@ export function LiveBlockRail() {
       role="status"
       aria-live="polite"
     >
-      {/* LATEST BLOCK */}
-      <Link
-        to="/blocks/$ref"
-        params={{ ref: String(latest.block_number) }}
-        className="mg-focus-ring flex items-center gap-3 rounded border border-transparent px-2 py-1.5 hover:border-border/70 hover:bg-surface/50"
-      >
+      {/* LATEST BLOCK. Not a single wrapping <Link>: AccountAddress below
+          renders its own <a>/<button> (account link + copy button), and an
+          anchor/button can't contain another without invalid HTML nesting
+          (breaks hydration). The block number is its own link instead. */}
+      <div className="flex items-center gap-3 rounded border border-transparent px-2 py-1.5">
         <span aria-hidden className="relative inline-flex size-2 items-center justify-center">
           <span className="absolute inline-flex size-2 animate-ping rounded-full bg-health-ok/60" />
           <span className="relative inline-flex size-1.5 rounded-full bg-health-ok" />
@@ -54,9 +53,13 @@ export function LiveBlockRail() {
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2">
             <span className="mg-type-micro text-ink-muted">Latest</span>
-            <span className="font-mono text-[14px] font-semibold tabular-nums text-ink-strong">
+            <Link
+              to="/blocks/$ref"
+              params={{ ref: String(latest.block_number) }}
+              className="mg-focus-ring rounded font-mono text-[14px] font-semibold tabular-nums text-ink-strong hover:text-accent"
+            >
               #{formatNumber(latest.block_number)}
-            </span>
+            </Link>
             <span className="font-mono text-[10px] text-ink-muted">
               <TimeAgo at={latest.observed_at} />
             </span>
@@ -75,7 +78,7 @@ export function LiveBlockRail() {
             {formatNumber(latest.event_count ?? 0)} evt
           </div>
         </div>
-      </Link>
+      </div>
 
       {/* MINI CADENCE STRIP */}
       <div className="flex flex-col justify-center gap-1.5 px-1">

--- a/apps/ui/src/components/metagraphed/tao-value.tsx
+++ b/apps/ui/src/components/metagraphed/tao-value.tsx
@@ -1,0 +1,80 @@
+import { useTaoPrice } from "@/hooks/use-tao-price";
+import { formatNumber } from "@/lib/metagraphed/format";
+import { useValueUnit } from "@/lib/metagraphed/value-unit";
+
+/**
+ * Renders an on-chain TAO amount alongside its USD equivalent.
+ * Respects the page-level ValueUnit preference (τ / USD / Both). When USD is
+ * requested but the price hasn't loaded, gracefully falls back to τ so a value
+ * always renders.
+ *
+ * Layout:
+ *  - inline (default): "τ 1.2345  ≈ $8.42"
+ *  - stacked:          amount on top, USD as a muted line below
+ */
+export function TaoValue({
+  amount,
+  layout = "inline",
+  precision = 4,
+  className,
+  align = "right",
+  size = "sm",
+}: {
+  amount: number | null | undefined;
+  layout?: "inline" | "stacked";
+  precision?: number;
+  className?: string;
+  align?: "left" | "right";
+  size?: "sm" | "md";
+}) {
+  const { price } = useTaoPrice();
+  const { unit } = useValueUnit();
+
+  if (amount == null || Number.isNaN(amount)) {
+    return <span className="font-mono text-[11px] text-ink-muted">—</span>;
+  }
+
+  const tao = `τ ${formatNumber(Number(amount.toFixed(precision)))}`;
+  const usd =
+    price != null
+      ? `$${formatNumber(Number((amount * price).toFixed(amount * price >= 1 ? 2 : 4)))}`
+      : null;
+
+  // Fall back to τ when USD is requested but unavailable.
+  const showTao = unit === "tao" || unit === "both" || (unit === "usd" && usd == null);
+  const showUsd = (unit === "usd" || unit === "both") && usd != null;
+
+  const taoClass =
+    size === "md"
+      ? "font-display text-base sm:text-xl md:text-2xl font-semibold tabular-nums leading-none text-ink-strong"
+      : "font-mono text-[11px] tabular-nums text-ink-strong";
+  const usdClass =
+    size === "md"
+      ? "font-mono text-[10px] tabular-nums text-ink-muted"
+      : "font-mono text-[10px] tabular-nums text-ink-muted";
+
+  const taoNode = showTao ? <span className={taoClass}>{tao}</span> : null;
+  const usdNode = showUsd ? (
+    <span className={usdClass} title="TAO price via coinpaprika, refreshed ~1×/min">
+      {unit === "both" ? `≈ ${usd}` : usd}
+    </span>
+  ) : null;
+
+  if (layout === "stacked") {
+    return (
+      <span
+        className={`inline-flex flex-col ${size === "md" ? "gap-1" : "leading-tight"} ${align === "right" ? "items-end" : "items-start"} ${className ?? ""}`}
+      >
+        {taoNode}
+        {usdNode}
+      </span>
+    );
+  }
+
+  return (
+    <span className={`inline-flex items-baseline gap-1.5 ${className ?? ""}`}>
+      {taoNode}
+      {usdNode}
+    </span>
+  );
+}

--- a/apps/ui/src/hooks/use-tao-price.ts
+++ b/apps/ui/src/hooks/use-tao-price.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { getTaoMarket, type TaoMarketData } from "@/lib/metagraphed/market.functions";
+
+/**
+ * Shared TAO/USD price hook. Backed by the same coinpaprika query used on
+ * /subnets so the browser cache dedupes across the app.
+ *
+ * Returns `null` price when the request is pending or has failed — callers
+ * must render a "USD unavailable" fallback rather than invent a number.
+ */
+export function useTaoPrice() {
+  const { data, isPending, isError } = useQuery<TaoMarketData>({
+    queryKey: ["tao-market"],
+    queryFn: () => getTaoMarket(),
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    retry: 1,
+  });
+  const price = typeof data?.price === "number" && data.price > 0 ? data.price : null;
+  return { price, isPending, isError };
+}

--- a/apps/ui/src/lib/metagraphed/market.functions.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.ts
@@ -1,0 +1,16 @@
+import { createServerFn } from "@tanstack/react-start";
+
+export interface TaoMarketData {
+  price?: number;
+  market_cap?: number;
+  volume_24h?: number;
+}
+
+export const getTaoMarket = createServerFn({ method: "GET" }).handler(
+  async (): Promise<TaoMarketData> => {
+    const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
+    if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
+    const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
+    return payload.quotes?.USD ?? {};
+  },
+);

--- a/apps/ui/src/lib/metagraphed/value-unit.tsx
+++ b/apps/ui/src/lib/metagraphed/value-unit.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+export type ValueUnit = "tao" | "usd" | "both";
+
+const STORAGE_KEY = "mg:value-unit";
+const DEFAULT: ValueUnit = "both";
+
+interface Ctx {
+  unit: ValueUnit;
+  setUnit: (u: ValueUnit) => void;
+}
+
+const ValueUnitContext = createContext<Ctx>({ unit: DEFAULT, setUnit: () => {} });
+
+/**
+ * Provides the τ/USD/Both display preference for money values on the current
+ * page. SSR-safe: initial render uses the DEFAULT and rehydrates the persisted
+ * choice from localStorage in an effect (so server/client HTML match).
+ */
+export function ValueUnitProvider({ children }: { children: ReactNode }) {
+  const [unit, setUnitState] = useState<ValueUnit>(DEFAULT);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw === "tao" || raw === "usd" || raw === "both") setUnitState(raw);
+    } catch {
+      /* storage blocked — keep default */
+    }
+  }, []);
+
+  const setUnit = (u: ValueUnit) => {
+    setUnitState(u);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, u);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <ValueUnitContext.Provider value={{ unit, setUnit }}>{children}</ValueUnitContext.Provider>
+  );
+}
+
+export function useValueUnit() {
+  return useContext(ValueUnitContext);
+}

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -1,23 +1,41 @@
 import { createFileRoute, Link, notFound, useNavigate } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, type ReactNode } from "react";
-import { ChevronLeft, ChevronRight, Boxes, FileText, Zap } from "lucide-react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from "react";
+import { FileText, Zap, CheckCircle2, ChevronDown, ChevronRight, DollarSign } from "lucide-react";
+
+import { ChainWalkRibbon } from "@/components/metagraphed/blocks/chain-walk-ribbon";
+import { NeighborCompare } from "@/components/metagraphed/blocks/neighbor-compare";
+import { BlockMetadataPanel } from "@/components/metagraphed/blocks/block-metadata-panel";
+import { PalletMethodBreakdown } from "@/components/metagraphed/blocks/pallet-method-breakdown";
+import { ShortcutsDialog } from "@/components/metagraphed/blocks/shortcuts-dialog";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { PageMasthead } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import {
   CopyableCode,
   CopyButton,
+  Kbd,
   TimeAgo,
-  PageHero,
   ShareButton,
   ActionBar,
   SectionAnchor,
   StatTile,
   TableState,
   DownloadCsvButton,
+  InfoTooltip,
+  BackToTop,
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
@@ -32,6 +50,10 @@ import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraph
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { formatChainEventArgs } from "@/lib/metagraphed/chain-event-args";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
+import { BLOCK_SECTION_HINTS, BLOCK_TERM_HINTS } from "@/lib/metagraphed/section-hints";
+import { TaoValue } from "@/components/metagraphed/tao-value";
+import { ValueUnitProvider, useValueUnit, type ValueUnit } from "@/lib/metagraphed/value-unit";
+import { nextTabIndex } from "@/hooks/use-roving-tablist";
 
 export const Route = createFileRoute("/blocks/$ref")({
   // #3422: validate the ref at the router level so an invalid one renders the
@@ -87,11 +109,14 @@ function BlockDetailPage() {
   const { ref } = Route.useParams();
   return (
     <AppShell>
-      <QueryErrorBoundary>
-        <Suspense fallback={<DetailSkeleton />}>
-          <BlockDetail refValue={ref} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <ValueUnitProvider>
+        <QueryErrorBoundary>
+          <Suspense fallback={<DetailSkeleton />}>
+            <BlockDetail refValue={ref} />
+          </Suspense>
+        </QueryErrorBoundary>
+      </ValueUnitProvider>
+      <BackToTop />
     </AppShell>
   );
 }
@@ -124,14 +149,22 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         tgt && (tgt.tagName === "INPUT" || tgt.tagName === "TEXTAREA" || tgt.isContentEditable);
       if (inField) return;
 
-      if (e.key === "ArrowLeft" && prevBlockNumber != null) {
+      // ArrowLeft / J → previous block; ArrowRight / K → next block.
+      // Matches the vim-style bindings used across the explorer feeds.
+      if ((e.key === "ArrowLeft" || e.key === "j" || e.key === "J") && prevBlockNumber != null) {
         e.preventDefault();
         navigate({ to: "/blocks/$ref", params: { ref: String(prevBlockNumber) } });
         return;
       }
-      if (e.key === "ArrowRight" && nextBlockNumber != null) {
+      if ((e.key === "ArrowRight" || e.key === "k" || e.key === "K") && nextBlockNumber != null) {
         e.preventDefault();
         navigate({ to: "/blocks/$ref", params: { ref: String(nextBlockNumber) } });
+        return;
+      }
+      // G → jump to blocks feed (head).
+      if (e.key === "g" || e.key === "G") {
+        e.preventDefault();
+        navigate({ to: "/blocks" });
       }
     }
 
@@ -166,7 +199,14 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
 
   return (
     <>
-      <PageHero
+      <ShortcutsDialog blockRef={refValue} />
+      <PageMasthead
+        crumbs={[
+          { to: "/", label: "Home" },
+          { to: "/blocks", label: "Blocks" },
+          { to: `/blocks/${refValue}`, label: `#${formatNumber(block.block_number)}` },
+        ]}
+        hideBreadcrumbs={false}
         eyebrow="Explorer · block"
         live
         title={`#${formatNumber(block.block_number)}`}
@@ -180,6 +220,10 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         actions={
           <>
             <ActionBar>
+              <ValueUnitControl />
+              <div className="hidden sm:flex">
+                <JumpToBlock />
+              </div>
               <ShareButton bare />
             </ActionBar>
             {isStaleFreshness(generatedAt) ? (
@@ -194,388 +238,778 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         caption="explorer / v1"
       />
 
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
-        <StatTile
-          icon={FileText}
-          eyebrow="Extrinsics"
-          value={formatNumber(block.extrinsic_count ?? 0)}
-        />
-        <StatTile icon={Zap} eyebrow="Events" value={formatNumber(block.event_count ?? 0)} />
-        <StatTile
-          icon={Boxes}
-          eyebrow="Observed"
-          value={<TimeAgo at={block.observed_at} />}
-          tone="accent"
-        />
-      </div>
+      <div className="space-y-10">
+        {(() => {
+          const withResult = extrinsics.filter((e) => e.success != null);
+          const successful = withResult.filter((e) => e.success).length;
+          const successRate = withResult.length > 0 ? (successful / withResult.length) * 100 : null;
+          const rateTone: "accent" | "warn" | "down" | "default" =
+            successRate == null
+              ? "default"
+              : successRate >= 99
+                ? "accent"
+                : successRate >= 90
+                  ? "warn"
+                  : "down";
+          // Sum of τ moved by economically-relevant events in this block.
+          // Only events that expose an `amount_tao` contribute — this is a
+          // signal, not a settlement total.
+          const valueMoved = events.reduce(
+            (sum, ev) => sum + (typeof ev.amount_tao === "number" ? ev.amount_tao : 0),
+            0,
+          );
+          const valueMovedNode = eventsQuery.isPending ? (
+            <span className="text-ink-muted">…</span>
+          ) : valueMoved > 0 ? (
+            <TaoValue amount={valueMoved} layout="stacked" precision={2} align="left" size="md" />
+          ) : (
+            "—"
+          );
+          return (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <StatTile
+                icon={FileText}
+                eyebrow="Extrinsics"
+                value={formatNumber(block.extrinsic_count ?? 0)}
+                tooltip={BLOCK_TERM_HINTS.extrinsic}
+              />
+              <StatTile
+                icon={Zap}
+                eyebrow="Events"
+                value={formatNumber(block.event_count ?? 0)}
+                tooltip={BLOCK_TERM_HINTS.event}
+              />
+              <StatTile
+                icon={CheckCircle2}
+                eyebrow="Success"
+                value={
+                  successRate == null ? "—" : `${successRate.toFixed(successRate === 100 ? 0 : 1)}%`
+                }
+                tone={rateTone}
+                tooltip={BLOCK_TERM_HINTS.successRate}
+              />
+              <StatTile
+                icon={DollarSign}
+                eyebrow="Value moved"
+                value={valueMovedNode}
+                tone={valueMoved > 0 ? "accent" : "default"}
+                tooltip={BLOCK_TERM_HINTS.valueMoved}
+              />
+            </div>
+          );
+        })()}
 
-      <SectionAnchor id="chain" title="Chain walk" tone="accent">
-        <div className="px-4 py-3">
-          <ActionBar>
-            {block.prev_block_number == null ? (
-              <span className="inline-flex cursor-not-allowed items-center gap-1 rounded px-2.5 py-1 text-[11px] text-ink-muted opacity-40">
-                <ChevronLeft className="size-3" /> Previous block
-              </span>
-            ) : (
-              <Link
-                to="/blocks/$ref"
-                params={{ ref: String(block.prev_block_number) }}
-                className="inline-flex items-center gap-1 rounded px-2.5 py-1 text-[11px] text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-              >
-                <ChevronLeft className="size-3" />
-                Previous block #{formatNumber(block.prev_block_number)}
-              </Link>
-            )}
-
-            {block.next_block_number == null ? (
-              <span className="inline-flex cursor-not-allowed items-center gap-1 rounded px-2.5 py-1 text-[11px] text-ink-muted opacity-40">
-                Next block <ChevronRight className="size-3" />
-              </span>
-            ) : (
-              <Link
-                to="/blocks/$ref"
-                params={{ ref: String(block.next_block_number) }}
-                className="inline-flex items-center gap-1 rounded px-2.5 py-1 text-[11px] text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-              >
-                Next block #{formatNumber(block.next_block_number)}
-                <ChevronRight className="size-3" />
-              </Link>
-            )}
-          </ActionBar>
+        <div className="flex items-center justify-end -mb-6">
+          <span className="mg-label inline-flex items-center gap-1.5">
+            Observed <TimeAgo at={block.observed_at} />
+          </span>
         </div>
-      </SectionAnchor>
 
-      <SectionAnchor id="details" title="Block details" tone="accent">
-        <dl className="rounded border border-border bg-card divide-y divide-border">
-          <FieldRow label="Block number">
-            <span className="font-mono text-sm text-ink-strong tabular-nums">
-              {formatNumber(block.block_number)}
-            </span>
-          </FieldRow>
-          <FieldRow label="Block hash">
-            {block.block_hash ? (
-              // Truncate to match "Parent hash" below (#5343) — the raw untruncated
-              // CopyableCode overflowed the details row on mobile. It's the current
-              // block, so no self-link; the full hash stays available on hover.
-              <span
-                className="font-mono text-[12px] text-ink-strong break-all"
-                title={block.block_hash}
-              >
-                {shortHash(block.block_hash, 10)}
+        <SectionAnchor id="chain" title="Chain walk" info={BLOCK_SECTION_HINTS.chain}>
+          <div className="space-y-3">
+            <ChainWalkRibbon current={block} radius={3} />
+            <NeighborCompare current={block} />
+          </div>
+        </SectionAnchor>
+
+        <SectionAnchor id="details" title="Block details" info={BLOCK_SECTION_HINTS.details}>
+          <dl className="rounded border border-border bg-card divide-y divide-border">
+            <FieldRow label="Block number">
+              <span className="font-mono text-sm text-ink-strong tabular-nums">
+                {formatNumber(block.block_number)}
               </span>
-            ) : (
-              <span className="text-ink-muted">—</span>
-            )}
-          </FieldRow>
-          <FieldRow label="Parent hash">
-            {block.parent_hash ? (
-              <Link
-                to="/blocks/$ref"
-                params={{ ref: block.parent_hash }}
-                className="font-mono text-[12px] text-ink-strong hover:underline break-all"
-                title={block.parent_hash}
-              >
-                {shortHash(block.parent_hash, 10)}
-              </Link>
-            ) : (
-              <span className="text-ink-muted">—</span>
-            )}
-          </FieldRow>
-          <FieldRow label="Author">
-            {/* #6424: linked like every other ss58 on this page (see the events
-                table below) -- untruncated, so the full value stays readable and
-                copyable exactly as it was. */}
-            <AccountAddress
-              ss58={block.author}
-              truncate={false}
-              fallback={<span className="text-ink-muted">—</span>}
-            />
-          </FieldRow>
-          <FieldRow label="Extrinsics">
-            <span className="font-mono text-sm text-ink tabular-nums">
-              {formatNumber(block.extrinsic_count ?? 0)}
-            </span>
-          </FieldRow>
-          <FieldRow label="Events">
-            <span className="font-mono text-sm text-ink tabular-nums">
-              {formatNumber(block.event_count ?? 0)}
-            </span>
-          </FieldRow>
-          <FieldRow label="Observed at">
-            <span className="font-mono text-[12px] text-ink-muted">
-              <TimeAgo at={block.observed_at} />
-            </span>
-          </FieldRow>
-        </dl>
-      </SectionAnchor>
-
-      <SectionAnchor
-        id="extrinsics"
-        title="Extrinsics"
-        tone="accent"
-        right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/extrinsics`)} />}
-      >
-        {extrinsicsQuery.isPending ? (
-          <Skeleton className="h-44" />
-        ) : extrinsicsQuery.error ? (
-          <TableState
-            variant="error"
-            title="Couldn't load block extrinsics"
-            description="This section is optional — the rest of the block detail is unaffected."
-            error={extrinsicsQuery.error}
-            onRetry={() => {
-              void extrinsicsQuery.refetch();
-            }}
-          />
-        ) : extrinsics.length === 0 ? (
-          <EmptyState
-            title="No block extrinsics"
-            description="This block has no indexed extrinsics (or the poller window for this shard is still catching up)."
-          />
-        ) : (
-          <div className="overflow-x-auto rounded border border-border bg-card">
-            <table className="w-full text-left text-sm">
-              <thead className="bg-surface/40">
-                <tr>
-                  <th className="px-4 py-2.5 text-right">Index</th>
-                  <th className="px-4 py-2.5">Extrinsic</th>
-                  <th className="px-4 py-2.5">Call</th>
-                  <th className="px-4 py-2.5">Result</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {extrinsics.map((extrinsic) => {
-                  const result =
-                    extrinsic.success == null ? "—" : extrinsic.success ? "Success" : "Failed";
-                  // This table spells the result out ("Success"/"Failed")
-                  // rather than the feeds' "ok"/"fail", so it keeps its own
-                  // rendering instead of the shared SuccessBadge -- swapping it
-                  // in would silently reword the page. What it borrows is the
-                  // token pair: the fail branch already used --health-down
-                  // while success stayed on raw emerald, so the two halves of
-                  // one ternary disagreed (#6403).
-                  const resultClass =
-                    extrinsic.success == null
-                      ? "text-ink-muted"
-                      : extrinsic.success
-                        ? "text-health-ok"
-                        : "text-health-down";
-
-                  return (
-                    <tr
-                      key={
-                        extrinsic.extrinsic_hash ||
-                        `${extrinsic.block_number}-${extrinsic.extrinsic_index}`
-                      }
-                      className="hover:bg-surface/40"
-                    >
-                      <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
-                        {extrinsic.extrinsic_index != null
-                          ? formatNumber(extrinsic.extrinsic_index)
-                          : "—"}
-                      </td>
-                      <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted break-all">
-                        {extrinsic.extrinsic_hash ? (
-                          <Link
-                            to="/extrinsics/$hash"
-                            params={{ hash: extrinsic.extrinsic_hash }}
-                            className="font-medium text-ink-strong hover:underline"
-                          >
-                            {shortHash(extrinsic.extrinsic_hash, 10)}
-                          </Link>
-                        ) : (
-                          "—"
-                        )}
-                      </td>
-                      <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                        {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
-                      </td>
-                      <td className={`px-4 py-2.5 font-mono text-[11px] ${resultClass}`}>
-                        {result}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </SectionAnchor>
-
-      <SectionAnchor
-        id="events"
-        title="Events"
-        tone="accent"
-        right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/events`)} />}
-      >
-        {eventsQuery.isPending ? (
-          <Skeleton className="h-44" />
-        ) : eventsQuery.error ? (
-          <TableState
-            variant="error"
-            title="Couldn't load block events"
-            description="This section is optional — the rest of the block detail is unaffected."
-            error={eventsQuery.error}
-            onRetry={() => {
-              void eventsQuery.refetch();
-            }}
-          />
-        ) : events.length === 0 ? (
-          <EmptyState
-            title="No block events"
-            description="This block has no decoded on-chain events indexed yet."
-          />
-        ) : (
-          <div className="overflow-x-auto rounded border border-border bg-card">
-            <table className="w-full text-left text-sm">
-              <thead className="bg-surface/40">
-                <tr>
-                  <th className="px-4 py-2.5">Kind</th>
-                  <th className="px-4 py-2.5">Hotkey</th>
-                  <th className="px-4 py-2.5 text-right">Amount</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {events.map((event) => {
-                  const amount =
-                    event.amount_tao != null ? `${formatNumber(event.amount_tao)} τ` : "—";
-                  return (
-                    <tr
-                      key={`${event.block_number}-${event.event_index}-${event.event_kind ?? "unknown"}`}
-                      className="hover:bg-surface/40"
-                    >
-                      <td
-                        className="px-4 py-2.5 font-mono text-[11px] text-ink-strong"
-                        title={event.event_kind ?? undefined}
-                      >
-                        {eventKindLabel(event.event_kind)}
-                      </td>
-                      <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
-                        <AccountAddress ss58={event.hotkey} keep={10} compact fallback="—" />
-                      </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
-                        {amount}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </SectionAnchor>
-
-      <SectionAnchor
-        id="chain-events"
-        title="Chain events"
-        subtitle="Every raw pallet-level event in this block, decoded from the chain — broader than the curated events above, but without account/amount attribution."
-        tone="accent"
-      >
-        {chainEventsQuery.isPending ? (
-          <Skeleton className="h-44" />
-        ) : chainEventsQuery.error ? (
-          <TableState
-            variant="error"
-            title="Couldn't load block chain events"
-            description="This section is optional — the rest of the block detail is unaffected."
-            error={chainEventsQuery.error}
-            onRetry={() => {
-              void chainEventsQuery.refetch();
-            }}
-          />
-        ) : chainEvents.length === 0 ? (
-          <EmptyState
-            title="No chain events"
-            description="This block has no decoded pallet events indexed yet, or the all-events backfill hasn't reached it."
-          />
-        ) : (
-          <div className="overflow-x-auto rounded border border-border bg-card">
-            <table className="w-full text-left text-sm">
-              <thead className="bg-surface/40">
-                <tr>
-                  <th className="px-4 py-2.5">Pallet.method</th>
-                  <th className="px-4 py-2.5">Phase</th>
-                  <th className="px-4 py-2.5 text-right">Extrinsic</th>
-                  <th className="px-4 py-2.5">Args</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {chainEvents.map((event) => (
-                  <tr
-                    key={`${event.block_number}-${event.event_index}`}
-                    className="hover:bg-surface/40"
+            </FieldRow>
+            <FieldRow label="Block hash" hint={BLOCK_TERM_HINTS.blockHash}>
+              {block.block_hash ? (
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span
+                    className="font-mono text-[12px] text-ink-strong break-all md:hidden"
+                    title={block.block_hash}
                   >
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                      {extrinsicCall(event.pallet, event.method)}
-                    </td>
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                      {event.phase ?? "—"}
-                    </td>
-                    <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
-                      {event.extrinsic_index != null ? formatNumber(event.extrinsic_index) : "—"}
-                    </td>
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                      <div className="flex max-w-xs items-center gap-1.5">
-                        <span className="truncate" title={formatChainEventArgs(event.args)}>
-                          {formatChainEventArgs(event.args)}
-                        </span>
-                        <CopyButton value={formatChainEventArgs(event.args)} label="args" compact />
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </SectionAnchor>
+                    {shortHash(block.block_hash, 10)}
+                  </span>
+                  <span className="hidden md:inline font-mono text-[12px] text-ink-strong break-all">
+                    {block.block_hash}
+                  </span>
+                  <CopyButton value={block.block_hash} label="block hash" compact />
+                </div>
+              ) : (
+                <span className="text-ink-muted">—</span>
+              )}
+            </FieldRow>
+            <FieldRow label="Parent hash" hint={BLOCK_TERM_HINTS.parentHash}>
+              {block.parent_hash ? (
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <Link
+                    to="/blocks/$ref"
+                    params={{ ref: block.parent_hash }}
+                    className="font-mono text-[12px] text-ink-strong hover:underline break-all md:hidden"
+                    title={block.parent_hash}
+                  >
+                    {shortHash(block.parent_hash, 10)}
+                  </Link>
+                  <Link
+                    to="/blocks/$ref"
+                    params={{ ref: block.parent_hash }}
+                    className="hidden md:inline font-mono text-[12px] text-ink-strong hover:underline break-all"
+                  >
+                    {block.parent_hash}
+                  </Link>
+                  <CopyButton value={block.parent_hash} label="parent hash" compact />
+                </div>
+              ) : (
+                <span className="text-ink-muted">—</span>
+              )}
+            </FieldRow>
+            <FieldRow label="Author" hint={BLOCK_TERM_HINTS.author}>
+              {/* #6424: full ss58 on desktop for readability; on mobile use the
+                  shortened form so it fits without wrapping ugly on 393px. */}
+              <div className="min-w-0">
+                <div className="md:hidden">
+                  <AccountAddress
+                    ss58={block.author}
+                    keep={8}
+                    compact
+                    fallback={<span className="text-ink-muted">—</span>}
+                  />
+                </div>
+                <div className="hidden md:block">
+                  <AccountAddress
+                    ss58={block.author}
+                    truncate={false}
+                    fallback={<span className="text-ink-muted">—</span>}
+                  />
+                </div>
+              </div>
+            </FieldRow>
+            <FieldRow label="Extrinsics">
+              <span className="font-mono text-sm text-ink tabular-nums">
+                {formatNumber(block.extrinsic_count ?? 0)}
+              </span>
+            </FieldRow>
+            <FieldRow label="Events">
+              <span className="font-mono text-sm text-ink tabular-nums">
+                {formatNumber(block.event_count ?? 0)}
+              </span>
+            </FieldRow>
+            <FieldRow label="Observed at">
+              <span className="font-mono text-[12px] text-ink-muted">
+                <TimeAgo at={block.observed_at} />
+              </span>
+            </FieldRow>
+          </dl>
+        </SectionAnchor>
 
-      <div className="mt-6">
-        <Link
-          to="/blocks"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+        <SectionAnchor
+          id="metadata"
+          title="Block metadata"
+          info="Extended header fields (runtime version, storage roots) returned by the block API."
         >
-          ← All blocks
-        </Link>
-      </div>
+          <BlockMetadataPanel block={block} />
+        </SectionAnchor>
 
-      <SectionAnchor
-        id="call"
-        title="Call this endpoint"
-        subtitle="Copy a ready-to-run request for this block."
-      >
-        <EndpointSnippet
-          rows={[
-            { label: "block", path: `/api/v1/blocks/${sourceRef}` },
-            { label: "extrinsics", path: `/api/v1/blocks/${sourceRef}/extrinsics` },
-            { label: "events", path: `/api/v1/blocks/${sourceRef}/events` },
-            {
-              label: "chain events",
-              path: `/api/v1/blocks/${sourceRef}/chain-events`,
-            },
-            { label: "artifact", path: `/metagraph/blocks/${sourceRef}.json` },
+        <SectionAnchor
+          id="extrinsics"
+          title="Extrinsics"
+          info={BLOCK_SECTION_HINTS.extrinsics}
+          right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/extrinsics`)} />}
+        >
+          {extrinsicsQuery.isPending ? (
+            <Skeleton className="h-44" />
+          ) : extrinsicsQuery.error ? (
+            <TableState
+              variant="error"
+              title="Couldn't load block extrinsics"
+              description="This section is optional — the rest of the block detail is unaffected."
+              error={extrinsicsQuery.error}
+              onRetry={() => {
+                void extrinsicsQuery.refetch();
+              }}
+            />
+          ) : extrinsics.length === 0 ? (
+            <EmptyState
+              title="No block extrinsics"
+              description="This block has no indexed extrinsics (or the poller window for this shard is still catching up)."
+            />
+          ) : (
+            <div className="overflow-x-auto rounded border border-border bg-card">
+              <table className="w-full text-left text-sm">
+                <thead className="bg-surface/40">
+                  <tr>
+                    <th className="px-4 py-2.5 text-right">Index</th>
+                    <th className="px-4 py-2.5">Extrinsic</th>
+                    <th className="px-4 py-2.5">Call</th>
+                    <th className="px-4 py-2.5">Result</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {extrinsics.map((extrinsic) => {
+                    const result =
+                      extrinsic.success == null ? "—" : extrinsic.success ? "Success" : "Failed";
+                    // This table spells the result out ("Success"/"Failed")
+                    // rather than the feeds' "ok"/"fail", so it keeps its own
+                    // rendering instead of the shared SuccessBadge -- swapping it
+                    // in would silently reword the page. What it borrows is the
+                    // token pair: the fail branch already used --health-down
+                    // while success stayed on raw emerald, so the two halves of
+                    // one ternary disagreed (#6403).
+                    const resultClass =
+                      extrinsic.success == null
+                        ? "text-ink-muted"
+                        : extrinsic.success
+                          ? "text-health-ok"
+                          : "text-health-down";
+
+                    return (
+                      <tr
+                        key={
+                          extrinsic.extrinsic_hash ||
+                          `${extrinsic.block_number}-${extrinsic.extrinsic_index}`
+                        }
+                        className="mg-row-accent hover:bg-surface/40"
+                      >
+                        <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                          {extrinsic.extrinsic_index != null
+                            ? formatNumber(extrinsic.extrinsic_index)
+                            : "—"}
+                        </td>
+                        <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted break-all">
+                          {extrinsic.extrinsic_hash ? (
+                            <Link
+                              to="/extrinsics/$hash"
+                              params={{ hash: extrinsic.extrinsic_hash }}
+                              className="font-medium text-ink-strong hover:underline"
+                            >
+                              {shortHash(extrinsic.extrinsic_hash, 10)}
+                            </Link>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                        <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+                          {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
+                        </td>
+                        <td className={`px-4 py-2.5 font-mono text-[11px] ${resultClass}`}>
+                          {result}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </SectionAnchor>
+
+        <SectionAnchor
+          id="events"
+          title="Events"
+          info={BLOCK_SECTION_HINTS.events}
+          subtitle="Grouped by parent extrinsic. System events (fees, deposits, ExtrinsicSuccess) are collapsed by default."
+          right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/events`)} />}
+        >
+          {eventsQuery.isPending ? (
+            <Skeleton className="h-44" />
+          ) : eventsQuery.error ? (
+            <TableState
+              variant="error"
+              title="Couldn't load block events"
+              description="This section is optional — the rest of the block detail is unaffected."
+              error={eventsQuery.error}
+              onRetry={() => {
+                void eventsQuery.refetch();
+              }}
+            />
+          ) : events.length === 0 ? (
+            <EmptyState
+              title="No block events"
+              description="This block has no decoded on-chain events indexed yet."
+            />
+          ) : (
+            <GroupedEvents events={events} extrinsics={extrinsics} />
+          )}
+        </SectionAnchor>
+
+        {chainEvents.length > 0 ? (
+          <SectionAnchor
+            id="pallets"
+            title="Pallet · method breakdown"
+            info="Ranked runtime pallet.method calls emitted by this block."
+          >
+            <PalletMethodBreakdown events={chainEvents} />
+          </SectionAnchor>
+        ) : null}
+
+        <SectionAnchor
+          id="chain-events"
+          title="Chain events (raw)"
+          info={BLOCK_SECTION_HINTS.chainEventsRaw}
+          subtitle="Curated events above are grouped by extrinsic; this table is the raw per-event stream — every pallet-level event in the block, decoded from the chain."
+        >
+          <details className="group rounded border border-border bg-card">
+            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+              <span>
+                {chainEventsQuery.isPending
+                  ? "Loading raw events…"
+                  : `${formatNumber(chainEvents.length)} raw pallet events`}
+              </span>
+              <span className="font-mono text-[10px] uppercase tracking-wider">
+                <span className="group-open:hidden">Show</span>
+                <span className="hidden group-open:inline">Hide</span>
+              </span>
+            </summary>
+            <div className="border-t border-border p-2">
+              {chainEventsQuery.isPending ? (
+                <Skeleton className="h-44" />
+              ) : chainEventsQuery.error ? (
+                <TableState
+                  variant="error"
+                  title="Couldn't load block chain events"
+                  description="This section is optional — the rest of the block detail is unaffected."
+                  error={chainEventsQuery.error}
+                  onRetry={() => {
+                    void chainEventsQuery.refetch();
+                  }}
+                />
+              ) : chainEvents.length === 0 ? (
+                <EmptyState
+                  title="No chain events"
+                  description="This block has no decoded pallet events indexed yet, or the all-events backfill hasn't reached it."
+                />
+              ) : (
+                <div className="overflow-x-auto rounded border border-border bg-card">
+                  <table className="w-full text-left text-sm">
+                    <thead className="bg-surface/40">
+                      <tr>
+                        <th className="px-4 py-2.5">Pallet.method</th>
+                        <th className="px-4 py-2.5">Phase</th>
+                        <th className="px-4 py-2.5 text-right">Extrinsic</th>
+                        <th className="px-4 py-2.5">Args</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {chainEvents.map((event) => (
+                        <tr
+                          key={`${event.block_number}-${event.event_index}`}
+                          className="mg-row-accent hover:bg-surface/40"
+                        >
+                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+                            {extrinsicCall(event.pallet, event.method)}
+                          </td>
+                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                            {event.phase ?? "—"}
+                          </td>
+                          <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
+                            {event.extrinsic_index != null
+                              ? formatNumber(event.extrinsic_index)
+                              : "—"}
+                          </td>
+                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                            <div className="flex max-w-xs items-center gap-1.5">
+                              <span className="truncate" title={formatChainEventArgs(event.args)}>
+                                {formatChainEventArgs(event.args)}
+                              </span>
+                              <CopyButton
+                                value={formatChainEventArgs(event.args)}
+                                label="args"
+                                compact
+                              />
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </details>
+        </SectionAnchor>
+
+        <SectionAnchor
+          id="call"
+          title="Call this endpoint"
+          info={BLOCK_SECTION_HINTS.call}
+          subtitle="Copy a ready-to-run request for this block."
+        >
+          <details className="group rounded border border-border bg-card">
+            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+              <span>API &amp; artifact URLs</span>
+              <span className="font-mono text-[10px] uppercase tracking-wider">
+                <span className="group-open:hidden">Show</span>
+                <span className="hidden group-open:inline">Hide</span>
+              </span>
+            </summary>
+            <div className="border-t border-border p-3">
+              <EndpointSnippet
+                rows={[
+                  { label: "block", path: `/api/v1/blocks/${sourceRef}` },
+                  { label: "extrinsics", path: `/api/v1/blocks/${sourceRef}/extrinsics` },
+                  { label: "events", path: `/api/v1/blocks/${sourceRef}/events` },
+                  {
+                    label: "chain events",
+                    path: `/api/v1/blocks/${sourceRef}/chain-events`,
+                  },
+                  { label: "artifact", path: `/metagraph/blocks/${sourceRef}.json` },
+                ]}
+              />
+            </div>
+          </details>
+        </SectionAnchor>
+
+        <ApiSourceFooter
+          paths={[
+            `/api/v1/blocks/${sourceRef}`,
+            `/api/v1/blocks/${sourceRef}/extrinsics`,
+            `/api/v1/blocks/${sourceRef}/events`,
+            `/api/v1/blocks/${sourceRef}/chain-events`,
           ]}
+          artifacts={[`/metagraph/blocks/${sourceRef}.json`]}
         />
-      </SectionAnchor>
-
-      <ApiSourceFooter
-        paths={[
-          `/api/v1/blocks/${sourceRef}`,
-          `/api/v1/blocks/${sourceRef}/extrinsics`,
-          `/api/v1/blocks/${sourceRef}/events`,
-          `/api/v1/blocks/${sourceRef}/chain-events`,
-        ]}
-        artifacts={[`/metagraph/blocks/${sourceRef}.json`]}
-      />
+      </div>
     </>
   );
 }
 
-function FieldRow({ label, children }: { label: string; children: ReactNode }) {
+type EventItem = {
+  block_number?: number | null;
+  event_index?: number | null;
+  event_kind?: string | null;
+  hotkey?: string | null;
+  amount_tao?: number | null;
+  extrinsic_index?: number | null;
+};
+
+type ExtrinsicItem = {
+  block_number?: number | null;
+  extrinsic_index?: number | null;
+  extrinsic_hash?: string | null;
+  call_module?: string | null;
+  call_function?: string | null;
+  success?: boolean | null;
+};
+
+function GroupedEvents({
+  events,
+  extrinsics,
+}: {
+  events: EventItem[];
+  extrinsics: ExtrinsicItem[];
+}) {
+  const groups = useMemo(() => {
+    const byIndex = new Map<number | "system", EventItem[]>();
+    for (const ev of events) {
+      const key: number | "system" = ev.extrinsic_index ?? "system";
+      const arr = byIndex.get(key) ?? [];
+      arr.push(ev);
+      byIndex.set(key, arr);
+    }
+    const extrinsicByIndex = new Map<number, ExtrinsicItem>();
+    for (const x of extrinsics) {
+      if (x.extrinsic_index != null) extrinsicByIndex.set(x.extrinsic_index, x);
+    }
+    const numeric = Array.from(byIndex.entries())
+      .filter(([k]) => k !== "system")
+      .map(([k, list]) => ({
+        key: `x-${k}` as const,
+        index: k as number,
+        list,
+        extrinsic: extrinsicByIndex.get(k as number) ?? null,
+        isSystem: false,
+        hasHotkey: list.some((e) => e.hotkey),
+      }))
+      .sort((a, b) => a.index - b.index);
+    const system = byIndex.get("system");
+    const systemGroup = system
+      ? [
+          {
+            key: "system" as const,
+            index: -1,
+            list: system,
+            extrinsic: null,
+            isSystem: true,
+            hasHotkey: system.some((e) => e.hotkey),
+          },
+        ]
+      : [];
+    return [...numeric, ...systemGroup];
+  }, [events, extrinsics]);
+
+  const defaultOpen = useMemo(() => {
+    const s = new Set<string>();
+    for (const g of groups) if (g.hasHotkey && !g.isSystem) s.add(g.key);
+    return s;
+  }, [groups]);
+
+  const [open, setOpen] = useState<Set<string>>(defaultOpen);
+  const allOpen = open.size === groups.length;
+  const [focusIdx, setFocusIdx] = useState(0);
+  const btnRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const toggle = useCallback((key: string) => {
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const onHeaderKey = (i: number, key: string) => (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Home" || e.key === "End") {
+      const next = nextTabIndex(i, e.key, groups.length);
+      if (next == null) return;
+      e.preventDefault();
+      setFocusIdx(next);
+      btnRefs.current[next]?.focus();
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setOpen((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setOpen((prev) => {
+        if (!prev.has(key)) return prev;
+        const n = new Set(prev);
+        n.delete(key);
+        return n;
+      });
+    }
+  };
+
+  return (
+    <div className="rounded border border-border bg-card">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="mg-label">
+          {groups.length} extrinsic{groups.length === 1 ? "" : "s"} · {events.length} event
+          {events.length === 1 ? "" : "s"}
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(allOpen ? new Set() : new Set(groups.map((g) => g.key)))}
+          className="text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
+        >
+          {allOpen ? "Collapse all" : "Expand all"}
+        </button>
+      </div>
+      <ul
+        className="divide-y divide-border"
+        role="tree"
+        aria-label="Extrinsics and events. Use up and down to move, right to expand, left to collapse."
+      >
+        {groups.map((g, i) => {
+          const isOpen = open.has(g.key);
+          const showHotkeyCol = g.list.some((e) => e.hotkey);
+          const title = g.isSystem
+            ? "System events"
+            : g.extrinsic
+              ? extrinsicCall(g.extrinsic.call_module, g.extrinsic.call_function)
+              : "Unknown extrinsic";
+          const success = g.extrinsic?.success;
+          return (
+            <li key={g.key} role="treeitem" aria-expanded={isOpen}>
+              <button
+                ref={(el) => {
+                  btnRefs.current[i] = el;
+                }}
+                type="button"
+                tabIndex={i === focusIdx ? 0 : -1}
+                onFocus={() => setFocusIdx(i)}
+                onKeyDown={onHeaderKey(i, g.key)}
+                onClick={() => {
+                  setFocusIdx(i);
+                  toggle(g.key);
+                }}
+                className="flex w-full items-center gap-2 sm:gap-3 px-3 py-2.5 text-left hover:bg-surface/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-expanded={isOpen}
+              >
+                {isOpen ? (
+                  <ChevronDown className="size-3.5 shrink-0 text-ink-muted" />
+                ) : (
+                  <ChevronRight className="size-3.5 shrink-0 text-ink-muted" />
+                )}
+                <span className="font-mono text-[11px] tabular-nums text-ink-muted w-8 sm:w-10 shrink-0">
+                  {g.isSystem ? "sys" : `#${g.index}`}
+                </span>
+                <span className="font-mono text-[11px] text-ink-strong truncate min-w-0 flex-1">
+                  {title}
+                </span>
+                {success != null ? (
+                  <span
+                    className={`hidden sm:inline font-mono text-[10px] uppercase tracking-wider ${success ? "text-health-ok" : "text-health-down"}`}
+                  >
+                    {success ? "success" : "failed"}
+                  </span>
+                ) : null}
+                <span className="mg-label shrink-0 hidden sm:inline">
+                  {g.list.length} evt{g.list.length === 1 ? "" : "s"}
+                </span>
+                {g.extrinsic?.extrinsic_hash ? (
+                  <Link
+                    to="/extrinsics/$hash"
+                    params={{ hash: g.extrinsic.extrinsic_hash }}
+                    onClick={(e) => e.stopPropagation()}
+                    className="hidden sm:inline font-mono text-[10px] text-ink-muted hover:text-ink-strong hover:underline shrink-0"
+                    title={g.extrinsic.extrinsic_hash}
+                  >
+                    {shortHash(g.extrinsic.extrinsic_hash, 6)}
+                  </Link>
+                ) : null}
+              </button>
+              {isOpen ? (
+                <div className="border-t border-border bg-surface/20 px-3 py-2">
+                  <table className="w-full text-left text-sm">
+                    <thead>
+                      <tr className="text-[10px] uppercase tracking-wider text-ink-muted">
+                        <th className="px-2 py-1.5 font-normal">Kind</th>
+                        {showHotkeyCol ? <th className="px-2 py-1.5 font-normal">Hotkey</th> : null}
+                        <th className="px-2 py-1.5 text-right font-normal">Amount</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {g.list.map((event) => (
+                        <tr
+                          key={`${event.block_number}-${event.event_index}-${event.event_kind ?? "unknown"}`}
+                        >
+                          <td
+                            className="px-2 py-1.5 font-mono text-[11px] text-ink-strong"
+                            title={event.event_kind ?? undefined}
+                          >
+                            {eventKindLabel(event.event_kind)}
+                          </td>
+                          {showHotkeyCol ? (
+                            <td className="px-2 py-1.5 font-mono text-[11px] text-ink">
+                              <AccountAddress
+                                ss58={event.hotkey}
+                                keep={10}
+                                compact
+                                fallback={<span className="text-ink-muted">—</span>}
+                              />
+                            </td>
+                          ) : null}
+                          <td className="px-2 py-1.5 text-right tabular-nums text-ink">
+                            {event.amount_tao != null ? (
+                              <TaoValue amount={event.amount_tao} layout="stacked" precision={4} />
+                            ) : (
+                              <span className="font-mono text-[11px] text-ink-muted">—</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function ValueUnitControl() {
+  const { unit, setUnit } = useValueUnit();
+  const opts: Array<{ v: ValueUnit; label: string; title: string }> = [
+    { v: "tao", label: "τ", title: "Show TAO only" },
+    { v: "usd", label: "$", title: "Show USD only" },
+    { v: "both", label: "Both", title: "Show TAO and USD" },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Value display unit"
+      className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
+    >
+      {opts.map((o) => {
+        const active = o.v === unit;
+        return (
+          <button
+            key={o.v}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            title={o.title}
+            onClick={() => setUnit(o.v)}
+            className={
+              "inline-flex items-center rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8 " +
+              (active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong")
+            }
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function JumpToBlock() {
+  const navigate = useNavigate();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  return (
+    <form
+      role="search"
+      aria-label="Jump to block"
+      className="flex items-center gap-1"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const v = value.trim();
+        if (!v) return;
+        if (!isValidBlockRef(v)) {
+          setError("Enter a decimal block number or 0x… hash");
+          return;
+        }
+        setError(null);
+        navigate({ to: "/blocks/$ref", params: { ref: v } });
+        setValue("");
+      }}
+    >
+      <label className="sr-only" htmlFor="jump-to-block">
+        Jump to block
+      </label>
+      <input
+        id="jump-to-block"
+        type="text"
+        inputMode="numeric"
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          if (error) setError(null);
+        }}
+        placeholder="Jump to # or 0x…"
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? "jump-to-block-err" : undefined}
+        className="mg-focus-ring h-8 w-40 rounded border border-border bg-paper px-2 font-mono text-[12px] tabular-nums text-ink-strong placeholder:text-ink-subtle sm:w-48"
+      />
+      <Kbd>↵</Kbd>
+      {error ? (
+        <span
+          id="jump-to-block-err"
+          role="alert"
+          className="ml-1 font-mono text-[10px] text-health-down"
+        >
+          {error}
+        </span>
+      ) : null}
+    </form>
+  );
+}
+
+function FieldRow({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
   return (
     <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-      <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted sm:w-40 sm:shrink-0">
-        {label}
+      <dt className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted sm:w-40 sm:shrink-0">
+        <span>{label}</span>
+        {hint ? <InfoTooltip label={hint} /> : null}
       </dt>
       <dd className="min-w-0">{children}</dd>
     </div>

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -1,36 +1,44 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Timer, Activity, Users, SlidersHorizontal } from "lucide-react";
+import { Timer, Activity, Users } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import {
+  AsyncPanel,
+  TableSkeleton,
+  PagerFooter,
+  MetricGrid,
+  PanelSkeleton,
+  QueryBar,
+  FilterSheet,
+  FilterChipRow,
+  type FilterChipItem,
+  PageMasthead,
+} from "@/components/metagraphed/primitives";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState } from "@/components/metagraphed/states";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import {
   TimeAgo,
-  PageHero,
   ListShell,
   ShareButton,
   DownloadCsvButton,
   ActionBar,
   StatTile,
-  Sparkline,
   CopyButton,
   CopyableCode,
-  PagerBar,
+  BackToTop,
 } from "@jsonbored/ui-kit";
-import {
-  PageSizeSelect,
-  ResetFiltersButton,
-  SearchInput,
-} from "@/components/metagraphed/table-controls";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { blocksQuery, blocksSummaryQuery, chainActivityQuery } from "@/lib/metagraphed/queries";
+import { PageSizeSelect } from "@/components/metagraphed/table-controls";
+import { LiveBlockRail } from "@/components/metagraphed/blocks/live-block-rail";
+import { CadenceHeatmap } from "@/components/metagraphed/blocks/cadence-heatmap";
+import { AuthorSharePanel } from "@/components/metagraphed/blocks/author-share-panel";
+import { RuntimeTimeline } from "@/components/metagraphed/blocks/runtime-timeline";
+import { blocksQuery, blocksSummaryQuery, metagraphedQueryKey } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
-import { activeFilterCount, filterToggleLabel } from "@/lib/metagraphed/filter-disclosure";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -92,84 +100,58 @@ function BlocksPage() {
 
   return (
     <AppShell>
-      <PageHero
+      <PageMasthead
         eyebrow="Explorer"
         live
         title="Blocks"
         description="Recent Bittensor blocks indexed directly from the chain — newest first, with author, extrinsic, and event counts."
         actions={
-          <>
-            <ActionBar>
-              <DownloadCsvButton url={blocksCsvUrl} bare />
-              <ShareButton bare />
-            </ActionBar>
-          </>
+          <ActionBar>
+            <DownloadCsvButton url={blocksCsvUrl} bare />
+            <ShareButton bare />
+          </ActionBar>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-24 w-full mb-3" />}>
-          <BlockThroughputCard />
-        </Suspense>
-      </QueryErrorBoundary>
-      <QueryErrorBoundary>
-        <Suspense
-          fallback={
-            // Shaped to BlockProductionHeader's own 3-tile grid (#6388), matching
-            // subnets.index.tsx's tile-skeleton convention -- a single flat box
-            // here visibly jumps in height/columns once the real 1/3-col grid
-            // of StatTiles resolves.
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-            </div>
-          }
-        >
-          <BlockProductionHeader />
-        </Suspense>
-      </QueryErrorBoundary>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-          <BlocksTable />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="Live block rail"
+        retryQueryKeys={[metagraphedQueryKey("blocks"), metagraphedQueryKey("chain-activity")]}
+        fallback={<PanelSkeleton height="sm" className="mb-3" />}
+      >
+        <LiveBlockRail />
+      </AsyncPanel>
+      <AsyncPanel
+        context="Block production"
+        retryQueryKeys={[metagraphedQueryKey("blocks-summary")]}
+        fallback={
+          <div className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-3">
+            <PanelSkeleton height="sm" />
+            <PanelSkeleton height="sm" />
+            <PanelSkeleton height="sm" />
+          </div>
+        }
+      >
+        <BlockProductionHeader />
+      </AsyncPanel>
+      <AsyncPanel
+        context="Runtime upgrades"
+        retryQueryKeys={[metagraphedQueryKey("runtime-version-history")]}
+        fallback={<PanelSkeleton height="sm" className="mb-6" />}
+      >
+        <RuntimeTimeline />
+      </AsyncPanel>
+      <AsyncPanel
+        context="Blocks table"
+        retryQueryKeys={[metagraphedQueryKey("blocks")]}
+        fallback={<TableSkeleton rows={10} columns={6} />}
+      >
+        <BlocksTable />
+      </AsyncPanel>
       <ApiSourceFooter
         paths={["/api/v1/blocks", "/api/v1/blocks/summary", "/api/v1/chain/activity"]}
         artifacts={["/metagraph/blocks.json", "/metagraph/blocks/summary.json"]}
       />
+      <BackToTop />
     </AppShell>
-  );
-}
-
-// #3390: block-throughput sparkline — daily block_count over the default window
-// from /api/v1/chain/activity (the source explorer.tsx already uses), rendered as
-// a compact card directly above the production-stats header so the throughput
-// trend sits with the other block-production metrics (no separate hero KPI).
-function BlockThroughputCard() {
-  const chrono = [...useSuspenseQuery(chainActivityQuery()).data.data.days].reverse();
-  const blockCounts = chrono.map((d) => d.block_count);
-  if (blockCounts.length === 0) return null;
-  const totalBlocks = blockCounts.reduce((acc, n) => acc + n, 0);
-  return (
-    <div className="mb-3 flex items-center justify-between gap-4 rounded-lg border border-border bg-card p-4">
-      <div>
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Blocks / day
-        </div>
-        <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink-strong">
-          {formatNumber(totalBlocks)}
-          <span className="ml-1.5 text-sm font-normal text-ink-muted">total</span>
-        </div>
-      </div>
-      <Sparkline
-        values={blockCounts}
-        points={chrono.map((d) => ({ t: d.day, v: d.block_count }))}
-        width={220}
-        height={44}
-        ariaLabel="Daily block throughput, oldest to newest"
-        formatValue={formatNumber}
-      />
-    </div>
   );
 }
 
@@ -184,10 +166,7 @@ function BlockProductionHeader() {
   const nakamoto = summary.author_concentration?.nakamoto_coefficient;
   const nakamotoStatTone = nakamotoTone(nakamoto);
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
-      {/* #6905: full-width tiles on mobile (grid-cols-1) so each label/hint fits
-          on one line instead of clipping mid-word in the old 2-col grid's cramped
-          ~165px cells; md+ keeps the 3-up row. */}
+    <MetricGrid cols={{ base: 1, sm: 2, md: 3 }} gap="md" className="mb-8">
       <StatTile
         icon={Timer}
         eyebrow="Inter-block time"
@@ -197,7 +176,6 @@ function BlockProductionHeader() {
       <StatTile
         icon={Activity}
         eyebrow="Throughput"
-        // #3940: bare number like the sibling tiles -- unit + secondary metric live in the hint.
         value={throughput ? formatNumber(throughput.mean_extrinsics_per_block) : "—"}
         hint={
           throughput
@@ -212,7 +190,7 @@ function BlockProductionHeader() {
         hint="Nakamoto coefficient"
         tone={nakamotoStatTone}
       />
-    </div>
+    </MetricGrid>
   );
 }
 
@@ -228,6 +206,11 @@ function BlocksTable() {
   const refetchInterval = useRefetchInterval(15_000, search.offset === 0);
   const rows = (useSuspenseQuery({ ...blocksQuery(queryParams), refetchInterval }).data.data ??
     []) as Block[];
+
+  // Per-page maxima drive the inline activity bars in the Extrinsics/Events
+  // cells so scanning "which blocks were busy" is a visual, not numeric, task.
+  const maxExt = Math.max(1, ...rows.map((b) => b.extrinsic_count ?? 0));
+  const maxEvt = Math.max(1, ...rows.map((b) => b.event_count ?? 0));
 
   // Offset pagination: the API returns newest-first pages with no total. A full
   // page (rows === limit) implies more may exist; a short page is the tail.
@@ -253,115 +236,207 @@ function BlocksTable() {
     search.min_events,
   );
 
-  const activeCount = activeFilterCount([
-    search.author,
-    search.spec_version,
-    search.block_start,
-    search.block_end,
-    search.min_extrinsics,
-    search.min_events,
-  ]);
-  // Six placeholder-only inputs stacked to ~a full 375px screen before any block
-  // row was visible (#5323). Collapse them behind a toggle on mobile — open by
-  // default when a filter is already applied (e.g. a shared URL), so the reason
-  // the list is narrowed is never hidden.
-  const [filtersOpen, setFiltersOpen] = useState(activeCount > 0);
+  const secondaryFilterCount =
+    (search.spec_version ? 1 : 0) +
+    (search.block_start ? 1 : 0) +
+    (search.block_end ? 1 : 0) +
+    (search.min_extrinsics ? 1 : 0) +
+    (search.min_events ? 1 : 0);
+  const activeCount = (search.author ? 1 : 0) + secondaryFilterCount;
+
+  const resetAll = () =>
+    setSearch({
+      author: "",
+      spec_version: "",
+      block_start: "",
+      block_end: "",
+      min_extrinsics: "",
+      min_events: "",
+      offset: 0,
+    });
+
+  const chipItems: FilterChipItem[] = [];
+  if (search.author)
+    chipItems.push({
+      id: "author",
+      label: "Author",
+      value: shortHash(search.author) ?? search.author,
+    });
+  if (search.spec_version)
+    chipItems.push({ id: "spec_version", label: "Spec", value: search.spec_version });
+  if (search.block_start || search.block_end)
+    chipItems.push({
+      id: "range",
+      label: "Range",
+      value: `${search.block_start || "…"} → ${search.block_end || "…"}`,
+    });
+  if (search.min_extrinsics)
+    chipItems.push({ id: "min_extrinsics", label: "Min ext", value: `≥ ${search.min_extrinsics}` });
+  if (search.min_events)
+    chipItems.push({ id: "min_events", label: "Min evt", value: `≥ ${search.min_events}` });
+
+  const removeChip = (id: string) => {
+    switch (id) {
+      case "author":
+        setSearch({ author: "", offset: 0 });
+        break;
+      case "spec_version":
+        setSearch({ spec_version: "", offset: 0 });
+        break;
+      case "range":
+        setSearch({ block_start: "", block_end: "", offset: 0 });
+        break;
+      case "min_extrinsics":
+        setSearch({ min_extrinsics: "", offset: 0 });
+        break;
+      case "min_events":
+        setSearch({ min_events: "", offset: 0 });
+        break;
+    }
+  };
+
+  const numericInputCls =
+    "w-full rounded border border-border bg-paper px-2 py-1.5 font-mono text-sm text-ink-strong placeholder:text-ink-muted focus:outline-none focus:border-accent/50 focus:ring-2 focus:ring-ring transition-colors";
 
   const filters = (
-    <>
-      <button
-        type="button"
-        onClick={() => setFiltersOpen((open) => !open)}
-        aria-expanded={filtersOpen}
-        aria-controls="blocks-filter-fields"
-        className="md:hidden inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-2.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors"
-      >
-        <SlidersHorizontal className="size-3" aria-hidden="true" />
-        {filterToggleLabel(activeCount)}
-      </button>
-      {/* `md:contents` dissolves this wrapper at md and up, so the fields lay out
-          as direct children of the filter bar exactly as they did before — the
-          collapse is mobile-only. */}
-      <div
-        id="blocks-filter-fields"
-        className={classNames(
-          "w-full flex-wrap items-center gap-2 md:contents",
-          filtersOpen ? "flex" : "hidden",
-        )}
-      >
-        <span
-          className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
-          title="Blocks are listed newest first"
-        >
-          <span aria-hidden="true">↓ </span>Newest first
-        </span>
-        <SearchInput
-          value={search.author}
-          onChange={(v) => setSearch({ author: v, offset: 0 })}
-          placeholder="Author ss58…"
-        />
-        <SearchInput
-          value={search.spec_version}
-          onChange={(v) => setSearch({ spec_version: v, offset: 0 })}
-          placeholder="Spec version…"
-          inputMode="numeric"
-          // SearchInput's own base hardcodes `min-w-[180px]` unconditionally, which
-          // wins the same-property (min-width) cascade over a plain `min-w-[120px]`
-          // override here regardless of prop order (classNames() is a plain
-          // string-join, not tailwind-merge-aware -- see #6904); the trailing `!`
-          // forces this narrower floor to actually apply so max-w-[140px] can take
-          // effect as intended for this compact numeric filter.
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <SearchInput
-          value={search.block_start}
-          onChange={(v) => setSearch({ block_start: v.replace(/[^0-9]/g, ""), offset: 0 })}
-          placeholder="Block from…"
-          inputMode="numeric"
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <SearchInput
-          value={search.block_end}
-          onChange={(v) => setSearch({ block_end: v.replace(/[^0-9]/g, ""), offset: 0 })}
-          placeholder="Block to…"
-          inputMode="numeric"
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <SearchInput
-          value={search.min_extrinsics}
-          onChange={(v) => setSearch({ min_extrinsics: v.replace(/[^0-9]/g, ""), offset: 0 })}
-          placeholder="Min extrinsics…"
-          inputMode="numeric"
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <SearchInput
-          value={search.min_events}
-          onChange={(v) => setSearch({ min_events: v.replace(/[^0-9]/g, ""), offset: 0 })}
-          placeholder="Min events…"
-          inputMode="numeric"
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <PageSizeSelect
-          value={search.limit}
-          onChange={(n) => setSearch({ limit: n, offset: 0 })}
-          options={[10, 25, 50, 100]}
-        />
-        <ResetFiltersButton
-          active={filtersActive}
-          onReset={() =>
-            setSearch({
-              author: "",
-              spec_version: "",
-              block_start: "",
-              block_end: "",
-              min_extrinsics: "",
-              min_events: "",
-              offset: 0,
-            })
-          }
-        />
+    <div className="flex w-full flex-col gap-0 min-w-0">
+      <div className="flex w-full items-center gap-2 min-w-0">
+        <QueryBar className="flex-1 min-w-0">
+          <QueryBar.Search
+            value={search.author}
+            onChange={(v) => setSearch({ author: v, offset: 0 })}
+            placeholder="Search by author ss58…"
+            shortcut
+            debounceMs={200}
+          />
+          <QueryBar.Divider />
+          <QueryBar.Utility className="ml-auto">
+            <span
+              className="hidden sm:inline font-mono text-[10px] uppercase tracking-widest text-ink-muted"
+              title="Blocks are always listed newest first"
+            >
+              ↓ Newest
+            </span>
+            <PageSizeSelect
+              value={search.limit}
+              onChange={(n) => setSearch({ limit: n, offset: 0 })}
+              options={[10, 25, 50, 100]}
+            />
+          </QueryBar.Utility>
+        </QueryBar>
+        <FilterSheet label="Filters" activeCount={secondaryFilterCount}>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Spec version
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.spec_version}
+                onChange={(e) =>
+                  setSearch({ spec_version: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 268"
+                className={numericInputCls}
+              />
+            </label>
+            <div className="hidden sm:block" aria-hidden />
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Block from
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.block_start}
+                onChange={(e) =>
+                  setSearch({ block_start: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 6000000"
+                className={numericInputCls}
+              />
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Block to
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.block_end}
+                onChange={(e) =>
+                  setSearch({ block_end: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 6100000"
+                className={numericInputCls}
+              />
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Min extrinsics
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.min_extrinsics}
+                onChange={(e) =>
+                  setSearch({ min_extrinsics: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 5"
+                className={numericInputCls}
+              />
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Min events
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.min_events}
+                onChange={(e) =>
+                  setSearch({ min_events: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 20"
+                className={numericInputCls}
+              />
+            </label>
+          </div>
+          {secondaryFilterCount > 0 ? (
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={() =>
+                  setSearch({
+                    spec_version: "",
+                    block_start: "",
+                    block_end: "",
+                    min_extrinsics: "",
+                    min_events: "",
+                    offset: 0,
+                  })
+                }
+                className="rounded border border-border bg-card px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-accent/40 hover:text-ink-strong transition-colors"
+              >
+                Clear numeric filters
+              </button>
+            </div>
+          ) : null}
+        </FilterSheet>
       </div>
-    </>
+      <QueryBar.MetaRow
+        count={rows.length}
+        noun="blocks"
+        activeCount={activeCount}
+        onReset={filtersActive ? resetAll : undefined}
+      />
+      <FilterChipRow
+        items={chipItems}
+        onRemove={removeChip}
+        onClearAll={activeCount > 1 ? resetAll : undefined}
+      />
+    </div>
   );
 
   const emptyNode = (
@@ -377,115 +452,207 @@ function BlocksTable() {
   );
 
   const footerNode = (
-    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 text-[11px] font-mono text-ink-muted">
-      <span>
-        {rows.length
-          ? `${formatNumber(search.offset + 1)}–${formatNumber(search.offset + rows.length)}`
-          : "0"}
-      </span>
-      <PagerBar hasPrev={hasPrev} hasNext={hasNext} onPrev={goPrev} onNext={goNext} />
+    <div className="px-4 py-2">
+      <PagerFooter
+        summary={
+          rows.length
+            ? `${formatNumber(search.offset + 1)}–${formatNumber(search.offset + rows.length)}`
+            : "0"
+        }
+        hasPrev={hasPrev}
+        hasNext={hasNext}
+        onPrev={goPrev}
+        onNext={goNext}
+      />
     </div>
   );
 
   return (
-    <ListShell
-      filters={filters}
-      isEmpty={rows.length === 0}
-      empty={emptyNode}
-      cards={rows.map((b) => (
-        <Link
-          key={b.block_hash || b.block_number}
-          to="/blocks/$ref"
-          params={{ ref: String(b.block_number) }}
-          className="block rounded border border-border bg-card p-3 min-h-11 active:bg-surface"
-        >
-          <div className="flex items-center justify-between gap-2">
-            <div className="font-mono text-sm font-medium text-ink-strong">
-              #{formatNumber(b.block_number)}
+    <>
+      {rows.length > 0 ? (
+        <>
+          <CadenceHeatmap rows={rows} />
+          <AuthorSharePanel rows={rows} />
+        </>
+      ) : null}
+      <ListShell
+        filters={filters}
+        isEmpty={rows.length === 0}
+        empty={emptyNode}
+        cards={rows.map((b) => (
+          <Link
+            key={b.block_hash || b.block_number}
+            to="/blocks/$ref"
+            params={{ ref: String(b.block_number) }}
+            className="block rounded border border-border bg-card p-3 min-h-11 active:bg-surface"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="font-mono text-sm font-medium text-ink-strong">
+                #{formatNumber(b.block_number)}
+              </div>
+              <span className="font-mono text-[11px] text-ink-muted">
+                <TimeAgo at={b.observed_at} />
+              </span>
             </div>
-            <span className="font-mono text-[11px] text-ink-muted">
-              <TimeAgo at={b.observed_at} />
-            </span>
-          </div>
-          <div className="mt-1 font-mono text-[11px] text-ink-muted truncate">
-            {shortHash(b.block_hash)}
-          </div>
-          <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
-            <span>{shortHash(b.author) ?? "no author"}</span>
-            <span>{formatNumber(b.extrinsic_count ?? 0)} ext</span>
-            <span>{formatNumber(b.event_count ?? 0)} evt</span>
-          </div>
-        </Link>
-      ))}
-      table={
-        <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
-            <tr>
-              <th className="px-4 py-2.5">Block</th>
-              <th className="px-4 py-2.5">Hash</th>
-              <th className="px-4 py-2.5">Author</th>
-              <th className="px-4 py-2.5 text-right">Extrinsics</th>
-              <th className="px-4 py-2.5 text-right">Events</th>
-              <th className="px-4 py-2.5 text-right">Observed</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border">
-            {rows.map((b) => (
-              <tr
-                key={b.block_hash || b.block_number}
-                className="mg-row-accent hover:bg-surface/40"
-              >
-                <td className="px-4 py-2.5 font-mono text-[12px]">
-                  <Link
-                    to="/blocks/$ref"
-                    params={{ ref: String(b.block_number) }}
-                    className="font-medium text-ink-strong hover:underline"
-                  >
-                    #{formatNumber(b.block_number)}
-                  </Link>
-                </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  <span className="inline-flex items-center gap-1 min-w-0">
-                    <Link
-                      to="/blocks/$ref"
-                      params={{ ref: b.block_hash || String(b.block_number) }}
-                      className="hover:text-ink-strong truncate"
-                      title={b.block_hash}
-                    >
-                      {shortHash(b.block_hash)}
-                    </Link>
-                    {b.block_hash ? (
-                      <CopyButton value={b.block_hash} label="block hash" compact />
-                    ) : null}
-                  </span>
-                </td>
-                <td
-                  className="px-4 py-2.5 font-mono text-[11px] text-ink-muted"
-                  title={b.author ?? undefined}
-                >
-                  <AccountAddress
-                    ss58={b.author}
-                    compact
-                    fallback={
-                      b.author ? <CopyableCode value={b.author} className="max-w-full" /> : "—"
-                    }
-                  />
-                </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
-                  {formatNumber(b.extrinsic_count ?? 0)}
-                </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
-                  {formatNumber(b.event_count ?? 0)}
-                </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
-                  <TimeAgo at={b.observed_at} />
-                </td>
+            <div className="mt-1 font-mono text-[11px] text-ink-muted truncate">
+              {shortHash(b.block_hash)}
+            </div>
+            <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
+              <span>{shortHash(b.author) ?? "no author"}</span>
+              <span>{formatNumber(b.extrinsic_count ?? 0)} ext</span>
+              <span>{formatNumber(b.event_count ?? 0)} evt</span>
+            </div>
+          </Link>
+        ))}
+        table={
+          <table className="w-full text-left text-sm">
+            <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+              <tr>
+                <th className="px-4 py-2.5">Block</th>
+                <th className="px-4 py-2.5">Hash</th>
+                <th className="px-4 py-2.5">Author</th>
+                <th className="px-4 py-2.5 text-right">Extrinsics</th>
+                <th className="px-4 py-2.5 text-right">Events</th>
+                <th className="px-4 py-2.5 text-right">Observed</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      }
-      footer={footerNode}
-    />
+            </thead>
+            <tbody className="divide-y divide-border">
+              {rows.map((b, i) => {
+                // Gap = seconds since the previous (older) block was produced.
+                // Rows are newest-first, so the older neighbor is at i+1.
+                const nextOlder = rows[i + 1];
+                const gapMs =
+                  b.observed_at && nextOlder?.observed_at
+                    ? Date.parse(b.observed_at) - Date.parse(nextOlder.observed_at)
+                    : null;
+                const gapSec = gapMs != null && Number.isFinite(gapMs) ? gapMs / 1000 : null;
+                const gapTone =
+                  gapSec == null
+                    ? "text-ink-subtle"
+                    : gapSec > 48
+                      ? "text-health-down"
+                      : gapSec > 24
+                        ? "text-health-warn-text"
+                        : "text-ink-subtle";
+                // Free decentralization tell: count how often this author appears
+                // on the current page. A repeat on a short window is worth flagging.
+                const authorRepeat = b.author
+                  ? rows.reduce((n, r) => (r.author === b.author ? n + 1 : n), 0)
+                  : 0;
+                return (
+                  <tr
+                    key={b.block_hash || b.block_number}
+                    className="group mg-row-accent odd:bg-surface/30 hover:bg-surface/60"
+                  >
+                    <td className="px-4 py-2.5 font-mono text-[12px] align-top">
+                      <Link
+                        to="/blocks/$ref"
+                        params={{ ref: String(b.block_number) }}
+                        className="font-medium text-ink-strong hover:underline"
+                      >
+                        #{formatNumber(b.block_number)}
+                      </Link>
+                      {gapSec != null ? (
+                        <div
+                          className={classNames("mt-0.5 text-[10px]", gapTone)}
+                          title="Seconds since previous block"
+                        >
+                          +{humaniseSeconds(gapSec)}
+                        </div>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted align-top">
+                      <span className="inline-flex items-center gap-1 min-w-0">
+                        <Link
+                          to="/blocks/$ref"
+                          params={{ ref: b.block_hash || String(b.block_number) }}
+                          className="hover:text-ink-strong truncate"
+                          title={b.block_hash}
+                        >
+                          {shortHash(b.block_hash)}
+                        </Link>
+                        {b.block_hash ? (
+                          <span className="opacity-0 group-hover:opacity-100 transition-opacity">
+                            <CopyButton value={b.block_hash} label="block hash" compact />
+                          </span>
+                        ) : null}
+                      </span>
+                    </td>
+                    <td
+                      className="px-4 py-2.5 font-mono text-[11px] text-ink-muted align-top"
+                      title={b.author ?? undefined}
+                    >
+                      <div className="flex items-center gap-1.5 min-w-0">
+                        <AccountAddress
+                          ss58={b.author}
+                          compact
+                          fallback={
+                            b.author ? (
+                              <CopyableCode value={b.author} className="max-w-full" />
+                            ) : (
+                              "—"
+                            )
+                          }
+                        />
+                        {authorRepeat > 1 ? (
+                          <span
+                            className="mg-chip h-4 px-1.5 text-[9px] text-accent-text border-accent/40"
+                            title={`Produced ${authorRepeat} blocks on this page`}
+                          >
+                            ×{authorRepeat}
+                          </span>
+                        ) : null}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink align-top">
+                      <ActivityCell value={b.extrinsic_count ?? 0} max={maxExt} tone="accent" />
+                    </td>
+                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink align-top">
+                      <ActivityCell value={b.event_count ?? 0} max={maxEvt} tone="ink" />
+                    </td>
+                    <td
+                      className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted align-top"
+                      title={b.observed_at ?? undefined}
+                    >
+                      <TimeAgo at={b.observed_at} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        }
+        footer={footerNode}
+      />
+    </>
+  );
+}
+
+/**
+ * Right-aligned number with a thin horizontal bar underneath, normalized
+ * against the page-max so busy blocks are visually obvious at a glance.
+ * `tone="accent"` (extrinsics) uses mint; `tone="ink"` (events) uses ink.
+ */
+function ActivityCell({
+  value,
+  max,
+  tone,
+}: {
+  value: number;
+  max: number;
+  tone: "accent" | "ink";
+}) {
+  const pct = max > 0 ? Math.max(2, Math.round((value / max) * 100)) : 0;
+  const barCls = tone === "accent" ? "bg-accent/70" : "bg-ink-strong/40";
+  return (
+    <span className="inline-flex flex-col items-end gap-1 min-w-[3.5rem]">
+      <span>{formatNumber(value)}</span>
+      <span aria-hidden className="block h-[3px] w-full rounded-full bg-border/50 overflow-hidden">
+        <span
+          className={classNames("block h-full rounded-full transition-[width]", barCls)}
+          style={{ width: `${pct}%` }}
+        />
+      </span>
+    </span>
   );
 }

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -394,7 +394,7 @@ function HomeHero() {
               type="button"
               onClick={openCommandPalette}
               aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
-              className="flex flex-1 items-center gap-3 px-4 py-3.5 text-left text-sm text-ink-muted transition-colors hover:text-ink"
+              className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3.5 text-left text-sm text-ink-muted transition-colors hover:text-ink"
             >
               <svg
                 aria-hidden="true"
@@ -407,7 +407,7 @@ function HomeHero() {
                 <circle cx="11" cy="11" r="7" />
                 <path d="m20 20-3.5-3.5" strokeLinecap="round" />
               </svg>
-              <span className="flex-1 truncate">
+              <span className="min-w-0 flex-1 truncate">
                 Search subnets, validators, endpoints, accounts…
               </span>
               <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">


### PR DESCRIPTION
## What changed

Completes the blocks/chain-explorer batch (#7746) — wires the 8 components shipped unwired in #7772 into their consuming routes.

- **`blocks.index.tsx`**: `LiveBlockRail`, `RuntimeTimeline`, `CadenceHeatmap`, `AuthorSharePanel` replace the old plain block-throughput card; filter UI moves from `SearchInput`/`PageSizeSelect`/manual mobile-toggle to `QueryBar`/`FilterSheet`/`FilterChipRow`; every section wraps in `AsyncPanel`. Confirmed no dropped production functionality — mono's `BlockThroughputCard` is a strict subset of the new `LiveBlockRail` (same `chainActivityQuery` 7d-sparkline data, plus a latest-block panel and cadence strip it lacked), so it's removed in favor of the richer component.
- **`blocks.$ref.tsx`**: `ChainWalkRibbon`, `NeighborCompare`, `BlockMetadataPanel`, `PalletMethodBreakdown`, `ShortcutsDialog`, plus a grouped/collapsible events tree, vim-style `j`/`k`/`g` block navigation, a jump-to-block form, and a τ/USD value-unit toggle. New self-contained dependencies: `TaoValue`, `value-unit.tsx`, `use-tao-price.ts`, `market.functions.ts`.

## Bugs found and fixed (live in the browser, not from reading the diff)

1. **`AsyncPanel`'s `retryQueryKeys`** used guessed key shapes from the Lovable source (e.g. `["blocks", "list"]`) that don't match this app's actual `metagraphedQueryKey()`-prefixed keys (`["metagraphed", {network}, "blocks", ...]`). TanStack Query's `invalidateQueries` does prefix matching, so the retry button's targeted invalidation would have silently no-op'd. Fixed to call `metagraphedQueryKey(...)` directly everywhere `AsyncPanel` is used, which also correctly resolves the current mainnet/testnet scope.
2. **Two invalid-HTML-nesting hydration errors**, caught live in the console: `live-block-rail.tsx` wrapped its "latest block" row in a `<Link>`, and `author-share-panel.tsx` wrapped each row in a `<button>` — both contain `AccountAddress`, which always renders its own `<a>` (account link) + `<button>` (copy button). An anchor/button can't contain another without breaking hydration. Restructured both so `AccountAddress` sits outside any outer link/button, moving the "navigate"/"filter" click affordance to the surrounding area instead. Screenshots of the errors and the clean-after state are in the session transcript.
3. **`PageMasthead`'s `hideBreadcrumbs` defaults to `true`** — the Lovable source passed a `crumbs` array on `blocks.$ref.tsx` without also passing `hideBreadcrumbs={false}`, so the breadcrumbs would have silently never rendered. Fixed.

## Test plan
- [x] `npm run typecheck --workspace=apps/ui` — 0 new errors
- [x] `npx eslint` — 0 errors, pre-existing-pattern warnings only
- [x] `npx prettier --check` clean
- [x] Verified live in the browser: `/blocks` and `/blocks/$ref` both render fully correctly (breadcrumbs, chain walk, metadata panel, grouped events, pallet breakdown, all real data), zero console errors after the fixes above

Closes #7773