### PR TITLE
fix(ui): annotate SegmentedToggle onChange param to fix a typecheck break

### DIFF
--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -784,7 +784,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                     { value: "90d", label: "90d" },
                   ]}
                   value={trendWindow}
-                  onChange={(v) => setTrendWindow(v)}
+                  onChange={(v: "7d" | "30d" | "90d") => setTrendWindow(v)}
                   ariaLabel="Trend window for row sparklines"
                   className="border-0 bg-transparent"
                 />


### PR DESCRIPTION
## Summary

`#7780` (merge Lovable's subnets sweep into subnets routes) left `subnets.index.tsx`'s trend-window `SegmentedToggle` call with an implicit-`any` `onChange` parameter, breaking `main`'s typecheck. One explicit type annotation, no behavior change.

Found while verifying an unrelated fix (#7794) -- confirmed via `git log` that `#7780` is the commit that introduced this, and that it's unrelated to anything else in flight.

## Test plan

- [x] `npx tsc --noEmit` (via `npm run typecheck --workspace=apps/ui`) -- clean.
- [x] `npm test --workspace=apps/ui` -- full suite green (182 files, 1393 tests).
- [x] `npm run format:check` / `npm run lint --workspace=apps/ui` on the touched file -- clean (zero errors; pre-existing repo-wide warnings elsewhere in this large file untouched).

No screenshot table: a type annotation only, zero rendered-output change.

Not linked to a numbered issue -- a small typecheck fix for a regression in an already-merged PR, not a planned deliverable.