### PR TITLE
fix(ui): resolve hydration mismatches on /subnets/:netuid

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import { Skeleton } from "@/components/metagraphed/states";
 import { Tooltip, TooltipContent, TooltipTrigger, InfoTooltip } from "@jsonbored/ui-kit";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 interface Props {
   netuid: number;
@@ -34,6 +35,10 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
   // drive the heatmap from the daily uptime rows and the incident SLA rows.
   const { data: uptimeRes, isLoading: tLoading } = useQuery(subnetUptimeQuery(netuid));
   const { data: incRes } = useQuery(subnetHealthIncidentsQuery(netuid));
+  // Plain (non-suspense) queries can already be resolved by hydration time
+  // even though SSR committed the loading branch — stay "loading" until
+  // hydration completes so both passes render the same skeleton.
+  const hydrated = useHydrated();
 
   const cells = useMemo<Cell[]>(() => {
     const days = weeks * 7;
@@ -97,7 +102,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
     return cols;
   }, [cells, weeks]);
 
-  if (tLoading) return <Skeleton className="h-44 w-full" />;
+  if (!hydrated || tLoading) return <Skeleton className="h-44 w-full" />;
 
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">

--- a/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
@@ -15,6 +15,7 @@ import {
   Donut,
   DonutLegend,
 } from "@jsonbored/ui-kit";
+import { useHydrated } from "@/hooks/use-hydrated";
 import type { SurfaceUptime } from "@/lib/metagraphed/types";
 
 interface Props {
@@ -61,9 +62,13 @@ export function EconomicsMini({ netuid }: Props) {
 
   // economicsQuery already returns the per-subnet array at res.data.
   const econ = (econRes?.data ?? []).find((r) => r.netuid === netuid);
+  // Plain (non-suspense) queries can already be resolved by hydration time
+  // even though SSR committed the loading branch — stay loading until
+  // hydration completes so both passes render the same skeleton.
+  const hydrated = useHydrated();
   const isLoading = ecLoading || uLoading;
 
-  if (isLoading) return <Skeleton className="h-44 w-full" />;
+  if (!hydrated || isLoading) return <Skeleton className="h-44 w-full" />;
 
   const price = numOrNull(econ?.alpha_price_tao);
   const inP = num(econ?.alpha_in_pool);

--- a/apps/ui/src/components/metagraphed/panel-shell.tsx
+++ b/apps/ui/src/components/metagraphed/panel-shell.tsx
@@ -5,6 +5,7 @@ import { SectionAnchor, TimeAgo, type SectionTone } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, isStaleFreshness, isUsableTimestamp } from "@/lib/metagraphed/format";
 import { reportError } from "@/lib/error-reporting";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 interface MetaInfo {
   generatedAt?: string;
@@ -53,6 +54,18 @@ export function PanelShell({
   const queryClient = useQueryClient();
   const [refreshing, setRefreshing] = useState(false);
   const stale = meta?.stale ?? isStaleFreshness(meta?.generatedAt);
+  // meta comes from a plain useQuery in most callers (not useSuspenseQuery), so
+  // its value can differ between the SSR pass and the client's first paint if
+  // the query resolves in the gap between them — gate the timestamp pill
+  // behind hydration so both passes agree, matching useHydrated's own doc.
+  const hydrated = useHydrated();
+  const showFreshnessPill = hydrated && isUsableTimestamp(meta?.generatedAt);
+  // isLoading is caller-supplied and usually derived from a plain (non-suspense)
+  // useQuery, so it can already be `false` by hydration time even though SSR
+  // committed the loading branch — stay loading until hydration completes so
+  // both passes agree, for every PanelShell caller, not just this file's own
+  // internal state.
+  const effectiveLoading = !hydrated || isLoading;
 
   const onRefresh = async () => {
     if (!refreshQueryKeys?.length) return;
@@ -71,7 +84,7 @@ export function PanelShell({
   const headerRight = (
     <div className="flex flex-col items-end gap-1.5 sm:flex-row sm:items-center sm:gap-2 min-w-0">
       <div className="flex items-center gap-2">
-        {isUsableTimestamp(meta?.generatedAt) ? (
+        {showFreshnessPill ? (
           <span
             className={
               "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[10px] " +
@@ -115,7 +128,7 @@ export function PanelShell({
         onRefresh={onRefresh}
         context={typeof title === "string" ? title : id}
       >
-        {isLoading ? (
+        {effectiveLoading ? (
           <div
             className="rounded-xl border border-border bg-card p-4"
             aria-busy="true"

--- a/apps/ui/src/components/metagraphed/resource-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/resource-explorer.tsx
@@ -27,6 +27,7 @@ import {
 } from "@jsonbored/ui-kit";
 import { PanelShell } from "@/components/metagraphed/panel-shell";
 import { useCopy } from "@/hooks/use-copy";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { classNames } from "@/lib/metagraphed/format";
 import {
   useSubnetFilter,
@@ -281,6 +282,11 @@ function EndpointsView({
   const epRes = epQ.data;
   const allRows = (epRes?.data ?? []) as Endpoint[];
   void (poolsQ.data?.data as RpcPool[] | undefined);
+  // epQ is a plain (non-suspense) query, so its cache can already be resolved
+  // by the time the client hydrates even though SSR committed the loading
+  // branch — treat the component as loading until hydration completes so both
+  // passes render the same skeleton, matching useHydrated's documented use.
+  const hydrated = useHydrated();
 
   const retry = () =>
     Promise.all([
@@ -288,7 +294,7 @@ function EndpointsView({
       queryClient.invalidateQueries({ queryKey: poolOpts.queryKey, refetchType: "active" }),
     ]);
 
-  if (epQ.isPending) return <Skeleton className="h-48 w-full" />;
+  if (!hydrated || epQ.isPending) return <Skeleton className="h-48 w-full" />;
   if (epQ.error) {
     return (
       <div className="p-4">
@@ -503,11 +509,15 @@ function SurfacesView({
   const surfaceQ = useQuery(surfaceOpts);
   const data = surfaceQ.data;
   const allRows = (data?.data ?? []) as Surface[];
+  // See EndpointsView above: gate the loading branch behind hydration so SSR
+  // and the client's first paint agree even when surfaceQ's cache is already
+  // resolved by hydration time.
+  const hydrated = useHydrated();
 
   const retry = () =>
     queryClient.invalidateQueries({ queryKey: surfaceOpts.queryKey, refetchType: "active" });
 
-  if (surfaceQ.isPending) return <Skeleton className="h-48 w-full" />;
+  if (!hydrated || surfaceQ.isPending) return <Skeleton className="h-48 w-full" />;
   if (surfaceQ.error) {
     return (
       <div className="p-4">

--- a/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { GitMerge, ArrowRight } from "lucide-react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import {
   economicsQuery,
   lineageQuery,
@@ -105,6 +106,11 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
   const { data: econRes } = useQuery(economicsQuery());
   const { data: lineageRes } = useQuery(lineageQuery());
   const { data: endpointsRes } = useQuery(subnetEndpointsQuery(netuid));
+  // lineageQuery is a plain (non-suspense) query, so its cache can already be
+  // resolved by hydration time even though SSR committed the "not paired"
+  // branch — gate the paired-callout swap behind hydration so both passes
+  // agree, matching useHydrated's documented use.
+  const hydrated = useHydrated();
   // economicsQuery already returns the per-subnet array at res.data (the
   // `.subnets` hop is unwrapped inside the query) — find our netuid directly.
   const econ = (econRes?.data ?? []).find((r) => r.netuid === netuid);
@@ -219,7 +225,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
 
         {/* Lineage callout — the canonical #lineage anchor lives in the route's
             SubnetLineageSection; this is an inline summary, so it carries no id. */}
-        {lineagePeer ? (
+        {hydrated && lineagePeer ? (
           <div className="flex flex-wrap items-center gap-2 px-4 py-2.5 border-b border-border bg-surface/20">
             <GitMerge className="size-3.5 text-accent" />
             <span className="text-[12px] text-ink">
@@ -241,8 +247,9 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
 
         {/* Visualizations row — pool composition donut + endpoint topology
             donut + top providers lockup. Always rendered, falls back per
-            slot when data is absent. */}
-        {poolSegments.some((s) => s.value > 0) || topology.length > 0 ? (
+            slot when data is absent. econ/endpoints are plain (non-suspense)
+            queries, so gate behind hydration — see the lineage callout above. */}
+        {hydrated && (poolSegments.some((s) => s.value > 0) || topology.length > 0) ? (
           <div className="grid md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-border border-b border-border">
             <div className="flex items-center gap-4 p-4">
               {poolSegments.some((s) => s.value > 0) ? (
@@ -345,8 +352,9 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
           </div>
         ) : null}
 
-        {/* Economics strip */}
-        {econ ? (
+        {/* Economics strip — econ is a plain (non-suspense) query, same hydration
+            gate as the lineage callout and visualizations row above. */}
+        {hydrated && econ ? (
           <div className="grid grid-cols-3 md:grid-cols-6 divide-x divide-border border-b border-border">
             {primary.map((f) => (
               <Stat key={f.label} field={f} />
@@ -361,8 +369,10 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
               Ownership
             </div>
             {(() => {
-              const coldkey = str(econ?.owner_coldkey);
-              const hotkey = str(econ?.owner_hotkey);
+              // econ is a plain (non-suspense) query — same hydration gate as
+              // the other econ-derived conditionals in this component.
+              const coldkey = hydrated ? str(econ?.owner_coldkey) : undefined;
+              const hotkey = hydrated ? str(econ?.owner_hotkey) : undefined;
               return coldkey || hotkey ? (
                 <>
                   {coldkey ? (

--- a/apps/ui/src/hooks/use-subnet-probe-health.ts
+++ b/apps/ui/src/hooks/use-subnet-probe-health.ts
@@ -8,6 +8,7 @@ import {
   resolveSubnetProbeHealth,
   worstActiveIncidentHealth,
 } from "@/lib/metagraphed/subnet-probe-health";
+import { useHydrated } from "@/hooks/use-hydrated";
 import type { EndpointIncident, HealthState } from "@/lib/metagraphed/types";
 
 /**
@@ -20,12 +21,15 @@ export function useSubnetProbeHealth(netuid: number): HealthState {
   const mapQ = useQuery(subnetHealthMapQuery());
   const detailQ = useQuery(subnetHealthQuery(netuid));
   const incidentsQ = useQuery({ ...endpointIncidentsQuery(), retry: 0 });
-  const mapHealth = mapQ.data?.data?.[netuid]?.health;
-  const summary = detailQ.data?.data;
-  const incidentHealth = worstActiveIncidentHealth(
-    incidentsQ.data?.data as EndpointIncident[] | undefined,
-    netuid,
-  );
+  // These are plain (non-suspense) queries, so their cache can already be
+  // resolved by hydration time even though SSR committed "unknown" — stay
+  // "unknown" until hydration completes so both passes agree.
+  const hydrated = useHydrated();
+  const mapHealth = hydrated ? mapQ.data?.data?.[netuid]?.health : undefined;
+  const summary = hydrated ? detailQ.data?.data : undefined;
+  const incidentHealth = hydrated
+    ? worstActiveIncidentHealth(incidentsQ.data?.data as EndpointIncident[] | undefined, netuid)
+    : undefined;
   return resolveSubnetProbeHealth({
     mapHealth,
     summary: summary


### PR DESCRIPTION
## Summary
Found while visually verifying the Lovable-sync work on `/subnets/:netuid` (unrelated to that sync — confirmed via `git diff origin/main --stat` that none of these files were touched by any prior sync commit).

Six components/hooks read plain (non-suspense) `useQuery` data to drive a conditional render or loading branch. Since these queries can already be resolved by the time the client hydrates — even though SSR committed the pre-data branch — React threw a hydration mismatch and discarded/regenerated the affected subtree on every page load:

- `panel-shell.tsx` — the freshness pill, and the shared `isLoading` branch used by every `PanelShell` caller
- `resource-explorer.tsx` — `EndpointsView` + `SurfacesView`'s manual loading gate
- `subnet-profile-panel.tsx` — the lineage callout, visualizations row, economics strip, and ownership-keys block
- `charts/activity-heatmap.tsx` and `charts/economics-mini.tsx` — their manual loading gates
- `hooks/use-subnet-probe-health.ts` — the shared probe-health resolver used by the masthead's `HealthPill`

Each fix follows the existing `useHydrated()` convention already used elsewhere in this codebase (e.g. `registry-ticker.tsx`, `subnet-priority-highlights.tsx`): treat the query as still "loading" (or the derived value as still absent) until hydration completes, so the SSR pass and the client's first paint always agree. No behavior change once hydrated — this only affects the brief pre-hydration window.

## Test plan
- [x] `tsc --noEmit` clean across the whole `apps/ui` workspace (only pre-existing, unrelated MDX/docs-collection codegen errors remain)
- [x] `eslint`/`prettier` clean on all 6 changed files (0 errors)
- [x] Verified in-browser with a fresh full page load (not HMR) across three different netuids exercising different states (paired/unpaired lineage, healthy/down/unknown probe health, with/without economics data) — zero hydration console errors in all three, versus multiple `[hydration-capture] window error` entries per load before the fix