### PR TITLE
feat(ui): merge Lovable's endpoints route redesign

### DIFF
--- a/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
@@ -47,43 +47,32 @@ export function AuthorSharePanel({ rows }: { rows: Block[] }) {
           const share = total > 0 ? (count / total) * 100 : 0;
           const pct = Math.max(3, Math.round((count / max) * 100));
           const heavy = share >= 20;
+          const filterByAuthor = () =>
+            navigate({
+              search: (prev: Record<string, unknown>) => ({ ...prev, author, offset: 0 }) as never,
+              resetScroll: false,
+            });
           return (
             <li key={author}>
-              <button
-                type="button"
-                onClick={() =>
-                  navigate({
-                    search: (prev: Record<string, unknown>) =>
-                      ({ ...prev, author, offset: 0 }) as never,
-                    resetScroll: false,
-                  })
-                }
-                className="mg-focus-ring group grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-2 text-left transition-colors hover:bg-surface/40 -mx-2 px-2 rounded"
-                title="Filter by this author"
-              >
+              {/* AccountAddress renders its own <a>/<button> (account link + copy
+                  button), so it can't sit inside a "filter by author" button/link
+                  without invalid HTML nesting (button-in-button breaks hydration).
+                  It's its own row; the bar + count below are the filter trigger. */}
+              <div className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-2 -mx-2 px-2 rounded">
                 <div className="min-w-0">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <AccountAddress
-                      ss58={author}
-                      compact
-                      keep={6}
-                      fallback={<span className="text-ink-muted">—</span>}
-                    />
-                  </div>
-                  <div
-                    aria-hidden
-                    className="mt-1.5 h-[3px] w-full overflow-hidden rounded-full bg-border/60"
-                  >
-                    <div
-                      className={classNames(
-                        "h-full rounded-full transition-[width]",
-                        heavy ? "bg-health-warn/80" : "bg-accent/70",
-                      )}
-                      style={{ width: `${pct}%` }}
-                    />
-                  </div>
+                  <AccountAddress
+                    ss58={author}
+                    compact
+                    keep={6}
+                    fallback={<span className="text-ink-muted">—</span>}
+                  />
                 </div>
-                <div className="shrink-0 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                <button
+                  type="button"
+                  onClick={filterByAuthor}
+                  className="mg-focus-ring shrink-0 text-right font-mono text-[11px] tabular-nums text-ink-strong"
+                  title="Filter by this author"
+                >
                   <div>{formatNumber(count)}</div>
                   <div
                     className={classNames(
@@ -93,6 +82,25 @@ export function AuthorSharePanel({ rows }: { rows: Block[] }) {
                   >
                     {share.toFixed(1)}%
                   </div>
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={filterByAuthor}
+                className="mg-focus-ring group -mt-1 block w-full text-left"
+                title="Filter by this author"
+              >
+                <div
+                  aria-hidden
+                  className="h-[3px] w-full overflow-hidden rounded-full bg-border/60 group-hover:opacity-80"
+                >
+                  <div
+                    className={classNames(
+                      "h-full rounded-full transition-[width]",
+                      heavy ? "bg-health-warn/80" : "bg-accent/70",
+                    )}
+                    style={{ width: `${pct}%` }}
+                  />
                 </div>
               </button>
             </li>

--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -41,12 +41,11 @@ export function LiveBlockRail() {
       role="status"
       aria-live="polite"
     >
-      {/* LATEST BLOCK */}
-      <Link
-        to="/blocks/$ref"
-        params={{ ref: String(latest.block_number) }}
-        className="mg-focus-ring flex items-center gap-3 rounded border border-transparent px-2 py-1.5 hover:border-border/70 hover:bg-surface/50"
-      >
+      {/* LATEST BLOCK. Not a single wrapping <Link>: AccountAddress below
+          renders its own <a>/<button> (account link + copy button), and an
+          anchor/button can't contain another without invalid HTML nesting
+          (breaks hydration). The block number is its own link instead. */}
+      <div className="flex items-center gap-3 rounded border border-transparent px-2 py-1.5">
         <span aria-hidden className="relative inline-flex size-2 items-center justify-center">
           <span className="absolute inline-flex size-2 animate-ping rounded-full bg-health-ok/60" />
           <span className="relative inline-flex size-1.5 rounded-full bg-health-ok" />
@@ -54,9 +53,13 @@ export function LiveBlockRail() {
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2">
             <span className="mg-type-micro text-ink-muted">Latest</span>
-            <span className="font-mono text-[14px] font-semibold tabular-nums text-ink-strong">
+            <Link
+              to="/blocks/$ref"
+              params={{ ref: String(latest.block_number) }}
+              className="mg-focus-ring rounded font-mono text-[14px] font-semibold tabular-nums text-ink-strong hover:text-accent"
+            >
               #{formatNumber(latest.block_number)}
-            </span>
+            </Link>
             <span className="font-mono text-[10px] text-ink-muted">
               <TimeAgo at={latest.observed_at} />
             </span>
@@ -75,7 +78,7 @@ export function LiveBlockRail() {
             {formatNumber(latest.event_count ?? 0)} evt
           </div>
         </div>
-      </Link>
+      </div>
 
       {/* MINI CADENCE STRIP */}
       <div className="flex flex-col justify-center gap-1.5 px-1">

--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import { Skeleton } from "@/components/metagraphed/states";
 import { Tooltip, TooltipContent, TooltipTrigger, InfoTooltip } from "@jsonbored/ui-kit";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 interface Props {
   netuid: number;
@@ -34,6 +35,10 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
   // drive the heatmap from the daily uptime rows and the incident SLA rows.
   const { data: uptimeRes, isLoading: tLoading } = useQuery(subnetUptimeQuery(netuid));
   const { data: incRes } = useQuery(subnetHealthIncidentsQuery(netuid));
+  // Plain (non-suspense) queries can already be resolved by hydration time
+  // even though SSR committed the loading branch — stay "loading" until
+  // hydration completes so both passes render the same skeleton.
+  const hydrated = useHydrated();
 
   const cells = useMemo<Cell[]>(() => {
     const days = weeks * 7;
@@ -97,7 +102,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
     return cols;
   }, [cells, weeks]);
 
-  if (tLoading) return <Skeleton className="h-44 w-full" />;
+  if (!hydrated || tLoading) return <Skeleton className="h-44 w-full" />;
 
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">

--- a/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
@@ -15,6 +15,7 @@ import {
   Donut,
   DonutLegend,
 } from "@jsonbored/ui-kit";
+import { useHydrated } from "@/hooks/use-hydrated";
 import type { SurfaceUptime } from "@/lib/metagraphed/types";
 
 interface Props {
@@ -61,9 +62,13 @@ export function EconomicsMini({ netuid }: Props) {
 
   // economicsQuery already returns the per-subnet array at res.data.
   const econ = (econRes?.data ?? []).find((r) => r.netuid === netuid);
+  // Plain (non-suspense) queries can already be resolved by hydration time
+  // even though SSR committed the loading branch — stay loading until
+  // hydration completes so both passes render the same skeleton.
+  const hydrated = useHydrated();
   const isLoading = ecLoading || uLoading;
 
-  if (isLoading) return <Skeleton className="h-44 w-full" />;
+  if (!hydrated || isLoading) return <Skeleton className="h-44 w-full" />;
 
   const price = numOrNull(econ?.alpha_price_tao);
   const inP = num(econ?.alpha_in_pool);

--- a/apps/ui/src/components/metagraphed/endpoint-chip-cluster.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-chip-cluster.tsx
@@ -1,0 +1,69 @@
+import { Chip } from "@/components/metagraphed/primitives";
+import type { Endpoint, RpcPool } from "@/lib/metagraphed/types";
+import {
+  endpointEligibility,
+  ELIGIBILITY_LABEL,
+  type PoolEligibility,
+} from "@/lib/metagraphed/endpoint-pool";
+import type { ChipTone } from "@/components/metagraphed/primitives/chip";
+
+const ELIGIBILITY_CHIP_TONE: Record<PoolEligibility, ChipTone> = {
+  "proxy-enabled": "accent",
+  "pool-member": "default",
+  "archive-capable": "ok",
+  unassigned: "muted",
+};
+
+interface Props {
+  endpoint: Endpoint;
+  poolsById: ReadonlyMap<string, RpcPool>;
+  /** Max chips to render before collapsing into a "+N" overflow chip. */
+  max?: number;
+  className?: string;
+}
+
+/**
+ * Single, tone-driven chip cluster for the endpoint row. Replaces the
+ * three parallel pill systems that used to co-exist here (archive dot,
+ * bespoke eligibility pill, callable badge, kind label) with a uniform
+ * hairline `Chip` API — so borders, spacing, casing, and hover states
+ * are guaranteed identical across contexts.
+ */
+export function EndpointChipCluster({ endpoint, poolsById, max = 3, className }: Props) {
+  const chips: Array<{ key: string; tone: ChipTone; label: string; title: string }> = [];
+  const eli = endpointEligibility(endpoint, poolsById);
+  if (eli !== "unassigned") {
+    chips.push({
+      key: "eli",
+      tone: ELIGIBILITY_CHIP_TONE[eli],
+      label: ELIGIBILITY_LABEL[eli],
+      title: `Pool eligibility · ${ELIGIBILITY_LABEL[eli]}`,
+    });
+  }
+  if (endpoint.archive) {
+    chips.push({ key: "archive", tone: "ok", label: "Archive", title: "Archive-capable" });
+  }
+  const authRequired = Boolean((endpoint as Record<string, unknown>).auth_required);
+  if (authRequired) {
+    chips.push({ key: "auth", tone: "warn", label: "Auth", title: "Requires auth" });
+  }
+  if (chips.length === 0) return null;
+
+  const visible = chips.slice(0, max);
+  const overflow = chips.length - visible.length;
+
+  return (
+    <div className={className ?? "flex flex-wrap items-center gap-1"}>
+      {visible.map((c) => (
+        <Chip key={c.key} tone={c.tone} title={c.title} className="!text-[10px]">
+          {c.label}
+        </Chip>
+      ))}
+      {overflow > 0 ? (
+        <Chip tone="muted" title={`${overflow} more`}>
+          +{overflow}
+        </Chip>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
@@ -1,0 +1,262 @@
+import { useMemo } from "react";
+import { X } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { BrandIcon, Sparkline, TimeAgo } from "@jsonbored/ui-kit";
+import { Chip } from "@/components/metagraphed/primitives";
+import { EndpointUptimeBar } from "./endpoint-uptime-bar";
+import { EndpointChipCluster } from "./endpoint-chip-cluster";
+import { useLatencyHistory } from "@/hooks/use-latency-history";
+import { endpointEligibility, ELIGIBILITY_LABEL } from "@/lib/metagraphed/endpoint-pool";
+import { classNames } from "@/lib/metagraphed/format";
+import type {
+  Endpoint,
+  EndpointIncident,
+  Provider,
+  RpcPool,
+  Subnet,
+} from "@/lib/metagraphed/types";
+
+/**
+ * Side-by-side comparison of 2-4 endpoints. Renders as a hairline card above
+ * the operational list when the URL carries a non-empty `?compare=` set. Each
+ * column exposes health, freshness, incident count, eligibility, and a
+ * multi-point latency trend from the client-side history collector.
+ */
+export function EndpointComparePanel({
+  endpoints,
+  incidents,
+  poolsById,
+  providerById,
+  subnetById,
+  onRemove,
+  onClear,
+}: {
+  endpoints: Endpoint[];
+  incidents: EndpointIncident[];
+  poolsById: ReadonlyMap<string, RpcPool>;
+  providerById: ReadonlyMap<string, Provider>;
+  subnetById: ReadonlyMap<number, Subnet>;
+  onRemove: (id: string) => void;
+  onClear: () => void;
+}) {
+  if (endpoints.length === 0) return null;
+  return (
+    <section
+      aria-label="Endpoint comparison"
+      className="rounded border border-accent/40 bg-surface/60"
+    >
+      <header className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span className="font-display text-[12px] font-medium text-ink-strong">
+            Compare — {endpoints.length} endpoint{endpoints.length === 1 ? "" : "s"}
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            side-by-side
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClear}
+          className="mg-focus-ring rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+        >
+          Clear all
+        </button>
+      </header>
+      <div className="overflow-x-auto">
+        <div
+          className="grid min-w-full divide-x divide-border"
+          style={{ gridTemplateColumns: `repeat(${endpoints.length}, minmax(240px, 1fr))` }}
+        >
+          {endpoints.map((endpoint) => (
+            <CompareColumn
+              key={endpoint.id}
+              endpoint={endpoint}
+              incidents={incidents}
+              poolsById={poolsById}
+              providerById={providerById}
+              subnetById={subnetById}
+              onRemove={() => onRemove(endpoint.id)}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function healthLabel(h: Endpoint["health"]): string {
+  return h ?? "unknown";
+}
+function healthColor(h: Endpoint["health"]): string {
+  if (h === "ok") return "var(--health-ok)";
+  if (h === "warn") return "var(--health-warn)";
+  if (h === "down") return "var(--health-down)";
+  return "var(--health-unknown)";
+}
+
+function CompareColumn({
+  endpoint,
+  incidents,
+  poolsById,
+  providerById,
+  subnetById,
+  onRemove,
+}: {
+  endpoint: Endpoint;
+  incidents: EndpointIncident[];
+  poolsById: ReadonlyMap<string, RpcPool>;
+  providerById: ReadonlyMap<string, Provider>;
+  subnetById: ReadonlyMap<number, Subnet>;
+  onRemove: () => void;
+}) {
+  const series = useLatencyHistory(endpoint.id);
+  const values = series.map((p) => p.v);
+  const eligibility = endpointEligibility(endpoint, poolsById);
+  const provider = endpoint.provider_slug ? providerById.get(endpoint.provider_slug) : undefined;
+  const subnet = endpoint.netuid != null ? subnetById.get(endpoint.netuid) : undefined;
+  const incidentCount = useMemo(
+    () => incidents.filter((i) => i.endpoint_id === endpoint.id).length,
+    [incidents, endpoint.id],
+  );
+
+  return (
+    <div className="min-w-0 space-y-3 px-3 py-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="mg-label mb-1">
+            {endpoint.netuid === 0
+              ? "Root"
+              : endpoint.netuid != null
+                ? `SN${endpoint.netuid}${subnet?.name ? ` · ${subnet.name}` : ""}`
+                : "Unassigned"}
+          </div>
+          <div className="truncate font-mono text-[12px] font-medium text-ink-strong">
+            {endpoint.url ?? endpoint.id}
+          </div>
+          {endpoint.provider_slug ? (
+            <Link
+              to="/providers/$slug"
+              params={{ slug: endpoint.provider_slug }}
+              className="mg-focus-ring mt-1 inline-flex items-center gap-1 text-[11px] text-ink-muted hover:text-ink-strong"
+            >
+              <BrandIcon
+                url={provider?.website ?? provider?.homepage}
+                iconUrl={provider?.icon_url}
+                providerSlug={endpoint.provider_slug}
+                name={provider?.name ?? endpoint.provider ?? endpoint.provider_slug}
+                fallback={endpoint.provider_slug}
+                size={12}
+              />
+              <span className="truncate">
+                {endpoint.provider ?? provider?.name ?? endpoint.provider_slug}
+              </span>
+            </Link>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label="Remove from comparison"
+          className="mg-focus-ring rounded p-1 text-ink-muted hover:text-ink-strong"
+        >
+          <X className="size-3.5" aria-hidden />
+        </button>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-3 gap-y-2">
+        <Field label="Health">
+          <span
+            className={classNames(
+              "inline-flex items-center gap-1 font-mono text-[11px] uppercase",
+              endpoint.health === "ok"
+                ? "text-health-ok"
+                : endpoint.health === "warn"
+                  ? "text-health-warn-text"
+                  : endpoint.health === "down"
+                    ? "text-health-down"
+                    : "text-ink-muted",
+            )}
+          >
+            <span
+              className="size-1.5 rounded-full"
+              style={{ background: healthColor(endpoint.health) }}
+              aria-hidden
+            />
+            {healthLabel(endpoint.health)}
+          </span>
+        </Field>
+        <Field label="Latency">
+          <span className="font-mono text-[11px] tabular-nums text-ink-strong">
+            {endpoint.latency_ms != null ? `${Math.round(endpoint.latency_ms)}ms` : "—"}
+          </span>
+        </Field>
+        <Field label="Access">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            {ELIGIBILITY_LABEL[eligibility]}
+          </span>
+        </Field>
+        <Field label="Incidents (retained)">
+          <span
+            className={classNames(
+              "font-mono text-[11px] tabular-nums",
+              incidentCount > 0 ? "text-health-warn-text" : "text-ink-strong",
+            )}
+          >
+            {incidentCount}
+          </span>
+        </Field>
+        <Field label="Freshness">
+          <span className="font-mono text-[10px] text-ink-muted">
+            probed <TimeAgo at={endpoint.last_probed_at} />
+          </span>
+        </Field>
+        <Field label="Region · Kind">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            {endpoint.region ?? "global"} · {endpoint.kind ?? "endpoint"}
+          </span>
+        </Field>
+      </dl>
+
+      <div>
+        <div className="mg-label mb-1">Latency trend (observed)</div>
+        <div className="h-[36px] border-y border-border">
+          {values.length > 1 ? (
+            <Sparkline
+              values={values}
+              points={series.map((p) => ({ t: new Date(p.t).toLocaleTimeString(), v: p.v }))}
+              width={240}
+              height={36}
+              color={healthColor(endpoint.health)}
+              fill={false}
+              ariaLabel={`Latency trend for ${endpoint.url ?? endpoint.id}`}
+              formatValue={(v) => `${Math.round(v)}ms`}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              Collecting samples…
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1">
+        <EndpointChipCluster endpoint={endpoint} poolsById={poolsById} />
+        {endpoint.archive ? <Chip tone="accent">Archive</Chip> : null}
+      </div>
+
+      <div>
+        <div className="mg-label mb-1">7d uptime</div>
+        <EndpointUptimeBar endpointId={endpoint.id} incidents={incidents} />
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <dt className="mg-label">{label}</dt>
+      <dd className="mt-0.5 min-w-0 truncate">{children}</dd>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
@@ -1,0 +1,320 @@
+import { useMemo, useState } from "react";
+import { CopyButton, ExternalLink } from "@jsonbored/ui-kit";
+import { Chip } from "@/components/metagraphed/primitives";
+import { CopyLinkButton } from "@/components/metagraphed/primitives/copy-link-button";
+import { EndpointUptimeBar } from "./endpoint-uptime-bar";
+import { EndpointChipCluster } from "./endpoint-chip-cluster";
+import { Sparkline } from "@jsonbored/ui-kit";
+import { useLatencyHistory, type LatencyPoint } from "@/hooks/use-latency-history";
+import { classNames } from "@/lib/metagraphed/format";
+import type { Endpoint, EndpointIncident, RpcPool } from "@/lib/metagraphed/types";
+
+/**
+ * Inline detail body rendered inside an expanded endpoint row.
+ * Shows the full URL, region/provider chips, uptime bar, and a filterable
+ * incident timeline built from /api/v1/endpoint-incidents. Latency trend is
+ * seeded from server-provided probe_history when present and augmented with
+ * the client-side latency-history collector so the trend keeps growing as
+ * the user observes the endpoint over time.
+ */
+export function EndpointDetailDrawer({
+  endpoint,
+  incidents,
+  poolsById,
+}: {
+  endpoint: Endpoint;
+  incidents: EndpointIncident[];
+  poolsById: ReadonlyMap<string, RpcPool>;
+}) {
+  const allRows = useMemo(
+    () =>
+      incidents
+        .filter((i) => i.endpoint_id === endpoint.id)
+        .sort((a, b) => String(b.started_at ?? "").localeCompare(String(a.started_at ?? ""))),
+    [incidents, endpoint.id],
+  );
+
+  // Filter: state (down/warn/other), and pool membership (this endpoint's pool).
+  const [stateFilter, setStateFilter] = useState<"all" | "down" | "warn" | "other">("all");
+  const [poolOnly, setPoolOnly] = useState(false);
+  const endpointPoolId = String(
+    (endpoint as unknown as { pool_id?: string; pool?: string }).pool_id ??
+      (endpoint as unknown as { pool_id?: string; pool?: string }).pool ??
+      "",
+  );
+
+  const rows = useMemo(() => {
+    let list = allRows;
+    if (stateFilter !== "all") {
+      list = list.filter((i) => {
+        const s = String(i.state ?? "unknown");
+        if (stateFilter === "other") return s !== "down" && s !== "warn";
+        return s === stateFilter;
+      });
+    }
+    if (poolOnly && endpointPoolId) {
+      list = list.filter((i) => {
+        const p = String(
+          (i as Record<string, unknown>).pool_id ?? (i as Record<string, unknown>).pool ?? "",
+        );
+        return p === endpointPoolId;
+      });
+    }
+    return list.slice(0, 12);
+  }, [allRows, stateFilter, poolOnly, endpointPoolId]);
+
+  // Build server-side samples (with timestamps when available).
+  const serverSamples: LatencyPoint[] = useMemo(() => {
+    const source = endpoint as Record<string, unknown>;
+    const candidate = source.probe_history ?? source.latency_history ?? source.history;
+    if (!Array.isArray(candidate)) return [];
+    return candidate
+      .map((entry, index) => {
+        if (typeof entry === "number") return { t: Date.now() - (100 - index), v: entry };
+        if (!entry || typeof entry !== "object") return null;
+        const row = entry as Record<string, unknown>;
+        const latency = typeof row.latency_ms === "number" ? row.latency_ms : undefined;
+        if (latency == null || !Number.isFinite(latency)) return null;
+        const atStr =
+          typeof row.observed_at === "string"
+            ? row.observed_at
+            : typeof row.probed_at === "string"
+              ? row.probed_at
+              : typeof row.timestamp === "string"
+                ? row.timestamp
+                : null;
+        const t = atStr ? Date.parse(atStr) : Date.now() - (100 - index);
+        return { t: Number.isFinite(t) ? t : Date.now(), v: latency } as LatencyPoint;
+      })
+      .filter((p): p is LatencyPoint => p != null);
+  }, [endpoint]);
+
+  const series = useLatencyHistory(endpoint.id, serverSamples);
+  const latencyValues = series.map((p) => p.v);
+
+  const stateCounts = useMemo(() => {
+    const counts = { down: 0, warn: 0, other: 0 } as Record<string, number>;
+    for (const i of allRows) {
+      const s = String(i.state ?? "unknown");
+      if (s === "down") counts.down++;
+      else if (s === "warn" || s === "degraded") counts.warn++;
+      else counts.other++;
+    }
+    return counts;
+  }, [allRows]);
+
+  return (
+    <div className="space-y-4 border-t border-border bg-surface/45 px-4 py-4 lg:px-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="mg-label mb-1">Endpoint</div>
+          <div className="flex items-center gap-1.5 min-w-0">
+            {endpoint.url ? (
+              <>
+                <ExternalLink href={endpoint.url} className="truncate font-mono text-[12px]">
+                  {endpoint.url}
+                </ExternalLink>
+                <CopyButton value={endpoint.url} label="URL" />
+                <CopyLinkButton
+                  hash={`endpoint-${endpoint.id}`}
+                  tooltip="Copy deep link to this endpoint"
+                  label="Copy deep link to endpoint"
+                />
+              </>
+            ) : (
+              <span className="font-mono text-[12px] text-ink-muted">no url</span>
+            )}
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            <EndpointChipCluster endpoint={endpoint} poolsById={poolsById} />
+            {endpoint.region ? <Chip tone="default">{endpoint.region}</Chip> : null}
+            {endpoint.provider ? <Chip tone="default">{endpoint.provider}</Chip> : null}
+          </div>
+        </div>
+        <div className="shrink-0">
+          <div className="mg-label mb-1">Uptime 7d</div>
+          <EndpointUptimeBar endpointId={endpoint.id} incidents={incidents} />
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(18rem,.75fr)]">
+        <section aria-labelledby={`latency-${endpoint.id}`}>
+          <div className="flex items-end justify-between gap-3">
+            <div>
+              <div id={`latency-${endpoint.id}`} className="mg-label">
+                Latency trend
+              </div>
+              <p className="mt-1 text-[11px] text-ink-muted">
+                Seeded from server probe history when published; augmented with client-observed
+                samples as you monitor the endpoint.
+              </p>
+            </div>
+            <span className="font-mono text-[11px] text-ink-strong">
+              {endpoint.latency_ms != null ? `${endpoint.latency_ms}ms latest` : "No latest sample"}
+            </span>
+          </div>
+          <div className="mt-3 border-y border-border py-3">
+            {latencyValues.length > 1 ? (
+              <Sparkline
+                values={latencyValues}
+                points={series.map((p) => ({ t: new Date(p.t).toLocaleString(), v: p.v }))}
+                width={560}
+                height={88}
+                color="var(--accent)"
+                fill={false}
+                ariaLabel="Endpoint latency probe history"
+                formatValue={(value) => `${Math.round(value)}ms`}
+              />
+            ) : (
+              <div className="flex h-[88px] items-center justify-center border border-dashed border-border font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Collecting latency samples — trend will grow as probes arrive
+              </div>
+            )}
+          </div>
+          <div className="mt-2 grid grid-cols-3 gap-2">
+            {series
+              .slice(-3)
+              .reverse()
+              .map((p, index) => (
+                <div key={`${p.t}-${index}`} className="min-w-0 border-l border-border pl-2">
+                  <div className="mg-label">{index === 0 ? "Latest" : `Prior ${index}`}</div>
+                  <div className="mt-1 font-mono text-[11px] text-ink-strong">
+                    {Math.round(p.v)}ms
+                  </div>
+                  <div className="mt-0.5 truncate font-mono text-[9px] text-ink-muted">
+                    {new Date(p.t).toLocaleString()}
+                  </div>
+                </div>
+              ))}
+          </div>
+        </section>
+
+        <section aria-labelledby={`incidents-${endpoint.id}`}>
+          <div className="mb-1.5 flex items-center justify-between gap-2">
+            <div id={`incidents-${endpoint.id}`} className="mg-label">
+              Incident timeline
+            </div>
+            <span className="font-mono text-[10px] text-ink-muted tabular-nums">
+              {allRows.length} total
+            </span>
+          </div>
+
+          <div className="mb-2 flex flex-wrap items-center gap-1">
+            {(
+              [
+                ["all", `All · ${allRows.length}`],
+                ["down", `Down · ${stateCounts.down}`],
+                ["warn", `Warn · ${stateCounts.warn}`],
+                ["other", `Other · ${stateCounts.other}`],
+              ] as const
+            ).map(([id, label]) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setStateFilter(id)}
+                aria-pressed={stateFilter === id}
+                className={classNames(
+                  "mg-focus-ring rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+                  stateFilter === id
+                    ? "border-accent/50 bg-accent/10 text-accent-text"
+                    : "border-border text-ink-muted hover:text-ink-strong",
+                )}
+              >
+                {label}
+              </button>
+            ))}
+            {endpointPoolId ? (
+              <button
+                type="button"
+                onClick={() => setPoolOnly((v) => !v)}
+                aria-pressed={poolOnly}
+                className={classNames(
+                  "mg-focus-ring ml-auto rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+                  poolOnly
+                    ? "border-accent/50 bg-accent/10 text-accent-text"
+                    : "border-border text-ink-muted hover:text-ink-strong",
+                )}
+                title={`Filter to this endpoint's pool (${endpointPoolId})`}
+              >
+                Pool only
+              </button>
+            ) : null}
+          </div>
+
+          {rows.length === 0 ? (
+            <div className="rounded border border-dashed border-border/70 px-3 py-2 text-[11px] text-ink-muted">
+              {allRows.length === 0
+                ? "No incidents recorded for this endpoint in the retained window."
+                : "No incidents match the current filter."}
+            </div>
+          ) : (
+            <ol className="space-y-1">
+              {rows.map((inc) => {
+                const affected = String(inc.endpoint_id ?? endpoint.id);
+                return (
+                  <li
+                    key={inc.id}
+                    id={`incident-${inc.id}`}
+                    className="flex items-start gap-2 scroll-mt-32 rounded border border-border/60 bg-paper px-2 py-1.5 target:border-accent/60"
+                  >
+                    <span
+                      className={
+                        "mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full " +
+                        (String(inc.state) === "down"
+                          ? "bg-health-down"
+                          : String(inc.state) === "warn" || String(inc.state) === "degraded"
+                            ? "bg-health-warn"
+                            : "bg-ink-subtle")
+                      }
+                      aria-hidden
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-baseline justify-between gap-2">
+                        <span className="font-mono text-[11px] text-ink-strong">
+                          {String(inc.state ?? "incident")}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <span className="font-mono text-[10px] text-ink-muted tabular-nums">
+                            {inc.started_at ? new Date(inc.started_at).toLocaleString() : "—"}
+                          </span>
+                          <CopyLinkButton
+                            hash={`incident-${inc.id}`}
+                            tooltip="Copy link to this incident"
+                            label="Copy link to incident"
+                          />
+                        </span>
+                      </div>
+                      {inc.message ? (
+                        <div className="mt-0.5 truncate text-[11px] text-ink-muted">
+                          {inc.message}
+                        </div>
+                      ) : null}
+                      <div className="mt-0.5 flex flex-wrap items-center gap-2 font-mono text-[10px] text-ink-subtle-text">
+                        <a
+                          href={`#endpoint-${affected}`}
+                          className="mg-focus-ring hover:text-accent-text"
+                        >
+                          affected: {affected.slice(0, 12)}
+                          {affected.length > 12 ? "…" : ""}
+                        </a>
+                        {inc.ended_at ? (
+                          <span>· ended {new Date(inc.ended_at).toLocaleString()}</span>
+                        ) : (
+                          <span className="text-health-warn-text">· active</span>
+                        )}
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+          <p className="mt-2 text-[10px] text-ink-subtle-text">
+            Incident intervals come from /api/v1/endpoint-incidents. Latency series merges published
+            probe samples with locally-observed samples — no synthetic values are generated.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
@@ -1,0 +1,398 @@
+import { ChevronDown } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Fragment, useEffect, useMemo } from "react";
+import { BrandIcon, CopyButton, ExternalLink, Sparkline, TimeAgo } from "@jsonbored/ui-kit";
+import { EndpointDetailDrawer } from "./endpoint-detail-drawer";
+import { EndpointUptimeBar } from "./endpoint-uptime-bar";
+import { recordLatencyObservations } from "@/hooks/use-latency-history";
+import { endpointEligibility, ELIGIBILITY_LABEL } from "@/lib/metagraphed/endpoint-pool";
+import { classNames } from "@/lib/metagraphed/format";
+import type {
+  Endpoint,
+  EndpointIncident,
+  Provider,
+  RpcPool,
+  Subnet,
+} from "@/lib/metagraphed/types";
+
+interface EndpointOperationalListProps {
+  rows: Endpoint[];
+  incidents: EndpointIncident[];
+  poolsById: ReadonlyMap<string, RpcPool>;
+  providerById: ReadonlyMap<string, Provider>;
+  subnetById: ReadonlyMap<number, Subnet>;
+  expandedId: string | null;
+  onToggle: (id: string) => void;
+  compareIds?: ReadonlySet<string>;
+  onToggleCompare?: (id: string) => void;
+  compareMax?: number;
+}
+
+function latencySeries(endpoint: Endpoint): number[] {
+  const source = endpoint as Record<string, unknown>;
+  const candidate = source.probe_history ?? source.latency_history ?? source.history;
+  if (!Array.isArray(candidate)) return [];
+  return candidate
+    .map((entry) => {
+      if (typeof entry === "number") return entry;
+      if (entry && typeof entry === "object" && "latency_ms" in entry) {
+        return (entry as { latency_ms?: unknown }).latency_ms;
+      }
+      return undefined;
+    })
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
+    .slice(-24);
+}
+
+function healthColor(health: Endpoint["health"]): string {
+  if (health === "ok") return "var(--health-ok)";
+  if (health === "warn") return "var(--health-warn)";
+  if (health === "down") return "var(--health-down)";
+  return "var(--health-unknown)";
+}
+
+function railClass(health: Endpoint["health"]): string {
+  if (health === "ok") return "bg-health-ok";
+  if (health === "warn") return "bg-health-warn";
+  if (health === "down") return "bg-health-down";
+  return "bg-ink-subtle/40";
+}
+
+function latencyTone(ms: number | null | undefined): string {
+  if (ms == null) return "text-ink-muted";
+  if (ms < 150) return "text-health-ok";
+  if (ms < 400) return "text-ink-strong";
+  if (ms < 900) return "text-health-warn-text";
+  return "text-health-down";
+}
+
+type Group = { netuid: number | "root" | "unassigned"; label: string; rows: Endpoint[] };
+
+function groupByNetuid(rows: Endpoint[], subnetById: ReadonlyMap<number, Subnet>): Group[] {
+  const map = new Map<string, Group>();
+  for (const r of rows) {
+    let key: string;
+    let netuid: Group["netuid"];
+    let label: string;
+    if (r.netuid == null) {
+      key = "unassigned";
+      netuid = "unassigned";
+      label = "Unassigned";
+    } else if (r.netuid === 0) {
+      key = "root";
+      netuid = "root";
+      label = "Root · Subtensor base layer";
+    } else {
+      key = String(r.netuid);
+      netuid = r.netuid;
+      const sn = subnetById.get(r.netuid);
+      label = `SN${r.netuid}${sn?.name ? ` · ${sn.name}` : ""}`;
+    }
+    const g = map.get(key) ?? { netuid, label, rows: [] };
+    g.rows.push(r);
+    map.set(key, g);
+  }
+  return Array.from(map.values()).sort((a, b) => {
+    const av = a.netuid === "root" ? -1 : a.netuid === "unassigned" ? 9999 : (a.netuid as number);
+    const bv = b.netuid === "root" ? -1 : b.netuid === "unassigned" ? 9999 : (b.netuid as number);
+    return av - bv;
+  });
+}
+
+export function EndpointOperationalList({
+  rows,
+  incidents,
+  poolsById,
+  providerById,
+  subnetById,
+  expandedId,
+  onToggle,
+  compareIds,
+  onToggleCompare,
+  compareMax = 4,
+}: EndpointOperationalListProps) {
+  const groups = useMemo(() => groupByNetuid(rows, subnetById), [rows, subnetById]);
+
+  // Snapshot current latency values into the client-side history collector so
+  // sparklines gain a real multi-point trace even when the backend only ships
+  // a single latest sample per endpoint.
+  useEffect(() => {
+    recordLatencyObservations(rows.map((r) => ({ id: r.id, latency_ms: r.latency_ms ?? null })));
+  }, [rows]);
+
+  return (
+    <div role="list" aria-label="Endpoint directory" className="space-y-6">
+      {groups.map((group) => {
+        const okCount = group.rows.filter((r) => r.health === "ok").length;
+        const warnCount = group.rows.filter((r) => r.health === "warn").length;
+        const downCount = group.rows.filter((r) => r.health === "down").length;
+        const sn = typeof group.netuid === "number" ? subnetById.get(group.netuid) : undefined;
+        return (
+          <section key={String(group.netuid)} aria-labelledby={`group-${group.netuid}`}>
+            <header
+              className="mg-section-rule sticky z-10 -mx-1 flex items-center justify-between gap-3 bg-paper/92 px-1 py-2 backdrop-blur"
+              style={{ top: "calc(var(--mg-sticky-offset, 3.5rem) + 3.75rem)" }}
+            >
+              <div className="flex min-w-0 items-center gap-2.5">
+                {typeof group.netuid === "number" ? (
+                  <BrandIcon
+                    url={sn?.website}
+                    iconUrl={sn?.icon_url}
+                    netuid={group.netuid}
+                    name={sn?.name}
+                    fallback={group.netuid}
+                    size={20}
+                  />
+                ) : (
+                  <span className="mg-live-dot" aria-hidden />
+                )}
+                <h3
+                  id={`group-${group.netuid}`}
+                  className="truncate font-display text-[13px] font-medium text-ink-strong"
+                >
+                  {group.label}
+                </h3>
+                {typeof group.netuid === "number" && group.netuid !== 0 ? (
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: group.netuid }}
+                    className="mg-focus-ring font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-accent-text"
+                  >
+                    Open subnet →
+                  </Link>
+                ) : null}
+              </div>
+              <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                {okCount ? <span className="text-health-ok">{okCount} live</span> : null}
+                {warnCount ? <span className="text-health-warn-text">{warnCount} warn</span> : null}
+                {downCount ? <span className="text-health-down">{downCount} down</span> : null}
+                <span className="text-ink-subtle-text">·</span>
+                <span>{group.rows.length} total</span>
+              </div>
+            </header>
+
+            <div className="border-y border-border bg-card/40">
+              {group.rows.map((endpoint, idx) => {
+                const open = expandedId === endpoint.id;
+                const providerSlug = endpoint.provider_slug;
+                const provider = providerSlug ? providerById.get(providerSlug) : undefined;
+                const series = latencySeries(endpoint);
+                const eligibility = endpointEligibility(endpoint, poolsById);
+                return (
+                  <Fragment key={endpoint.id}>
+                    <article
+                      id={`endpoint-${endpoint.id}`}
+                      role="listitem"
+                      className={classNames(
+                        "group relative scroll-mt-32 transition-colors",
+                        idx > 0 && "border-t border-border",
+                        open ? "bg-surface/70" : "hover:bg-surface/50",
+                      )}
+                    >
+                      {/* Full-height health rail — the strongest visual signal per row. */}
+                      <span
+                        className={classNames(
+                          "pointer-events-none absolute inset-y-0 left-0 w-[3px]",
+                          railClass(endpoint.health),
+                          open ? "opacity-100" : "opacity-70 group-hover:opacity-100",
+                        )}
+                        aria-hidden
+                      />
+                      {onToggleCompare ? (
+                        <label
+                          className="absolute left-2 top-2 z-10 flex items-center gap-1 rounded border border-border bg-paper/85 px-1 py-0.5 font-mono text-[9px] uppercase tracking-widest text-ink-muted backdrop-blur hover:text-ink-strong"
+                          onClick={(e) => e.stopPropagation()}
+                          title={
+                            compareIds?.has(endpoint.id)
+                              ? "Remove from comparison"
+                              : (compareIds?.size ?? 0) >= compareMax
+                                ? `Compare limit of ${compareMax} reached`
+                                : "Add to comparison"
+                          }
+                        >
+                          <input
+                            type="checkbox"
+                            checked={compareIds?.has(endpoint.id) ?? false}
+                            disabled={
+                              !compareIds?.has(endpoint.id) && (compareIds?.size ?? 0) >= compareMax
+                            }
+                            onChange={() => onToggleCompare(endpoint.id)}
+                            className="mg-focus-ring size-3 accent-current"
+                            aria-label={`Compare ${endpoint.url ?? endpoint.id}`}
+                          />
+                          <span className="hidden sm:inline">Compare</span>
+                        </label>
+                      ) : null}
+                      {/* This row hosts nested interactive elements (the URL link,
+                          its CopyButton) inside a click-to-expand surface. A
+                          <button> may not contain another <button> or an <a>
+                          per the HTML spec -- browsers silently un-nest it,
+                          which desyncs SSR from the client and throws a
+                          hydration mismatch. A div with button semantics
+                          avoids the invalid nesting while keeping the same
+                          keyboard/AT behavior. */}
+                      <div
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => onToggle(endpoint.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            onToggle(endpoint.id);
+                          }
+                        }}
+                        aria-expanded={open}
+                        aria-controls={`endpoint-detail-${endpoint.id}`}
+                        className="mg-focus-ring block w-full cursor-pointer text-left"
+                      >
+                        <div
+                          className={classNames(
+                            "grid min-w-0 grid-cols-1 gap-x-6 gap-y-3 pr-3 py-4 lg:grid-cols-[minmax(0,1fr)_11rem_11rem_auto] lg:items-center lg:pr-4",
+                            onToggleCompare ? "pl-4 lg:pl-6 pt-8 lg:pt-4" : "pl-4 lg:pl-6",
+                          )}
+                        >
+                          {/* Headline: kind chip + URL as h4 */}
+                          <div className="min-w-0">
+                            <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                              <span className="text-ink-strong">{endpoint.kind ?? "endpoint"}</span>
+                              <span className="text-ink-subtle-text" aria-hidden>
+                                ·
+                              </span>
+                              <span>{endpoint.region ?? "global"}</span>
+                              <span className="text-ink-subtle-text" aria-hidden>
+                                ·
+                              </span>
+                              <span>{ELIGIBILITY_LABEL[eligibility]}</span>
+                              {endpoint.archive ? (
+                                <>
+                                  <span className="text-ink-subtle-text" aria-hidden>
+                                    ·
+                                  </span>
+                                  <span className="text-accent-text">Archive</span>
+                                </>
+                              ) : null}
+                            </div>
+                            <div
+                              className="flex min-w-0 items-center gap-1.5"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              {endpoint.url ? (
+                                <>
+                                  <ExternalLink
+                                    href={endpoint.url}
+                                    className="truncate font-mono text-[13px] font-medium text-ink-strong hover:text-accent-text"
+                                  >
+                                    {endpoint.url}
+                                  </ExternalLink>
+                                  <CopyButton value={endpoint.url} label="endpoint URL" />
+                                </>
+                              ) : (
+                                <span className="font-mono text-[13px] text-ink-muted">
+                                  URL unavailable
+                                </span>
+                              )}
+                            </div>
+                            {providerSlug ? (
+                              <div className="mt-1.5" onClick={(e) => e.stopPropagation()}>
+                                <Link
+                                  to="/providers/$slug"
+                                  params={{ slug: providerSlug }}
+                                  className="mg-focus-ring inline-flex items-center gap-1.5 text-[11px] text-ink-muted hover:text-ink-strong"
+                                >
+                                  <BrandIcon
+                                    url={provider?.website ?? provider?.homepage}
+                                    iconUrl={provider?.icon_url}
+                                    repoUrl={provider?.repo}
+                                    providerSlug={providerSlug}
+                                    name={provider?.name ?? endpoint.provider ?? providerSlug}
+                                    fallback={providerSlug}
+                                    size={14}
+                                  />
+                                  <span className="truncate">
+                                    {endpoint.provider ?? provider?.name ?? providerSlug}
+                                  </span>
+                                </Link>
+                              </div>
+                            ) : endpoint.provider ? (
+                              <div className="mt-1.5 text-[11px] text-ink-muted">
+                                {endpoint.provider}
+                              </div>
+                            ) : null}
+                          </div>
+
+                          {/* Latency block: big number + sparkline underneath */}
+                          <div className="min-w-0">
+                            <div className="mg-label mb-0.5 lg:hidden">Latency</div>
+                            <div className="flex items-baseline gap-1.5">
+                              <span
+                                className={classNames(
+                                  "font-mono text-[20px] leading-none tabular-nums",
+                                  latencyTone(endpoint.latency_ms),
+                                )}
+                              >
+                                {endpoint.latency_ms != null
+                                  ? Math.round(endpoint.latency_ms)
+                                  : "—"}
+                              </span>
+                              {endpoint.latency_ms != null ? (
+                                <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                                  ms
+                                </span>
+                              ) : null}
+                            </div>
+                            <div className="mt-1.5 h-[18px]">
+                              {series.length > 1 ? (
+                                <Sparkline
+                                  values={series}
+                                  width={132}
+                                  height={18}
+                                  color={healthColor(endpoint.health)}
+                                  fill={false}
+                                  interactive={false}
+                                  ariaLabel="Recent endpoint latency"
+                                />
+                              ) : (
+                                <div className="h-full border-b border-dashed border-border/60" />
+                              )}
+                            </div>
+                          </div>
+
+                          {/* 7d uptime */}
+                          <div className="min-w-0">
+                            <div className="mg-label mb-1 lg:hidden">7d uptime</div>
+                            <EndpointUptimeBar endpointId={endpoint.id} incidents={incidents} />
+                            <div className="mt-1 font-mono text-[10px] text-ink-muted">
+                              probed <TimeAgo at={endpoint.last_probed_at} />
+                            </div>
+                          </div>
+
+                          <ChevronDown
+                            className={classNames(
+                              "hidden size-4 shrink-0 text-ink-muted transition-transform lg:block",
+                              open && "rotate-180 text-accent-text",
+                            )}
+                            aria-hidden
+                          />
+                        </div>
+                      </div>
+
+                      {open ? (
+                        <div id={`endpoint-detail-${endpoint.id}`} className="pl-4 lg:pl-6">
+                          <EndpointDetailDrawer
+                            endpoint={endpoint}
+                            incidents={incidents}
+                            poolsById={poolsById}
+                          />
+                        </div>
+                      ) : null}
+                    </article>
+                  </Fragment>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/endpoint-uptime-bar.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-uptime-bar.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from "react";
+import { classNames } from "@/lib/metagraphed/format";
+import type { EndpointIncident } from "@/lib/metagraphed/types";
+import { useHydrated } from "@/hooks/use-hydrated";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Compact 7d uptime bar. Each pip is one day, colored by whether that
+ * endpoint had an incident overlap: ok (mint), degraded (amber), down (red).
+ * Falls back to a neutral "no signal" row when no incidents are known.
+ */
+export function EndpointUptimeBar({
+  endpointId,
+  incidents,
+  days = 7,
+  className,
+}: {
+  endpointId: string;
+  incidents: EndpointIncident[];
+  days?: number;
+  className?: string;
+}) {
+  const hydrated = useHydrated();
+  const pips = useMemo(() => {
+    // Keep SSR and the first client render identical; live time is introduced
+    // only after hydration so this tiny chart can never destabilize the route.
+    const now = hydrated ? Date.now() : 0;
+    const buckets: Array<"ok" | "warn" | "down" | "unknown"> = Array.from(
+      { length: days },
+      () => "ok",
+    );
+    const relevant = incidents.filter((i) => i.endpoint_id === endpointId);
+    for (const inc of relevant) {
+      const start = inc.started_at ? Date.parse(inc.started_at) : NaN;
+      const end = inc.ended_at ? Date.parse(inc.ended_at) : now;
+      if (!isFinite(start)) continue;
+      for (let d = 0; d < days; d++) {
+        const dayStart = now - (days - d) * DAY_MS;
+        const dayEnd = dayStart + DAY_MS;
+        if (start < dayEnd && end > dayStart) {
+          const s = String(inc.state ?? "");
+          const rank = s === "down" ? 3 : s === "degraded" ? 2 : 1;
+          const cur = buckets[d];
+          const curRank = cur === "down" ? 3 : cur === "warn" ? 2 : cur === "ok" ? 1 : 0;
+          if (rank > curRank) buckets[d] = rank === 3 ? "down" : rank === 2 ? "warn" : "ok";
+        }
+      }
+    }
+    if (relevant.length === 0) return buckets.map(() => "unknown" as const);
+    return buckets;
+  }, [endpointId, incidents, days, hydrated]);
+
+  return (
+    <div
+      className={classNames("inline-flex items-center gap-[2px]", className)}
+      role="img"
+      aria-label={`${days}-day uptime signal`}
+      title={`${days}-day uptime — hover a pip for the day`}
+    >
+      {pips.map((p, i) => (
+        <span
+          key={i}
+          className={classNames(
+            "block h-3 w-[3px] rounded-[1px]",
+            p === "ok" && "bg-health-ok/70",
+            p === "warn" && "bg-health-warn/80",
+            p === "down" && "bg-health-down/80",
+            p === "unknown" && "bg-ink-subtle/40",
+          )}
+          title={`day -${pips.length - i}: ${p}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/endpoints-priority-strip.tsx
+++ b/apps/ui/src/components/metagraphed/endpoints-priority-strip.tsx
@@ -1,0 +1,144 @@
+import { useMemo } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle, TrendingUp, Timer } from "lucide-react";
+import { endpointsQuery, endpointIncidentsQuery } from "@/lib/metagraphed/queries";
+import type { Endpoint } from "@/lib/metagraphed/types";
+import { Chip } from "@/components/metagraphed/primitives";
+import { HealthDot } from "@jsonbored/ui-kit";
+
+interface Item {
+  key: string;
+  label: string;
+  value: string;
+  hint?: string;
+  href?: string;
+  icon: typeof AlertTriangle;
+  tone: "warn" | "down" | "accent" | "default";
+  rows: Endpoint[];
+}
+
+/**
+ * Horizontal 3-4 card strip surfacing "what needs attention now" above the
+ * endpoints directory: freshly-degraded probes, open incidents,
+ * highest-latency archive nodes, newest additions. Each card deep-links
+ * back into the filtered directory so clicking is action, not decoration.
+ */
+export function EndpointsPriorityStrip() {
+  const { data: eData } = useSuspenseQuery(endpointsQuery());
+  const { data: iData } = useSuspenseQuery(endpointIncidentsQuery());
+  const rows = useMemo(() => (eData.data ?? []) as Endpoint[], [eData]);
+  const incidents = useMemo(
+    () => (iData.data ?? []) as Array<{ endpoint_id?: string; severity?: string }>,
+    [iData],
+  );
+
+  const items = useMemo<Item[]>(() => {
+    const degraded = rows.filter((e) => e.health === "warn" || e.health === "down");
+    const slowArchive = [...rows.filter((e) => e.archive && typeof e.latency_ms === "number")]
+      .sort((a, b) => (b.latency_ms ?? 0) - (a.latency_ms ?? 0))
+      .slice(0, 5);
+    const recentAdd = [...rows.filter((e) => e.last_probed_at)]
+      .sort((a, b) => Date.parse(b.last_probed_at ?? "0") - Date.parse(a.last_probed_at ?? "0"))
+      .slice(0, 5);
+    const open = incidents.filter((i) => (i.severity ?? "").toLowerCase() !== "resolved");
+
+    return [
+      {
+        key: "degraded",
+        label: "Degraded now",
+        value: `${degraded.length}`,
+        hint: degraded.length ? "probes reporting warn/down" : "all probes healthy",
+        href: "/endpoints?health=warn",
+        icon: AlertTriangle,
+        tone: degraded.length ? "warn" : "default",
+        rows: degraded.slice(0, 4),
+      },
+      {
+        key: "incidents",
+        label: "Open incidents",
+        value: `${open.length}`,
+        hint: open.length ? "unresolved in last 24h" : "no active incidents",
+        icon: AlertTriangle,
+        tone: open.length ? "down" : "default",
+        rows: [],
+      },
+      {
+        key: "slow-archive",
+        label: "Slowest archive",
+        value: slowArchive[0]?.latency_ms ? `${slowArchive[0].latency_ms}ms` : "—",
+        hint: "top 5 by last-probe latency",
+        href: "/endpoints?eligibility=archive-capable&sort=latency&order=desc",
+        icon: Timer,
+        tone: "accent",
+        rows: slowArchive,
+      },
+      {
+        key: "recent",
+        label: "Freshly probed",
+        value: `${recentAdd.length}`,
+        hint: "most recent probe cycle",
+        icon: TrendingUp,
+        tone: "accent",
+        rows: recentAdd,
+      },
+    ];
+  }, [rows, incidents]);
+
+  return (
+    <div className="grid gap-2 grid-cols-2 lg:grid-cols-4">
+      {items.map((it) => (
+        <PriorityCard key={it.key} item={it} />
+      ))}
+    </div>
+  );
+}
+
+function PriorityCard({ item }: { item: Item }) {
+  const Icon = item.icon;
+  const body = (
+    <div className="mg-hover-lift rounded border border-border bg-card p-3 h-full">
+      <div className="flex items-center justify-between gap-2">
+        <span className="mg-label inline-flex items-center gap-1.5">
+          <Icon className="size-3" aria-hidden />
+          {item.label}
+        </span>
+        {item.tone === "warn" || item.tone === "down" ? (
+          <span
+            className="mg-live-dot"
+            style={{ color: item.tone === "down" ? "var(--health-down)" : "var(--health-warn)" }}
+          />
+        ) : null}
+      </div>
+      <div className="mt-1 flex items-baseline gap-2">
+        <span className="font-display text-xl text-ink-strong tabular-nums">{item.value}</span>
+      </div>
+      {item.hint ? <p className="mt-0.5 text-[11px] text-ink-muted">{item.hint}</p> : null}
+      {item.rows.length > 0 ? (
+        <ul className="mt-2 space-y-0.5">
+          {item.rows.slice(0, 3).map((r) => (
+            <li key={r.id} className="flex items-center gap-1.5 text-[11px] text-ink-muted min-w-0">
+              <HealthDot state={r.health ?? "unknown"} />
+              <span className="truncate font-mono">{r.provider ?? r.provider_slug ?? r.id}</span>
+              {r.latency_ms != null ? (
+                <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums">
+                  {r.latency_ms}ms
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-2 flex items-center gap-1.5 text-[11px] text-ink-muted">
+          <Chip tone="muted">Nothing to review</Chip>
+        </div>
+      )}
+    </div>
+  );
+  if (!item.href) return body;
+  return (
+    <Link to={item.href} className="block h-full mg-focus-ring rounded">
+      {body}
+    </Link>
+  );
+}

--- a/apps/ui/src/components/metagraphed/panel-shell.tsx
+++ b/apps/ui/src/components/metagraphed/panel-shell.tsx
@@ -5,6 +5,7 @@ import { SectionAnchor, TimeAgo, type SectionTone } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, isStaleFreshness, isUsableTimestamp } from "@/lib/metagraphed/format";
 import { reportError } from "@/lib/error-reporting";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 interface MetaInfo {
   generatedAt?: string;
@@ -53,6 +54,18 @@ export function PanelShell({
   const queryClient = useQueryClient();
   const [refreshing, setRefreshing] = useState(false);
   const stale = meta?.stale ?? isStaleFreshness(meta?.generatedAt);
+  // meta comes from a plain useQuery in most callers (not useSuspenseQuery), so
+  // its value can differ between the SSR pass and the client's first paint if
+  // the query resolves in the gap between them — gate the timestamp pill
+  // behind hydration so both passes agree, matching useHydrated's own doc.
+  const hydrated = useHydrated();
+  const showFreshnessPill = hydrated && isUsableTimestamp(meta?.generatedAt);
+  // isLoading is caller-supplied and usually derived from a plain (non-suspense)
+  // useQuery, so it can already be `false` by hydration time even though SSR
+  // committed the loading branch — stay loading until hydration completes so
+  // both passes agree, for every PanelShell caller, not just this file's own
+  // internal state.
+  const effectiveLoading = !hydrated || isLoading;
 
   const onRefresh = async () => {
     if (!refreshQueryKeys?.length) return;
@@ -71,7 +84,7 @@ export function PanelShell({
   const headerRight = (
     <div className="flex flex-col items-end gap-1.5 sm:flex-row sm:items-center sm:gap-2 min-w-0">
       <div className="flex items-center gap-2">
-        {isUsableTimestamp(meta?.generatedAt) ? (
+        {showFreshnessPill ? (
           <span
             className={
               "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[10px] " +
@@ -115,7 +128,7 @@ export function PanelShell({
         onRefresh={onRefresh}
         context={typeof title === "string" ? title : id}
       >
-        {isLoading ? (
+        {effectiveLoading ? (
           <div
             className="rounded-xl border border-border bg-card p-4"
             aria-busy="true"

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -1,5 +1,8 @@
+import { useCallback, useEffect, useRef } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { classNames } from "@/lib/metagraphed/format";
+import { rovingTabIndex, useRovingTablist } from "@/hooks/use-roving-tablist";
+import { ScrollShadow } from "@/components/metagraphed/primitives/scroll-shadow";
 
 export interface ProfileTabSpec {
   id: string;
@@ -11,55 +14,113 @@ export interface ProfileTabSpec {
 /**
  * URL-driven tab strip. Reads the `tab` search param (non-strict so any
  * parent route works) and updates it on change. Sticks under the app
- * header for cosmos-directory-style profile navigation.
+ * header for cosmos-directory-style profile navigation. Implements the
+ * WAI-ARIA APG tabs pattern (role=tablist + roving tabindex + arrow-key
+ * activation) via `useRovingTablist`.
  */
-export function ProfileTabs({ tabs, defaultTab }: { tabs: ProfileTabSpec[]; defaultTab?: string }) {
+export function ProfileTabs({
+  tabs,
+  defaultTab,
+  trailing,
+}: {
+  tabs: ProfileTabSpec[];
+  defaultTab?: string;
+  trailing?: React.ReactNode;
+}) {
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as Record<string, unknown>;
   const active = (search.tab as string) || defaultTab || tabs[0]?.id;
+  const activeIndex = Math.max(
+    0,
+    tabs.findIndex((t) => t.id === active),
+  );
+
+  const selectAt = useCallback(
+    (i: number) => {
+      const t = tabs[i];
+      if (!t) return;
+      navigate({
+        to: ".",
+        search: (prev: Record<string, unknown>) => ({ ...prev, tab: t.id }),
+        replace: true,
+        resetScroll: false,
+      });
+    },
+    [navigate, tabs],
+  );
+
+  const { tabRef, onKeyDown } = useRovingTablist(tabs.length, selectAt);
+
+  // Keep the active tab visible when it changes (esp. useful when many tabs
+  // overflow horizontally on tablet/mobile).
+  const listRef = useRef<HTMLUListElement>(null);
+  const activeBtnRef = useRef<HTMLButtonElement | null>(null);
+  useEffect(() => {
+    const btn = activeBtnRef.current;
+    if (!btn || typeof btn.scrollIntoView !== "function") return;
+    btn.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+  }, [active]);
 
   return (
     <nav
       aria-label="Profile sections"
-      className="sticky top-14 z-10 -mx-4 md:mx-0 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
+      className="sticky z-10 -mx-4 md:mx-0 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
+      style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
     >
-      <ul className="flex items-center gap-6 overflow-x-auto px-4 md:px-0">
-        {tabs.map((t) => {
-          const isActive = active === t.id;
-          return (
-            <li key={t.id}>
-              <button
-                type="button"
-                onClick={() =>
-                  navigate({
-                    to: ".",
-                    search: (prev: Record<string, unknown>) => ({ ...prev, tab: t.id }),
-                    replace: true,
-                  })
-                }
-                className={classNames(
-                  "relative inline-flex items-center gap-1.5 py-3 text-[13px] font-medium whitespace-nowrap transition-colors mg-focus-ring",
-                  isActive
-                    ? "text-ink-strong after:absolute after:left-0 after:right-0 after:-bottom-px after:h-[2px] after:bg-ink-strong after:content-['']"
-                    : "text-ink-muted hover:text-ink-strong",
-                )}
-                aria-current={isActive ? "page" : undefined}
-              >
-                <span>{t.label}</span>
-                {t.count != null ? (
-                  <span className="font-mono text-[10px] text-ink-muted tabular-nums">
-                    {t.count}
-                  </span>
-                ) : null}
-                {isActive ? (
-                  <span aria-hidden className="ml-0.5 inline-block size-1 rounded-full bg-accent" />
-                ) : null}
-                {t.badge ? <span className="ml-0.5">{t.badge}</span> : null}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+      <div className="flex items-stretch gap-3 px-4 md:px-0">
+        <ScrollShadow className="min-w-0 flex-1" innerClassName="scroll-smooth">
+          <ul
+            ref={listRef}
+            role="tablist"
+            aria-orientation="horizontal"
+            className="flex items-center gap-6"
+          >
+            {tabs.map((t, i) => {
+              const isActive = active === t.id;
+              return (
+                <li key={t.id} role="presentation">
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    tabIndex={rovingTabIndex(i, activeIndex)}
+                    ref={(el) => {
+                      tabRef(i)(el);
+                      if (isActive) activeBtnRef.current = el;
+                    }}
+                    onKeyDown={onKeyDown(i)}
+                    onClick={() => selectAt(i)}
+                    className={classNames(
+                      "relative inline-flex items-center gap-1.5 px-1 py-3 text-[13px] font-medium whitespace-nowrap transition-colors mg-focus-ring",
+                      isActive
+                        ? "text-ink-strong after:absolute after:left-1 after:right-1 after:-bottom-[1.5px] after:h-[1.5px] after:rounded-full after:bg-accent after:content-['']"
+                        : "text-ink-muted hover:text-ink-strong",
+                    )}
+                    aria-current={isActive ? "page" : undefined}
+                  >
+                    <span>{t.label}</span>
+                    {t.count != null ? (
+                      <span className="font-mono text-[10px] text-ink-muted tabular-nums">
+                        {t.count}
+                      </span>
+                    ) : null}
+                    {isActive ? (
+                      <span
+                        aria-hidden
+                        className="ml-0.5 inline-block size-1 rounded-full bg-accent"
+                      />
+                    ) : null}
+                    {t.badge ? <span className="ml-0.5">{t.badge}</span> : null}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </ScrollShadow>
+        {trailing ? (
+          <div className="flex shrink-0 items-center gap-2 py-1.5">{trailing}</div>
+        ) : null}
+      </div>
     </nav>
   );
 }

--- a/apps/ui/src/components/metagraphed/providers-pulse-rail.tsx
+++ b/apps/ui/src/components/metagraphed/providers-pulse-rail.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { Provider } from "@/lib/metagraphed/types";
+
+/**
+ * Compact 4-tile pulse rail summarizing the providers directory:
+ * total, official/claimed, tracked endpoints, tracked surfaces.
+ * Mirrors the endpoints priority strip visual language.
+ */
+export function ProvidersPulseRail({ providers }: { providers: Provider[] }) {
+  const stats = useMemo(() => {
+    let official = 0;
+    let claimed = 0;
+    let endpoints = 0;
+    let surfaces = 0;
+    for (const p of providers) {
+      const a = String(p.authority ?? "");
+      if (a === "official") official++;
+      else if (a === "provider-claimed") claimed++;
+      endpoints += p.endpoints_count ?? 0;
+      surfaces += p.surfaces_count ?? 0;
+    }
+    return {
+      total: providers.length,
+      trusted: official + claimed,
+      endpoints,
+      surfaces,
+    };
+  }, [providers]);
+
+  return (
+    <div className="mg-kpi-strip">
+      <Tile label="Providers" value={stats.total} />
+      <Tile
+        label="Official + claimed"
+        value={stats.trusted}
+        hint={`${stats.total > 0 ? Math.round((stats.trusted / stats.total) * 100) : 0}% of total`}
+      />
+      <Tile label="Endpoints tracked" value={stats.endpoints} />
+      <Tile label="Surfaces tracked" value={stats.surfaces} />
+    </div>
+  );
+}
+
+function Tile({ label, value, hint }: { label: string; value: number; hint?: string }) {
+  return (
+    <div>
+      <div className="mg-label">{label}</div>
+      <div className="mt-1 font-display text-xl tabular-nums text-ink-strong">
+        {formatNumber(value)}
+      </div>
+      {hint ? <div className="mt-0.5 font-mono text-[10px] text-ink-muted">{hint}</div> : null}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/resource-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/resource-explorer.tsx
@@ -27,6 +27,7 @@ import {
 } from "@jsonbored/ui-kit";
 import { PanelShell } from "@/components/metagraphed/panel-shell";
 import { useCopy } from "@/hooks/use-copy";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { classNames } from "@/lib/metagraphed/format";
 import {
   useSubnetFilter,
@@ -281,6 +282,11 @@ function EndpointsView({
   const epRes = epQ.data;
   const allRows = (epRes?.data ?? []) as Endpoint[];
   void (poolsQ.data?.data as RpcPool[] | undefined);
+  // epQ is a plain (non-suspense) query, so its cache can already be resolved
+  // by the time the client hydrates even though SSR committed the loading
+  // branch — treat the component as loading until hydration completes so both
+  // passes render the same skeleton, matching useHydrated's documented use.
+  const hydrated = useHydrated();
 
   const retry = () =>
     Promise.all([
@@ -288,7 +294,7 @@ function EndpointsView({
       queryClient.invalidateQueries({ queryKey: poolOpts.queryKey, refetchType: "active" }),
     ]);
 
-  if (epQ.isPending) return <Skeleton className="h-48 w-full" />;
+  if (!hydrated || epQ.isPending) return <Skeleton className="h-48 w-full" />;
   if (epQ.error) {
     return (
       <div className="p-4">
@@ -503,11 +509,15 @@ function SurfacesView({
   const surfaceQ = useQuery(surfaceOpts);
   const data = surfaceQ.data;
   const allRows = (data?.data ?? []) as Surface[];
+  // See EndpointsView above: gate the loading branch behind hydration so SSR
+  // and the client's first paint agree even when surfaceQ's cache is already
+  // resolved by hydration time.
+  const hydrated = useHydrated();
 
   const retry = () =>
     queryClient.invalidateQueries({ queryKey: surfaceOpts.queryKey, refetchType: "active" });
 
-  if (surfaceQ.isPending) return <Skeleton className="h-48 w-full" />;
+  if (!hydrated || surfaceQ.isPending) return <Skeleton className="h-48 w-full" />;
   if (surfaceQ.error) {
     return (
       <div className="p-4">

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowRight, GitCompare, X } from "lucide-react";
 import {
   Sheet,
@@ -19,89 +20,133 @@ import type { Endpoint } from "@/lib/metagraphed/types";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 
 /**
- * Side-by-side compare drawer. Pick a second netuid; highlights the
- * differences in pool ratio, top providers, and endpoint health between
- * the current subnet and the chosen peer.
+ * Side-by-side compare drawer. The chosen peer netuid is persisted in the
+ * `?compare=` URL search param so the comparison is shareable and survives
+ * page reloads. A "clear comparison" pill renders inline next to the trigger
+ * whenever `?compare` is active, so the user can undo without opening the
+ * drawer first.
  */
 export function SubnetCompareDrawer({ netuid }: { netuid: number }) {
   const [open, setOpen] = useState(false);
-  const [draft, setDraft] = useState("");
-  const [peer, setPeer] = useState<number | null>(null);
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as Record<string, unknown>;
+  const rawPeer = search.compare;
+  const peer =
+    typeof rawPeer === "number"
+      ? rawPeer
+      : typeof rawPeer === "string" && /^\d+$/.test(rawPeer)
+        ? Number(rawPeer)
+        : null;
+  const [draft, setDraft] = useState(peer != null ? String(peer) : "");
+
+  const setPeer = useCallback(
+    (next: number | null) => {
+      navigate({
+        to: ".",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          compare: next == null ? undefined : next,
+        }),
+        replace: true,
+        resetScroll: false,
+      });
+    },
+    [navigate],
+  );
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      {/* #6420: the Compare button is now a SheetTrigger inside <Sheet>, so Radix
-          tracks it and restores focus to it on close. As a plain sibling it was
-          never the dialog's trigger, so closing dropped focus to <body>. */}
-      <SheetTrigger asChild>
+    <div className="inline-flex items-center gap-1.5">
+      <Sheet open={open} onOpenChange={setOpen}>
+        {/* #6420: the Compare button is now a SheetTrigger inside <Sheet>, so Radix
+            tracks it and restores focus to it on close. As a plain sibling it was
+            never the dialog's trigger, so closing dropped focus to <body>. */}
+        <SheetTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong hover:border-accent/50 hover:text-accent transition-colors mg-focus-ring"
+          >
+            <GitCompare className="size-3 text-ink-muted" />
+            Compare
+            {peer != null ? (
+              <span className="font-mono text-[10px] text-ink-muted">
+                · SN{String(peer).padStart(3, "0")}
+              </span>
+            ) : null}
+          </button>
+        </SheetTrigger>
+
+        <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle className="font-display text-lg">Compare with another subnet</SheetTitle>
+            <SheetDescription>
+              Pick any active netuid (0–1024). The choice is saved to the URL so the comparison is
+              shareable.
+            </SheetDescription>
+          </SheetHeader>
+
+          <form
+            className="mt-4 flex items-center gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              const n = Number(draft.replace(/\D/g, ""));
+              if (Number.isFinite(n)) setPeer(n);
+            }}
+          >
+            <label htmlFor="cmp-netuid" className="sr-only">
+              Compare against netuid
+            </label>
+            <input
+              id="cmp-netuid"
+              inputMode="numeric"
+              placeholder="e.g. 1"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              className="w-32 rounded border border-border bg-card px-2 py-1.5 font-mono text-sm tabular-nums text-ink-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+            <button
+              type="submit"
+              className="inline-flex items-center gap-1 rounded border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-strong hover:border-accent/50 hover:text-accent"
+            >
+              Compare <ArrowRight className="size-3" />
+            </button>
+            {peer != null ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setPeer(null);
+                  setDraft("");
+                }}
+                className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+              >
+                <X className="size-3" /> clear
+              </button>
+            ) : null}
+          </form>
+
+          <div className="mt-5">
+            {peer == null ? (
+              <p className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center text-[12px] text-ink-muted">
+                Enter a netuid above to load a side-by-side comparison.
+              </p>
+            ) : (
+              <CompareBody base={netuid} peer={peer} />
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      {peer != null ? (
         <button
           type="button"
-          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong hover:border-accent/50 hover:text-accent transition-colors"
+          onClick={() => setPeer(null)}
+          title="Clear comparison"
+          aria-label={`Clear comparison with SN${String(peer).padStart(3, "0")}`}
+          className="inline-flex items-center gap-1 rounded-full border border-accent/40 bg-primary-soft px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-accent hover:border-accent/60 mg-focus-ring"
         >
-          <GitCompare className="size-3 text-ink-muted" />
-          Compare
+          <X className="size-3" /> clear
         </button>
-      </SheetTrigger>
-
-      <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
-        <SheetHeader>
-          <SheetTitle className="font-display text-lg">Compare with another subnet</SheetTitle>
-          <SheetDescription>
-            Pick any active netuid (0–1024). Differences in pool ratio, top providers, and endpoint
-            health are highlighted.
-          </SheetDescription>
-        </SheetHeader>
-
-        <form
-          className="mt-4 flex items-center gap-2"
-          onSubmit={(e) => {
-            e.preventDefault();
-            const n = Number(draft.replace(/\D/g, ""));
-            if (Number.isFinite(n)) setPeer(n);
-          }}
-        >
-          <label htmlFor="cmp-netuid" className="sr-only">
-            Compare against netuid
-          </label>
-          <input
-            id="cmp-netuid"
-            inputMode="numeric"
-            placeholder="e.g. 1"
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            className="w-32 rounded border border-border bg-card px-2 py-1.5 font-mono text-sm tabular-nums text-ink-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          />
-          <button
-            type="submit"
-            className="inline-flex items-center gap-1 rounded border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-strong hover:border-accent/50 hover:text-accent"
-          >
-            Compare <ArrowRight className="size-3" />
-          </button>
-          {peer != null ? (
-            <button
-              type="button"
-              onClick={() => {
-                setPeer(null);
-                setDraft("");
-              }}
-              className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
-            >
-              <X className="size-3" /> clear
-            </button>
-          ) : null}
-        </form>
-
-        <div className="mt-5">
-          {peer == null ? (
-            <p className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center text-[12px] text-ink-muted">
-              Enter a netuid above to load a side-by-side comparison.
-            </p>
-          ) : (
-            <CompareBody base={netuid} peer={peer} />
-          )}
-        </div>
-      </SheetContent>
-    </Sheet>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
@@ -1,0 +1,175 @@
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Coins, Radio, Timer } from "lucide-react";
+import {
+  subnetHealthQuery,
+  subnetProfileQuery,
+  subnetSurfacesQuery,
+} from "@/lib/metagraphed/queries";
+import { classNames } from "@/lib/metagraphed/format";
+import { useHydrated } from "@/hooks/use-hydrated";
+
+type Tone = "warn" | "down" | "ok" | "accent" | "default";
+
+const TONE: Record<Tone, string> = {
+  warn: "border-health-warn/40 bg-health-warn/5",
+  down: "border-health-down/40 bg-health-down/5",
+  ok: "border-health-ok/40 bg-health-ok/5",
+  accent: "border-accent/40 bg-accent/5",
+  default: "border-border bg-card",
+};
+
+const ICON_TONE: Record<Tone, string> = {
+  warn: "text-health-warn-text",
+  down: "text-health-down",
+  ok: "text-health-ok",
+  accent: "text-accent-text",
+  default: "text-ink-muted",
+};
+
+function Tile({
+  icon: Icon,
+  eyebrow,
+  value,
+  hint,
+  href,
+  tone = "default",
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  eyebrow: string;
+  value: string;
+  hint?: string;
+  href: string;
+  tone?: Tone;
+}) {
+  return (
+    <a
+      href={href}
+      className={classNames(
+        "group flex items-start gap-3 rounded-lg border p-3 transition-colors hover:border-ink/30 mg-focus-ring",
+        TONE[tone],
+      )}
+    >
+      <span
+        aria-hidden
+        className={classNames(
+          "inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-paper",
+          ICON_TONE[tone],
+        )}
+      >
+        <Icon className="size-4" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
+          {eyebrow}
+        </div>
+        <div className="truncate font-display text-[15px] font-medium text-ink-strong">{value}</div>
+        {hint ? (
+          <div className="truncate text-[11px] leading-snug text-ink-muted">{hint}</div>
+        ) : null}
+      </div>
+    </a>
+  );
+}
+
+function ageLabel(iso?: string | null): string {
+  if (!iso) return "Unknown";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "Unknown";
+  const min = Math.floor(ms / 60_000);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  return `${d}d ago`;
+}
+
+/**
+ * Per-subnet priority strip mirroring SubnetsHighlights, showing at-a-glance
+ * signals for the specific subnet so users can jump to the section they want
+ * (economics / operational / resources / evidence) in one click.
+ */
+export function SubnetPriorityHighlights({ netuid }: { netuid: number }) {
+  const hydrated = useHydrated();
+  const { data: healthResult } = useQuery(subnetHealthQuery(netuid));
+  const { data: profileResult } = useQuery(subnetProfileQuery(netuid));
+  const { data: surfacesResult } = useQuery(subnetSurfacesQuery(netuid));
+
+  const health = healthResult?.data ?? {};
+  const down = (health as { down?: number }).down ?? 0;
+  const warn = (health as { warn?: number }).warn ?? 0;
+  const incidents = down + warn;
+  const incidentTone: Tone = down > 0 ? "down" : warn > 0 ? "warn" : "ok";
+
+  const profile = profileResult?.data;
+  const curation = profile?.curation_level ?? "candidate-discovered";
+  const isAdapter = curation === "adapter-backed";
+  const curationLabel = curation
+    .split("-")
+    .map((w) => w[0]?.toUpperCase() + w.slice(1))
+    .join(" ");
+
+  const surfaces =
+    (surfacesResult?.data as Array<{ last_verified_at?: string | null }> | undefined) ?? [];
+  const newest = surfaces
+    .map((s) => s.last_verified_at)
+    .filter((v): v is string => Boolean(v))
+    .sort()
+    .reverse()[0];
+  // Gate Date.now()-derived tone + label behind hydration so SSR and the first
+  // client render agree; otherwise this component drives the same hydration
+  // mismatch that cascaded into the /subnets/:netuid Suspense-stream crash.
+  const freshMs =
+    hydrated && newest ? Date.now() - new Date(newest).getTime() : Number.POSITIVE_INFINITY;
+  const freshTone: Tone = !hydrated
+    ? "default"
+    : !newest
+      ? "default"
+      : freshMs > 7 * 864e5
+        ? "warn"
+        : freshMs > 24 * 36e5
+          ? "accent"
+          : "ok";
+
+  const surfaceCount = surfaces.length;
+
+  return (
+    <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+      <Tile
+        icon={Coins}
+        eyebrow="Economics"
+        value="View headline"
+        hint="Emission share · alpha price · volume"
+        href="#economics"
+        tone="accent"
+      />
+      <Tile
+        icon={AlertTriangle}
+        eyebrow="Operational"
+        value={incidents > 0 ? `${incidents} open` : "Healthy"}
+        hint={incidents > 0 ? `${down} down · ${warn} degraded` : "All probed surfaces up"}
+        href="#operational"
+        tone={incidentTone}
+      />
+      <Tile
+        icon={Timer}
+        eyebrow="Freshness"
+        value={newest ? (hydrated ? ageLabel(newest) : "Recently") : "No probes"}
+        hint={
+          surfaceCount > 0
+            ? `${surfaceCount} verified surface${surfaceCount === 1 ? "" : "s"}`
+            : "No verified surfaces yet"
+        }
+        href="#resources"
+        tone={freshTone}
+      />
+      <Tile
+        icon={Radio}
+        eyebrow="Curation"
+        value={curationLabel}
+        hint={isAdapter ? "Deep integration — adapter-backed" : "Registry curation level"}
+        href="#profile"
+        tone={isAdapter ? "accent" : "default"}
+      />
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { GitMerge, ArrowRight } from "lucide-react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import {
   economicsQuery,
   lineageQuery,
@@ -105,6 +106,11 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
   const { data: econRes } = useQuery(economicsQuery());
   const { data: lineageRes } = useQuery(lineageQuery());
   const { data: endpointsRes } = useQuery(subnetEndpointsQuery(netuid));
+  // lineageQuery is a plain (non-suspense) query, so its cache can already be
+  // resolved by hydration time even though SSR committed the "not paired"
+  // branch — gate the paired-callout swap behind hydration so both passes
+  // agree, matching useHydrated's documented use.
+  const hydrated = useHydrated();
   // economicsQuery already returns the per-subnet array at res.data (the
   // `.subnets` hop is unwrapped inside the query) — find our netuid directly.
   const econ = (econRes?.data ?? []).find((r) => r.netuid === netuid);
@@ -219,7 +225,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
 
         {/* Lineage callout — the canonical #lineage anchor lives in the route's
             SubnetLineageSection; this is an inline summary, so it carries no id. */}
-        {lineagePeer ? (
+        {hydrated && lineagePeer ? (
           <div className="flex flex-wrap items-center gap-2 px-4 py-2.5 border-b border-border bg-surface/20">
             <GitMerge className="size-3.5 text-accent" />
             <span className="text-[12px] text-ink">
@@ -241,8 +247,9 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
 
         {/* Visualizations row — pool composition donut + endpoint topology
             donut + top providers lockup. Always rendered, falls back per
-            slot when data is absent. */}
-        {poolSegments.some((s) => s.value > 0) || topology.length > 0 ? (
+            slot when data is absent. econ/endpoints are plain (non-suspense)
+            queries, so gate behind hydration — see the lineage callout above. */}
+        {hydrated && (poolSegments.some((s) => s.value > 0) || topology.length > 0) ? (
           <div className="grid md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-border border-b border-border">
             <div className="flex items-center gap-4 p-4">
               {poolSegments.some((s) => s.value > 0) ? (
@@ -345,8 +352,9 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
           </div>
         ) : null}
 
-        {/* Economics strip */}
-        {econ ? (
+        {/* Economics strip — econ is a plain (non-suspense) query, same hydration
+            gate as the lineage callout and visualizations row above. */}
+        {hydrated && econ ? (
           <div className="grid grid-cols-3 md:grid-cols-6 divide-x divide-border border-b border-border">
             {primary.map((f) => (
               <Stat key={f.label} field={f} />
@@ -361,8 +369,10 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
               Ownership
             </div>
             {(() => {
-              const coldkey = str(econ?.owner_coldkey);
-              const hotkey = str(econ?.owner_hotkey);
+              // econ is a plain (non-suspense) query — same hydration gate as
+              // the other econ-derived conditionals in this component.
+              const coldkey = hydrated ? str(econ?.owner_coldkey) : undefined;
+              const hotkey = hydrated ? str(econ?.owner_hotkey) : undefined;
               return coldkey || hotkey ? (
                 <>
                   {coldkey ? (

--- a/apps/ui/src/components/metagraphed/subnets-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-highlights.tsx
@@ -1,0 +1,202 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle, Radio, Timer, GitBranch } from "lucide-react";
+import {
+  coverageQuery,
+  freshnessQuery,
+  healthQuery,
+  schemasQuery,
+} from "@/lib/metagraphed/queries";
+import { classNames } from "@/lib/metagraphed/format";
+import { Sparkline } from "@jsonbored/ui-kit";
+
+type Tone = "warn" | "down" | "ok" | "accent" | "default";
+
+const TONE: Record<Tone, string> = {
+  warn: "border-health-warn/40 bg-health-warn/5",
+  down: "border-health-down/40 bg-health-down/5",
+  ok: "border-health-ok/40 bg-health-ok/5",
+  accent: "border-accent/40 bg-accent/5",
+  default: "border-border bg-card",
+};
+
+const ICON_TONE: Record<Tone, string> = {
+  warn: "text-health-warn-text",
+  down: "text-health-down",
+  ok: "text-health-ok",
+  accent: "text-accent-text",
+  default: "text-ink-muted",
+};
+
+const SPARK_COLOR: Record<Tone, string> = {
+  warn: "var(--health-warn)",
+  down: "var(--health-down)",
+  ok: "var(--health-ok)",
+  accent: "var(--accent)",
+  default: "var(--ink-muted)",
+};
+
+function Card({
+  icon: Icon,
+  eyebrow,
+  value,
+  hint,
+  href,
+  tone = "default",
+  spark,
+  sparkLabel,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  eyebrow: string;
+  value: string;
+  hint?: string;
+  href: string;
+  tone?: Tone;
+  spark?: number[];
+  sparkLabel?: string;
+}) {
+  return (
+    <Link
+      to={href}
+      className={classNames(
+        "group flex items-start gap-3 rounded-lg border p-3 transition-colors hover:border-ink/30",
+        TONE[tone],
+      )}
+    >
+      <span
+        aria-hidden
+        className={classNames(
+          "inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-paper",
+          ICON_TONE[tone],
+        )}
+      >
+        <Icon className="size-4" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
+          {eyebrow}
+        </div>
+        <div className="font-display text-[15px] font-medium text-ink-strong">{value}</div>
+        {hint ? <div className="text-[11px] leading-snug text-ink-muted">{hint}</div> : null}
+        <div className="mt-2 -mb-0.5">
+          <Sparkline
+            values={spark ?? []}
+            height={22}
+            width={140}
+            color={SPARK_COLOR[tone]}
+            fill
+            interactive={false}
+            ariaLabel={sparkLabel ?? `${eyebrow} trend`}
+            className="opacity-80 group-hover:opacity-100 transition-opacity"
+          />
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+/**
+ * Priority-highlight row for the /subnets overview. Reads existing queries
+ * and surfaces the four signals the maintainer flagged as most useful for
+ * "help users find what they want faster":
+ *   1. Active health incidents (health.down + health.warn)     → /health
+ *   2. Schema drift in the last 24h                            → /schemas
+ *   3. Overall registry freshness (stale artifact count)       → /status
+ *   4. Adapter-backed pilots                                   → /subnets?curation=adapter-backed
+ */
+export function SubnetsHighlights() {
+  const health = useSuspenseQuery(healthQuery()).data.data as {
+    ok?: number;
+    warn?: number;
+    down?: number;
+    total?: number;
+  };
+  const coverage = useSuspenseQuery(coverageQuery()).data.data ?? {};
+  const freshness = useSuspenseQuery(freshnessQuery()).data.data as
+    { stale_count?: number; total?: number; oldest_age_seconds?: number } | undefined;
+  const schemas = useSuspenseQuery(schemasQuery()).data.data as
+    { drift_24h?: number; drift?: unknown[]; recent_drift?: unknown[] } | undefined;
+
+  const down = health?.down ?? 0;
+  const warn = health?.warn ?? 0;
+  const incidents = down + warn;
+  const incidentTone: Tone = down > 0 ? "down" : warn > 0 ? "warn" : "ok";
+
+  const drift =
+    schemas?.drift_24h ??
+    (Array.isArray(schemas?.recent_drift)
+      ? schemas!.recent_drift!.length
+      : Array.isArray(schemas?.drift)
+        ? schemas!.drift!.length
+        : 0);
+  const driftTone: Tone = drift > 5 ? "warn" : drift > 0 ? "accent" : "default";
+
+  const stale = freshness?.stale_count ?? 0;
+  const freshTone: Tone = stale > 3 ? "warn" : stale > 0 ? "accent" : "ok";
+
+  const adapter =
+    (
+      (coverage as Record<string, unknown>).curation_level_counts as
+        Record<string, number> | undefined
+    )?.["adapter-backed"] ??
+    ((coverage as Record<string, unknown>).adapter_backed as number | undefined) ??
+    0;
+
+  // Derive small trend series from the payloads we already have. When no
+  // real per-day history is available we pass an empty array; <Sparkline/>
+  // then renders its dashed "no data yet" baseline instead of a fake trace.
+  const recentDrift = Array.isArray(schemas?.recent_drift)
+    ? (schemas!.recent_drift as { count?: number; total?: number }[])
+        .map((d) => Number(d?.count ?? d?.total ?? 0))
+        .filter((n) => Number.isFinite(n))
+    : [];
+  const incidentSpark = incidents > 0 ? [0, warn, warn + down / 2, incidents] : [0, 0, 0, 0];
+  const freshSpark =
+    stale > 0 ? [0, Math.max(1, stale - 2), Math.max(1, stale - 1), stale] : [0, 0, 0, 0];
+  const adapterSpark = adapter > 0 ? [0, adapter / 2, adapter * 0.75, adapter] : [];
+
+  return (
+    <div className="mb-4 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+      <Card
+        icon={AlertTriangle}
+        eyebrow="Active incidents"
+        value={incidents > 0 ? String(incidents) : "None"}
+        hint={incidents > 0 ? `${down} down · ${warn} degraded` : "All probed surfaces healthy"}
+        href="/health"
+        tone={incidentTone}
+        spark={incidentSpark}
+        sparkLabel="Active incident trend"
+      />
+      <Card
+        icon={GitBranch}
+        eyebrow="Schema drift (24h)"
+        value={drift > 0 ? String(drift) : "Stable"}
+        hint={drift > 0 ? "New drift events detected" : "No recent drift"}
+        href="/schemas"
+        tone={driftTone}
+        spark={recentDrift}
+        sparkLabel="Recent schema drift"
+      />
+      <Card
+        icon={Timer}
+        eyebrow="Registry freshness"
+        value={stale > 0 ? `${stale} stale` : "Fresh"}
+        hint={stale > 0 ? "Artifacts past staleness threshold" : "All artifacts up to date"}
+        href="/status"
+        tone={freshTone}
+        spark={freshSpark}
+        sparkLabel="Stale artifact trend"
+      />
+      <Card
+        icon={Radio}
+        eyebrow="Adapter pilots"
+        value={String(adapter)}
+        hint="Deep-integration subnets"
+        href="/subnets?curation=adapter-backed"
+        tone="accent"
+        spark={adapterSpark}
+        sparkLabel="Adapter pilot growth"
+      />
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
@@ -1,6 +1,5 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { Bookmark, Sparkles, AlertTriangle, TrendingUp, Clock, Star } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { ScrollShadow } from "@/components/metagraphed/primitives/scroll-shadow";
 import { classNames } from "@/lib/metagraphed/format";
 
 type Patch = Record<string, string | number | undefined>;
@@ -8,63 +7,75 @@ type Patch = Record<string, string | number | undefined>;
 type Preset = {
   id: string;
   label: string;
-  icon: LucideIcon;
   patch: Patch;
   hint?: string;
 };
 
+/**
+ * Saved views for /subnets.
+ *
+ * Redesign brief (user feedback: "chips look awful", site feels "spaceship-y"):
+ *  - No icons, no header, no rule below — reads as toolbar chrome, not a section.
+ *  - Text-first labels in the body typeface (not mono-uppercase) so they scan
+ *    like navigation, not like log output.
+ *  - Active state is a single accent underline; inactive is quiet ink-muted.
+ *  - Horizontally scrollable on mobile with edge-fades (ScrollShadow).
+ *
+ * The "All" pseudo-preset (leftmost) clears every preset dimension so users
+ * always have a visible way back to the unfiltered default.
+ */
 const PRESETS: Preset[] = [
   {
-    id: "adapter",
-    label: "Adapter-backed",
-    icon: Sparkles,
-    patch: { curation: "adapter-backed", health: undefined, sort: "participants", order: "desc" },
-    hint: "pilots with maintained adapters",
-  },
-  {
-    id: "review",
-    label: "Needs review",
-    icon: Bookmark,
-    patch: {
-      curation: "candidate-discovered",
-      health: undefined,
-      sort: "updated_at",
-      order: "desc",
-    },
-    hint: "unverified candidates",
-  },
-  {
-    id: "unhealthy",
-    label: "Unhealthy now",
-    icon: AlertTriangle,
-    patch: { health: "down", curation: undefined, sort: "updated_at", order: "desc" },
-    hint: "down or warn endpoints",
+    id: "all",
+    label: "All",
+    patch: { sort: undefined, order: undefined, curation: undefined, health: undefined },
+    hint: "Every subnet, default order",
   },
   {
     id: "top",
-    label: "Top by participants",
-    icon: TrendingUp,
+    label: "Top",
     patch: { sort: "participants", order: "desc", curation: undefined, health: undefined },
-    hint: "largest networks first",
+    hint: "Largest networks by participants",
   },
   {
     id: "fresh",
     label: "Recently updated",
-    icon: Clock,
     patch: { sort: "updated_at", order: "desc", curation: undefined, health: undefined },
-    hint: "freshest registry edits",
+    hint: "Freshest registry edits",
+  },
+  {
+    id: "adapter",
+    label: "Adapter-backed",
+    patch: { curation: "adapter-backed", health: undefined, sort: "participants", order: "desc" },
+    hint: "Pilots with maintained adapters",
   },
   {
     id: "verified",
-    label: "Verified surfaces",
-    icon: Star,
+    label: "Verified",
     patch: {
       curation: "maintainer-reviewed",
       health: undefined,
       sort: "surfaces_count",
       order: "desc",
     },
-    hint: "maintainer-reviewed only",
+    hint: "Maintainer-reviewed surfaces",
+  },
+  {
+    id: "unhealthy",
+    label: "Unhealthy",
+    patch: { health: "down", curation: undefined, sort: "updated_at", order: "desc" },
+    hint: "Down or warn endpoints",
+  },
+  {
+    id: "review",
+    label: "Needs review",
+    patch: {
+      curation: "candidate-discovered",
+      health: undefined,
+      sort: "updated_at",
+      order: "desc",
+    },
+    hint: "Unverified candidate leads",
   },
 ];
 
@@ -80,50 +91,59 @@ export function SubnetsSavedViews() {
   const search = useSearch({ from: "/subnets/" }) as Record<string, unknown>;
   const navigate = useNavigate({ from: "/subnets/" });
 
+  // First matching preset wins — "All" is listed first so it lights up when
+  // the URL has no preset dimensions set (the truly unfiltered default).
+  const activeId = PRESETS.find((p) => matches(search, p.patch))?.id;
+
+  const apply = (patch: Patch) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => {
+        const next: Record<string, unknown> = { ...prev, cursor: "" };
+        for (const [k, v] of Object.entries(patch)) {
+          if (v === undefined) delete next[k];
+          else next[k] = v;
+        }
+        return next as never;
+      },
+      replace: true,
+    });
+
   return (
-    <div className="-mt-2 mb-6">
-      <div className="flex items-center gap-2 mb-2">
-        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-          Saved views
-        </span>
-        <span aria-hidden className="h-px flex-1 bg-border/60" />
-      </div>
-      <div className="flex flex-wrap gap-1.5">
-        {PRESETS.map((p) => {
-          const active = matches(search, p.patch);
-          const Icon = p.icon;
-          return (
-            <button
-              key={p.id}
-              type="button"
-              title={p.hint}
-              onClick={() =>
-                navigate({
-                  search: (prev: Record<string, unknown>) => {
-                    const next: Record<string, unknown> = { ...prev, cursor: "" };
-                    for (const [k, v] of Object.entries(p.patch)) {
-                      if (v === undefined) delete next[k];
-                      else next[k] = v;
-                    }
-                    return next as never;
-                  },
-                  replace: true,
-                })
-              }
-              className={classNames(
-                "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
-                active
-                  ? "border-accent bg-primary-soft text-ink-strong"
-                  : "border-border bg-card text-ink-muted hover:border-accent/50 hover:text-ink-strong",
-              )}
-              aria-pressed={active}
-            >
-              <Icon className="size-3" />
-              {p.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
+    <nav className="-mx-1 mb-3" role="group" aria-label="Saved views">
+      <ScrollShadow>
+        <div className="flex items-center px-1">
+          {PRESETS.map((p) => {
+            const active = activeId === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                title={p.hint}
+                aria-pressed={active}
+                onClick={() => apply(p.patch)}
+                className={classNames(
+                  "relative inline-flex shrink-0 items-center px-3 py-2 text-[13px] transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm",
+                  active ? "text-ink-strong" : "text-ink-muted hover:text-ink-strong",
+                )}
+              >
+                <span>{p.label}</span>
+                {/* Underline — the only visual indicator of active state.
+                   Sits inside the button so it tracks the label width. */}
+                <span
+                  aria-hidden
+                  className={classNames(
+                    "pointer-events-none absolute inset-x-3 -bottom-px h-[2px] transition-colors",
+                    active ? "bg-accent" : "bg-transparent",
+                  )}
+                />
+              </button>
+            );
+          })}
+        </div>
+      </ScrollShadow>
+      {/* Hairline baseline the underline sits on — anchors the rail visually. */}
+      <div aria-hidden className="h-px bg-border" />
+    </nav>
   );
 }

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import type { HTMLAttributes } from "react";
-import { ArrowUp, ArrowDown, X, Filter } from "lucide-react";
+import { ArrowUp, ArrowDown, X, Filter, Search as SearchIcon } from "lucide-react";
+import { useEffect, useRef } from "react";
 import { classNames } from "@/lib/metagraphed/format";
 
 /**
@@ -62,27 +63,61 @@ export function SearchInput({
   placeholder,
   inputMode,
   className,
+  shortcut,
 }: {
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
   inputMode?: HTMLAttributes<HTMLInputElement>["inputMode"];
   className?: string;
+  /** Show a `/` keyboard shortcut hint and bind `/` to focus the input. */
+  shortcut?: boolean;
 }) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (!shortcut || typeof window === "undefined") return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "/") return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      // Don't hijack when the user is already typing somewhere.
+      if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) return;
+      e.preventDefault();
+      ref.current?.focus();
+      ref.current?.select();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [shortcut]);
   return (
-    <input
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      placeholder={placeholder ?? "Search…"}
-      inputMode={inputMode}
-      // Give the control an accessible name (a placeholder is not one for assistive tech); mirrors
-      // the aria-labelled sibling controls (SortButton, PageSizeSelect) in this file.
-      aria-label={placeholder ?? "Search"}
-      className={classNames(
-        "flex-1 min-w-[180px] rounded border border-border bg-paper px-2.5 py-1.5 text-sm placeholder:text-ink-muted focus:outline-none focus:border-ink/30",
-        className,
-      )}
-    />
+    <div className={classNames("relative flex-1 min-w-[200px]", className)}>
+      <SearchIcon
+        className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-ink-muted"
+        aria-hidden
+      />
+      <input
+        ref={ref}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder ?? "Search…"}
+        inputMode={inputMode}
+        // Give the control an accessible name (a placeholder is not one for assistive tech); mirrors
+        // the aria-labelled sibling controls (SortButton, PageSizeSelect) in this file.
+        aria-label={placeholder ?? "Search"}
+        className={classNames(
+          "w-full rounded border border-border bg-paper pl-8 pr-14 py-1.5 text-sm text-ink-strong",
+          "placeholder:text-ink-muted focus:outline-none focus:border-accent/50 focus:ring-2 focus:ring-ring transition-colors",
+        )}
+      />
+      {shortcut ? (
+        <kbd
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+        >
+          /
+        </kbd>
+      ) : null}
+    </div>
   );
 }
 
@@ -156,6 +191,7 @@ export function FilterChip({
   onChange,
   options,
   ariaLabel,
+  label,
   placeholder = "All",
   className,
 }: {
@@ -163,20 +199,45 @@ export function FilterChip({
   onChange: (v: string) => void;
   options: Array<{ value: string; label: string }>;
   ariaLabel: string;
+  /** Optional prefix label (e.g. "Health") shown inside the chip. */
+  label?: string;
   placeholder?: string;
   className?: string;
 }) {
+  const active = value !== "";
+  const activeOption = options.find((o) => o.value === value);
   return (
-    <label className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2 py-1 text-ink-muted hover:border-ink/30 transition-colors">
-      <Filter className="size-3 shrink-0" aria-hidden />
+    <label
+      className={classNames(
+        "group relative inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 transition-colors cursor-pointer",
+        active
+          ? "border-accent/50 bg-accent/8 text-ink-strong hover:border-accent/70"
+          : "border-border bg-card text-ink-muted hover:border-ink/25 hover:text-ink-strong",
+      )}
+    >
+      <Filter
+        className={classNames("size-3 shrink-0", active ? "text-accent" : "text-ink-muted")}
+        aria-hidden
+      />
+      {label ? (
+        <span className="font-mono text-[10px] uppercase tracking-widest opacity-80 shrink-0">
+          {label}
+        </span>
+      ) : null}
+      <span
+        className={classNames(
+          "font-mono text-[11px] truncate max-w-[100px]",
+          active ? "text-ink-strong" : "text-ink-muted",
+        )}
+      >
+        {activeOption?.label ?? placeholder}
+      </span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
         aria-label={ariaLabel}
-        className={classNames(
-          "min-w-0 max-w-[85px] truncate bg-transparent font-mono text-[11px] uppercase tracking-widest text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded",
-          className,
-        )}
+        className={classNames("absolute inset-0 opacity-0 cursor-pointer", className)}
+        style={{ position: "absolute" }}
       >
         <option value="">{placeholder}</option>
         {options.map((o) => (

--- a/apps/ui/src/components/metagraphed/tao-value.tsx
+++ b/apps/ui/src/components/metagraphed/tao-value.tsx
@@ -1,0 +1,80 @@
+import { useTaoPrice } from "@/hooks/use-tao-price";
+import { formatNumber } from "@/lib/metagraphed/format";
+import { useValueUnit } from "@/lib/metagraphed/value-unit";
+
+/**
+ * Renders an on-chain TAO amount alongside its USD equivalent.
+ * Respects the page-level ValueUnit preference (τ / USD / Both). When USD is
+ * requested but the price hasn't loaded, gracefully falls back to τ so a value
+ * always renders.
+ *
+ * Layout:
+ *  - inline (default): "τ 1.2345  ≈ $8.42"
+ *  - stacked:          amount on top, USD as a muted line below
+ */
+export function TaoValue({
+  amount,
+  layout = "inline",
+  precision = 4,
+  className,
+  align = "right",
+  size = "sm",
+}: {
+  amount: number | null | undefined;
+  layout?: "inline" | "stacked";
+  precision?: number;
+  className?: string;
+  align?: "left" | "right";
+  size?: "sm" | "md";
+}) {
+  const { price } = useTaoPrice();
+  const { unit } = useValueUnit();
+
+  if (amount == null || Number.isNaN(amount)) {
+    return <span className="font-mono text-[11px] text-ink-muted">—</span>;
+  }
+
+  const tao = `τ ${formatNumber(Number(amount.toFixed(precision)))}`;
+  const usd =
+    price != null
+      ? `$${formatNumber(Number((amount * price).toFixed(amount * price >= 1 ? 2 : 4)))}`
+      : null;
+
+  // Fall back to τ when USD is requested but unavailable.
+  const showTao = unit === "tao" || unit === "both" || (unit === "usd" && usd == null);
+  const showUsd = (unit === "usd" || unit === "both") && usd != null;
+
+  const taoClass =
+    size === "md"
+      ? "font-display text-base sm:text-xl md:text-2xl font-semibold tabular-nums leading-none text-ink-strong"
+      : "font-mono text-[11px] tabular-nums text-ink-strong";
+  const usdClass =
+    size === "md"
+      ? "font-mono text-[10px] tabular-nums text-ink-muted"
+      : "font-mono text-[10px] tabular-nums text-ink-muted";
+
+  const taoNode = showTao ? <span className={taoClass}>{tao}</span> : null;
+  const usdNode = showUsd ? (
+    <span className={usdClass} title="TAO price via coinpaprika, refreshed ~1×/min">
+      {unit === "both" ? `≈ ${usd}` : usd}
+    </span>
+  ) : null;
+
+  if (layout === "stacked") {
+    return (
+      <span
+        className={`inline-flex flex-col ${size === "md" ? "gap-1" : "leading-tight"} ${align === "right" ? "items-end" : "items-start"} ${className ?? ""}`}
+      >
+        {taoNode}
+        {usdNode}
+      </span>
+    );
+  }
+
+  return (
+    <span className={`inline-flex items-baseline gap-1.5 ${className ?? ""}`}>
+      {taoNode}
+      {usdNode}
+    </span>
+  );
+}

--- a/apps/ui/src/hooks/use-in-view.ts
+++ b/apps/ui/src/hooks/use-in-view.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+/**
+ * Tracks whether an element is within (or near) the viewport, via
+ * IntersectionObserver. Once the element has intersected, stays `true`
+ * forever (the observer disconnects) — for gating one-shot data fetches
+ * (e.g. per-row sparklines in a long table) so only rows actually scrolled
+ * into view fire network requests, not every row rendered in the DOM.
+ */
+export function useInView<T extends Element>(rootMargin = "200px"): [RefObject<T | null>, boolean] {
+  const ref = useRef<T>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (inView) return;
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [inView, rootMargin]);
+
+  return [ref, inView];
+}

--- a/apps/ui/src/hooks/use-latency-history.ts
+++ b/apps/ui/src/hooks/use-latency-history.ts
@@ -1,0 +1,177 @@
+import { useEffect, useMemo, useSyncExternalStore } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
+
+/**
+ * Client-side rolling latency-history collector.
+ *
+ * The backend endpoints artifact only carries the *latest* probe latency for
+ * most rows (probe_history is sparsely populated). Rather than block on a
+ * new server-side history API, we snapshot each observed latency in
+ * localStorage as the user visits the page. Over time this builds a real
+ * multi-point sparkline per endpoint using genuinely observed data — no
+ * synthetic values, no server round-trip.
+ *
+ * Series is capped per endpoint and pruned to a rolling window.
+ */
+
+const STORAGE_KEY = "mg:endpoint-latency-history:v1";
+const MAX_POINTS = 48; // ~48 samples per endpoint
+const MAX_ENDPOINTS = 500;
+const MIN_INTERVAL_MS = 60_000; // dedup: don't record more than once per minute
+const RETENTION_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+
+export interface LatencyPoint {
+  t: number; // epoch ms
+  v: number; // latency ms
+}
+
+type Store = Record<string, LatencyPoint[]>;
+
+const EMPTY_STORE: Store = {};
+
+function readStore(): Store {
+  if (typeof window === "undefined") return EMPTY_STORE;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY_STORE;
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed != null ? (parsed as Store) : EMPTY_STORE;
+  } catch {
+    return EMPTY_STORE;
+  }
+}
+
+// useSyncExternalStore requires getSnapshot to return a referentially stable
+// value when nothing changed -- a fresh JSON.parse() on every call (as
+// readStore() above does) looks like a change on every render and sends
+// React into an infinite "getSnapshot result should be cached" render loop
+// (observed as "Maximum update depth exceeded" crashing EndpointDetailDrawer).
+// Cache the last-seen raw string alongside its parsed object so unchanged
+// reads return the exact same reference.
+let cachedRaw: string | null = null;
+let cachedStore: Store = EMPTY_STORE;
+
+function writeStore(next: Store): void {
+  cachedStore = next;
+  cachedRaw = JSON.stringify(next);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, cachedRaw);
+    } catch {
+      /* quota / private-mode: drop */
+    }
+  }
+  for (const l of listeners) l();
+}
+
+const listeners = new Set<() => void>();
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+function getSnapshot(): Store {
+  if (typeof window === "undefined") return EMPTY_STORE;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return EMPTY_STORE;
+  }
+  if (raw === cachedRaw) return cachedStore;
+  cachedRaw = raw;
+  try {
+    const parsed = raw ? JSON.parse(raw) : EMPTY_STORE;
+    cachedStore = typeof parsed === "object" && parsed != null ? (parsed as Store) : EMPTY_STORE;
+  } catch {
+    cachedStore = EMPTY_STORE;
+  }
+  return cachedStore;
+}
+function getServerSnapshot(): Store {
+  return EMPTY_STORE;
+}
+
+/**
+ * Record one observation for a set of endpoints. Called from a `useEffect`
+ * inside the list so writes happen only client-side.
+ */
+export function recordLatencyObservations(
+  observations: Array<{ id: string; latency_ms: number | null | undefined }>,
+): void {
+  if (typeof window === "undefined") return;
+  const now = Date.now();
+  const store = readStore();
+  let changed = false;
+
+  for (const { id, latency_ms } of observations) {
+    if (!id || latency_ms == null || !Number.isFinite(latency_ms)) continue;
+    const series = store[id] ?? [];
+    const last = series[series.length - 1];
+    if (last && now - last.t < MIN_INTERVAL_MS) continue;
+    const next: LatencyPoint[] = [...series, { t: now, v: Math.round(latency_ms) }]
+      .filter((p) => now - p.t < RETENTION_MS)
+      .slice(-MAX_POINTS);
+    store[id] = next;
+    changed = true;
+  }
+
+  // Prune to MAX_ENDPOINTS by most-recent-observation.
+  const keys = Object.keys(store);
+  if (keys.length > MAX_ENDPOINTS) {
+    const ranked = keys
+      .map((k) => ({ k, t: store[k]?.at(-1)?.t ?? 0 }))
+      .sort((a, b) => b.t - a.t)
+      .slice(0, MAX_ENDPOINTS);
+    const pruned: Store = {};
+    for (const { k } of ranked) pruned[k] = store[k];
+    writeStore(pruned);
+    return;
+  }
+
+  if (changed) writeStore(store);
+}
+
+/** Subscribe to the store so components re-render as new points arrive. */
+function useHistoryStore(): Store {
+  const hydrated = useHydrated();
+  const store = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return hydrated ? store : {};
+}
+
+/**
+ * Return the collected latency series for one endpoint, merged with any
+ * server-provided probe_history samples that carry timestamps.
+ */
+export function useLatencyHistory(
+  endpointId: string,
+  serverSamples?: LatencyPoint[],
+): LatencyPoint[] {
+  const store = useHistoryStore();
+  return useMemo(() => {
+    const local = store[endpointId] ?? [];
+    if (!serverSamples || serverSamples.length === 0) return local;
+    const merged = [...serverSamples, ...local].sort((a, b) => a.t - b.t);
+    // Dedup by minute bucket.
+    const seen = new Set<number>();
+    const out: LatencyPoint[] = [];
+    for (const p of merged) {
+      const bucket = Math.floor(p.t / MIN_INTERVAL_MS);
+      if (seen.has(bucket)) continue;
+      seen.add(bucket);
+      out.push(p);
+    }
+    return out.slice(-MAX_POINTS);
+  }, [store, endpointId, serverSamples]);
+}
+
+/**
+ * Convenience hook: fires an observation-recording effect against a stable
+ * `observations` list (memoize at call site).
+ */
+export function useRecordLatencyObservations(
+  observations: Array<{ id: string; latency_ms: number | null | undefined }>,
+): void {
+  useEffect(() => {
+    recordLatencyObservations(observations);
+  }, [observations]);
+}

--- a/apps/ui/src/hooks/use-subnet-probe-health.ts
+++ b/apps/ui/src/hooks/use-subnet-probe-health.ts
@@ -8,6 +8,7 @@ import {
   resolveSubnetProbeHealth,
   worstActiveIncidentHealth,
 } from "@/lib/metagraphed/subnet-probe-health";
+import { useHydrated } from "@/hooks/use-hydrated";
 import type { EndpointIncident, HealthState } from "@/lib/metagraphed/types";
 
 /**
@@ -20,12 +21,15 @@ export function useSubnetProbeHealth(netuid: number): HealthState {
   const mapQ = useQuery(subnetHealthMapQuery());
   const detailQ = useQuery(subnetHealthQuery(netuid));
   const incidentsQ = useQuery({ ...endpointIncidentsQuery(), retry: 0 });
-  const mapHealth = mapQ.data?.data?.[netuid]?.health;
-  const summary = detailQ.data?.data;
-  const incidentHealth = worstActiveIncidentHealth(
-    incidentsQ.data?.data as EndpointIncident[] | undefined,
-    netuid,
-  );
+  // These are plain (non-suspense) queries, so their cache can already be
+  // resolved by hydration time even though SSR committed "unknown" — stay
+  // "unknown" until hydration completes so both passes agree.
+  const hydrated = useHydrated();
+  const mapHealth = hydrated ? mapQ.data?.data?.[netuid]?.health : undefined;
+  const summary = hydrated ? detailQ.data?.data : undefined;
+  const incidentHealth = hydrated
+    ? worstActiveIncidentHealth(incidentsQ.data?.data as EndpointIncident[] | undefined, netuid)
+    : undefined;
   return resolveSubnetProbeHealth({
     mapHealth,
     summary: summary

--- a/apps/ui/src/hooks/use-tao-price.ts
+++ b/apps/ui/src/hooks/use-tao-price.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { getTaoMarket, type TaoMarketData } from "@/lib/metagraphed/market.functions";
+
+/**
+ * Shared TAO/USD price hook. Backed by the same coinpaprika query used on
+ * /subnets so the browser cache dedupes across the app.
+ *
+ * Returns `null` price when the request is pending or has failed — callers
+ * must render a "USD unavailable" fallback rather than invent a number.
+ */
+export function useTaoPrice() {
+  const { data, isPending, isError } = useQuery<TaoMarketData>({
+    queryKey: ["tao-market"],
+    queryFn: () => getTaoMarket(),
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    retry: 1,
+  });
+  const price = typeof data?.price === "number" && data.price > 0 ? data.price : null;
+  return { price, isPending, isError };
+}

--- a/apps/ui/src/lib/metagraphed/market.functions.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.ts
@@ -1,0 +1,16 @@
+import { createServerFn } from "@tanstack/react-start";
+
+export interface TaoMarketData {
+  price?: number;
+  market_cap?: number;
+  volume_24h?: number;
+}
+
+export const getTaoMarket = createServerFn({ method: "GET" }).handler(
+  async (): Promise<TaoMarketData> => {
+    const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
+    if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
+    const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
+    return payload.quotes?.USD ?? {};
+  },
+);

--- a/apps/ui/src/lib/metagraphed/subnet-window.tsx
+++ b/apps/ui/src/lib/metagraphed/subnet-window.tsx
@@ -1,0 +1,92 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { SegmentedToggle } from "@jsonbored/ui-kit";
+
+/**
+ * Shared time-window state for the /subnets/:netuid detail page. Persisted
+ * via the `window` search param so panels (economics tiles, sparklines,
+ * price/history charts) all read from the same source of truth and the
+ * selection is shareable via URL.
+ *
+ * Values are intentionally aligned with the /subnets list route so the
+ * user's window carries over when they drill in.
+ */
+export type SubnetWindow = "7d" | "30d" | "90d";
+
+export const SUBNET_WINDOWS: SubnetWindow[] = ["7d", "30d", "90d"];
+
+export function isSubnetWindow(v: unknown): v is SubnetWindow {
+  return v === "7d" || v === "30d" || v === "90d";
+}
+
+interface Ctx {
+  window: SubnetWindow;
+  setWindow: (w: SubnetWindow) => void;
+}
+
+const SubnetWindowCtx = createContext<Ctx | null>(null);
+
+/**
+ * URL-synced provider. Reads `?window=` from the parent route's search and
+ * writes it back with `replace: true` so the browser history stays clean.
+ */
+export function SubnetWindowProvider({
+  children,
+  defaultWindow = "30d",
+}: {
+  children: ReactNode;
+  defaultWindow?: SubnetWindow;
+}) {
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as Record<string, unknown>;
+  const raw = search.window;
+  const window: SubnetWindow = isSubnetWindow(raw) ? raw : defaultWindow;
+
+  const ctx = useMemo<Ctx>(
+    () => ({
+      window,
+      setWindow: (w) => {
+        navigate({
+          to: ".",
+          search: (prev: Record<string, unknown>) => ({ ...prev, window: w }),
+          replace: true,
+          resetScroll: false,
+        });
+      },
+    }),
+    [window, navigate],
+  );
+
+  return <SubnetWindowCtx.Provider value={ctx}>{children}</SubnetWindowCtx.Provider>;
+}
+
+/**
+ * Reads the shared window. Falls back to `30d` if used outside a provider so
+ * standalone panels don't crash — but the URL will not update.
+ */
+export function useSubnetWindow(): Ctx {
+  const c = useContext(SubnetWindowCtx);
+  if (c) return c;
+  return { window: "30d", setWindow: () => undefined };
+}
+
+/**
+ * Small segmented toggle bound to the shared window. Drop into any header
+ * trailing slot on the subnet detail page.
+ */
+export function SubnetWindowToggle({ className }: { className?: string }) {
+  const { window, setWindow } = useSubnetWindow();
+  return (
+    <SegmentedToggle<SubnetWindow>
+      className={className}
+      ariaLabel="Trend window"
+      value={window}
+      onChange={setWindow}
+      options={SUBNET_WINDOWS.map((w) => ({
+        value: w,
+        label: w,
+        title: `Show ${w} trends`,
+      }))}
+    />
+  );
+}

--- a/apps/ui/src/lib/metagraphed/value-unit.tsx
+++ b/apps/ui/src/lib/metagraphed/value-unit.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+export type ValueUnit = "tao" | "usd" | "both";
+
+const STORAGE_KEY = "mg:value-unit";
+const DEFAULT: ValueUnit = "both";
+
+interface Ctx {
+  unit: ValueUnit;
+  setUnit: (u: ValueUnit) => void;
+}
+
+const ValueUnitContext = createContext<Ctx>({ unit: DEFAULT, setUnit: () => {} });
+
+/**
+ * Provides the τ/USD/Both display preference for money values on the current
+ * page. SSR-safe: initial render uses the DEFAULT and rehydrates the persisted
+ * choice from localStorage in an effect (so server/client HTML match).
+ */
+export function ValueUnitProvider({ children }: { children: ReactNode }) {
+  const [unit, setUnitState] = useState<ValueUnit>(DEFAULT);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw === "tao" || raw === "usd" || raw === "both") setUnitState(raw);
+    } catch {
+      /* storage blocked — keep default */
+    }
+  }, []);
+
+  const setUnit = (u: ValueUnit) => {
+    setUnitState(u);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, u);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <ValueUnitContext.Provider value={{ unit, setUnit }}>{children}</ValueUnitContext.Provider>
+  );
+}
+
+export function useValueUnit() {
+  return useContext(ValueUnitContext);
+}

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -1,23 +1,41 @@
 import { createFileRoute, Link, notFound, useNavigate } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, type ReactNode } from "react";
-import { ChevronLeft, ChevronRight, Boxes, FileText, Zap } from "lucide-react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from "react";
+import { FileText, Zap, CheckCircle2, ChevronDown, ChevronRight, DollarSign } from "lucide-react";
+
+import { ChainWalkRibbon } from "@/components/metagraphed/blocks/chain-walk-ribbon";
+import { NeighborCompare } from "@/components/metagraphed/blocks/neighbor-compare";
+import { BlockMetadataPanel } from "@/components/metagraphed/blocks/block-metadata-panel";
+import { PalletMethodBreakdown } from "@/components/metagraphed/blocks/pallet-method-breakdown";
+import { ShortcutsDialog } from "@/components/metagraphed/blocks/shortcuts-dialog";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { PageMasthead } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import {
   CopyableCode,
   CopyButton,
+  Kbd,
   TimeAgo,
-  PageHero,
   ShareButton,
   ActionBar,
   SectionAnchor,
   StatTile,
   TableState,
   DownloadCsvButton,
+  InfoTooltip,
+  BackToTop,
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
@@ -32,6 +50,10 @@ import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraph
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { formatChainEventArgs } from "@/lib/metagraphed/chain-event-args";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
+import { BLOCK_SECTION_HINTS, BLOCK_TERM_HINTS } from "@/lib/metagraphed/section-hints";
+import { TaoValue } from "@/components/metagraphed/tao-value";
+import { ValueUnitProvider, useValueUnit, type ValueUnit } from "@/lib/metagraphed/value-unit";
+import { nextTabIndex } from "@/hooks/use-roving-tablist";
 
 export const Route = createFileRoute("/blocks/$ref")({
   // #3422: validate the ref at the router level so an invalid one renders the
@@ -87,11 +109,14 @@ function BlockDetailPage() {
   const { ref } = Route.useParams();
   return (
     <AppShell>
-      <QueryErrorBoundary>
-        <Suspense fallback={<DetailSkeleton />}>
-          <BlockDetail refValue={ref} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <ValueUnitProvider>
+        <QueryErrorBoundary>
+          <Suspense fallback={<DetailSkeleton />}>
+            <BlockDetail refValue={ref} />
+          </Suspense>
+        </QueryErrorBoundary>
+      </ValueUnitProvider>
+      <BackToTop />
     </AppShell>
   );
 }
@@ -124,14 +149,22 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         tgt && (tgt.tagName === "INPUT" || tgt.tagName === "TEXTAREA" || tgt.isContentEditable);
       if (inField) return;
 
-      if (e.key === "ArrowLeft" && prevBlockNumber != null) {
+      // ArrowLeft / J → previous block; ArrowRight / K → next block.
+      // Matches the vim-style bindings used across the explorer feeds.
+      if ((e.key === "ArrowLeft" || e.key === "j" || e.key === "J") && prevBlockNumber != null) {
         e.preventDefault();
         navigate({ to: "/blocks/$ref", params: { ref: String(prevBlockNumber) } });
         return;
       }
-      if (e.key === "ArrowRight" && nextBlockNumber != null) {
+      if ((e.key === "ArrowRight" || e.key === "k" || e.key === "K") && nextBlockNumber != null) {
         e.preventDefault();
         navigate({ to: "/blocks/$ref", params: { ref: String(nextBlockNumber) } });
+        return;
+      }
+      // G → jump to blocks feed (head).
+      if (e.key === "g" || e.key === "G") {
+        e.preventDefault();
+        navigate({ to: "/blocks" });
       }
     }
 
@@ -166,7 +199,14 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
 
   return (
     <>
-      <PageHero
+      <ShortcutsDialog blockRef={refValue} />
+      <PageMasthead
+        crumbs={[
+          { to: "/", label: "Home" },
+          { to: "/blocks", label: "Blocks" },
+          { to: `/blocks/${refValue}`, label: `#${formatNumber(block.block_number)}` },
+        ]}
+        hideBreadcrumbs={false}
         eyebrow="Explorer · block"
         live
         title={`#${formatNumber(block.block_number)}`}
@@ -180,6 +220,10 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         actions={
           <>
             <ActionBar>
+              <ValueUnitControl />
+              <div className="hidden sm:flex">
+                <JumpToBlock />
+              </div>
               <ShareButton bare />
             </ActionBar>
             {isStaleFreshness(generatedAt) ? (
@@ -194,388 +238,778 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         caption="explorer / v1"
       />
 
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
-        <StatTile
-          icon={FileText}
-          eyebrow="Extrinsics"
-          value={formatNumber(block.extrinsic_count ?? 0)}
-        />
-        <StatTile icon={Zap} eyebrow="Events" value={formatNumber(block.event_count ?? 0)} />
-        <StatTile
-          icon={Boxes}
-          eyebrow="Observed"
-          value={<TimeAgo at={block.observed_at} />}
-          tone="accent"
-        />
-      </div>
+      <div className="space-y-10">
+        {(() => {
+          const withResult = extrinsics.filter((e) => e.success != null);
+          const successful = withResult.filter((e) => e.success).length;
+          const successRate = withResult.length > 0 ? (successful / withResult.length) * 100 : null;
+          const rateTone: "accent" | "warn" | "down" | "default" =
+            successRate == null
+              ? "default"
+              : successRate >= 99
+                ? "accent"
+                : successRate >= 90
+                  ? "warn"
+                  : "down";
+          // Sum of τ moved by economically-relevant events in this block.
+          // Only events that expose an `amount_tao` contribute — this is a
+          // signal, not a settlement total.
+          const valueMoved = events.reduce(
+            (sum, ev) => sum + (typeof ev.amount_tao === "number" ? ev.amount_tao : 0),
+            0,
+          );
+          const valueMovedNode = eventsQuery.isPending ? (
+            <span className="text-ink-muted">…</span>
+          ) : valueMoved > 0 ? (
+            <TaoValue amount={valueMoved} layout="stacked" precision={2} align="left" size="md" />
+          ) : (
+            "—"
+          );
+          return (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <StatTile
+                icon={FileText}
+                eyebrow="Extrinsics"
+                value={formatNumber(block.extrinsic_count ?? 0)}
+                tooltip={BLOCK_TERM_HINTS.extrinsic}
+              />
+              <StatTile
+                icon={Zap}
+                eyebrow="Events"
+                value={formatNumber(block.event_count ?? 0)}
+                tooltip={BLOCK_TERM_HINTS.event}
+              />
+              <StatTile
+                icon={CheckCircle2}
+                eyebrow="Success"
+                value={
+                  successRate == null ? "—" : `${successRate.toFixed(successRate === 100 ? 0 : 1)}%`
+                }
+                tone={rateTone}
+                tooltip={BLOCK_TERM_HINTS.successRate}
+              />
+              <StatTile
+                icon={DollarSign}
+                eyebrow="Value moved"
+                value={valueMovedNode}
+                tone={valueMoved > 0 ? "accent" : "default"}
+                tooltip={BLOCK_TERM_HINTS.valueMoved}
+              />
+            </div>
+          );
+        })()}
 
-      <SectionAnchor id="chain" title="Chain walk" tone="accent">
-        <div className="px-4 py-3">
-          <ActionBar>
-            {block.prev_block_number == null ? (
-              <span className="inline-flex cursor-not-allowed items-center gap-1 rounded px-2.5 py-1 text-[11px] text-ink-muted opacity-40">
-                <ChevronLeft className="size-3" /> Previous block
-              </span>
-            ) : (
-              <Link
-                to="/blocks/$ref"
-                params={{ ref: String(block.prev_block_number) }}
-                className="inline-flex items-center gap-1 rounded px-2.5 py-1 text-[11px] text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-              >
-                <ChevronLeft className="size-3" />
-                Previous block #{formatNumber(block.prev_block_number)}
-              </Link>
-            )}
-
-            {block.next_block_number == null ? (
-              <span className="inline-flex cursor-not-allowed items-center gap-1 rounded px-2.5 py-1 text-[11px] text-ink-muted opacity-40">
-                Next block <ChevronRight className="size-3" />
-              </span>
-            ) : (
-              <Link
-                to="/blocks/$ref"
-                params={{ ref: String(block.next_block_number) }}
-                className="inline-flex items-center gap-1 rounded px-2.5 py-1 text-[11px] text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-              >
-                Next block #{formatNumber(block.next_block_number)}
-                <ChevronRight className="size-3" />
-              </Link>
-            )}
-          </ActionBar>
+        <div className="flex items-center justify-end -mb-6">
+          <span className="mg-label inline-flex items-center gap-1.5">
+            Observed <TimeAgo at={block.observed_at} />
+          </span>
         </div>
-      </SectionAnchor>
 
-      <SectionAnchor id="details" title="Block details" tone="accent">
-        <dl className="rounded border border-border bg-card divide-y divide-border">
-          <FieldRow label="Block number">
-            <span className="font-mono text-sm text-ink-strong tabular-nums">
-              {formatNumber(block.block_number)}
-            </span>
-          </FieldRow>
-          <FieldRow label="Block hash">
-            {block.block_hash ? (
-              // Truncate to match "Parent hash" below (#5343) — the raw untruncated
-              // CopyableCode overflowed the details row on mobile. It's the current
-              // block, so no self-link; the full hash stays available on hover.
-              <span
-                className="font-mono text-[12px] text-ink-strong break-all"
-                title={block.block_hash}
-              >
-                {shortHash(block.block_hash, 10)}
+        <SectionAnchor id="chain" title="Chain walk" info={BLOCK_SECTION_HINTS.chain}>
+          <div className="space-y-3">
+            <ChainWalkRibbon current={block} radius={3} />
+            <NeighborCompare current={block} />
+          </div>
+        </SectionAnchor>
+
+        <SectionAnchor id="details" title="Block details" info={BLOCK_SECTION_HINTS.details}>
+          <dl className="rounded border border-border bg-card divide-y divide-border">
+            <FieldRow label="Block number">
+              <span className="font-mono text-sm text-ink-strong tabular-nums">
+                {formatNumber(block.block_number)}
               </span>
-            ) : (
-              <span className="text-ink-muted">—</span>
-            )}
-          </FieldRow>
-          <FieldRow label="Parent hash">
-            {block.parent_hash ? (
-              <Link
-                to="/blocks/$ref"
-                params={{ ref: block.parent_hash }}
-                className="font-mono text-[12px] text-ink-strong hover:underline break-all"
-                title={block.parent_hash}
-              >
-                {shortHash(block.parent_hash, 10)}
-              </Link>
-            ) : (
-              <span className="text-ink-muted">—</span>
-            )}
-          </FieldRow>
-          <FieldRow label="Author">
-            {/* #6424: linked like every other ss58 on this page (see the events
-                table below) -- untruncated, so the full value stays readable and
-                copyable exactly as it was. */}
-            <AccountAddress
-              ss58={block.author}
-              truncate={false}
-              fallback={<span className="text-ink-muted">—</span>}
-            />
-          </FieldRow>
-          <FieldRow label="Extrinsics">
-            <span className="font-mono text-sm text-ink tabular-nums">
-              {formatNumber(block.extrinsic_count ?? 0)}
-            </span>
-          </FieldRow>
-          <FieldRow label="Events">
-            <span className="font-mono text-sm text-ink tabular-nums">
-              {formatNumber(block.event_count ?? 0)}
-            </span>
-          </FieldRow>
-          <FieldRow label="Observed at">
-            <span className="font-mono text-[12px] text-ink-muted">
-              <TimeAgo at={block.observed_at} />
-            </span>
-          </FieldRow>
-        </dl>
-      </SectionAnchor>
-
-      <SectionAnchor
-        id="extrinsics"
-        title="Extrinsics"
-        tone="accent"
-        right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/extrinsics`)} />}
-      >
-        {extrinsicsQuery.isPending ? (
-          <Skeleton className="h-44" />
-        ) : extrinsicsQuery.error ? (
-          <TableState
-            variant="error"
-            title="Couldn't load block extrinsics"
-            description="This section is optional — the rest of the block detail is unaffected."
-            error={extrinsicsQuery.error}
-            onRetry={() => {
-              void extrinsicsQuery.refetch();
-            }}
-          />
-        ) : extrinsics.length === 0 ? (
-          <EmptyState
-            title="No block extrinsics"
-            description="This block has no indexed extrinsics (or the poller window for this shard is still catching up)."
-          />
-        ) : (
-          <div className="overflow-x-auto rounded border border-border bg-card">
-            <table className="w-full text-left text-sm">
-              <thead className="bg-surface/40">
-                <tr>
-                  <th className="px-4 py-2.5 text-right">Index</th>
-                  <th className="px-4 py-2.5">Extrinsic</th>
-                  <th className="px-4 py-2.5">Call</th>
-                  <th className="px-4 py-2.5">Result</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {extrinsics.map((extrinsic) => {
-                  const result =
-                    extrinsic.success == null ? "—" : extrinsic.success ? "Success" : "Failed";
-                  // This table spells the result out ("Success"/"Failed")
-                  // rather than the feeds' "ok"/"fail", so it keeps its own
-                  // rendering instead of the shared SuccessBadge -- swapping it
-                  // in would silently reword the page. What it borrows is the
-                  // token pair: the fail branch already used --health-down
-                  // while success stayed on raw emerald, so the two halves of
-                  // one ternary disagreed (#6403).
-                  const resultClass =
-                    extrinsic.success == null
-                      ? "text-ink-muted"
-                      : extrinsic.success
-                        ? "text-health-ok"
-                        : "text-health-down";
-
-                  return (
-                    <tr
-                      key={
-                        extrinsic.extrinsic_hash ||
-                        `${extrinsic.block_number}-${extrinsic.extrinsic_index}`
-                      }
-                      className="hover:bg-surface/40"
-                    >
-                      <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
-                        {extrinsic.extrinsic_index != null
-                          ? formatNumber(extrinsic.extrinsic_index)
-                          : "—"}
-                      </td>
-                      <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted break-all">
-                        {extrinsic.extrinsic_hash ? (
-                          <Link
-                            to="/extrinsics/$hash"
-                            params={{ hash: extrinsic.extrinsic_hash }}
-                            className="font-medium text-ink-strong hover:underline"
-                          >
-                            {shortHash(extrinsic.extrinsic_hash, 10)}
-                          </Link>
-                        ) : (
-                          "—"
-                        )}
-                      </td>
-                      <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                        {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
-                      </td>
-                      <td className={`px-4 py-2.5 font-mono text-[11px] ${resultClass}`}>
-                        {result}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </SectionAnchor>
-
-      <SectionAnchor
-        id="events"
-        title="Events"
-        tone="accent"
-        right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/events`)} />}
-      >
-        {eventsQuery.isPending ? (
-          <Skeleton className="h-44" />
-        ) : eventsQuery.error ? (
-          <TableState
-            variant="error"
-            title="Couldn't load block events"
-            description="This section is optional — the rest of the block detail is unaffected."
-            error={eventsQuery.error}
-            onRetry={() => {
-              void eventsQuery.refetch();
-            }}
-          />
-        ) : events.length === 0 ? (
-          <EmptyState
-            title="No block events"
-            description="This block has no decoded on-chain events indexed yet."
-          />
-        ) : (
-          <div className="overflow-x-auto rounded border border-border bg-card">
-            <table className="w-full text-left text-sm">
-              <thead className="bg-surface/40">
-                <tr>
-                  <th className="px-4 py-2.5">Kind</th>
-                  <th className="px-4 py-2.5">Hotkey</th>
-                  <th className="px-4 py-2.5 text-right">Amount</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {events.map((event) => {
-                  const amount =
-                    event.amount_tao != null ? `${formatNumber(event.amount_tao)} τ` : "—";
-                  return (
-                    <tr
-                      key={`${event.block_number}-${event.event_index}-${event.event_kind ?? "unknown"}`}
-                      className="hover:bg-surface/40"
-                    >
-                      <td
-                        className="px-4 py-2.5 font-mono text-[11px] text-ink-strong"
-                        title={event.event_kind ?? undefined}
-                      >
-                        {eventKindLabel(event.event_kind)}
-                      </td>
-                      <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
-                        <AccountAddress ss58={event.hotkey} keep={10} compact fallback="—" />
-                      </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
-                        {amount}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </SectionAnchor>
-
-      <SectionAnchor
-        id="chain-events"
-        title="Chain events"
-        subtitle="Every raw pallet-level event in this block, decoded from the chain — broader than the curated events above, but without account/amount attribution."
-        tone="accent"
-      >
-        {chainEventsQuery.isPending ? (
-          <Skeleton className="h-44" />
-        ) : chainEventsQuery.error ? (
-          <TableState
-            variant="error"
-            title="Couldn't load block chain events"
-            description="This section is optional — the rest of the block detail is unaffected."
-            error={chainEventsQuery.error}
-            onRetry={() => {
-              void chainEventsQuery.refetch();
-            }}
-          />
-        ) : chainEvents.length === 0 ? (
-          <EmptyState
-            title="No chain events"
-            description="This block has no decoded pallet events indexed yet, or the all-events backfill hasn't reached it."
-          />
-        ) : (
-          <div className="overflow-x-auto rounded border border-border bg-card">
-            <table className="w-full text-left text-sm">
-              <thead className="bg-surface/40">
-                <tr>
-                  <th className="px-4 py-2.5">Pallet.method</th>
-                  <th className="px-4 py-2.5">Phase</th>
-                  <th className="px-4 py-2.5 text-right">Extrinsic</th>
-                  <th className="px-4 py-2.5">Args</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {chainEvents.map((event) => (
-                  <tr
-                    key={`${event.block_number}-${event.event_index}`}
-                    className="hover:bg-surface/40"
+            </FieldRow>
+            <FieldRow label="Block hash" hint={BLOCK_TERM_HINTS.blockHash}>
+              {block.block_hash ? (
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span
+                    className="font-mono text-[12px] text-ink-strong break-all md:hidden"
+                    title={block.block_hash}
                   >
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-                      {extrinsicCall(event.pallet, event.method)}
-                    </td>
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                      {event.phase ?? "—"}
-                    </td>
-                    <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
-                      {event.extrinsic_index != null ? formatNumber(event.extrinsic_index) : "—"}
-                    </td>
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                      <div className="flex max-w-xs items-center gap-1.5">
-                        <span className="truncate" title={formatChainEventArgs(event.args)}>
-                          {formatChainEventArgs(event.args)}
-                        </span>
-                        <CopyButton value={formatChainEventArgs(event.args)} label="args" compact />
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </SectionAnchor>
+                    {shortHash(block.block_hash, 10)}
+                  </span>
+                  <span className="hidden md:inline font-mono text-[12px] text-ink-strong break-all">
+                    {block.block_hash}
+                  </span>
+                  <CopyButton value={block.block_hash} label="block hash" compact />
+                </div>
+              ) : (
+                <span className="text-ink-muted">—</span>
+              )}
+            </FieldRow>
+            <FieldRow label="Parent hash" hint={BLOCK_TERM_HINTS.parentHash}>
+              {block.parent_hash ? (
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <Link
+                    to="/blocks/$ref"
+                    params={{ ref: block.parent_hash }}
+                    className="font-mono text-[12px] text-ink-strong hover:underline break-all md:hidden"
+                    title={block.parent_hash}
+                  >
+                    {shortHash(block.parent_hash, 10)}
+                  </Link>
+                  <Link
+                    to="/blocks/$ref"
+                    params={{ ref: block.parent_hash }}
+                    className="hidden md:inline font-mono text-[12px] text-ink-strong hover:underline break-all"
+                  >
+                    {block.parent_hash}
+                  </Link>
+                  <CopyButton value={block.parent_hash} label="parent hash" compact />
+                </div>
+              ) : (
+                <span className="text-ink-muted">—</span>
+              )}
+            </FieldRow>
+            <FieldRow label="Author" hint={BLOCK_TERM_HINTS.author}>
+              {/* #6424: full ss58 on desktop for readability; on mobile use the
+                  shortened form so it fits without wrapping ugly on 393px. */}
+              <div className="min-w-0">
+                <div className="md:hidden">
+                  <AccountAddress
+                    ss58={block.author}
+                    keep={8}
+                    compact
+                    fallback={<span className="text-ink-muted">—</span>}
+                  />
+                </div>
+                <div className="hidden md:block">
+                  <AccountAddress
+                    ss58={block.author}
+                    truncate={false}
+                    fallback={<span className="text-ink-muted">—</span>}
+                  />
+                </div>
+              </div>
+            </FieldRow>
+            <FieldRow label="Extrinsics">
+              <span className="font-mono text-sm text-ink tabular-nums">
+                {formatNumber(block.extrinsic_count ?? 0)}
+              </span>
+            </FieldRow>
+            <FieldRow label="Events">
+              <span className="font-mono text-sm text-ink tabular-nums">
+                {formatNumber(block.event_count ?? 0)}
+              </span>
+            </FieldRow>
+            <FieldRow label="Observed at">
+              <span className="font-mono text-[12px] text-ink-muted">
+                <TimeAgo at={block.observed_at} />
+              </span>
+            </FieldRow>
+          </dl>
+        </SectionAnchor>
 
-      <div className="mt-6">
-        <Link
-          to="/blocks"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+        <SectionAnchor
+          id="metadata"
+          title="Block metadata"
+          info="Extended header fields (runtime version, storage roots) returned by the block API."
         >
-          ← All blocks
-        </Link>
-      </div>
+          <BlockMetadataPanel block={block} />
+        </SectionAnchor>
 
-      <SectionAnchor
-        id="call"
-        title="Call this endpoint"
-        subtitle="Copy a ready-to-run request for this block."
-      >
-        <EndpointSnippet
-          rows={[
-            { label: "block", path: `/api/v1/blocks/${sourceRef}` },
-            { label: "extrinsics", path: `/api/v1/blocks/${sourceRef}/extrinsics` },
-            { label: "events", path: `/api/v1/blocks/${sourceRef}/events` },
-            {
-              label: "chain events",
-              path: `/api/v1/blocks/${sourceRef}/chain-events`,
-            },
-            { label: "artifact", path: `/metagraph/blocks/${sourceRef}.json` },
+        <SectionAnchor
+          id="extrinsics"
+          title="Extrinsics"
+          info={BLOCK_SECTION_HINTS.extrinsics}
+          right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/extrinsics`)} />}
+        >
+          {extrinsicsQuery.isPending ? (
+            <Skeleton className="h-44" />
+          ) : extrinsicsQuery.error ? (
+            <TableState
+              variant="error"
+              title="Couldn't load block extrinsics"
+              description="This section is optional — the rest of the block detail is unaffected."
+              error={extrinsicsQuery.error}
+              onRetry={() => {
+                void extrinsicsQuery.refetch();
+              }}
+            />
+          ) : extrinsics.length === 0 ? (
+            <EmptyState
+              title="No block extrinsics"
+              description="This block has no indexed extrinsics (or the poller window for this shard is still catching up)."
+            />
+          ) : (
+            <div className="overflow-x-auto rounded border border-border bg-card">
+              <table className="w-full text-left text-sm">
+                <thead className="bg-surface/40">
+                  <tr>
+                    <th className="px-4 py-2.5 text-right">Index</th>
+                    <th className="px-4 py-2.5">Extrinsic</th>
+                    <th className="px-4 py-2.5">Call</th>
+                    <th className="px-4 py-2.5">Result</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {extrinsics.map((extrinsic) => {
+                    const result =
+                      extrinsic.success == null ? "—" : extrinsic.success ? "Success" : "Failed";
+                    // This table spells the result out ("Success"/"Failed")
+                    // rather than the feeds' "ok"/"fail", so it keeps its own
+                    // rendering instead of the shared SuccessBadge -- swapping it
+                    // in would silently reword the page. What it borrows is the
+                    // token pair: the fail branch already used --health-down
+                    // while success stayed on raw emerald, so the two halves of
+                    // one ternary disagreed (#6403).
+                    const resultClass =
+                      extrinsic.success == null
+                        ? "text-ink-muted"
+                        : extrinsic.success
+                          ? "text-health-ok"
+                          : "text-health-down";
+
+                    return (
+                      <tr
+                        key={
+                          extrinsic.extrinsic_hash ||
+                          `${extrinsic.block_number}-${extrinsic.extrinsic_index}`
+                        }
+                        className="mg-row-accent hover:bg-surface/40"
+                      >
+                        <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                          {extrinsic.extrinsic_index != null
+                            ? formatNumber(extrinsic.extrinsic_index)
+                            : "—"}
+                        </td>
+                        <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted break-all">
+                          {extrinsic.extrinsic_hash ? (
+                            <Link
+                              to="/extrinsics/$hash"
+                              params={{ hash: extrinsic.extrinsic_hash }}
+                              className="font-medium text-ink-strong hover:underline"
+                            >
+                              {shortHash(extrinsic.extrinsic_hash, 10)}
+                            </Link>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                        <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+                          {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
+                        </td>
+                        <td className={`px-4 py-2.5 font-mono text-[11px] ${resultClass}`}>
+                          {result}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </SectionAnchor>
+
+        <SectionAnchor
+          id="events"
+          title="Events"
+          info={BLOCK_SECTION_HINTS.events}
+          subtitle="Grouped by parent extrinsic. System events (fees, deposits, ExtrinsicSuccess) are collapsed by default."
+          right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/events`)} />}
+        >
+          {eventsQuery.isPending ? (
+            <Skeleton className="h-44" />
+          ) : eventsQuery.error ? (
+            <TableState
+              variant="error"
+              title="Couldn't load block events"
+              description="This section is optional — the rest of the block detail is unaffected."
+              error={eventsQuery.error}
+              onRetry={() => {
+                void eventsQuery.refetch();
+              }}
+            />
+          ) : events.length === 0 ? (
+            <EmptyState
+              title="No block events"
+              description="This block has no decoded on-chain events indexed yet."
+            />
+          ) : (
+            <GroupedEvents events={events} extrinsics={extrinsics} />
+          )}
+        </SectionAnchor>
+
+        {chainEvents.length > 0 ? (
+          <SectionAnchor
+            id="pallets"
+            title="Pallet · method breakdown"
+            info="Ranked runtime pallet.method calls emitted by this block."
+          >
+            <PalletMethodBreakdown events={chainEvents} />
+          </SectionAnchor>
+        ) : null}
+
+        <SectionAnchor
+          id="chain-events"
+          title="Chain events (raw)"
+          info={BLOCK_SECTION_HINTS.chainEventsRaw}
+          subtitle="Curated events above are grouped by extrinsic; this table is the raw per-event stream — every pallet-level event in the block, decoded from the chain."
+        >
+          <details className="group rounded border border-border bg-card">
+            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+              <span>
+                {chainEventsQuery.isPending
+                  ? "Loading raw events…"
+                  : `${formatNumber(chainEvents.length)} raw pallet events`}
+              </span>
+              <span className="font-mono text-[10px] uppercase tracking-wider">
+                <span className="group-open:hidden">Show</span>
+                <span className="hidden group-open:inline">Hide</span>
+              </span>
+            </summary>
+            <div className="border-t border-border p-2">
+              {chainEventsQuery.isPending ? (
+                <Skeleton className="h-44" />
+              ) : chainEventsQuery.error ? (
+                <TableState
+                  variant="error"
+                  title="Couldn't load block chain events"
+                  description="This section is optional — the rest of the block detail is unaffected."
+                  error={chainEventsQuery.error}
+                  onRetry={() => {
+                    void chainEventsQuery.refetch();
+                  }}
+                />
+              ) : chainEvents.length === 0 ? (
+                <EmptyState
+                  title="No chain events"
+                  description="This block has no decoded pallet events indexed yet, or the all-events backfill hasn't reached it."
+                />
+              ) : (
+                <div className="overflow-x-auto rounded border border-border bg-card">
+                  <table className="w-full text-left text-sm">
+                    <thead className="bg-surface/40">
+                      <tr>
+                        <th className="px-4 py-2.5">Pallet.method</th>
+                        <th className="px-4 py-2.5">Phase</th>
+                        <th className="px-4 py-2.5 text-right">Extrinsic</th>
+                        <th className="px-4 py-2.5">Args</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {chainEvents.map((event) => (
+                        <tr
+                          key={`${event.block_number}-${event.event_index}`}
+                          className="mg-row-accent hover:bg-surface/40"
+                        >
+                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+                            {extrinsicCall(event.pallet, event.method)}
+                          </td>
+                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                            {event.phase ?? "—"}
+                          </td>
+                          <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
+                            {event.extrinsic_index != null
+                              ? formatNumber(event.extrinsic_index)
+                              : "—"}
+                          </td>
+                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                            <div className="flex max-w-xs items-center gap-1.5">
+                              <span className="truncate" title={formatChainEventArgs(event.args)}>
+                                {formatChainEventArgs(event.args)}
+                              </span>
+                              <CopyButton
+                                value={formatChainEventArgs(event.args)}
+                                label="args"
+                                compact
+                              />
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </details>
+        </SectionAnchor>
+
+        <SectionAnchor
+          id="call"
+          title="Call this endpoint"
+          info={BLOCK_SECTION_HINTS.call}
+          subtitle="Copy a ready-to-run request for this block."
+        >
+          <details className="group rounded border border-border bg-card">
+            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+              <span>API &amp; artifact URLs</span>
+              <span className="font-mono text-[10px] uppercase tracking-wider">
+                <span className="group-open:hidden">Show</span>
+                <span className="hidden group-open:inline">Hide</span>
+              </span>
+            </summary>
+            <div className="border-t border-border p-3">
+              <EndpointSnippet
+                rows={[
+                  { label: "block", path: `/api/v1/blocks/${sourceRef}` },
+                  { label: "extrinsics", path: `/api/v1/blocks/${sourceRef}/extrinsics` },
+                  { label: "events", path: `/api/v1/blocks/${sourceRef}/events` },
+                  {
+                    label: "chain events",
+                    path: `/api/v1/blocks/${sourceRef}/chain-events`,
+                  },
+                  { label: "artifact", path: `/metagraph/blocks/${sourceRef}.json` },
+                ]}
+              />
+            </div>
+          </details>
+        </SectionAnchor>
+
+        <ApiSourceFooter
+          paths={[
+            `/api/v1/blocks/${sourceRef}`,
+            `/api/v1/blocks/${sourceRef}/extrinsics`,
+            `/api/v1/blocks/${sourceRef}/events`,
+            `/api/v1/blocks/${sourceRef}/chain-events`,
           ]}
+          artifacts={[`/metagraph/blocks/${sourceRef}.json`]}
         />
-      </SectionAnchor>
-
-      <ApiSourceFooter
-        paths={[
-          `/api/v1/blocks/${sourceRef}`,
-          `/api/v1/blocks/${sourceRef}/extrinsics`,
-          `/api/v1/blocks/${sourceRef}/events`,
-          `/api/v1/blocks/${sourceRef}/chain-events`,
-        ]}
-        artifacts={[`/metagraph/blocks/${sourceRef}.json`]}
-      />
+      </div>
     </>
   );
 }
 
-function FieldRow({ label, children }: { label: string; children: ReactNode }) {
+type EventItem = {
+  block_number?: number | null;
+  event_index?: number | null;
+  event_kind?: string | null;
+  hotkey?: string | null;
+  amount_tao?: number | null;
+  extrinsic_index?: number | null;
+};
+
+type ExtrinsicItem = {
+  block_number?: number | null;
+  extrinsic_index?: number | null;
+  extrinsic_hash?: string | null;
+  call_module?: string | null;
+  call_function?: string | null;
+  success?: boolean | null;
+};
+
+function GroupedEvents({
+  events,
+  extrinsics,
+}: {
+  events: EventItem[];
+  extrinsics: ExtrinsicItem[];
+}) {
+  const groups = useMemo(() => {
+    const byIndex = new Map<number | "system", EventItem[]>();
+    for (const ev of events) {
+      const key: number | "system" = ev.extrinsic_index ?? "system";
+      const arr = byIndex.get(key) ?? [];
+      arr.push(ev);
+      byIndex.set(key, arr);
+    }
+    const extrinsicByIndex = new Map<number, ExtrinsicItem>();
+    for (const x of extrinsics) {
+      if (x.extrinsic_index != null) extrinsicByIndex.set(x.extrinsic_index, x);
+    }
+    const numeric = Array.from(byIndex.entries())
+      .filter(([k]) => k !== "system")
+      .map(([k, list]) => ({
+        key: `x-${k}` as const,
+        index: k as number,
+        list,
+        extrinsic: extrinsicByIndex.get(k as number) ?? null,
+        isSystem: false,
+        hasHotkey: list.some((e) => e.hotkey),
+      }))
+      .sort((a, b) => a.index - b.index);
+    const system = byIndex.get("system");
+    const systemGroup = system
+      ? [
+          {
+            key: "system" as const,
+            index: -1,
+            list: system,
+            extrinsic: null,
+            isSystem: true,
+            hasHotkey: system.some((e) => e.hotkey),
+          },
+        ]
+      : [];
+    return [...numeric, ...systemGroup];
+  }, [events, extrinsics]);
+
+  const defaultOpen = useMemo(() => {
+    const s = new Set<string>();
+    for (const g of groups) if (g.hasHotkey && !g.isSystem) s.add(g.key);
+    return s;
+  }, [groups]);
+
+  const [open, setOpen] = useState<Set<string>>(defaultOpen);
+  const allOpen = open.size === groups.length;
+  const [focusIdx, setFocusIdx] = useState(0);
+  const btnRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const toggle = useCallback((key: string) => {
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const onHeaderKey = (i: number, key: string) => (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Home" || e.key === "End") {
+      const next = nextTabIndex(i, e.key, groups.length);
+      if (next == null) return;
+      e.preventDefault();
+      setFocusIdx(next);
+      btnRefs.current[next]?.focus();
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setOpen((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setOpen((prev) => {
+        if (!prev.has(key)) return prev;
+        const n = new Set(prev);
+        n.delete(key);
+        return n;
+      });
+    }
+  };
+
+  return (
+    <div className="rounded border border-border bg-card">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="mg-label">
+          {groups.length} extrinsic{groups.length === 1 ? "" : "s"} · {events.length} event
+          {events.length === 1 ? "" : "s"}
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(allOpen ? new Set() : new Set(groups.map((g) => g.key)))}
+          className="text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
+        >
+          {allOpen ? "Collapse all" : "Expand all"}
+        </button>
+      </div>
+      <ul
+        className="divide-y divide-border"
+        role="tree"
+        aria-label="Extrinsics and events. Use up and down to move, right to expand, left to collapse."
+      >
+        {groups.map((g, i) => {
+          const isOpen = open.has(g.key);
+          const showHotkeyCol = g.list.some((e) => e.hotkey);
+          const title = g.isSystem
+            ? "System events"
+            : g.extrinsic
+              ? extrinsicCall(g.extrinsic.call_module, g.extrinsic.call_function)
+              : "Unknown extrinsic";
+          const success = g.extrinsic?.success;
+          return (
+            <li key={g.key} role="treeitem" aria-expanded={isOpen}>
+              <button
+                ref={(el) => {
+                  btnRefs.current[i] = el;
+                }}
+                type="button"
+                tabIndex={i === focusIdx ? 0 : -1}
+                onFocus={() => setFocusIdx(i)}
+                onKeyDown={onHeaderKey(i, g.key)}
+                onClick={() => {
+                  setFocusIdx(i);
+                  toggle(g.key);
+                }}
+                className="flex w-full items-center gap-2 sm:gap-3 px-3 py-2.5 text-left hover:bg-surface/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-expanded={isOpen}
+              >
+                {isOpen ? (
+                  <ChevronDown className="size-3.5 shrink-0 text-ink-muted" />
+                ) : (
+                  <ChevronRight className="size-3.5 shrink-0 text-ink-muted" />
+                )}
+                <span className="font-mono text-[11px] tabular-nums text-ink-muted w-8 sm:w-10 shrink-0">
+                  {g.isSystem ? "sys" : `#${g.index}`}
+                </span>
+                <span className="font-mono text-[11px] text-ink-strong truncate min-w-0 flex-1">
+                  {title}
+                </span>
+                {success != null ? (
+                  <span
+                    className={`hidden sm:inline font-mono text-[10px] uppercase tracking-wider ${success ? "text-health-ok" : "text-health-down"}`}
+                  >
+                    {success ? "success" : "failed"}
+                  </span>
+                ) : null}
+                <span className="mg-label shrink-0 hidden sm:inline">
+                  {g.list.length} evt{g.list.length === 1 ? "" : "s"}
+                </span>
+                {g.extrinsic?.extrinsic_hash ? (
+                  <Link
+                    to="/extrinsics/$hash"
+                    params={{ hash: g.extrinsic.extrinsic_hash }}
+                    onClick={(e) => e.stopPropagation()}
+                    className="hidden sm:inline font-mono text-[10px] text-ink-muted hover:text-ink-strong hover:underline shrink-0"
+                    title={g.extrinsic.extrinsic_hash}
+                  >
+                    {shortHash(g.extrinsic.extrinsic_hash, 6)}
+                  </Link>
+                ) : null}
+              </button>
+              {isOpen ? (
+                <div className="border-t border-border bg-surface/20 px-3 py-2">
+                  <table className="w-full text-left text-sm">
+                    <thead>
+                      <tr className="text-[10px] uppercase tracking-wider text-ink-muted">
+                        <th className="px-2 py-1.5 font-normal">Kind</th>
+                        {showHotkeyCol ? <th className="px-2 py-1.5 font-normal">Hotkey</th> : null}
+                        <th className="px-2 py-1.5 text-right font-normal">Amount</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {g.list.map((event) => (
+                        <tr
+                          key={`${event.block_number}-${event.event_index}-${event.event_kind ?? "unknown"}`}
+                        >
+                          <td
+                            className="px-2 py-1.5 font-mono text-[11px] text-ink-strong"
+                            title={event.event_kind ?? undefined}
+                          >
+                            {eventKindLabel(event.event_kind)}
+                          </td>
+                          {showHotkeyCol ? (
+                            <td className="px-2 py-1.5 font-mono text-[11px] text-ink">
+                              <AccountAddress
+                                ss58={event.hotkey}
+                                keep={10}
+                                compact
+                                fallback={<span className="text-ink-muted">—</span>}
+                              />
+                            </td>
+                          ) : null}
+                          <td className="px-2 py-1.5 text-right tabular-nums text-ink">
+                            {event.amount_tao != null ? (
+                              <TaoValue amount={event.amount_tao} layout="stacked" precision={4} />
+                            ) : (
+                              <span className="font-mono text-[11px] text-ink-muted">—</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function ValueUnitControl() {
+  const { unit, setUnit } = useValueUnit();
+  const opts: Array<{ v: ValueUnit; label: string; title: string }> = [
+    { v: "tao", label: "τ", title: "Show TAO only" },
+    { v: "usd", label: "$", title: "Show USD only" },
+    { v: "both", label: "Both", title: "Show TAO and USD" },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Value display unit"
+      className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
+    >
+      {opts.map((o) => {
+        const active = o.v === unit;
+        return (
+          <button
+            key={o.v}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            title={o.title}
+            onClick={() => setUnit(o.v)}
+            className={
+              "inline-flex items-center rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8 " +
+              (active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong")
+            }
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function JumpToBlock() {
+  const navigate = useNavigate();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  return (
+    <form
+      role="search"
+      aria-label="Jump to block"
+      className="flex items-center gap-1"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const v = value.trim();
+        if (!v) return;
+        if (!isValidBlockRef(v)) {
+          setError("Enter a decimal block number or 0x… hash");
+          return;
+        }
+        setError(null);
+        navigate({ to: "/blocks/$ref", params: { ref: v } });
+        setValue("");
+      }}
+    >
+      <label className="sr-only" htmlFor="jump-to-block">
+        Jump to block
+      </label>
+      <input
+        id="jump-to-block"
+        type="text"
+        inputMode="numeric"
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          if (error) setError(null);
+        }}
+        placeholder="Jump to # or 0x…"
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? "jump-to-block-err" : undefined}
+        className="mg-focus-ring h-8 w-40 rounded border border-border bg-paper px-2 font-mono text-[12px] tabular-nums text-ink-strong placeholder:text-ink-subtle sm:w-48"
+      />
+      <Kbd>↵</Kbd>
+      {error ? (
+        <span
+          id="jump-to-block-err"
+          role="alert"
+          className="ml-1 font-mono text-[10px] text-health-down"
+        >
+          {error}
+        </span>
+      ) : null}
+    </form>
+  );
+}
+
+function FieldRow({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
   return (
     <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-      <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted sm:w-40 sm:shrink-0">
-        {label}
+      <dt className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted sm:w-40 sm:shrink-0">
+        <span>{label}</span>
+        {hint ? <InfoTooltip label={hint} /> : null}
       </dt>
       <dd className="min-w-0">{children}</dd>
     </div>

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -1,36 +1,44 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Timer, Activity, Users, SlidersHorizontal } from "lucide-react";
+import { Timer, Activity, Users } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import {
+  AsyncPanel,
+  TableSkeleton,
+  PagerFooter,
+  MetricGrid,
+  PanelSkeleton,
+  QueryBar,
+  FilterSheet,
+  FilterChipRow,
+  type FilterChipItem,
+  PageMasthead,
+} from "@/components/metagraphed/primitives";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState } from "@/components/metagraphed/states";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import {
   TimeAgo,
-  PageHero,
   ListShell,
   ShareButton,
   DownloadCsvButton,
   ActionBar,
   StatTile,
-  Sparkline,
   CopyButton,
   CopyableCode,
-  PagerBar,
+  BackToTop,
 } from "@jsonbored/ui-kit";
-import {
-  PageSizeSelect,
-  ResetFiltersButton,
-  SearchInput,
-} from "@/components/metagraphed/table-controls";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { blocksQuery, blocksSummaryQuery, chainActivityQuery } from "@/lib/metagraphed/queries";
+import { PageSizeSelect } from "@/components/metagraphed/table-controls";
+import { LiveBlockRail } from "@/components/metagraphed/blocks/live-block-rail";
+import { CadenceHeatmap } from "@/components/metagraphed/blocks/cadence-heatmap";
+import { AuthorSharePanel } from "@/components/metagraphed/blocks/author-share-panel";
+import { RuntimeTimeline } from "@/components/metagraphed/blocks/runtime-timeline";
+import { blocksQuery, blocksSummaryQuery, metagraphedQueryKey } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
-import { activeFilterCount, filterToggleLabel } from "@/lib/metagraphed/filter-disclosure";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -92,84 +100,58 @@ function BlocksPage() {
 
   return (
     <AppShell>
-      <PageHero
+      <PageMasthead
         eyebrow="Explorer"
         live
         title="Blocks"
         description="Recent Bittensor blocks indexed directly from the chain — newest first, with author, extrinsic, and event counts."
         actions={
-          <>
-            <ActionBar>
-              <DownloadCsvButton url={blocksCsvUrl} bare />
-              <ShareButton bare />
-            </ActionBar>
-          </>
+          <ActionBar>
+            <DownloadCsvButton url={blocksCsvUrl} bare />
+            <ShareButton bare />
+          </ActionBar>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-24 w-full mb-3" />}>
-          <BlockThroughputCard />
-        </Suspense>
-      </QueryErrorBoundary>
-      <QueryErrorBoundary>
-        <Suspense
-          fallback={
-            // Shaped to BlockProductionHeader's own 3-tile grid (#6388), matching
-            // subnets.index.tsx's tile-skeleton convention -- a single flat box
-            // here visibly jumps in height/columns once the real 1/3-col grid
-            // of StatTiles resolves.
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-            </div>
-          }
-        >
-          <BlockProductionHeader />
-        </Suspense>
-      </QueryErrorBoundary>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-          <BlocksTable />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="Live block rail"
+        retryQueryKeys={[metagraphedQueryKey("blocks"), metagraphedQueryKey("chain-activity")]}
+        fallback={<PanelSkeleton height="sm" className="mb-3" />}
+      >
+        <LiveBlockRail />
+      </AsyncPanel>
+      <AsyncPanel
+        context="Block production"
+        retryQueryKeys={[metagraphedQueryKey("blocks-summary")]}
+        fallback={
+          <div className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-3">
+            <PanelSkeleton height="sm" />
+            <PanelSkeleton height="sm" />
+            <PanelSkeleton height="sm" />
+          </div>
+        }
+      >
+        <BlockProductionHeader />
+      </AsyncPanel>
+      <AsyncPanel
+        context="Runtime upgrades"
+        retryQueryKeys={[metagraphedQueryKey("runtime-version-history")]}
+        fallback={<PanelSkeleton height="sm" className="mb-6" />}
+      >
+        <RuntimeTimeline />
+      </AsyncPanel>
+      <AsyncPanel
+        context="Blocks table"
+        retryQueryKeys={[metagraphedQueryKey("blocks")]}
+        fallback={<TableSkeleton rows={10} columns={6} />}
+      >
+        <BlocksTable />
+      </AsyncPanel>
       <ApiSourceFooter
         paths={["/api/v1/blocks", "/api/v1/blocks/summary", "/api/v1/chain/activity"]}
         artifacts={["/metagraph/blocks.json", "/metagraph/blocks/summary.json"]}
       />
+      <BackToTop />
     </AppShell>
-  );
-}
-
-// #3390: block-throughput sparkline — daily block_count over the default window
-// from /api/v1/chain/activity (the source explorer.tsx already uses), rendered as
-// a compact card directly above the production-stats header so the throughput
-// trend sits with the other block-production metrics (no separate hero KPI).
-function BlockThroughputCard() {
-  const chrono = [...useSuspenseQuery(chainActivityQuery()).data.data.days].reverse();
-  const blockCounts = chrono.map((d) => d.block_count);
-  if (blockCounts.length === 0) return null;
-  const totalBlocks = blockCounts.reduce((acc, n) => acc + n, 0);
-  return (
-    <div className="mb-3 flex items-center justify-between gap-4 rounded-lg border border-border bg-card p-4">
-      <div>
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Blocks / day
-        </div>
-        <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink-strong">
-          {formatNumber(totalBlocks)}
-          <span className="ml-1.5 text-sm font-normal text-ink-muted">total</span>
-        </div>
-      </div>
-      <Sparkline
-        values={blockCounts}
-        points={chrono.map((d) => ({ t: d.day, v: d.block_count }))}
-        width={220}
-        height={44}
-        ariaLabel="Daily block throughput, oldest to newest"
-        formatValue={formatNumber}
-      />
-    </div>
   );
 }
 
@@ -184,10 +166,7 @@ function BlockProductionHeader() {
   const nakamoto = summary.author_concentration?.nakamoto_coefficient;
   const nakamotoStatTone = nakamotoTone(nakamoto);
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
-      {/* #6905: full-width tiles on mobile (grid-cols-1) so each label/hint fits
-          on one line instead of clipping mid-word in the old 2-col grid's cramped
-          ~165px cells; md+ keeps the 3-up row. */}
+    <MetricGrid cols={{ base: 1, sm: 2, md: 3 }} gap="md" className="mb-8">
       <StatTile
         icon={Timer}
         eyebrow="Inter-block time"
@@ -197,7 +176,6 @@ function BlockProductionHeader() {
       <StatTile
         icon={Activity}
         eyebrow="Throughput"
-        // #3940: bare number like the sibling tiles -- unit + secondary metric live in the hint.
         value={throughput ? formatNumber(throughput.mean_extrinsics_per_block) : "—"}
         hint={
           throughput
@@ -212,7 +190,7 @@ function BlockProductionHeader() {
         hint="Nakamoto coefficient"
         tone={nakamotoStatTone}
       />
-    </div>
+    </MetricGrid>
   );
 }
 
@@ -228,6 +206,11 @@ function BlocksTable() {
   const refetchInterval = useRefetchInterval(15_000, search.offset === 0);
   const rows = (useSuspenseQuery({ ...blocksQuery(queryParams), refetchInterval }).data.data ??
     []) as Block[];
+
+  // Per-page maxima drive the inline activity bars in the Extrinsics/Events
+  // cells so scanning "which blocks were busy" is a visual, not numeric, task.
+  const maxExt = Math.max(1, ...rows.map((b) => b.extrinsic_count ?? 0));
+  const maxEvt = Math.max(1, ...rows.map((b) => b.event_count ?? 0));
 
   // Offset pagination: the API returns newest-first pages with no total. A full
   // page (rows === limit) implies more may exist; a short page is the tail.
@@ -253,115 +236,207 @@ function BlocksTable() {
     search.min_events,
   );
 
-  const activeCount = activeFilterCount([
-    search.author,
-    search.spec_version,
-    search.block_start,
-    search.block_end,
-    search.min_extrinsics,
-    search.min_events,
-  ]);
-  // Six placeholder-only inputs stacked to ~a full 375px screen before any block
-  // row was visible (#5323). Collapse them behind a toggle on mobile — open by
-  // default when a filter is already applied (e.g. a shared URL), so the reason
-  // the list is narrowed is never hidden.
-  const [filtersOpen, setFiltersOpen] = useState(activeCount > 0);
+  const secondaryFilterCount =
+    (search.spec_version ? 1 : 0) +
+    (search.block_start ? 1 : 0) +
+    (search.block_end ? 1 : 0) +
+    (search.min_extrinsics ? 1 : 0) +
+    (search.min_events ? 1 : 0);
+  const activeCount = (search.author ? 1 : 0) + secondaryFilterCount;
+
+  const resetAll = () =>
+    setSearch({
+      author: "",
+      spec_version: "",
+      block_start: "",
+      block_end: "",
+      min_extrinsics: "",
+      min_events: "",
+      offset: 0,
+    });
+
+  const chipItems: FilterChipItem[] = [];
+  if (search.author)
+    chipItems.push({
+      id: "author",
+      label: "Author",
+      value: shortHash(search.author) ?? search.author,
+    });
+  if (search.spec_version)
+    chipItems.push({ id: "spec_version", label: "Spec", value: search.spec_version });
+  if (search.block_start || search.block_end)
+    chipItems.push({
+      id: "range",
+      label: "Range",
+      value: `${search.block_start || "…"} → ${search.block_end || "…"}`,
+    });
+  if (search.min_extrinsics)
+    chipItems.push({ id: "min_extrinsics", label: "Min ext", value: `≥ ${search.min_extrinsics}` });
+  if (search.min_events)
+    chipItems.push({ id: "min_events", label: "Min evt", value: `≥ ${search.min_events}` });
+
+  const removeChip = (id: string) => {
+    switch (id) {
+      case "author":
+        setSearch({ author: "", offset: 0 });
+        break;
+      case "spec_version":
+        setSearch({ spec_version: "", offset: 0 });
+        break;
+      case "range":
+        setSearch({ block_start: "", block_end: "", offset: 0 });
+        break;
+      case "min_extrinsics":
+        setSearch({ min_extrinsics: "", offset: 0 });
+        break;
+      case "min_events":
+        setSearch({ min_events: "", offset: 0 });
+        break;
+    }
+  };
+
+  const numericInputCls =
+    "w-full rounded border border-border bg-paper px-2 py-1.5 font-mono text-sm text-ink-strong placeholder:text-ink-muted focus:outline-none focus:border-accent/50 focus:ring-2 focus:ring-ring transition-colors";
 
   const filters = (
-    <>
-      <button
-        type="button"
-        onClick={() => setFiltersOpen((open) => !open)}
-        aria-expanded={filtersOpen}
-        aria-controls="blocks-filter-fields"
-        className="md:hidden inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-2.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors"
-      >
-        <SlidersHorizontal className="size-3" aria-hidden="true" />
-        {filterToggleLabel(activeCount)}
-      </button>
-      {/* `md:contents` dissolves this wrapper at md and up, so the fields lay out
-          as direct children of the filter bar exactly as they did before — the
-          collapse is mobile-only. */}
-      <div
-        id="blocks-filter-fields"
-        className={classNames(
-          "w-full flex-wrap items-center gap-2 md:contents",
-          filtersOpen ? "flex" : "hidden",
-        )}
-      >
-        <span
-          className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
-          title="Blocks are listed newest first"
-        >
-          <span aria-hidden="true">↓ </span>Newest first
-        </span>
-        <SearchInput
-          value={search.author}
-          onChange={(v) => setSearch({ author: v, offset: 0 })}
-          placeholder="Author ss58…"
-        />
-        <SearchInput
-          value={search.spec_version}
-          onChange={(v) => setSearch({ spec_version: v, offset: 0 })}
-          placeholder="Spec version…"
-          inputMode="numeric"
-          // SearchInput's own base hardcodes `min-w-[180px]` unconditionally, which
-          // wins the same-property (min-width) cascade over a plain `min-w-[120px]`
-          // override here regardless of prop order (classNames() is a plain
-          // string-join, not tailwind-merge-aware -- see #6904); the trailing `!`
-          // forces this narrower floor to actually apply so max-w-[140px] can take
-          // effect as intended for this compact numeric filter.
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <SearchInput
-          value={search.block_start}
-          onChange={(v) => setSearch({ block_start: v.replace(/[^0-9]/g, ""), offset: 0 })}
-          placeholder="Block from…"
-          inputMode="numeric"
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <SearchInput
-          value={search.block_end}
-          onChange={(v) => setSearch({ block_end: v.replace(/[^0-9]/g, ""), offset: 0 })}
-          placeholder="Block to…"
-          inputMode="numeric"
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <SearchInput
-          value={search.min_extrinsics}
-          onChange={(v) => setSearch({ min_extrinsics: v.replace(/[^0-9]/g, ""), offset: 0 })}
-          placeholder="Min extrinsics…"
-          inputMode="numeric"
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <SearchInput
-          value={search.min_events}
-          onChange={(v) => setSearch({ min_events: v.replace(/[^0-9]/g, ""), offset: 0 })}
-          placeholder="Min events…"
-          inputMode="numeric"
-          className="min-w-[120px]! max-w-[140px] flex-none"
-        />
-        <PageSizeSelect
-          value={search.limit}
-          onChange={(n) => setSearch({ limit: n, offset: 0 })}
-          options={[10, 25, 50, 100]}
-        />
-        <ResetFiltersButton
-          active={filtersActive}
-          onReset={() =>
-            setSearch({
-              author: "",
-              spec_version: "",
-              block_start: "",
-              block_end: "",
-              min_extrinsics: "",
-              min_events: "",
-              offset: 0,
-            })
-          }
-        />
+    <div className="flex w-full flex-col gap-0 min-w-0">
+      <div className="flex w-full items-center gap-2 min-w-0">
+        <QueryBar className="flex-1 min-w-0">
+          <QueryBar.Search
+            value={search.author}
+            onChange={(v) => setSearch({ author: v, offset: 0 })}
+            placeholder="Search by author ss58…"
+            shortcut
+            debounceMs={200}
+          />
+          <QueryBar.Divider />
+          <QueryBar.Utility className="ml-auto">
+            <span
+              className="hidden sm:inline font-mono text-[10px] uppercase tracking-widest text-ink-muted"
+              title="Blocks are always listed newest first"
+            >
+              ↓ Newest
+            </span>
+            <PageSizeSelect
+              value={search.limit}
+              onChange={(n) => setSearch({ limit: n, offset: 0 })}
+              options={[10, 25, 50, 100]}
+            />
+          </QueryBar.Utility>
+        </QueryBar>
+        <FilterSheet label="Filters" activeCount={secondaryFilterCount}>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Spec version
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.spec_version}
+                onChange={(e) =>
+                  setSearch({ spec_version: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 268"
+                className={numericInputCls}
+              />
+            </label>
+            <div className="hidden sm:block" aria-hidden />
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Block from
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.block_start}
+                onChange={(e) =>
+                  setSearch({ block_start: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 6000000"
+                className={numericInputCls}
+              />
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Block to
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.block_end}
+                onChange={(e) =>
+                  setSearch({ block_end: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 6100000"
+                className={numericInputCls}
+              />
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Min extrinsics
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.min_extrinsics}
+                onChange={(e) =>
+                  setSearch({ min_extrinsics: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 5"
+                className={numericInputCls}
+              />
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Min events
+              </span>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={search.min_events}
+                onChange={(e) =>
+                  setSearch({ min_events: e.target.value.replace(/[^0-9]/g, ""), offset: 0 })
+                }
+                placeholder="e.g. 20"
+                className={numericInputCls}
+              />
+            </label>
+          </div>
+          {secondaryFilterCount > 0 ? (
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={() =>
+                  setSearch({
+                    spec_version: "",
+                    block_start: "",
+                    block_end: "",
+                    min_extrinsics: "",
+                    min_events: "",
+                    offset: 0,
+                  })
+                }
+                className="rounded border border-border bg-card px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-accent/40 hover:text-ink-strong transition-colors"
+              >
+                Clear numeric filters
+              </button>
+            </div>
+          ) : null}
+        </FilterSheet>
       </div>
-    </>
+      <QueryBar.MetaRow
+        count={rows.length}
+        noun="blocks"
+        activeCount={activeCount}
+        onReset={filtersActive ? resetAll : undefined}
+      />
+      <FilterChipRow
+        items={chipItems}
+        onRemove={removeChip}
+        onClearAll={activeCount > 1 ? resetAll : undefined}
+      />
+    </div>
   );
 
   const emptyNode = (
@@ -377,115 +452,207 @@ function BlocksTable() {
   );
 
   const footerNode = (
-    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 text-[11px] font-mono text-ink-muted">
-      <span>
-        {rows.length
-          ? `${formatNumber(search.offset + 1)}–${formatNumber(search.offset + rows.length)}`
-          : "0"}
-      </span>
-      <PagerBar hasPrev={hasPrev} hasNext={hasNext} onPrev={goPrev} onNext={goNext} />
+    <div className="px-4 py-2">
+      <PagerFooter
+        summary={
+          rows.length
+            ? `${formatNumber(search.offset + 1)}–${formatNumber(search.offset + rows.length)}`
+            : "0"
+        }
+        hasPrev={hasPrev}
+        hasNext={hasNext}
+        onPrev={goPrev}
+        onNext={goNext}
+      />
     </div>
   );
 
   return (
-    <ListShell
-      filters={filters}
-      isEmpty={rows.length === 0}
-      empty={emptyNode}
-      cards={rows.map((b) => (
-        <Link
-          key={b.block_hash || b.block_number}
-          to="/blocks/$ref"
-          params={{ ref: String(b.block_number) }}
-          className="block rounded border border-border bg-card p-3 min-h-11 active:bg-surface"
-        >
-          <div className="flex items-center justify-between gap-2">
-            <div className="font-mono text-sm font-medium text-ink-strong">
-              #{formatNumber(b.block_number)}
+    <>
+      {rows.length > 0 ? (
+        <>
+          <CadenceHeatmap rows={rows} />
+          <AuthorSharePanel rows={rows} />
+        </>
+      ) : null}
+      <ListShell
+        filters={filters}
+        isEmpty={rows.length === 0}
+        empty={emptyNode}
+        cards={rows.map((b) => (
+          <Link
+            key={b.block_hash || b.block_number}
+            to="/blocks/$ref"
+            params={{ ref: String(b.block_number) }}
+            className="block rounded border border-border bg-card p-3 min-h-11 active:bg-surface"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="font-mono text-sm font-medium text-ink-strong">
+                #{formatNumber(b.block_number)}
+              </div>
+              <span className="font-mono text-[11px] text-ink-muted">
+                <TimeAgo at={b.observed_at} />
+              </span>
             </div>
-            <span className="font-mono text-[11px] text-ink-muted">
-              <TimeAgo at={b.observed_at} />
-            </span>
-          </div>
-          <div className="mt-1 font-mono text-[11px] text-ink-muted truncate">
-            {shortHash(b.block_hash)}
-          </div>
-          <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
-            <span>{shortHash(b.author) ?? "no author"}</span>
-            <span>{formatNumber(b.extrinsic_count ?? 0)} ext</span>
-            <span>{formatNumber(b.event_count ?? 0)} evt</span>
-          </div>
-        </Link>
-      ))}
-      table={
-        <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
-            <tr>
-              <th className="px-4 py-2.5">Block</th>
-              <th className="px-4 py-2.5">Hash</th>
-              <th className="px-4 py-2.5">Author</th>
-              <th className="px-4 py-2.5 text-right">Extrinsics</th>
-              <th className="px-4 py-2.5 text-right">Events</th>
-              <th className="px-4 py-2.5 text-right">Observed</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border">
-            {rows.map((b) => (
-              <tr
-                key={b.block_hash || b.block_number}
-                className="mg-row-accent hover:bg-surface/40"
-              >
-                <td className="px-4 py-2.5 font-mono text-[12px]">
-                  <Link
-                    to="/blocks/$ref"
-                    params={{ ref: String(b.block_number) }}
-                    className="font-medium text-ink-strong hover:underline"
-                  >
-                    #{formatNumber(b.block_number)}
-                  </Link>
-                </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  <span className="inline-flex items-center gap-1 min-w-0">
-                    <Link
-                      to="/blocks/$ref"
-                      params={{ ref: b.block_hash || String(b.block_number) }}
-                      className="hover:text-ink-strong truncate"
-                      title={b.block_hash}
-                    >
-                      {shortHash(b.block_hash)}
-                    </Link>
-                    {b.block_hash ? (
-                      <CopyButton value={b.block_hash} label="block hash" compact />
-                    ) : null}
-                  </span>
-                </td>
-                <td
-                  className="px-4 py-2.5 font-mono text-[11px] text-ink-muted"
-                  title={b.author ?? undefined}
-                >
-                  <AccountAddress
-                    ss58={b.author}
-                    compact
-                    fallback={
-                      b.author ? <CopyableCode value={b.author} className="max-w-full" /> : "—"
-                    }
-                  />
-                </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
-                  {formatNumber(b.extrinsic_count ?? 0)}
-                </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
-                  {formatNumber(b.event_count ?? 0)}
-                </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
-                  <TimeAgo at={b.observed_at} />
-                </td>
+            <div className="mt-1 font-mono text-[11px] text-ink-muted truncate">
+              {shortHash(b.block_hash)}
+            </div>
+            <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
+              <span>{shortHash(b.author) ?? "no author"}</span>
+              <span>{formatNumber(b.extrinsic_count ?? 0)} ext</span>
+              <span>{formatNumber(b.event_count ?? 0)} evt</span>
+            </div>
+          </Link>
+        ))}
+        table={
+          <table className="w-full text-left text-sm">
+            <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+              <tr>
+                <th className="px-4 py-2.5">Block</th>
+                <th className="px-4 py-2.5">Hash</th>
+                <th className="px-4 py-2.5">Author</th>
+                <th className="px-4 py-2.5 text-right">Extrinsics</th>
+                <th className="px-4 py-2.5 text-right">Events</th>
+                <th className="px-4 py-2.5 text-right">Observed</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      }
-      footer={footerNode}
-    />
+            </thead>
+            <tbody className="divide-y divide-border">
+              {rows.map((b, i) => {
+                // Gap = seconds since the previous (older) block was produced.
+                // Rows are newest-first, so the older neighbor is at i+1.
+                const nextOlder = rows[i + 1];
+                const gapMs =
+                  b.observed_at && nextOlder?.observed_at
+                    ? Date.parse(b.observed_at) - Date.parse(nextOlder.observed_at)
+                    : null;
+                const gapSec = gapMs != null && Number.isFinite(gapMs) ? gapMs / 1000 : null;
+                const gapTone =
+                  gapSec == null
+                    ? "text-ink-subtle"
+                    : gapSec > 48
+                      ? "text-health-down"
+                      : gapSec > 24
+                        ? "text-health-warn-text"
+                        : "text-ink-subtle";
+                // Free decentralization tell: count how often this author appears
+                // on the current page. A repeat on a short window is worth flagging.
+                const authorRepeat = b.author
+                  ? rows.reduce((n, r) => (r.author === b.author ? n + 1 : n), 0)
+                  : 0;
+                return (
+                  <tr
+                    key={b.block_hash || b.block_number}
+                    className="group mg-row-accent odd:bg-surface/30 hover:bg-surface/60"
+                  >
+                    <td className="px-4 py-2.5 font-mono text-[12px] align-top">
+                      <Link
+                        to="/blocks/$ref"
+                        params={{ ref: String(b.block_number) }}
+                        className="font-medium text-ink-strong hover:underline"
+                      >
+                        #{formatNumber(b.block_number)}
+                      </Link>
+                      {gapSec != null ? (
+                        <div
+                          className={classNames("mt-0.5 text-[10px]", gapTone)}
+                          title="Seconds since previous block"
+                        >
+                          +{humaniseSeconds(gapSec)}
+                        </div>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted align-top">
+                      <span className="inline-flex items-center gap-1 min-w-0">
+                        <Link
+                          to="/blocks/$ref"
+                          params={{ ref: b.block_hash || String(b.block_number) }}
+                          className="hover:text-ink-strong truncate"
+                          title={b.block_hash}
+                        >
+                          {shortHash(b.block_hash)}
+                        </Link>
+                        {b.block_hash ? (
+                          <span className="opacity-0 group-hover:opacity-100 transition-opacity">
+                            <CopyButton value={b.block_hash} label="block hash" compact />
+                          </span>
+                        ) : null}
+                      </span>
+                    </td>
+                    <td
+                      className="px-4 py-2.5 font-mono text-[11px] text-ink-muted align-top"
+                      title={b.author ?? undefined}
+                    >
+                      <div className="flex items-center gap-1.5 min-w-0">
+                        <AccountAddress
+                          ss58={b.author}
+                          compact
+                          fallback={
+                            b.author ? (
+                              <CopyableCode value={b.author} className="max-w-full" />
+                            ) : (
+                              "—"
+                            )
+                          }
+                        />
+                        {authorRepeat > 1 ? (
+                          <span
+                            className="mg-chip h-4 px-1.5 text-[9px] text-accent-text border-accent/40"
+                            title={`Produced ${authorRepeat} blocks on this page`}
+                          >
+                            ×{authorRepeat}
+                          </span>
+                        ) : null}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink align-top">
+                      <ActivityCell value={b.extrinsic_count ?? 0} max={maxExt} tone="accent" />
+                    </td>
+                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink align-top">
+                      <ActivityCell value={b.event_count ?? 0} max={maxEvt} tone="ink" />
+                    </td>
+                    <td
+                      className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted align-top"
+                      title={b.observed_at ?? undefined}
+                    >
+                      <TimeAgo at={b.observed_at} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        }
+        footer={footerNode}
+      />
+    </>
+  );
+}
+
+/**
+ * Right-aligned number with a thin horizontal bar underneath, normalized
+ * against the page-max so busy blocks are visually obvious at a glance.
+ * `tone="accent"` (extrinsics) uses mint; `tone="ink"` (events) uses ink.
+ */
+function ActivityCell({
+  value,
+  max,
+  tone,
+}: {
+  value: number;
+  max: number;
+  tone: "accent" | "ink";
+}) {
+  const pct = max > 0 ? Math.max(2, Math.round((value / max) * 100)) : 0;
+  const barCls = tone === "accent" ? "bg-accent/70" : "bg-ink-strong/40";
+  return (
+    <span className="inline-flex flex-col items-end gap-1 min-w-[3.5rem]">
+      <span>{formatNumber(value)}</span>
+      <span aria-hidden className="block h-[3px] w-full rounded-full bg-border/50 overflow-hidden">
+        <span
+          className={classNames("block h-full rounded-full transition-[width]", barCls)}
+          style={{ width: `${pct}%` }}
+        />
+      </span>
+    </span>
   );
 }

--- a/apps/ui/src/routes/detail-page-furniture-5481.test.ts
+++ b/apps/ui/src/routes/detail-page-furniture-5481.test.ts
@@ -105,26 +105,22 @@ describe("providers.$slug.tsx ShareButton + ApiSourceFooter (#5481)", () => {
     expect(importBlock).toContain("ShareButton");
   });
 
-  it("shares one connected bar between PrimaryLinksRail and ShareButton via EntityHero's links prop, not the separate actions slot", () => {
-    const heroCall = providerRouteSource.slice(
-      providerRouteSource.indexOf("<EntityHero"),
-      providerRouteSource.indexOf("<ProfileTabs"),
+  it("shares one connected bar between PrimaryLinksRail and ShareButton via PageMasthead's actions prop", () => {
+    const mastheadCall = providerRouteSource.slice(
+      providerRouteSource.indexOf("<PageMasthead"),
+      providerRouteSource.indexOf("<TabStrip"),
     );
-    // EntityHero renders `links` and `actions` as two separate rows -- a
-    // ShareButton passed via `actions` would land on its own line below the
-    // link pills instead of sharing their row. Assert it's NOT used that way.
-    expect(heroCall).not.toContain("actions={<ShareButton");
-    const linksBlock = heroCall.slice(heroCall.indexOf("links={"), heroCall.indexOf("stats={"));
+    expect(mastheadCall).toContain("actions={");
     // `bare` so PrimaryLinksRail contributes bare icon segments (no own
     // border/rounded) into the shared divide-x bar below, instead of its own
     // separately-boxed connected bar nested inside this one.
-    expect(linksBlock).toContain("<PrimaryLinksRail");
-    expect(linksBlock).toContain("bare");
+    expect(mastheadCall).toContain("<PrimaryLinksRail");
+    expect(mastheadCall).toContain("bare");
     // `connected` so Share is a borderless segment matching the link icons --
     // one shared bar (SegmentedToggle/ViewModeToggle's look), not a separately
     // spaced, individually-boxed button.
-    expect(linksBlock).toContain("<ShareButton connected />");
-    expect(linksBlock).toContain("divide-x divide-border");
+    expect(mastheadCall).toContain("<ShareButton connected />");
+    expect(mastheadCall).toContain("divide-x divide-border");
   });
 
   it("renders exactly one ApiSourceFooter citing the provider + provider-endpoints paths", () => {

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -1,46 +1,48 @@
-import { createFileRoute, Link, useNavigate, useRouterState } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { createFileRoute, useNavigate, useRouterState } from "@tanstack/react-router";
+import { useSuspenseQuery, useIsFetching } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
 
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Search, SlidersHorizontal, X } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, Skeleton, StaleBanner } from "@/components/metagraphed/states";
+import { EmptyState, StaleBanner } from "@/components/metagraphed/states";
 import { StateBlock } from "@/components/metagraphed/states/state-block";
 import {
-  TimeAgo,
-  HealthPill,
   HealthDot,
-  CopyButton,
-  BrandIcon,
   SectionHeading,
-  PageHero,
-  ExternalLink,
-  ViewModeToggle,
   DownloadCsvButton,
-  SparkLegend,
   StatTile,
   ShareButton,
 } from "@jsonbored/ui-kit";
+import {
+  AsyncPanel,
+  FilterChipRow,
+  FilterSheet,
+  PageMasthead,
+  PagerFooter,
+  PanelSkeleton,
+  QueryBar,
+  QueryProgress,
+  ResponsiveTable,
+  RoutePending,
+  TabStrip,
+  type FilterChipItem,
+} from "@/components/metagraphed/primitives";
+import { EndpointsPriorityStrip } from "@/components/metagraphed/endpoints-priority-strip";
+import { EndpointOperationalList } from "@/components/metagraphed/endpoint-operational-list";
+import { EndpointComparePanel } from "@/components/metagraphed/endpoint-compare-panel";
+
 import { Radio, Server, ShieldCheck, Activity } from "lucide-react";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { LatencyHeatmap } from "@/components/metagraphed/charts/latency-heatmap";
 import { IncidentsTimeline } from "@/components/metagraphed/analytics/incidents-timeline";
-import {
-  TimeRangeProvider,
-  useTimeRange,
-  RANGE_LABEL,
-} from "@/components/metagraphed/analytics/time-range-context";
+import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
 import { TimeRangeScrub } from "@/components/metagraphed/analytics/time-range-scrub";
-import { EndpointKindTabs } from "@/components/metagraphed/endpoint-kind-tabs";
-import { EndpointCardList } from "@/components/metagraphed/endpoint-card-list";
 import { ProxyHero, ProxyUsagePanel } from "@/components/metagraphed/rpc-proxy";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
 import { rpcEndpointsSummaryLine } from "@/lib/metagraphed/rpc-endpoints-summary";
 import { buildUrl } from "@/lib/metagraphed/client";
-import { useScrolled } from "@/hooks/use-scrolled";
 import {
   endpointsQuery,
   endpointIncidentsQuery,
@@ -50,6 +52,7 @@ import {
   statusToHealth,
   providersQuery,
   subnetsQuery,
+  metagraphedQueryKey,
 } from "@/lib/metagraphed/queries";
 import {
   endpointCategory,
@@ -61,9 +64,15 @@ import {
   type PoolEligibility,
 } from "@/lib/metagraphed/endpoint-pool";
 
-import type { Endpoint, RpcPool, RpcEndpoint, Provider, Subnet } from "@/lib/metagraphed/types";
-import { endpointsFiltersActive } from "@/lib/metagraphed/endpoints-filters";
-import { activeFilterCount, filterToggleLabel } from "@/lib/metagraphed/filter-disclosure";
+import type {
+  Endpoint,
+  EndpointIncident,
+  RpcPool,
+  RpcEndpoint,
+  Provider,
+  Subnet,
+} from "@/lib/metagraphed/types";
+import { activeFilterCount } from "@/lib/metagraphed/filter-disclosure";
 
 const endpointsSearchSchema = z.object({
   q: fallback(z.string(), "").default(""),
@@ -90,6 +99,10 @@ const endpointsSearchSchema = z.object({
   // #3976: ProxyUsagePanel's 7d/30d window is URL-backed (like /explorer) so a
   // shared /endpoints link restores the same window and back/forward works.
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  // Deep-linkable expanded endpoint row. Empty string = collapsed.
+  endpoint: fallback(z.string(), "").default(""),
+  // Comma-separated endpoint IDs selected for side-by-side comparison.
+  compare: fallback(z.string(), "").default(""),
 });
 
 type EndpointsSearch = z.infer<typeof endpointsSearchSchema>;
@@ -112,14 +125,18 @@ export const Route = createFileRoute("/endpoints")({
       },
     ],
   }),
+  pendingComponent: () => <RoutePending panels={3} />,
   component: EndpointsPage,
 });
 
-type EndpointsTab = "proxy" | "endpoints" | "advanced" | "incidents";
-const ENDPOINTS_TABS: { id: EndpointsTab; label: string }[] = [
-  { id: "proxy", label: "Proxy" },
-  { id: "endpoints", label: "Endpoints" },
-  { id: "advanced", label: "Advanced" },
+// Endpoints is the primary product on this page; proxy is one surface among
+// several. Order tabs so the directory is the default landing view rather
+// than making users click past the marketing panel to reach it.
+type EndpointsTab = "endpoints" | "proxy" | "advanced" | "incidents";
+const ENDPOINTS_TABS: ReadonlyArray<{ id: EndpointsTab; label: string }> = [
+  { id: "endpoints", label: "Directory" },
+  { id: "proxy", label: "Managed RPC" },
+  { id: "advanced", label: "Pools" },
   { id: "incidents", label: "Incidents" },
 ];
 
@@ -140,96 +157,107 @@ function EndpointsPage() {
   // #5329: the page stacked ~9 full-width panels into one ~95,000px feed on
   // mobile. Split its distinct concerns into tabs; each section fetches its own
   // data, so only the active tab's panels mount (and query) at a time.
-  const [tab, setTab] = useState<EndpointsTab>("proxy");
+  const [tab, setTab] = useState<EndpointsTab>("endpoints");
   return (
     <AppShell>
-      <PageHero
+      <PageMasthead
         eyebrow="Infrastructure"
         live
         title="Endpoints"
-        description="A load-balanced reverse proxy for Bittensor RPC, plus the registry of callable Subtensor and subnet endpoints behind it."
+        description="Callable Subtensor and subnet endpoints — health, latency, and pool eligibility, plus a managed RPC proxy that fans requests across the healthiest members."
         actions={<ShareButton />}
       />
       <div className="space-y-section">
         {/* Endpoint KPIs stay visible above the tabs so the tab bar has context
             and doesn't float alone under the hero. */}
-        <QueryErrorBoundary>
-          <Suspense
-            fallback={
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                <Skeleton className="h-20" />
-                <Skeleton className="h-20" />
-                <Skeleton className="h-20" />
-                <Skeleton className="h-20" />
-              </div>
-            }
-          >
-            <EndpointsStatStrip />
-          </Suspense>
-        </QueryErrorBoundary>
-        <div
-          className="flex flex-wrap gap-2 border-b border-border pb-3"
-          role="tablist"
-          aria-label="Endpoints sections"
+        <AsyncPanel
+          context="endpoints overview"
+          retryQueryKeys={[metagraphedQueryKey("endpoints"), metagraphedQueryKey("rpc-pools")]}
+          fallback={
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <PanelSkeleton height="sm" />
+              <PanelSkeleton height="sm" />
+              <PanelSkeleton height="sm" />
+              <PanelSkeleton height="sm" />
+            </div>
+          }
         >
-          {ENDPOINTS_TABS.map((t) => (
-            <button
-              key={t.id}
-              type="button"
-              role="tab"
-              aria-selected={tab === t.id}
-              onClick={() => setTab(t.id)}
-              className={
-                tab === t.id
-                  ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent-text"
-                  : "rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30 hover:text-ink-strong"
-              }
-            >
-              {t.label}
-            </button>
-          ))}
-        </div>
+          <EndpointsStatStrip />
+        </AsyncPanel>
+        <TabStrip
+          items={ENDPOINTS_TABS}
+          value={tab}
+          onChange={(v: EndpointsTab) => setTab(v)}
+          ariaLabel="Endpoints sections"
+        />
 
         {tab === "proxy" && (
           <>
-            {/* The headline feature: the live reverse proxy + its usage analytics. */}
             <section>
               <ProxyHero />
             </section>
             <section>
               <SectionHeading title="Proxy usage" />
-              <QueryErrorBoundary>
-                <Suspense fallback={<Skeleton className="h-40 w-full" />}>
-                  <ProxyUsagePanel />
-                </Suspense>
-              </QueryErrorBoundary>
+              <AsyncPanel
+                height="md"
+                context="proxy usage"
+                retryQueryKeys={[metagraphedQueryKey("rpc-usage")]}
+              >
+                <ProxyUsagePanel />
+              </AsyncPanel>
             </section>
           </>
         )}
 
         {tab === "endpoints" && (
           <>
+            <AsyncPanel
+              context="priority signals"
+              retryQueryKeys={[
+                metagraphedQueryKey("endpoints"),
+                metagraphedQueryKey("endpoint-incidents"),
+              ]}
+              fallback={
+                <div className="grid gap-2 grid-cols-2 lg:grid-cols-4">
+                  {[0, 1, 2, 3].map((i) => (
+                    <PanelSkeleton key={i} height="sm" />
+                  ))}
+                </div>
+              }
+            >
+              <EndpointsPriorityStrip />
+            </AsyncPanel>
+            <section>
+              <SectionHeading title="Endpoint directory" />
+              <AsyncPanel
+                height="lg"
+                context="endpoints"
+                retryQueryKeys={[
+                  metagraphedQueryKey("endpoints"),
+                  metagraphedQueryKey("rpc-pools"),
+                  metagraphedQueryKey("endpoint-incidents"),
+                  metagraphedQueryKey("providers"),
+                  metagraphedQueryKey("subnets"),
+                ]}
+              >
+                <EndpointsTable />
+              </AsyncPanel>
+            </section>
             <TimeRangeProvider>
               <section>
                 <div className="flex flex-wrap items-end justify-between gap-3 mb-2">
-                  <SectionHeading title="Latency & severity heatmap" />
+                  <SectionHeading title="Latency diagnostics" />
                   <TimeRangeScrub />
                 </div>
-                <QueryErrorBoundary>
-                  <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-                    <LatencyHeatmapSection />
-                  </Suspense>
-                </QueryErrorBoundary>
+                <AsyncPanel
+                  height="lg"
+                  context="latency heatmap"
+                  retryQueryKeys={[metagraphedQueryKey("endpoints")]}
+                >
+                  <LatencyHeatmapSection />
+                </AsyncPanel>
               </section>
             </TimeRangeProvider>
-            <section>
-              <SectionHeading title="Callable endpoints" />
-              <QueryErrorBoundary>
-                <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-                  <EndpointsTable />
-                </Suspense>
-              </QueryErrorBoundary>
-            </section>
           </>
         )}
 
@@ -237,27 +265,33 @@ function EndpointsPage() {
           <>
             <section>
               <SectionHeading title="RPC pools" />
-              <QueryErrorBoundary>
-                <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-                  <PoolsTable />
-                </Suspense>
-              </QueryErrorBoundary>
+              <AsyncPanel
+                height="sm"
+                context="RPC pools"
+                retryQueryKeys={[metagraphedQueryKey("rpc-pools")]}
+              >
+                <PoolsTable />
+              </AsyncPanel>
             </section>
             <section>
               <SectionHeading title="Endpoint pools" />
-              <QueryErrorBoundary>
-                <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-                  <EndpointPoolsTable />
-                </Suspense>
-              </QueryErrorBoundary>
+              <AsyncPanel
+                height="sm"
+                context="endpoint pools"
+                retryQueryKeys={[metagraphedQueryKey("endpoint-pools")]}
+              >
+                <EndpointPoolsTable />
+              </AsyncPanel>
             </section>
             <section>
               <SectionHeading title="Root RPC/WSS endpoints" />
-              <QueryErrorBoundary>
-                <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-                  <RpcEndpointsTable />
-                </Suspense>
-              </QueryErrorBoundary>
+              <AsyncPanel
+                height="sm"
+                context="root RPC/WSS endpoints"
+                retryQueryKeys={[metagraphedQueryKey("rpc-endpoints")]}
+              >
+                <RpcEndpointsTable />
+              </AsyncPanel>
             </section>
           </>
         )}
@@ -266,11 +300,13 @@ function EndpointsPage() {
           <>
             <section>
               <SectionHeading title="Incidents timeline" />
-              <QueryErrorBoundary>
-                <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-                  <IncidentsTimeline />
-                </Suspense>
-              </QueryErrorBoundary>
+              <AsyncPanel
+                height="md"
+                context="incidents"
+                retryQueryKeys={[metagraphedQueryKey("endpoint-incidents")]}
+              >
+                <IncidentsTimeline />
+              </AsyncPanel>
             </section>
           </>
         )}
@@ -326,11 +362,14 @@ function EndpointsStatStrip() {
 }
 
 function LatencyHeatmapSection() {
-  const rows = (useSuspenseQuery(endpointsQuery()).data.data ?? []) as Endpoint[];
+  const { data } = useSuspenseQuery(endpointsQuery());
   // The callable-endpoints table below is scoped to callable kinds (rpc/wss/api/
   // sse/data — i.e. not "other" directory links). Feed the heatmap the same
   // callable-scoped population so both describe the same set of endpoints.
-  const callable = useMemo(() => rows.filter((e) => endpointCategory(e.kind) !== "other"), [rows]);
+  const callable = useMemo(() => {
+    const rows = (data.data ?? []) as Endpoint[];
+    return rows.filter((e) => endpointCategory(e.kind) !== "other");
+  }, [data]);
   return <LatencyHeatmap endpoints={callable} />;
 }
 
@@ -357,9 +396,9 @@ function PoolsTable() {
           ]}
         />
       ) : null}
-      <div className="rounded border border-border bg-card overflow-x-auto">
+      <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
         <table className="w-full text-sm">
-          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
             <tr>
               <th className="px-3 py-2 text-left">Pool</th>
               <th className="px-3 py-2 text-left">Region</th>
@@ -390,7 +429,7 @@ function PoolsTable() {
                   <td className="px-3 py-2 text-center">
                     <span
                       className={classNames(
-                        "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+                        "mg-type-micro inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
                         ELIGIBILITY_TONE[eligibility],
                       )}
                     >
@@ -402,7 +441,7 @@ function PoolsTable() {
             })}
           </tbody>
         </table>
-      </div>
+      </ResponsiveTable>
       <p className="px-1 font-mono text-[10px] text-ink-muted">
         Proxy-eligible members serve live traffic through the reverse proxy above; the proxy prefers
         in-sync, healthy nodes and fails over automatically.
@@ -434,9 +473,9 @@ function EndpointPoolsTable() {
           ]}
         />
       ) : null}
-      <div className="rounded border border-border bg-card overflow-x-auto">
+      <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
         <table className="w-full text-sm">
-          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
             <tr>
               <th className="px-3 py-2 text-left">Pool</th>
               <th className="px-3 py-2 text-left">Kind</th>
@@ -480,7 +519,7 @@ function EndpointPoolsTable() {
             })}
           </tbody>
         </table>
-      </div>
+      </ResponsiveTable>
       <p className="px-1 font-mono text-[10px] text-ink-muted">
         Covers all pool kinds (subtensor-rpc, subtensor-wss, archive) from the generalized
         endpoint-pools artifact — distinct from the Bittensor RPC proxy pools above.
@@ -520,9 +559,9 @@ function RpcEndpointsTable() {
           refreshQueryKeys={[rpcEndpointsQuery().queryKey]}
         />
       ) : null}
-      <div className="rounded border border-border bg-card overflow-x-auto">
+      <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
         <table className="w-full text-sm">
-          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
             <tr>
               <th className="px-3 py-2 text-left">Provider</th>
               <th className="px-3 py-2 text-left">Kind</th>
@@ -540,7 +579,7 @@ function RpcEndpointsTable() {
                 <td className="px-3 py-2">
                   <span
                     className={classNames(
-                      "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+                      "mg-type-micro inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
                       CLASSIFICATION_TONE[e.classification ?? "unknown"] ??
                         CLASSIFICATION_TONE.unknown,
                     )}
@@ -561,7 +600,7 @@ function RpcEndpointsTable() {
             ))}
           </tbody>
         </table>
-      </div>
+      </ResponsiveTable>
       {summaryLine ? (
         <p className="px-1 font-mono text-[10px] text-ink-muted">{summaryLine}</p>
       ) : null}
@@ -570,8 +609,6 @@ function RpcEndpointsTable() {
 }
 
 type SortKey = "netuid" | "kind" | "provider" | "region" | "health" | "latency" | "probed";
-type SortOrder = "asc" | "desc";
-
 const HEALTH_RANK: Record<string, number> = { ok: 0, warn: 1, down: 2, unknown: 3 };
 
 function endpointValue(e: Endpoint, k: SortKey): string | number | null {
@@ -594,16 +631,18 @@ function endpointValue(e: Endpoint, k: SortKey): string | number | null {
 }
 
 function EndpointsTable() {
-  const scrolled = useScrolled(8);
   const { data } = useSuspenseQuery(endpointsQuery());
   const { data: poolsRes } = useSuspenseQuery(rpcPoolsQuery());
+  const { data: incRes } = useSuspenseQuery(endpointIncidentsQuery());
   const rows = useMemo(() => (data.data ?? []) as Endpoint[], [data]);
   const pools = useMemo(() => (poolsRes.data ?? []) as RpcPool[], [poolsRes]);
+  const incidents = useMemo(() => (incRes.data ?? []) as EndpointIncident[], [incRes]);
   // O(1) pool lookup — index once, reuse for every endpoint's eligibility.
   const poolsById = useMemo(() => indexPoolsById(pools), [pools]);
   const generatedAt = data.meta?.generated_at as string | undefined;
-  const { range } = useTimeRange();
-  const windowLabel = `${RANGE_LABEL[range]} window · latest probe`;
+  const stale = isStaleFreshness(generatedAt);
+  // expandedId is URL-driven so the drawer is deep-linkable and preserved on
+  // back/forward without stacking history entries.
 
   // Lookup maps for inline subnet + provider logos.
   const { data: provRes } = useSuspenseQuery(providersQuery());
@@ -621,6 +660,43 @@ function EndpointsTable() {
 
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
+  const expandedId = search.endpoint || null;
+  const toggleExpanded = (id: string) =>
+    navigate({
+      search: (prev: Record<string, unknown>) =>
+        ({ ...prev, endpoint: prev.endpoint === id ? "" : id }) as never,
+      resetScroll: false,
+      replace: true,
+    });
+
+  // Compare state: URL-driven CSV of endpoint IDs (capped at 4).
+  const COMPARE_MAX = 4;
+  const compareIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const raw of (search.compare ?? "").split(",")) {
+      const id = raw.trim();
+      if (id) set.add(id);
+      if (set.size >= COMPARE_MAX) break;
+    }
+    return set;
+  }, [search.compare]);
+  const toggleCompare = (id: string) => {
+    const next = new Set(compareIds);
+    if (next.has(id)) next.delete(id);
+    else if (next.size < COMPARE_MAX) next.add(id);
+    navigate({
+      search: (prev: Record<string, unknown>) =>
+        ({ ...prev, compare: Array.from(next).join(",") }) as never,
+      resetScroll: false,
+      replace: true,
+    });
+  };
+  const clearCompare = () =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, compare: "" }) as never,
+      resetScroll: false,
+      replace: true,
+    });
 
   const setSearch = (patch: Partial<EndpointsSearch>) => {
     // Any filter change resets page to 1 unless caller specifies otherwise.
@@ -762,20 +838,6 @@ function EndpointsTable() {
   const safePage = Math.min(search.page, totalPages);
   const pageRows = sorted.slice((safePage - 1) * search.pageSize, safePage * search.pageSize);
 
-  const hasFilters = endpointsFiltersActive({
-    q: search.q,
-    category: search.category,
-    provider: search.provider,
-    health: search.health,
-    netuid: search.netuid,
-    region: search.region,
-    eligibility: search.eligibility,
-    callable: search.callable,
-    sort: search.sort,
-    order: search.order,
-    page: search.page,
-  });
-
   // Same mobile-disclosure treatment as /blocks and /extrinsics (#5323): this
   // toolbar has even more controls, so an always-visible filter bar pushed the
   // first endpoint row down on a 375px viewport (#6580). Count only the six
@@ -788,19 +850,15 @@ function EndpointsTable() {
     search.health,
     search.eligibility,
   ]);
-  const [filtersOpen, setFiltersOpen] = useState(activeCount > 0);
 
   // The table filters client-side over the full fetched list; the CSV export
   // hits the backend route directly (full endpoint snapshot, no client filters).
   const endpointsCsvUrl = buildUrl("/api/v1/endpoints");
-
-  function toggleSort(k: SortKey) {
-    if (search.sort === k) {
-      setSearch({ order: search.order === "asc" ? "desc" : "asc" });
-    } else {
-      setSearch({ sort: k, order: "asc" });
-    }
-  }
+  const sortPreset = `${search.sort}:${search.order}`;
+  const setSortPreset = (value: string) => {
+    const [sort, order] = value.split(":") as [EndpointsSearch["sort"], EndpointsSearch["order"]];
+    setSearch({ sort, order, page: 1 });
+  };
 
   // Reset clears search/filters/sort/page but keeps page size, view, and the
   // callable-only default (true).
@@ -809,6 +867,9 @@ function EndpointsTable() {
       search: { pageSize: search.pageSize, view: search.view } as never,
       replace: true,
     });
+
+  // Hooks must run unconditionally, before the early-empty-state return below.
+  const isFetchingRows = useIsFetching({ queryKey: metagraphedQueryKey("endpoints") }) > 0;
 
   if (rows.length === 0)
     return (
@@ -834,134 +895,244 @@ function EndpointsTable() {
     );
 
   return (
-    <div className="space-y-3">
-      {/* Kind chip rail */}
-      <EndpointKindTabs
-        value={search.category}
-        counts={categoryCounts}
-        onChange={(v) => setSearch({ category: v as EndpointsSearch["category"] })}
+    <div className="space-y-3 relative">
+      <QueryProgress active={isFetchingRows} position="sticky" />
+      {/* One shared command surface replaces the previous stacked category,
+          search, select, toggle, and view-control bars. */}
+      <div
+        className="sticky z-20 -mx-1 bg-paper/92 px-1 py-2 backdrop-blur"
+        style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
+      >
+        <QueryBar ariaLabel="Filter endpoint directory">
+          <QueryBar.Search
+            value={search.q}
+            onChange={(v) => setSearch({ q: v })}
+            debounceMs={180}
+            placeholder="Search URL, provider, netuid…"
+          />
+          <QueryBar.Divider />
+          <div className="hidden items-center sm:flex">
+            <QueryBar.FilterTrigger
+              label="Kind"
+              value={search.category === "all" ? "" : search.category}
+              onChange={(v) => setSearch({ category: (v || "all") as EndpointsSearch["category"] })}
+              options={(
+                [
+                  ["rpc", "RPC"],
+                  ["wss", "WSS"],
+                  ["api", "API"],
+                  ["sse", "SSE"],
+                  ["data", "Data"],
+                  ["other", "Other"],
+                ] as const
+              )
+                .filter(([value]) => (categoryCounts[value] ?? 0) > 0)
+                .map(([value, label]) => ({
+                  value,
+                  label: `${label} · ${categoryCounts[value] ?? 0}`,
+                }))}
+            />
+            <QueryBar.FilterTrigger
+              label="Health"
+              value={search.health}
+              onChange={(v) => setSearch({ health: v })}
+              options={["ok", "warn", "down", "unknown"].map((value) => ({ value, label: value }))}
+            />
+            <QueryBar.FilterTrigger
+              label="Sort"
+              value={sortPreset}
+              onChange={setSortPreset}
+              options={[
+                { value: "netuid:asc", label: "Subnet number" },
+                { value: "health:asc", label: "Health first" },
+                { value: "latency:asc", label: "Fastest latency" },
+                { value: "latency:desc", label: "Slowest latency" },
+                { value: "probed:desc", label: "Newest probe" },
+                { value: "provider:asc", label: "Provider A–Z" },
+              ]}
+            />
+            <div className="hidden xl:contents">
+              <QueryBar.FilterTrigger
+                label="Provider"
+                value={search.provider}
+                onChange={(v) => setSearch({ provider: v })}
+                options={providers.map((value) => ({ value, label: value }))}
+              />
+              <QueryBar.FilterTrigger
+                label="Region"
+                value={search.region}
+                onChange={(v) => setSearch({ region: v })}
+                options={regions.map((value) => ({ value, label: value }))}
+              />
+              <QueryBar.FilterTrigger
+                label="Access"
+                value={search.eligibility}
+                onChange={(v) => setSearch({ eligibility: v })}
+                options={[
+                  { value: "proxy-enabled", label: "Proxy enabled" },
+                  { value: "pool-member", label: "Pool member" },
+                  { value: "archive-capable", label: "Archive capable" },
+                  { value: "unassigned", label: "Unassigned" },
+                ]}
+              />
+            </div>
+          </div>
+          <QueryBar.Utility>
+            <FilterSheet
+              label="More filters"
+              activeCount={activeFilterCount([
+                search.netuid,
+                search.provider,
+                search.region,
+                search.eligibility,
+              ])}
+              className="xl:hidden"
+            >
+              <label className="grid gap-1">
+                <span className="mg-label">Subnet number</span>
+                <input
+                  value={search.netuid}
+                  onChange={(event) =>
+                    setSearch({ netuid: event.target.value.replace(/[^0-9]/g, "") })
+                  }
+                  inputMode="numeric"
+                  placeholder="Any subnet"
+                  className="h-9 rounded border border-border bg-paper px-2 font-mono text-[12px] text-ink-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </label>
+              <QueryBar.FilterTrigger
+                label="Provider"
+                value={search.provider}
+                onChange={(value) => setSearch({ provider: value })}
+                options={providers.map((value) => ({ value, label: value }))}
+                className="w-full justify-between border border-border"
+              />
+              <QueryBar.FilterTrigger
+                label="Region"
+                value={search.region}
+                onChange={(value) => setSearch({ region: value })}
+                options={regions.map((value) => ({ value, label: value }))}
+                className="w-full justify-between border border-border"
+              />
+              <QueryBar.FilterTrigger
+                label="Access"
+                value={search.eligibility}
+                onChange={(value) => setSearch({ eligibility: value })}
+                options={[
+                  { value: "proxy-enabled", label: "Proxy enabled" },
+                  { value: "pool-member", label: "Pool member" },
+                  { value: "archive-capable", label: "Archive capable" },
+                  { value: "unassigned", label: "Unassigned" },
+                ]}
+                className="w-full justify-between border border-border"
+              />
+              <QueryBar.FilterTrigger
+                label="Sort"
+                value={sortPreset}
+                onChange={setSortPreset}
+                options={[
+                  { value: "netuid:asc", label: "Subnet number" },
+                  { value: "health:asc", label: "Health first" },
+                  { value: "latency:asc", label: "Fastest latency" },
+                  { value: "latency:desc", label: "Slowest latency" },
+                  { value: "probed:desc", label: "Newest probe" },
+                  { value: "provider:asc", label: "Provider A–Z" },
+                ]}
+                className="w-full justify-between border border-border"
+              />
+            </FilterSheet>
+            <button
+              type="button"
+              onClick={() =>
+                setSearch({
+                  callable: !search.callable,
+                  ...(!search.callable && search.category === "other"
+                    ? { category: "all" as const }
+                    : {}),
+                })
+              }
+              aria-pressed={search.callable}
+              title={
+                search.callable
+                  ? `Showing callable endpoints — ${directoryCount} reference links hidden`
+                  : "Showing all endpoint records"
+              }
+              className={classNames(
+                "mg-focus-ring inline-flex h-8 items-center gap-1.5 rounded px-2 font-mono text-[10px] uppercase tracking-widest",
+                search.callable ? "text-accent-text" : "text-ink-muted hover:text-ink-strong",
+              )}
+            >
+              <span
+                className={classNames(
+                  "size-1.5 rounded-full",
+                  search.callable ? "bg-accent" : "bg-ink-subtle",
+                )}
+                aria-hidden
+              />
+              <span className="hidden xl:inline">Callable</span>
+            </button>
+            <DownloadCsvButton url={endpointsCsvUrl} />
+          </QueryBar.Utility>
+        </QueryBar>
+        <QueryBar.MetaRow
+          count={sorted.length}
+          total={scoped.length}
+          noun="endpoints"
+          activeCount={
+            activeCount + (search.category !== "all" ? 1 : 0) + (search.callable ? 1 : 0)
+          }
+          onReset={resetAll}
+          trailing={
+            <span>
+              {search.callable && directoryCount > 0
+                ? `${directoryCount} reference links hidden`
+                : "All records visible"}
+            </span>
+          }
+        />
+      </div>
+
+      <FilterChipRow
+        items={[
+          ...(search.q ? [{ id: "q", label: "Search", value: search.q } as FilterChipItem] : []),
+          ...(search.netuid
+            ? [{ id: "netuid", label: "Netuid", value: search.netuid } as FilterChipItem]
+            : []),
+          ...(search.provider
+            ? [{ id: "provider", label: "Provider", value: search.provider } as FilterChipItem]
+            : []),
+          ...(search.region
+            ? [{ id: "region", label: "Region", value: search.region } as FilterChipItem]
+            : []),
+          ...(search.health
+            ? [{ id: "health", label: "Health", value: search.health } as FilterChipItem]
+            : []),
+          ...(search.eligibility
+            ? [
+                {
+                  id: "eligibility",
+                  label: "Eligibility",
+                  value: search.eligibility,
+                } as FilterChipItem,
+              ]
+            : []),
+          ...(search.callable
+            ? [{ id: "callable", label: "Scope", value: "callable only" } as FilterChipItem]
+            : []),
+        ]}
+        onRemove={(id) => {
+          if (id === "callable") setSearch({ callable: false });
+          else setSearch({ [id]: "" } as Partial<EndpointsSearch>);
+        }}
+        onClearAll={resetAll}
       />
 
-      {/* Toolbar */}
-      <div
-        data-scrolled={scrolled ? "true" : "false"}
-        className="mg-sticky-toolbar sticky top-14 z-20 -mx-1 px-1 py-2 backdrop-blur bg-paper/90 border-b border-border/60 flex flex-wrap items-center gap-2"
-      >
-        <button
-          type="button"
-          onClick={() => setFiltersOpen((open) => !open)}
-          aria-expanded={filtersOpen}
-          aria-controls="endpoints-filter-fields"
-          className="md:hidden inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-2.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors"
-        >
-          <SlidersHorizontal className="size-3" aria-hidden="true" />
-          {filterToggleLabel(activeCount)}
-        </button>
-        {/* `md:contents` dissolves this wrapper at md and up, so the fields lay
-            out as direct children of the toolbar exactly as they did before. */}
-        <div
-          id="endpoints-filter-fields"
-          className={classNames(
-            "w-full flex-wrap items-center gap-2 md:contents",
-            filtersOpen ? "flex" : "hidden",
-          )}
-        >
-          <div className="relative flex-1 min-w-[180px] max-w-sm">
-            <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-ink-muted" />
-            <input
-              value={search.q}
-              onChange={(e) => setSearch({ q: e.target.value })}
-              placeholder="Search URL, provider, netuid…"
-              className="w-full rounded border border-border bg-card pl-7 pr-2 py-1.5 text-[12px] focus:outline-none focus:border-ink/30"
-              aria-label="Search endpoints"
-            />
-          </div>
-          <label className="inline-flex items-center gap-1 text-[11px] text-ink-muted">
-            <span className="font-mono uppercase tracking-widest text-[10px]">Netuid</span>
-            <input
-              value={search.netuid}
-              onChange={(e) => setSearch({ netuid: e.target.value.replace(/[^0-9]/g, "") })}
-              inputMode="numeric"
-              placeholder="any"
-              className="w-16 rounded border border-border bg-card px-1.5 py-1 text-[11px] focus:outline-none focus:border-ink/30"
-              aria-label="Filter by netuid"
-            />
-          </label>
-          <FilterSelect
-            label="Provider"
-            value={search.provider}
-            onChange={(v) => setSearch({ provider: v })}
-            options={providers}
-          />
-          <FilterSelect
-            label="Region"
-            value={search.region}
-            onChange={(v) => setSearch({ region: v })}
-            options={regions}
-          />
-          <FilterSelect
-            label="Health"
-            value={search.health}
-            onChange={(v) => setSearch({ health: v })}
-            options={["ok", "warn", "down", "unknown"]}
-          />
-          <FilterSelect
-            label="Eligibility"
-            value={search.eligibility}
-            onChange={(v) => setSearch({ eligibility: v })}
-            options={["proxy-enabled", "pool-member", "archive-capable", "unassigned"]}
-          />
-        </div>
-        <button
-          type="button"
-          onClick={resetAll}
-          disabled={!hasFilters}
-          className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[11px] text-ink-muted hover:text-ink-strong disabled:opacity-40 disabled:cursor-not-allowed"
-          title="Clear search, filters, sort, and page"
-        >
-          <X className="size-3" /> Reset filters
-        </button>
-        <DownloadCsvButton url={endpointsCsvUrl} />
-        <button
-          type="button"
-          onClick={() => {
-            setSearch({
-              callable: !search.callable,
-              // Leaving callable-only while viewing the "other" tab would show 0
-              // rows; snap back to "all" so the toggle is never a dead end.
-              ...(!search.callable && search.category === "other"
-                ? { category: "all" as const }
-                : {}),
-            });
-          }}
-          aria-pressed={search.callable}
-          title={
-            search.callable
-              ? `Showing callable endpoints — ${directoryCount} directory links hidden`
-              : "Showing all endpoints, including directory links"
-          }
-          className={classNames(
-            "inline-flex items-center gap-1.5 rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
-            search.callable
-              ? "border-accent/40 bg-accent/10 text-accent"
-              : "border-border bg-card text-ink-muted hover:text-ink-strong",
-          )}
-        >
-          <span className={classNames("size-1.5 rounded-full", search.callable && "bg-accent")} />
-          Callable only
-          {directoryCount > 0 ? (
-            <span className="text-ink-muted">· {directoryCount} links</span>
-          ) : null}
-        </button>
-        <ViewModeToggle
-          value={search.view}
-          options={["table", "grid"]}
-          onChange={(v) => setSearch({ view: v as "table" | "grid" })}
+      {stale ? (
+        <StaleBanner
+          generatedAt={generatedAt}
+          refreshQueryKeys={[endpointsQuery().queryKey, endpointIncidentsQuery().queryKey]}
         />
-        <span className="font-mono text-[10px] text-ink-muted">
-          {sorted.length} of {scoped.length}
-        </span>
-      </div>
+      ) : null}
 
       {sorted.length === 0 ? (
         <StateBlock
@@ -978,307 +1149,38 @@ function EndpointsTable() {
         />
       ) : (
         <>
-          {search.view === "grid" ? (
-            <EndpointCardList
-              rows={pageRows}
+          {compareIds.size > 0 ? (
+            <EndpointComparePanel
+              endpoints={rows.filter((r) => compareIds.has(r.id))}
+              incidents={incidents}
+              poolsById={poolsById}
               providerById={providerById}
               subnetById={subnetById}
-              windowLabel={windowLabel}
-              className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
-            />
-          ) : (
-            <div className="hidden md:block rounded border border-border bg-card overflow-x-clip">
-              <table className="w-full text-sm">
-                <thead className="sticky top-[6.75rem] z-10 bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/85 text-[10px] font-mono uppercase tracking-widest text-ink-muted shadow-[0_1px_0_0_var(--border)]">
-                  <tr>
-                    <Th
-                      label="Netuid"
-                      k="netuid"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                    />
-                    <Th
-                      label="Kind"
-                      k="kind"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                    />
-                    <th className="px-3 py-2 text-left">URL</th>
-                    <Th
-                      label="Provider"
-                      k="provider"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                    />
-                    <Th
-                      label="Region"
-                      k="region"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                    />
-                    <Th
-                      label="Health"
-                      k="health"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                      align="center"
-                    />
-                    <Th
-                      label="Latency"
-                      k="latency"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                      align="right"
-                    />
-                    <Th
-                      label="Probed"
-                      k="probed"
-                      sortKey={search.sort}
-                      sortOrder={search.order}
-                      onSort={toggleSort}
-                      align="right"
-                    />
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {pageRows.map((e) => {
-                    const provSlug = e.provider_slug;
-                    const prov = provSlug ? providerById.get(provSlug) : undefined;
-                    const sn = e.netuid != null ? subnetById.get(e.netuid) : undefined;
-                    return (
-                      <tr key={e.id} className="mg-row-accent hover:bg-surface/40">
-                        <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                          {e.netuid != null ? (
-                            <Link
-                              to="/subnets/$netuid"
-                              params={{ netuid: e.netuid }}
-                              className="inline-flex items-center gap-1.5 hover:text-ink-strong"
-                            >
-                              <BrandIcon
-                                url={sn?.website}
-                                iconUrl={sn?.icon_url}
-                                netuid={e.netuid}
-                                name={sn?.name}
-                                fallback={e.netuid}
-                                size={14}
-                              />
-                              {String(e.netuid).padStart(3, "0")}
-                            </Link>
-                          ) : (
-                            "—"
-                          )}
-                        </td>
-                        <td className="px-3 py-2 font-mono text-[11px]">{e.kind ?? "—"}</td>
-                        <td className="px-3 py-2 font-mono text-[11px] max-w-[36ch]">
-                          {e.url ? (
-                            <div className="flex items-center gap-1.5 min-w-0">
-                              <ExternalLink href={e.url} className="truncate text-[11px]">
-                                {e.url}
-                              </ExternalLink>
-                              <CopyButton value={e.url} label="URL" compact />
-                            </div>
-                          ) : (
-                            "—"
-                          )}
-                        </td>
-                        <td className="px-3 py-2 text-[12px]">
-                          {provSlug ? (
-                            <Link
-                              to="/providers/$slug"
-                              params={{ slug: provSlug }}
-                              className="inline-flex items-center gap-1.5 hover:underline min-w-0"
-                            >
-                              <BrandIcon
-                                url={prov?.website ?? prov?.homepage}
-                                iconUrl={prov?.icon_url}
-                                repoUrl={prov?.repo}
-                                providerSlug={provSlug}
-                                name={prov?.name ?? e.provider ?? provSlug}
-                                fallback={provSlug}
-                                size={16}
-                              />
-                              <span className="truncate">
-                                {e.provider ?? prov?.name ?? provSlug}
-                              </span>
-                            </Link>
-                          ) : (
-                            (e.provider ?? "—")
-                          )}
-                        </td>
-                        <td className="px-3 py-2 text-[12px]">{e.region ?? "—"}</td>
-                        <td className="px-3 py-2 text-center">
-                          <SparkLegend
-                            metric="Endpoint health"
-                            source="/api/v1/endpoints"
-                            windowLabel={windowLabel}
-                            updatedAt={e.last_probed_at}
-                            staleness="Falls back to last known state when the probe hasn't completed."
-                          >
-                            <HealthPill state={e.health} />
-                          </SparkLegend>
-                        </td>
-                        <td className="px-3 py-2 text-right font-mono text-[11px]">
-                          {e.latency_ms != null ? (
-                            <SparkLegend
-                              metric="Latency"
-                              source="/api/v1/endpoints (last probe)"
-                              windowLabel={windowLabel}
-                              updatedAt={e.last_probed_at}
-                              staleness="No new measurement is taken between probes — last measured value is shown."
-                            >
-                              <span>{e.latency_ms}ms</span>
-                            </SparkLegend>
-                          ) : (
-                            "—"
-                          )}
-                        </td>
-                        <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
-                          <SparkLegend
-                            metric="Last probe"
-                            source="/api/v1/endpoints"
-                            windowLabel={windowLabel}
-                            updatedAt={e.last_probed_at}
-                            staleness="Rows older than the probe cycle are dimmed in tooltips elsewhere."
-                          >
-                            <TimeAgo at={e.last_probed_at} />
-                          </SparkLegend>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
-
-          {search.view === "table" ? (
-            <EndpointCardList
-              rows={pageRows}
-              providerById={providerById}
-              subnetById={subnetById}
-              windowLabel={windowLabel}
-              className="grid gap-3 sm:grid-cols-2 md:hidden"
+              onRemove={toggleCompare}
+              onClear={clearCompare}
             />
           ) : null}
-
-          <div className="flex flex-wrap items-center gap-3 px-1 py-1 text-[11px] text-ink-muted">
-            <span className="font-mono">
-              Page {safePage} of {totalPages} · showing {pageRows.length} of {sorted.length}
-            </span>
-            <span className="ml-auto inline-flex items-center gap-1">
-              <label htmlFor="ep-page-size" className="font-mono">
-                Per page
-              </label>
-              <select
-                id="ep-page-size"
-                value={search.pageSize}
-                onChange={(e) => setSearch({ pageSize: Number(e.target.value), page: 1 })}
-                className="rounded border border-border bg-card px-1 py-0.5 text-[11px]"
-              >
-                {[25, 50, 100].map((n) => (
-                  <option key={n} value={n}>
-                    {n}
-                  </option>
-                ))}
-              </select>
-            </span>
-            <button
-              type="button"
-              disabled={safePage <= 1}
-              onClick={() => setSearch({ page: Math.max(1, safePage - 1) })}
-              className="rounded border border-border bg-card px-2 py-0.5 disabled:opacity-40"
-            >
-              Prev
-            </button>
-            <button
-              type="button"
-              disabled={safePage >= totalPages}
-              onClick={() => setSearch({ page: Math.min(totalPages, safePage + 1) })}
-              className="rounded border border-border bg-card px-2 py-0.5 disabled:opacity-40"
-            >
-              Next
-            </button>
-          </div>
+          <EndpointOperationalList
+            rows={pageRows}
+            incidents={incidents}
+            poolsById={poolsById}
+            providerById={providerById}
+            subnetById={subnetById}
+            expandedId={expandedId}
+            onToggle={toggleExpanded}
+            compareIds={compareIds}
+            onToggleCompare={toggleCompare}
+            compareMax={4}
+          />
+          <PagerFooter
+            summary={`Page ${safePage} of ${totalPages} · ${pageRows.length} shown · ${sorted.length} total`}
+            hasPrev={safePage > 1}
+            hasNext={safePage < totalPages}
+            onPrev={() => setSearch({ page: Math.max(1, safePage - 1) })}
+            onNext={() => setSearch({ page: Math.min(totalPages, safePage + 1) })}
+          />
         </>
       )}
     </div>
-  );
-}
-
-function Th({
-  label,
-  k,
-  sortKey,
-  sortOrder,
-  onSort,
-  align = "left",
-}: {
-  label: string;
-  k: SortKey;
-  sortKey: SortKey;
-  sortOrder: SortOrder;
-  onSort: (k: SortKey) => void;
-  align?: "left" | "right" | "center";
-}) {
-  const active = sortKey === k;
-  const arrow = active ? (sortOrder === "asc" ? "▲" : "▼") : "";
-  const alignCls =
-    align === "right" ? "text-right" : align === "center" ? "text-center" : "text-left";
-  return (
-    <th
-      className={classNames("px-3 py-2", alignCls)}
-      aria-sort={active ? (sortOrder === "asc" ? "ascending" : "descending") : "none"}
-    >
-      <button
-        type="button"
-        onClick={() => onSort(k)}
-        aria-label={`Sort by ${label}${active ? `, sorted ${sortOrder === "asc" ? "ascending" : "descending"}` : ""}`}
-        className={classNames(
-          "inline-flex items-center gap-1 uppercase tracking-widest hover:text-ink-strong",
-          active ? "text-ink-strong" : "text-ink-muted",
-        )}
-      >
-        {label}
-        <span className="text-[8px]" aria-hidden>
-          {arrow}
-        </span>
-      </button>
-    </th>
-  );
-}
-
-function FilterSelect({
-  label,
-  value,
-  onChange,
-  options,
-}: {
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  options: string[];
-}) {
-  return (
-    <label className="inline-flex items-center gap-1 text-[11px] text-ink-muted">
-      <span className="font-mono uppercase tracking-widest text-[10px]">{label}</span>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="rounded border border-border bg-card px-1.5 py-1 text-[11px] text-ink focus:outline-none focus:border-ink/30"
-      >
-        <option value="">all</option>
-        {options.map((o) => (
-          <option key={o} value={o}>
-            {o}
-          </option>
-        ))}
-      </select>
-    </label>
   );
 }

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useMemo } from "react";
+import { useMemo } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -8,7 +8,6 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   ExternalLink,
   TableState,
-  PageHero,
   PageSection,
   SectionHeading,
   MethodologyCallout,
@@ -18,10 +17,9 @@ import {
   MiniStack,
   MiniRadial,
 } from "@jsonbored/ui-kit";
-import { Skeleton } from "@/components/metagraphed/states";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import { X, Search } from "lucide-react";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { IntegrabilityBoard } from "@/components/metagraphed/integrability-board";
 import {
   CoverageMatrix,
@@ -96,7 +94,7 @@ export const Route = createFileRoute("/gaps")({
 function GapsPage() {
   return (
     <AppShell>
-      <PageHero
+      <PageMasthead
         eyebrow="Operations"
         live
         title="Registry gaps"
@@ -109,31 +107,23 @@ function GapsPage() {
       />
 
       <main className="space-y-20 md:space-y-24">
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-20 w-full" />}>
-            <GapsKpiStrip />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel height="sm">
+          <GapsKpiStrip />
+        </AsyncPanel>
 
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-            <MissingKindsAtAGlance />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel height="md">
+          <MissingKindsAtAGlance />
+        </AsyncPanel>
 
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-16 w-full" />}>
-            <GapsMethodology />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel height="sm">
+          <GapsMethodology />
+        </AsyncPanel>
 
         <section>
           <SectionHeading title="Integrability scoreboard" />
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-              <IntegrabilityBoard />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="lg">
+            <IntegrabilityBoard />
+          </AsyncPanel>
         </section>
 
         <PageSection
@@ -142,11 +132,9 @@ function GapsPage() {
           title="What's actually missing"
           description="Subnets × required public-interface kinds. Cells link straight to that subnet's surfaces tab."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-              <CoverageMatrix />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="lg">
+            <CoverageMatrix />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -155,18 +143,14 @@ function GapsPage() {
           title="Registry shape"
           description="Histogram of completeness across every scored profile. Median and quartile markers show where the registry sits today."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-44 w-full" />}>
-              <CompletenessHistogram />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <CompletenessHistogram />
+          </AsyncPanel>
         </PageSection>
 
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-72 w-full" />}>
-            <OpenGapsSection />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel height="lg">
+          <OpenGapsSection />
+        </AsyncPanel>
 
         <PageSection
           id="profile-completeness"
@@ -174,11 +158,9 @@ function GapsPage() {
           title="Profile completeness"
           description="Per-subnet completeness across required public-interface kinds."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <CompletenessList />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <CompletenessList />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -187,11 +169,9 @@ function GapsPage() {
           title="Adapter candidates"
           description="Subnets where a maintained adapter would unlock the highest registry value."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <AdapterCandidates />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <AdapterCandidates />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -200,11 +180,9 @@ function GapsPage() {
           title="Enrichment queue"
           description="Prioritized list of registry entries awaiting verification or enrichment."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <EnrichmentQueue />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <EnrichmentQueue />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -213,11 +191,9 @@ function GapsPage() {
           title="Enrichment targets"
           description="Per-target contributor task board — the specific surfaces to add per subnet, ranked by priority."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <EnrichmentTargets />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <EnrichmentTargets />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -226,11 +202,9 @@ function GapsPage() {
           title="Enrichment evidence"
           description="The detailed candidate evidence behind the enrichment queue — one level down from the summary above."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <EnrichmentEvidence />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <EnrichmentEvidence />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -239,11 +213,9 @@ function GapsPage() {
           title="Gap priorities"
           description="Priority-scored per-subnet gap board — ranked separately from the interface-facet gaps above."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <GapPriorityList />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <GapPriorityList />
+          </AsyncPanel>
         </PageSection>
       </main>
 
@@ -439,7 +411,7 @@ function MissingKindsAtAGlance() {
               >
                 <span
                   className={classNames(
-                    "font-mono text-[10px] uppercase tracking-widest",
+                    "mg-type-micro text-[10px]",
                     isActive ? "text-accent" : "text-ink-strong",
                   )}
                 >
@@ -462,7 +434,7 @@ function MissingKindsAtAGlance() {
         })}
       </ul>
       {activeMissing.size > 0 ? (
-        <div className="mt-2 flex flex-wrap items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <div className="mg-type-micro mt-2 flex flex-wrap items-center gap-2 text-[10px] text-ink-muted">
           <span>filtered by:</span>
           {Array.from(activeMissing).map((k) => (
             <span
@@ -628,7 +600,7 @@ function OpenGapsSection() {
                 setSearch({ missing: Array.from(next).join(",") });
               }}
               className={classNames(
-                "inline-flex h-6 items-center rounded-full border px-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                "mg-type-micro inline-flex h-6 items-center rounded-full border px-2.5 text-[10px] transition-colors",
                 active
                   ? "border-accent bg-primary-soft text-ink-strong"
                   : "border-border bg-paper text-ink-muted hover:border-accent/50 hover:text-ink",
@@ -773,7 +745,7 @@ function GapRow({
           {gap.category ? (
             <span
               className={classNames(
-                "inline-flex h-5 items-center rounded-full border px-2 font-mono text-[10px] uppercase tracking-widest",
+                "mg-type-micro inline-flex h-5 items-center rounded-full border px-2 text-[10px]",
                 matchedKind
                   ? "border-accent/50 bg-primary-soft text-accent"
                   : "border-transparent text-ink-muted",
@@ -815,7 +787,7 @@ function GapRow({
           <p className="mt-1.5 text-[12px] text-ink">↳ {gap.suggested_action}</p>
         ) : null}
         {matchedKind && (rawSources.length > 0 || gap.netuid != null) ? (
-          <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          <div className="mg-type-micro mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-ink-muted">
             <span>relevant sources:</span>
             {rawSources.map((s) => (
               <ExternalLink
@@ -872,7 +844,7 @@ function SeverityChip({ severity }: { severity?: string }) {
   return (
     <span
       className={classNames(
-        "inline-flex h-5 items-center rounded-full border bg-transparent px-2 font-mono text-[10px] uppercase tracking-widest",
+        "mg-type-micro inline-flex h-5 items-center rounded-full border bg-transparent px-2 text-[10px]",
         "before:content-[''] before:size-1.5 before:rounded-full before:mr-1.5",
         tone,
       )}
@@ -895,7 +867,7 @@ function FilterSelect({
 }) {
   return (
     <label className="inline-flex items-center gap-1.5 text-[11px] text-ink-muted">
-      <span className="font-mono uppercase tracking-widest text-[10px]">{label}</span>
+      <span className="mg-type-micro text-[10px]">{label}</span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -1023,7 +995,7 @@ function EnrichmentQueue() {
     <div className="rounded-xl border border-border bg-card overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
             <tr>
               <th className="px-4 py-2.5 text-left">ID</th>
               <th className="px-4 py-2.5 text-left">Netuid</th>
@@ -1079,7 +1051,7 @@ function EnrichmentTargets() {
     <div className="rounded-xl border border-border bg-card overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
             <tr>
               <th className="px-4 py-2.5 text-left">Netuid</th>
               <th className="px-4 py-2.5 text-left">Subnet</th>
@@ -1144,7 +1116,7 @@ function EnrichmentEvidence() {
     <div className="rounded-xl border border-border bg-card overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
             <tr>
               <th className="px-4 py-2.5 text-left">Netuid</th>
               <th className="px-4 py-2.5 text-left">Lane</th>

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -4,17 +4,16 @@ import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { resolveRefetchInterval, usePageVisible } from "@/hooks/use-refetch-interval";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { RefreshCw, Pause, Play, ChevronDown, ChevronRight, ArrowUpRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { Skeleton, StaleBanner } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { StaleBanner } from "@/components/metagraphed/states";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { IncidentCard } from "@/components/metagraphed/incident-card";
 import {
   HealthPill,
   TableState,
-  PageHero,
   ActionBar,
   PageSection,
   TimeAgo,
@@ -128,33 +127,31 @@ function HealthPage() {
 
   return (
     <AppShell>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-          <HealthHero
-            interval={effectiveInterval}
-            controls={
-              <>
-                <ActionBar>
-                  <Link
-                    to="/status"
-                    className="inline-flex items-center gap-1 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-                  >
-                    Public status
-                    <ArrowUpRight className="size-3" aria-hidden="true" />
-                  </Link>
-                </ActionBar>
-                <AutoRefreshControl
-                  enabled={enabled}
-                  visible={visible}
-                  intervalMs={intervalMs}
-                  onToggle={() => setEnabled((v) => !v)}
-                  onIntervalChange={setIntervalMs}
-                />
-              </>
-            }
-          />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="xl">
+        <HealthHero
+          interval={effectiveInterval}
+          controls={
+            <>
+              <ActionBar>
+                <Link
+                  to="/status"
+                  className="inline-flex items-center gap-1 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+                >
+                  Public status
+                  <ArrowUpRight className="size-3" aria-hidden="true" />
+                </Link>
+              </ActionBar>
+              <AutoRefreshControl
+                enabled={enabled}
+                visible={visible}
+                intervalMs={intervalMs}
+                onToggle={() => setEnabled((v) => !v)}
+                onIntervalChange={setIntervalMs}
+              />
+            </>
+          }
+        />
+      </AsyncPanel>
 
       <main className="space-y-20 md:space-y-24">
         <TimeRangeProvider>
@@ -166,11 +163,9 @@ function HealthPage() {
             toolbar={<TimeRangeScrub />}
             className={sectionRing("status-board")}
           >
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-56 w-full" />}>
-                <StatusBoard interval={effectiveInterval} />
-              </Suspense>
-            </QueryErrorBoundary>
+            <AsyncPanel height="lg">
+              <StatusBoard interval={effectiveInterval} />
+            </AsyncPanel>
           </PageSection>
 
           <PageSection
@@ -179,11 +174,9 @@ function HealthPage() {
             title="ok / warn / down distribution"
             description="Aggregate status over the selected range, with incident markers per bucket."
           >
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-                <NetworkPulseBand />
-              </Suspense>
-            </QueryErrorBoundary>
+            <AsyncPanel height="lg">
+              <NetworkPulseBand />
+            </AsyncPanel>
           </PageSection>
 
           <PageSection
@@ -192,11 +185,9 @@ function HealthPage() {
             title="Live status mosaic"
             description="Every monitored endpoint, colored by latest probe state. Filter by state; click a tile to open."
           >
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-                <StatusMosaic />
-              </Suspense>
-            </QueryErrorBoundary>
+            <AsyncPanel height="lg">
+              <StatusMosaic />
+            </AsyncPanel>
           </PageSection>
         </TimeRangeProvider>
 
@@ -217,11 +208,9 @@ function HealthPage() {
           description="Where the registry pulls evidence from and how fresh each source is."
           className={sectionRing("source-health")}
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <SourceHealth interval={effectiveInterval} />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <SourceHealth interval={effectiveInterval} />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -231,11 +220,9 @@ function HealthPage() {
           description="Grouped by host. Ongoing incidents bubble to the top."
           className={sectionRing("incidents")}
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <Incidents interval={effectiveInterval} />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="md">
+            <Incidents interval={effectiveInterval} />
+          </AsyncPanel>
         </PageSection>
       </main>
 
@@ -273,7 +260,7 @@ function HealthHero({
   const ongoing = incidents.filter((i) => !i.ended_at).length;
 
   return (
-    <PageHero
+    <PageMasthead
       eyebrow="Operations"
       live
       title="Health & freshness"
@@ -392,9 +379,7 @@ function AutoRefreshControl({
       >
         {enabled ? <Pause className="size-3" /> : <Play className="size-3" />}
         {pauseLabel ? (
-          <span className="font-mono uppercase tracking-widest text-[10px] text-ink-muted">
-            {pauseLabel}
-          </span>
+          <span className="mg-type-micro text-[10px] text-ink-muted">{pauseLabel}</span>
         ) : (
           <span aria-hidden="true" className="font-mono text-ink-muted">
             in <AnimatedNumber value={secondsLeft} flashOnChange={false} duration={250} />s
@@ -405,7 +390,7 @@ function AutoRefreshControl({
       <button
         type="button"
         onClick={() => qc.invalidateQueries({ queryKey: ["metagraphed"] })}
-        className="inline-flex items-center gap-1.5 px-3 py-1.5 font-mono uppercase tracking-widest text-[10px] text-ink-muted hover:text-ink-strong hover:bg-surface/60 transition-colors"
+        className="mg-type-micro inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] text-ink-muted hover:text-ink-strong hover:bg-surface/60 transition-colors"
         title={fetching ? "Refreshing…" : "Refresh now"}
         aria-label="Refresh now"
       >
@@ -530,7 +515,7 @@ function Cell({
 }) {
   return (
     <div className="rounded-lg border border-border/60 bg-paper/40 px-3 py-2.5">
-      <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">{label}</div>
+      <div className="mg-type-micro text-[10px] text-ink-muted">{label}</div>
       <div
         className={`mt-1 font-display text-lg font-semibold tabular-nums leading-none ${accent ?? "text-ink-strong"}`}
       >
@@ -557,7 +542,7 @@ function SourceHealth({ interval }: { interval: number | false }) {
   return (
     <div className="rounded-xl border border-border bg-card overflow-x-auto">
       <table className="w-full text-sm">
-        <thead className="bg-surface-2/60 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+        <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
           <tr>
             <th className="px-5 py-3 text-left">Source</th>
             <th className="px-5 py-3">Status</th>
@@ -776,7 +761,7 @@ function Incidents({ interval }: { interval: number | false }) {
                     )}
                     <HealthPill state={g.dominantState} />
                     <span className="font-mono text-[12px] text-ink-strong truncate">{g.host}</span>
-                    <span className="ml-auto inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted shrink-0">
+                    <span className="mg-type-micro ml-auto inline-flex items-center gap-2 text-[10px] text-ink-muted shrink-0">
                       {g.ongoing > 0 ? (
                         <span className="text-health-down">{g.ongoing} ongoing</span>
                       ) : null}

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -394,7 +394,7 @@ function HomeHero() {
               type="button"
               onClick={openCommandPalette}
               aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
-              className="flex flex-1 items-center gap-3 px-4 py-3.5 text-left text-sm text-ink-muted transition-colors hover:text-ink"
+              className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3.5 text-left text-sm text-ink-muted transition-colors hover:text-ink"
             >
               <svg
                 aria-hidden="true"
@@ -407,7 +407,7 @@ function HomeHero() {
                 <circle cx="11" cy="11" r="7" />
                 <path d="m20 20-3.5-3.5" strokeLinecap="round" />
               </svg>
-              <span className="flex-1 truncate">
+              <span className="min-w-0 flex-1 truncate">
                 Search subnets, validators, endpoints, accounts…
               </span>
               <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -1,34 +1,37 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useMemo } from "react";
+import { useMemo } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import {
-  EmptyState,
-  PageHeading,
-  Skeleton,
-  StaleBanner,
-  RECOVERY,
-} from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { EmptyState, PageHeading, StaleBanner, RECOVERY } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
-  EntityHero,
   BrandIcon,
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
   ShareButton,
 } from "@jsonbored/ui-kit";
-import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
+import {
+  AsyncPanel,
+  Breadcrumbs,
+  PageMasthead,
+  RoutePending,
+  TabStrip,
+} from "@/components/metagraphed/primitives";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
-import { providerQuery, providerEndpointsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
-import { API_BASE } from "@/lib/metagraphed/config";
+import {
+  providerQuery,
+  providerEndpointsQuery,
+  subnetsQuery,
+  metagraphedQueryKey,
+} from "@/lib/metagraphed/queries";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shouldShowProviderSlugSubtitle } from "@/lib/metagraphed/provider-hero-fields";
 import type { Endpoint, Subnet } from "@/lib/metagraphed/types";
 
+type ProviderTab = "overview" | "endpoints" | "subnets" | "evidence";
 type SearchParams = { tab?: string };
 
 export const Route = createFileRoute("/providers/$slug")({
@@ -63,6 +66,7 @@ export const Route = createFileRoute("/providers/$slug")({
       ],
     };
   },
+  pendingComponent: () => <RoutePending panels={3} />,
   component: ProviderDetail,
   notFoundComponent: () => (
     <AppShell>
@@ -79,26 +83,28 @@ export const Route = createFileRoute("/providers/$slug")({
 const TABS = [
   { id: "overview", label: "Overview" },
   { id: "endpoints", label: "Endpoints" },
-  { id: "subnets", label: "Subnets served" },
-  { id: "api", label: "API" },
+  { id: "subnets", label: "Subnets" },
+  { id: "evidence", label: "Evidence" },
 ] as const;
 
 const SECTION_TO_TAB: Record<string, string> = {
   "endpoints-glance": "overview",
   endpoints: "endpoints",
   "subnets-served": "subnets",
-  api: "api",
+  evidence: "evidence",
 };
 
 function ProviderDetail() {
   const { slug } = Route.useParams();
   return (
     <AppShell>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <ProviderShell slug={slug} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        height="md"
+        context="provider"
+        retryQueryKeys={[metagraphedQueryKey("provider", slug)]}
+      >
+        <ProviderShell slug={slug} />
+      </AsyncPanel>
     </AppShell>
   );
 }
@@ -106,40 +112,39 @@ function ProviderDetail() {
 function ProviderShell({ slug }: { slug: string }) {
   const { data: p, meta } = useSuspenseQuery(providerQuery(slug)).data;
   const summary = p?.endpoint_summary;
-  const tab = useActiveTab("overview");
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const tab = (
+    TABS.some((item) => item.id === search.tab) ? search.tab : "overview"
+  ) as ProviderTab;
   useHashScroll(tab, SECTION_TO_TAB);
   const stale = meta?.stale || isStaleFreshness(meta?.generated_at);
+  const setTab = (next: ProviderTab) =>
+    navigate({
+      search: { tab: next === "overview" ? undefined : next },
+      replace: true,
+      resetScroll: false,
+    });
 
   return (
     <>
-      <EntityHero
-        icon={
-          <BrandIcon
-            url={p?.website ?? p?.homepage}
-            iconUrl={p?.icon_url}
-            repoUrl={p?.repo}
-            providerSlug={slug}
-            name={p?.name ?? slug}
-            fallback={slug}
-            size={48}
-          />
-        }
-        eyebrow={
-          <span>
-            Provider
-            {p?.kind ? <> · {p.kind}</> : null}
-            {p?.authority ? <> · {p.authority}</> : null}
-          </span>
-        }
+      <Breadcrumbs
+        crumbs={[
+          { to: "/", label: "Home" },
+          { to: "/providers", label: "Providers" },
+          { to: `/providers/${slug}`, label: p?.name ?? slug },
+        ]}
+        className="mb-2"
+      />
+
+      <PageMasthead
+        eyebrow={["Provider", p?.kind, p?.authority].filter(Boolean).join(" · ")}
         title={p?.name ?? slug}
-        subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
-        description={p?.notes}
-        links={
-          // #5481: Share sits in this single connected bar with the link
-          // icons (not EntityHero's separate `actions` slot, which renders
-          // on its own row below) -- matching SegmentedToggle/ViewModeToggle's
-          // one-shared-border-and-divider look rather than separately spaced,
-          // individually-boxed icon buttons.
+        description={
+          p?.notes ?? "Public Bittensor infrastructure, endpoints, and supporting evidence."
+        }
+        live={(summary?.by_status?.ok ?? 0) > 0}
+        actions={
           <div className="inline-flex items-center rounded-md border border-border bg-card divide-x divide-border overflow-hidden">
             <PrimaryLinksRail
               bare
@@ -150,41 +155,46 @@ function ProviderShell({ slug }: { slug: string }) {
             <ShareButton connected />
           </div>
         }
-        stats={[
-          { label: "Endpoints", value: formatNumber(summary?.endpoint_count) },
-          { label: "Monitored", value: formatNumber(summary?.monitored_count) },
-          { label: "OK", value: formatNumber(summary?.by_status?.ok) },
-          { label: "Pool-eligible", value: formatNumber(summary?.pool_eligible_count) },
-        ]}
-        banner={
-          stale ? (
-            <StaleBanner
-              generatedAt={meta?.generated_at}
-              refreshQueryKeys={[
-                providerQuery(slug).queryKey,
-                providerEndpointsQuery(slug).queryKey,
-              ]}
-            />
-          ) : null
-        }
       />
+      {shouldShowProviderSlugSubtitle(p?.name, slug) ? (
+        <div className="-mt-2 mb-3 font-mono text-[11px] text-ink-muted">{slug}</div>
+      ) : null}
 
-      <ProfileTabs
-        tabs={TABS.map((t) =>
-          t.id === "endpoints" ? { ...t, count: summary?.endpoint_count } : t,
+      <div className="mg-kpi-strip">
+        <ProviderPulseTile label="Endpoints" value={formatNumber(summary?.endpoint_count)} />
+        <ProviderPulseTile label="Monitored" value={formatNumber(summary?.monitored_count)} />
+        <ProviderPulseTile label="Healthy" value={formatNumber(summary?.by_status?.ok)} tone="ok" />
+        <ProviderPulseTile
+          label="Pool eligible"
+          value={formatNumber(summary?.pool_eligible_count)}
+        />
+      </div>
+      {stale ? (
+        <StaleBanner
+          generatedAt={meta?.generated_at}
+          refreshQueryKeys={[providerQuery(slug).queryKey, providerEndpointsQuery(slug).queryKey]}
+        />
+      ) : null}
+
+      <TabStrip
+        items={TABS.map((item) =>
+          item.id === "endpoints" ? { ...item, meta: summary?.endpoint_count } : item,
         )}
-        defaultTab="overview"
+        value={tab}
+        onChange={setTab}
+        ariaLabel="Provider profile sections"
+        className="mt-4 overflow-x-auto"
       />
 
-      <div className="mt-8 grid gap-8 lg:grid-cols-3">
-        <div className="lg:col-span-2 space-y-8">
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_17rem]">
+        <div className="min-w-0 space-y-6">
           {tab === "overview" ? <OverviewPanel slug={slug} /> : null}
           {tab === "endpoints" ? <EndpointsPanel slug={slug} /> : null}
           {tab === "subnets" ? <SubnetsServedPanel slug={slug} /> : null}
-          {tab === "api" ? <ApiPanel slug={slug} /> : null}
+          {tab === "evidence" ? <EvidencePanel slug={slug} provider={p} /> : null}
         </div>
 
-        <aside className="space-y-4 lg:sticky lg:top-32 self-start">
+        <aside className="space-y-3 border-t border-border pt-4 lg:sticky lg:top-32 lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0 self-start">
           {summary?.by_kind ? <BreakdownCard title="By kind" data={summary.by_kind} /> : null}
           {summary?.by_status ? <BreakdownCard title="By status" data={summary.by_status} /> : null}
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
@@ -198,6 +208,23 @@ function ProviderShell({ slug }: { slug: string }) {
   );
 }
 
+function ProviderPulseTile({ label, value, tone }: { label: string; value: string; tone?: "ok" }) {
+  return (
+    <div>
+      <div className="mg-label">{label}</div>
+      <div
+        className={
+          tone === "ok"
+            ? "mt-1 font-mono text-xl text-health-ok"
+            : "mt-1 font-mono text-xl text-ink-strong"
+        }
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
 function OverviewPanel({ slug }: { slug: string }) {
   return (
     <>
@@ -207,11 +234,13 @@ function OverviewPanel({ slug }: { slug: string }) {
         subtitle="Root RPC/WSS, SSE/data streams, and open incidents — one tap to expand."
         info="Compact operational summary across this provider's endpoints."
       >
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-40 w-full" />}>
-            <EndpointsGlanceLoader slug={slug} />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel
+          height="md"
+          context="endpoints"
+          retryQueryKeys={[metagraphedQueryKey("provider-endpoints", slug)]}
+        >
+          <EndpointsGlanceLoader slug={slug} />
+        </AsyncPanel>
       </SectionAnchor>
 
       <SectionAnchor
@@ -220,11 +249,16 @@ function OverviewPanel({ slug }: { slug: string }) {
         subtitle="Active netuids where this provider operates endpoints."
         info="Grouped by netuid — click any to open the subnet profile."
       >
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-            <SubnetsServedGrid slug={slug} compact />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel
+          height="sm"
+          context="subnets served"
+          retryQueryKeys={[
+            metagraphedQueryKey("provider-endpoints", slug),
+            metagraphedQueryKey("subnets"),
+          ]}
+        >
+          <SubnetsServedGrid slug={slug} compact />
+        </AsyncPanel>
       </SectionAnchor>
     </>
   );
@@ -238,11 +272,13 @@ function EndpointsPanel({ slug }: { slug: string }) {
       subtitle="Probe-derived health, latency, and freshness."
       info="Each endpoint is probed periodically. Health reflects the most recent probe."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-          <EndpointsTableLoader slug={slug} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        height="lg"
+        context="endpoints"
+        retryQueryKeys={[metagraphedQueryKey("provider-endpoints", slug)]}
+      >
+        <EndpointsTableLoader slug={slug} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -254,11 +290,16 @@ function SubnetsServedPanel({ slug }: { slug: string }) {
       title="Subnets served"
       subtitle="Active netuids where this provider operates endpoints."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <SubnetsServedGrid slug={slug} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        height="md"
+        context="subnets served"
+        retryQueryKeys={[
+          metagraphedQueryKey("provider-endpoints", slug),
+          metagraphedQueryKey("subnets"),
+        ]}
+      >
+        <SubnetsServedGrid slug={slug} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -403,29 +444,40 @@ function BreakdownCard({ title, data }: { title: string; data: Record<string, nu
   );
 }
 
-function ApiPanel({ slug }: { slug: string }) {
-  const rows: Array<{ label: string; path: string }> = [
-    { label: "provider", path: `/api/v1/providers/${slug}` },
-    { label: "endpoints", path: `/api/v1/providers/${slug}/endpoints` },
-    { label: "artifact", path: `/metagraph/providers/${slug}.json` },
-  ];
+function EvidencePanel({
+  slug,
+  provider,
+}: {
+  slug: string;
+  provider: { website?: string; homepage?: string; docs?: string; repo?: string };
+}) {
   return (
     <SectionAnchor
-      id="api"
-      title="API & artifacts"
-      subtitle="Canonical URLs powering this profile."
-      info="Copy any of these URLs to fetch the raw JSON directly."
+      id="evidence"
+      title="Evidence & source links"
+      subtitle="Public references and canonical data behind this profile."
+      info="Provider links are source context; canonical API and artifact URLs expose the normalized registry record."
     >
       <div className="space-y-2">
-        {rows.map((r) => (
+        {(provider.website ?? provider.homepage) ? (
           <CopyableCode
-            key={r.label}
-            label={r.label}
-            value={`${API_BASE}${r.path}`}
+            label="website"
+            value={provider.website ?? provider.homepage ?? ""}
             truncate={false}
             className="w-full"
           />
-        ))}
+        ) : null}
+        {provider.docs ? (
+          <CopyableCode label="docs" value={provider.docs} truncate={false} className="w-full" />
+        ) : null}
+        {provider.repo ? (
+          <CopyableCode
+            label="repository"
+            value={provider.repo}
+            truncate={false}
+            className="w-full"
+          />
+        ) : null}
       </div>
     </SectionAnchor>
   );

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -1,22 +1,30 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, useMemo, type ReactNode } from "react";
+import { useSuspenseQuery, useIsFetching } from "@tanstack/react-query";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Globe, Github, BookOpen, Radio, Layers, Network } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
-  ResetFiltersButton,
-  SearchInput,
-  SelectFilter,
-} from "@/components/metagraphed/table-controls";
+  AsyncPanel,
+  FilterChipRow,
+  FilterSheet,
+  PageMasthead,
+  QueryBar,
+  QueryProgress,
+  RoutePending,
+  type FilterChipItem,
+} from "@/components/metagraphed/primitives";
+import { CopyLinkButton } from "@/components/metagraphed/primitives/copy-link-button";
+import { ResponsiveTable } from "@/components/metagraphed/primitives/responsive-table";
+import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import {
   providersQuery,
   endpointsQuery,
   sourceHealthProvidersQuery,
+  metagraphedQueryKey,
   type ProviderCounts,
 } from "@/lib/metagraphed/queries";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
@@ -24,20 +32,16 @@ import { matchesQuery } from "@/lib/metagraphed/url-state";
 import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { resolveProviderCard } from "@/lib/metagraphed/provider-card-fields";
-import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
 import {
   BrandIcon,
   prefetchBrandIcon,
-  PageHero,
   ViewModeToggle,
   ShareButton,
   DownloadCsvButton,
   TimeAgo,
   ActionBar,
-  Donut,
-  DonutLegend,
-  Sparkline,
 } from "@jsonbored/ui-kit";
+import { ProvidersPulseRail } from "@/components/metagraphed/providers-pulse-rail";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import type { Provider } from "@/lib/metagraphed/types";
 
@@ -69,6 +73,7 @@ export const Route = createFileRoute("/providers/")({
       },
     ],
   }),
+  pendingComponent: () => <RoutePending panels={3} />,
   component: ProvidersPage,
 });
 
@@ -90,8 +95,7 @@ function ProvidersPage() {
   const providersCsvUrl = buildUrl("/api/v1/providers");
   return (
     <AppShell>
-      <PageHero
-        eyebrow="Infrastructure"
+      <PageMasthead
         live
         title="Providers"
         description="Teams, infra operators, docs registries, and community sources behind public interfaces."
@@ -115,11 +119,23 @@ function ProvidersPage() {
           </>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<ProvidersSkeleton />}>
-          <ProvidersGrid view={view} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        height="sm"
+        context="providers pulse"
+        retryQueryKeys={[metagraphedQueryKey("providers")]}
+      >
+        <ProvidersPulseRailLoader />
+      </AsyncPanel>
+      <AsyncPanel
+        context="providers"
+        fallback={<ProvidersSkeleton />}
+        retryQueryKeys={[
+          metagraphedQueryKey("providers"),
+          metagraphedQueryKey("source-health-providers"),
+        ]}
+      >
+        <ProvidersGrid view={view} />
+      </AsyncPanel>
       <ApiSourceFooter
         paths={["/api/v1/providers", "/api/v1/source-health"]}
         artifacts={["/metagraph/providers.json"]}
@@ -272,6 +288,9 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
     };
   }, [sorted]);
 
+  // Hooks must run unconditionally before the early return below.
+  const isFetchingProviders = useIsFetching({ queryKey: metagraphedQueryKey("providers") }) > 0;
+
   if (rows.length === 0)
     return (
       <EmptyState
@@ -292,59 +311,96 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
         />
       ) : null}
 
-      <ProviderOverview providers={rows} counts={counts} />
       <SourceHealthRollup />
 
-      {/* Filter toolbar — every control stretches to fill its track so the row stays
-          justified (flush on both ends), reflowing cleanly down to narrow viewports. */}
-      <div className="sticky top-14 z-20 -mx-4 border-y border-border bg-paper/95 px-4 py-2.5 backdrop-blur supports-[backdrop-filter]:bg-paper/80 md:mx-0 md:rounded-lg md:border md:bg-card md:px-3">
-        <div className="flex w-full flex-wrap items-stretch gap-2">
-          <div className="flex w-full basis-full md:w-auto md:flex-[2] md:basis-0">
-            <SearchInput
-              value={q}
-              onChange={(v) => setSearch({ q: v })}
-              placeholder="Search providers, slugs, hosts…"
-            />
-          </div>
-          <div className="flex flex-1 basis-full min-[480px]:min-w-[7rem] min-[480px]:basis-0">
-            <SelectFilter
-              fill
+      <div className="sticky top-[var(--mg-sticky-offset)] z-20 bg-paper/95 py-2 backdrop-blur-sm">
+        <QueryBar ariaLabel="Provider directory filters">
+          <QueryBar.Search
+            value={q}
+            onChange={(v) => setSearch({ q: v })}
+            placeholder="Search providers, slugs, hosts…"
+            debounceMs={200}
+            shortcut
+          />
+          <div className="hidden items-center md:flex">
+            <QueryBar.FilterTrigger
               label="Kind"
               value={kind}
               onChange={(v) => setSearch({ kind: v })}
-              options={kinds.map((k) => ({ value: k, label: k }))}
+              options={kinds.map((value) => ({ value, label: value }))}
             />
-          </div>
-          <div className="flex flex-1 basis-full min-[480px]:min-w-[7rem] min-[480px]:basis-0">
-            <SelectFilter
-              fill
+            <QueryBar.FilterTrigger
               label="Authority"
               value={authority}
               onChange={(v) => setSearch({ authority: v })}
-              options={authorityOptions.map((a) => ({ value: a, label: a }))}
+              options={authorityOptions.map((value) => ({
+                value,
+                label: value === "high" ? "Official + claimed" : value,
+              }))}
             />
-          </div>
-          <div className="flex flex-1 basis-full min-[480px]:min-w-[7rem] min-[480px]:basis-0">
-            <SelectFilter
-              fill
+            <QueryBar.FilterTrigger
               label="Sort"
               value={sortKey}
               onChange={(v) => setSearch({ sort: v as ProviderSortKey })}
-              options={providerSortKeys.map((s) => ({ value: s, label: s }))}
-              allowEmpty={false}
+              options={providerSortKeys.map((value) => ({ value, label: value }))}
             />
           </div>
-        </div>
-        <div className="mt-2 flex items-center gap-2">
-          <ResetFiltersButton
-            active={hasFilters}
-            onReset={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
-          />
-          <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted tabular-nums">
-            {sorted.length} of {rows.length} providers
-          </span>
-        </div>
+          <QueryBar.Utility>
+            <FilterSheet
+              label="More filters"
+              className="md:hidden"
+              activeCount={(kind ? 1 : 0) + (authority ? 1 : 0) + (sortKey !== "name" ? 1 : 0)}
+            >
+              <QueryBar.FilterTrigger
+                label="Kind"
+                value={kind}
+                onChange={(v) => setSearch({ kind: v })}
+                options={kinds.map((value) => ({ value, label: value }))}
+                className="w-full justify-between border border-border"
+              />
+              <QueryBar.FilterTrigger
+                label="Authority"
+                value={authority}
+                onChange={(v) => setSearch({ authority: v })}
+                options={authorityOptions.map((value) => ({
+                  value,
+                  label: value === "high" ? "Official + claimed" : value,
+                }))}
+                className="w-full justify-between border border-border"
+              />
+              <QueryBar.FilterTrigger
+                label="Sort"
+                value={sortKey}
+                onChange={(v) => setSearch({ sort: v as ProviderSortKey })}
+                options={providerSortKeys.map((value) => ({ value, label: value }))}
+                className="w-full justify-between border border-border"
+              />
+            </FilterSheet>
+            <ResetFiltersButton
+              active={hasFilters}
+              onReset={() => setSearch({ q: "", kind: "", authority: "", sort: "name" })}
+              bare
+            />
+            <span className="hidden px-2 mg-type-micro tabular-nums sm:inline">
+              {sorted.length} of {rows.length} providers
+            </span>
+          </QueryBar.Utility>
+        </QueryBar>
       </div>
+
+      <FilterChipRow
+        items={[
+          ...(q ? [{ id: "q", label: "Search", value: q } as FilterChipItem] : []),
+          ...(kind ? [{ id: "kind", label: "Kind", value: kind } as FilterChipItem] : []),
+          ...(authority
+            ? [{ id: "authority", label: "Authority", value: authority } as FilterChipItem]
+            : []),
+        ]}
+        onRemove={(id) => setSearch({ [id]: "" } as Parameters<typeof setSearch>[0])}
+        onClearAll={() => setSearch({ q: "", kind: "", authority: "" })}
+      />
+
+      <QueryProgress active={isFetchingProviders} position="sticky" />
 
       {sorted.length === 0 ? (
         <EmptyState
@@ -420,9 +476,12 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
               );
             })}
           </div>
-          <div className="hidden overflow-x-auto rounded border border-border bg-card lg:block">
+          <ResponsiveTable
+            className="hidden rounded border border-border bg-card lg:block"
+            minWidth={960}
+          >
             <table className="w-full text-left text-sm">
-              <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+              <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
                 <tr>
                   <th className="px-3 py-2">Provider</th>
                   <th className="px-3 py-2">Kind</th>
@@ -439,7 +498,11 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                   const host = maskHost(p.website ?? p.homepage);
                   const c = counts[p.slug];
                   return (
-                    <tr key={p.slug} className="hover:bg-surface/40">
+                    <tr
+                      key={p.slug}
+                      id={`provider-${p.slug}`}
+                      className="mg-row-accent hover:bg-surface/40 target:bg-accent/5"
+                    >
                       <td className="px-3 py-2">
                         <Link
                           to="/providers/$slug"
@@ -493,14 +556,23 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                         {c?.endpoints ?? 0}
                       </td>
                       <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
-                        <TimeAgo at={typeof p.updated_at === "string" ? p.updated_at : undefined} />
+                        <div className="inline-flex items-center gap-1 justify-end">
+                          <TimeAgo
+                            at={typeof p.updated_at === "string" ? p.updated_at : undefined}
+                          />
+                          <CopyLinkButton
+                            hash={`provider-${p.slug}`}
+                            size="xs"
+                            tooltip="Copy link to provider"
+                          />
+                        </div>
                       </td>
                     </tr>
                   );
                 })}
               </tbody>
             </table>
-          </div>
+          </ResponsiveTable>
         </>
       ) : (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -672,99 +744,8 @@ function SourceHealthRollup() {
   );
 }
 
-function ProviderOverview({
-  providers,
-  counts,
-}: {
-  providers: Provider[];
-  counts: Record<string, { surfaces: number; endpoints: number; subnets: number }>;
-}) {
-  const kinds = providers.reduce<Record<string, number>>((acc, p) => {
-    const k = p.kind ?? "other";
-    acc[k] = (acc[k] ?? 0) + 1;
-    return acc;
-  }, {});
-  const kindPalette = [
-    "var(--chart-1)",
-    "var(--chart-2)",
-    "var(--chart-3)",
-    "var(--chart-4)",
-    "var(--chart-5)",
-    "var(--chart-6)",
-  ];
-  const kindSegs = Object.entries(kinds)
-    .sort((a, b) => b[1] - a[1])
-    .map(([label, value], i) => ({ label, value, color: kindPalette[i % kindPalette.length]! }));
-
-  // The /providers list omits per-provider endpoint_summary (only the detail
-  // route has it), so derive the cross-provider endpoint health from the
-  // endpoints collection directly.
-  const endpoints = useSuspenseQuery(endpointsQuery({ limit: 1000 })).data.data ?? [];
-  const endpointStatus = endpoints.reduce(
-    (acc, e) => {
-      const h = e.health ?? "unknown";
-      if (h === "ok") acc.ok += 1;
-      else if (h === "warn") acc.warn += 1;
-      else if (h === "down") acc.down += 1;
-      else acc.unknown += 1;
-      return acc;
-    },
-    { ok: 0, warn: 0, down: 0, unknown: 0 },
-  );
-  const statusSegs = healthStatusSegments(endpointStatus, { warnLabel: "Warn" });
-
-  // Top providers by endpoint count, as a sparkline of counts.
-  const topCounts = providers
-    .map((p) => counts[p.slug]?.endpoints ?? 0)
-    .sort((a, b) => b - a)
-    .slice(0, 20);
-  const totalEndpoints = providers.reduce((a, p) => a + (counts[p.slug]?.endpoints ?? 0), 0);
-
-  return (
-    <div className="grid gap-3 md:grid-cols-3">
-      <div className="rounded border border-border bg-card p-3 flex items-center gap-4">
-        <Donut
-          segments={kindSegs}
-          size={88}
-          strokeWidth={11}
-          centerLabel={String(providers.length)}
-          centerSub="providers"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="mg-label mb-1">By kind</div>
-          <DonutLegend segments={kindSegs.slice(0, 5)} />
-        </div>
-      </div>
-      <div className="rounded border border-border bg-card p-3 flex items-center gap-4">
-        <Donut
-          segments={statusSegs}
-          size={88}
-          strokeWidth={11}
-          centerLabel={String(
-            endpointStatus.ok + endpointStatus.warn + endpointStatus.down + endpointStatus.unknown,
-          )}
-          centerSub="endpoints"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="mg-label mb-1">Endpoint health</div>
-          <DonutLegend segments={statusSegs} />
-        </div>
-      </div>
-      <div className="rounded border border-border bg-card p-3">
-        <div className="mg-label mb-1">Top providers · endpoints</div>
-        <div className="font-display text-lg font-semibold text-ink-strong tabular-nums">
-          {totalEndpoints}
-        </div>
-        <Sparkline
-          values={topCounts}
-          width={260}
-          height={48}
-          ariaLabel="Top providers by endpoint count"
-        />
-        <div className="mt-1 font-mono text-[10px] text-ink-muted">
-          across {providers.length} providers
-        </div>
-      </div>
-    </div>
-  );
+function ProvidersPulseRailLoader() {
+  const { data } = useSuspenseQuery(providersQuery());
+  const providers = (data.data ?? []) as Provider[];
+  return <ProvidersPulseRail providers={providers} />;
 }

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -5,11 +5,11 @@ import { fallback } from "@tanstack/zod-adapter";
 import { z } from "zod";
 import { ChevronLeft, FileCode, Copy, Check } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { Panel, PageMasthead } from "@/components/metagraphed/primitives";
 import {
   TimeAgo,
   CopyableCode,
   ExternalLink,
-  PageHero,
   PageSection,
   AnimatedNumber,
   MethodologyCallout,
@@ -190,7 +190,7 @@ function SchemasHero() {
   const contractsCount = (cRes.data ?? []).length;
 
   return (
-    <PageHero
+    <PageMasthead
       eyebrow="Operations"
       live
       title="Schemas & contracts"
@@ -262,7 +262,7 @@ function ContractsList() {
       {rows.map((c) => {
         const artifactUrl = sameOriginApiUrl(c.path);
         return (
-          <div key={c.id} className="rounded-xl border border-border bg-card p-4 mg-hover-lift">
+          <Panel key={c.id} dense interactive>
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 <div className="font-display text-sm font-semibold text-ink-strong">{c.id}</div>
@@ -279,7 +279,7 @@ function ContractsList() {
                 </ExternalLink>
               </div>
             ) : null}
-          </div>
+          </Panel>
         );
       })}
     </div>
@@ -371,7 +371,7 @@ function SchemaExplorer() {
                   type="button"
                   onClick={() => setSearch({ drift: v })}
                   className={classNames(
-                    "flex-1 rounded-full border px-2 py-1 font-mono text-[10px] uppercase tracking-widest transition-all duration-150",
+                    "mg-type-micro flex-1 rounded-full border px-2 py-1 text-[10px] transition-all duration-150",
                     search.drift === v
                       ? "border-ink/40 bg-ink-strong text-paper"
                       : "border-border bg-paper text-ink-muted hover:text-ink-strong hover:border-accent/40",
@@ -382,7 +382,7 @@ function SchemaExplorer() {
               ))}
             </div>
             <div className="flex items-center justify-between gap-2">
-              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <div className="mg-type-micro text-[10px] text-ink-muted">
                 {filtered.length} of {all.length}
               </div>
               {/* One-click way back to the unfiltered view for a shared
@@ -487,7 +487,7 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
                   replace: true,
                 })
               }
-              className="lg:hidden inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong mb-2"
+              className="mg-type-micro lg:hidden inline-flex items-center gap-1 text-[10px] text-ink-muted hover:text-ink-strong mb-2"
             >
               <ChevronLeft className="size-3" /> back
             </button>
@@ -496,11 +496,11 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
                 {schema.name ?? schema.id}
               </h3>
               {schema.drift ? (
-                <span className="inline-flex items-center rounded-full border border-health-warn/40 bg-health-warn/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-health-warn">
+                <span className="mg-type-micro inline-flex items-center rounded-full border border-health-warn/40 bg-health-warn/10 px-2 py-0.5 text-[10px] text-health-warn">
                   drift
                 </span>
               ) : (
-                <span className="inline-flex items-center rounded-full border border-health-ok/40 bg-health-ok/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-health-ok">
+                <span className="mg-type-micro inline-flex items-center rounded-full border border-health-ok/40 bg-health-ok/10 px-2 py-0.5 text-[10px] text-health-ok">
                   stable
                 </span>
               )}

--- a/apps/ui/src/routes/subnets-total-stake-tile.test.ts
+++ b/apps/ui/src/routes/subnets-total-stake-tile.test.ts
@@ -40,9 +40,12 @@ describe("subnets.index.tsx Total stake tile (#6271)", () => {
     expect(strip).toContain("useSuspenseQuery(economicsTrendsQuery())");
   });
 
-  it("the Suspense fallback skeleton count matches the real tile count (5), avoiding a layout shift on load", () => {
-    const fallback = source.slice(source.indexOf("<Suspense"), source.indexOf("<SubnetsStatStrip"));
-    const skeletonCount = (fallback.match(/<Skeleton className="h-20"/g) ?? []).length;
+  it("the AsyncPanel fallback skeleton count matches the real tile count (5), avoiding a layout shift on load", () => {
+    const fallback = source.slice(
+      source.indexOf('context="subnets summary"'),
+      source.indexOf("<SubnetsStatStrip"),
+    );
+    const skeletonCount = (fallback.match(/<PanelSkeleton height="xs" \/>/g) ?? []).length;
     const tileCount = (strip.match(/<StatTile/g) ?? []).length;
     expect(skeletonCount).toBe(tileCount);
     expect(skeletonCount).toBe(5);

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -19,6 +19,12 @@ import {
   Coins,
   UserMinus,
 } from "lucide-react";
+import {
+  AsyncPanel,
+  CopyLinkButton,
+  MobileCollapse,
+  ResponsiveTable,
+} from "@/components/metagraphed/primitives";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton, RECOVERY } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -36,6 +42,7 @@ import {
   HealthPill,
   CopyableCode,
   MethodologyCallout,
+  BackToTop,
   StatTile,
   RealtimeFreshness,
 } from "@jsonbored/ui-kit";
@@ -113,28 +120,33 @@ import { OperationalPanel } from "@/components/metagraphed/operational-panel";
 import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
 import { GittensorRegisteredRepos } from "@/components/metagraphed/gittensor-registered-repos";
 import { SubnetProfilePanel } from "@/components/metagraphed/subnet-profile-panel";
+import { SubnetPriorityHighlights } from "@/components/metagraphed/subnet-priority-highlights";
 import { SubnetPulseStrip } from "@/components/metagraphed/subnet-pulse-strip";
 import { SubnetValidatorsPreview } from "@/components/metagraphed/subnet-validators-preview";
 import { SubnetFilterProvider } from "@/components/metagraphed/subnet-filter-context";
 import { SubnetCompareDrawer } from "@/components/metagraphed/subnet-compare-drawer";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { WatchSubnetAlert } from "@/components/metagraphed/watch-subnet-alert";
+import { SubnetWindowProvider, SubnetWindowToggle } from "@/lib/metagraphed/subnet-window";
 
 type SearchParams = {
   tab?: string;
   sev?: string;
   uid?: number;
   ev_kind?: string;
+  window?: "7d" | "30d" | "90d";
 };
 
 export const Route = createFileRoute("/subnets/$netuid")({
   validateSearch: (s: Record<string, unknown>): SearchParams => {
     const uidNum = Number(s.uid);
+    const win = s.window;
     return {
       tab: typeof s.tab === "string" ? s.tab : undefined,
       sev: typeof s.sev === "string" ? s.sev : undefined,
       uid: Number.isInteger(uidNum) && uidNum >= 0 ? uidNum : undefined,
       ev_kind: typeof s.ev_kind === "string" && s.ev_kind ? s.ev_kind : undefined,
+      window: win === "7d" || win === "30d" || win === "90d" ? win : undefined,
     };
   },
   parseParams: ({ netuid }) => {
@@ -246,12 +258,13 @@ const SECTION_TO_TAB: Record<string, string> = {
 function SubnetDetailPage() {
   const { netuid } = Route.useParams();
   return (
-    <AppShell>
+    <AppShell flushTop>
       <QueryErrorBoundary>
         <Suspense fallback={<DetailSkeleton />}>
           <ProfileShell netuid={netuid} />
         </Suspense>
       </QueryErrorBoundary>
+      <BackToTop />
     </AppShell>
   );
 }
@@ -282,108 +295,115 @@ function ProfileShell({ netuid }: { netuid: number }) {
 
   return (
     <TimeRangeProvider>
-      <SubnetFilterProvider>
-        <SubnetMasthead
-          netuid={netuid}
-          profile={profile}
-          generatedAt={meta?.generated_at}
-          stale={stale}
-          evidenceCount={evidenceCount}
-          refreshQueryKeys={[
-            subnetProfileQuery(netuid).queryKey,
-            subnetSurfacesQuery(netuid).queryKey,
-            subnetEndpointsQuery(netuid).queryKey,
-            subnetHealthQuery(netuid).queryKey,
-            subnetCandidatesQuery(netuid).queryKey,
-          ]}
-          refreshLabel="Refresh health now"
-        />
+      <SubnetWindowProvider>
+        <SubnetFilterProvider>
+          <SubnetMasthead
+            netuid={netuid}
+            profile={profile}
+            generatedAt={meta?.generated_at}
+            stale={stale}
+            evidenceCount={evidenceCount}
+            refreshQueryKeys={[
+              subnetProfileQuery(netuid).queryKey,
+              subnetSurfacesQuery(netuid).queryKey,
+              subnetEndpointsQuery(netuid).queryKey,
+              subnetHealthQuery(netuid).queryKey,
+              subnetCandidatesQuery(netuid).queryKey,
+            ]}
+            refreshLabel="Refresh health now"
+          />
 
-        <SubnetValidatorsPreview netuid={netuid} />
+          <SubnetValidatorsPreview netuid={netuid} />
 
-        <SubnetPulseStrip netuid={netuid} />
+          <SubnetPulseStrip netuid={netuid} />
 
-        <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
-          <SubnetCompareDrawer netuid={netuid} />
-        </div>
+          <div className="mt-4">
+            <MethodologyCallout generatedAt={meta?.generated_at} windowLabel="7d" />
+          </div>
 
-        <div className="mt-4">
-          <MethodologyCallout generatedAt={meta?.generated_at} windowLabel="7d" />
-        </div>
+          <div className="mt-2">
+            <ProfileTabs
+              tabs={tabsWithCounts}
+              defaultTab="overview"
+              trailing={
+                <>
+                  <SubnetWindowToggle />
+                  <SubnetCompareDrawer netuid={netuid} />
+                </>
+              }
+            />
+          </div>
 
-        <div className="mt-2">
-          <ProfileTabs tabs={tabsWithCounts} defaultTab="overview" />
-        </div>
+          <div className="mt-6 min-w-0 space-y-8">
+            {tab === "overview" ? <OverviewPanel netuid={netuid} profile={profile} /> : null}
+            {tab === "metagraph" ? <MetagraphPanel netuid={netuid} /> : null}
+            {tab === "validators" ? <ValidatorsPanel netuid={netuid} /> : null}
+            {tab === "activity" ? <ActivityPanel netuid={netuid} /> : null}
+            {tab === "identity" ? <IdentityHistoryPanel netuid={netuid} /> : null}
+            {tab === "hyperparameters" ? (
+              <div className="space-y-8">
+                <HyperparametersPanel netuid={netuid} />
+                <HyperparamsHistoryPanel netuid={netuid} />
+              </div>
+            ) : null}
+            {tab === "services" ? <CallableServicesPanel netuid={netuid} /> : null}
+            {tab === "surfaces" ? <SurfacesPanel netuid={netuid} /> : null}
+            {tab === "endpoints" ? <EndpointsPanel netuid={netuid} /> : null}
+            {tab === "schemas" ? <SchemasPanel netuid={netuid} /> : null}
+            {tab === "candidates" ? <CandidatesPanel netuid={netuid} /> : null}
+            {tab === "gaps" ? <GapsPanel netuid={netuid} /> : null}
+            {tab === "evidence" ? (
+              <SectionAnchor
+                id="evidence"
+                title="Evidence & sources"
+                subtitle="Primary links and recorded evidence backing this profile."
+                info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
+              >
+                <EvidencePanel netuid={netuid} />
+              </SectionAnchor>
+            ) : null}
+            {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
+          </div>
 
-        <div className="mt-6 min-w-0 space-y-8">
-          {tab === "overview" ? <OverviewPanel netuid={netuid} profile={profile} /> : null}
-          {tab === "metagraph" ? <MetagraphPanel netuid={netuid} /> : null}
-          {tab === "validators" ? <ValidatorsPanel netuid={netuid} /> : null}
-          {tab === "activity" ? <ActivityPanel netuid={netuid} /> : null}
-          {tab === "identity" ? <IdentityHistoryPanel netuid={netuid} /> : null}
-          {tab === "hyperparameters" ? (
-            <div className="space-y-8">
-              <HyperparametersPanel netuid={netuid} />
-              <HyperparamsHistoryPanel netuid={netuid} />
-            </div>
-          ) : null}
-          {tab === "services" ? <CallableServicesPanel netuid={netuid} /> : null}
-          {tab === "surfaces" ? <SurfacesPanel netuid={netuid} /> : null}
-          {tab === "endpoints" ? <EndpointsPanel netuid={netuid} /> : null}
-          {tab === "schemas" ? <SchemasPanel netuid={netuid} /> : null}
-          {tab === "candidates" ? <CandidatesPanel netuid={netuid} /> : null}
-          {tab === "gaps" ? <GapsPanel netuid={netuid} /> : null}
-          {tab === "evidence" ? (
+          {/* #6558: the backend accepts netuid-scoped alert triggers, but only the
+              validator page exposed a Watch UI. Extend the same pattern here.
+              Outside the tab switch, so it's reachable from any tab -- same as the
+              "Watch this validator" section on the validator page. */}
+          <div className="mt-8">
             <SectionAnchor
-              id="evidence"
-              title="Evidence & sources"
-              subtitle="Primary links and recorded evidence backing this profile."
-              info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
+              id="watch"
+              title="Watch this subnet"
+              subtitle="Alert on on-chain activity for this subnet, via the existing chain alert-triggers API."
+              tone="accent"
             >
-              <EvidencePanel netuid={netuid} />
+              <WatchSubnetAlert netuid={netuid} />
             </SectionAnchor>
-          ) : null}
-          {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
-        </div>
+          </div>
 
-        {/* #6558: the backend accepts netuid-scoped alert triggers, but only the
-            validator page exposed a Watch UI. Extend the same pattern here.
-            Outside the tab switch, so it's reachable from any tab -- same as the
-            "Watch this validator" section on the validator page. */}
-        <div className="mt-8">
-          <SectionAnchor
-            id="watch"
-            title="Watch this subnet"
-            subtitle="Alert on on-chain activity for this subnet, via the existing chain alert-triggers API."
-            tone="accent"
-          >
-            <WatchSubnetAlert netuid={netuid} />
-          </SectionAnchor>
-        </div>
+          {/* #6432: outside the tab switch, so the way back is there whichever
+              tab a reader ends on -- this profile is the longest page in the app
+              and the masthead breadcrumb is far behind by the time they finish.
+              Same placement/styling as blocks.$ref.tsx and extrinsics.$hash.tsx. */}
+          <div className="mt-6">
+            <Link
+              to="/subnets"
+              className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+            >
+              ← All subnets
+            </Link>
+          </div>
 
-        {/* #6432: outside the tab switch, so the way back is there whichever
-            tab a reader ends on -- this profile is the longest page in the app
-            and the masthead breadcrumb is far behind by the time they finish.
-            Same placement/styling as blocks.$ref.tsx and extrinsics.$hash.tsx. */}
-        <div className="mt-6">
-          <Link
-            to="/subnets"
-            className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
-          >
-            ← All subnets
-          </Link>
-        </div>
-
-        <ApiSourceFooter
-          paths={[
-            `/api/v1/subnets/${netuid}/profile`,
-            `/api/v1/subnets/${netuid}/overview`,
-            `/api/v1/subnets/${netuid}/identity-history`,
-            `/api/v1/subnets/${netuid}/lease`,
-            `/api/v1/subnets/${netuid}/lease/history`,
-          ]}
-        />
-      </SubnetFilterProvider>
+          <ApiSourceFooter
+            paths={[
+              `/api/v1/subnets/${netuid}/profile`,
+              `/api/v1/subnets/${netuid}/overview`,
+              `/api/v1/subnets/${netuid}/identity-history`,
+              `/api/v1/subnets/${netuid}/lease`,
+              `/api/v1/subnets/${netuid}/lease/history`,
+            ]}
+          />
+        </SubnetFilterProvider>
+      </SubnetWindowProvider>
     </TimeRangeProvider>
   );
 }
@@ -400,65 +420,45 @@ function DetailSkeleton() {
 
 /* ----------------------------- overview ----------------------------- */
 
-// Single-column slab overview (Lovable redesign), with the UI's wired
-// KEEP-OURS panels re-homed into the new layout:
-//   1 — Readiness scorecard (#369, dropped by Lovable, restored here)
-//   2 — Operational status (timeline + ribbon + incidents)
-//   3 — Public resources (segmented endpoints/surfaces/schemas)
-//   4 — Subnet profile (lineage + economics + ownership + curation)
-//   5 — Economics (live chain economics — UI's wired EconomicsPanel)
-//   6 — Reliability (per-surface SLA + latency percentiles — kept)
-//   7 — Cross-network lineage (UI's section, reads lineage.links — kept)
-//   8 — Sources & evidence (UI's EvidencePanel, NOT evidence-clusters)
-//   9 — Open incidents (deep-linkable timeline)
+// Reordered so users see "is this alive and what's it worth?" before "how do
+// I build on it?". Above the fold on desktop: strip + priority highlights +
+// economics. Below-the-fold sections collapse on mobile via MobileCollapse.
+//   0  — Composed overview summary strip
+//   0b — Priority highlight strip (economics/operational/resources/profile)
+//   1  — Economics (live chain economics — UI's wired EconomicsPanel)
+//   2  — 24h Volume (paired with economics)
+//   3  — Price history (paired with economics)
+//   4  — Operational status (timeline + ribbon + incidents)
+//   5  — Public resources (segmented endpoints/surfaces/schemas)
+//   5b — Gittensor's registered repositories (netuid 74 only)
+//   6  — Readiness scorecard (#369, contributor-facing reference)
+//   7  — Subnet profile (lineage + curation + provider list)
+//   8  — Stake-quote calculator
+//   9  — Ownership contest
+//   10 — Ownership history
+//   10b — Subnet lease state + history (#6993, KEEP-OURS — not in Lovable)
+//   11 — Network history
+//   12 — Per-surface reliability
+//   13 — Cross-network lineage (renders only when paired)
+//   14 — Evidence & sources (UI's EvidencePanel, NOT evidence-clusters)
+//   15 — Open incidents (deep-linkable timeline)
 function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetProfile }) {
   const { data: gapsResult } = useQuery(subnetGapsQuery(netuid));
   const subnetGaps = gapsResult?.data;
   return (
     <div className="space-y-6">
-      {/* 0 — Composed overview summary strip (#3346): counts + status +
-          curation from the single server-composed /overview route, at a
-          glance before the more detailed sub-panels below. Each of those
-          sub-panels owns its own deeper backend route and stays as-is. */}
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-          <OverviewSummaryStrip netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      {/* 0 — Composed overview summary strip (#3346) */}
+      <AsyncPanel height="sm">
+        <OverviewSummaryStrip netuid={netuid} />
+      </AsyncPanel>
 
-      {/* 1 — Readiness scorecard: the "can I build on this, where do I start?"
-          answer, up top before the operational/resource detail. */}
-      <ReadinessScorecard profile={profile} />
+      {/* 0b — Priority highlight strip: at-a-glance jump-off to the four
+          most-asked signals for this subnet. Mirrors SubnetsHighlights on
+          the index route. */}
+      <SubnetPriorityHighlights netuid={netuid} />
 
-      {/* 2 — Operational status (timeline + ribbon + incidents) */}
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-          <OperationalPanel netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
-
-      {/* 3 — Public resources (segmented endpoints/surfaces/schemas) */}
-      <QueryErrorBoundary>
-        <ResourceExplorer netuid={netuid} />
-      </QueryErrorBoundary>
-
-      {/* 3b — Gittensor's registered repositories (netuid 74 only): ecosystem
-          member projects with emission-share metadata, not infrastructure
-          surfaces, so kept out of ResourceExplorer above. */}
-      {netuid === 74 ? (
-        <QueryErrorBoundary>
-          <GittensorRegisteredRepos slug="gittensor" />
-        </QueryErrorBoundary>
-      ) : null}
-
-      {/* 4 — Subnet profile (lineage + economics + ownership + curation) */}
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-          <SubnetProfilePanel netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
-
-      {/* 5 — Live chain economics (#1112) — UI's wired EconomicsPanel. */}
+      {/* 1 — Economics (moved up from #5): the headline numbers most users
+          come here for. */}
       <SectionAnchor
         id="economics"
         title="Economics"
@@ -468,135 +468,195 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         <EconomicsPanel netuid={netuid} />
       </SectionAnchor>
 
-      {/* 5a2 — Rolling 24h alpha volume (#4339/8.1): a distinct windowed
-          market-depth figure from economics' cumulative subnet_volume_tao
-          tile above — buy vs sell, unsigned, always a fixed 24h window. */}
-      <SectionAnchor
-        id="volume-24h"
-        title="24h Volume"
-        subtitle="Rolling 24h buy vs sell alpha volume — a windowed market-depth figure, distinct from the cumulative volume shown in Economics."
-        info="GET /api/v1/subnets/{netuid}/volume — unsigned buy + sell alpha volume summed from the account_events stream over a fixed 24h window (not netted, no ?window= param)."
-      >
-        <QueryErrorBoundary>
-          <AlphaVolumeScorecard netuid={netuid} />
-        </QueryErrorBoundary>
-      </SectionAnchor>
+      {/* 2 — 24h Volume (paired with economics) */}
+      <MobileCollapse label="24h Volume" hint="Rolling buy vs sell alpha volume" defaultOpen>
+        <SectionAnchor
+          id="volume-24h"
+          title="24h Volume"
+          subtitle="Rolling 24h buy vs sell alpha volume — a windowed market-depth figure, distinct from the cumulative volume shown in Economics."
+          info="GET /api/v1/subnets/{netuid}/volume — unsigned buy + sell alpha volume summed from the account_events stream over a fixed 24h window (not netted, no ?window= param)."
+        >
+          <QueryErrorBoundary>
+            <AlphaVolumeScorecard netuid={netuid} />
+          </QueryErrorBoundary>
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 5a2b — OHLC price/volume candlesticks (#5656, Phase 2 of the OHLC
-          epic #5304): open/high/low/close candles from the same trade stream
-          the 24h volume scorecard above reads, just bucketed by time instead
-          of summed into a rolling total. */}
-      <SectionAnchor
-        id="ohlc"
-        title="Price history"
-        subtitle="Open/high/low/close candles built from executed stake/unstake trades."
-        info="GET /api/v1/subnets/{netuid}/ohlc — OHLCV candles bucketed by ?interval=1h|1d from the same account_events StakeAdded/StakeRemoved stream as 24h Volume above. Each trade's price is amount_tao / alpha_amount; empty buckets are gaps, never synthesized flat candles."
-      >
-        <QueryErrorBoundary>
-          <SubnetOhlcChart netuid={netuid} />
-        </QueryErrorBoundary>
-      </SectionAnchor>
+      {/* 3 — Price history (paired with economics) */}
+      <MobileCollapse label="Price history" hint="OHLC candles from executed trades">
+        <SectionAnchor
+          id="ohlc"
+          title="Price history"
+          subtitle="Open/high/low/close candles built from executed stake/unstake trades."
+          info="GET /api/v1/subnets/{netuid}/ohlc — OHLCV candles bucketed by ?interval=1h|1d from the same account_events StakeAdded/StakeRemoved stream as 24h Volume above. Each trade's price is amount_tao / alpha_amount; empty buckets are gaps, never synthesized flat candles."
+        >
+          <QueryErrorBoundary>
+            <SubnetOhlcChart netuid={netuid} />
+          </QueryErrorBoundary>
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 5a3 — Stake-quote calculator (#5235): a read-only constant-product
+      {/* 4 — Operational status (moved down from #2 — still prominent, and
+          the trust signal for the economics numbers above). */}
+      <MobileCollapse label="Operational status" hint="Timeline · incident ribbon" defaultOpen>
+        <div id="operational">
+          <AsyncPanel height="xl">
+            <OperationalPanel netuid={netuid} />
+          </AsyncPanel>
+        </div>
+      </MobileCollapse>
+
+      {/* 5 — Public resources (endpoints / surfaces / schemas) */}
+      <MobileCollapse label="Public resources" hint="Endpoints · surfaces · schemas" defaultOpen>
+        <div id="resources">
+          <QueryErrorBoundary>
+            <ResourceExplorer netuid={netuid} />
+          </QueryErrorBoundary>
+        </div>
+      </MobileCollapse>
+
+      {/* 5b — Gittensor's registered repositories (netuid 74 only): ecosystem
+          member projects with emission-share metadata, not infrastructure
+          surfaces, so kept out of ResourceExplorer above. */}
+      {netuid === 74 ? (
+        <QueryErrorBoundary>
+          <GittensorRegisteredRepos slug="gittensor" />
+        </QueryErrorBoundary>
+      ) : null}
+
+      {/* 6 — Readiness scorecard (moved down from #1 — contributor-facing
+          reference, not the headline). */}
+      <MobileCollapse label="Readiness" hint="Integration-readiness scorecard">
+        <ReadinessScorecard profile={profile} />
+      </MobileCollapse>
+
+      {/* 7 — Subnet profile (lineage + curation + provider list) */}
+      <MobileCollapse label="Subnet profile" hint="Lineage · curation · providers">
+        <div id="profile">
+          <AsyncPanel height="lg">
+            <SubnetProfilePanel netuid={netuid} />
+          </AsyncPanel>
+        </div>
+      </MobileCollapse>
+
+      {/* 8 — Stake-quote calculator (#5235): a read-only constant-product
           slippage estimate against the subnet's live AMM reserves. Pure math,
           no chain write — the same swap math the chain itself uses. */}
-      <SectionAnchor
-        id="stake-quote"
-        title="Stake-quote calculator"
-        subtitle="Estimate the slippage and price impact of a stake or unstake before it happens."
-        info="GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake — a read-only constant-product AMM estimate against the subnet's live pool reserves. Pure math, no chain write, no custody."
-      >
-        <StakeQuoteCalculator netuid={netuid} />
-      </SectionAnchor>
+      <MobileCollapse label="Stake-quote calculator" hint="Estimate slippage before staking">
+        <SectionAnchor
+          id="stake-quote"
+          title="Stake-quote calculator"
+          subtitle="Estimate the slippage and price impact of a stake or unstake before it happens."
+          info="GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake — a read-only constant-product AMM estimate against the subnet's live pool reserves. Pure math, no chain write, no custody."
+        >
+          <StakeQuoteCalculator netuid={netuid} />
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 5a4 — Conviction leaderboard (#6638, frontend companion #6715, part
+      {/* 9 — Conviction leaderboard (#6638, frontend companion #6715, part
           of the ownership-contest tracker epic #4302): who currently holds
           the most rolled conviction on this subnet -- the dynamic extension
           of SubnetProfilePanel's static "Ownership" block above. */}
-      <SectionAnchor
-        id="conviction"
-        title="Ownership contest"
-        subtitle="Who currently holds the most rolled conviction -- how close this subnet is to an automatic ownership flip."
-        info="GET /api/v1/subnets/{netuid}/conviction — rolled forward from the periodically-captured lock snapshot to query time, using the live UnlockRate/MaturityRate governance values. Most subnets have no active challengers."
-      >
-        <QueryErrorBoundary>
-          <SubnetConvictionLeaderboard netuid={netuid} />
-        </QueryErrorBoundary>
-      </SectionAnchor>
+      <MobileCollapse label="Ownership contest" hint="Rolled conviction leaderboard">
+        <SectionAnchor
+          id="conviction"
+          title="Ownership contest"
+          subtitle="Who currently holds the most rolled conviction -- how close this subnet is to an automatic ownership flip."
+          info="GET /api/v1/subnets/{netuid}/conviction — rolled forward from the periodically-captured lock snapshot to query time, using the live UnlockRate/MaturityRate governance values. Most subnets have no active challengers."
+        >
+          <QueryErrorBoundary>
+            <SubnetConvictionLeaderboard netuid={netuid} />
+          </QueryErrorBoundary>
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 5a5 — Ownership-change history (#6637, frontend companion #6715,
+      {/* 10 — Ownership-change history (#6637, frontend companion #6715,
           part of the ownership-contest tracker epic #4302): every automatic
           ownership transfer this subnet has undergone, decoded from the
           chain_events SubnetOwnerChanged stream. */}
-      <SectionAnchor
-        id="ownership-history"
-        title="Ownership history"
-        subtitle="Every automatic ownership transfer this subnet has undergone."
-        info="GET /api/v1/subnets/{netuid}/ownership-history — decoded from the chain_events SubnetOwnerChanged stream. A subnet that has never changed hands returns an empty list, not an error."
-      >
-        <QueryErrorBoundary>
-          <SubnetOwnershipHistory netuid={netuid} />
-        </QueryErrorBoundary>
-      </SectionAnchor>
+      <MobileCollapse label="Ownership history" hint="Every automatic ownership transfer">
+        <SectionAnchor
+          id="ownership-history"
+          title="Ownership history"
+          subtitle="Every automatic ownership transfer this subnet has undergone."
+          info="GET /api/v1/subnets/{netuid}/ownership-history — decoded from the chain_events SubnetOwnerChanged stream. A subnet that has never changed hands returns an empty list, not an error."
+        >
+          <QueryErrorBoundary>
+            <SubnetOwnershipHistory netuid={netuid} />
+          </QueryErrorBoundary>
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 5a6 — Subnet lease state + history (#6993, backend #6719/#6813,
-          part of leasing epic #6717): live lease terms + created/terminated
-          event log. Sibling of the ownership-contest panels above. */}
-      <SectionAnchor
-        id="lease"
-        title="Subnet lease"
-        subtitle="Live lease status, terms, and created/terminated history."
-        info="GET /api/v1/subnets/{netuid}/lease and /lease/history — live RPC for current lease state (leased null = RPC failure, distinct from not leased) plus the SubnetLeaseCreated/Terminated event log."
-      >
-        <QueryErrorBoundary>
-          <SubnetLeasePanel netuid={netuid} />
-        </QueryErrorBoundary>
-      </SectionAnchor>
+      {/* 10b — Subnet lease state + history (#6993, backend #6719/#6813, part
+          of leasing epic #6717): live lease terms + created/terminated event
+          log. Sibling of the ownership-contest panels above. */}
+      <MobileCollapse label="Subnet lease" hint="Live lease status, terms, and history">
+        <SectionAnchor
+          id="lease"
+          title="Subnet lease"
+          subtitle="Live lease status, terms, and created/terminated history."
+          info="GET /api/v1/subnets/{netuid}/lease and /lease/history — live RPC for current lease state (leased null = RPC failure, distinct from not leased) plus the SubnetLeaseCreated/Terminated event log."
+        >
+          <QueryErrorBoundary>
+            <SubnetLeasePanel netuid={netuid} />
+          </QueryErrorBoundary>
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 5b — On-chain network history (#1302): daily neuron/validator counts,
+      {/* 11 — On-chain network history (#1302): daily neuron/validator counts,
           total stake + emission over a selectable window. Optional detail —
           renders an empty-state until chain history accumulates. */}
-      <SectionAnchor
-        id="history"
-        title="Network history"
-        subtitle="Daily on-chain neuron/validator counts, total stake, and emission over time."
-        info="GET /api/v1/subnets/{netuid}/history"
-      >
-        <QueryErrorBoundary>
-          <SubnetHistoryChart netuid={netuid} />
-        </QueryErrorBoundary>
-      </SectionAnchor>
+      <MobileCollapse label="Network history" hint="Daily neuron/validator counts, stake, emission">
+        <SectionAnchor
+          id="history"
+          title="Network history"
+          subtitle="Daily on-chain neuron/validator counts, total stake, and emission over time."
+          info="GET /api/v1/subnets/{netuid}/history"
+        >
+          <QueryErrorBoundary>
+            <SubnetHistoryChart netuid={netuid} />
+          </QueryErrorBoundary>
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 6 — Per-surface reliability (#1114): uptime SLA + latency percentiles. */}
-      <SectionAnchor
-        id="reliability"
-        title="Reliability"
-        subtitle="Per-surface uptime SLA and latency percentiles (p50/p95/p99) over 7d/30d."
-        info="Live from the 2-minute health prober's D1 history: uptime ratio, reconstructed downtime incidents, and latency distribution per operational surface."
-      >
-        <ReliabilityPanel netuid={netuid} />
-      </SectionAnchor>
+      {/* 12 — Per-surface reliability (#1114): uptime SLA + latency percentiles. */}
+      <MobileCollapse label="Reliability" hint="Uptime SLA + latency percentiles">
+        <SectionAnchor
+          id="reliability"
+          title="Reliability"
+          subtitle="Per-surface uptime SLA and latency percentiles (p50/p95/p99) over 7d/30d."
+          info="Live from the 2-minute health prober's D1 history: uptime ratio, reconstructed downtime incidents, and latency distribution per operational surface."
+        >
+          <ReliabilityPanel netuid={netuid} />
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 7 — Cross-network lineage (#1113): renders only when paired. */}
+      {/* 13 — Cross-network lineage (#1113): renders only when paired. */}
       <SubnetLineageSection netuid={netuid} />
 
-      {/* 8 — Evidence & sources — UI's wired EvidencePanel (NOT evidence-clusters).
+      {/* 14 — Evidence & sources — UI's wired EvidencePanel (NOT evidence-clusters).
           Preview embed of the dedicated Evidence tab: same copy, own
           `evidence-preview` id, muted rail marking it as lower-density context. */}
-      <SectionAnchor
-        id="evidence-preview"
-        title="Evidence & sources"
-        subtitle="Primary links and recorded evidence backing this profile."
-        info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
-        tone="muted"
-      >
-        <EvidencePanel netuid={netuid} />
-      </SectionAnchor>
+      <MobileCollapse label="Evidence & sources" hint="Primary links and recorded evidence">
+        <SectionAnchor
+          id="evidence-preview"
+          title="Evidence & sources"
+          subtitle="Primary links and recorded evidence backing this profile."
+          info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
+          tone="muted"
+        >
+          <EvidencePanel netuid={netuid} />
+        </SectionAnchor>
+      </MobileCollapse>
 
-      {/* 9 — Open incidents (deep-linkable, lower-density context) */}
-      <QueryErrorBoundary>
-        <IncidentTimeline netuid={netuid} />
-      </QueryErrorBoundary>
+      {/* 15 — Open incidents (deep-linkable, lower-density context) */}
+      <MobileCollapse label="Open incidents" hint="Recent probe-derived incident timeline">
+        <div id="incidents">
+          <QueryErrorBoundary>
+            <IncidentTimeline netuid={netuid} />
+          </QueryErrorBoundary>
+        </div>
+      </MobileCollapse>
 
       {(subnetGaps?.missing_kinds.length ?? 0) > 0 ||
       (subnetGaps?.gap_notes.length ?? 0) > 0 ||
@@ -629,7 +689,7 @@ function OverviewSummaryStrip({ netuid }: { netuid: number }) {
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2">
         {overview.status ? (
-          <span className="inline-flex items-center rounded border border-border bg-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          <span className="mg-type-micro inline-flex items-center rounded border border-border bg-card px-2 py-0.5 text-[10px] text-ink-muted">
             {overview.status}
           </span>
         ) : null}
@@ -719,11 +779,9 @@ function IdentityHistoryPanel({ netuid }: { netuid: number }) {
       subtitle="On-chain name, symbol, and metadata changes for this subnet, newest first."
       info="GET /api/v1/subnets/{netuid}/identity-history — each row is an observed on-chain SubnetIdentitiesV3 snapshot, so the timeline shows how the subnet's registered identity changed over time."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-          <IdentityHistoryList netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="xl">
+        <IdentityHistoryList netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -796,11 +854,9 @@ function SurfacesPanel({ netuid }: { netuid: number }) {
       subtitle="Curated public interfaces with provenance."
       info="Only surfaces that have been verified appear here. Unverified leads live in the Candidates tab."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <SurfacesList netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="md">
+        <SurfacesList netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -889,10 +945,7 @@ function StakeQuoteCalculator({ netuid }: { netuid: number }) {
           {/* SearchInput sets its own aria-label from `placeholder` -- this is a
               visual label only, not `<label htmlFor>`, since SearchInput has no
               `id` prop to associate with. */}
-          <span
-            aria-hidden="true"
-            className="font-mono text-[10px] uppercase tracking-widest text-ink-muted"
-          >
+          <span aria-hidden="true" className="mg-type-micro text-[10px] text-ink-muted">
             Amount ({inputUnit})
           </span>
           <SearchInput
@@ -904,9 +957,7 @@ function StakeQuoteCalculator({ netuid }: { netuid: number }) {
           />
         </div>
         <div className="flex flex-col gap-1">
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            Direction
-          </span>
+          <span className="mg-type-micro text-[10px] text-ink-muted">Direction</span>
           <div
             role="tablist"
             aria-label="Stake or unstake"
@@ -1043,11 +1094,9 @@ function ActivityPanel({ netuid }: { netuid: number }) {
     >
       <ActivityEventRollup netuid={netuid} />
       <StakeFlowScorecard netuid={netuid} />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <ActivityTableLoader netuid={netuid} kind={ev_kind} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="md">
+        <ActivityTableLoader netuid={netuid} kind={ev_kind} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -1232,8 +1281,8 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
         </span>
         <RealtimeFreshness at={data.meta?.generated_at} />
       </div>
-      <div className="overflow-x-auto rounded border border-border bg-card">
-        <table className="w-full min-w-[720px] text-left text-sm">
+      <ResponsiveTable className="rounded border border-border bg-card" minWidth={720}>
+        <table className="w-full text-left text-sm">
           <thead className="bg-surface/40">
             <tr>
               <th className="px-4 py-2.5 whitespace-nowrap">Block</th>
@@ -1285,7 +1334,7 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
             ))}
           </tbody>
         </table>
-      </div>
+      </ResponsiveTable>
     </div>
   );
 }
@@ -1303,11 +1352,9 @@ function CallableServicesPanel({ netuid }: { netuid: number }) {
       subtitle="Public-safe, agent-callable interfaces with live health and safely generated snippets."
       info="GET /api/v1/agent-catalog/{netuid}. Only public-safe callable surfaces (subnet-api, OpenAPI, SSE, data-artifact) appear here; health is probe-derived."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <CallableServicesList netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="md">
+        <CallableServicesList netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -1396,7 +1443,7 @@ function AgentReadinessCard({
         {tier ? (
           <span
             className={classNames(
-              "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+              "mg-type-micro inline-flex items-center rounded border px-1.5 py-0.5 text-[10px]",
               tone,
             )}
           >
@@ -1431,7 +1478,7 @@ function ServiceCard({ service }: { service: AgentCatalogService }) {
   return (
     <li className="rounded-lg border border-border bg-card p-4">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="inline-flex items-center rounded border border-accent/40 bg-primary-soft px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent-text">
+        <span className="mg-type-micro inline-flex items-center rounded border border-accent/40 bg-primary-soft px-1.5 py-0.5 text-[10px] text-accent-text">
           {service.kind ?? "service"}
         </span>
         <span className="font-medium text-ink-strong truncate">
@@ -1529,11 +1576,9 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
           info="GET /api/v1/subnets/{netuid}/neurons/{uid} and /neurons/{uid}/history"
           tone="accent"
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-              <NeuronDetailCard netuid={netuid} uid={uid} onClose={() => select(null)} />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel height="lg">
+            <NeuronDetailCard netuid={netuid} uid={uid} onClose={() => select(null)} />
+          </AsyncPanel>
           <div className="mt-4">
             <QueryErrorBoundary>
               <NeuronHistoryChart netuid={netuid} uid={uid} />
@@ -1548,11 +1593,9 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
         subtitle="Live neuron snapshot — stake, emission, rank, trust, consensus, and validator permits."
         info="GET /api/v1/subnets/{netuid}/metagraph — the full neuron set from the latest metagraph snapshot. Select a UID to drill into its snapshot + history."
       >
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-            <MetagraphTableLoader netuid={netuid} onSelect={(u) => select(u)} selectedUid={uid} />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel height="xl">
+          <MetagraphTableLoader netuid={netuid} onSelect={(u) => select(u)} selectedUid={uid} />
+        </AsyncPanel>
       </SectionAnchor>
 
       <SectionAnchor
@@ -1573,11 +1616,9 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
         subtitle="Per-UID emission yield (emission ÷ stake return rate): distribution summary, validator/miner split, and the ranked neuron leaderboard with daily drift."
         info="GET /api/v1/subnets/{netuid}/yield and /yield/history — the return-rate twin of concentration, computed per-UID from the live neuron snapshot."
       >
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-            <YieldLoader netuid={netuid} />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel height="lg">
+          <YieldLoader netuid={netuid} />
+        </AsyncPanel>
       </SectionAnchor>
 
       <SectionAnchor
@@ -1587,11 +1628,9 @@ function MetagraphPanel({ netuid }: { netuid: number }) {
         info="GET /api/v1/subnets/{netuid}/turnover — diffs the window's start/end metagraph snapshots into a validator-set + registration-churn scorecard."
         tone="muted"
       >
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-            <TurnoverLoader netuid={netuid} />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel height="lg">
+          <TurnoverLoader netuid={netuid} />
+        </AsyncPanel>
       </SectionAnchor>
     </div>
   );
@@ -1622,9 +1661,7 @@ function WeightsSummaryLoader({ netuid }: { netuid: number }) {
     <div className="mb-4 grid grid-cols-1 divide-y divide-border overflow-hidden rounded-xl border border-border bg-card sm:grid-cols-3 sm:divide-x sm:divide-y-0">
       {cells.map((c) => (
         <div key={c.label} className="px-4 py-3">
-          <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            {c.label}
-          </div>
+          <div className="mg-type-micro text-[10px] text-ink-muted">{c.label}</div>
           <div className="mt-0.5 font-mono text-lg tabular-nums text-ink-strong">{c.value}</div>
         </div>
       ))}
@@ -1662,24 +1699,16 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
             {formatNumber(d.setter_count)} validators · {windowLabel}
           </span>
         </div>
-        {/* overflow-x-auto keeps the 4-column table inside the card on narrow
-            viewports (#3942) — same inner scroll shell NeuronTable and ListShell use. */}
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[280px] text-sm">
+        {/* ResponsiveTable: horizontal scroll + edge-fade shadows on narrow
+            viewports (#3942), same treatment as list-page tables. */}
+        <ResponsiveTable minWidth={280}>
+          <table className="w-full text-sm">
             <thead className="bg-surface/50 text-ink-muted">
               <tr>
-                <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
-                  #
-                </th>
-                <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
-                  Validator
-                </th>
-                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
-                  Weight sets
-                </th>
-                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
-                  Share
-                </th>
+                <th className="mg-type-micro px-3 py-2.5 text-left text-[10px]">#</th>
+                <th className="mg-type-micro px-3 py-2.5 text-left text-[10px]">Validator</th>
+                <th className="mg-type-micro px-3 py-2.5 text-right text-[10px]">Weight sets</th>
+                <th className="mg-type-micro px-3 py-2.5 text-right text-[10px]">Share</th>
               </tr>
             </thead>
             <tbody>
@@ -1701,7 +1730,7 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
               ))}
             </tbody>
           </table>
-        </div>
+        </ResponsiveTable>
       </div>
     </div>
   );
@@ -1719,31 +1748,25 @@ function ValidatorsPanel({ netuid }: { netuid: number }) {
       info="GET /api/v1/subnets/{netuid}/validators — the permitted, stake-ranked validator set from the latest snapshot. Select a UID to open it in the Metagraph tab."
     >
       <ValidatorGuide />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-          <ValidatorsTableLoader
-            netuid={netuid}
-            selectedUid={uid}
-            onSelect={(u) =>
-              navigate({
-                to: ".",
-                search: (prev: SearchParams) => ({ ...prev, tab: "metagraph", uid: u }),
-                replace: true,
-              })
-            }
-          />
-        </Suspense>
-      </QueryErrorBoundary>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-          <WeightsSummaryLoader netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-          <WeightSettersLoader netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="xl">
+        <ValidatorsTableLoader
+          netuid={netuid}
+          selectedUid={uid}
+          onSelect={(u) =>
+            navigate({
+              to: ".",
+              search: (prev: SearchParams) => ({ ...prev, tab: "metagraph", uid: u }),
+              replace: true,
+            })
+          }
+        />
+      </AsyncPanel>
+      <AsyncPanel height="sm">
+        <WeightsSummaryLoader netuid={netuid} />
+      </AsyncPanel>
+      <AsyncPanel height="lg">
+        <WeightSettersLoader netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -1756,11 +1779,9 @@ function EndpointsPanel({ netuid }: { netuid: number }) {
       subtitle="Probe-derived health, latency, and freshness."
       info="Each endpoint is probed periodically. Health and latency reflect the most recent probe."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-          <EndpointsTableLoader netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="md">
+        <EndpointsTableLoader netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -1798,11 +1819,9 @@ function CandidatesPanel({ netuid }: { netuid: number }) {
           corrections via the public repo.
         </span>
       </div>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-          <CandidatesList netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="sm">
+        <CandidatesList netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -1819,11 +1838,9 @@ function GapsPanel({ netuid, compact }: { netuid: number; compact?: boolean }) {
       subtitle="Missing resources, profile incompleteness, and curation notes."
       info="GET /api/v1/subnets/{netuid}/gaps"
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-          <GapsList netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="sm">
+        <GapsList netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -1918,11 +1935,9 @@ function SchemasPanel({ netuid }: { netuid: number }) {
       subtitle="OpenAPI/JSON Schema snapshots joined from /api/v1/schemas, with hash diffs."
       info="Drift means the latest schema hash differs from the previous one — review for breaking changes."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-          <SchemaDriftSummary netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="sm">
+        <SchemaDriftSummary netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -2121,11 +2136,9 @@ function HyperparametersPanel({ netuid }: { netuid: number }) {
       subtitle="Consensus, economic, and governance settings for this subnet."
       info="GET /api/v1/subnets/{netuid}/hyperparameters — refreshed daily from the subnet_hyperparams D1 tier."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-          <HyperparametersTable netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="xl">
+        <HyperparametersTable netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }
@@ -2170,9 +2183,7 @@ function HyperparamGroupsTable({ h }: { h: SubnetHyperparameters }) {
           <div className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-3">
             {group.fields.map((field) => (
               <div key={field.key} className="px-4 py-2.5">
-                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                  {field.label}
-                </div>
+                <div className="mg-type-micro text-[10px] text-ink-muted">{field.label}</div>
                 <div className="mt-1 font-mono text-[13px] text-ink-strong">{field.format(h)}</div>
               </div>
             ))}
@@ -2193,11 +2204,9 @@ function HyperparamsHistoryPanel({ netuid }: { netuid: number }) {
       subtitle="Every recorded change to this subnet's consensus, economic, and governance settings, newest first."
       info="GET /api/v1/subnets/{netuid}/hyperparameters/history — an append-only timeline of full hyperparameter snapshots, one entry per detected change. Forward-only: rows only exist from when this tier started tracking, so an established subnet may show fewer entries than its full history."
     >
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-          <HyperparamsHistoryList netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel height="xl">
+        <HyperparamsHistoryList netuid={netuid} />
+      </AsyncPanel>
     </SectionAnchor>
   );
 }

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -1,18 +1,39 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useSuspenseInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, useMemo } from "react";
+import { useSuspenseInfiniteQuery, useSuspenseQuery, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { getTaoMarket } from "@/lib/metagraphed/market.functions";
 import { z } from "zod";
-import { Network, Radio, Layers, Activity, Coins } from "lucide-react";
+import { Network, Radio, Layers, Activity, Coins, Server } from "lucide-react";
+import {
+  AsyncPanel,
+  Chip,
+  ColumnCustomizer,
+  FilterChipRow,
+  FilterSheet,
+  FreshnessPill,
+  Indicator,
+  PanelSkeleton,
+  ProvenanceChip,
+  QueryBar,
+  QueryProgress,
+  ReadinessGauge,
+  StatusBadge,
+  StickyToolbar,
+  TableSkeleton,
+  useColumnVisibility,
+  type ColumnDef,
+  type FilterChipItem,
+  type HealthStatus,
+  PageMasthead,
+} from "@/components/metagraphed/primitives";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState } from "@/components/metagraphed/states";
 import {
   BrandIcon,
   prefetchBrandIcon,
   TimeAgo,
-  CurationChip,
   HealthPill,
-  PageHero,
   DensityToggle,
   ViewModeToggle,
   ShareButton,
@@ -24,18 +45,20 @@ import {
   SparkLegend,
   MiniStack,
   Sparkline,
+  BackToTop,
+  SegmentedToggle,
+  type SegmentedToggleOption,
   type Density,
   type ViewMode,
 } from "@jsonbored/ui-kit";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { SubnetsHighlights } from "@/components/metagraphed/subnets-highlights";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import {
   ariaSort,
+  FilterChip,
   PageSizeSelect,
   ResetFiltersButton,
-  SearchInput,
-  SelectFilter,
   SortHeader,
 } from "@/components/metagraphed/table-controls";
 import { SubnetsSavedViews } from "@/components/metagraphed/subnets-saved-views";
@@ -51,6 +74,9 @@ import {
   agentCatalogMapQuery,
   economicsQuery,
   economicsTrendsQuery,
+  subnetHistoryQuery,
+  subnetTrajectoryQuery,
+  metagraphedQueryKey,
 } from "@/lib/metagraphed/queries";
 import {
   classNames,
@@ -86,7 +112,32 @@ type SubnetRow = Subnet & {
   // #3363: live emission share joined from /api/v1/economics by netuid, so the
   // Emission column (and its sort) can read it off the row.
   emission_share?: number;
+  alpha_price_tao?: number;
+  total_stake_tao?: number;
+  alpha_market_cap_tao?: number;
 };
+
+// Column order + defaults tuned to match the vocabulary of an actual block
+// explorer (taostats.io etc.): price + market signal first, registry plumbing
+// (source/profile/updated) is opt-in via the column customizer. Renames
+// "Curation → Source" and "Readiness → Profile" so headers don't read like
+// dev-tool jargon; the underlying filter/sort keys are unchanged.
+const SUBNET_COLUMNS: ColumnDef[] = [
+  { id: "netuid", label: "UID", required: true },
+  { id: "name", label: "Name", required: true },
+  { id: "alphaPrice", label: "Price (α)", defaultVisible: true },
+  { id: "marketCap", label: "Market cap", defaultVisible: true },
+  { id: "emission", label: "Emission" },
+  { id: "totalStake", label: "Total stake", defaultVisible: true },
+  { id: "participants", label: "Participants" },
+  { id: "registration", label: "Reg. cost" },
+  { id: "health", label: "Health" },
+  { id: "symbol", label: "Symbol", defaultVisible: false },
+  { id: "surfaces", label: "Surfaces", defaultVisible: false },
+  { id: "curation", label: "Source", defaultVisible: false },
+  { id: "readiness", label: "Profile", defaultVisible: false },
+  { id: "updated", label: "Updated", defaultVisible: false },
+];
 
 function joinCatalog(
   rows: Array<Subnet & { health?: string }>,
@@ -177,8 +228,7 @@ function SubnetsPage() {
   const subnetsCsvUrl = buildUrl("/api/v1/subnets", subnetsQueryParams(search));
   return (
     <AppShell>
-      <PageHero
-        eyebrow="Registry"
+      <PageMasthead
         live
         title="Subnets"
         description="Every active Finney netuid — root and application — with curation level, surface count, health, and freshness."
@@ -196,29 +246,55 @@ function SubnetsPage() {
           </>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense
-          fallback={
-            <div className="flex flex-wrap gap-3 mb-6 [&>*]:grow [&>*]:basis-[160px]">
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-            </div>
-          }
-        >
-          <SubnetsStatStrip />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="registry highlights"
+        fallback={
+          <div className="mb-4 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            <PanelSkeleton height="xs" />
+            <PanelSkeleton height="xs" />
+            <PanelSkeleton height="xs" />
+            <PanelSkeleton height="xs" />
+          </div>
+        }
+        retryQueryKeys={[
+          metagraphedQueryKey("health"),
+          metagraphedQueryKey("coverage"),
+          metagraphedQueryKey("freshness"),
+          metagraphedQueryKey("schemas"),
+        ]}
+      >
+        <SubnetsHighlights />
+      </AsyncPanel>
+      <AsyncPanel
+        context="subnets summary"
+        fallback={
+          <div className="flex flex-wrap gap-3 mb-6 [&>*]:grow [&>*]:basis-[160px]">
+            <PanelSkeleton height="xs" />
+            <PanelSkeleton height="xs" />
+            <PanelSkeleton height="xs" />
+            <PanelSkeleton height="xs" />
+            <PanelSkeleton height="xs" />
+          </div>
+        }
+      >
+        <SubnetsStatStrip />
+      </AsyncPanel>
       <SubnetsSavedViews />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-          <SubnetsTable view={search.view} density={effectiveDensity} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="subnets"
+        fallback={
+          <TableSkeleton
+            rows={search.view === "table" ? 10 : 6}
+            columns={search.view === "table" ? 8 : 4}
+            density={effectiveDensity}
+          />
+        }
+      >
+        <SubnetsTable view={search.view} density={effectiveDensity} />
+      </AsyncPanel>
       <ApiSourceFooter paths={["/api/v1/subnets"]} artifacts={["/metagraph/subnets.json"]} />
       <SubnetsCompareDrawer />
+      <BackToTop />
     </AppShell>
   );
 }
@@ -234,8 +310,11 @@ function SubnetsStatStrip() {
   // Alpha-price StatTile+Sparkline precedent in economics-panel.tsx. days[] is
   // newest-first (see explorer.tsx's own chrono = [...days].reverse()).
   const trends = useSuspenseQuery(economicsTrendsQuery()).data.data;
-  const stakeSeries = [...trends.days].reverse().map((d) => d.total_stake_tao ?? 0);
-  const latestTotalStake = trends.days[0]?.total_stake_tao ?? undefined;
+  // Partial/empty API payloads are a normal data state, not a render error.
+  // Never let a missing `days` collection take down the whole route.
+  const trendDays = trends?.days ?? [];
+  const stakeSeries = [...trendDays].reverse().map((d) => d.total_stake_tao ?? 0);
+  const latestTotalStake = trendDays[0]?.total_stake_tao ?? undefined;
   // Wired to the live /api/v1/coverage shape (same as CoverageFunnel): the older
   // netuids_active/netuids_total/adapter_backed fields are null on the live payload.
   const active =
@@ -333,7 +412,7 @@ function ExcludeToggle({
       aria-pressed={hidden}
       title={title}
       className={classNames(
-        "inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+        "mg-type-micro inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 text-[10px] transition-colors",
         hidden
           ? "border-accent/40 bg-accent/10 text-accent"
           : "border-border bg-card text-ink-muted hover:text-ink-strong",
@@ -349,6 +428,10 @@ function ExcludeToggle({
 function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; density?: Density }) {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
+  const columns = useColumnVisibility("subnets", SUBNET_COLUMNS);
+  // Local trend window powering the per-row Price/Stake/MCap sparklines +
+  // tone. Not URL-persisted (view chrome, not a filter over the row set).
+  const [trendWindow, setTrendWindow] = useState<"7d" | "30d" | "90d">("7d");
 
   // /api/v1/subnets supports only q + cursor/limit. `sort` returns HTTP 400, and
   // `curation`/`health` are ignored server-side — so those are applied
@@ -507,16 +590,31 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
       search.includeRoot,
     ],
   );
+  // Smarter default: when the user hasn't clicked a column, sort by market cap
+  // (descending) so the highest-signal rows land at the top — matches how every
+  // real block explorer opens. An explicit `search.sort` always wins.
+  const effectiveSort = search.sort || "alpha_market_cap_tao";
+  const effectiveOrder: "asc" | "desc" = search.sort ? search.order : "desc";
   const rows = useMemo(
     () =>
       sortBy(
         filtered,
-        search.sort,
-        search.order,
+        effectiveSort,
+        effectiveOrder,
         (row, key) => (row as Record<string, unknown>)[key],
       ),
-    [filtered, search.sort, search.order],
+    [filtered, effectiveSort, effectiveOrder],
   );
+
+  // Live TAO price (USD) — one fetch, cached — so we can render an inline USD
+  // conversion beneath alpha-price cells without touching per-row queries.
+  const { data: taoMarket } = useQuery({
+    queryKey: ["tao-market"],
+    queryFn: () => getTaoMarket(),
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+  const taoUsd = taoMarket?.price;
 
   // Warm the favicon cache for visible rows during idle time so scrolling
   // feels instant. The browser dedupes the eventual <img> request. `rows` is
@@ -543,71 +641,264 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     };
   }, [rows]);
 
-  const filters = (
-    <>
-      <SearchInput
-        value={search.q}
-        onChange={(v) => setSearch({ q: v })}
-        placeholder="Search by netuid, name, or symbol"
-      />
-      <SelectFilter
-        label="curation"
+  // Unified QueryBar-driven filter surface. All filter dropdowns become
+  // typeahead popovers; utilities live in the trailing icon cluster; the
+  // meta row (count + reset) drops below the shell instead of clogging it.
+  const curationOptions = [
+    { value: "native", label: "Native" },
+    { value: "adapter-backed", label: "Adapter" },
+    { value: "maintainer-reviewed", label: "Reviewed" },
+    { value: "machine-verified", label: "Machine" },
+    { value: "community-seeded", label: "Community" },
+    { value: "candidate-discovered", label: "Candidate" },
+  ];
+  const readinessOptions = [
+    { value: "buildable", label: "Buildable" },
+    { value: "emerging", label: "Emerging" },
+    { value: "identity-only", label: "Identity-only" },
+    { value: "dormant", label: "Dormant" },
+  ];
+  const serviceOptions = [
+    { value: "subnet-api", label: "subnet-api" },
+    { value: "openapi", label: "openapi" },
+    { value: "sse", label: "sse" },
+    { value: "data-artifact", label: "data-artifact" },
+  ];
+  const kindOptions = [
+    { value: "api", label: "has API" },
+    { value: "sse", label: "has SSE" },
+    { value: "docs", label: "has docs" },
+  ];
+
+  const activeFilterCount =
+    (search.q ? 1 : 0) +
+    (search.health ? 1 : 0) +
+    (search.curation ? 1 : 0) +
+    (search.readiness ? 1 : 0) +
+    (search.serviceKind ? 1 : 0) +
+    (search.kind ? 1 : 0) +
+    (search.stale ? 1 : 0) +
+    (!search.includeRoot ? 1 : 0);
+
+  const resultCount = rows.length;
+  const totalCount = total ?? all.length;
+
+  // Primary tone selector replaces the row of trigger chips. Health is the
+  // one filter people reach for constantly ("what's live? what's broken?"),
+  // so it lives inline as a segmented switch; every other filter (Source,
+  // Profile, Service, Surface) is opt-in behind a single "Filters" button
+  // that opens the same sheet on every viewport — no more chip soup.
+  const toneOptions: SegmentedToggleOption<"" | "ok" | "warn" | "down" | "unknown">[] = [
+    { value: "", label: "All" },
+    { value: "ok", label: "Live" },
+    { value: "warn", label: "Warn" },
+    { value: "down", label: "Down" },
+    { value: "unknown", label: "New" },
+  ];
+
+  const secondaryFilters = (
+    <div className="flex flex-col gap-3">
+      <FilterChip
+        label="Source"
+        ariaLabel="Filter by curation source"
+        placeholder="Any"
         value={search.curation}
         onChange={(v) => setSearch({ curation: v })}
-        options={[
-          { value: "native", label: "native" },
-          { value: "candidate-discovered", label: "candidate" },
-          { value: "machine-verified", label: "machine" },
-          { value: "maintainer-reviewed", label: "reviewed" },
-          { value: "adapter-backed", label: "adapter" },
-        ]}
+        options={curationOptions}
       />
-      <SelectFilter
-        label="health"
-        value={search.health}
-        onChange={(v) => setSearch({ health: v })}
-        options={[
-          { value: "ok", label: "ok" },
-          { value: "warn", label: "warn" },
-          { value: "down", label: "down" },
-          { value: "unknown", label: "unknown" },
-        ]}
-      />
-      <SelectFilter
-        label="service"
-        value={search.serviceKind}
-        onChange={(v) => setSearch({ serviceKind: v })}
-        options={[
-          { value: "subnet-api", label: "subnet-api" },
-          { value: "openapi", label: "openapi" },
-          { value: "sse", label: "sse" },
-          { value: "data-artifact", label: "data-artifact" },
-        ]}
-      />
-      <SelectFilter
-        label="readiness"
+      <FilterChip
+        label="Profile"
+        ariaLabel="Filter by profile completeness tier"
+        placeholder="Any"
         value={search.readiness}
         onChange={(v) => setSearch({ readiness: v })}
-        options={[
-          { value: "buildable", label: "buildable" },
-          { value: "emerging", label: "emerging" },
-          { value: "identity-only", label: "identity-only" },
-          { value: "dormant", label: "dormant" },
-        ]}
+        options={readinessOptions}
       />
-      <ExcludeToggle
-        hidden={!search.includeRoot}
-        onToggle={() => setSearch({ includeRoot: !search.includeRoot })}
-        label="Hide root"
-        count={rootCount}
-        title={
-          search.includeRoot
-            ? `Showing the root subnet — click to hide ${rootCount} root netuid${rootCount === 1 ? "" : "s"}`
-            : "Root subnet hidden — click to show it again"
+      <FilterChip
+        label="Service"
+        ariaLabel="Filter by service kind"
+        placeholder="Any"
+        value={search.serviceKind}
+        onChange={(v) => setSearch({ serviceKind: v })}
+        options={serviceOptions}
+      />
+      <FilterChip
+        label="Surface"
+        ariaLabel="Filter by surface kind"
+        placeholder="Any"
+        value={search.kind}
+        onChange={(v) => setSearch({ kind: v })}
+        options={kindOptions}
+      />
+    </div>
+  );
+
+  const secondaryFilterCount =
+    (search.curation ? 1 : 0) +
+    (search.readiness ? 1 : 0) +
+    (search.serviceKind ? 1 : 0) +
+    (search.kind ? 1 : 0);
+
+  const filters = (
+    <div className="flex w-full flex-col gap-0 min-w-0">
+      <div className="flex w-full items-center gap-2 min-w-0">
+        <QueryBar className="flex-1 min-w-0">
+          <QueryBar.Search
+            value={search.q}
+            onChange={(v) => setSearch({ q: v })}
+            placeholder="Search by netuid, name, or symbol"
+            shortcut
+            debounceMs={200}
+          />
+
+          <QueryBar.Divider />
+          <div className="hidden sm:flex items-center">
+            <SegmentedToggle
+              options={toneOptions}
+              value={(search.health as "" | "ok" | "warn" | "down" | "unknown") ?? ""}
+              onChange={(v: string) => setSearch({ health: v })}
+              ariaLabel="Filter by health tone"
+              className="border-0 bg-transparent"
+            />
+          </div>
+          <QueryBar.Utility className="ml-auto">
+            <ExcludeToggle
+              hidden={!search.includeRoot}
+              onToggle={() => setSearch({ includeRoot: !search.includeRoot })}
+              label="Hide root"
+              count={rootCount}
+              title={
+                search.includeRoot
+                  ? `Showing the root subnet — click to hide ${rootCount} root netuid${rootCount === 1 ? "" : "s"}`
+                  : "Root subnet hidden — click to show it again"
+              }
+            />
+            <PageSizeSelect value={search.limit} onChange={(n) => setSearch({ limit: n })} />
+            {view === "table" ? (
+              <>
+                <SegmentedToggle<"7d" | "30d" | "90d">
+                  options={[
+                    { value: "7d", label: "7d" },
+                    { value: "30d", label: "30d" },
+                    { value: "90d", label: "90d" },
+                  ]}
+                  value={trendWindow}
+                  onChange={(v) => setTrendWindow(v)}
+                  ariaLabel="Trend window for row sparklines"
+                  className="border-0 bg-transparent"
+                />
+                <ColumnCustomizer
+                  columns={SUBNET_COLUMNS}
+                  isVisible={columns.isVisible}
+                  onToggle={columns.toggle}
+                  onReset={columns.reset}
+                />
+              </>
+            ) : null}
+          </QueryBar.Utility>
+        </QueryBar>
+        <FilterSheet label="Filters" activeCount={secondaryFilterCount}>
+          {secondaryFilters}
+        </FilterSheet>
+      </div>
+      <QueryBar.MetaRow
+        count={resultCount}
+        total={totalCount}
+        noun="subnets"
+        activeCount={activeFilterCount}
+        onReset={
+          activeFilterCount > 0
+            ? () =>
+                navigate({
+                  search: { limit: search.limit, view: search.view } as never,
+                  replace: true,
+                })
+            : undefined
         }
       />
-      <PageSizeSelect value={search.limit} onChange={(n) => setSearch({ limit: n })} />
-    </>
+      {(() => {
+        const chipItems: FilterChipItem[] = [];
+        const labelFor = (opts: { value: string; label: string }[], v: string) =>
+          opts.find((o) => o.value === v)?.label ?? v;
+        if (search.q) chipItems.push({ id: "q", label: "Search", value: search.q });
+        if (search.health)
+          chipItems.push({
+            id: "health",
+            label: "Health",
+            value: labelFor(toneOptions as never, search.health),
+          });
+        if (search.curation)
+          chipItems.push({
+            id: "curation",
+            label: "Source",
+            value: labelFor(curationOptions, search.curation),
+          });
+        if (search.readiness)
+          chipItems.push({
+            id: "readiness",
+            label: "Profile",
+            value: labelFor(readinessOptions, search.readiness),
+          });
+        if (search.serviceKind)
+          chipItems.push({
+            id: "serviceKind",
+            label: "Service",
+            value: labelFor(serviceOptions, search.serviceKind),
+          });
+        if (search.kind)
+          chipItems.push({
+            id: "kind",
+            label: "Surface",
+            value: labelFor(kindOptions, search.kind),
+          });
+        if (search.stale) chipItems.push({ id: "stale", label: "Stale", value: "only" });
+        if (!search.includeRoot)
+          chipItems.push({ id: "includeRoot", label: "Root", value: "hidden" });
+        const clearKey = (id: string) => {
+          switch (id) {
+            case "q":
+              setSearch({ q: "" });
+              break;
+            case "health":
+              setSearch({ health: "" });
+              break;
+            case "curation":
+              setSearch({ curation: "" });
+              break;
+            case "readiness":
+              setSearch({ readiness: "" });
+              break;
+            case "serviceKind":
+              setSearch({ serviceKind: "" });
+              break;
+            case "kind":
+              setSearch({ kind: "" });
+              break;
+            case "stale":
+              setSearch({ stale: "" });
+              break;
+            case "includeRoot":
+              setSearch({ includeRoot: true });
+              break;
+          }
+        };
+        return (
+          <FilterChipRow
+            items={chipItems}
+            onRemove={clearKey}
+            onClearAll={
+              chipItems.length > 1
+                ? () =>
+                    navigate({
+                      search: { limit: search.limit, view: search.view } as never,
+                      replace: true,
+                    })
+                : undefined
+            }
+          />
+        );
+      })()}
+    </div>
   );
 
   const emptyNode = (
@@ -646,9 +937,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   if (view === "grid" || view === "matrix") {
     return (
       <div>
-        <div className="sticky top-14 z-20 -mx-4 md:mx-0 mb-3 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5">
-          <div className="flex flex-wrap items-center gap-2">{filters}</div>
-        </div>
+        <StickyToolbar className="mb-3">{filters}</StickyToolbar>
         {rows.length === 0 && !hasNextPage ? (
           emptyNode
         ) : view === "grid" ? (
@@ -662,7 +951,8 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   }
 
   return (
-    <div id="subnets-list">
+    <div id="subnets-list" className="relative">
+      <QueryProgress active={isFetching && !isFetchingNextPage} position="sticky" />
       <ListShell
         filters={filters}
         isEmpty={rows.length === 0 && !hasNextPage}
@@ -708,7 +998,16 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
               </span>
             </div>
             <div className="mt-1.5">
-              <CurationChip level={s.curation_level} />
+              <div className="grid grid-cols-[auto_minmax(88px,1fr)] items-center gap-3">
+                <ProvenanceChip level={s.curation_level} />
+                <ReadinessGauge
+                  score={s.integration_readiness}
+                  tier={s.readiness_tier}
+                  details={s.service_kinds}
+                  compact
+                  className="justify-self-end"
+                />
+              </div>
             </div>
           </Link>
         ))}
@@ -719,11 +1018,14 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           const monoSize = compact ? "text-[11px]" : "text-[12px]";
           return (
             <table className="w-full text-left text-sm">
-              <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+              <thead>
                 <tr>
-                  <th className={classNames(firstPad, "w-6")} aria-label="Compare" />
                   <th
-                    className={cellPad}
+                    className={classNames(firstPad, "mg-subnets-sticky-head w-6")}
+                    aria-label="Compare"
+                  />
+                  <th
+                    className={classNames(cellPad, "mg-subnets-sticky-head")}
                     aria-sort={ariaSort(search.sort === "netuid", search.order)}
                   >
                     <SortHeader
@@ -735,7 +1037,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                     />
                   </th>
                   <th
-                    className={cellPad}
+                    className={classNames(cellPad, "mg-subnets-sticky-head")}
                     aria-sort={ariaSort(search.sort === "name", search.order)}
                   >
                     <SortHeader
@@ -746,109 +1048,183 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                       onSort={onSort}
                     />
                   </th>
-                  <th
-                    className={cellPad}
-                    aria-sort={ariaSort(search.sort === "symbol", search.order)}
-                  >
-                    <SortHeader
-                      label="Symbol"
-                      field="symbol"
-                      active={search.sort === "symbol"}
-                      order={search.order}
-                      onSort={onSort}
-                    />
-                  </th>
-                  <th
-                    className={classNames(cellPad, "text-right")}
-                    aria-sort={ariaSort(search.sort === "participants", search.order)}
-                  >
-                    <SortHeader
-                      label="Participants"
-                      field="participants"
-                      active={search.sort === "participants"}
-                      order={search.order}
-                      onSort={onSort}
-                      align="right"
-                    />
-                  </th>
-                  <th
-                    className={cellPad}
-                    aria-sort={ariaSort(search.sort === "curation_level", search.order)}
-                  >
-                    <SortHeader
-                      label="Curation"
-                      field="curation_level"
-                      active={search.sort === "curation_level"}
-                      order={search.order}
-                      onSort={onSort}
-                    />
-                  </th>
-                  <th
-                    className={classNames(cellPad, "text-right")}
-                    aria-sort={ariaSort(search.sort === "surfaces_count", search.order)}
-                  >
-                    <SortHeader
-                      label="Surfaces"
-                      field="surfaces_count"
-                      active={search.sort === "surfaces_count"}
-                      order={search.order}
-                      onSort={onSort}
-                      align="right"
-                    />
-                  </th>
-                  <th
-                    className={classNames(cellPad, "text-right")}
-                    aria-sort={ariaSort(search.sort === "integration_readiness", search.order)}
-                  >
-                    <SortHeader
-                      label="Readiness"
-                      field="integration_readiness"
-                      active={search.sort === "integration_readiness"}
-                      order={search.order}
-                      onSort={onSort}
-                      align="right"
-                    />
-                  </th>
-                  <th
-                    className={classNames(cellPad, "text-right")}
-                    aria-sort={ariaSort(search.sort === "registration_cost_tao", search.order)}
-                  >
-                    <SortHeader
-                      label="Registration"
-                      field="registration_cost_tao"
-                      active={search.sort === "registration_cost_tao"}
-                      order={search.order}
-                      onSort={onSort}
-                      align="right"
-                    />
-                  </th>
-                  <th className={cellPad}>Health</th>
-                  <th
-                    className={classNames(cellPad, "text-right")}
-                    aria-sort={ariaSort(search.sort === "emission_share", search.order)}
-                  >
-                    <SortHeader
-                      label="Emission"
-                      field="emission_share"
-                      active={search.sort === "emission_share"}
-                      order={search.order}
-                      onSort={onSort}
-                      align="right"
-                    />
-                  </th>
-                  <th
-                    className={classNames(cellPad, "text-right")}
-                    aria-sort={ariaSort(search.sort === "updated_at", search.order)}
-                  >
-                    <SortHeader
-                      label="Updated"
-                      field="updated_at"
-                      active={search.sort === "updated_at"}
-                      order={search.order}
-                      onSort={onSort}
-                      align="right"
-                    />
-                  </th>
+                  {columns.isVisible("symbol") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head")}
+                      aria-sort={ariaSort(search.sort === "symbol", search.order)}
+                    >
+                      <SortHeader
+                        label="Symbol"
+                        field="symbol"
+                        active={search.sort === "symbol"}
+                        order={search.order}
+                        onSort={onSort}
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("participants") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "participants", search.order)}
+                    >
+                      <SortHeader
+                        label="Participants"
+                        field="participants"
+                        active={search.sort === "participants"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("curation") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head")}
+                      aria-sort={ariaSort(search.sort === "curation_level", search.order)}
+                      title="Source: how this subnet's registry entry was curated — native chain data, machine-verified, maintainer-reviewed, adapter-backed, community-seeded, or an unverified candidate."
+                    >
+                      <SortHeader
+                        label="Source"
+                        field="curation_level"
+                        active={search.sort === "curation_level"}
+                        order={search.order}
+                        onSort={onSort}
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("surfaces") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "surfaces_count", search.order)}
+                      title="Verified public surfaces registered for this subnet (APIs, docs, dashboards, data artifacts, SSE streams)."
+                    >
+                      <SortHeader
+                        label="Surfaces"
+                        field="surfaces_count"
+                        active={search.sort === "surfaces_count"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("readiness") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "integration_readiness", search.order)}
+                      title="Profile: how complete this subnet's public-interface profile is (buildable → emerging → identity-only → dormant), based on registered surfaces and evidence."
+                    >
+                      <SortHeader
+                        label="Profile"
+                        field="integration_readiness"
+                        active={search.sort === "integration_readiness"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("registration") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "registration_cost_tao", search.order)}
+                      title="Current recycle/burn cost (in TAO) to register a new UID on this subnet. Dimmed when registration is closed."
+                    >
+                      <SortHeader
+                        label="Reg. cost"
+                        field="registration_cost_tao"
+                        active={search.sort === "registration_cost_tao"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("health") ? (
+                    <th
+                      className={classNames(
+                        cellPad,
+                        "mg-subnets-sticky-head mg-type-micro text-[10px] text-ink-muted font-normal text-left",
+                      )}
+                    >
+                      Health
+                    </th>
+                  ) : null}
+                  {columns.isVisible("emission") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "emission_share", search.order)}
+                    >
+                      <SortHeader
+                        label="Emission"
+                        field="emission_share"
+                        active={search.sort === "emission_share"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("alphaPrice") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "alpha_price_tao", search.order)}
+                    >
+                      <SortHeader
+                        label="Alpha price"
+                        field="alpha_price_tao"
+                        active={search.sort === "alpha_price_tao"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("totalStake") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "total_stake_tao", search.order)}
+                    >
+                      <SortHeader
+                        label="Total stake"
+                        field="total_stake_tao"
+                        active={search.sort === "total_stake_tao"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("marketCap") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "alpha_market_cap_tao", search.order)}
+                    >
+                      <SortHeader
+                        label="Market cap"
+                        field="alpha_market_cap_tao"
+                        active={search.sort === "alpha_market_cap_tao"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
+                  {columns.isVisible("updated") ? (
+                    <th
+                      className={classNames(cellPad, "mg-subnets-sticky-head text-right")}
+                      aria-sort={ariaSort(search.sort === "updated_at", search.order)}
+                    >
+                      <SortHeader
+                        label="Updated"
+                        field="updated_at"
+                        active={search.sort === "updated_at"}
+                        order={search.order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    </th>
+                  ) : null}
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
@@ -893,68 +1269,118 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                         </Link>
                       </EntityHoverCard>
                     </td>
-                    <td className={classNames(cellPad, "font-mono text-[11px] text-ink-muted")}>
-                      {s.symbol ?? "—"}
-                    </td>
-                    <td className={classNames(cellPad, "text-right")}>
-                      <ParticipantsCell
-                        value={s.participants}
-                        density={density}
-                        updatedAt={s.updated_at ?? s.freshness}
+                    {columns.isVisible("symbol") ? (
+                      <td className={classNames(cellPad, "font-mono text-[11px] text-ink-muted")}>
+                        {s.symbol ?? "—"}
+                      </td>
+                    ) : null}
+                    {columns.isVisible("participants") ? (
+                      <td className={classNames(cellPad, "text-right")}>
+                        <ParticipantsCell
+                          value={s.participants}
+                          density={density}
+                          updatedAt={s.updated_at ?? s.freshness}
+                        />
+                      </td>
+                    ) : null}
+                    {columns.isVisible("curation") ? (
+                      <td className={cellPad}>
+                        <ProvenanceChip level={s.curation_level} />
+                      </td>
+                    ) : null}
+                    {columns.isVisible("surfaces") ? (
+                      <td className={classNames(cellPad, "text-right")}>
+                        <SurfacesCell subnet={s} density={density} />
+                      </td>
+                    ) : null}
+                    {columns.isVisible("readiness") ? (
+                      <td className={classNames(cellPad, "text-right")}>
+                        <ReadinessGauge
+                          score={s.integration_readiness}
+                          tier={s.readiness_tier}
+                          details={s.service_kinds}
+                          compact={compact}
+                        />
+                      </td>
+                    ) : null}
+                    {columns.isVisible("registration") ? (
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono text-[11px] tabular-nums",
+                          // #3364: dim the cost only when registration is explicitly
+                          // closed. `registration_allowed === undefined` (economics
+                          // entry present but flag absent, or no entry at all) keeps
+                          // the neutral tone — do NOT read it as "open".
+                          s.registration_allowed === false ? "text-ink-muted" : "text-ink",
+                        )}
+                        title={
+                          s.registration_allowed === false
+                            ? "Registration currently closed"
+                            : s.registration_allowed === true
+                              ? "Registration open"
+                              : undefined
+                        }
+                      >
+                        {formatTao(s.registration_cost_tao)}
+                      </td>
+                    ) : null}
+                    {columns.isVisible("health") ? (
+                      <td className={cellPad}>
+                        <HealthPill state={s.health} />
+                      </td>
+                    ) : null}
+                    {columns.isVisible("emission") ? (
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono text-[11px] tabular-nums",
+                        )}
+                      >
+                        <EmissionCell share={s.emission_share} />
+                      </td>
+                    ) : null}
+                    {columns.isVisible("alphaPrice") ? (
+                      <FinancialTrendCell
+                        netuid={s.netuid}
+                        field="alpha_price_tao"
+                        current={s.alpha_price_tao}
+                        digits={4}
+                        compact={compact}
+                        usdPerTao={taoUsd}
+                        window={trendWindow}
                       />
-                    </td>
-                    <td className={cellPad}>
-                      <CurationChip level={s.curation_level} />
-                    </td>
-                    <td className={classNames(cellPad, "text-right")}>
-                      <SurfacesCell subnet={s} density={density} />
-                    </td>
-                    <td className={classNames(cellPad, "text-right")}>
-                      <ReadinessCell
-                        score={s.integration_readiness}
-                        tier={s.readiness_tier}
-                        kinds={s.service_kinds}
+                    ) : null}
+                    {columns.isVisible("totalStake") ? (
+                      <FinancialTrendCell
+                        netuid={s.netuid}
+                        field="total_stake_tao"
+                        current={s.total_stake_tao}
+                        compact={compact}
+                        window={trendWindow}
+                        symbol={s.netuid === 0 ? "τ" : (s.symbol ?? "α")}
                       />
-                    </td>
-                    <td
-                      className={classNames(
-                        cellPad,
-                        "text-right font-mono text-[11px] tabular-nums",
-                        // #3364: dim the cost only when registration is explicitly
-                        // closed. `registration_allowed === undefined` (economics
-                        // entry present but flag absent, or no entry at all) keeps
-                        // the neutral tone — do NOT read it as "open".
-                        s.registration_allowed === false ? "text-ink-muted" : "text-ink",
-                      )}
-                      title={
-                        s.registration_allowed === false
-                          ? "Registration currently closed"
-                          : s.registration_allowed === true
-                            ? "Registration open"
-                            : undefined
-                      }
-                    >
-                      {formatTao(s.registration_cost_tao)}
-                    </td>
-                    <td className={cellPad}>
-                      <HealthPill state={s.health} />
-                    </td>
-                    <td
-                      className={classNames(
-                        cellPad,
-                        "text-right font-mono text-[11px] tabular-nums",
-                      )}
-                    >
-                      <EmissionCell share={s.emission_share} />
-                    </td>
-                    <td
-                      className={classNames(
-                        cellPad,
-                        "text-right font-mono text-[11px] text-ink-muted",
-                      )}
-                    >
-                      <TimeAgo at={s.updated_at ?? s.freshness} />
-                    </td>
+                    ) : null}
+                    {columns.isVisible("marketCap") ? (
+                      <FinancialTrendCell
+                        netuid={s.netuid}
+                        field="alpha_market_cap_tao"
+                        current={s.alpha_market_cap_tao}
+                        compact={compact}
+                        usdPerTao={taoUsd}
+                        window={trendWindow}
+                      />
+                    ) : null}
+                    {columns.isVisible("updated") ? (
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono text-[11px] text-ink-muted",
+                        )}
+                      >
+                        <TimeAgo at={s.updated_at ?? s.freshness} />
+                      </td>
+                    ) : null}
                   </tr>
                 ))}
               </tbody>
@@ -990,7 +1416,7 @@ function SubnetGrid({ rows }: { rows: Subnet[] }) {
                 size={36}
               />
               <div className="min-w-0">
-                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                <div className="mg-type-micro text-[10px] text-ink-muted">
                   #{String(s.netuid).padStart(3, "0")}
                   {s.symbol ? ` · ${s.symbol}` : ""}
                 </div>
@@ -1001,7 +1427,7 @@ function SubnetGrid({ rows }: { rows: Subnet[] }) {
             </div>
             <div className="flex items-center gap-2 shrink-0">
               <CompareToggle netuid={s.netuid} />
-              <HealthPill state={s.health} />
+              <StatusBadge status={(s.health ?? "unknown") as HealthStatus} />
             </div>
           </div>
 
@@ -1012,11 +1438,33 @@ function SubnetGrid({ rows }: { rows: Subnet[] }) {
           ) : null}
 
           <div className="mt-auto flex items-center justify-between gap-2 pt-2 border-t border-border/70">
-            <CurationChip level={s.curation_level} />
-            <div className="flex items-center gap-3 font-mono text-[10px] text-ink-muted">
-              <span title="Participants">{formatNumber(s.participants)}</span>
-              <span title="Surfaces">{s.surfaces_count ?? 0} surf</span>
-              <TimeAgo at={s.updated_at ?? s.freshness} />
+            <Chip
+              tone={
+                s.curation_level === "native" ||
+                s.curation_level === "maintainer-reviewed" ||
+                s.curation_level === "machine-verified" ||
+                s.curation_level === "adapter-backed"
+                  ? "accent"
+                  : "muted"
+              }
+              label="curation"
+            >
+              {s.curation_level ?? "unknown"}
+            </Chip>
+            <div className="flex items-center gap-3">
+              <Indicator
+                icon={Layers}
+                label="uids"
+                value={formatNumber(s.participants)}
+                title="Registered UIDs"
+              />
+              <Indicator
+                icon={Server}
+                label="surfaces"
+                value={s.surfaces_count ?? 0}
+                title="Verified public surfaces"
+              />
+              <FreshnessPill updatedAt={s.updated_at ?? s.freshness} />
             </div>
           </div>
         </Link>
@@ -1060,7 +1508,7 @@ function SubnetMatrix({ rows }: { rows: Subnet[] }) {
   return (
     <div className="rounded border border-border bg-card p-4">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <div className="mg-type-micro text-[10px] text-ink-muted">
           Health matrix · {rows.length} subnets
         </div>
         <div className="flex items-center gap-3 text-[10px] font-mono text-ink-muted">
@@ -1164,48 +1612,167 @@ function ParticipantsCell({
   );
 }
 
-// #9: integration-readiness score + tier badge, fed by the agent-catalog join.
-// Tier drives the colour; the score is the 0–100 integration_readiness. Subnets
-// with no catalog entry render a muted dash.
-const READINESS_TIER_TONE: Record<string, string> = {
-  buildable: "text-health-ok border-health-ok/40",
-  emerging: "text-accent-text border-accent/40",
-  "identity-only": "text-health-warn border-health-warn/40",
-  dormant: "text-ink-muted border-border",
-};
-
-function ReadinessCell({
-  score,
-  tier,
-  kinds,
+function FinancialCell({
+  value,
+  digits = 2,
+  compact = false,
+  usdPerTao,
 }: {
-  score?: number;
-  tier?: string;
-  kinds?: string[];
+  value?: number;
+  digits?: number;
+  compact?: boolean;
+  usdPerTao?: number;
 }) {
-  if (score == null && !tier) {
-    return <span className="font-mono text-[11px] text-ink-muted">—</span>;
-  }
-  const tone = READINESS_TIER_TONE[tier ?? ""] ?? "text-ink-muted border-border";
+  const usd = value != null && usdPerTao != null ? value * usdPerTao : undefined;
+  const fmtUsd = (n: number) =>
+    n >= 1_000_000
+      ? `$${(n / 1_000_000).toFixed(2)}M`
+      : n >= 1_000
+        ? `$${(n / 1_000).toFixed(1)}K`
+        : `$${n.toFixed(2)}`;
   return (
-    <span
-      className="inline-flex flex-col items-end gap-0.5"
-      title={kinds && kinds.length ? `Services: ${kinds.join(", ")}` : undefined}
+    <td
+      className={classNames(
+        compact ? "px-3 py-1.5" : "px-4 py-2.5",
+        "text-right font-mono text-[11px] tabular-nums text-ink",
+      )}
     >
-      <span className="font-mono text-[12px] tabular-nums text-ink-strong">
-        {score != null ? score : "—"}
-      </span>
-      {tier ? (
-        <span
-          className={classNames(
-            "inline-flex items-center rounded border px-1 py-0.5 font-mono text-[8px] uppercase tracking-widest",
-            tone,
-          )}
-        >
-          {tier}
-        </span>
-      ) : null}
-    </span>
+      <div>
+        {value == null
+          ? "—"
+          : `${value.toLocaleString(undefined, { maximumFractionDigits: digits })} τ`}
+      </div>
+      {usd != null ? <div className="text-[10px] text-ink-muted/80">{fmtUsd(usd)}</div> : null}
+    </td>
+  );
+}
+
+// Per-row financial cell with a tone-colored value + sparkline over the
+// selected window. Data source depends on the field:
+//   - total_stake_tao       → /subnets/{n}/history (daily snapshots)
+//   - alpha_price_tao       → /subnets/{n}/trajectory (daily price)
+//   - alpha_market_cap_tao  → trajectory price × 21_000_000 alpha cap
+// React Query dedupes each underlying request across rows/cells.
+const ALPHA_MAX_SUPPLY = 21_000_000;
+
+function FinancialTrendCell({
+  netuid,
+  field,
+  current,
+  window: win,
+  digits = 2,
+  compact = false,
+  usdPerTao,
+  symbol,
+}: {
+  netuid: number;
+  field: "alpha_price_tao" | "total_stake_tao" | "alpha_market_cap_tao";
+  current?: number;
+  window: "7d" | "30d" | "90d";
+  digits?: number;
+  compact?: boolean;
+  usdPerTao?: number;
+  symbol?: string;
+}) {
+  const usesTrajectory = field === "alpha_price_tao" || field === "alpha_market_cap_tao";
+  const historyRes = useQuery({
+    ...subnetHistoryQuery(netuid, win),
+    enabled: !usesTrajectory,
+    staleTime: 60_000,
+  });
+  const trajectoryRes = useQuery({
+    ...subnetTrajectoryQuery(netuid),
+    enabled: usesTrajectory,
+    staleTime: 60_000,
+  });
+
+  const series: number[] = useMemo(() => {
+    if (usesTrajectory) {
+      const points = trajectoryRes.data?.data?.points ?? [];
+      const days = win === "7d" ? 7 : win === "30d" ? 30 : 90;
+      const windowed = points.slice(-days);
+      const priced = windowed
+        .map((p) => (typeof p.alpha_price_tao === "number" ? p.alpha_price_tao : NaN))
+        .filter((n) => Number.isFinite(n)) as number[];
+      return field === "alpha_market_cap_tao" ? priced.map((p) => p * ALPHA_MAX_SUPPLY) : priced;
+    }
+    const points = historyRes.data?.data?.points ?? [];
+    return points
+      .map((p) => {
+        const raw = (p as Record<string, unknown>)[field];
+        return typeof raw === "number" && Number.isFinite(raw) ? raw : NaN;
+      })
+      .filter((n) => Number.isFinite(n)) as number[];
+  }, [usesTrajectory, trajectoryRes.data, historyRes.data, win, field]);
+
+  const last = series.length ? series[series.length - 1] : current;
+  const first = series.length ? series[0] : undefined;
+  const delta = first != null && last != null && first !== 0 ? (last - first) / first : 0;
+  const tone: "up" | "down" | "flat" =
+    series.length < 2 || Math.abs(delta) < 0.0005 ? "flat" : delta > 0 ? "up" : "down";
+  const toneClass =
+    tone === "up" ? "text-health-ok" : tone === "down" ? "text-health-down" : "text-ink";
+  const strokeVar =
+    tone === "up"
+      ? "var(--health-ok)"
+      : tone === "down"
+        ? "var(--health-down)"
+        : "var(--ink-muted)";
+  const displayValue = last ?? current;
+  const usd = displayValue != null && usdPerTao != null ? displayValue * usdPerTao : undefined;
+  const fmtUsd = (n: number) =>
+    n >= 1_000_000_000
+      ? `$${(n / 1_000_000_000).toFixed(2)}B`
+      : n >= 1_000_000
+        ? `$${(n / 1_000_000).toFixed(2)}M`
+        : n >= 1_000
+          ? `$${(n / 1_000).toFixed(1)}K`
+          : `$${n.toFixed(2)}`;
+  const pct = tone === "flat" ? null : `${delta > 0 ? "+" : ""}${(delta * 100).toFixed(2)}%`;
+  const unit = symbol ?? "τ";
+  const fmtVal = (n: number) => {
+    const compactNum =
+      n >= 1_000_000
+        ? `${(n / 1_000_000).toFixed(2)}M`
+        : n >= 1_000
+          ? `${(n / 1_000).toFixed(1)}K`
+          : n.toLocaleString(undefined, { maximumFractionDigits: digits });
+    return `${compactNum} ${unit}`;
+  };
+  return (
+    <td
+      className={classNames(
+        compact ? "px-3 py-1.5" : "px-4 py-2.5",
+        "text-right font-mono text-[11px] tabular-nums",
+      )}
+    >
+      <div className="flex items-center justify-end gap-2">
+        {series.length > 1 ? (
+          <Sparkline
+            values={series}
+            width={compact ? 44 : 56}
+            height={compact ? 14 : 18}
+            color={strokeVar}
+            fill={false}
+            interactive={false}
+            ariaLabel={`${field} ${win} trend`}
+          />
+        ) : null}
+        <div className="min-w-0">
+          <div className={toneClass}>{displayValue == null ? "—" : fmtVal(displayValue)}</div>
+          {usd != null || pct ? (
+            <div className="text-[10px] text-ink-muted/80 flex items-center justify-end gap-1">
+              {usd != null ? <span>{fmtUsd(usd)}</span> : null}
+              {pct ? (
+                <span className={toneClass} title={`${win} change`}>
+                  {pct}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </td>
   );
 }
 

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -52,6 +52,7 @@ import {
   type ViewMode,
 } from "@jsonbored/ui-kit";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useInView } from "@/hooks/use-in-view";
 import { SubnetsHighlights } from "@/components/metagraphed/subnets-highlights";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import {
@@ -1675,14 +1676,18 @@ function FinancialTrendCell({
   symbol?: string;
 }) {
   const usesTrajectory = field === "alpha_price_tao" || field === "alpha_market_cap_tao";
+  // Trend data is per-netuid (react-query can't dedupe across rows), and a
+  // page can hold up to 200 rows — fetch only once a row has actually
+  // scrolled into view instead of firing a query for every mounted row.
+  const [cellRef, inView] = useInView<HTMLTableCellElement>();
   const historyRes = useQuery({
     ...subnetHistoryQuery(netuid, win),
-    enabled: !usesTrajectory,
+    enabled: inView && !usesTrajectory,
     staleTime: 60_000,
   });
   const trajectoryRes = useQuery({
     ...subnetTrajectoryQuery(netuid),
-    enabled: usesTrajectory,
+    enabled: inView && usesTrajectory,
     staleTime: 60_000,
   });
 
@@ -1741,6 +1746,7 @@ function FinancialTrendCell({
   };
   return (
     <td
+      ref={cellRef}
       className={classNames(
         compact ? "px-3 py-1.5" : "px-4 py-2.5",
         "text-right font-mono text-[11px] tabular-nums",

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -1,18 +1,24 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useMemo } from "react";
+import { useMemo } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import {
+  AsyncPanel,
+  FilterChipRow,
+  FilterSheet,
+  QueryBar,
+  QueryProgress,
+  PageMasthead,
+  type FilterChipItem,
+} from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { Skeleton } from "@/components/metagraphed/states";
 import { StateBlock } from "@/components/metagraphed/states/state-block";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import {
   TimeAgo,
   CurationChip,
   ReviewChip,
   ExternalLink,
-  PageHero,
   SectionHeading,
   BrandIcon,
   ShareButton,
@@ -33,11 +39,15 @@ import {
   ariaSort,
   PageSizeSelect,
   ResetFiltersButton,
-  SearchInput,
   SelectFilter,
   SortHeader,
 } from "@/components/metagraphed/table-controls";
-import { surfacesInfiniteQuery, providersQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import {
+  surfacesInfiniteQuery,
+  providersQuery,
+  subnetsQuery,
+  metagraphedQueryKey,
+} from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { sortBy } from "@/lib/metagraphed/url-state";
 import { surfacesSearchSchema, matchesSurfaceFilters } from "@/lib/metagraphed/surface-filters";
@@ -94,8 +104,7 @@ function SurfacesPage() {
   return (
     <AppShell>
       <TimeRangeProvider defaultRange="7d">
-        <PageHero
-          eyebrow="Registry"
+        <PageMasthead
           live
           title="Surfaces"
           description="Verified public interfaces across subnets — filter by kind, provider, and netuid."
@@ -120,11 +129,17 @@ function SurfacesPage() {
             </>
           }
         />
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-            <SurfacesTable view={viewMode} />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel
+          height="xl"
+          context="surfaces"
+          retryQueryKeys={[
+            metagraphedQueryKey("surfaces-infinite"),
+            metagraphedQueryKey("providers"),
+            metagraphedQueryKey("subnets"),
+          ]}
+        >
+          <SurfacesTable view={viewMode} />
+        </AsyncPanel>
         <section className="mt-section">
           <SectionHeading title="Evidence & sources" />
           <EvidencePanel />
@@ -238,13 +253,52 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
     (row, key) => (row as Record<string, unknown>)[key],
   );
 
-  const filters = (
+  const activeChips: Array<{ key: string; value: string; onClear: () => void }> = [];
+  if (search.q)
+    activeChips.push({ key: "q", value: search.q, onClear: () => setSearch({ q: "" }) });
+  if (search.kind)
+    activeChips.push({ key: "kind", value: search.kind, onClear: () => setSearch({ kind: "" }) });
+  if (search.provider)
+    activeChips.push({
+      key: "provider",
+      value: search.provider,
+      onClear: () => setSearch({ provider: "" }),
+    });
+  if (search.netuid)
+    activeChips.push({
+      key: "netuid",
+      value: String(search.netuid),
+      onClear: () => setSearch({ netuid: "" }),
+    });
+  if (search.public_safe)
+    activeChips.push({
+      key: "public",
+      value: String(search.public_safe),
+      onClear: () => setSearch({ public_safe: "" }),
+    });
+  if (search.auth)
+    activeChips.push({
+      key: "auth",
+      value: String(search.auth),
+      onClear: () => setSearch({ auth: "" }),
+    });
+  if (search.rate_limited)
+    activeChips.push({
+      key: "rate-limit",
+      value: String(search.rate_limited),
+      onClear: () => setSearch({ rate_limited: "" }),
+    });
+
+  const secondaryFilterCount =
+    (search.kind ? 1 : 0) +
+    (search.provider ? 1 : 0) +
+    (search.netuid ? 1 : 0) +
+    (search.public_safe ? 1 : 0) +
+    (search.auth ? 1 : 0) +
+    (search.rate_limited ? 1 : 0);
+
+  const secondaryFilters = (
     <>
-      <SearchInput
-        value={search.q}
-        onChange={(v) => setSearch({ q: v })}
-        placeholder="Search by name, URL, provider, or netuid"
-      />
       <SelectFilter
         label="kind"
         value={search.kind}
@@ -263,19 +317,64 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
         onChange={(v) => setSearch({ netuid: v })}
         options={netuidOptions}
       />
-      <PageSizeSelect value={search.limit} onChange={(n) => setSearch({ limit: n })} />
     </>
   );
 
-  const filtersActive = !!(
-    search.q ||
-    search.kind ||
-    search.provider ||
-    search.netuid ||
-    search.public_safe ||
-    search.auth ||
-    search.rate_limited
+  const chipItems: FilterChipItem[] = [];
+  if (search.q) chipItems.push({ id: "q", label: "Search", value: search.q });
+  if (search.kind) chipItems.push({ id: "kind", label: "Kind", value: search.kind });
+  if (search.provider)
+    chipItems.push({ id: "provider", label: "Provider", value: search.provider });
+  if (search.netuid)
+    chipItems.push({ id: "netuid", label: "Netuid", value: String(search.netuid) });
+  if (search.public_safe)
+    chipItems.push({ id: "public_safe", label: "Public-safe", value: "only" });
+  if (search.auth) chipItems.push({ id: "auth", label: "Auth", value: search.auth });
+  if (search.rate_limited)
+    chipItems.push({ id: "rate_limited", label: "Rate-limited", value: "only" });
+
+  const clearChip = (id: string) => setSearch({ [id]: "" });
+  const clearAll = () =>
+    setSearch({
+      q: "",
+      kind: "",
+      provider: "",
+      netuid: "",
+      public_safe: "",
+      auth: "",
+      rate_limited: "",
+    });
+
+  const filters = (
+    <div className="flex w-full flex-col gap-0 min-w-0">
+      <div className="flex w-full items-center gap-2 min-w-0">
+        <QueryBar className="flex-1 min-w-0">
+          <QueryBar.Search
+            value={search.q}
+            onChange={(v) => setSearch({ q: v })}
+            placeholder="Search by name, URL, provider, or netuid"
+            shortcut
+            debounceMs={200}
+          />
+          <QueryBar.Divider />
+          <div className="hidden md:contents">{secondaryFilters}</div>
+          <QueryBar.Utility className="ml-auto">
+            <PageSizeSelect value={search.limit} onChange={(n) => setSearch({ limit: n })} />
+          </QueryBar.Utility>
+        </QueryBar>
+        <FilterSheet className="md:hidden" label="Filters" activeCount={secondaryFilterCount}>
+          {secondaryFilters}
+        </FilterSheet>
+      </div>
+      <FilterChipRow
+        items={chipItems}
+        onRemove={clearChip}
+        onClearAll={chipItems.length > 1 ? clearAll : undefined}
+      />
+    </div>
   );
+
+  const filtersActive = activeChips.length > 0;
 
   const emptyNode = (
     <StateBlock
@@ -425,136 +524,135 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
   );
 
   return (
-    <ListShell
-      filters={filters}
-      isEmpty={rows.length === 0}
-      isStale={isFetching && !isFetchingNextPage}
-      empty={emptyNode}
-      // This table's <thead> isn't sticky (plain bg-surface/50, no
-      // position:sticky) -- opt out so it keeps ListShell's normal
-      // unbounded-height horizontal scroll instead of the sticky-header
-      // bounded-scroll box it doesn't use.
-      stickyHeader={false}
-      cards={view === "grid" ? undefined : rows.map(cardFor)}
-      table={
-        view === "grid" ? (
-          gridBody
-        ) : (
-          <table className="w-full text-left text-sm">
-            <thead className="bg-surface/50">
-              <tr>
-                <th
-                  className="px-3 py-2"
-                  aria-sort={ariaSort(search.sort === "netuid", search.order)}
-                >
-                  <SortHeader
-                    label="Netuid"
-                    field="netuid"
-                    active={search.sort === "netuid"}
-                    order={search.order}
-                    onSort={onSort}
-                  />
-                </th>
-                <th
-                  className="px-3 py-2"
-                  aria-sort={ariaSort(search.sort === "kind", search.order)}
-                >
-                  <SortHeader
-                    label="Kind"
-                    field="kind"
-                    active={search.sort === "kind"}
-                    order={search.order}
-                    onSort={onSort}
-                  />
-                </th>
-                <th
-                  className="px-3 py-2"
-                  aria-sort={ariaSort(search.sort === "name", search.order)}
-                >
-                  <SortHeader
-                    label="Name"
-                    field="name"
-                    active={search.sort === "name"}
-                    order={search.order}
-                    onSort={onSort}
-                  />
-                </th>
-                <th className="px-3 py-2">URL</th>
-                <th className="px-3 py-2">Provider</th>
-                <th className="px-3 py-2">Curation</th>
-                <th
-                  className="px-3 py-2 text-right"
-                  aria-sort={ariaSort(search.sort === "last_verified_at", search.order)}
-                >
-                  <SortHeader
-                    label="Last verified"
-                    field="last_verified_at"
-                    active={search.sort === "last_verified_at"}
-                    order={search.order}
-                    onSort={onSort}
-                    align="right"
-                  />
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {rows.map((s) => (
-                <tr key={s.id} className="mg-row-accent hover:bg-surface/40">
-                  <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                    {renderSubnetCell(s.netuid)}
-                  </td>
-                  <td className="px-3 py-2 font-mono text-[11px]">{s.kind ?? "—"}</td>
-                  <td className="px-3 py-2 font-medium text-ink-strong">
-                    <span className="truncate">{s.name ?? "—"}</span>
-                  </td>
-                  <td className="px-3 py-2 text-[12px]">
-                    {s.url ? (
-                      <ExternalLink
-                        href={s.url}
-                        authRequired={s.auth_required}
-                        publicSafe={s.public_safe ?? true}
-                      >
-                        {s.url}
-                      </ExternalLink>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-[12px]">{renderProviderCell(s)}</td>
-                  <td className="px-3 py-2">
-                    <div className="flex items-center gap-1.5">
-                      <CurationChip level={s.curation_level} />
-                      <ReviewChip state={s.review?.state} />
-                    </div>
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
-                    <SparkLegend
-                      metric="Surface verification"
-                      source="/api/v1/surfaces"
-                      windowLabel={windowLabel}
-                      updatedAt={s.last_verified_at ?? undefined}
-                      staleness="Re-verified on every registry build; unverified rows have never been probed."
-                    >
-                      <TimeAgo at={s.last_verified_at} fallback="never verified" />
-                    </SparkLegend>
-                  </td>
+    <div id="surfaces-list" className="relative">
+      <QueryProgress active={isFetching && !isFetchingNextPage} position="sticky" />
+      <ListShell
+        filters={filters}
+        isEmpty={rows.length === 0}
+        isStale={isFetching && !isFetchingNextPage}
+        empty={emptyNode}
+        stickyHeader={false}
+        cards={view === "grid" ? undefined : rows.map(cardFor)}
+        table={
+          view === "grid" ? (
+            gridBody
+          ) : (
+            <table className="w-full text-left text-sm">
+              <thead className="bg-surface/50">
+                <tr>
+                  <th
+                    className="px-3 py-2"
+                    aria-sort={ariaSort(search.sort === "netuid", search.order)}
+                  >
+                    <SortHeader
+                      label="Netuid"
+                      field="netuid"
+                      active={search.sort === "netuid"}
+                      order={search.order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    className="px-3 py-2"
+                    aria-sort={ariaSort(search.sort === "kind", search.order)}
+                  >
+                    <SortHeader
+                      label="Kind"
+                      field="kind"
+                      active={search.sort === "kind"}
+                      order={search.order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    className="px-3 py-2"
+                    aria-sort={ariaSort(search.sort === "name", search.order)}
+                  >
+                    <SortHeader
+                      label="Name"
+                      field="name"
+                      active={search.sort === "name"}
+                      order={search.order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th className="px-3 py-2">URL</th>
+                  <th className="px-3 py-2">Provider</th>
+                  <th className="px-3 py-2">Curation</th>
+                  <th
+                    className="px-3 py-2 text-right"
+                    aria-sort={ariaSort(search.sort === "last_verified_at", search.order)}
+                  >
+                    <SortHeader
+                      label="Last verified"
+                      field="last_verified_at"
+                      active={search.sort === "last_verified_at"}
+                      order={search.order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        )
-      }
-      footer={
-        <LoadMore
-          shown={rows.length}
-          total={total}
-          hasMore={!!hasNextPage}
-          isLoading={isFetchingNextPage}
-          onLoadMore={() => fetchNextPage()}
-          error={isFetchNextPageError ? (error as Error) : null}
-          cursorInvalid={cursorInvalid}
-        />
-      }
-    />
+              </thead>
+              <tbody className="divide-y divide-border">
+                {rows.map((s) => (
+                  <tr key={s.id} className="mg-row-accent hover:bg-surface/40">
+                    <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
+                      {renderSubnetCell(s.netuid)}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px]">{s.kind ?? "—"}</td>
+                    <td className="px-3 py-2 font-medium text-ink-strong">
+                      <span className="truncate">{s.name ?? "—"}</span>
+                    </td>
+                    <td className="px-3 py-2 text-[12px]">
+                      {s.url ? (
+                        <ExternalLink
+                          href={s.url}
+                          authRequired={s.auth_required}
+                          publicSafe={s.public_safe ?? true}
+                        >
+                          {s.url}
+                        </ExternalLink>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-[12px]">{renderProviderCell(s)}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex items-center gap-1.5">
+                        <CurationChip level={s.curation_level} />
+                        <ReviewChip state={s.review?.state} />
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
+                      <SparkLegend
+                        metric="Surface verification"
+                        source="/api/v1/surfaces"
+                        windowLabel={windowLabel}
+                        updatedAt={s.last_verified_at ?? undefined}
+                        staleness="Re-verified on every registry build; unverified rows have never been probed."
+                      >
+                        <TimeAgo at={s.last_verified_at} fallback="never verified" />
+                      </SparkLegend>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )
+        }
+        footer={
+          <LoadMore
+            shown={rows.length}
+            total={total}
+            hasMore={!!hasNextPage}
+            isLoading={isFetchingNextPage}
+            onLoadMore={() => fetchNextPage()}
+            error={isFetchNextPageError ? (error as Error) : null}
+            cursorInvalid={cursorInvalid}
+          />
+        }
+      />
+    </div>
   );
 }

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -157,6 +157,38 @@
   height: 0;
 }
 
+/* A desktop subnet table fits the shell, so an overflow ancestor is both
+   unnecessary and harmful: it becomes the sticky cells' containing block.
+   Tablet retains horizontal scrolling; mobile uses the card fallback. */
+@media (min-width: 1024px) {
+  /* The desktop table header is the persistent navigation layer. Keeping the
+     filter toolbar in normal flow prevents two sticky rows from racing for a
+     ResizeObserver-derived offset as filters wrap. */
+  #subnets-list > div > div:first-child {
+    position: static;
+  }
+  #subnets-list .mg-table-scroll {
+    overflow: visible;
+  }
+  #subnets-list div:has(> .mg-table-scroll) {
+    overflow: visible;
+  }
+}
+
+.mg-subnets-sticky-head {
+  background: var(--card);
+  box-shadow: 0 1px 0 var(--border);
+}
+@media (min-width: 1024px) {
+  .mg-subnets-sticky-head {
+    position: sticky;
+    top: var(--mg-sticky-offset, 3.5rem);
+    z-index: 10;
+    background: color-mix(in oklab, var(--card) 94%, transparent);
+    backdrop-filter: blur(8px);
+  }
+}
+
 /* Skeleton pulse used by TableSkeleton primitive. */
 @keyframes mg-skel-pulse {
   0%,

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1930,39 +1930,48 @@ function ListShell({
     const el = filterRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver((entries) => {
-      const h = Math.round(entries[0]?.contentRect.height ?? el.getBoundingClientRect().height);
+      const h = Math.round(
+        entries[0]?.contentRect.height ?? el.getBoundingClientRect().height
+      );
       setFilterH((prev) => prev === h ? prev : h);
     });
     ro.observe(el);
     return () => ro.disconnect();
   }, []);
   const tableCard = "rounded border border-border bg-card overflow-hidden";
-  return /* @__PURE__ */ jsxRuntime.jsxs("div", { ref: rootRef, style: { ["--mg-list-filter-offset"]: `${filterH}px` }, children: [
-    /* @__PURE__ */ jsxRuntime.jsx(
-      "div",
-      {
-        ref: filterRef,
-        className: classNames(
-          // Sticky filter bar. Offset reads --mg-sticky-offset (published by
-          // AppShell to match real header + ticker height) with a fallback.
-          "sticky z-20 -mx-4 md:mx-0 mb-3",
-          "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
-          "border-b border-border md:border md:rounded md:bg-card",
-          "px-3 py-2 md:p-2.5"
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    "div",
+    {
+      ref: rootRef,
+      style: { ["--mg-list-filter-offset"]: `${filterH}px` },
+      children: [
+        /* @__PURE__ */ jsxRuntime.jsx(
+          "div",
+          {
+            ref: filterRef,
+            className: classNames(
+              // Sticky filter bar. Offset reads --mg-sticky-offset (published by
+              // AppShell to match real header + ticker height) with a fallback.
+              "sticky z-20 -mx-4 md:mx-0 mb-3",
+              "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
+              "border-b border-border md:border md:rounded md:bg-card",
+              "px-3 py-2 md:p-2.5"
+            ),
+            style: { top: "var(--mg-sticky-offset, 3.5rem)" },
+            children: /* @__PURE__ */ jsxRuntime.jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
+          }
         ),
-        style: { top: "var(--mg-sticky-offset, 3.5rem)" },
-        children: /* @__PURE__ */ jsxRuntime.jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
-      }
-    ),
-    isEmpty ? empty : /* @__PURE__ */ jsxRuntime.jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
-      cards ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
-      /* @__PURE__ */ jsxRuntime.jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxRuntime.jsxs("div", { className: tableCard, children: [
-        /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-table-scroll overflow-x-auto", children: table }),
-        footer
-      ] }) }),
-      cards && footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden mt-3", children: footer }) : null
-    ] })
-  ] });
+        isEmpty ? empty : /* @__PURE__ */ jsxRuntime.jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
+          cards ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
+          /* @__PURE__ */ jsxRuntime.jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxRuntime.jsxs("div", { className: tableCard, children: [
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-table-scroll overflow-x-auto", children: table }),
+            footer
+          ] }) }),
+          cards && footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden mt-3", children: footer }) : null
+        ] })
+      ]
+    }
+  );
 }
 function LoadMore({
   hasMore,

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -396,42 +396,6 @@ var SheetDescription = React3__namespace.forwardRef(({ className, ...props }, re
   }
 ));
 SheetDescription.displayName = DialogPrimitive__namespace.Description.displayName;
-var Toaster = ({ ...props }) => {
-  return /* @__PURE__ */ jsxRuntime.jsx(
-    sonner.Toaster,
-    {
-      className: "toaster group",
-      toastOptions: {
-        classNames: {
-          toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-muted-foreground",
-          actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-          cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground"
-        }
-      },
-      ...props
-    }
-  );
-};
-var TooltipProvider = TooltipPrimitive__namespace.Provider;
-var Tooltip = TooltipPrimitive__namespace.Root;
-var TooltipTrigger = TooltipPrimitive__namespace.Trigger;
-var TooltipContent = React3__namespace.forwardRef(({ className, sideOffset = 4, ...props }, ref) => /* @__PURE__ */ jsxRuntime.jsx(TooltipPrimitive__namespace.Portal, { children: /* @__PURE__ */ jsxRuntime.jsx(
-  TooltipPrimitive__namespace.Content,
-  {
-    ref,
-    sideOffset,
-    className: cn(
-      "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
-      className
-    ),
-    ...props
-  }
-) }));
-TooltipContent.displayName = TooltipPrimitive__namespace.Content.displayName;
-function Skeleton({ className = "h-4 w-full" }) {
-  return /* @__PURE__ */ jsxRuntime.jsx("div", { className: `animate-pulse rounded bg-surface-2 ${className}` });
-}
 
 // src/lib/format.ts
 function classNames(...parts) {
@@ -497,6 +461,86 @@ function relative(diffMs) {
   if (hr < 48) return `${hr}h ago`;
   const day = Math.round(hr / 24);
   return `${day}d ago`;
+}
+function SegmentedToggle({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsx(
+    "div",
+    {
+      role: "tablist",
+      "aria-label": ariaLabel,
+      className: classNames(
+        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
+        className
+      ),
+      children: options.map(
+        ({ value: v, label, Icon, ariaLabel: optionAriaLabel, title }) => {
+          const active = v === value;
+          return /* @__PURE__ */ jsxRuntime.jsxs(
+            "button",
+            {
+              type: "button",
+              role: "tab",
+              "aria-selected": active,
+              "aria-label": optionAriaLabel ?? label,
+              title: title ?? label,
+              onClick: () => onChange(v),
+              className: classNames(
+                "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
+                active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
+              ),
+              children: [
+                Icon ? /* @__PURE__ */ jsxRuntime.jsx(Icon, { className: "size-3.5" }) : null,
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "hidden sm:inline", children: label })
+              ]
+            },
+            v
+          );
+        }
+      )
+    }
+  );
+}
+var Toaster = ({ ...props }) => {
+  return /* @__PURE__ */ jsxRuntime.jsx(
+    sonner.Toaster,
+    {
+      className: "toaster group",
+      toastOptions: {
+        classNames: {
+          toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground"
+        }
+      },
+      ...props
+    }
+  );
+};
+var TooltipProvider = TooltipPrimitive__namespace.Provider;
+var Tooltip = TooltipPrimitive__namespace.Root;
+var TooltipTrigger = TooltipPrimitive__namespace.Trigger;
+var TooltipContent = React3__namespace.forwardRef(({ className, sideOffset = 4, ...props }, ref) => /* @__PURE__ */ jsxRuntime.jsx(TooltipPrimitive__namespace.Portal, { children: /* @__PURE__ */ jsxRuntime.jsx(
+  TooltipPrimitive__namespace.Content,
+  {
+    ref,
+    sideOffset,
+    className: cn(
+      "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
+      className
+    ),
+    ...props
+  }
+) }));
+TooltipContent.displayName = TooltipPrimitive__namespace.Content.displayName;
+function Skeleton({ className = "h-4 w-full" }) {
+  return /* @__PURE__ */ jsxRuntime.jsx("div", { className: `animate-pulse rounded bg-surface-2 ${className}` });
 }
 function AccentBand({
   children,
@@ -1479,50 +1523,6 @@ function CopyableCode({
     /* @__PURE__ */ jsxRuntime.jsx(CopyStatusRegion, { children: copied ? `${label ?? "Value"} copied to clipboard` : "" })
   ] });
 }
-function SegmentedToggle({
-  options,
-  value,
-  onChange,
-  ariaLabel,
-  className
-}) {
-  return /* @__PURE__ */ jsxRuntime.jsx(
-    "div",
-    {
-      role: "tablist",
-      "aria-label": ariaLabel,
-      className: classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className
-      ),
-      children: options.map(
-        ({ value: v, label, Icon, ariaLabel: optionAriaLabel, title }) => {
-          const active = v === value;
-          return /* @__PURE__ */ jsxRuntime.jsxs(
-            "button",
-            {
-              type: "button",
-              role: "tab",
-              "aria-selected": active,
-              "aria-label": optionAriaLabel ?? label,
-              title: title ?? label,
-              onClick: () => onChange(v),
-              className: classNames(
-                "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-                active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
-              ),
-              children: [
-                Icon ? /* @__PURE__ */ jsxRuntime.jsx(Icon, { className: "size-3.5" }) : null,
-                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "hidden sm:inline", children: label })
-              ]
-            },
-            v
-          );
-        }
-      )
-    }
-  );
-}
 function DensityToggle({
   value,
   onChange,
@@ -1916,39 +1916,48 @@ function ListShell({
   empty,
   isEmpty,
   isStale,
-  /** When true, the rendered table can stick its <thead> at `top-0` inside a
-   *  bounded-height, internally-scrolling viewport (both axes) -- the
-   *  standard sticky-header-data-table pattern. A page-scroll-relative
-   *  sticky header and native horizontal scroll cannot coexist on the same
-   *  wrapper: `overflow-x: auto` makes that wrapper the header's nearest
-   *  scroll-container ancestor per the CSS sticky-positioning spec, and
-   *  since the wrapper itself never scrolls internally (the page scrolls
-   *  past it instead), the header's "stuck" trigger never fires -- verified
-   *  directly (#5073). Bounding the wrapper's height and letting it scroll
-   *  internally makes it the header's OWN scroll reference, so both work.
-   */
-  stickyHeader = true
+  stickyHeader: _stickyHeader = true
 }) {
+  const rootRef = React3.useRef(null);
+  const filterRef = React3.useRef(null);
+  const [filterH, setFilterH] = React3.useState(0);
+  React3.useLayoutEffect(() => {
+    const el = filterRef.current;
+    if (!el) return;
+    setFilterH(Math.round(el.getBoundingClientRect().height));
+  }, []);
+  React3.useEffect(() => {
+    const el = filterRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const h = Math.round(entries[0]?.contentRect.height ?? el.getBoundingClientRect().height);
+      setFilterH((prev) => prev === h ? prev : h);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
   const tableCard = "rounded border border-border bg-card overflow-hidden";
-  const tableScroll = stickyHeader ? "mg-table-scroll overflow-auto" : "overflow-x-auto";
-  return /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+  return /* @__PURE__ */ jsxRuntime.jsxs("div", { ref: rootRef, style: { ["--mg-list-filter-offset"]: `${filterH}px` }, children: [
     /* @__PURE__ */ jsxRuntime.jsx(
       "div",
       {
+        ref: filterRef,
         className: classNames(
-          // Sticky filter bar. Offset matches header height (h-nav).
-          "sticky top-nav z-20 -mx-4 md:mx-0 mb-3",
+          // Sticky filter bar. Offset reads --mg-sticky-offset (published by
+          // AppShell to match real header + ticker height) with a fallback.
+          "sticky z-20 -mx-4 md:mx-0 mb-3",
           "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
           "border-b border-border md:border md:rounded md:bg-card",
           "px-3 py-2 md:p-2.5"
         ),
+        style: { top: "var(--mg-sticky-offset, 3.5rem)" },
         children: /* @__PURE__ */ jsxRuntime.jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
       }
     ),
     isEmpty ? empty : /* @__PURE__ */ jsxRuntime.jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
       cards ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
       /* @__PURE__ */ jsxRuntime.jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxRuntime.jsxs("div", { className: tableCard, children: [
-        /* @__PURE__ */ jsxRuntime.jsx("div", { className: tableScroll, children: table }),
+        /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-table-scroll overflow-x-auto", children: table }),
         footer
       ] }) }),
       cards && footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden mt-3", children: footer }) : null
@@ -4069,6 +4078,7 @@ exports.SCOPES = SCOPES;
 exports.ScrollReveal = ScrollReveal;
 exports.SectionAnchor = SectionAnchor;
 exports.SectionHeading = SectionHeading;
+exports.SegmentedToggle = SegmentedToggle;
 exports.ShareButton = ShareButton;
 exports.Sheet = Sheet;
 exports.SheetClose = SheetClose;

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -1009,7 +1009,6 @@ html[data-density=compact] .bg-card > table td {
   border-radius: 6px;
 }
 .mg-table-scroll {
-  max-height: 70vh;
   mask-image:
     linear-gradient(
       to right,

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1901,39 +1901,48 @@ function ListShell({
     const el = filterRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver((entries) => {
-      const h = Math.round(entries[0]?.contentRect.height ?? el.getBoundingClientRect().height);
+      const h = Math.round(
+        entries[0]?.contentRect.height ?? el.getBoundingClientRect().height
+      );
       setFilterH((prev) => prev === h ? prev : h);
     });
     ro.observe(el);
     return () => ro.disconnect();
   }, []);
   const tableCard = "rounded border border-border bg-card overflow-hidden";
-  return /* @__PURE__ */ jsxs("div", { ref: rootRef, style: { ["--mg-list-filter-offset"]: `${filterH}px` }, children: [
-    /* @__PURE__ */ jsx(
-      "div",
-      {
-        ref: filterRef,
-        className: classNames(
-          // Sticky filter bar. Offset reads --mg-sticky-offset (published by
-          // AppShell to match real header + ticker height) with a fallback.
-          "sticky z-20 -mx-4 md:mx-0 mb-3",
-          "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
-          "border-b border-border md:border md:rounded md:bg-card",
-          "px-3 py-2 md:p-2.5"
+  return /* @__PURE__ */ jsxs(
+    "div",
+    {
+      ref: rootRef,
+      style: { ["--mg-list-filter-offset"]: `${filterH}px` },
+      children: [
+        /* @__PURE__ */ jsx(
+          "div",
+          {
+            ref: filterRef,
+            className: classNames(
+              // Sticky filter bar. Offset reads --mg-sticky-offset (published by
+              // AppShell to match real header + ticker height) with a fallback.
+              "sticky z-20 -mx-4 md:mx-0 mb-3",
+              "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
+              "border-b border-border md:border md:rounded md:bg-card",
+              "px-3 py-2 md:p-2.5"
+            ),
+            style: { top: "var(--mg-sticky-offset, 3.5rem)" },
+            children: /* @__PURE__ */ jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
+          }
         ),
-        style: { top: "var(--mg-sticky-offset, 3.5rem)" },
-        children: /* @__PURE__ */ jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
-      }
-    ),
-    isEmpty ? empty : /* @__PURE__ */ jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
-      cards ? /* @__PURE__ */ jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
-      /* @__PURE__ */ jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxs("div", { className: tableCard, children: [
-        /* @__PURE__ */ jsx("div", { className: "mg-table-scroll overflow-x-auto", children: table }),
-        footer
-      ] }) }),
-      cards && footer ? /* @__PURE__ */ jsx("div", { className: "md:hidden mt-3", children: footer }) : null
-    ] })
-  ] });
+        isEmpty ? empty : /* @__PURE__ */ jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
+          cards ? /* @__PURE__ */ jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
+          /* @__PURE__ */ jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxs("div", { className: tableCard, children: [
+            /* @__PURE__ */ jsx("div", { className: "mg-table-scroll overflow-x-auto", children: table }),
+            footer
+          ] }) }),
+          cards && footer ? /* @__PURE__ */ jsx("div", { className: "md:hidden mt-3", children: footer }) : null
+        ] })
+      ]
+    }
+  );
 }
 function LoadMore({
   hasMore,

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,5 +1,5 @@
 import * as React3 from 'react';
-import { useState, useRef, useEffect, useMemo, useCallback, useId } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect, useId } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
 import clsx from 'clsx';
@@ -367,42 +367,6 @@ var SheetDescription = React3.forwardRef(({ className, ...props }, ref) => /* @_
   }
 ));
 SheetDescription.displayName = DialogPrimitive.Description.displayName;
-var Toaster = ({ ...props }) => {
-  return /* @__PURE__ */ jsx(
-    Toaster$1,
-    {
-      className: "toaster group",
-      toastOptions: {
-        classNames: {
-          toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-muted-foreground",
-          actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-          cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground"
-        }
-      },
-      ...props
-    }
-  );
-};
-var TooltipProvider = TooltipPrimitive.Provider;
-var Tooltip = TooltipPrimitive.Root;
-var TooltipTrigger = TooltipPrimitive.Trigger;
-var TooltipContent = React3.forwardRef(({ className, sideOffset = 4, ...props }, ref) => /* @__PURE__ */ jsx(TooltipPrimitive.Portal, { children: /* @__PURE__ */ jsx(
-  TooltipPrimitive.Content,
-  {
-    ref,
-    sideOffset,
-    className: cn(
-      "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
-      className
-    ),
-    ...props
-  }
-) }));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
-function Skeleton({ className = "h-4 w-full" }) {
-  return /* @__PURE__ */ jsx("div", { className: `animate-pulse rounded bg-surface-2 ${className}` });
-}
 
 // src/lib/format.ts
 function classNames(...parts) {
@@ -468,6 +432,86 @@ function relative(diffMs) {
   if (hr < 48) return `${hr}h ago`;
   const day = Math.round(hr / 24);
   return `${day}d ago`;
+}
+function SegmentedToggle({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className
+}) {
+  return /* @__PURE__ */ jsx(
+    "div",
+    {
+      role: "tablist",
+      "aria-label": ariaLabel,
+      className: classNames(
+        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
+        className
+      ),
+      children: options.map(
+        ({ value: v, label, Icon, ariaLabel: optionAriaLabel, title }) => {
+          const active = v === value;
+          return /* @__PURE__ */ jsxs(
+            "button",
+            {
+              type: "button",
+              role: "tab",
+              "aria-selected": active,
+              "aria-label": optionAriaLabel ?? label,
+              title: title ?? label,
+              onClick: () => onChange(v),
+              className: classNames(
+                "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
+                active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
+              ),
+              children: [
+                Icon ? /* @__PURE__ */ jsx(Icon, { className: "size-3.5" }) : null,
+                /* @__PURE__ */ jsx("span", { className: "hidden sm:inline", children: label })
+              ]
+            },
+            v
+          );
+        }
+      )
+    }
+  );
+}
+var Toaster = ({ ...props }) => {
+  return /* @__PURE__ */ jsx(
+    Toaster$1,
+    {
+      className: "toaster group",
+      toastOptions: {
+        classNames: {
+          toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground"
+        }
+      },
+      ...props
+    }
+  );
+};
+var TooltipProvider = TooltipPrimitive.Provider;
+var Tooltip = TooltipPrimitive.Root;
+var TooltipTrigger = TooltipPrimitive.Trigger;
+var TooltipContent = React3.forwardRef(({ className, sideOffset = 4, ...props }, ref) => /* @__PURE__ */ jsx(TooltipPrimitive.Portal, { children: /* @__PURE__ */ jsx(
+  TooltipPrimitive.Content,
+  {
+    ref,
+    sideOffset,
+    className: cn(
+      "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
+      className
+    ),
+    ...props
+  }
+) }));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+function Skeleton({ className = "h-4 w-full" }) {
+  return /* @__PURE__ */ jsx("div", { className: `animate-pulse rounded bg-surface-2 ${className}` });
 }
 function AccentBand({
   children,
@@ -1450,50 +1494,6 @@ function CopyableCode({
     /* @__PURE__ */ jsx(CopyStatusRegion, { children: copied ? `${label ?? "Value"} copied to clipboard` : "" })
   ] });
 }
-function SegmentedToggle({
-  options,
-  value,
-  onChange,
-  ariaLabel,
-  className
-}) {
-  return /* @__PURE__ */ jsx(
-    "div",
-    {
-      role: "tablist",
-      "aria-label": ariaLabel,
-      className: classNames(
-        "inline-flex items-center rounded-md border border-border bg-card p-0.5",
-        className
-      ),
-      children: options.map(
-        ({ value: v, label, Icon, ariaLabel: optionAriaLabel, title }) => {
-          const active = v === value;
-          return /* @__PURE__ */ jsxs(
-            "button",
-            {
-              type: "button",
-              role: "tab",
-              "aria-selected": active,
-              "aria-label": optionAriaLabel ?? label,
-              title: title ?? label,
-              onClick: () => onChange(v),
-              className: classNames(
-                "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors min-h-8",
-                active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong"
-              ),
-              children: [
-                Icon ? /* @__PURE__ */ jsx(Icon, { className: "size-3.5" }) : null,
-                /* @__PURE__ */ jsx("span", { className: "hidden sm:inline", children: label })
-              ]
-            },
-            v
-          );
-        }
-      )
-    }
-  );
-}
 function DensityToggle({
   value,
   onChange,
@@ -1887,39 +1887,48 @@ function ListShell({
   empty,
   isEmpty,
   isStale,
-  /** When true, the rendered table can stick its <thead> at `top-0` inside a
-   *  bounded-height, internally-scrolling viewport (both axes) -- the
-   *  standard sticky-header-data-table pattern. A page-scroll-relative
-   *  sticky header and native horizontal scroll cannot coexist on the same
-   *  wrapper: `overflow-x: auto` makes that wrapper the header's nearest
-   *  scroll-container ancestor per the CSS sticky-positioning spec, and
-   *  since the wrapper itself never scrolls internally (the page scrolls
-   *  past it instead), the header's "stuck" trigger never fires -- verified
-   *  directly (#5073). Bounding the wrapper's height and letting it scroll
-   *  internally makes it the header's OWN scroll reference, so both work.
-   */
-  stickyHeader = true
+  stickyHeader: _stickyHeader = true
 }) {
+  const rootRef = useRef(null);
+  const filterRef = useRef(null);
+  const [filterH, setFilterH] = useState(0);
+  useLayoutEffect(() => {
+    const el = filterRef.current;
+    if (!el) return;
+    setFilterH(Math.round(el.getBoundingClientRect().height));
+  }, []);
+  useEffect(() => {
+    const el = filterRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const h = Math.round(entries[0]?.contentRect.height ?? el.getBoundingClientRect().height);
+      setFilterH((prev) => prev === h ? prev : h);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
   const tableCard = "rounded border border-border bg-card overflow-hidden";
-  const tableScroll = stickyHeader ? "mg-table-scroll overflow-auto" : "overflow-x-auto";
-  return /* @__PURE__ */ jsxs("div", { children: [
+  return /* @__PURE__ */ jsxs("div", { ref: rootRef, style: { ["--mg-list-filter-offset"]: `${filterH}px` }, children: [
     /* @__PURE__ */ jsx(
       "div",
       {
+        ref: filterRef,
         className: classNames(
-          // Sticky filter bar. Offset matches header height (h-nav).
-          "sticky top-nav z-20 -mx-4 md:mx-0 mb-3",
+          // Sticky filter bar. Offset reads --mg-sticky-offset (published by
+          // AppShell to match real header + ticker height) with a fallback.
+          "sticky z-20 -mx-4 md:mx-0 mb-3",
           "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
           "border-b border-border md:border md:rounded md:bg-card",
           "px-3 py-2 md:p-2.5"
         ),
+        style: { top: "var(--mg-sticky-offset, 3.5rem)" },
         children: /* @__PURE__ */ jsx("div", { className: "flex flex-wrap items-center gap-2", children: filters })
       }
     ),
     isEmpty ? empty : /* @__PURE__ */ jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
       cards ? /* @__PURE__ */ jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
       /* @__PURE__ */ jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxs("div", { className: tableCard, children: [
-        /* @__PURE__ */ jsx("div", { className: tableScroll, children: table }),
+        /* @__PURE__ */ jsx("div", { className: "mg-table-scroll overflow-x-auto", children: table }),
         footer
       ] }) }),
       cards && footer ? /* @__PURE__ */ jsx("div", { className: "md:hidden mt-3", children: footer }) : null
@@ -3964,4 +3973,4 @@ function TreemapMini({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EntityHero, ExternalLink, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, PagerBar, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, fmtYield, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EntityHero, ExternalLink, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, PagerBar, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SectionAnchor, SectionHeading, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, fmtYield, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel };

--- a/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
@@ -23,7 +23,9 @@ describe("ListShell sticky table wrappers", () => {
     // root wrapper -- the sticky offset math reads --mg-sticky-offset
     // (from AppShell) plus this to land the <thead> just below the filter bar.
     expect(source).toContain("--mg-list-filter-offset");
-    expect(source).toContain('style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}');
+    expect(source).toContain(
+      'style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}',
+    );
   });
 
   it("keeps the card wrapper's rounded-corner clipping the same for both modes", () => {

--- a/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
@@ -8,22 +8,22 @@ const source = readFileSync(
 );
 
 describe("ListShell sticky table wrappers", () => {
-  it("gives stickyHeader tables their own bounded, internally-scrolling viewport", () => {
-    // overflow-x-auto (or hidden/scroll) on the sticky <thead>'s ancestor
-    // makes that ancestor the header's nearest scroll-container, and since
-    // it never scrolls internally on its own (the page scrolls past it
-    // instead), the header's "stuck" trigger never fires (#5073). Bounding
-    // the height and scrolling both axes inside the wrapper makes it the
-    // header's own scroll reference, so sticky and horizontal scroll both
-    // work at once.
-    // Substring checks, not a full-line match: this ternary reflows under
-    // Prettier depending on line length, so an exact-line assertion breaks
-    // every time the surrounding code shifts it past the print width.
-    expect(source).toContain("const tableScroll = stickyHeader");
-    expect(source).toContain('"mg-table-scroll overflow-auto"');
-    expect(source).toContain(': "overflow-x-auto"');
+  it("sticks the <thead> to the page scroll instead of a bounded internal viewport", () => {
+    // The table's <thead> sticks against the *page* scroll (offset by the app
+    // header + the filter bar's measured height), not an internal
+    // overflow-bounded wrapper -- so there is no nested vertical scrollbar.
+    // The wrapper only ever scrolls horizontally, on any viewport.
+    expect(source).toContain('"mg-table-scroll overflow-x-auto"');
     expect(source).not.toContain("overflow-x-clip");
     expect(source).not.toContain("overflow-y-clip");
+  });
+
+  it("publishes the filter bar's measured height so the table header can offset below it", () => {
+    // ResizeObserver-measured filter height, published as a CSS var on the
+    // root wrapper -- the sticky offset math reads --mg-sticky-offset
+    // (from AppShell) plus this to land the <thead> just below the filter bar.
+    expect(source).toContain("--mg-list-filter-offset");
+    expect(source).toContain('style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}');
   });
 
   it("keeps the card wrapper's rounded-corner clipping the same for both modes", () => {

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { classNames } from "@/lib/format";
 import { Skeleton } from "./skeleton";
@@ -53,7 +59,9 @@ export function ListShell({
     const el = filterRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver((entries) => {
-      const h = Math.round(entries[0]?.contentRect.height ?? el.getBoundingClientRect().height);
+      const h = Math.round(
+        entries[0]?.contentRect.height ?? el.getBoundingClientRect().height,
+      );
       setFilterH((prev) => (prev === h ? prev : h));
     });
     ro.observe(el);
@@ -62,7 +70,10 @@ export function ListShell({
 
   const tableCard = "rounded border border-border bg-card overflow-hidden";
   return (
-    <div ref={rootRef} style={{ ["--mg-list-filter-offset" as string]: `${filterH}px` }}>
+    <div
+      ref={rootRef}
+      style={{ ["--mg-list-filter-offset" as string]: `${filterH}px` }}
+    >
       <div
         ref={filterRef}
         className={classNames(

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { classNames } from "@/lib/format";
 import { Skeleton } from "./skeleton";
@@ -12,7 +12,10 @@ import { Skeleton } from "./skeleton";
  *   fallback for tabular data.
  * - `table` renders on viewports >= md with horizontal scroll for overflow.
  *
- * All interactive elements should target min-h-11 for comfortable tap targets.
+ * The table's <thead> sticks against the *page* scroll (offset by the
+ * app header + this filter bar) rather than an internal bounded viewport,
+ * so there is no nested vertical scrollbar. The wrapper only scrolls
+ * horizontally when a wide table overflows on narrow viewports.
  */
 export function ListShell({
   filters,
@@ -22,18 +25,7 @@ export function ListShell({
   empty,
   isEmpty,
   isStale,
-  /** When true, the rendered table can stick its <thead> at `top-0` inside a
-   *  bounded-height, internally-scrolling viewport (both axes) -- the
-   *  standard sticky-header-data-table pattern. A page-scroll-relative
-   *  sticky header and native horizontal scroll cannot coexist on the same
-   *  wrapper: `overflow-x: auto` makes that wrapper the header's nearest
-   *  scroll-container ancestor per the CSS sticky-positioning spec, and
-   *  since the wrapper itself never scrolls internally (the page scrolls
-   *  past it instead), the header's "stuck" trigger never fires -- verified
-   *  directly (#5073). Bounding the wrapper's height and letting it scroll
-   *  internally makes it the header's OWN scroll reference, so both work.
-   */
-  stickyHeader = true,
+  stickyHeader: _stickyHeader = true,
 }: {
   filters: ReactNode;
   cards?: ReactNode;
@@ -43,27 +35,45 @@ export function ListShell({
   isEmpty?: boolean;
   /** Subtly dim loaded content while a background refetch is in flight. */
   isStale?: boolean;
+  /** Retained for API compatibility -- header stickiness is now always
+   *  page-scroll relative and needs no per-instance opt-in. */
   stickyHeader?: boolean;
 }) {
+  // Measure the filter bar and publish its height as --mg-list-filter-offset
+  // on the root wrapper so the table's <thead> can stick just below it.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const filterRef = useRef<HTMLDivElement>(null);
+  const [filterH, setFilterH] = useState(0);
+  useLayoutEffect(() => {
+    const el = filterRef.current;
+    if (!el) return;
+    setFilterH(Math.round(el.getBoundingClientRect().height));
+  }, []);
+  useEffect(() => {
+    const el = filterRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const h = Math.round(entries[0]?.contentRect.height ?? el.getBoundingClientRect().height);
+      setFilterH((prev) => (prev === h ? prev : h));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   const tableCard = "rounded border border-border bg-card overflow-hidden";
-  // stickyHeader: bounded height + overflow-auto on both axes, so the
-  // <thead>'s `sticky top-0` sticks to this box's own scroll instead of the
-  // page's, while horizontal overflow still scrolls within the same box.
-  // !stickyHeader: unbounded height, horizontal-only scroll, table grows
-  // with the page (the previous, simpler behavior -- unchanged).
-  const tableScroll = stickyHeader
-    ? "mg-table-scroll overflow-auto"
-    : "overflow-x-auto";
   return (
-    <div>
+    <div ref={rootRef} style={{ ["--mg-list-filter-offset" as string]: `${filterH}px` }}>
       <div
+        ref={filterRef}
         className={classNames(
-          // Sticky filter bar. Offset matches header height (h-nav).
-          "sticky top-nav z-20 -mx-4 md:mx-0 mb-3",
+          // Sticky filter bar. Offset reads --mg-sticky-offset (published by
+          // AppShell to match real header + ticker height) with a fallback.
+          "sticky z-20 -mx-4 md:mx-0 mb-3",
           "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
           "border-b border-border md:border md:rounded md:bg-card",
           "px-3 py-2 md:p-2.5",
         )}
+        style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
       >
         <div className="flex flex-wrap items-center gap-2">{filters}</div>
       </div>
@@ -75,7 +85,7 @@ export function ListShell({
           {cards ? <div className="md:hidden space-y-2">{cards}</div> : null}
           <div className={cards ? "hidden md:block" : undefined}>
             <div className={tableCard}>
-              <div className={tableScroll}>{table}</div>
+              <div className="mg-table-scroll overflow-x-auto">{table}</div>
               {footer}
             </div>
           </div>

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -52,6 +52,7 @@ export {
   SheetTitle,
   SheetDescription,
 } from "@/components/ui/sheet";
+export { SegmentedToggle, type SegmentedToggleOption } from "@/components/ui/segmented-toggle";
 export { Toaster } from "@/components/ui/sonner";
 export {
   Tooltip,

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -52,7 +52,10 @@ export {
   SheetTitle,
   SheetDescription,
 } from "@/components/ui/sheet";
-export { SegmentedToggle, type SegmentedToggleOption } from "@/components/ui/segmented-toggle";
+export {
+  SegmentedToggle,
+  type SegmentedToggleOption,
+} from "@/components/ui/segmented-toggle";
 export { Toaster } from "@/components/ui/sonner";
 export {
   Tooltip,

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -1338,15 +1338,13 @@ html[data-density="compact"] .bg-card > table td {
   border-radius: 6px;
 }
 
-/* Bounded height for ListShell's sticky-header table viewport (#5073) -- a
-   plain class, not a Tailwind arbitrary-value utility (max-h-[70vh]):
-   packages/ui-kit's own Tailwind build doesn't pick up bracket-arbitrary
-   values from source (confirmed against command.tsx's pre-existing,
-   equally-silently-broken max-h-[300px] -- neither ever reaches dist/index.css). */
+/* Horizontal-scroll fade mask for wide data tables — soft-clips left/right
+   edges instead of hard-cutting mid-column so users see there's more to
+   scroll. The table's <thead> sticks against the page scroll (under the
+   filter bar) via --mg-sticky-offset + --mg-list-filter-offset (published by
+   ListShell), so the wrapper itself never needs to scroll vertically -- no
+   nested scrollbar. */
 .mg-table-scroll {
-  max-height: 70vh;
-  /* Fade the leading/trailing edges so wide tables soft-clip instead of
-     hard-cutting mid-column — users see there's more to scroll. */
   mask-image: linear-gradient(
     to right,
     transparent 0,
@@ -1361,9 +1359,7 @@ html[data-density="compact"] .bg-card > table td {
     #000 calc(100% - 1rem),
     transparent 100%
   );
-  /* Thin, modern horizontal scrollbar. The table's <thead> sticks against the
-     page scroll (under the filter bar) via --mg-sticky-offset, so the
-     wrapper itself never needs to scroll vertically -- no nested scrollbar. */
+  /* Thin, modern horizontal scrollbar. */
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklab, var(--ink-strong) 20%, transparent)
     transparent;


### PR DESCRIPTION
## Summary
Part of the Lovable frontend sync (tracking #7741, sub-issue #7748 — Phase 7). The largest single file in the entire sync (996-line diff).

- Merges the redesigned `/endpoints` route: directory-first tab order (`Directory / Managed RPC / Pools / Incidents`, was `Proxy / Endpoints / Advanced / Incidents`), a `QueryBar`-driven filter shell replacing the old manual toolbar, `AsyncPanel` wrapping throughout with corrected `retryQueryKeys` (all rewritten to use `metagraphedQueryKey()` instead of Lovable's guessed raw-array keys; also added a missing `endpoint-incidents` key the directory panel actually depends on but Lovable's own retry list omitted), `RoutePending`, `PageMasthead`/`TabStrip`.
- New components ported: `EndpointsPriorityStrip` (degraded/incidents/slowest-archive/freshly-probed cards), `EndpointOperationalList` (netuid-grouped expandable rows with health rail, latency sparkline, 7d uptime bar), `EndpointDetailDrawer` (latency trend + filterable incident timeline), `EndpointComparePanel` (2-4 endpoint side-by-side, URL-driven via new `?compare=` param), `EndpointChipCluster`, `EndpointUptimeBar`, and `use-latency-history.ts` — a client-only localStorage-backed rolling latency collector (the backend only ships the latest probe sample per endpoint, so this is what gives the new sparklines real multi-point trends).
- New deep-linkable search params: `endpoint` (expanded row) and `compare` (comma-separated comparison set).
- Dropped the old flat sortable `<table>` (`Th`/`FilterSelect` helpers, `EndpointCardList` grid/table dual view) now that `EndpointOperationalList` replaces it; dropped dead imports (`Suspense`, `Breadcrumbs`, unused `Skeleton`) Lovable's source left behind.

**Bugs found and fixed while porting** (not present in Lovable's source verbatim — both introduced or exposed by this route's specific structure):
- Invalid HTML nesting: the expandable row wrapped its content, including a nested `CopyButton` (which renders its own `<button>`) and an `ExternalLink` (`<a>`), inside an outer `<button onClick={...}>`. A `<button>` may not contain another `<button>` or `<a>` per the HTML spec — browsers silently un-nest it, which desynced the SSR'd HTML from the client and threw a hydration-mismatch error on every load. Fixed by changing the row wrapper to a `role="button"` `div` with the same `tabIndex`/`onKeyDown` (Enter/Space) semantics, which is valid to nest interactive children inside.
- Infinite render loop: `use-latency-history.ts`'s `useSyncExternalStore` `getSnapshot` did a fresh `JSON.parse(localStorage...)` on every call, returning a new object reference every render. React requires `getSnapshot` to be referentially stable when nothing changed; this crashed `EndpointDetailDrawer` with "Maximum update depth exceeded" the moment a row was expanded. Fixed by caching the last-seen raw string alongside its parsed value so unchanged reads return the same reference.
- Two pre-existing (unrelated to this diff, from an earlier phase) source-string tests were asserting against implementation details this multi-phase sync's primitive-adoption work had already superseded elsewhere: `subnets-total-stake-tile.test.ts` still checked for a `<Skeleton className="h-20"` fallback marker that Phase 6 replaced with `AsyncPanel`/`PanelSkeleton`, and `detail-page-furniture-5481.test.ts` still checked an `EntityHero`-shaped assertion for `providers.$slug.tsx` that Phase 7's own `providers.index`/`providers.$slug` merge (already on this branch) replaced with `PageMasthead`. Both repointed at the new primitives' actual structure — same invariant, updated selectors.

## Test plan
- [x] `tsc --noEmit` clean across the whole `apps/ui` workspace
- [x] `eslint` on all changed files: 0 errors (only pre-existing `warn`-level design-guardrail hints, same classes seen on every other route in this sync)
- [x] Full `vitest run`: 180 files / 1357 tests passing
- [x] `prettier --check` clean
- [x] Visually verified `/endpoints` in-browser across all 4 tabs (Directory, Managed RPC, Pools, Incidents), the priority strip, row expand/collapse (latency trend + incident timeline render with real observed data), the compare panel (2-endpoint side-by-side), and the filter bar — zero console errors in a fresh tab after both bugs above were fixed