### PR TITLE
fix(ci): drop shell brace expansion from test:ci:artifacts (breaks under dash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:ci": "vitest run --coverage --fileParallelism --testTimeout=30000 --exclude '**/artifacts.test.{mjs,ts}' --exclude '**/discovery-artifacts.test.{mjs,ts}' --exclude '**/public-safety.test.{mjs,ts}' --exclude '**/validate-error-messages.test.{mjs,ts}' --exclude '**/refresh-build-summary.test.{mjs,ts}'",
-    "test:ci:artifacts": "vitest run tests/artifacts.test.{mjs,ts} tests/discovery-artifacts.test.{mjs,ts} tests/public-safety.test.{mjs,ts} tests/validate-error-messages.test.{mjs,ts} tests/refresh-build-summary.test.{mjs,ts}",
+    "test:ci:artifacts": "vitest run tests/artifacts.test tests/discovery-artifacts.test tests/public-safety.test tests/validate-error-messages.test tests/refresh-build-summary.test",
     "curation:brief": "node scripts/curation-brief.ts",
     "curation:stale-notes": "node scripts/stale-gap-notes.ts",
     "curation:identity-divergence": "node scripts/identity-field-divergence.ts",


### PR DESCRIPTION
## Summary
- Follow-up to #7806: `test:ci:artifacts`'s positional file arguments used unquoted shell brace expansion (`tests/artifacts.test.{mjs,ts}`), which only works under bash/zsh. npm scripts execute via `/bin/sh`, which is `dash` on this repo's Ubuntu GitHub Actions runners — dash has no brace expansion, so the pattern was passed through completely literal and unexpanded, matching no file at all: `No test files found, exiting with code 1`, failing the whole Actions job outright.
- Vitest's positional arguments are substring filters against its own discovered test-file list, not filesystem globs needing shell expansion. Dropping the extension entirely (`tests/artifacts.test`) matches whichever of `.mjs`/`.ts` currently exists, with no brace syntax — shell-level or otherwise — required.
- `test:ci`'s own `--exclude` glob patterns are unaffected: they're single-quoted, so the shell never touches them, and vitest's own glob engine resolves the `{mjs,ts}` group directly.

## Test plan
- [x] `npm run test:ci:artifacts` locally: 5 files, 83/83 tests passing
- [x] `npx vitest run tests/artifacts.test` (extension-less) resolves to `tests/artifacts.test.ts` and runs correctly, confirming the substring-filter behavior this fix relies on