### PR TITLE
fix(ui): harden the analytics proxy defensively; enable pageleave + native web vitals

### DIFF
--- a/apps/ui/src/lib/analytics-proxy.ts
+++ b/apps/ui/src/lib/analytics-proxy.ts
@@ -60,7 +60,16 @@ export async function retrieveAnalyticsAsset(
   ctx: PostHogAssetContext,
 ): Promise<Response> {
   const hasEdgeCache = typeof caches !== "undefined";
-  const cached = hasEdgeCache ? await caches.default.match(request) : undefined;
+  // Same best-effort posture as the put() below -- a read failure must fall
+  // through to a normal upstream fetch, never take the whole request down.
+  let cached: Response | undefined;
+  if (hasEdgeCache) {
+    try {
+      cached = await caches.default.match(request);
+    } catch (err) {
+      console.error("[analytics-proxy] edge-cache match failed:", err);
+    }
+  }
   if (cached) return cached;
   const upstream = await fetch(`https://${POSTHOG_ASSET_HOST}${pathWithParams}`);
   // A rejected promise passed to ctx.waitUntil() becomes an unhandled

--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -100,6 +100,19 @@ describe("analytics (PostHog web analytics)", () => {
       expect(options.persistence).toBe("memory");
     });
 
+    it("enables pageleave and native web vitals capture despite capture_pageview being disabled", async () => {
+      // Regression coverage: posthog-js's own capture_pageleave defaults to
+      // 'if_capture_pageview', which piggybacks on (and is silently disabled
+      // by) capture_pageview: false unless overridden explicitly.
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      const { initAnalytics } = await import("./analytics");
+      initAnalytics();
+      await vi.waitFor(() => expect(init).toHaveBeenCalled());
+      const options = init.mock.calls[0][1];
+      expect(options.capture_pageleave).toBe(true);
+      expect(options.capture_performance).toEqual({ web_vitals: true });
+    });
+
     it("configures session replay with input/text masking and a conservative sample rate", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
       const { initAnalytics } = await import("./analytics");

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -90,6 +90,30 @@ function loadPostHog(): Promise<PostHog | null> {
         ui_host: POSTHOG_UI_HOST,
         defaults: SDK_DEFAULTS_DATE,
         capture_pageview: false,
+        // posthog-js's own default for capture_pageleave is
+        // 'if_capture_pageview' -- i.e. it piggybacks on capture_pageview's
+        // value and is OFF whenever that's `false` (see @posthog/types' own
+        // doc comment on the option). This app disables capture_pageview
+        // deliberately (manual SPA-aware pageviews below), which would
+        // silently take pageleave down with it unless overridden here --
+        // pageleave has no such caveat itself (driven by the page-unload
+        // event, which fires correctly regardless of client-side routing),
+        // so there's no reason to lose it. PostHog's own Installation
+        // Health check flagged this gap directly ("Without $pageleave
+        // events, bounce rate and session duration might be inaccurate").
+        capture_pageleave: true,
+        // Native Core Web Vitals capture (LCP/INP/CLS/FCP as posthog-js's
+        // own $web_vitals events), independent of and in addition to this
+        // app's existing custom 'web_vitals' event (src/server.ts's
+        // WEB_VITALS_SNIPPET, which also feeds Umami -- kept as-is, this
+        // doesn't replace it). Explicit here rather than relying solely on
+        // the dashboard's own "Web vitals autocapture" project setting: that
+        // setting only reaches the client via the /array/*/config remote-
+        // config fetch, so a client-side default keeps this working even if
+        // that fetch is ever degraded, matching this module's established
+        // "don't depend on state this code can't guarantee" posture (see
+        // the persistence choice below).
+        capture_performance: { web_vitals: true },
         // metagraphed#7760's own explicit requirement: "respect DNT, no
         // cookies beyond what's justified" -- parity with the self-hosted
         // Umami tracker this sits alongside, which never sets cookies either.

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -572,7 +572,21 @@ export default {
   async fetch(request: Request, env: unknown, ctx: unknown) {
     const statsResponse = await handleStatsProxy(request);
     if (statsResponse) return statsResponse;
-    const analyticsResponse = await handleAnalyticsProxy(request, ctx as PostHogAssetContext);
+    // A top-level safety net, not just belt-and-suspenders: this proxy's own
+    // internal error handling (analytics-proxy.ts) has already had one real
+    // production incident where an unguarded background failure escaped as
+    // an unhandled rejection and corrupted the response for every
+    // /ingest/static/* and /ingest/array/* request. A public analytics
+    // proxy must never be able to take down request handling -- catch
+    // ANYTHING it throws and treat it as "not handled" so the request falls
+    // through to the real SSR app below, rather than surfacing a broken
+    // response for a concern this unrelated to the page being requested.
+    let analyticsResponse: Response | null = null;
+    try {
+      analyticsResponse = await handleAnalyticsProxy(request, ctx as PostHogAssetContext);
+    } catch (error) {
+      console.error("[analytics-proxy] request handling failed:", error);
+    }
     if (analyticsResponse) return analyticsResponse;
     const ogResponse = await handleOgImage(request);
     if (ogResponse) return ogResponse;


### PR DESCRIPTION
## Summary

Two fixes found while directly verifying the pageview-token fix (#7794's predecessor issue) in production against the live PostHog Installation Health panel.

### 1. Defensive hardening on the analytics proxy

`#7794` fixed one unhandled-rejection path (`caches.default.put()` had no `.catch()`). While verifying that fix was live, `/ingest/array/*` was still intermittently 500ing in production and I couldn't get a clean root-cause read via `wrangler tail` (tail sessions weren't reliably capturing traffic during testing). Rather than chase an inconclusive live-debugging signal further, this hardens the actual remaining gap I could find by code review:

- `caches.default.match()` had **no error handling at all**, unlike the `put()` path already fixed -- a read failure there hits the exact same "unhandled rejection corrupts an already-correct response" mechanism through a different line.
- `server.ts` now wraps the entire `handleAnalyticsProxy` call in try/catch -- a top-level safety net, not just belt-and-suspenders. A public analytics proxy should never be able to take down request handling for the rest of the site (all other routes), regardless of what internal bug -- known today or introduced later -- it might hit.

### 2. `capture_pageleave` + native `$web_vitals`

PostHog's Installation Health panel flagged both as not detected once `$pageview` itself started working:

- **`$pageleave`**: posthog-js's own `capture_pageleave` defaults to `'if_capture_pageview'` -- it silently disables itself whenever `capture_pageview` is `false` (see `@posthog/types`' own doc comment on the option). This app deliberately sets `capture_pageview: false` (manual SPA-aware pageviews, `#7760`), which took pageleave down as a side effect I hadn't traced through. Pageleave has no such SPA caveat itself (driven by the page-unload event, which fires correctly regardless of client-side routing), so there's no reason to lose it -- set explicitly.
- **`$web_vitals`**: the project's dashboard already has "Web vitals autocapture" enabled (confirmed live), but that setting only reaches the client through the `/array/*/config` remote-config fetch -- the exact route the `cache.put()` bug above was breaking. Rather than depend entirely on that fetch succeeding, `capture_performance: { web_vitals: true }` sets a client-side default too, matching this module's established "don't depend on state this code can't guarantee" posture (same reasoning as the existing `persistence: "memory"` choice). This is additive to, not a replacement for, the existing custom `'web_vitals'` event in `server.ts`'s `WEB_VITALS_SNIPPET` (which also feeds Umami).

## Test plan

- [x] New test: `capture_pageleave: true` and `capture_performance: { web_vitals: true }` are present in the `posthog.init()` call.
- [x] Existing `analytics-proxy.test.ts` suite (18 tests, including the earlier `cache.put()` regression test) stays green with the new `match()` guard.
- [x] `npm test --workspace=apps/ui` -- full suite green (182 files, 1394 tests).
- [x] `npx tsc --noEmit` / `npm run format:check` / `npm run lint --workspace=apps/ui` -- clean.
- [x] Real `vite build` (`LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module`, matching CI) -- 305 KB gzipped initial client JS, still under the 320 KB budget.

No screenshot table: `src/lib/**` + `src/server.ts`, no visual change.

Not linked to a numbered issue -- production hardening found during manual verification of #7760/#7761/#7794, not a planned deliverable.