### PR TITLE
feat(ui): adopt AsyncPanel across remaining routes (Phase 11 batch 5)

### DIFF
--- a/apps/ui/src/routes/accounts.index.tsx
+++ b/apps/ui/src/routes/accounts.index.tsx
@@ -1,15 +1,15 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { Search } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { TopActiveAccounts } from "@/components/metagraphed/top-active-accounts";
 import { TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS } from "@/components/metagraphed/top-active-accounts-ranking";
 import { ActionBar, ShareButton } from "@jsonbored/ui-kit";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
+import { chainSignersQuery } from "@/lib/metagraphed/queries";
 
 export const Route = createFileRoute("/accounts/")({
   head: () => ({
@@ -105,11 +105,13 @@ function AccountsPage() {
           Ranked by extrinsics signed on-chain in the last {TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS} days —
           jump straight to an account below.
         </p>
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-40 w-full" />}>
-            <TopActiveAccounts />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel
+          context="active accounts"
+          fallback={<Skeleton className="h-40 w-full" />}
+          retryQueryKeys={[chainSignersQuery().queryKey]}
+        >
+          <TopActiveAccounts />
+        </AsyncPanel>
       </section>
       <ApiSourceFooter paths={["/api/v1/accounts/{ss58}", "/api/v1/chain/signers"]} />
     </AppShell>

--- a/apps/ui/src/routes/admin-changes.index.tsx
+++ b/apps/ui/src/routes/admin-changes.index.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Suspense } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -8,8 +7,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
 import { ShareButton, DownloadCsvButton, ActionBar, StatTile } from "@jsonbored/ui-kit";
-import { PageMasthead, TableSkeleton } from "@/components/metagraphed/primitives";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { AsyncPanel, PageMasthead, TableSkeleton } from "@/components/metagraphed/primitives";
 import { CallModuleExtrinsicsTable } from "@/components/metagraphed/call-module-extrinsics-table";
 import { governanceConfigChangesQuery, networkParametersQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
@@ -82,27 +80,25 @@ function AdminChangesPage() {
       {/* #6997: the change-log below is a history of governance config-change
           events -- it never showed the *current* live values of the three
           key protocol/governance parameters those changes actually move.
-          Own QueryErrorBoundary/Suspense so a slow/failed RPC read never
-          blocks the (unrelated, artifact-backed) change-log table below. */}
-      <QueryErrorBoundary>
-        <Suspense
-          fallback={
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-              <Skeleton className="h-20" />
-            </div>
-          }
-        >
-          <NetworkParametersCard />
-        </Suspense>
-      </QueryErrorBoundary>
+          Own AsyncPanel so a slow/failed RPC read never blocks the
+          (unrelated, artifact-backed) change-log table below. */}
+      <AsyncPanel
+        context="network parameters"
+        fallback={
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+            <Skeleton className="h-20" />
+            <Skeleton className="h-20" />
+            <Skeleton className="h-20" />
+          </div>
+        }
+        retryQueryKeys={[networkParametersQuery().queryKey]}
+      >
+        <NetworkParametersCard />
+      </AsyncPanel>
       <div className="min-w-0">
-        <QueryErrorBoundary>
-          <Suspense fallback={<TableSkeleton rows={10} columns={6} />}>
-            <AdminChangesTable />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel context="admin changes" fallback={<TableSkeleton rows={10} columns={6} />}>
+          <AdminChangesTable />
+        </AsyncPanel>
       </div>
       <ApiSourceFooter
         paths={["/api/v1/governance/config-changes", "/api/v1/network/parameters"]}

--- a/apps/ui/src/routes/agents.tsx
+++ b/apps/ui/src/routes/agents.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
 import {
   Bot,
   Terminal,
@@ -22,11 +21,10 @@ import {
   McpToolsList,
   SectionHeading,
 } from "@jsonbored/ui-kit";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { AskBox } from "@/components/metagraphed/ask-box";
 import { SearchBox } from "@/components/metagraphed/search-box";
 import { Skeleton } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { agentResourcesQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import type { AgentResources } from "@/lib/metagraphed/types";
@@ -106,11 +104,13 @@ function AgentsPage() {
           </ActionBar>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-[40rem] w-full" />}>
-          <AgentsBody />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="agent resources"
+        fallback={<Skeleton className="h-[40rem] w-full" />}
+        retryQueryKeys={[agentResourcesQuery().queryKey]}
+      >
+        <AgentsBody />
+      </AsyncPanel>
       <ApiSourceFooter paths={["/api/v1/agent-resources"]} />
     </AppShell>
   );

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link, notFound, useNavigate } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import {
-  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -19,7 +18,7 @@ import { PalletMethodBreakdown } from "@/components/metagraphed/blocks/pallet-me
 import { ShortcutsDialog } from "@/components/metagraphed/blocks/shortcuts-dialog";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
@@ -37,7 +36,6 @@ import {
   InfoTooltip,
   BackToTop,
 } from "@jsonbored/ui-kit";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
   blockChainEventsQuery,
   blockEventsQuery,
@@ -110,11 +108,13 @@ function BlockDetailPage() {
   return (
     <AppShell>
       <ValueUnitProvider>
-        <QueryErrorBoundary>
-          <Suspense fallback={<DetailSkeleton />}>
-            <BlockDetail refValue={ref} />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel
+          context="block detail"
+          fallback={<DetailSkeleton />}
+          retryQueryKeys={[blockQuery(ref).queryKey]}
+        >
+          <BlockDetail refValue={ref} />
+        </AsyncPanel>
       </ValueUnitProvider>
       <BackToTop />
     </AppShell>

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1,13 +1,12 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useQuery, useSuspenseQueries } from "@tanstack/react-query";
-import { Suspense, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Activity, Boxes, Coins, Layers, UserPlus, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
   ShareButton,
   ActionBar,
@@ -19,7 +18,7 @@ import {
   Donut,
   CopyButton,
 } from "@jsonbored/ui-kit";
-import { PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { EXPLORER_LEADERBOARD_IDS } from "@/components/metagraphed/explorer-leaderboard-layout";
 import { ExplorerLeaderboardTableShell } from "@/components/metagraphed/explorer-leaderboard-table-shell";
 import { ChainEventsFeed } from "@/components/metagraphed/chain-events-feed";
@@ -135,11 +134,9 @@ function ExplorerPage() {
           </>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-[40rem] w-full" />}>
-          <ExplorerDashboard />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel context="explorer dashboard" fallback={<Skeleton className="h-[40rem] w-full" />}>
+        <ExplorerDashboard />
+      </AsyncPanel>
       <ChainEventsFeedSection />
       <ApiSourceFooter
         paths={[

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Boxes, Clock, FileText, Link2, UserCog } from "lucide-react";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -16,8 +16,7 @@ import {
   StatTile,
   TableState,
 } from "@jsonbored/ui-kit";
-import { PageMasthead } from "@/components/metagraphed/primitives";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -90,11 +89,13 @@ function ExtrinsicDetailPage() {
   const { hash } = Route.useParams();
   return (
     <AppShell>
-      <QueryErrorBoundary>
-        <Suspense fallback={<DetailSkeleton />}>
-          <ExtrinsicDetail hash={hash} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="extrinsic detail"
+        fallback={<DetailSkeleton />}
+        retryQueryKeys={[extrinsicQuery(hash).queryKey]}
+      >
+        <ExtrinsicDetail hash={hash} />
+      </AsyncPanel>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { SlidersHorizontal } from "lucide-react";
@@ -15,7 +15,6 @@ import {
   SearchInput,
   SelectFilter,
 } from "@/components/metagraphed/table-controls";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import {
   TimeAgo,
@@ -27,7 +26,7 @@ import {
   DownloadCsvButton,
   Sparkline,
 } from "@jsonbored/ui-kit";
-import { PageMasthead, PagerFooter } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, PagerFooter } from "@/components/metagraphed/primitives";
 import { chainFeesQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { activeFilterCount, filterToggleLabel } from "@/lib/metagraphed/filter-disclosure";
@@ -102,16 +101,16 @@ function ExtrinsicsPage() {
           </>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="mb-6 h-24 w-full" />}>
-          <FeesTrendCard />
-        </Suspense>
-      </QueryErrorBoundary>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-          <ExtrinsicsTable />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="fees trend"
+        fallback={<Skeleton className="mb-6 h-24 w-full" />}
+        retryQueryKeys={[chainFeesQuery("7d").queryKey]}
+      >
+        <FeesTrendCard />
+      </AsyncPanel>
+      <AsyncPanel context="extrinsics" fallback={<Skeleton className="h-96 w-full" />}>
+        <ExtrinsicsTable />
+      </AsyncPanel>
       <ApiSourceFooter
         paths={["/api/v1/extrinsics", "/api/v1/chain/fees"]}
         artifacts={["/metagraph/extrinsics.json"]}

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -6,6 +6,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, ErrorState, Skeleton, StatUnavailable } from "@/components/metagraphed/states";
 import { statPhase, type StatPhase } from "@/lib/metagraphed/stat-phase";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { AsyncPanel } from "@/components/metagraphed/primitives";
 import {
   AccentBand,
   BrandIcon,
@@ -48,6 +49,10 @@ import {
   healthQuery,
   subnetsQuery,
   adapterQuery,
+  registrySummaryQuery,
+  coverageDepthQuery,
+  changelogQuery,
+  endpointIncidentsQuery,
 } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
@@ -151,25 +156,34 @@ function OverviewPage() {
                   />
                   <TimeRangeScrub />
                 </div>
-                <QueryErrorBoundary>
-                  <div className="grid gap-4 lg:grid-cols-12">
-                    <Suspense fallback={<Skeleton className="h-72 lg:col-span-5" />}>
-                      <div className="lg:col-span-5">
-                        <CoverageFunnel />
-                      </div>
-                    </Suspense>
-                    <Suspense fallback={<Skeleton className="h-72 lg:col-span-7" />}>
-                      <div className="lg:col-span-7">
-                        <NetworkPulseBand />
-                      </div>
-                    </Suspense>
-                    <Suspense fallback={<Skeleton className="h-64 lg:col-span-12" />}>
-                      <div className="lg:col-span-12">
-                        <WhatChangedFeed />
-                      </div>
-                    </Suspense>
-                  </div>
-                </QueryErrorBoundary>
+                <div className="grid gap-4 lg:grid-cols-12">
+                  <AsyncPanel
+                    context="coverage funnel"
+                    fallback={<Skeleton className="h-72 lg:col-span-5" />}
+                    retryQueryKeys={[coverageQuery().queryKey]}
+                  >
+                    <div className="lg:col-span-5">
+                      <CoverageFunnel />
+                    </div>
+                  </AsyncPanel>
+                  <AsyncPanel
+                    context="network pulse"
+                    fallback={<Skeleton className="h-72 lg:col-span-7" />}
+                  >
+                    <div className="lg:col-span-7">
+                      <NetworkPulseBand />
+                    </div>
+                  </AsyncPanel>
+                  <AsyncPanel
+                    context="what changed"
+                    fallback={<Skeleton className="h-64 lg:col-span-12" />}
+                    retryQueryKeys={[changelogQuery().queryKey, endpointIncidentsQuery().queryKey]}
+                  >
+                    <div className="lg:col-span-12">
+                      <WhatChangedFeed />
+                    </div>
+                  </AsyncPanel>
+                </div>
               </TimeRangeProvider>
             </section>
           </ScrollReveal>
@@ -186,29 +200,35 @@ function OverviewPage() {
                 description="Completeness scores, surface-dimension coverage, and the highest-priority subnets to enrich next."
               />
               <div className="grid gap-4 lg:grid-cols-12">
-                <QueryErrorBoundary>
-                  <Suspense fallback={<Skeleton className="h-64 lg:col-span-7" />}>
-                    <div className="lg:col-span-7">
-                      <RegistryScoreHistogram className="h-full" />
-                    </div>
-                  </Suspense>
-                </QueryErrorBoundary>
-                <QueryErrorBoundary>
-                  <Suspense fallback={<Skeleton className="h-64 lg:col-span-5" />}>
-                    <div className="lg:col-span-5">
-                      <DimensionCoverageHeatmap className="h-full" />
-                    </div>
-                  </Suspense>
-                </QueryErrorBoundary>
+                <AsyncPanel
+                  context="registry score histogram"
+                  fallback={<Skeleton className="h-64 lg:col-span-7" />}
+                  retryQueryKeys={[registrySummaryQuery().queryKey]}
+                >
+                  <div className="lg:col-span-7">
+                    <RegistryScoreHistogram className="h-full" />
+                  </div>
+                </AsyncPanel>
+                <AsyncPanel
+                  context="dimension coverage heatmap"
+                  fallback={<Skeleton className="h-64 lg:col-span-5" />}
+                  retryQueryKeys={[registrySummaryQuery().queryKey]}
+                >
+                  <div className="lg:col-span-5">
+                    <DimensionCoverageHeatmap className="h-full" />
+                  </div>
+                </AsyncPanel>
                 <div className="lg:col-span-12">
                   <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
                     Enrichment queue
                   </div>
-                  <QueryErrorBoundary>
-                    <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                      <EnrichmentQueueTable />
-                    </Suspense>
-                  </QueryErrorBoundary>
+                  <AsyncPanel
+                    context="enrichment queue"
+                    fallback={<Skeleton className="h-64 w-full" />}
+                    retryQueryKeys={[coverageDepthQuery().queryKey]}
+                  >
+                    <EnrichmentQueueTable />
+                  </AsyncPanel>
                 </div>
               </div>
             </section>
@@ -245,11 +265,13 @@ function OverviewPage() {
                 <ArrowUpRight className="size-3 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
               </Link>
             </div>
-            <QueryErrorBoundary>
-              <Suspense fallback={<TableSkeleton />}>
-                <SubnetPreviewTable />
-              </Suspense>
-            </QueryErrorBoundary>
+            <AsyncPanel
+              context="subnets"
+              fallback={<TableSkeleton />}
+              retryQueryKeys={[subnetsQuery({ limit: 12 }).queryKey]}
+            >
+              <SubnetPreviewTable />
+            </AsyncPanel>
           </section>
 
           {/* #3474: live network-wide feed of recent subnet-identity changes. */}

--- a/apps/ui/src/routes/portfolio.tsx
+++ b/apps/ui/src/routes/portfolio.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Suspense } from "react";
 import { Wallet } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { useWallet } from "@/hooks/use-wallet";
 import { WalletConnectButton } from "@/components/metagraphed/wallet-connect";
 import { YourPositionsPanel } from "@/components/metagraphed/your-positions-panel";
@@ -47,11 +45,9 @@ function PortfolioPage() {
       />
 
       {wallet ? (
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-            <YourPositionsPanel address={wallet.address} />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel context="your positions" fallback={<Skeleton className="h-96 w-full" />}>
+          <YourPositionsPanel address={wallet.address} />
+        </AsyncPanel>
       ) : (
         <div className="rounded border border-dashed border-ink-subtle bg-surface/30 p-8 text-center">
           <Wallet className="mx-auto mb-3 size-6 text-ink-muted" aria-hidden />

--- a/apps/ui/src/routes/runtime.index.tsx
+++ b/apps/ui/src/routes/runtime.index.tsx
@@ -1,12 +1,11 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
 import { ShareButton, DownloadCsvButton, ActionBar, TableState, TimeAgo } from "@jsonbored/ui-kit";
-import { PageMasthead } from "@/components/metagraphed/primitives";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import {
   RuntimeUpgradeCardList,
   orderRuntimeUpgradesNewestFirst,
@@ -55,11 +54,13 @@ function RuntimePage() {
           </ActionBar>
         }
       />
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-          <RuntimeContent />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="runtime upgrades"
+        fallback={<Skeleton className="h-96 w-full" />}
+        retryQueryKeys={[runtimeVersionHistoryQuery().queryKey]}
+      >
+        <RuntimeContent />
+      </AsyncPanel>
       <ApiSourceFooter paths={["/api/v1/runtime"]} artifacts={["/metagraph/runtime.json"]} />
     </AppShell>
   );

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { fallback } from "@tanstack/zod-adapter";
 import { z } from "zod";
 import { ChevronLeft, FileCode, Copy, Check } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { Panel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, Panel, PageMasthead } from "@/components/metagraphed/primitives";
 import {
   TimeAgo,
   CopyableCode,
@@ -17,13 +17,17 @@ import {
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { DownloadOpenApiButton } from "@/components/metagraphed/download-openapi-button";
 import { Skeleton, StaleBanner, EmptyState } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { SchemaDriftMatrix } from "@/components/metagraphed/analytics/schema-drift-matrix";
 import { DriftActivity } from "@/components/metagraphed/analytics/drift-activity";
 import { SchemaDriftDetail } from "@/components/metagraphed/schema-drift-detail";
 import { SchemaSnapshotSummary } from "@/components/metagraphed/schema-snapshot-summary";
 import { useCopy } from "@/hooks/use-copy";
-import { schemasQuery, contractsQuery, metagraphedQueryKey } from "@/lib/metagraphed/queries";
+import {
+  schemasQuery,
+  contractsQuery,
+  evidenceQuery,
+  metagraphedQueryKey,
+} from "@/lib/metagraphed/queries";
 import { normalizeDriftStatus } from "@/lib/metagraphed/schema-drift";
 import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { isStaleFreshness, classNames } from "@/lib/metagraphed/format";
@@ -73,29 +77,35 @@ export const Route = createFileRoute("/schemas")({
 function SchemasPage() {
   return (
     <AppShell>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-          <SchemasHero />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="schemas overview"
+        fallback={<Skeleton className="h-64 w-full" />}
+        retryQueryKeys={[schemasQuery().queryKey, contractsQuery().queryKey]}
+      >
+        <SchemasHero />
+      </AsyncPanel>
 
       <main className="space-y-section">
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-10 w-full" />}>
-            <SchemasMethodology />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel
+          context="schemas methodology"
+          fallback={<Skeleton className="h-10 w-full" />}
+          retryQueryKeys={[schemasQuery().queryKey]}
+        >
+          <SchemasMethodology />
+        </AsyncPanel>
 
         <PageSection
           eyebrow="Activity"
           title="Drift activity"
           description="Per-schema change weight. Stable schemas are dim; drifting schemas surface on top — click a drifting row for change details, or a stable row to open it in the explorer below."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <DriftActivityRibbon />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="drift activity"
+            fallback={<Skeleton className="h-32 w-full" />}
+            retryQueryKeys={[schemasQuery().queryKey]}
+          >
+            <DriftActivityRibbon />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -103,11 +113,13 @@ function SchemasPage() {
           title="Schema drift matrix"
           description="Every tracked schema classified by change type, with one-click access to source evidence."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-              <SchemaDriftMatrix />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="schema drift matrix"
+            fallback={<Skeleton className="h-48 w-full" />}
+            retryQueryKeys={[schemasQuery().queryKey, evidenceQuery({ limit: 500 }).queryKey]}
+          >
+            <SchemaDriftMatrix />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -115,11 +127,13 @@ function SchemasPage() {
           title="Published contracts"
           description="Versioned envelope contracts that govern API responses."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-              <ContractsList />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="published contracts"
+            fallback={<Skeleton className="h-24 w-full" />}
+            retryQueryKeys={[contractsQuery().queryKey]}
+          >
+            <ContractsList />
+          </AsyncPanel>
         </PageSection>
 
         <PageSection
@@ -127,11 +141,13 @@ function SchemasPage() {
           title="Schema index"
           description="Browse every tracked JSON Schema. Select one to inspect the latest snapshot and recent drift."
         >
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-[480px] w-full" />}>
-              <SchemaExplorer />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="schema index"
+            fallback={<Skeleton className="h-[480px] w-full" />}
+            retryQueryKeys={[schemasQuery().queryKey]}
+          >
+            <SchemaExplorer />
+          </AsyncPanel>
         </PageSection>
       </main>
 
@@ -140,11 +156,9 @@ function SchemasPage() {
         artifacts={["/metagraph/openapi.json"]}
       />
 
-      <QueryErrorBoundary>
-        <Suspense fallback={null}>
-          <SchemaDriftDetailHost />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel context="schema drift detail" fallback={null}>
+        <SchemaDriftDetailHost />
+      </AsyncPanel>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -4,13 +4,12 @@ import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
-import { Suspense, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { AlertTriangle, ArrowUpRight, CheckCircle2, XCircle } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { Panel } from "@/components/metagraphed/primitives";
+import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
   CopyableCode,
   ExternalLink,
@@ -20,7 +19,15 @@ import {
   Donut,
   DonutLegend,
 } from "@jsonbored/ui-kit";
-import { healthQuery, globalIncidentsQuery, incidentsFeedQuery } from "@/lib/metagraphed/queries";
+import {
+  healthQuery,
+  globalIncidentsQuery,
+  incidentsFeedQuery,
+  chainConcentrationQuery,
+  chainPerformanceQuery,
+  chainYieldQuery,
+  sourceHealthProvidersQuery,
+} from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { classNames, humaniseSeconds, isStaleFreshness } from "@/lib/metagraphed/format";
 import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
@@ -116,18 +123,18 @@ function StatusPage() {
         }
       />
       <div className="space-y-section">
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-28 w-full" />}>
-            <Verdict />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel
+          context="status verdict"
+          fallback={<Skeleton className="h-28 w-full" />}
+          retryQueryKeys={[healthQuery().queryKey]}
+        >
+          <Verdict />
+        </AsyncPanel>
         <section>
           <SectionHeading title="Recent incidents" />
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <RecentIncidents />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel context="recent incidents" fallback={<Skeleton className="h-32 w-full" />}>
+            <RecentIncidents />
+          </AsyncPanel>
         </section>
 
         <section>
@@ -135,11 +142,13 @@ function StatusPage() {
             title="Subscribe"
             intro="Copy or open the incidents feed in RSS, Atom, or JSON Feed format — the same probe-detected downtime stream shown above."
           />
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-              <IncidentsFeedSubscribe />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="incidents feed"
+            fallback={<Skeleton className="h-32 w-full" />}
+            retryQueryKeys={[incidentsFeedQuery().queryKey]}
+          >
+            <IncidentsFeedSubscribe />
+          </AsyncPanel>
         </section>
 
         {/* #3471: network-scope decentralization scorecard — stake &
@@ -151,11 +160,13 @@ function StatusPage() {
             title="Network decentralization"
             intro="Chain-wide stake & emission concentration (Gini, HHI, Nakamoto coefficient, entropy, top-1% share) and the trust/consensus score spread, computed across every subnet from the metagraph snapshot."
           />
-          <QueryErrorBoundary>
-            <Suspense fallback={<NetworkDecentralizationSkeleton />}>
-              <NetworkDecentralizationPanel />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="network decentralization"
+            fallback={<NetworkDecentralizationSkeleton />}
+            retryQueryKeys={[chainConcentrationQuery().queryKey, chainPerformanceQuery().queryKey]}
+          >
+            <NetworkDecentralizationPanel />
+          </AsyncPanel>
         </section>
 
         {/* #3472: network emission-yield summary — the return-rate companion to
@@ -166,11 +177,13 @@ function StatusPage() {
             title="Network emission yield"
             intro="Chain-wide emission yield — total emission over total stake, split by validator/miner role — plus the per-neuron return distribution, computed across every neuron from the metagraph snapshot."
           />
-          <QueryErrorBoundary>
-            <Suspense fallback={<EmissionYieldSkeleton />}>
-              <EmissionYieldPanel />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="network emission yield"
+            fallback={<EmissionYieldSkeleton />}
+            retryQueryKeys={[chainYieldQuery().queryKey]}
+          >
+            <EmissionYieldPanel />
+          </AsyncPanel>
         </section>
 
         {/* #8: operational diagnostics — a per-day probe drill-down and a
@@ -180,11 +193,13 @@ function StatusPage() {
             title="Probe history"
             intro="Per-surface probe results for any captured day. Pick a date to inspect."
           />
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-              <HealthHistoryDrilldown />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="probe history"
+            fallback={<Skeleton className="h-48 w-full" />}
+            retryQueryKeys={[healthQuery().queryKey]}
+          >
+            <HealthHistoryDrilldown />
+          </AsyncPanel>
         </section>
 
         <section>
@@ -192,11 +207,13 @@ function StatusPage() {
             title="Source health"
             intro="Per-provider verification status, endpoint counts, and classification mix."
           />
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-              <SourceHealthTable />
-            </Suspense>
-          </QueryErrorBoundary>
+          <AsyncPanel
+            context="source health"
+            fallback={<Skeleton className="h-48 w-full" />}
+            retryQueryKeys={[sourceHealthProvidersQuery().queryKey]}
+          >
+            <SourceHealthTable />
+          </AsyncPanel>
         </section>
       </div>
       <ApiSourceFooter

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -259,11 +259,13 @@ function SubnetDetailPage() {
   const { netuid } = Route.useParams();
   return (
     <AppShell flushTop>
-      <QueryErrorBoundary>
-        <Suspense fallback={<DetailSkeleton />}>
-          <ProfileShell netuid={netuid} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="subnet profile"
+        fallback={<DetailSkeleton />}
+        retryQueryKeys={[subnetProfileQuery(netuid).queryKey]}
+      >
+        <ProfileShell netuid={netuid} />
+      </AsyncPanel>
       <BackToTop />
     </AppShell>
   );

--- a/apps/ui/src/routes/sudo.index.tsx
+++ b/apps/ui/src/routes/sudo.index.tsx
@@ -1,14 +1,12 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
 import { ShareButton, DownloadCsvButton, ActionBar, CopyButton, TimeAgo } from "@jsonbored/ui-kit";
-import { PageMasthead } from "@/components/metagraphed/primitives";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
 import { CallModuleExtrinsicsTable } from "@/components/metagraphed/call-module-extrinsics-table";
 import { sudoCallsQuery, sudoKeyQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
@@ -104,11 +102,9 @@ function SudoPage() {
         ]}
       />
       <div className="min-w-0">
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-            <SudoTable />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel context="sudo calls" fallback={<Skeleton className="h-96 w-full" />}>
+          <SudoTable />
+        </AsyncPanel>
       </div>
       <ApiSourceFooter
         paths={["/api/v1/sudo", "/api/v1/sudo/key"]}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -11,11 +10,10 @@ import {
   DensityToggle,
   type Density,
 } from "@jsonbored/ui-kit";
-import { PageMasthead, TableSkeleton } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, TableSkeleton } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { API_BASE } from "@/lib/metagraphed/config";
-import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber, isStaleFreshness, classNames } from "@/lib/metagraphed/format";
@@ -132,30 +130,31 @@ function ValidatorsPage() {
         }
       />
       <ValidatorGuide />
-      <QueryErrorBoundary>
-        <Suspense fallback={<TableSkeleton rows={10} columns={6} />}>
-          <ValidatorsTable
-            sort={sort}
-            order={order}
-            density={density}
-            onSort={onSort}
-            onDensityChange={onDensityChange}
-          />
-        </Suspense>
-      </QueryErrorBoundary>
+      <AsyncPanel
+        context="validators"
+        fallback={<TableSkeleton rows={10} columns={6} />}
+        retryQueryKeys={[validatorsQuery({ sort }).queryKey]}
+      >
+        <ValidatorsTable
+          sort={sort}
+          order={order}
+          density={density}
+          onSort={onSort}
+          onDensityChange={onDensityChange}
+        />
+      </AsyncPanel>
       <div className="mt-6" id="validator-dominance">
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-            <ValidatorDominanceChart />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel context="validator dominance" fallback={<Skeleton className="h-48 w-full" />}>
+          <ValidatorDominanceChart />
+        </AsyncPanel>
       </div>
       <div className="mt-6" id="validator-subnet-heatmap">
-        <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-            <ValidatorSubnetHeatmap />
-          </Suspense>
-        </QueryErrorBoundary>
+        <AsyncPanel
+          context="validator subnet heatmap"
+          fallback={<Skeleton className="h-64 w-full" />}
+        >
+          <ValidatorSubnetHeatmap />
+        </AsyncPanel>
       </div>
       <ApiSourceFooter paths={["/api/v1/validators"]} />
       <ValidatorsCompareDrawer />


### PR DESCRIPTION
## Summary
Consolidated batch (per feedback to stop splitting Phase 11 into many tiny PRs) converting the remaining plain `QueryErrorBoundary`+`Suspense` pairs to `AsyncPanel` across 14 route files plus the homepage: `blocks.$ref`, `sudo.index`, `extrinsics.$hash`, `explorer`, `agents`, `admin-changes.index`, `portfolio`, `validators.index`, `extrinsics.index`, `accounts.index`, `runtime.index`, `status`, `schemas`, the single matching pair in `subnets.$netuid` (`ProfileShell`), and `index.tsx` (homepage).

Each panel gets a `retryQueryKeys` derived from the wrapped component's own query builder(s) where trivial to reconstruct at the call site. Multi-param/multi-query panels (batched dashboards, filtered tables with derived search params) omit it and rely on `AsyncPanel`'s documented `resetQueries()` fallback — matching existing precedent elsewhere in the codebase (e.g. `subnets.index.tsx`'s `SubnetsStatStrip`/`SubnetsTable` panels).

On the homepage specifically: the registry-signal grid (`CoverageFunnel`/`NetworkPulseBand`/`WhatChangedFeed`) previously shared **one** error boundary for all three sections — split into three independent `AsyncPanel`s so one section's failure doesn't blank the other two, matching the isolation pattern the very next section on the page already used.

**Deliberately out of scope** (flagged rather than rushed):
- The five `fallback={() => null}` homepage panels (`SubnetPriceTicker`, `NetworkMoodGauge`, `HeroSubnetChips`, `MoversBand`, `PilotsSection`) — intentional silent-fail widgets. `AsyncPanel` always renders a visible `ErrorState` on failure, so converting these would be a real behavior change, not a mechanical swap.
- `RecentIdentityChanges`' bare `QueryErrorBoundary` — self-manages loading/error via plain `useQuery`, no `Suspense` pairing, nothing to convert.
- `PilotCard`'s per-card `QueryErrorBoundary` with a custom fallback — a bespoke link-styled fallback card so a failed adapter still navigates, not the standard `ErrorState` `AsyncPanel` provides.
- The ~20 bare `<QueryErrorBoundary>{child}</QueryErrorBoundary>` pairs in `subnets.$netuid.tsx` with no sibling `Suspense` — a deliberately different, error-only pattern (see #3961), not a mechanical-swap candidate.
- Component-internal boundaries (e.g. `status-diagnostics.tsx`'s own nested boundary) — this sweep stays scoped to route files, matching every prior Phase 8-11 batch.

No visual changes. Part of the ongoing #7752 primitive-adoption sweep (not closing the parent issue — it's explicitly open-ended).

## Test plan
- [x] `npx tsc --noEmit` clean across the whole project
- [x] `npx eslint` on all touched files — 0 errors (pre-existing warnings only)
- [x] `npx prettier --check` clean
- [x] `npx vitest run` — full suite, 182 files / 1393 tests passing
- [x] Live-browser verified every touched route (`/status`, `/schemas`, `/explorer`, `/validators`, `/admin-changes`, `/accounts`, `/runtime`, `/agents`, `/sudo`, `/extrinsics`, an extrinsic detail page, a block detail page, `/subnets/1`, `/portfolio`, and the homepage with "Show more" expanded) — all render live data through the new AsyncPanel boundaries, zero console errors