### PR TITLE
feat(ui): adopt PageMasthead/AsyncPanel on domains + about (Phase 11 batch 1)

### DIFF
--- a/apps/ui/src/routes/about.tsx
+++ b/apps/ui/src/routes/about.tsx
@@ -10,7 +10,8 @@ import {
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { CopyableCode, ExternalLink, PageHero } from "@jsonbored/ui-kit";
+import { CopyableCode, ExternalLink } from "@jsonbored/ui-kit";
+import { PageMasthead } from "@/components/metagraphed/primitives";
 import { API_BASE, GITHUB_REPO } from "@/lib/metagraphed/config";
 import { coverageQuery, freshnessQuery, healthQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
@@ -34,7 +35,7 @@ export const Route = createFileRoute("/about")({
 function AboutPage() {
   return (
     <AppShell>
-      <PageHero
+      <PageMasthead
         eyebrow="About"
         title="Methodology & scope"
         description="An unofficial, public explorer and integration registry for Bittensor — blocks, subnets, validators, and accounts alongside the public interfaces each subnet exposes, all machine-readable for developers and AI agents."

--- a/apps/ui/src/routes/domains.tsx
+++ b/apps/ui/src/routes/domains.tsx
@@ -1,11 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Suspense } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { Skeleton } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { DomainsRollup } from "@/components/metagraphed/domains-rollup";
-import { PageHero, ActionBar, ShareButton } from "@jsonbored/ui-kit";
+import { ActionBar, ShareButton } from "@jsonbored/ui-kit";
+import { AsyncPanel, PageMasthead, PanelSkeleton } from "@/components/metagraphed/primitives";
+import { metagraphedQueryKey } from "@/lib/metagraphed/queries";
 
 export const Route = createFileRoute("/domains")({
   head: () => ({
@@ -27,20 +26,10 @@ export const Route = createFileRoute("/domains")({
   component: DomainsPage,
 });
 
-function DomainsRollupSkeleton() {
-  return (
-    <div className="space-y-2">
-      {Array.from({ length: 8 }, (_, i) => (
-        <Skeleton key={i} className="h-12 w-full" />
-      ))}
-    </div>
-  );
-}
-
 function DomainsPage() {
   return (
     <AppShell>
-      <PageHero
+      <PageMasthead
         eyebrow="Explorer"
         live
         title="Domains"
@@ -51,11 +40,13 @@ function DomainsPage() {
           </ActionBar>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<DomainsRollupSkeleton />}>
-          <DomainsRollup />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="domains"
+        fallback={<PanelSkeleton height="md" />}
+        retryQueryKeys={[metagraphedQueryKey("domains"), metagraphedQueryKey("subnets")]}
+      >
+        <DomainsRollup />
+      </AsyncPanel>
       <ApiSourceFooter paths={["/api/v1/domains", "/api/v1/subnets"]} />
     </AppShell>
   );


### PR DESCRIPTION
## Summary
Part of #7752 (Phase 11 — proactive primitive-adoption sweep beyond what Lovable's own redesign touched). Per that issue's explicit instruction to scope each PR narrowly rather than one giant sweep, this is a first, small batch — not closing #7752, since more routes remain (graphql.explorer.tsx, docs.*, and others still need the same audit).

- `domains.tsx`: `PageHero`→`PageMasthead`, and the hand-rolled `QueryErrorBoundary`+`Suspense` loading boundary → `AsyncPanel` with `retryQueryKeys` correctly using `metagraphedQueryKey("domains")`/`metagraphedQueryKey("subnets")` (matching every other route converted earlier in this sync).
- `about.tsx`: `PageHero`→`PageMasthead`. (Its one other flagged lint warning — a hand-rolled `<a target="_blank">` GitHub CTA button — is a fully bespoke pill-button design, not a plain text link; forcing it through `<ExternalLink>` would fight that component's own styling for no real safety benefit here since `GITHUB_REPO` is a static, always-safe constant. Left as-is.)

## Test plan
- [x] `tsc --noEmit` clean across the whole `apps/ui` workspace
- [x] `eslint`: 0 errors (only pre-existing `warn`-level design-guardrail hints)
- [x] Full `vitest run`: 182 files / 1392 tests passing
- [x] `prettier --check` clean
- [x] Visually verified `/domains` and `/about` in-browser (fresh tab), zero console errors