### PR TITLE
feat(ui): adopt PageMasthead on design.primitives.tsx (Phase 11 batch 3)

### DIFF
--- a/apps/ui/src/routes/design.primitives.tsx
+++ b/apps/ui/src/routes/design.primitives.tsx
@@ -17,6 +17,7 @@ import {
   MetaStrip,
   PagerFooter,
   Panel,
+  PageMasthead,
   SectionLabel,
   StatusBadge,
   StickyToolbar,
@@ -24,7 +25,7 @@ import {
   useColumnVisibility,
   type ColumnDef,
 } from "@/components/metagraphed/primitives";
-import { DensityToggle, PageHero } from "@jsonbored/ui-kit";
+import { DensityToggle } from "@jsonbored/ui-kit";
 import { useState } from "react";
 
 export const Route = createFileRoute("/design/primitives")({
@@ -69,7 +70,7 @@ function PrimitivesPreview() {
           ]}
         />
       </div>
-      <PageHero
+      <PageMasthead
         eyebrow="Design system"
         title="Registry primitives"
         description="Shared building blocks — chips, badges, filter toolbars, freshness pills, breadcrumbs, density and column controls — used across the subnets, surfaces, endpoints, providers, and blocks tables."


### PR DESCRIPTION
## Summary
Part of #7752 (Phase 11 — proactive primitive-adoption sweep). Third narrow batch, not closing #7752 since more routes remain (leaderboards.tsx is next).

The internal (`robots: noindex,nofollow`) design-system showcase page at `/design/primitives` was itself still using the pre-primitives `PageHero` for its own header — swaps to `PageMasthead`, matching everything else it demonstrates.

## Test plan
- [x] `tsc --noEmit` clean across the whole `apps/ui` workspace
- [x] `eslint`: 0 errors (only pre-existing `warn`-level design-guardrail hints)
- [x] Full `vitest run`: 182 files / 1393 tests passing
- [x] `prettier --check` clean
- [x] Visually verified `/design/primitives` in-browser (fresh tab), zero console errors