### PR TITLE
feat(ui): adopt PageMasthead on graphql.explorer.tsx (Phase 11 batch 2)

### DIFF
--- a/apps/ui/src/routes/graphql.explorer.tsx
+++ b/apps/ui/src/routes/graphql.explorer.tsx
@@ -4,6 +4,7 @@ import { CopyableCode } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { GraphiqlExplorer } from "@/components/metagraphed/graphiql-explorer";
+import { PageMasthead } from "@/components/metagraphed/primitives";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { toGraphqlSubscriptionUrl } from "@/lib/metagraphed/graphql-subscription-url";
 
@@ -39,13 +40,13 @@ function GraphqlExplorerPage() {
         <ArrowLeft aria-hidden className="size-3.5" />
         GraphQL docs
       </Link>
-      <h1 className="mt-2 font-display text-2xl font-semibold text-ink-strong md:text-3xl">
-        Explorer
-      </h1>
-      <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-ink-muted">
-        Schema-aware autocomplete, docs, and history against the live GraphQL endpoint — queries
-        over HTTP, live chainEvents subscriptions over WebSocket. No API key.
-      </p>
+      <PageMasthead
+        eyebrow="GraphQL"
+        title="Explorer"
+        description="Schema-aware autocomplete, docs, and history against the live GraphQL endpoint — queries over HTTP, live chainEvents subscriptions over WebSocket. No API key."
+        hideBreadcrumbs
+        className="mt-2"
+      />
 
       {/* Same CopyableCode row treatment as EndpointSnippet / ApiSourceFooter —
           one labeled chip per transport, each with its own copy control. */}


### PR DESCRIPTION
## Summary
Part of #7752 (Phase 11 — proactive primitive-adoption sweep). Second narrow batch, not closing #7752 since more routes remain.

`graphql/explorer` had no masthead primitive at all — a hand-rolled `<h1>`+`<p>` header instead. Swaps that for `PageMasthead` (title/description), keeping the existing "← GraphQL docs" back-link exactly as it was above it (breadcrumbs hidden via `hideBreadcrumbs`, since that back-link points to reference docs — a different intent than a hierarchy trail — rather than forcing it into `PageMasthead`'s own `crumbs` prop).

## Test plan
- [x] `tsc --noEmit` clean across the whole `apps/ui` workspace
- [x] `eslint`: 0 errors (only pre-existing `warn`-level design-guardrail hints)
- [x] Full `vitest run`: 182 files / 1393 tests passing
- [x] `prettier --check` clean
- [x] Visually verified `/graphql/explorer` in-browser (fresh tab), zero console errors — back-link, masthead, and the live GraphiQL explorer all render correctly