### PR TITLE
feat(observability): add PostHog error tracking via raw $exception capture

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -8,6 +8,7 @@ import {
 } from "graphql";
 import * as Sentry from "@sentry/cloudflare";
 import { readArtifact, readHealthKv } from "../workers/storage.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
 // #6986: GraphQL parity for source-snapshots, reusing list_source_snapshots'
 // own loader unchanged (same artifact read, filter, sort, and page logic REST
 // and MCP already use) -- not a reimplementation.
@@ -10373,6 +10374,17 @@ export async function handleGraphQLRequest(request, env) {
   for (const fault of genuineFaults) {
     Sentry.captureException(fault.originalError, {
       tags: { route: "graphql" },
+    });
+    // metagraphed#7758: PostHog $exception capture, parallel-run alongside
+    // Sentry above. handleGraphQLRequest has no ExecutionContext (see this
+    // function's own comment in workers/api.mjs), so this is awaited inline
+    // rather than fire-and-forget via waitUntil -- the only real cost is a
+    // little latency on this already-failing response, not silent event
+    // loss from an isolate torn down mid-fetch.
+    await recordExceptionEvent(env, {
+      error: fault.originalError,
+      route: "graphql",
+      errorCode: "graphql_execution_error",
     });
   }
   const errorCode =

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -38,6 +38,7 @@
 import * as Sentry from "@sentry/cloudflare";
 import {
   isUsageTelemetryConfigured,
+  recordExceptionEvent,
   recordMcpInitializeEvent,
   recordMcpToolCallEvent,
   recordUsageEvent,
@@ -16315,6 +16316,19 @@ function scheduleMcpInitializeEvent(ctx, event) {
   }
 }
 
+// metagraphed#7758: PostHog $exception capture, parallel-run alongside the
+// existing Sentry.captureException at the same site below. Same
+// waitUntil/no-throw discipline as the schedulers above.
+function scheduleExceptionEvent(ctx, event) {
+  try {
+    const record = ctx?.recordExceptionEvent ?? recordExceptionEvent;
+    const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
 async function dispatchTool(params, ctx) {
   const name = params?.name;
   const tool = typeof name === "string" ? TOOLS_BY_NAME.get(name) : undefined;
@@ -16371,6 +16385,11 @@ async function dispatchTool(params, ctx) {
     // AI degraded to fallback, etc.) and deliberately NOT captured here --
     // only genuinely unexpected faults should page/alert.
     Sentry.captureException(error, { tags: { mcp_tool: name } });
+    scheduleExceptionEvent(ctx, {
+      error,
+      mcpTool: name,
+      errorCode: "internal_error",
+    });
     console.error("MCP tool handler failed:", error);
     return {
       content: [

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -364,3 +364,172 @@ export async function recordMcpInitializeEvent(
     return false;
   }
 }
+
+// Error tracking via PostHog's manual/raw $exception capture (#7758). No SDK
+// needed for this either -- PostHog documents a raw capture-API shape for
+// exactly the "no SDK for your platform" case (a real, first-class path, not
+// a hack). The public docs page (posthog.com/docs/api/capture) only
+// summarizes the shape; the exact property names/types below are confirmed
+// against PostHog's own repo (docs/onboarding/error-tracking/api.tsx, the
+// source their public docs render from), including a real example payload.
+// Parallel-run alongside the existing Sentry.captureException call at every
+// site this wires into -- additive, not a replacement (metagraphed#7757 is
+// the consolidation epic; #7766 is the gated Sentry removal, which happens
+// in its own PR once parity is proven, not here).
+
+/** One PostHog `$exception_list` stack frame. `platform`/`lang` are always
+ * "custom"/"javascript" -- PostHog's required marker for a manually built
+ * (non-SDK) frame, not something derived from the actual error. */
+interface ExceptionStackFrame {
+  platform: "custom";
+  lang: "javascript";
+  function: string;
+  filename?: string;
+  lineno?: number;
+  colno?: number;
+  in_app?: boolean;
+}
+
+// Caps how many stack frames get sent -- a runaway recursive error could
+// otherwise produce hundreds of near-identical frames for little value.
+const MAX_EXCEPTION_FRAMES = 30;
+
+// Matches V8's `Error.prototype.stack` frame format (Workers run the same V8
+// engine Node does): "    at functionName (file:line:col)" or
+// "    at file:line:col" for an anonymous/top-level frame. Never throws on
+// an unrecognized line -- it still becomes a frame (the raw text as
+// `function`, no file/line/col) rather than being silently dropped.
+const STACK_FRAME_PATTERN =
+  /^\s*at\s+(?:(.+?)\s+\()?([^()]+):(\d+):(\d+)\)?\s*$/;
+
+function parseStackFrames(stack: string): ExceptionStackFrame[] {
+  // The first line is "ErrorName: message", not a frame.
+  const lines = stack.split("\n").slice(1, MAX_EXCEPTION_FRAMES + 1);
+  const frames: ExceptionStackFrame[] = [];
+  for (const line of lines) {
+    const match = STACK_FRAME_PATTERN.exec(line);
+    if (match) {
+      const [, fn, filename, lineno, colno] = match;
+      frames.push({
+        platform: "custom",
+        lang: "javascript",
+        function: fn?.trim() || "<anonymous>",
+        filename: filename.trim(),
+        lineno: Number(lineno),
+        colno: Number(colno),
+        in_app: !filename.includes("node_modules"),
+      });
+    } else if (line.trim()) {
+      frames.push({
+        platform: "custom",
+        lang: "javascript",
+        function: line.trim(),
+      });
+    }
+  }
+  // PostHog/Sentry's event protocol (this shape is explicitly modeled on
+  // Sentry's) orders frames oldest-call-first -- the LAST entry is where the
+  // exception was thrown. That's the reverse of how V8 prints a stack
+  // (most-recent-call-first), so the parsed order is reversed here to match.
+  return frames.reverse();
+}
+
+/** Inputs for a captured exception. `error` is the raw caught value -- this
+ * module extracts type/message/stack itself, callers never format it.
+ * `route`/`mcpTool` mirror UsageEvent's own fields (same vocabulary, so
+ * insights can filter consistently across usage_event/$mcp_tool_call/
+ * $exception) and double as the fingerprint's grouping key. */
+export interface ExceptionEvent {
+  error: unknown;
+  route?: string;
+  mcpTool?: string;
+  errorCode?: string;
+}
+
+function exceptionListEntry(error: unknown): {
+  type: string;
+  entry: Record<string, unknown>;
+} {
+  const isError = error instanceof Error;
+  const type =
+    sanitizeLabel(isError && error.name ? error.name : "Error") ?? "Error";
+  const rawMessage = isError ? error.message : String(error);
+  const value = sanitizeLabel(rawMessage) ?? "(no message)";
+  const frames =
+    isError && typeof error.stack === "string"
+      ? parseStackFrames(error.stack)
+      : [];
+  return {
+    type,
+    entry: {
+      type,
+      value,
+      // Every capture site wraps a genuinely caught (try/catch), non-fatal
+      // fault -- never an uncaught/fatal one (those reach Sentry only, via
+      // the existing withSentry() wrap this module has no visibility into).
+      mechanism: { handled: true, synthetic: false },
+      stacktrace: { type: "raw", frames },
+    },
+  };
+}
+
+/**
+ * Capture one exception as a PostHog `$exception` event. Same no-throw,
+ * no-op-when-unconfigured contract as recordUsageEvent/recordMcpToolCallEvent.
+ *
+ * Message/stack text is NOT run through the key-based redaction
+ * (redactMcpSensitiveFields) that $mcp_parameters/$mcp_response get --
+ * that helper redacts by object KEY name, and an exception message is free
+ * text with no keys to match. Every capture site this wires into is an
+ * unexpected internal fault (not a caller-input-echoing path), and the one
+ * call site that could plausibly embed a credential in an error string
+ * (call_subnet_surface's own fetches) already scrubs it at the source
+ * (redactCredentialValue in src/call-subnet-surface.ts) before it ever
+ * becomes a thrown/logged error -- so there is no known raw-secret vector
+ * into this function, only the general caution free text always deserves.
+ */
+export async function recordExceptionEvent(
+  env: Env | null | undefined,
+  event: ExceptionEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+    if (!event || typeof event !== "object") return false;
+
+    const { type, entry } = exceptionListEntry(event.error);
+    const route = sanitizeLabel(event.route);
+    const mcpTool = sanitizeLabel(event.mcpTool);
+    const properties: Record<string, unknown> = {
+      $exception_list: [entry],
+      // A stable string groups every occurrence of "this site threw this
+      // error type" into one PostHog issue -- matching the route/mcp_tool
+      // tag Sentry already gets at these sites, so the two dashboards read
+      // consistently. Falls back to "unknown" only if neither is supplied.
+      $exception_fingerprint: `${route ?? mcpTool ?? "unknown"}:${type}`,
+    };
+    if (route !== undefined) properties.route = route;
+    if (mcpTool !== undefined) properties.mcp_tool = mcpTool;
+    const errorCode = sanitizeLabel(event.errorCode);
+    if (errorCode !== undefined) properties.error_code = errorCode;
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: "$exception",
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/api-ai-routes-sentry.test.mjs
+++ b/tests/api-ai-routes-sentry.test.mjs
@@ -9,6 +9,7 @@
 // same rationale for src/mcp-server.mjs.
 import assert from "node:assert/strict";
 import { afterEach, test, vi } from "vitest";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 
 const captureException = vi.hoisted(() => vi.fn());
 
@@ -19,8 +20,11 @@ vi.mock("@sentry/cloudflare", () => ({
 const { handleRequest } = await import("../workers/api.mjs");
 const { createLocalArtifactEnv } = await import("../scripts/lib.ts");
 
+const originalFetch = globalThis.fetch;
+
 afterEach(() => {
   captureException.mockClear();
+  globalThis.fetch = originalFetch;
 });
 
 const SEMANTIC_URL = "https://api.metagraph.sh/api/v1/search/semantic";
@@ -74,6 +78,74 @@ test("an ask backend failure reaches Sentry, tagged by route", async () => {
   const [capturedError, context] = captureException.mock.calls[0];
   assert.equal(capturedError.message, "model down");
   assert.deepEqual(context, { tags: { route: "ask" } });
+});
+
+// metagraphed#7758: captureAiRouteError now also posts a PostHog $exception
+// alongside the existing Sentry.captureException above -- parallel-run, same
+// route tag on both sides.
+test("a semantic-search backend failure also reaches PostHog as $exception, tagged by the same route", async () => {
+  const posted = [];
+  globalThis.fetch = async (url, init) => {
+    posted.push({ url, body: JSON.parse(init.body) });
+    return { ok: true };
+  };
+  const env = aiWorkerEnv({
+    [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+    AI: stubAi(() => Promise.reject(new Error("model down"))),
+  });
+  const res = await handleRequest(new Request(`${SEMANTIC_URL}?q=x`), env, {});
+  assert.equal(res.status, 502);
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].body.event, "$exception");
+  assert.equal(posted[0].body.properties.route, "semantic_search");
+  assert.equal(posted[0].body.properties.error_code, "ai_error");
+  assert.equal(
+    posted[0].body.properties.$exception_list[0].value,
+    "model down",
+  );
+});
+
+test("an ask backend failure also reaches PostHog as $exception, tagged by the same route", async () => {
+  const posted = [];
+  globalThis.fetch = async (url, init) => {
+    posted.push({ url, body: JSON.parse(init.body) });
+    return { ok: true };
+  };
+  const env = aiWorkerEnv({
+    [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+    AI: stubAi(() => Promise.reject(new Error("model down"))),
+  });
+  const res = await handleRequest(
+    new Request(ASK_URL, {
+      method: "POST",
+      body: JSON.stringify({ question: "x" }),
+    }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 502);
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].body.properties.route, "ask");
+});
+
+test("a caller-input rejection (aiInput) on either route never reaches PostHog either", async () => {
+  const posted = [];
+  globalThis.fetch = async (url, init) => {
+    posted.push({ url, body: JSON.parse(init.body) });
+    return { ok: true };
+  };
+  const env = aiWorkerEnv({ [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" });
+  await handleRequest(new Request(`${SEMANTIC_URL}?q=x&type=bogus`), env, {});
+  await handleRequest(
+    new Request(ASK_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ question: "which?", type: "bogus" }),
+    }),
+    env,
+    {},
+  );
+  assert.equal(posted.length, 0);
 });
 
 test("a caller-input rejection (aiInput) on either route never reaches Sentry", async () => {

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -12,6 +12,7 @@ import {
   identityHash as subnetIdentityHash,
   identitySnapshotFromProfile,
 } from "../src/subnet-identity-history.ts";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 
 const sqlCalls = vi.hoisted(() => []);
 const sqlBeginOptions = vi.hoisted(() => []);
@@ -54,6 +55,11 @@ const rollupFailure = vi.hoisted(() => ({ error: null }));
 const subnetHyperparamsSyncFailure = vi.hoisted(() => ({ error: null }));
 const subnetHyperparamsPruneRows = vi.hoisted(() => ({ current: [] }));
 const subnetHyperparamsLatestHashes = vi.hoisted(() => ({ current: [] }));
+// State for the subnet-locks-sync write route's tests only (metagraphed#7758
+// -- this route had zero existing coverage; added the minimal failure-path
+// test needed to cover captureDataApiError's new PostHog wiring at this
+// site, mirroring the fixture shape every sibling sync route above uses).
+const subnetLocksSyncFailure = vi.hoisted(() => ({ error: null }));
 // State for the account-identity-sync write route's tests only (#4832
 // gap-closure). No prune-rows hook -- unlike subnet_hyperparams, this table
 // has no purge step (see handleAccountIdentitySync's own header comment).
@@ -212,6 +218,12 @@ vi.mock("postgres", () => ({
         /INSERT INTO subnet_hyperparams\b/.test(text)
       ) {
         return Promise.reject(subnetHyperparamsSyncFailure.error);
+      }
+      if (
+        subnetLocksSyncFailure.error &&
+        /INSERT INTO subnet_locks\b/.test(text)
+      ) {
+        return Promise.reject(subnetLocksSyncFailure.error);
       }
       if (
         accountIdentitySyncFailure.error &&
@@ -408,6 +420,7 @@ const NEURONS_SYNC_SECRET = "test-neurons-sync-secret";
 const NEURON_DAILY_BACKFILL_SECRET = "test-neuron-daily-backfill-secret";
 const ROLLUP_SYNC_SECRET = "test-rollup-sync-secret";
 const SUBNET_HYPERPARAMS_SYNC_SECRET = "test-subnet-hyperparams-sync-secret";
+const SUBNET_LOCKS_SYNC_SECRET = "test-subnet-locks-sync-secret";
 const ACCOUNT_IDENTITY_SYNC_SECRET = "test-account-identity-sync-secret";
 const VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET =
   "test-validator-nominator-counts-sync-secret";
@@ -423,6 +436,7 @@ const env = {
   NEURON_DAILY_BACKFILL_SECRET,
   ROLLUP_SYNC_SECRET,
   SUBNET_HYPERPARAMS_SYNC_SECRET,
+  SUBNET_LOCKS_SYNC_SECRET,
   ACCOUNT_IDENTITY_SYNC_SECRET,
   VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
   SUBNET_IDENTITY_SYNC_SECRET,
@@ -448,6 +462,7 @@ beforeEach(() => {
   subnetHyperparamsSyncFailure.error = null;
   subnetHyperparamsPruneRows.current = [];
   subnetHyperparamsLatestHashes.current = [];
+  subnetLocksSyncFailure.error = null;
   accountIdentitySyncFailure.error = null;
   accountIdentityLatestHashes.current = [];
   validatorNominatorCountsSyncFailure.error = null;
@@ -3381,6 +3396,47 @@ test("neurons-sync maps a DB failure to a clean 502 instead of throwing", async 
   expect((await res.json()).error).toBe("write failed");
 });
 
+// metagraphed#7758: captureDataApiError now also posts a PostHog $exception
+// alongside the existing Sentry.captureException, for every one of this
+// file's 26 sync/query error sites -- this is the one representative case
+// proving the (mechanically identical) wiring pattern actually works
+// end-to-end, since all 26 share this exact catch-block shape. Uses a
+// one-off env/ctx (not the shared module-level `env`/`req`) so the other
+// ~500 tests in this file stay on the unconfigured, PostHog-silent path.
+test("neurons-sync's DB failure also reaches PostHog as $exception, tagged with the route", async () => {
+  neuronsSyncFailure.error = new Error("connection reset");
+  const posted = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    posted.push({ url, body: JSON.parse(init.body) });
+    return { ok: true };
+  };
+  try {
+    const res = await worker.fetch(
+      new Request("https://d/api/v1/internal/neurons-sync", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-neurons-sync-token": NEURONS_SYNC_SECRET,
+        },
+        body: JSON.stringify([neuronSyncRow()]),
+      }),
+      { ...env, [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" },
+      ctx,
+    );
+    expect(res.status).toBe(502);
+    expect(posted.length).toBe(1);
+    expect(posted[0].body.event).toBe("$exception");
+    expect(posted[0].body.properties.route).toBe("neurons-sync");
+    expect(posted[0].body.properties.error_code).toBe("internal_error");
+    expect(posted[0].body.properties.$exception_list[0].value).toBe(
+      "connection reset",
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
 // POST /api/v1/internal/backfill-neuron-daily -- deep-history ingest for
 // scripts/backfill-neuron-history.py and scripts/backfill-stake-monthly.py
 // (workers/data-api.mjs's handleNeuronDailyBackfill). Same row shape as
@@ -5044,6 +5100,35 @@ test("subnet-hyperparams-sync maps a DB failure to a clean 502 instead of throwi
   subnetHyperparamsSyncFailure.error = new Error("connection reset");
   const res = await postSubnetHyperparams([hyperparamsSyncRow()], {
     secret: SUBNET_HYPERPARAMS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});
+
+// metagraphed#7758: subnet-locks-sync had no coverage at all before this --
+// added the minimal failure-path test needed to cover captureDataApiError's
+// new (await ..., env) call at this site, mirroring every sibling
+// "maps a DB failure to a clean 502" test above.
+test("subnet-locks-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  subnetLocksSyncFailure.error = new Error("connection reset");
+  const res = await req("/api/v1/internal/subnet-locks-sync", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-subnet-locks-sync-token": SUBNET_LOCKS_SYNC_SECRET,
+    },
+    body: JSON.stringify([
+      {
+        netuid: 1,
+        hotkey: "5FakeHotkeyAddress",
+        is_owner: true,
+        is_perpetual: false,
+        locked_mass: 1000,
+        conviction_bits: "12345",
+        last_update: 100,
+        captured_at: 1_780_000_000_000,
+      },
+    ]),
   });
   expect(res.status).toBe(502);
   expect((await res.json()).error).toBe("write failed");

--- a/tests/graphql-sentry-and-error-code.test.mjs
+++ b/tests/graphql-sentry-and-error-code.test.mjs
@@ -12,6 +12,7 @@
 // and tests/api-ai-routes-sentry.test.mjs's own identical rationale.
 import assert from "node:assert/strict";
 import { afterEach, test, vi } from "vitest";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 
 const captureException = vi.hoisted(() => vi.fn());
 const resolveLiveEconomics = vi.hoisted(() => vi.fn());
@@ -69,6 +70,55 @@ test("a resolver's genuine exception reaches Sentry and is tagged graphql_execut
   const [capturedError, context] = captureException.mock.calls[0];
   assert.equal(capturedError.message, "hyperdrive unavailable");
   assert.deepEqual(context, { tags: { route: "graphql" } });
+});
+
+// metagraphed#7758: PostHog $exception capture, parallel-run alongside the
+// Sentry.captureException above -- same route tag, same genuine-fault-only
+// discriminator.
+test("a resolver's genuine exception also reaches PostHog as $exception, tagged the same way", async () => {
+  resolveLiveEconomics.mockRejectedValue(new Error("hyperdrive unavailable"));
+  const original = globalThis.fetch;
+  const posted = [];
+  globalThis.fetch = async (url, init) => {
+    posted.push({ url, body: JSON.parse(init.body) });
+    return { ok: true };
+  };
+  try {
+    const { res } = await gql("{ economics { total } }", {
+      [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+    });
+    assert.equal(res.status, 200);
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].body.event, "$exception");
+    assert.equal(posted[0].body.properties.route, "graphql");
+    assert.equal(
+      posted[0].body.properties.error_code,
+      "graphql_execution_error",
+    );
+    assert.equal(
+      posted[0].body.properties.$exception_list[0].value,
+      "hyperdrive unavailable",
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("a deliberate GraphQLError (bad user input) never reaches PostHog either", async () => {
+  const original = globalThis.fetch;
+  const posted = [];
+  globalThis.fetch = async (url, init) => {
+    posted.push({ url, body: JSON.parse(init.body) });
+    return { ok: true };
+  };
+  try {
+    await gql("{ subnet_identity_history(netuid: -1) { __typename } }", {
+      [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+    });
+    assert.equal(posted.length, 0);
+  } finally {
+    globalThis.fetch = original;
+  }
 });
 
 test("a deliberate GraphQLError (bad user input) never reaches Sentry, tagged graphql_field_error", async () => {

--- a/tests/mcp-usage-telemetry.test.mjs
+++ b/tests/mcp-usage-telemetry.test.mjs
@@ -420,3 +420,97 @@ describe("MCP tool-dispatch usage telemetry", () => {
     }
   });
 });
+
+// metagraphed#7758: dispatchTool's PostHog $exception capture, parallel-run
+// alongside the existing Sentry.captureException at the same site. Uses the
+// same real internal-error trigger as
+// tests/mcp-server-branch-coverage.test.mjs's "semantic_search wraps a
+// Vectorize rejection as an internal error" -- a genuine unexpected fault,
+// not a toolError, so it's the one path that reaches dispatchTool's catch.
+describe("MCP dispatchTool exception capture ($exception)", () => {
+  function aiEnv(overrides = {}) {
+    return {
+      ...CONFIGURED_ENV,
+      METAGRAPH_ENABLE_AI: "true",
+      AI: {
+        run(_model, input) {
+          if (input?.text) {
+            const n = Array.isArray(input.text) ? input.text.length : 1;
+            return Promise.resolve({
+              data: Array.from({ length: n }, () => new Array(1024).fill(0.02)),
+            });
+          }
+          return Promise.resolve({ response: "answer." });
+        },
+      },
+      VECTORIZE: {
+        query: () => Promise.reject(new Error("vectorize exploded")),
+      },
+      ...overrides,
+    };
+  }
+
+  test("an unexpected internal fault posts a $exception event tagged with the tool name", async () => {
+    const original = globalThis.fetch;
+    const posted = [];
+    globalThis.fetch = async (url, init) => {
+      posted.push({ url, body: JSON.parse(init.body) });
+      return { ok: true };
+    };
+    try {
+      const executionCtx = fakeExecutionCtx();
+      const payload = await callMcp(
+        toolCall("semantic_search", { query: "images" }),
+        aiEnv(),
+        { executionCtx },
+      );
+      await Promise.all(executionCtx.scheduled);
+
+      assert.equal(payload.result.isError, true);
+      assert.equal(
+        payload.result.structuredContent.error.code,
+        "internal_error",
+      );
+      // The PUBLIC tool response stays sanitized (no internal message) --
+      // already covered by tests/mcp-server-branch-coverage.test.mjs. The
+      // PRIVATE $exception payload sent to PostHog is a different channel:
+      // it's SUPPOSED to carry the real error, that's the point of error
+      // tracking.
+      const exceptionPost = posted.find((p) => p.body.event === "$exception");
+      assert.ok(exceptionPost, "$exception should be posted");
+      assert.equal(exceptionPost.body.properties.mcp_tool, "semantic_search");
+      assert.equal(exceptionPost.body.properties.error_code, "internal_error");
+      assert.equal(
+        exceptionPost.body.properties.$exception_list[0].value,
+        "vectorize exploded",
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("an expected toolError (invalid_params) never posts a $exception event", async () => {
+    const original = globalThis.fetch;
+    const posted = [];
+    globalThis.fetch = async (url, init) => {
+      posted.push({ url, body: JSON.parse(init.body) });
+      return { ok: true };
+    };
+    try {
+      const executionCtx = fakeExecutionCtx();
+      await callMcp(
+        toolCall("get_subnet", { netuid: "not-a-netuid" }),
+        CONFIGURED_ENV,
+        { executionCtx },
+      );
+      await Promise.all(executionCtx.scheduled);
+
+      assert.equal(
+        posted.some((p) => p.body.event === "$exception"),
+        false,
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/tests/usage-telemetry.test.mjs
+++ b/tests/usage-telemetry.test.mjs
@@ -7,6 +7,7 @@ import {
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
   isUsageTelemetryConfigured,
+  recordExceptionEvent,
   recordMcpInitializeEvent,
   recordMcpToolCallEvent,
   recordUsageEvent,
@@ -687,5 +688,345 @@ describe("recordMcpInitializeEvent", () => {
       { fetch: fakeFetch({ throws: true }) },
     );
     assert.equal(recorded, false);
+  });
+});
+
+// #7758: schema verified directly against PostHog's own ingestion Rust types
+// (rust/cymbal/src/core/types/{exception,stacktrace}.rs,
+// rust/cymbal/src/core/types/langs/custom.rs) and a real production
+// $exception fixture, not just the docs page -- see the module's own header
+// comment for the sources. These tests pin that shape so a future refactor
+// can't silently drift from it.
+describe("recordExceptionEvent", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  function thrownError(ErrorClass, message) {
+    // A real thrown-and-caught error, not a hand-built object -- so
+    // error.stack is a genuine V8 stack string, same as every real call site.
+    try {
+      throw new ErrorClass(message);
+    } catch (e) {
+      return e;
+    }
+  }
+
+  test("posts a well-formed $exception event for a real thrown Error", async () => {
+    const calls = [];
+    const recorded = await recordExceptionEvent(
+      CONFIGURED,
+      {
+        error: thrownError(RangeError, "boom"),
+        route: "test-route",
+        errorCode: "internal_error",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    const { body } = calls[0];
+    assert.equal(body.event, "$exception");
+    assert.equal(body.api_key, "phc_token");
+    assert.equal(body.distinct_id, USAGE_EVENT_DISTINCT_ID);
+
+    const list = body.properties.$exception_list;
+    assert.equal(list.length, 1);
+    assert.equal(list[0].type, "RangeError");
+    assert.equal(list[0].value, "boom");
+    assert.deepEqual(list[0].mechanism, { handled: true, synthetic: false });
+    assert.equal(list[0].stacktrace.type, "raw");
+    assert.ok(list[0].stacktrace.frames.length > 0);
+    for (const frame of list[0].stacktrace.frames) {
+      // PostHog's required markers for a manually-built (non-SDK) frame.
+      assert.equal(frame.platform, "custom");
+      assert.equal(frame.lang, "javascript");
+      assert.equal(typeof frame.function, "string");
+    }
+
+    assert.equal(
+      body.properties.$exception_fingerprint,
+      "test-route:RangeError",
+    );
+    assert.equal(body.properties.route, "test-route");
+    assert.equal(body.properties.error_code, "internal_error");
+  });
+
+  test("orders frames oldest-call-first (thrown frame last), matching the Sentry-derived protocol", async () => {
+    function inner() {
+      throw new Error("deep");
+    }
+    function outer() {
+      inner();
+    }
+    let error;
+    try {
+      outer();
+    } catch (e) {
+      error = e;
+    }
+
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error, route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const frames =
+      calls[0].body.properties.$exception_list[0].stacktrace.frames;
+    // The innermost/throwing frame ("inner") must be LAST, not first.
+    assert.equal(frames.at(-1).function, "inner");
+    assert.equal(frames.at(-2).function, "outer");
+  });
+
+  test("marks node_modules frames as not in_app, everything else as in_app", async () => {
+    const fakeStack =
+      "Error: boom\n" +
+      "    at ourFunction (/repo/src/usage-telemetry.ts:10:5)\n" +
+      "    at vendorFunction (/repo/node_modules/some-pkg/index.js:20:3)\n";
+    const error = new Error("boom");
+    error.stack = fakeStack;
+
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error, route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const frames =
+      calls[0].body.properties.$exception_list[0].stacktrace.frames;
+    const ours = frames.find((f) => f.function === "ourFunction");
+    const vendor = frames.find((f) => f.function === "vendorFunction");
+    assert.equal(ours.in_app, true);
+    assert.equal(vendor.in_app, false);
+  });
+
+  test("parses filename/lineno/colno out of a standard V8 frame line", async () => {
+    const fakeStack =
+      "Error: boom\n" + "    at doThing (/repo/src/foo.ts:42:13)\n";
+    const error = new Error("boom");
+    error.stack = fakeStack;
+
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error, route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const [frame] =
+      calls[0].body.properties.$exception_list[0].stacktrace.frames;
+    assert.equal(frame.function, "doThing");
+    assert.equal(frame.filename, "/repo/src/foo.ts");
+    assert.equal(frame.lineno, 42);
+    assert.equal(frame.colno, 13);
+  });
+
+  test("never drops an unparseable stack line -- it becomes a frame with just raw text", async () => {
+    const fakeStack =
+      "Error: boom\n" + "    something unusual, not a normal V8 frame\n";
+    const error = new Error("boom");
+    error.stack = fakeStack;
+
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error, route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const frames =
+      calls[0].body.properties.$exception_list[0].stacktrace.frames;
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].platform, "custom");
+    assert.equal(frames[0].lang, "javascript");
+    assert.equal(
+      frames[0].function,
+      "something unusual, not a normal V8 frame",
+    );
+    assert.equal("filename" in frames[0], false);
+  });
+
+  test("caps the number of stack frames sent", async () => {
+    const many = Array.from(
+      { length: 200 },
+      (_, i) => `    at fn${i} (/repo/src/foo.ts:${i}:1)`,
+    ).join("\n");
+    const error = new Error("boom");
+    error.stack = `Error: boom\n${many}`;
+
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error, route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const frames =
+      calls[0].body.properties.$exception_list[0].stacktrace.frames;
+    assert.ok(frames.length <= 30);
+  });
+
+  test("handles a thrown non-Error value without crashing", async () => {
+    const calls = [];
+    const recorded = await recordExceptionEvent(
+      CONFIGURED,
+      { error: "just a string", route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    const entry = calls[0].body.properties.$exception_list[0];
+    assert.equal(entry.type, "Error");
+    assert.equal(entry.value, "just a string");
+    assert.deepEqual(entry.stacktrace.frames, []);
+  });
+
+  test("falls back to a generic type/message when an Error has a blank name/message", async () => {
+    const error = new Error("");
+    error.name = "";
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error, route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const entry = calls[0].body.properties.$exception_list[0];
+    assert.equal(entry.type, "Error");
+    assert.equal(entry.value, "(no message)");
+  });
+
+  test("falls back to a generic type when an Error's name is truthy but whitespace-only", async () => {
+    // Distinct from the blank-name case above: "" is falsy (the ternary
+    // itself picks the "Error" literal), but "   " is a truthy non-empty
+    // string (the ternary picks it), and only THEN does sanitizeLabel find
+    // it blank and fall back -- a different branch in the same expression.
+    const error = new Error("boom");
+    error.name = "   ";
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error, route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(calls[0].body.properties.$exception_list[0].type, "Error");
+  });
+
+  test("caps an overlong message the same way sanitizeLabel caps every other free-form field", async () => {
+    const error = new Error("x".repeat(1000));
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error, route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const entry = calls[0].body.properties.$exception_list[0];
+    assert.equal(entry.value.length, 256);
+  });
+
+  test("falls back to mcpTool for the fingerprint and properties when route is absent", async () => {
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      {
+        error: thrownError(TypeError, "bad arg"),
+        mcpTool: "call_subnet_surface",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const { properties } = calls[0].body;
+    assert.equal(properties.mcp_tool, "call_subnet_surface");
+    assert.equal("route" in properties, false);
+    assert.equal(
+      properties.$exception_fingerprint,
+      "call_subnet_surface:TypeError",
+    );
+  });
+
+  test("falls back to 'unknown' in the fingerprint when neither route nor mcpTool is given", async () => {
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error: thrownError(Error, "boom") },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(
+      calls[0].body.properties.$exception_fingerprint,
+      "unknown:Error",
+    );
+  });
+
+  test("omits error_code when not supplied", async () => {
+    const calls = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error: thrownError(Error, "boom"), route: "x" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal("error_code" in calls[0].body.properties, false);
+  });
+
+  test("never posts when the deployment is unconfigured", async () => {
+    let calls = 0;
+    const recorded = await recordExceptionEvent(
+      {},
+      { error: thrownError(Error, "boom"), route: "x" },
+      {
+        fetch: fakeFetch({
+          onCall: () => {
+            calls += 1;
+          },
+        }),
+      },
+    );
+    assert.equal(recorded, false);
+    assert.equal(calls, 0);
+  });
+
+  test("returns false for a malformed event without capturing", async () => {
+    let calls = 0;
+    const onCall = () => {
+      calls += 1;
+    };
+    assert.equal(
+      await recordExceptionEvent(CONFIGURED, null, {
+        fetch: fakeFetch({ onCall }),
+      }),
+      false,
+    );
+    assert.equal(
+      await recordExceptionEvent(CONFIGURED, undefined, {
+        fetch: fakeFetch({ onCall }),
+      }),
+      false,
+    );
+    assert.equal(calls, 0);
+  });
+
+  test("reports a rejected capture as not recorded", async () => {
+    const recorded = await recordExceptionEvent(
+      CONFIGURED,
+      { error: thrownError(Error, "boom"), route: "x" },
+      { fetch: fakeFetch({ ok: false }) },
+    );
+    assert.equal(recorded, false);
+  });
+
+  test("swallows a transport failure", async () => {
+    const recorded = await recordExceptionEvent(
+      CONFIGURED,
+      { error: thrownError(Error, "boom"), route: "x" },
+      { fetch: fakeFetch({ throws: true }) },
+    );
+    assert.equal(recorded, false);
+  });
+
+  test("defaults to the platform fetch when none is injected", async () => {
+    const original = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      const recorded = await recordExceptionEvent(CONFIGURED, {
+        error: thrownError(Error, "boom"),
+        route: "x",
+      });
+      assert.equal(recorded, true);
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -8,6 +8,7 @@ import {
 } from "../src/contracts.mjs";
 import {
   isUsageTelemetryConfigured,
+  recordExceptionEvent,
   recordUsageEvent,
 } from "../src/usage-telemetry.ts";
 import {
@@ -4797,8 +4798,14 @@ async function handleEventsRequest(request, env) {
 // the top-level wrap. Sentry.captureException is a safe no-op with no
 // active client (confirmed live, same as captureDataApiError's own note),
 // which is every test importing this raw handler directly.
-function captureAiRouteError(error, route) {
+// metagraphed#7758: awaited (not waitUntil) -- both call sites are already
+// deep in the catch of an async route handler about to return an error
+// response; there's no separate ExecutionContext threaded down to this
+// helper the way mcp-server.mjs's schedulers have. The cost is a little
+// latency on an already-failing request, not silent event loss.
+async function captureAiRouteError(error, route, env) {
   Sentry.captureException(error, { tags: { route } });
+  await recordExceptionEvent(env, { error, route, errorCode: "ai_error" });
 }
 
 function aiUnavailableResponse() {
@@ -4902,7 +4909,7 @@ async function handleSemanticSearchRequest(request, env, url) {
     logEvent(env, "error", "semantic_search_failed", {
       message: error?.message,
     });
-    captureAiRouteError(error, "semantic_search");
+    await captureAiRouteError(error, "semantic_search", env);
     return errorResponse(
       "ai_error",
       "Semantic search failed. Please retry shortly.",
@@ -4968,7 +4975,7 @@ async function handleAskRequest(request, env) {
       return errorResponse("invalid_request", error.message, 400);
     }
     logEvent(env, "error", "ask_failed", { message: error?.message });
-    captureAiRouteError(error, "ask");
+    await captureAiRouteError(error, "ask", env);
     return errorResponse(
       "ai_error",
       "The answer service failed. Please retry shortly.",

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -21,6 +21,7 @@
 // read routes' `cache-control: public, max-age=10`).
 import postgres from "postgres";
 import * as Sentry from "@sentry/cloudflare";
+import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 import { parseJsonPreservingBigIntegers } from "../src/postgres-json-parse.ts";
 import { decodeCursor, encodeCursor } from "../src/cursor.ts";
 import { buildBlock, buildBlockFeed } from "../src/blocks.ts";
@@ -376,8 +377,21 @@ import { CHAIN_SIGNERS_SORTS } from "../src/chain-query-loaders.ts";
 // Sentry.captureException is a safe no-op with no active client (confirmed
 // live: returns an event id, doesn't throw), which is every test in this
 // file -- they import this raw, unwrapped handler directly.
-function captureDataApiError(err, route) {
+//
+// metagraphed#7758: PostHog $exception capture added alongside, parallel-run.
+// Awaited (not waitUntil) -- callers are already deep in an async handler's
+// catch block about to return an error response, with no ExecutionContext
+// threaded down to this helper. The cost is a little latency on an
+// already-failing request, not silent event loss. recordExceptionEvent is
+// itself a safe no-op with no configured token, same guarantee as Sentry
+// above -- this can't newly break any of this file's existing tests.
+async function captureDataApiError(err, route, env) {
   Sentry.captureException(err, { tags: { route } });
+  await recordExceptionEvent(env, {
+    error: err,
+    route,
+    errorCode: "internal_error",
+  });
 }
 
 const DATA_API_READ_TRANSACTION = "isolation level repeatable read read only";
@@ -908,7 +922,7 @@ async function handleNeuronsSync(request, env) {
     });
   } catch (err) {
     console.error("data-api neurons-sync write failed:", err);
-    captureDataApiError(err, "neurons-sync");
+    await captureDataApiError(err, "neurons-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
   // No sql.end() here: Hyperdrive automatically cleans up the connection when
@@ -1104,7 +1118,7 @@ async function handleNeuronDailyBackfill(request, env) {
     });
   } catch (err) {
     console.error("data-api neuron-daily-backfill write failed:", err);
-    captureDataApiError(err, "neuron-daily-backfill");
+    await captureDataApiError(err, "neuron-daily-backfill", env);
     return writeJson({ error: "write failed" }, 502);
   }
   // No sql.end() here: Hyperdrive automatically cleans up the connection when
@@ -1227,7 +1241,7 @@ async function handleRollupAccountEventsDaily(request, env) {
     });
   } catch (err) {
     console.error("data-api account-events-daily rollup failed:", err);
-    captureDataApiError(err, "account-events-daily-rollup");
+    await captureDataApiError(err, "account-events-daily-rollup", env);
     return writeJson({ error: "rollup failed" }, 502);
   }
 }
@@ -1488,7 +1502,7 @@ async function handleSubnetHyperparamsSync(request, env) {
     });
   } catch (err) {
     console.error("data-api subnet-hyperparams-sync write failed:", err);
-    captureDataApiError(err, "subnet-hyperparams-sync");
+    await captureDataApiError(err, "subnet-hyperparams-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -1662,7 +1676,7 @@ async function handleSubnetLocksSync(request, env) {
     });
   } catch (err) {
     console.error("data-api subnet-locks-sync write failed:", err);
-    captureDataApiError(err, "subnet-locks-sync");
+    await captureDataApiError(err, "subnet-locks-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -1871,7 +1885,7 @@ async function handleAccountIdentitySync(request, env) {
     });
   } catch (err) {
     console.error("data-api account-identity-sync write failed:", err);
-    captureDataApiError(err, "account-identity-sync");
+    await captureDataApiError(err, "account-identity-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -2039,7 +2053,7 @@ async function handleValidatorNominatorCountsSync(request, env) {
       "data-api validator-nominator-counts-sync write failed:",
       err,
     );
-    captureDataApiError(err, "validator-nominator-counts-sync");
+    await captureDataApiError(err, "validator-nominator-counts-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -2169,7 +2183,7 @@ async function handleNominatorPositionsSync(request, env) {
     });
   } catch (err) {
     console.error("data-api nominator-positions-sync write failed:", err);
-    captureDataApiError(err, "nominator-positions-sync");
+    await captureDataApiError(err, "nominator-positions-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -2300,7 +2314,7 @@ async function handleAccountBalancesSync(request, env) {
     return writeJson({ ok: true, account_balances_written: incoming.length });
   } catch (err) {
     console.error("data-api account-balances-sync write failed:", err);
-    captureDataApiError(err, "account-balances-sync");
+    await captureDataApiError(err, "account-balances-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -2464,7 +2478,7 @@ async function handleSubnetIdentitySync(request, env) {
     });
   } catch (err) {
     console.error("data-api subnet-identity-sync write failed:", err);
-    captureDataApiError(err, "subnet-identity-sync");
+    await captureDataApiError(err, "subnet-identity-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -2645,7 +2659,7 @@ async function handleHealthChecksSync(request, env) {
     });
   } catch (err) {
     console.error("data-api health-checks-sync write failed:", err);
-    captureDataApiError(err, "health-checks-sync");
+    await captureDataApiError(err, "health-checks-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -2786,7 +2800,7 @@ async function handleHealthUptimeRollupSync(request, env) {
     });
   } catch (err) {
     console.error("data-api health-uptime-rollup-sync write failed:", err);
-    captureDataApiError(err, "health-uptime-rollup-sync");
+    await captureDataApiError(err, "health-uptime-rollup-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -2961,7 +2975,7 @@ async function handleSubnetSnapshotSync(request, env) {
     });
   } catch (err) {
     console.error("data-api subnet-snapshot-sync write failed:", err);
-    captureDataApiError(err, "subnet-snapshot-sync");
+    await captureDataApiError(err, "subnet-snapshot-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -3046,7 +3060,7 @@ async function handleRpcUsageEventSync(request, env) {
     return writeJson({ ok: true });
   } catch (err) {
     console.error("data-api rpc-usage-sync write failed:", err);
-    captureDataApiError(err, "rpc-usage-sync");
+    await captureDataApiError(err, "rpc-usage-sync", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -3100,7 +3114,7 @@ async function handleRpcUsageEventPrune(request, env) {
     return writeJson({ ok: true, rows_deleted: result.count });
   } catch (err) {
     console.error("data-api rpc-usage-prune write failed:", err);
-    captureDataApiError(err, "rpc-usage-prune");
+    await captureDataApiError(err, "rpc-usage-prune", env);
     return writeJson({ error: "write failed" }, 502);
   }
 }
@@ -3139,7 +3153,7 @@ function json(data, status = 200) {
 // response. `sql.savepoint()` runs the read in its own nested scope so a
 // failure there rolls back to a savepoint instead of the whole transaction,
 // leaving the enclosing transaction (and its other queries) unaffected.
-async function loadFeaturedHotkeys(sql) {
+async function loadFeaturedHotkeys(sql, env) {
   try {
     const rows = await sql.savepoint(
       (sql) => sql`SELECT hotkey FROM featured_validators`,
@@ -3147,7 +3161,7 @@ async function loadFeaturedHotkeys(sql) {
     return new Set(rows.map((row) => row.hotkey));
   } catch (err) {
     console.error("featured_validators query failed:", err);
-    captureDataApiError(err, "featured-validators-query");
+    await captureDataApiError(err, "featured-validators-query", env);
     return new Set();
   }
 }
@@ -3161,7 +3175,7 @@ async function loadFeaturedHotkeys(sql) {
 // Hyperdrive fetch_types:false setting breaks postgres.js's automatic
 // ARRAY-literal serialization for a bound JS array (ANY($1)), so every IN
 // clause here builds its own scalar placeholder list instead.
-async function loadAccountIdentitiesByColdkey(sql, coldkeys) {
+async function loadAccountIdentitiesByColdkey(sql, coldkeys, env) {
   if (coldkeys.length === 0) return new Map();
   try {
     const placeholders = coldkeys.map((_, i) => `$${i + 1}::text`).join(", ");
@@ -3175,7 +3189,7 @@ async function loadAccountIdentitiesByColdkey(sql, coldkeys) {
     return new Map(rows.map((row) => [row.account, row]));
   } catch (err) {
     console.error("account_identity join query failed:", err);
-    captureDataApiError(err, "account-identity-join-query");
+    await captureDataApiError(err, "account-identity-join-query", env);
     return new Map();
   }
 }
@@ -3195,7 +3209,7 @@ function distinctColdkeys(rows) {
 // /api/v1/validators response to nominator_count: null everywhere rather
 // than failing the request or rolling back the enclosing transaction's other
 // queries.
-async function loadValidatorNominatorCounts(sql) {
+async function loadValidatorNominatorCounts(sql, env) {
   try {
     const rows = await sql.savepoint(
       (sql) =>
@@ -3204,7 +3218,7 @@ async function loadValidatorNominatorCounts(sql) {
     return nominatorCountsByHotkey(rows);
   } catch (err) {
     console.error("validator_nominator_counts query failed:", err);
-    captureDataApiError(err, "validator-nominator-counts-query");
+    await captureDataApiError(err, "validator-nominator-counts-query", env);
     return new Map();
   }
 }
@@ -3214,7 +3228,7 @@ async function loadValidatorNominatorCounts(sql) {
 // null everywhere (accumulateApyRow's tempoByNetuid.get(...) == null branch)
 // rather than failing /api/v1/validators or /api/v1/validators/:hotkey, or
 // rolling back the enclosing transaction's other queries.
-async function loadSubnetTempos(sql) {
+async function loadSubnetTempos(sql, env) {
   try {
     const rows = await sql.savepoint(
       (sql) => sql`SELECT netuid, tempo FROM subnet_hyperparams`,
@@ -3222,7 +3236,7 @@ async function loadSubnetTempos(sql) {
     return buildTempoByNetuid(rows);
   } catch (err) {
     console.error("subnet_hyperparams tempo query failed:", err);
-    captureDataApiError(err, "subnet-hyperparams-tempo-query");
+    await captureDataApiError(err, "subnet-hyperparams-tempo-query", env);
     return new Map();
   }
 }
@@ -3245,7 +3259,7 @@ const REALIZED_RETURN_WINDOWS = { d1: 1, d7: 7, d30: 30 };
 // realized_return_* to null rather than failing /api/v1/validators or
 // /api/v1/validators/:hotkey, or rolling back the enclosing transaction's
 // other queries. `hotkey` scopes the scan to the single-validator detail route.
-async function loadRealizedStakeBaselines(sql, { hotkey = null } = {}) {
+async function loadRealizedStakeBaselines(sql, { hotkey = null } = {}, env) {
   const windows = Object.entries(REALIZED_RETURN_WINDOWS);
   try {
     const perWindow = await sql.savepoint((sql) =>
@@ -3293,7 +3307,7 @@ async function loadRealizedStakeBaselines(sql, { hotkey = null } = {}) {
     return byHotkey;
   } catch (err) {
     console.error("neuron_daily realized-return baseline query failed:", err);
-    captureDataApiError(err, "realized-return-baseline-query");
+    await captureDataApiError(err, "realized-return-baseline-query", env);
     return new Map();
   }
 }
@@ -3307,7 +3321,7 @@ async function loadRealizedStakeBaselines(sql, { hotkey = null } = {}) {
 // subnet-hyperparams.ts's own nonNegativeInt -- Number(null) is 0, not
 // NaN -- written inline rather than imported since each domain file owns its
 // small D1/Postgres cell-coercion copies (see that file's own header).
-async function loadSubnetImmunityPeriod(sql, netuid) {
+async function loadSubnetImmunityPeriod(sql, netuid, env) {
   try {
     const rows = await sql.savepoint(
       (sql) =>
@@ -3319,7 +3333,11 @@ async function loadSubnetImmunityPeriod(sql, netuid) {
     return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
   } catch (err) {
     console.error("subnet_hyperparams immunity_period query failed:", err);
-    captureDataApiError(err, "subnet-hyperparams-immunity-period-query");
+    await captureDataApiError(
+      err,
+      "subnet-hyperparams-immunity-period-query",
+      env,
+    );
     return null;
   }
 }
@@ -3327,7 +3345,7 @@ async function loadSubnetImmunityPeriod(sql, netuid) {
 // Raw nominator_positions rows for one coldkey (#5233) -- savepoint-isolated
 // like the loaders above, so a cold/absent table degrades this specific
 // route to an empty positions card rather than failing the request.
-async function loadNominatorPositions(sql, ss58) {
+async function loadNominatorPositions(sql, ss58, env) {
   try {
     return await sql.savepoint(
       (sql) => sql`
@@ -3336,7 +3354,7 @@ async function loadNominatorPositions(sql, ss58) {
     );
   } catch (err) {
     console.error("nominator_positions query failed:", err);
-    captureDataApiError(err, "nominator-positions-query");
+    await captureDataApiError(err, "nominator-positions-query", env);
     return [];
   }
 }
@@ -3347,7 +3365,7 @@ async function loadNominatorPositions(sql, ss58) {
 // scalar-placeholder IN-list shape as loadAccountIdentitiesByColdkey above
 // (this Worker's Hyperdrive fetch_types:false setting breaks automatic
 // ARRAY-literal binding for a JS array).
-async function loadNeuronStakeByHotkeys(sql, hotkeys) {
+async function loadNeuronStakeByHotkeys(sql, hotkeys, env) {
   if (hotkeys.length === 0) return new Map();
   try {
     const placeholders = hotkeys.map((_, i) => `$${i + 1}::text`).join(", ");
@@ -3360,7 +3378,7 @@ async function loadNeuronStakeByHotkeys(sql, hotkeys) {
     return stakeByHotkeyNetuid(rows);
   } catch (err) {
     console.error("neurons stake-by-hotkey join query failed:", err);
-    captureDataApiError(err, "neurons-stake-by-hotkey-query");
+    await captureDataApiError(err, "neurons-stake-by-hotkey-query", env);
     return new Map();
   }
 }
@@ -3502,7 +3520,7 @@ async function withAlertTriggersSql(env, fn) {
     return await fn(sql);
   } catch (err) {
     console.error("data-api alert-triggers write failed:", err);
-    captureDataApiError(err, "alert-triggers");
+    await captureDataApiError(err, "alert-triggers", env);
     return writeJson({ error: "write failed" }, 502);
   }
   // No sql.end() -- Hyperdrive cleans up the connection when the request/
@@ -3991,7 +4009,7 @@ async function withAccountsSql(env, fn) {
     return await fn(sql);
   } catch (err) {
     console.error("data-api wallet-auth/keys write failed:", err);
-    captureDataApiError(err, "wallet-auth-keys");
+    await captureDataApiError(err, "wallet-auth-keys", env);
     return writeJson({ error: "write failed" }, 502);
   }
   // No sql.end() -- same Hyperdrive-cleans-up-on-invocation-end convention
@@ -7942,7 +7960,7 @@ export default {
               : sql`
               SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take
               FROM neurons WHERE netuid = ${netuid} ORDER BY uid`,
-            loadSubnetImmunityPeriod(sql, netuid),
+            loadSubnetImmunityPeriod(sql, netuid, env),
           ]);
           return json(buildSubnetMetagraph(rows, netuid, { immunityPeriod }));
         }
@@ -7960,7 +7978,7 @@ export default {
             sql`
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take
           FROM neurons WHERE netuid = ${netuid} AND uid = ${uid} LIMIT 1`,
-            loadSubnetImmunityPeriod(sql, netuid),
+            loadSubnetImmunityPeriod(sql, netuid, env),
           ]);
           return json(
             buildNeuronDetail(rows[0] ?? null, netuid, { immunityPeriod }),
@@ -7979,7 +7997,7 @@ export default {
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take
           FROM neurons WHERE netuid = ${netuid} AND validator_permit = TRUE
           ORDER BY stake_tao DESC, uid ASC`,
-            loadFeaturedHotkeys(sql),
+            loadFeaturedHotkeys(sql, env),
           ]);
           return json(buildSubnetValidators(rows, netuid, { featuredHotkeys }));
         }
@@ -8011,16 +8029,17 @@ export default {
           SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at, take
           FROM neurons WHERE validator_permit = TRUE AND hotkey IS NOT NULL
           ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
-            loadFeaturedHotkeys(sql),
-            loadValidatorNominatorCounts(sql),
-            loadSubnetTempos(sql),
-            loadRealizedStakeBaselines(sql),
+            loadFeaturedHotkeys(sql, env),
+            loadValidatorNominatorCounts(sql, env),
+            loadSubnetTempos(sql, env),
+            loadRealizedStakeBaselines(sql, {}, env),
           ]);
           // Identity join (#5234): needs `rows` resolved first to know which
           // coldkeys to look up, so it can't join the Promise.all above.
           const identityByColdkey = await loadAccountIdentitiesByColdkey(
             sql,
             distinctColdkeys(rows),
+            env,
           );
           return json(
             buildGlobalValidators(rows, {
@@ -8048,14 +8067,15 @@ export default {
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take, netuid
           FROM neurons WHERE hotkey = ${hotkey} AND validator_permit = TRUE
           ORDER BY netuid ASC, uid ASC`,
-              loadValidatorNominatorCounts(sql),
-              loadSubnetTempos(sql),
-              loadRealizedStakeBaselines(sql, { hotkey }),
+              loadValidatorNominatorCounts(sql, env),
+              loadSubnetTempos(sql, env),
+              loadRealizedStakeBaselines(sql, { hotkey }, env),
             ]);
           // Identity join (#5234): see the /api/v1/validators comment above.
           const identityByColdkey = await loadAccountIdentitiesByColdkey(
             sql,
             distinctColdkeys(rows),
+            env,
           );
           return json(
             buildValidatorDetail(rows, hotkey, {
@@ -8307,10 +8327,11 @@ export default {
         );
         if (acctPositions) {
           const ss58 = decodeURIComponent(acctPositions[1]);
-          const positionRows = await loadNominatorPositions(sql, ss58);
+          const positionRows = await loadNominatorPositions(sql, ss58, env);
           const hotkeyNetuidStake = await loadNeuronStakeByHotkeys(
             sql,
             distinctHotkeys(positionRows),
+            env,
           );
           return json(
             buildAccountPositions(positionRows, hotkeyNetuidStake, ss58),
@@ -8860,7 +8881,7 @@ export default {
       // url.pathname (not a static tag) -- this catch is the generic
       // fallback for the WHOLE route dispatcher above, so the actual
       // failing route is the only thing that makes the Sentry event useful.
-      captureDataApiError(err, url.pathname);
+      await captureDataApiError(err, url.pathname, env);
       return json({ error: "data query failed" }, 502);
     }
     // No sql.end() here: Hyperdrive automatically cleans up the connection


### PR DESCRIPTION
## Summary

- Adds `recordExceptionEvent` (`src/usage-telemetry.ts`): captures a caught exception as PostHog's canonical `$exception` event via the same bundle-safe raw-fetch pattern as the existing `usage_event`/`$mcp_tool_call` telemetry -- `posthog-node` isn't needed here either.
- **Schema verified directly against PostHog's own ingestion source** (`rust/cymbal/src/core/types/{exception,stacktrace}.rs`, `.../langs/custom.rs`), not just the docs page, plus a real production `$exception` fixture from their test suite -- `$exception_list` (`type`/`value`/`mechanism`/`stacktrace`), `platform:"custom"`/`lang:"javascript"` frame markers (PostHog's dedicated "no SDK" frame shape), and `$exception_fingerprint` (a plain string, confirmed against their own Rust test code).
- Includes a small V8 stack-trace parser -- bounded to 30 frames, never silently drops an unparseable line, marks `node_modules` frames as `in_app: false` -- and orders frames oldest-call-first to match the Sentry-derived protocol PostHog's schema is built on.
- Wired in **parallel** alongside every existing `Sentry.captureException` call site:
  - `src/mcp-server.mjs`'s `dispatchTool` catch (fire-and-forget via `waitUntil`, `ctx` already available there -- mirrors `scheduleMcpToolCallEvent`'s existing pattern).
  - `src/graphql.mjs`'s genuine-fault loop.
  - `workers/api.mjs`'s two AI-route error sites.
  - `workers/data-api.mjs`'s 26 sync/query error sites -- 8 of which required threading `env` through query-loader helpers (`loadFeaturedHotkeys`, `loadAccountIdentitiesByColdkey`, etc.) that didn't have it before, since they're called from inside a `Promise.all` one level below the route handler.
- The latter three (graphql/api/data-api) have no `ExecutionContext` at their capture site, so the PostHog POST is `await`ed inline instead of fire-and-forget -- the cost is a little latency on an already-failing response, not silent event loss from an isolate torn down mid-fetch.

## Why

Part of the PostHog consolidation epic (#7757) -- this is Phase 1 (errors) for the Workers side. This is additive: existing Sentry capture is completely untouched, and stays that way until parity is proven and the gated decommission issue (#7766) is ready.

## Test plan

- [x] New unit tests directly on `recordExceptionEvent` (`tests/usage-telemetry.test.mjs`): full event shape for a real thrown error, frame ordering (thrown frame last), `in_app` detection, filename/line/col parsing, unparseable-line fallback, frame-count capping, non-Error thrown values, message truncation, fingerprint fallback logic (`route` → `mcpTool` → `"unknown"`), blank/whitespace-only name & message edge cases, unconfigured no-op, malformed-event rejection, transport-failure/rejected-capture handling, platform-fetch fallback.
- [x] End-to-end tests through the real dispatch path for all 4 wiring sites, each proving the `$exception` event actually posts with the right route/tool tag and error message, and that expected (non-exceptional) errors never trigger it:
  - `tests/mcp-usage-telemetry.test.mjs` -- a real `semantic_search` internal fault (Vectorize rejection) vs. an expected `toolError`.
  - `tests/graphql-sentry-and-error-code.test.mjs` -- a genuine resolver exception vs. a deliberate `GraphQLError`.
  - `tests/api-ai-routes-sentry.test.mjs` -- both AI routes' backend failures vs. a caller-input rejection.
  - `tests/data-api.test.mjs` -- `neurons-sync`'s DB-failure path (representative of all 26 identically-shaped sites) plus a net-new failure-path test for `subnet-locks-sync`, which had zero prior test coverage at all.
- [x] `npm run test:coverage` -- full suite green (11389 tests), and I verified with a line-by-line diff-to-lcov cross-check (not just the aggregate file percentage) that **every single added line and branch across all 5 changed source files is covered** -- 100% on `src/usage-telemetry.ts` (120/120 lines, 134/134 branches) and zero uncovered added lines in `mcp-server.mjs`/`graphql.mjs`/`api.mjs`/`data-api.mjs`.
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run format:check` -- all clean.
- [x] `npm run validate` -- unaffected (no schema/route changes, no `npm run build` needed).

## Notes

`POSTHOG_PROJECT_TOKEN` is already configured as a deployed secret (from #7754), so this capture goes live as soon as this merges and the Worker redeploys.

Closes #7758