### PR TITLE
fix(ui): stop a background cache.put() rejection from 500ing the response

### DIFF
--- a/apps/ui/src/lib/analytics-proxy.test.ts
+++ b/apps/ui/src/lib/analytics-proxy.test.ts
@@ -240,6 +240,41 @@ describe("retrieveAnalyticsAsset", () => {
     await Promise.all(ctx.calls);
     expect(put).toHaveBeenCalledTimes(1);
   });
+
+  it("swallows a rejected cache.put() instead of leaking an unhandled rejection through ctx.waitUntil", async () => {
+    // Regression test: a promise passed to ctx.waitUntil() that rejects
+    // becomes an unhandled rejection at the Worker's global scope, which
+    // Nitro/h3's own safety net (src/lib/error-capture.ts) turns into a
+    // generic 500 for the CURRENT request -- even though the response this
+    // function already returned was correct. Confirmed live in production
+    // (every /ingest/static/* and /ingest/array/* request 500'd this way
+    // before the .catch() below was added).
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const match = vi.fn(async () => undefined);
+    const putError = new Error("cache.put: response contains an unsupported Vary header");
+    const put = vi.fn(async () => {
+      throw putError;
+    });
+    // @ts-expect-error -- test-only stub of the ambient Cloudflare `caches` global.
+    globalThis.caches = { default: { match, put } };
+    globalThis.fetch = vi.fn(async () => new Response("/* js */", { status: 200 })) as typeof fetch;
+
+    const ctx = fakeCtx();
+    const request = new Request(`https://metagraph.sh${ANALYTICS_PREFIX}/static/array.js`);
+    const response = await retrieveAnalyticsAsset(request, "/static/array.js", ctx);
+
+    // The response itself must be unaffected by the background failure.
+    expect(response.status).toBe(200);
+    // The promise handed to ctx.waitUntil must resolve, never reject --
+    // this is the actual regression: a REJECTED promise there is what
+    // corrupts the response via the global unhandled-rejection handler.
+    await expect(Promise.all(ctx.calls)).resolves.toBeDefined();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[analytics-proxy] edge-cache put failed:",
+      putError,
+    );
+    consoleErrorSpy.mockRestore();
+  });
 });
 
 describe("handleAnalyticsProxy routing", () => {

--- a/apps/ui/src/lib/analytics-proxy.ts
+++ b/apps/ui/src/lib/analytics-proxy.ts
@@ -63,7 +63,24 @@ export async function retrieveAnalyticsAsset(
   const cached = hasEdgeCache ? await caches.default.match(request) : undefined;
   if (cached) return cached;
   const upstream = await fetch(`https://${POSTHOG_ASSET_HOST}${pathWithParams}`);
-  if (hasEdgeCache) ctx.waitUntil(caches.default.put(request, upstream.clone()));
+  // A rejected promise passed to ctx.waitUntil() becomes an unhandled
+  // rejection at the Worker's global scope -- Nitro/h3's own safety net
+  // (src/lib/error-capture.ts's "error"/"unhandledrejection" listeners)
+  // then turns that into a generic 500 for the CURRENT request, even though
+  // the response below was already computed correctly (confirmed live:
+  // every /ingest/static/* and /ingest/array/* request 500'd this way in
+  // production, while /ingest/e/ -- forwardToAnalyticsHost, which never
+  // touches ctx.waitUntil -- kept working). The edge cache is a best-effort
+  // optimization; a write failure (a malformed Vary header from upstream, a
+  // transient Cache API error, anything) must never take down the response
+  // that's already correct and already on its way to the browser.
+  if (hasEdgeCache) {
+    ctx.waitUntil(
+      caches.default.put(request, upstream.clone()).catch((err) => {
+        console.error("[analytics-proxy] edge-cache put failed:", err);
+      }),
+    );
+  }
   return upstream;
 }
 


### PR DESCRIPTION
## Summary

**Live production bug**, found while verifying the PostHog web-analytics fix: every `/ingest/static/*` and `/ingest/array/*` request (PostHog's own script/config bootstrap, proxied through `analytics-proxy.ts`) was returning a generic 500, while `/ingest/e/` (event capture) worked fine.

Root cause: `retrieveAnalyticsAsset` passed `caches.default.put(request, upstream.clone())` straight into `ctx.waitUntil()` with no `.catch()`. When that promise rejects, it becomes an **unhandled rejection at the Worker's global scope** -- Nitro/h3's own safety net (`error-capture.ts`'s `error`/`unhandledrejection` listeners) then turns that into a generic `{"error":true,"status":500,"unhandled":true}` response for the *current* request, even though the actual response had already been computed correctly and was on its way back to the browser. `forwardToAnalyticsHost` (the `/ingest/e/` path) never touches `ctx.waitUntil` at all, which is exactly why it kept working while the asset routes didn't.

Fix: `.catch()` the cache-write promise and log the failure instead of letting it propagate. The edge cache is a best-effort optimization -- a write failure (this session couldn't confirm the exact upstream trigger, but it's irrelevant now) must never take down a response that's already correct.

## How this was found

Confirmed live via `wrangler tail metagraphed-ui`, triggering the actual failing requests and reading the real Worker logs -- not guessed from code review. Both `GET /ingest/static/array.js` and `GET /ingest/array/{token}/config` reproduced the same `(error) { status: 500, unhandled: true, message: 'HTTPError' }` log line, while the upstream PostHog host itself returned a clean `200` when fetched directly, ruling out an upstream problem.

This is a pre-existing gap in #7781 (merged) -- untested against the *real* deployed Cloudflare Worker's Cache API, since `caches` is `undefined` in every local test/dev environment (`typeof caches !== "undefined"` guards exactly this), so `analytics-proxy.test.ts`'s existing mocks always resolved cleanly and never exercised a rejection.

## Test plan

- [x] New regression test: a rejected `cache.put()` no longer propagates through `ctx.waitUntil()` -- the promise handed to `waitUntil` now always resolves, and the response returned to the caller is unaffected.
- [x] `npm test --workspace=apps/ui` -- full suite green (182 files, 1393 tests).
- [x] `npx tsc --noEmit` / `npm run format:check` / `npm run lint --workspace=apps/ui` on the two touched files -- clean.

No screenshot table: confined to `src/lib/analytics-proxy.ts` + its test, no visual change.

Not linked to a numbered issue -- a live-production hotfix found during manual verification of #7760/#7761, not itself a planned deliverable.