### PR TITLE
fix(ui): stop assuming ctx is a valid ExecutionContext in the analytics proxy

### DIFF
--- a/apps/ui/src/lib/analytics-proxy.test.ts
+++ b/apps/ui/src/lib/analytics-proxy.test.ts
@@ -275,6 +275,28 @@ describe("retrieveAnalyticsAsset", () => {
     );
     consoleErrorSpy.mockRestore();
   });
+
+  it("degrades to an uncached passthrough fetch when ctx is undefined, instead of throwing", async () => {
+    // Regression test for the actual confirmed root cause of the production
+    // incident the two tests above were hardening against: `wrangler tail`
+    // against the live Worker showed `ctx` itself arriving `undefined` for
+    // this request path ("Cannot read properties of undefined (reading
+    // 'waitUntil')"), not a Cache API rejection. server.ts's own `ctx:
+    // unknown` parameter is cast, not runtime-checked, so this module can't
+    // assume the type-level contract holds.
+    const match = vi.fn(async () => undefined);
+    const put = vi.fn(async () => {});
+    // @ts-expect-error -- test-only stub of the ambient Cloudflare `caches` global.
+    globalThis.caches = { default: { match, put } };
+    globalThis.fetch = vi.fn(async () => new Response("/* js */", { status: 200 })) as typeof fetch;
+
+    const request = new Request(`https://metagraph.sh${ANALYTICS_PREFIX}/static/array.js`);
+    const response = await retrieveAnalyticsAsset(request, "/static/array.js", undefined);
+
+    expect(response.status).toBe(200);
+    expect(match).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
 });
 
 describe("handleAnalyticsProxy routing", () => {
@@ -311,6 +333,19 @@ describe("handleAnalyticsProxy routing", () => {
     const request = new Request(`https://metagraph.sh${ANALYTICS_PREFIX}/array/phc_test/config.js`);
     await handleAnalyticsProxy(request, fakeCtx());
     expect(calls[0]).toBe("https://us-assets.i.posthog.com/array/phc_test/config.js");
+  });
+
+  it(`routes ${ANALYTICS_PREFIX}/array/* correctly even when ctx is undefined (the confirmed production root cause)`, async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      calls.push(String(url));
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+
+    const request = new Request(`https://metagraph.sh${ANALYTICS_PREFIX}/array/phc_test/config.js`);
+    const response = await handleAnalyticsProxy(request, undefined);
+    expect(calls[0]).toBe("https://us-assets.i.posthog.com/array/phc_test/config.js");
+    expect(response?.status).toBe(200);
   });
 
   it(`routes everything else under ${ANALYTICS_PREFIX} to the main API host`, async () => {

--- a/apps/ui/src/lib/analytics-proxy.ts
+++ b/apps/ui/src/lib/analytics-proxy.ts
@@ -57,9 +57,23 @@ declare const caches:
 export async function retrieveAnalyticsAsset(
   request: Request,
   pathWithParams: string,
-  ctx: PostHogAssetContext,
+  ctx: PostHogAssetContext | undefined,
 ): Promise<Response> {
-  const hasEdgeCache = typeof caches !== "undefined";
+  // Root cause of a real production incident, found via `wrangler tail`
+  // against the live Worker: `ctx` itself arrived `undefined` for this
+  // request path (`ctx.waitUntil` throwing "Cannot read properties of
+  // undefined (reading 'waitUntil')"), not a Cache API rejection -- the
+  // earlier .catch()/try-catch additions around match()/put() were real
+  // hardening but didn't address the actual trigger. server.ts casts its
+  // own `ctx: unknown` parameter straight through (`ctx as
+  // PostHogAssetContext`), a compile-time-only assertion with no runtime
+  // guarantee -- whatever produces an undefined ctx for some requests
+  // (still unconfirmed) is upstream of this module, so the only correct fix
+  // here is to never assume the type-level contract holds at runtime.
+  // Edge caching is a best-effort optimization; treat a missing/unusable
+  // ctx exactly like a missing `caches` global -- degrade to an uncached
+  // passthrough fetch, never throw.
+  const hasEdgeCache = typeof caches !== "undefined" && typeof ctx?.waitUntil === "function";
   // Same best-effort posture as the put() below -- a read failure must fall
   // through to a normal upstream fetch, never take the whole request down.
   let cached: Response | undefined;
@@ -76,13 +90,11 @@ export async function retrieveAnalyticsAsset(
   // rejection at the Worker's global scope -- Nitro/h3's own safety net
   // (src/lib/error-capture.ts's "error"/"unhandledrejection" listeners)
   // then turns that into a generic 500 for the CURRENT request, even though
-  // the response below was already computed correctly (confirmed live:
-  // every /ingest/static/* and /ingest/array/* request 500'd this way in
-  // production, while /ingest/e/ -- forwardToAnalyticsHost, which never
-  // touches ctx.waitUntil -- kept working). The edge cache is a best-effort
-  // optimization; a write failure (a malformed Vary header from upstream, a
-  // transient Cache API error, anything) must never take down the response
-  // that's already correct and already on its way to the browser.
+  // the response below was already computed correctly. The edge cache is a
+  // best-effort optimization; a write failure (a malformed Vary header from
+  // upstream, a transient Cache API error, anything) must never take down
+  // the response that's already correct and already on its way to the
+  // browser.
   if (hasEdgeCache) {
     ctx.waitUntil(
       caches.default.put(request, upstream.clone()).catch((err) => {
@@ -148,7 +160,7 @@ export async function forwardToAnalyticsHost(
 // above is the actual abuse control (bounded body size), not path filtering.
 export async function handleAnalyticsProxy(
   request: Request,
-  ctx: PostHogAssetContext,
+  ctx: PostHogAssetContext | undefined,
 ): Promise<Response | null> {
   const url = new URL(request.url);
   if (!url.pathname.startsWith(`${ANALYTICS_PREFIX}/`)) return null;


### PR DESCRIPTION
## Summary

**The actual, confirmed root cause** of the `/ingest/static/*` and `/ingest/array/*` failures the previous two fixes (#7794, #7804) were chasing without a definitive live signal: `wrangler tail` against the production Worker just now caught the real error clearly, thanks to #7804's own new logging:

```
GET https://metagraph.sh/ingest/array/REDACTED/config?ver=1.407.1 - Ok
  (error) [analytics-proxy] request handling failed: TypeError: Cannot read properties of undefined (reading 'waitUntil')
```

`ctx` itself arrives `undefined` for this request path -- not a Cache API rejection. `server.ts`'s own `ctx: unknown` parameter is passed through via `ctx as PostHogAssetContext`, a compile-time-only assertion with zero runtime guarantee. What actually produces an undefined `ctx` for some requests is still unconfirmed (upstream of this module, possibly Nitro/TanStack Start's own request handling for certain paths) -- but regardless of that "why," the correct fix on this side is to stop assuming the type-level contract holds at runtime.

`retrieveAnalyticsAsset` and `handleAnalyticsProxy` now accept `ctx: PostHogAssetContext | undefined` and treat a missing/unusable `ctx` exactly like a missing `caches` global (already-established pattern): degrade to an uncached passthrough fetch instead of throwing. Edge caching stays a pure best-effort optimization -- never a requirement for the response to succeed.

## Verification

Confirmed via `wrangler tail` immediately after this change was written (before this PR): the exact error message pinpointed the line precisely, no further guessing required. This is a targeted fix for a directly-observed failure, not another layer of speculative hardening.

## Test plan

- [x] Two new regression tests: `retrieveAnalyticsAsset(request, path, undefined)` returns a normal 200 without touching `caches` at all, and `handleAnalyticsProxy` routes `/array/*` correctly end-to-end with `ctx: undefined`.
- [x] Existing 18 tests in `analytics-proxy.test.ts` (including the two prior regression tests for the Cache API failure modes) stay green.
- [x] `npm test --workspace=apps/ui` -- full suite green (182 files, 1396 tests).
- [x] `npx tsc --noEmit` / `npm run format:check` / `npm run lint --workspace=apps/ui` -- clean.

No screenshot table: `src/lib/analytics-proxy.ts` + its test only, no visual change.

Not linked to a numbered issue -- production hotfix found via live debugging, not a planned deliverable.