### PR TITLE
fix(ui): tighten raw-hex-color ESLint guardrail (Lovable sync 11.4)

### DIFF
--- a/apps/ui/eslint.config.js
+++ b/apps/ui/eslint.config.js
@@ -27,7 +27,15 @@ const BASE_DESIGN_RULES = [
       "Bone & Ink caps font-weight at 600. Use font-medium or font-semibold — never bold/extrabold/black.",
   },
   {
-    selector: "Literal[value=/#[0-9a-fA-F]{3,8}\\b/][value!=/^#$/]",
+    // Anchored to the whole literal (a bare hex value, e.g. a theme-color meta
+    // string) or Tailwind's `[#...]` arbitrary-value bracket syntax -- NOT a
+    // bare `\b#[0-9a-f]{3,8}\b` scan, which false-positives on GitHub issue
+    // references embedded in prose strings (test descriptions, tooltip copy,
+    // JSDoc-in-string), e.g. "...(#6424)..." reads as a 4-digit hex color to
+    // an unanchored regex. A 2026-07-23 audit found 26 of 27 "hits" were this
+    // exact false positive; only the real one (an unavoidable meta theme-color
+    // literal, __root.tsx) survives this tightened match.
+    selector: "Literal[value=/^#[0-9a-fA-F]{3,8}$|\\[#[0-9a-fA-F]{3,8}\\]/]",
     message:
       "No raw hex colors in className / string literals. Author new colors in OKLCH in packages/ui-kit/src/styles.css.",
   },

--- a/apps/ui/src/components/metagraphed/account-address.test.ts
+++ b/apps/ui/src/components/metagraphed/account-address.test.ts
@@ -35,7 +35,7 @@ function findElement(
 
 const linkIn = (node: ReactNode) => findElement(node, (p) => p.to === "/accounts/$ss58");
 
-describe("AccountAddress links ss58 values to their account page (#6424)", () => {
+describe("AccountAddress links ss58 values to their account page", () => {
   it("renders a /accounts/$ss58 link for a valid ss58", () => {
     const tree = AccountAddress({ ss58: SS58, fallback: "—" });
     const link = linkIn(tree);
@@ -66,7 +66,7 @@ describe("AccountAddress links ss58 values to their account page (#6424)", () =>
     }
   });
 
-  it("valueClassName merges onto the link's own hover:underline class (#6427)", () => {
+  it("valueClassName merges onto the link's own hover:underline class", () => {
     const link = linkIn(
       AccountAddress({
         ss58: SS58,

--- a/apps/ui/src/components/metagraphed/app-shell-mobile-focus.test.ts
+++ b/apps/ui/src/components/metagraphed/app-shell-mobile-focus.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it } from "vitest";
 // the suite is node-environment.
 const source = readFileSync(fileURLToPath(new URL("./app-shell.tsx", import.meta.url)), "utf8");
 
-describe("mobile nav Sheet returns focus to the hamburger (#6416)", () => {
+describe("mobile nav Sheet returns focus to the hamburger", () => {
   it("keeps a ref on the hamburger button", () => {
     expect(source).toContain("const hamburgerRef = useRef<HTMLButtonElement | null>(null)");
     // The ref is attached to the aria-label="Open menu" button.

--- a/apps/ui/src/components/metagraphed/entity-hover-placement.test.ts
+++ b/apps/ui/src/components/metagraphed/entity-hover-placement.test.ts
@@ -5,7 +5,7 @@ import {
   resolveEntityHoverPlacement,
 } from "./entity-hover-placement";
 
-describe("entity hover placement tokens (#5337)", () => {
+describe("entity hover placement tokens", () => {
   it("defaults entity cells to top-start with a 250ms open delay", () => {
     expect(ENTITY_HOVER_DEFAULTS).toEqual({
       side: "top",

--- a/apps/ui/src/components/metagraphed/explorer-leaderboard-layout.test.ts
+++ b/apps/ui/src/components/metagraphed/explorer-leaderboard-layout.test.ts
@@ -7,7 +7,7 @@ import {
   explorerLeaderboardScrollClass,
 } from "./explorer-leaderboard-layout";
 
-describe("explorer leaderboard layout tokens (#3932)", () => {
+describe("explorer leaderboard layout tokens", () => {
   it("enables horizontal scroll via a dedicated inner wrapper", () => {
     expect(EXPLORER_LEADERBOARD_SCROLL_CLASS).toBe("overflow-x-auto");
   });

--- a/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.test.ts
+++ b/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.test.ts
@@ -7,7 +7,7 @@ import type { MegaMenuLivePreviewItem } from "./mega-menu-live-preview-link";
  * to `.test.ts` (no RTL), so we pin the placement wiring the component relies
  * on rather than mounting React.
  */
-describe("MegaMenuLivePreviewLink contract (#5337)", () => {
+describe("MegaMenuLivePreviewLink contract", () => {
   it("accepts subnet and provider live items with a numeric/string preview id", () => {
     const subnet: MegaMenuLivePreviewItem = {
       kind: "subnet",

--- a/apps/ui/src/components/metagraphed/network-switcher.test.ts
+++ b/apps/ui/src/components/metagraphed/network-switcher.test.ts
@@ -15,7 +15,7 @@ const source = readFileSync(
   "utf8",
 );
 
-describe("NetworkSwitcher custom API-origin input has an accessible name (#6422)", () => {
+describe("NetworkSwitcher custom API-origin input has an accessible name", () => {
   it("gives the origin input an aria-label", () => {
     // The input is the one carrying the localhost placeholder; its opening tag
     // must now also carry a non-empty aria-label.
@@ -35,7 +35,7 @@ describe("NetworkSwitcher custom API-origin input has an accessible name (#6422)
 // by collapsing to icon+dot only below `sm`, so the network stays reachable
 // on mobile (tap still opens the same popover) instead of overflowing or
 // being silently removed.
-describe("NetworkSwitcher trigger collapses to icon-only on mobile (#6902)", () => {
+describe("NetworkSwitcher trigger collapses to icon-only on mobile", () => {
   const triggerButton = (() => {
     const start = source.indexOf("<PopoverTrigger asChild>");
     const open = source.indexOf("<button", start);

--- a/apps/ui/src/components/metagraphed/schema-drift-detail.test.ts
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.test.ts
@@ -35,7 +35,7 @@ const source = readFileSync(
   "utf8",
 );
 
-describe("SchemaDriftDetail returns focus to its opener on close (#6555)", () => {
+describe("SchemaDriftDetail returns focus to its opener on close", () => {
   it("records document.activeElement when the dialog opens", () => {
     expect(source).toContain("restoreFocusRef");
     expect(source).toContain("document.activeElement");

--- a/apps/ui/src/components/metagraphed/stake-unstake-modal.test.ts
+++ b/apps/ui/src/components/metagraphed/stake-unstake-modal.test.ts
@@ -14,7 +14,7 @@ const source = readFileSync(
   "utf8",
 );
 
-describe("StakeUnstakeModal returns focus to its trigger (#6415)", () => {
+describe("StakeUnstakeModal returns focus to its trigger", () => {
   it("wraps the render-prop trigger in a SheetTrigger", () => {
     expect(source).toContain("<SheetTrigger asChild>{trigger(() => setOpen(true))}</SheetTrigger>");
   });

--- a/apps/ui/src/components/metagraphed/status-indicator-roles.test.ts
+++ b/apps/ui/src/components/metagraphed/status-indicator-roles.test.ts
@@ -41,7 +41,7 @@ function elementCarrying(source: string, label: string) {
   return source.slice(open, close);
 }
 
-describe("colour-only status indicators expose their label (#6423)", () => {
+describe("colour-only status indicators expose their label", () => {
   for (const [name, file, label] of SITES) {
     it(`${name} carries role="img" beside its aria-label`, () => {
       const el = elementCarrying(read(file), label);

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.test.ts
@@ -15,7 +15,7 @@ const source = readFileSync(
   "utf8",
 );
 
-describe("SubnetCompareDrawer returns focus to its trigger (#6420)", () => {
+describe("SubnetCompareDrawer returns focus to its trigger", () => {
   it("wraps the Compare button in a SheetTrigger", () => {
     // The trigger must be a SheetTrigger with the button as its asChild child —
     // that is the only thing that makes Radix restore focus on close.

--- a/apps/ui/src/components/metagraphed/take-management-modal.test.ts
+++ b/apps/ui/src/components/metagraphed/take-management-modal.test.ts
@@ -17,7 +17,7 @@ const source = readFileSync(
   "utf8",
 );
 
-describe("TakeManagementModal returns focus to its trigger (#6419)", () => {
+describe("TakeManagementModal returns focus to its trigger", () => {
   it("wraps the render-prop trigger in a SheetTrigger", () => {
     expect(source).toContain("<SheetTrigger asChild>{trigger(() => setOpen(true))}</SheetTrigger>");
   });

--- a/apps/ui/src/components/metagraphed/top-active-accounts-ranking.test.ts
+++ b/apps/ui/src/components/metagraphed/top-active-accounts-ranking.test.ts
@@ -6,7 +6,7 @@ import {
   formatTopActiveShare,
 } from "./top-active-accounts-ranking";
 
-describe("top-active-accounts ranking (#5315)", () => {
+describe("top-active-accounts ranking", () => {
   const sample = [
     { signer: "5AAA", tx_count: 100 },
     { signer: "5BBB", tx_count: 50 },

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -23,19 +23,19 @@ const METRICS: Array<{ term: string; def: string }> = [
   },
   {
     term: "Operator",
-    def: "The coldkey's self-declared on-chain identity (name, logo, links) joined server-side (#5234). It belongs to the operator's coldkey, not the hotkey — the same operator can run multiple validators.",
+    def: "The coldkey's self-declared on-chain identity (name, logo, links) joined server-side. It belongs to the operator's coldkey, not the hotkey — the same operator can run multiple validators.",
   },
   {
     term: "Take",
-    def: "The validator's commission (#2548): the fraction of delegator rewards the validator keeps (0–100%). Lower take means nominators keep more of the emission flow.",
+    def: "The validator's commission: the fraction of delegator rewards the validator keeps (0–100%). Lower take means nominators keep more of the emission flow.",
   },
   {
     term: "Est. APY",
-    def: "Annualized delegator yield estimated from emission÷stake, net of take — the latest captured rate scaled to a year, not a forecast of future returns. On the directory this uses the latest metagraph snapshot; on a validator detail page, 7d/30d/90d windows use daily neuron_daily history. Root stake (netuid 0) is TAO-denominated with no principal risk; alpha stake is price-exposed, so a positive nominal APY here can still net-lose TAO if the alpha token's price falls faster than the yield accrues. Server-side modelling (#2551) will supersede these client estimates.",
+    def: "Annualized delegator yield estimated from emission÷stake, net of take — the latest captured rate scaled to a year, not a forecast of future returns. On the directory this uses the latest metagraph snapshot; on a validator detail page, 7d/30d/90d windows use daily neuron_daily history. Root stake (netuid 0) is TAO-denominated with no principal risk; alpha stake is price-exposed, so a positive nominal APY here can still net-lose TAO if the alpha token's price falls faster than the yield accrues. Server-side modelling will supersede these client estimates.",
   },
   {
     term: "Nominators",
-    def: "How many distinct coldkeys currently have stake delegated to this hotkey, network-wide (#2549). Sourced from a lower-frequency chain scan than the other columns, so it can lag them briefly — a dash means no count has been captured for this hotkey yet, not zero nominators.",
+    def: "How many distinct coldkeys currently have stake delegated to this hotkey, network-wide. Sourced from a lower-frequency chain scan than the other columns, so it can lag them briefly — a dash means no count has been captured for this hotkey yet, not zero nominators.",
   },
   {
     term: "Dominance",

--- a/apps/ui/src/components/metagraphed/watch-subnet-alert.test.ts
+++ b/apps/ui/src/components/metagraphed/watch-subnet-alert.test.ts
@@ -13,7 +13,7 @@ const subnetForm = readFileSync(
   "utf8",
 );
 
-describe("WatchSubnetAlert posts a netuid-scoped trigger (#6558)", () => {
+describe("WatchSubnetAlert posts a netuid-scoped trigger", () => {
   it("sends netuid, not account, to the alert-triggers endpoint", () => {
     const body = subnetForm.slice(
       subnetForm.indexOf("body: JSON.stringify"),

--- a/apps/ui/src/components/metagraphed/your-positions-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.test.ts
@@ -5,7 +5,7 @@ import { buildUnifiedPositions } from "./your-positions-panel";
 // portfolio + coldkey-delegated nominator positions) into one list, deriving
 // each alpha holding from the per-subnet price so a slippage-aware exit quote
 // can be requested. buildUnifiedPositions is the pure core of that.
-describe("buildUnifiedPositions (#5243)", () => {
+describe("buildUnifiedPositions", () => {
   const prices = new Map<number, number>([
     [1, 0.5],
     [2, 2],

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -286,7 +286,11 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
         // pages unfurl to themselves, not the homepage.
         { name: "twitter:card", content: "summary_large_image" },
         // Brand ink (mint-M favicon set). og:image stays the per-route /og card
-        // injected in src/server.ts.
+        // injected in src/server.ts. theme-color is read directly by browser
+        // chrome outside the CSS cascade, so it can't reference a custom
+        // property -- a literal hex is unavoidable here, same as
+        // health-tokens.ts/og-image.ts.
+        // eslint-disable-next-line no-restricted-syntax -- see comment above
         { name: "theme-color", content: "#0B1F1A" },
       ],
       links: [

--- a/apps/ui/src/routes/detail-page-furniture-5481.test.ts
+++ b/apps/ui/src/routes/detail-page-furniture-5481.test.ts
@@ -22,7 +22,7 @@ const providerRouteSource = readFileSync(
   "utf8",
 );
 
-describe("subnet-masthead ShareButton (#5481)", () => {
+describe("subnet-masthead ShareButton", () => {
   it("imports ShareButton from @jsonbored/ui-kit", () => {
     const importBlock = mastheadSource.slice(
       0,
@@ -77,7 +77,7 @@ describe("subnet-masthead ShareButton (#5481)", () => {
   });
 });
 
-describe("subnets.$netuid.tsx ApiSourceFooter (#5481)", () => {
+describe("subnets.$netuid.tsx ApiSourceFooter", () => {
   it("imports ApiSourceFooter", () => {
     expect(subnetRouteSource).toContain(
       'import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";',
@@ -93,7 +93,7 @@ describe("subnets.$netuid.tsx ApiSourceFooter (#5481)", () => {
   });
 });
 
-describe("providers.$slug.tsx ShareButton + ApiSourceFooter (#5481)", () => {
+describe("providers.$slug.tsx ShareButton + ApiSourceFooter", () => {
   it("imports both ShareButton and ApiSourceFooter", () => {
     expect(providerRouteSource).toContain(
       'import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";',

--- a/apps/ui/src/routes/leaderboards-csv-export-menu.test.ts
+++ b/apps/ui/src/routes/leaderboards-csv-export-menu.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it } from "vitest";
 // validators-index-empty-action.test.ts's own convention.
 const source = readFileSync(fileURLToPath(new URL("./leaderboards.tsx", import.meta.url)), "utf8");
 
-describe("leaderboards ActionBar CSV export (#6577)", () => {
+describe("leaderboards ActionBar CSV export", () => {
   it("renders exactly one CsvExportMenu trigger in the ActionBar, not a DownloadCsvButton per board", () => {
     const actionBar = source.slice(source.indexOf("<ActionBar>"), source.indexOf("</ActionBar>"));
     expect(actionBar).toContain("<CsvExportMenu");

--- a/apps/ui/src/routes/subnets-total-stake-tile.test.ts
+++ b/apps/ui/src/routes/subnets-total-stake-tile.test.ts
@@ -23,7 +23,7 @@ const strip = source.slice(
   source.indexOf("function ExcludeToggle"),
 );
 
-describe("subnets.index.tsx Total stake tile (#6271)", () => {
+describe("subnets.index.tsx Total stake tile", () => {
   it("uses flex-wrap for the stat strip, not a fixed-column grid", () => {
     expect(strip).toContain("flex flex-wrap");
     expect(strip).not.toMatch(/grid grid-cols-\d/);

--- a/apps/ui/src/routes/validators-index-empty-action.test.ts
+++ b/apps/ui/src/routes/validators-index-empty-action.test.ts
@@ -19,7 +19,7 @@ const feed = readFileSync(
   "utf8",
 );
 
-describe("empty-state 'Open the API' actions (#6340)", () => {
+describe("empty-state 'Open the API' actions", () => {
   it("Validators index links its empty state to /api/v1/validators", () => {
     const empty = validators.slice(
       validators.indexOf("No validators indexed yet"),


### PR DESCRIPTION
## Summary
Closes #7811 by fixing the guardrail rather than the (nonexistent) violations, and cleans up the source of the confusion.

The `no-restricted-syntax` selector for raw hex colors used `#[0-9a-fA-F]{3,8}\b` against every string literal in the codebase — unanchored, no className/style context requirement. GitHub issue-number references embedded in prose (`"...(#6424)..."` in test descriptions and tooltip copy) parse as 4-digit hex colors to that regex.

Audited all 27 flagged sites: **26 of 27 were this exact false positive**, across 20 files (mostly `*.test.ts` `describe`/`it` strings and copy citing issue numbers). Two changes:

1. Tightened the selector to require either a bare whole-literal hex value (`^#...$`) or Tailwind's `[#...]` arbitrary-value bracket syntax — catches the real pattern, silences prose-embedded issue refs.
2. Removed the "(#NNNN)" issue-number citations themselves from the 26 sites (22 test `describe`/`it` names across 18 files, plus 4 mid-sentence citations in `validator-guide.tsx`'s tooltip copy) — they didn't carry information a reader needs (git history/PRs already tie each to its issue) and just invite the next regex-based guardrail to trip over them again.

The one genuine hex site (`__root.tsx`'s `theme-color` meta content) is a legitimate, unavoidable exception — browser chrome reads that value directly outside the CSS cascade, so it can't reference a design-token custom property. Documented with an `eslint-disable-next-line` + comment, same pattern as the existing `health-tokens.ts`/`og-image.ts` exceptions.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/routes src/components` — 0 errors; confirmed 0 remaining hex-color hits after the fix
- [x] `npx prettier --check` clean
- [x] `npx vitest run` — full suite, 182 files / 1396 tests passing (none assert on the edited describe/it strings)
- [x] Live-browser verified `validator-guide.tsx`'s edited tooltip copy on `/validators` — all four edited definitions render with clean grammar, zero console errors