### PR TITLE
feat(ui): add PostHog error tracking and source-map upload

### DIFF
--- a/apps/ui/.env.example
+++ b/apps/ui/.env.example
@@ -54,3 +54,17 @@ VITE_POSTHOG_HOST=
 # https://us.posthog.com; override only if this project ever moves to EU
 # cloud or a different region.
 VITE_POSTHOG_UI_HOST=
+
+# PostHog error tracking + source maps (vite.config.ts, metagraphed#7759).
+# POSTHOG_API_KEY is a PERSONAL API key (real read/write access, unlike the
+# write-only VITE_POSTHOG_PROJECT_TOKEN above) -- same "real secret, dashboard
+# build variable only" treatment as SENTRY_AUTH_TOKEN, deliberately NOT
+# VITE_-prefixed so it's never bundled into client JS. POSTHOG_PROJECT_ID is
+# this project's numeric ID (220683), not a secret but has no safe code-level
+# default the way VITE_POSTHOG_UI_HOST above does, since it identifies the
+# specific PostHog project sourcemaps upload to. Sourcemap upload is optional
+# (readable stack traces in PostHog's error tracking vs. raw minified
+# column:line refs) -- both must be set together or upload stays disabled,
+# same all-or-nothing gate SENTRY_AUTH_TOKEN's own upload step uses.
+POSTHOG_API_KEY=
+POSTHOG_PROJECT_ID=

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -32,6 +32,7 @@
     "@jsonbored/ui-kit": "*",
     "@polkadot/api": "^16.5.6",
     "@polkadot/extension-dapp": "^0.63.1",
+    "@posthog/rollup-plugin": "^1.4.7",
     "@sentry/browser": "^10.60.0",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.83.0",

--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -6,14 +6,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // `import posthog from 'posthog-js'` in real code).
 const init = vi.hoisted(() => vi.fn());
 const capture = vi.hoisted(() => vi.fn());
+const captureExceptionSpy = vi.hoisted(() => vi.fn());
 
-vi.mock("posthog-js", () => ({ default: { init, capture } }));
+vi.mock("posthog-js", () => ({
+  default: { init, capture, captureException: captureExceptionSpy },
+}));
 
 describe("analytics (PostHog web analytics)", () => {
   beforeEach(() => {
     vi.resetModules();
     init.mockClear();
     capture.mockClear();
+    captureExceptionSpy.mockClear();
   });
 
   afterEach(() => {
@@ -45,6 +49,15 @@ describe("analytics (PostHog web analytics)", () => {
       await Promise.resolve();
       expect(init).not.toHaveBeenCalled();
       expect(capture).not.toHaveBeenCalled();
+    });
+
+    it("captureException never loads posthog-js or captures", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "");
+      const { captureException } = await import("./analytics");
+      captureException(new Error("boom"), { boundary: "panel_shell" });
+      await Promise.resolve();
+      expect(init).not.toHaveBeenCalled();
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -119,6 +132,30 @@ describe("analytics (PostHog web analytics)", () => {
       captureEvent("web_vitals", { metric: "CLS", value: 12 });
       await vi.waitFor(() => expect(capture).toHaveBeenCalled());
       expect(capture).toHaveBeenCalledWith("web_vitals", { metric: "CLS", value: 12 });
+    });
+
+    it("captureException calls posthog-js's dedicated captureException (never the generic .capture)", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      const { captureException } = await import("./analytics");
+      const err = new Error("boom");
+      captureException(err, { boundary: "panel_shell", componentStack: "<stack>" });
+      await vi.waitFor(() => expect(captureExceptionSpy).toHaveBeenCalled());
+      expect(captureExceptionSpy).toHaveBeenCalledWith(err, {
+        boundary: "panel_shell",
+        componentStack: "<stack>",
+      });
+      // Properties are merged FLAT (posthog-js's own signature), never
+      // nested under an `extra` key the way the Sentry sink does it.
+      expect(capture).not.toHaveBeenCalled();
+    });
+
+    it("captureException shares the same lazily-loaded instance as capturePageview/captureEvent (no second init)", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      const { capturePageview, captureException } = await import("./analytics");
+      capturePageview("https://metagraph.sh/");
+      captureException(new Error("boom"));
+      await vi.waitFor(() => expect(captureExceptionSpy).toHaveBeenCalled());
+      expect(init).toHaveBeenCalledTimes(1);
     });
 
     it("a posthog-js init failure never throws, and later captures are silently dropped", async () => {

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -1,11 +1,17 @@
 /**
- * Centralized PostHog web-analytics seam (metagraphed#7760).
+ * Centralized PostHog web-analytics + error-tracking seam
+ * (metagraphed#7760, #7759).
  *
- * Single chokepoint for client-side product analytics: the app calls
- * `initAnalytics()`/`capturePageview()`/`captureEvent()` and never touches
- * `posthog-js` directly elsewhere. Additive alongside the existing
- * self-hosted Umami tracker (src/server.ts) while parity is proven -- see
- * the consolidation epic (metagraphed#7757) for the decommission plan.
+ * Single chokepoint for client-side product analytics AND exception
+ * reporting: the app calls `initAnalytics()`/`capturePageview()`/
+ * `captureEvent()`/`captureException()` and never touches `posthog-js`
+ * directly elsewhere. `captureException` is called from
+ * error-reporting.ts's `reportError` -- a second, parallel sink alongside
+ * the existing Sentry one there, sharing THIS module's one `posthog-js`
+ * instance rather than each maintaining its own. Additive alongside the
+ * existing self-hosted Umami tracker (src/server.ts) and Sentry while parity
+ * is proven -- see the consolidation epic (metagraphed#7757) for the
+ * decommission plan.
  *
  * `posthog-js` is loaded via a DYNAMIC import, mirroring error-reporting.ts's
  * exact Sentry-loading pattern: this keeps it out of the initial client
@@ -134,4 +140,18 @@ export function capturePageview(url?: string): void {
 export function captureEvent(name: string, properties?: Record<string, unknown>): void {
   if (!POSTHOG_TOKEN) return;
   void loadPostHog().then((posthog) => posthog?.capture(name, properties));
+}
+
+/** Captures a caught exception via posthog-js's dedicated `captureException`
+ * (never the generic `.capture("$exception", ...)`, which PostHog's own docs
+ * warn is "unreliable because it does not attach required metadata" --
+ * `captureException` builds the stack trace / mechanism / fingerprint
+ * PostHog's error tracking needs automatically). `properties` is merged
+ * flat into the event (PostHog's own signature), not nested the way
+ * Sentry's `{ extra: context }` shape is -- see error-reporting.ts's own
+ * call site. Same best-effort, no-op-when-unconfigured contract as every
+ * other export here. */
+export function captureException(error: unknown, properties?: Record<string, unknown>): void {
+  if (!POSTHOG_TOKEN) return;
+  void loadPostHog().then((posthog) => posthog?.captureException(error, properties));
 }

--- a/apps/ui/src/lib/error-reporting.test.ts
+++ b/apps/ui/src/lib/error-reporting.test.ts
@@ -4,9 +4,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const captureException = vi.hoisted(() => vi.fn());
 const init = vi.hoisted(() => vi.fn());
 const reportLovableError = vi.hoisted(() => vi.fn());
+const posthogCaptureException = vi.hoisted(() => vi.fn());
 
 vi.mock("@sentry/browser", () => ({ init, captureException }));
 vi.mock("./lovable-error-reporting", () => ({ reportLovableError }));
+// analytics.ts is a real, independently-tested module (analytics.test.ts) --
+// mocked here purely to isolate reportError's own fan-out logic from
+// analytics.ts's own token-gating / lazy-load behavior.
+vi.mock("./analytics", () => ({ captureException: posthogCaptureException }));
 
 describe("reportError", () => {
   beforeEach(() => {
@@ -14,6 +19,7 @@ describe("reportError", () => {
     captureException.mockClear();
     init.mockClear();
     reportLovableError.mockClear();
+    posthogCaptureException.mockClear();
   });
 
   afterEach(() => {
@@ -26,6 +32,32 @@ describe("reportError", () => {
     const err = new Error("boom");
     reportError(err, { boundary: "panel_shell" });
     expect(reportLovableError).toHaveBeenCalledWith(err, { boundary: "panel_shell" });
+  });
+
+  it("forwards to PostHog (analytics.ts) regardless of Sentry DSN -- a parallel sink, not a replacement", async () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+    const { reportError } = await import("./error-reporting");
+    const err = new Error("boom");
+    const ctx = { boundary: "panel_shell", componentStack: "<stack>" };
+    reportError(err, ctx);
+    // analytics.ts's own captureException does its own token-gating/no-op
+    // internally (verified in analytics.test.ts) -- reportError must call it
+    // unconditionally and let that module decide whether it's a no-op.
+    expect(posthogCaptureException).toHaveBeenCalledWith(err, ctx);
+  });
+
+  it("passes properties FLAT to PostHog, never nested under `extra` the way the Sentry call site is", async () => {
+    // DSN intentionally unset: this test only cares about the PostHog call
+    // shape, and leaving Sentry unconfigured avoids its own async dynamic
+    // import resolving after this test has already finished (which would
+    // otherwise bleed a captureException call into a later test).
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+    const { reportError } = await import("./error-reporting");
+    const err = new Error("boom");
+    const ctx = { boundary: "panel_shell" };
+    reportError(err, ctx);
+    expect(posthogCaptureException).toHaveBeenCalledWith(err, ctx);
+    expect(posthogCaptureException).not.toHaveBeenCalledWith(err, { extra: ctx });
   });
 
   it("does NOT touch Sentry when no DSN is configured and it's not a production build", async () => {

--- a/apps/ui/src/lib/error-reporting.ts
+++ b/apps/ui/src/lib/error-reporting.ts
@@ -1,4 +1,5 @@
 import { reportLovableError } from "./lovable-error-reporting";
+import { captureException as capturePostHogException } from "./analytics";
 
 /**
  * Centralized error-reporting seam for React error boundaries.
@@ -22,8 +23,19 @@ import { reportLovableError } from "./lovable-error-reporting";
  *     token, unlike the DSN below, so it can't have a code-level default
  *     the same way -- sourcemap upload stays opt-in until a maintainer sets
  *     it as a Workers Builds dashboard build variable).
- *  2. Lovable capture channel — best-effort, no-op outside the Lovable editor.
- *  3. `console.error` in dev so the boundary + context are always greppable
+ *  2. PostHog (metagraphed#7759) — a second, PARALLEL sink, not a
+ *     replacement; enabled whenever `VITE_POSTHOG_PROJECT_TOKEN` is
+ *     configured (see analytics.ts). Reuses analytics.ts's own
+ *     `captureException`, which shares the SAME lazily-loaded `posthog-js`
+ *     instance web analytics already manages -- this file never touches
+ *     `posthog-js` directly or triggers a second init. Release correlation
+ *     for PostHog works differently than Sentry's `release` property: it's
+ *     inferred at read time from the chunk IDs `@posthog/rollup-plugin`
+ *     injects into the built JS at upload time (vite.config.ts), not
+ *     something passed at capture time -- so there's no per-call release tag
+ *     to set here, unlike the Sentry sink above.
+ *  3. Lovable capture channel — best-effort, no-op outside the Lovable editor.
+ *  4. `console.error` in dev so the boundary + context are always greppable
  *     locally.
  *
  * DSN resolution mirrors DEFAULT_API_BASE's own convention
@@ -80,10 +92,14 @@ export function reportError(error: unknown, context: Record<string, unknown> = {
     });
   }
 
-  // 2. Forward to the existing Lovable capture channel (no-op when unavailable / SSR).
+  // 2. PostHog — a parallel sink, not a replacement; analytics.ts's own
+  // VITE_POSTHOG_PROJECT_TOKEN gate makes this a no-op when unconfigured.
+  capturePostHogException(error, context);
+
+  // 3. Forward to the existing Lovable capture channel (no-op when unavailable / SSR).
   reportLovableError(error, context);
 
-  // 3. Always surface locally in dev for greppable boundary + context.
+  // 4. Always surface locally in dev for greppable boundary + context.
   if (import.meta.env?.DEV) {
     console.error("[reportError]", context.boundary ?? "boundary", error, context);
   }

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -6,8 +6,10 @@
 // You can pass additional config via defineConfig({ vite: { ... }, etc... }) if needed.
 import { defineConfig, type LovableViteTanstackOptions } from "@lovable.dev/vite-tanstack-config";
 import type { NitroPluginConfig } from "nitro/vite";
+import type { NormalizedOutputOptions, OutputBundle, Plugin, PluginContext } from "rollup";
 import mdx from "fumadocs-mdx/vite";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
+import posthogRollupPlugin from "@posthog/rollup-plugin";
 
 // Cloudflare Workers Builds auto-injects this (no manual dashboard step) --
 // confirmed via Cloudflare's own docs (workers/ci-cd/builds/configuration/,
@@ -16,6 +18,53 @@ import { sentryVitePlugin } from "@sentry/vite-plugin";
 // locally/in PR CI, where it's simply undefined -- Sentry accepts an
 // undefined release (just omits release tagging), not an error condition.
 const commitSha = process.env.WORKERS_CI_COMMIT_SHA;
+
+// @posthog/rollup-plugin's own `writeBundle` hook (the step that actually
+// uploads source maps, node_modules/@posthog/rollup-plugin/src/index.ts) has
+// NO `errorHandler` option, unlike sentryVitePlugin above -- a rejected
+// upload (network blip, expired personal API key, missing `posthog-cli`
+// binary -- confirmed via @posthog/plugin-utils' spawnLocal, which rejects
+// on any non-zero exit code) propagates straight out of the hook and fails
+// the ENTIRE build. Wrap the returned plugin's handler in the same
+// tolerant warn-and-continue behavior sentryVitePlugin gets for free via its
+// own `errorHandler`, so a PostHog-side hiccup can never block a real deploy.
+function withTolerantSourcemapUpload(plugin: Plugin): Plugin {
+  const writeBundle = plugin.writeBundle;
+  if (typeof writeBundle !== "object" || writeBundle === null) return plugin;
+  const originalHandler = writeBundle.handler as (
+    this: PluginContext,
+    options: NormalizedOutputOptions,
+    bundle: OutputBundle,
+  ) => void | Promise<void>;
+  return {
+    ...plugin,
+    writeBundle: {
+      ...writeBundle,
+      async handler(this: PluginContext, options: NormalizedOutputOptions, bundle: OutputBundle) {
+        try {
+          await originalHandler.call(this, options, bundle);
+        } catch (err) {
+          console.warn("[posthog-rollup-plugin] source map upload failed:", err);
+        }
+      },
+    },
+  };
+}
+
+// POSTHOG_API_KEY (a personal API key, NOT the VITE_POSTHOG_PROJECT_TOKEN
+// client-side ingest token from src/lib/analytics.ts -- that one is
+// write-only/public-safe, this one is a real secret with read access) and
+// POSTHOG_PROJECT_ID gate sourcemap upload the same opt-in way
+// SENTRY_AUTH_TOKEN gates Sentry's above: both env vars must be present, or
+// this stays a true no-op. Explicit `sourcemaps.enabled` (rather than relying
+// on @posthog/plugin-utils' own default) is load-bearing here -- resolveConfig
+// THROWS SYNCHRONOUSLY at plugin-construction time (i.e. this very module's
+// eval, not a lazy build step) when sourcemaps default-enable with either
+// value missing (node_modules/@posthog/plugin-utils/src/config.ts), which
+// would otherwise break every unconfigured build (every PR/local dev today).
+const posthogApiKey = process.env.POSTHOG_API_KEY;
+const posthogProjectId = process.env.POSTHOG_PROJECT_ID;
+const posthogSourcemapsEnabled = Boolean(posthogApiKey && posthogProjectId);
 
 export default defineConfig({
   tanstackStart: {
@@ -70,6 +119,30 @@ export default defineConfig({
         filesToDeleteAfterUpload: ["**/*.js.map"],
       },
     }),
+    // PostHog error tracking (metagraphed#7759) source-map upload --
+    // independent of sentryVitePlugin above (no documented ordering
+    // requirement between the two; each only touches its own upload step),
+    // wrapped for the two build-safety gaps documented above this file's
+    // `posthogSourcemapsEnabled` const.
+    withTolerantSourcemapUpload(
+      posthogRollupPlugin({
+        personalApiKey: posthogApiKey ?? "",
+        projectId: posthogProjectId,
+        sourcemaps: {
+          enabled: posthogSourcemapsEnabled,
+          // Same release-correlation value as Sentry's `release.name` above
+          // (Cloudflare Workers Builds' own commit SHA) -- undefined locally/
+          // in PR CI, where sourcemaps.enabled is already false anyway.
+          releaseName: commitSha,
+          // Same "don't publicly serve the app's own source maps" rationale
+          // as Sentry's filesToDeleteAfterUpload above -- this plugin's own
+          // equivalent option (config.ts's `deleteAfterUpload`, defaults
+          // true) already matches, set explicitly so the intent is documented
+          // here rather than relying on an unstated default.
+          deleteAfterUpload: true,
+        },
+      }),
+    ),
   ],
   // `vite: { ... }` is this preset's own documented passthrough for plain
   // Vite options beyond plugins (see the header comment above) --

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@jsonbored/ui-kit": "*",
         "@polkadot/api": "^16.5.6",
         "@polkadot/extension-dapp": "^0.63.1",
+        "@posthog/rollup-plugin": "^1.4.7",
         "@sentry/browser": "^10.60.0",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.83.0",
@@ -4284,6 +4285,49 @@
         "@posthog/types": "^1.397.1"
       }
     },
+    "node_modules/@posthog/cli": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@posthog/cli/-/cli-0.7.34.tgz",
+      "integrity": "sha512-wrRwj0FhbypW01TLpFRo1HkPBrwZHKP2tFE9xI4NTb84yMKZnXy49ibBdbImktJ5NbW7ndeWidOCZx+2Lkk7/Q==",
+      "hasInstallScript": true,
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "posthog-cli": "run-posthog-cli.js"
+      },
+      "engines": {
+        "node": ">=14.14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@posthog/cli/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@posthog/core": {
       "version": "1.45.0",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.45.0.tgz",
@@ -4291,6 +4335,28 @@
       "license": "MIT",
       "dependencies": {
         "@posthog/types": "^1.398.0"
+      }
+    },
+    "node_modules/@posthog/plugin-utils": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@posthog/plugin-utils/-/plugin-utils-1.1.2.tgz",
+      "integrity": "sha512-CS/14cMmny9NN/LHAb4QZdW3TfxhbKzsfyVYMCjsRdE0IKMTrXMr0cPRZxwczsN6VnWvVoy2Dd5wcG6RrIjlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
+    },
+    "node_modules/@posthog/rollup-plugin": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@posthog/rollup-plugin/-/rollup-plugin-1.4.7.tgz",
+      "integrity": "sha512-bJgQLKZ5gkq79PBGTNqC8S6OAE8QtNIPYbvHnoboIh8qoZ0PS7RRpxuunoeOflxrHxpnM0Id9OxvrkGKJ2JE6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/cli": "~0.7.21",
+        "@posthog/plugin-utils": "^1.1.2"
+      },
+      "peerDependencies": {
+        "rollup": ">= 4.0.0"
       }
     },
     "node_modules/@posthog/types": {
@@ -9436,7 +9502,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -11396,7 +11461,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -13731,7 +13795,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14805,7 +14868,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14818,7 +14880,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16686,7 +16747,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"


### PR DESCRIPTION
## Summary

- `src/lib/analytics.ts`: adds `captureException(error, properties)`, using posthog-js's dedicated `captureException` (never the generic `.capture("$exception", ...)`, which PostHog's own docs warn is "unreliable because it does not attach required metadata"). Shares this module's one lazily-loaded `posthog-js` instance with the existing web-analytics exports (#7760) -- no second init.
- `src/lib/error-reporting.ts`: wires `captureException` into `reportError()` as a second, parallel sink alongside the existing Sentry one -- both fire on every call, neither replaces the other. Properties are passed flat (posthog-js's own signature), not nested under `extra` the way the Sentry call site is.
- `vite.config.ts`: adds `@posthog/rollup-plugin` for build-time source-map upload, gated on `POSTHOG_API_KEY` + `POSTHOG_PROJECT_ID` (both must be set, mirroring `SENTRY_AUTH_TOKEN`'s "real secret, dashboard build variable only" treatment -- `POSTHOG_API_KEY` is a personal API key with real read/write access, unlike the write-only `VITE_POSTHOG_PROJECT_TOKEN` ingest token).
- `.env.example`: documents `POSTHOG_API_KEY` / `POSTHOG_PROJECT_ID`.

Two build-safety gaps in `@posthog/rollup-plugin` confirmed by reading its actual source (`node_modules/@posthog/plugin-utils/src/config.ts`, `cli.ts`, `spawn-local.ts`) and verified empirically against a real `vite build`:

1. **`resolveConfig()` throws synchronously** at plugin-construction time (this file's own eval, not a lazy build step) when `sourcemaps.enabled` default-enables (`true` by default) with either `projectId` or `personalApiKey` missing. Confirmed live: `posthogRollupPlugin({ personalApiKey: '' })` throws `"projectId is required when sourcemaps are enabled"` immediately. Fixed by computing `sourcemaps.enabled` explicitly (`Boolean(posthogApiKey && posthogProjectId)`) instead of relying on the plugin's own default -- every unconfigured build (every PR/local dev today) now builds clean, confirmed via a real `vite build`.
2. **No `errorHandler` for a failed upload**, unlike `sentryVitePlugin` above it. `writeBundle.handler` → `runSourcemapCli` → `spawnLocal` rejects on any non-zero CLI exit code, and that rejection propagates straight out and fails the whole build. Reproduced live with a fake API key: the CLI hit a real 401 (`authentication_error`) three times (client/server/ssr build stages) and the build still exited 0, because `withTolerantSourcemapUpload()` wraps the plugin's `writeBundle.handler` in try/catch and only warns (`[posthog-rollup-plugin] source map upload failed: ...`) -- confirmed via the actual build log.

## Why

Part of the PostHog consolidation epic (#7757), closing #7759. Additive alongside the existing Sentry error tracking -- Sentry keeps running until parity is proven (metagraphed-infra tracks the box-side half separately).

## Test plan

- [x] New/updated unit tests: `src/lib/analytics.test.ts` (+2 tests: unconfigured no-op, and configured -- calls the dedicated `captureException`, never the generic `.capture`, and shares the one lazy `posthog-js` instance) and `src/lib/error-reporting.test.ts` (+2 tests: fires regardless of Sentry DSN state, properties passed flat not nested under `extra`).
- [x] `npm test --workspace=apps/ui` -- full suite green (182 files, 1390 tests).
- [x] `npx tsc --noEmit` (via `npm run typecheck --workspace=apps/ui`) and `npm run format:check --workspace=apps/ui` -- both clean.
- [x] `npm run lint --workspace=apps/ui` -- zero errors on every file this PR touches.
- [x] Real `vite build` (unconfigured, matching every PR/local dev) -- builds clean, no throw from the rollup plugin.
- [x] Real `vite build` with a fake `POSTHOG_API_KEY`/`POSTHOG_PROJECT_ID` -- the CLI genuinely fails auth (confirmed via its own log output), build still exits 0 and completes, confirming the tolerant-upload wrapper works under a real failure, not just a mocked one.

No screenshot table: this PR is confined to `src/lib/**` (analytics/error-reporting modules + their tests) and `vite.config.ts` (build-time only, no client runtime behavior change) -- the skill's own "no visual change" carve-out.

## Notes

`POSTHOG_API_KEY`/`POSTHOG_PROJECT_ID` aren't set anywhere yet, so source-map upload ships as a no-op until a maintainer sets both as Cloudflare Workers Builds dashboard build variables -- a deliberate, separate "enable upload" step, not part of this PR. `captureException` itself is live as soon as `VITE_POSTHOG_PROJECT_TOKEN` (#7760) is set, independent of the upload gate.

Closes #7759