### PR TITLE
fix(mcp): stream-bound POST /mcp bodies so missing/lying Content-Length can't DoS the Worker

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -16589,6 +16589,63 @@ function bodyTooLargeResponse() {
   );
 }
 
+// Streams the request body with an early-abort byte counter instead of
+// buffering it whole via request.text() first -- a missing, chunked, or
+// simply untruthful Content-Length header bypasses a pre-read
+// `contentLength > MAX_MCP_BODY_BYTES` check entirely (this endpoint is
+// public and unauthenticated, rate-limited by IP only -- rate limiting
+// throttles request COUNT, not a single request's body size), so the
+// declared length can only ever be a fast-path optimization, never the
+// actual enforcement. Mirrors src/graphql.mjs's readLimitedJson (same
+// vulnerability class, already fixed there) -- kept as its own copy rather
+// than a shared helper since the two files' error-response shapes
+// (JSON-RPC vs GraphQL) differ enough that a shared abstraction would need
+// to take a response-builder callback for no real reuse benefit.
+async function readLimitedMcpBody(request) {
+  const declaredLength = Number(request.headers.get("content-length") || 0);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_MCP_BODY_BYTES) {
+    return { error: bodyTooLargeResponse() };
+  }
+
+  const chunks = [];
+  let total = 0;
+  if (request.body) {
+    const reader = request.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > MAX_MCP_BODY_BYTES) {
+          await reader.cancel();
+          return { error: bodyTooLargeResponse() };
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  try {
+    return { value: JSON.parse(new TextDecoder().decode(bytes)) };
+  } catch {
+    return {
+      error: jsonResponse(
+        rpcError(null, RPC_PARSE_ERROR, "Request body is not valid JSON."),
+        400,
+      ),
+    };
+  }
+}
+
 // MCP-Protocol-Version header (2025-06-18+): every request after the first
 // carries this; the first (`initialize`) negotiates the version in its BODY
 // instead, since the client has nothing to declare in a header yet. Per spec,
@@ -16763,24 +16820,8 @@ export async function handleMcpRequest(request, env = {}, deps = {}) {
     );
   }
 
-  const contentLength = Number(request.headers.get("content-length") || 0);
-  if (contentLength > MAX_MCP_BODY_BYTES) {
-    return bodyTooLargeResponse();
-  }
-
-  let body;
-  try {
-    const bodyText = await request.text();
-    if (new TextEncoder().encode(bodyText).length > MAX_MCP_BODY_BYTES) {
-      return bodyTooLargeResponse();
-    }
-    body = JSON.parse(bodyText);
-  } catch {
-    return jsonResponse(
-      rpcError(null, RPC_PARSE_ERROR, "Request body is not valid JSON."),
-      400,
-    );
-  }
+  const { value: body, error: bodyError } = await readLimitedMcpBody(request);
+  if (bodyError) return bodyError;
 
   const versionError = validateMcpProtocolVersionHeader(request);
   if (versionError) return versionError;

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1063,6 +1063,94 @@ describe("MCP transport handling", () => {
     assert.equal(body.error.code, -32600);
   });
 
+  test("a truthful, oversized Content-Length is rejected by the fast-path pre-check", async () => {
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(MAX_MCP_BODY_BYTES + 1),
+      },
+      body: "{}",
+    });
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 413);
+    const responseBody = await response.json();
+    assert.equal(responseBody.error.code, -32600);
+  });
+
+  test("a POST with no body at all is rejected as invalid JSON, not treated as a valid empty request", async () => {
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    assert.equal(request.body, null);
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.error.code, -32700);
+  });
+
+  test("a malformed Content-Length does not bypass the size guard", async () => {
+    // Number("not-a-real-length") is NaN, so the fast-path pre-check in
+    // readLimitedMcpBody can't reject this early; enforcement has to come
+    // from the reader loop's own running byte count instead.
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "not-a-real-length",
+      },
+      body: `"${"x".repeat(MAX_MCP_BODY_BYTES)}"`,
+    });
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 413);
+    const body = await response.json();
+    assert.equal(body.error.code, -32600);
+  });
+
+  test("an oversized body is aborted mid-stream, never buffered to completion (regression: a missing/lying Content-Length must not force the whole body into memory first)", async () => {
+    // Without a real upper bound, this stream would never end -- exactly the
+    // shape of the actual DoS: an attacker doesn't send a big-but-finite
+    // body, they send one with no natural end and let a buffer-then-check
+    // implementation (the old `await request.text()`) keep draining it
+    // forever. This body has NO content-length header at all (undici/fetch
+    // never auto-sets one for a stream body), so the fast-path pre-check in
+    // readLimitedMcpBody is a no-op here too -- the only thing that can stop
+    // this is the reader loop cancelling once its running total crosses
+    // MAX_MCP_BODY_BYTES.
+    const CHUNK_BYTES = 8 * 1024;
+    let bytesProduced = 0;
+    let cancelled = false;
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (cancelled) return;
+        bytesProduced += CHUNK_BYTES;
+        controller.enqueue(new Uint8Array(CHUNK_BYTES).fill(0x78));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: stream,
+      duplex: "half",
+    });
+
+    const response = await handleMcpRequest(request, {}, makeDeps());
+
+    assert.equal(response.status, 413);
+    assert.equal(cancelled, true);
+    // A few chunks of overshoot past the limit is expected (the loop only
+    // notices *after* a chunk lands); draining indefinitely would mean the
+    // fix regressed back to buffer-then-check.
+    assert.ok(
+      bytesProduced < MAX_MCP_BODY_BYTES + CHUNK_BYTES * 4,
+      `expected the stream to be cancelled shortly after crossing the limit, but ${bytesProduced} bytes were produced before cancellation`,
+    );
+  });
+
   test("the MCP rate limiter also covers GET and DELETE before session routing", async () => {
     for (const method of ["GET", "DELETE"]) {
       const hub = fakeMcpSessionHubBinding();


### PR DESCRIPTION
## Summary

`handleMcpRequest` (`src/mcp-server.mjs`) checked `Content-Length` against `MAX_MCP_BODY_BYTES`, then called `await request.text()` unconditionally regardless of whether that pre-check actually fired. A missing, chunked, or untruthful `Content-Length` header sails past the pre-check entirely, and `request.text()` still fully buffers whatever the real body is before a second, post-hoc size check ever runs. `POST /mcp` is public, unauthenticated, and rate-limited by IP only (throttles request *count*, not a single request's body size) -- this is an attacker-controlled unbounded buffer allocation per request.

`readLimitedMcpBody` replaces the buffer-then-check with a streaming read: it tracks a running byte total via `request.body.getReader()` and cancels the reader the moment it crosses `MAX_MCP_BODY_BYTES`, regardless of what (or whether) `Content-Length` claims. This mirrors `src/graphql.mjs`'s existing `readLimitedJson`, which already has this fixed for GraphQL -- kept as its own copy in `mcp-server.mjs` rather than extracted into a shared helper, since the two files' error-response shapes (JSON-RPC vs GraphQL) differ enough that sharing would need a response-builder callback parameter for no real reuse benefit.

## Why

A comment on #7150 (2026-07-20) reported this, noting a prior fix (#6773) had green CI but was auto-closed solely for lacking a linked open issue (forks can't `CreateIssue` on this repo). Filed #7800 to give this a proper home; closing it here.

## Test plan

- [x] New regression tests in `tests/mcp-server.test.mjs`:
  - A malformed (`NaN`-producing) `Content-Length` no longer bypasses the guard.
  - An oversized body streamed with **no** `Content-Length` header at all is aborted mid-stream (`reader.cancel()`) after only a few chunks past the limit -- not drained to completion. This directly exercises the actual vulnerability: an infinite-stream body (no natural end, exactly the DoS shape) gets cut off early rather than buffered forever.
  - A truthful, oversized `Content-Length` is still rejected by the fast-path pre-check (unchanged behavior, still covered).
  - A `POST` with no body at all is rejected as invalid JSON (`-32700`), matching the prior behavior of `JSON.parse("")` throwing -- not silently treated as a valid empty request.
- [x] `npx vitest run tests/mcp-server.test.mjs` -- 1193/1193 passing.
- [x] Full root suite (`npx vitest run`) -- 476 files, 11391+ tests, all green.
- [x] Diff-to-lcov cross-reference: every added line/branch in `src/mcp-server.mjs` is covered by the new tests (verified directly against `coverage/lcov.info`, not the misleading whole-file aggregate percentage).
- [x] `npx eslint` / `npx prettier --check` on both touched files -- clean.

No screenshot table: `src/` + `tests/`, no `apps/ui/**` touch.

Fixes #7800