### PR TITLE
feat(observability): add PostHog feature flags (Workers HTTP+KV, UI client)

### DIFF
--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -8,9 +8,18 @@ const init = vi.hoisted(() => vi.fn());
 const capture = vi.hoisted(() => vi.fn());
 const captureExceptionSpy = vi.hoisted(() => vi.fn());
 const startSessionRecording = vi.hoisted(() => vi.fn());
+const onFeatureFlags = vi.hoisted(() => vi.fn());
+const isFeatureEnabledSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("posthog-js", () => ({
-  default: { init, capture, captureException: captureExceptionSpy, startSessionRecording },
+  default: {
+    init,
+    capture,
+    captureException: captureExceptionSpy,
+    startSessionRecording,
+    onFeatureFlags,
+    isFeatureEnabled: isFeatureEnabledSpy,
+  },
 }));
 
 describe("analytics (PostHog web analytics)", () => {
@@ -20,6 +29,8 @@ describe("analytics (PostHog web analytics)", () => {
     capture.mockClear();
     captureExceptionSpy.mockClear();
     startSessionRecording.mockClear();
+    onFeatureFlags.mockClear();
+    isFeatureEnabledSpy.mockClear();
   });
 
   afterEach(() => {
@@ -61,6 +72,14 @@ describe("analytics (PostHog web analytics)", () => {
       expect(init).not.toHaveBeenCalled();
       expect(captureExceptionSpy).not.toHaveBeenCalled();
       expect(startSessionRecording).not.toHaveBeenCalled();
+    });
+
+    it("isFeatureEnabled resolves false without loading posthog-js", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "");
+      const { isFeatureEnabled } = await import("./analytics");
+      await expect(isFeatureEnabled("kill-switch")).resolves.toBe(false);
+      expect(init).not.toHaveBeenCalled();
+      expect(onFeatureFlags).not.toHaveBeenCalled();
     });
   });
 
@@ -199,6 +218,41 @@ describe("analytics (PostHog web analytics)", () => {
       captureException(new Error("boom"));
       await vi.waitFor(() => expect(captureExceptionSpy).toHaveBeenCalled());
       expect(init).toHaveBeenCalledTimes(1);
+    });
+
+    it("isFeatureEnabled waits for onFeatureFlags before resolving (no flash of the wrong state)", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      let fireFlagsReady: (() => void) | undefined;
+      onFeatureFlags.mockImplementation((cb: () => void) => {
+        fireFlagsReady = cb;
+        return vi.fn(); // the unsubscribe function
+      });
+      isFeatureEnabledSpy.mockReturnValue(true);
+
+      const { isFeatureEnabled } = await import("./analytics");
+      const resultPromise = isFeatureEnabled("kill-switch");
+
+      // Not yet resolved -- onFeatureFlags hasn't fired.
+      await vi.waitFor(() => expect(onFeatureFlags).toHaveBeenCalled());
+      expect(isFeatureEnabledSpy).not.toHaveBeenCalled();
+
+      fireFlagsReady?.();
+      await expect(resultPromise).resolves.toBe(true);
+      expect(isFeatureEnabledSpy).toHaveBeenCalledWith("kill-switch");
+    });
+
+    it("isFeatureEnabled unsubscribes from onFeatureFlags after the first resolution", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      const unsubscribe = vi.fn();
+      onFeatureFlags.mockImplementation((cb: () => void) => {
+        cb();
+        return unsubscribe;
+      });
+      isFeatureEnabledSpy.mockReturnValue(false);
+
+      const { isFeatureEnabled } = await import("./analytics");
+      await expect(isFeatureEnabled("kill-switch")).resolves.toBe(false);
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
 
     it("a posthog-js init failure never throws, and later captures are silently dropped", async () => {

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -1,11 +1,12 @@
 /**
- * Centralized PostHog web-analytics + error-tracking + session-replay seam
- * (metagraphed#7760, #7759, #7761).
+ * Centralized PostHog web-analytics + error-tracking + session-replay +
+ * feature-flags seam (metagraphed#7760, #7759, #7761, #7762).
  *
  * Single chokepoint for client-side product analytics, exception reporting,
- * AND session replay: the app calls `initAnalytics()`/`capturePageview()`/
- * `captureEvent()`/`captureException()` and never touches `posthog-js`
- * directly elsewhere. Session replay has no separate exported function --
+ * session replay, AND feature flags: the app calls `initAnalytics()`/
+ * `capturePageview()`/`captureEvent()`/`captureException()`/
+ * `isFeatureEnabled()` and never touches `posthog-js` directly elsewhere.
+ * Session replay has no separate exported function --
  * it's configured once in `loadPostHog`'s `session_recording` block below
  * and otherwise runs itself (posthog-js's own recorder), except for the
  * exception-linked force-record call inside `captureException`.
@@ -235,5 +236,51 @@ export function captureException(error: unknown, properties?: Record<string, unk
     // recording from this instant. A no-op if replay is already recording.
     posthog?.startSessionRecording(true);
     posthog?.captureException(error, properties);
+  });
+}
+
+/** Resolves whether a feature flag is on for the current visitor
+ * (metagraphed#7762). Always `false` when unconfigured.
+ *
+ * A Promise, not a synchronous read: posthog-js resolves flags
+ * asynchronously after init (a network round-trip against the /ingest
+ * proxy), so a naive synchronous `posthog.isFeatureEnabled()` call made
+ * before that finishes returns `undefined` -- a caller checking it
+ * immediately on mount would render the OFF state first and only correct
+ * itself once flags arrive, a visible flash of the wrong UI. Waiting on
+ * `onFeatureFlags` (fires once flags are loaded, and immediately if
+ * they're already loaded by the time this is called) means callers only
+ * ever see the real, settled value. */
+export function isFeatureEnabled(key: string): Promise<boolean> {
+  if (!POSTHOG_TOKEN) return Promise.resolve(false);
+  return loadPostHog().then((posthog) => {
+    if (!posthog) return false;
+    return new Promise<boolean>((resolve) => {
+      // onFeatureFlags calls back SYNCHRONOUSLY when flags are already
+      // loaded (the common case for a second call in the same page life,
+      // and possibly even the first if init() itself resolved flags before
+      // this runs) -- so `unsubscribe` can still be mid-assignment (not yet
+      // in scope) the first time this fires. `resolved`/the post-call check
+      // below cover that: an early synchronous fire is caught right after
+      // onFeatureFlags() returns, a later async one calls the by-then-
+      // assigned `unsubscribe` directly. Either way this settles exactly
+      // once and never leaks a live subscription past that.
+      let resolved = false;
+      // handleFlagsReady's closure must see this binding change from
+      // `undefined` to the real unsubscribe function once it's assigned a
+      // few lines down (after the closure is defined but before it can
+      // possibly run) -- that requires `let`, a `const` would only be
+      // legal if the callback never referenced this variable at all.
+      // eslint-disable-next-line prefer-const -- false positive, see above.
+      let unsubscribe: (() => void) | undefined;
+      const handleFlagsReady = () => {
+        if (resolved) return;
+        resolved = true;
+        unsubscribe?.();
+        resolve(posthog.isFeatureEnabled(key) === true);
+      };
+      unsubscribe = posthog.onFeatureFlags(handleFlagsReady);
+      if (resolved) unsubscribe();
+    });
   });
 }

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,0 +1,166 @@
+// Cloudflare-KV-cached PostHog feature-flag evaluation for the Worker
+// backend (metagraphed#7762).
+//
+// Design decision (required by the issue before implementing): raw HTTP to
+// PostHog's own /flags evaluation endpoint on every miss, cached in
+// METAGRAPH_CONTROL KV with a short freshness window -- NOT a periodic
+// flag-definition sync that re-evaluates rollout/targeting rules locally.
+//
+// Every other data source in this system syncs on a schedule into KV/R2,
+// Workers read-only (ADR 0001) -- that pattern was the first instinct here
+// too, and it's the wrong one. PostHog's real evaluation can depend on
+// property/cohort targeting and a percentage-rollout hash that isn't a
+// small, stable, publicly-documented algorithm safe to reimplement:
+// "local evaluation" is a whole SDK feature (posthog.com/docs/feature-flags/
+// local-evaluation), not a spec, and posthog-node itself is the thing this
+// codebase already excludes on bundle-size grounds (see
+// usage-telemetry.ts's own header). Reimplementing a subset of it here
+// would risk a caller seeing a DIFFERENT flag state server-side than
+// posthog-js resolves for the same person client-side -- a correctness bug
+// worse than an extra network hop. Delegating evaluation to PostHog's own
+// servers and caching the RESULT keeps this Worker correct by construction.
+//
+// Same raw-fetch, no-SDK posture as the rest of usage-telemetry.ts, and the
+// same POSTHOG_PROJECT_TOKEN secret -- PostHog's /flags endpoint is
+// documented as safe to call with the project token (it "does not return
+// any sensitive data"), the same write-only-ish trust level as capture.
+//
+// Cache freshness is short (well under a minute) so a flag flip in
+// PostHog's dashboard reaches this Worker fast enough to function as a real
+// kill switch -- the whole point of this issue. A fetch or KV failure
+// degrades to the last-known cached value when one exists, or the caller's
+// own documented default otherwise -- flags must never block a request.
+
+import {
+  POSTHOG_PROJECT_TOKEN_ENV,
+  isUsageTelemetryConfigured,
+  resolvePostHogHost,
+} from "./usage-telemetry.js";
+
+/** PostHog's flag-evaluation endpoint, appended to the resolved host. */
+export const POSTHOG_FLAGS_PATH = "/flags/?v=2";
+
+// KV entries are kept indefinitely (no expirationTtl) so a stale value
+// always exists as the last-known-good fallback -- freshness is judged in
+// code below, not by letting the entry disappear.
+const CACHE_KEY_PREFIX = "feature-flag:";
+
+// Short enough that toggling a flag in the dashboard reaches production
+// within a duration a human calls "fast" while babysitting a rollback --
+// long enough that a route taking real traffic doesn't refetch on every
+// request. Not user-configurable (yet): revisit with real traffic data if
+// this ever needs tuning per-flag.
+const CACHE_FRESH_MS = 30_000;
+
+interface CachedFlagState {
+  value: boolean;
+  fetchedAt: number;
+}
+
+export interface EvaluateFeatureFlagDeps {
+  /** Injectable fetch (tests). */
+  fetch?: typeof fetch;
+  /** Injectable clock (tests). */
+  now?: () => number;
+}
+
+function cacheKey(flagKey: string): string {
+  return `${CACHE_KEY_PREFIX}${flagKey}`;
+}
+
+async function readCache(
+  env: Env | null | undefined,
+  flagKey: string,
+): Promise<CachedFlagState | null> {
+  if (!env?.METAGRAPH_CONTROL?.get) return null;
+  try {
+    const cached = await env.METAGRAPH_CONTROL.get<CachedFlagState>(
+      cacheKey(flagKey),
+      { type: "json" },
+    );
+    return cached ?? null;
+  } catch {
+    // A KV read failure is not a cache miss's fault -- treat it the same
+    // way (fall through to a live fetch) rather than letting it propagate.
+    return null;
+  }
+}
+
+async function writeCache(
+  env: Env | null | undefined,
+  flagKey: string,
+  state: CachedFlagState,
+): Promise<void> {
+  if (!env?.METAGRAPH_CONTROL?.put) return;
+  try {
+    await env.METAGRAPH_CONTROL.put(cacheKey(flagKey), JSON.stringify(state));
+  } catch {
+    // A cache-write failure only costs the next request an extra fetch --
+    // never let it fail the evaluation that's already in hand.
+  }
+}
+
+/**
+ * Resolve one boolean feature flag for `distinctId`. Never throws --
+ * degrades to `defaultValue` (or the last-known-good cached value, if one
+ * exists and is more recently known-good than "never fetched") on any
+ * failure: unconfigured token, network error, non-2xx response, or a
+ * malformed payload. A flag must never be the reason a request fails.
+ *
+ * `distinctId` matters even for an operational kill-switch flag with no
+ * real per-person targeting configured today: PostHog's own evaluation
+ * always takes one, and passing a stable, purpose-specific id (e.g.
+ * `"metagraphed-worker"`, mirroring usage-telemetry.ts's own
+ * USAGE_EVENT_DISTINCT_ID) keeps this call forward-compatible with adding
+ * real targeting later without a call-site change.
+ */
+export async function evaluateFeatureFlag(
+  flagKey: string,
+  distinctId: string,
+  defaultValue: boolean,
+  env: Env | null | undefined,
+  deps: EvaluateFeatureFlagDeps = {},
+): Promise<boolean> {
+  const now = deps.now ?? Date.now;
+  const cached = await readCache(env, flagKey);
+
+  if (cached && now() - cached.fetchedAt < CACHE_FRESH_MS) {
+    return cached.value;
+  }
+
+  if (!isUsageTelemetryConfigured(env)) {
+    return cached ? cached.value : defaultValue;
+  }
+
+  try {
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_FLAGS_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          distinct_id: distinctId,
+        }),
+      },
+    );
+    // No `response?.` guard: fetch()'s real contract never resolves to a
+    // falsy value -- it either resolves to a real Response or the promise
+    // rejects, which the surrounding try/catch already handles.
+    if (!response.ok) {
+      throw new Error(`flags endpoint returned ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      flags?: Record<string, { enabled?: boolean } | undefined>;
+    };
+    const value = payload?.flags?.[flagKey]?.enabled === true;
+
+    await writeCache(env, flagKey, { value, fetchedAt: now() });
+    return value;
+  } catch (err) {
+    console.error(`[feature-flags] evaluate("${flagKey}") failed:`, err);
+    return cached ? cached.value : defaultValue;
+  }
+}

--- a/tests/feature-flags.test.ts
+++ b/tests/feature-flags.test.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  POSTHOG_FLAGS_PATH,
+  evaluateFeatureFlag,
+  type EvaluateFeatureFlagDeps,
+} from "../src/feature-flags.ts";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+
+interface FakeFetchCall {
+  url: string;
+  init: RequestInit;
+  body: Record<string, unknown>;
+}
+
+interface FakeFetchOptions {
+  onCall?: (call: FakeFetchCall) => void;
+  ok?: boolean;
+  status?: number;
+  flags?: Record<string, { enabled?: boolean }>;
+  throws?: boolean;
+}
+
+// A minimal fetch stand-in -- records what it was handed and lets a test
+// choose the PostHog /flags-shaped response (or a transport failure).
+function fakeFetch(options: FakeFetchOptions = {}): typeof fetch {
+  const { onCall, ok = true, status = 200, flags, throws = false } = options;
+  return (async (url: string, init: RequestInit) => {
+    if (throws) throw new Error("network unreachable");
+    onCall?.({ url, init, body: JSON.parse(String(init.body)) });
+    return {
+      ok,
+      status,
+      json: async () => ({ flags: flags ?? {} }),
+    } as Response;
+  }) as typeof fetch;
+}
+
+interface FakeKv {
+  store: Map<string, string>;
+  get(key: string, options?: { type: "json" }): Promise<unknown>;
+  put(key: string, value: string): Promise<void>;
+}
+
+function fakeKv(initial: Record<string, string> = {}): FakeKv {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    async get(key, options) {
+      const value = store.get(key);
+      if (value === undefined) return null;
+      return options?.type === "json" ? JSON.parse(value) : value;
+    },
+    async put(key, value) {
+      store.set(key, value);
+    },
+  };
+}
+
+function envWith(
+  kv?: FakeKv,
+  extra: Record<string, unknown> = {
+    [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+  },
+): Env {
+  return {
+    ...extra,
+    ...(kv ? { METAGRAPH_CONTROL: kv } : {}),
+  } as unknown as Env;
+}
+
+describe("evaluateFeatureFlag", () => {
+  test("unconfigured (no token) with no cache returns the caller's default, never fetches", async () => {
+    const kv = fakeKv();
+    const calls: FakeFetchCall[] = [];
+    const fetch = fakeFetch({ onCall: (c) => calls.push(c) });
+
+    const result = await evaluateFeatureFlag(
+      "kill-switch",
+      "metagraphed-worker",
+      true,
+      envWith(kv, {}),
+      { fetch, now: () => 1000 } satisfies EvaluateFeatureFlagDeps,
+    );
+
+    assert.equal(result, true);
+    assert.deepEqual(calls, []);
+  });
+
+  test("falls back to globalThis.fetch and the real Date.now when no deps are injected", async () => {
+    // No `deps` argument at all -- exercises the `deps.fetch ?? globalThis.fetch`
+    // and `deps.now ?? Date.now` fallbacks real callers hit (only tests pass
+    // overrides). Stubs globalThis.fetch for just this call so it never makes
+    // a real network request.
+    const originalFetch = globalThis.fetch;
+    const calls: FakeFetchCall[] = [];
+    globalThis.fetch = fakeFetch({
+      onCall: (c) => calls.push(c),
+      flags: { "kill-switch": { enabled: true } },
+    });
+
+    try {
+      const result = await evaluateFeatureFlag(
+        "kill-switch",
+        "metagraphed-worker",
+        false,
+        envWith(fakeKv()),
+      );
+      assert.equal(result, true);
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("unconfigured with a stale cached value returns the cached value, not the default", async () => {
+    const kv = fakeKv({
+      "feature-flag:kill-switch": JSON.stringify({
+        value: false,
+        fetchedAt: 0,
+      }),
+    });
+
+    const result = await evaluateFeatureFlag(
+      "kill-switch",
+      "metagraphed-worker",
+      true,
+      envWith(kv, {}),
+      { fetch: fakeFetch(), now: () => 1_000_000 },
+    );
+
+    assert.equal(result, false);
+  });
+
+  test("fresh cache hit returns the cached value without fetching", async () => {
+    const kv = fakeKv({
+      "feature-flag:kill-switch": JSON.stringify({
+        value: true,
+        fetchedAt: 1000,
+      }),
+    });
+    const calls: FakeFetchCall[] = [];
+
+    const result = await evaluateFeatureFlag(
+      "kill-switch",
+      "metagraphed-worker",
+      false,
+      envWith(kv),
+      {
+        fetch: fakeFetch({ onCall: (c) => calls.push(c) }),
+        now: () => 1000 + 29_000,
+      },
+    );
+
+    assert.equal(result, true);
+    assert.deepEqual(calls, []);
+  });
+
+  test("expired cache triggers a live fetch and refreshes the cache", async () => {
+    const kv = fakeKv({
+      "feature-flag:kill-switch": JSON.stringify({
+        value: false,
+        fetchedAt: 1000,
+      }),
+    });
+    const calls: FakeFetchCall[] = [];
+    const fetch = fakeFetch({
+      onCall: (c) => calls.push(c),
+      flags: { "kill-switch": { enabled: true } },
+    });
+
+    const result = await evaluateFeatureFlag(
+      "kill-switch",
+      "metagraphed-worker",
+      false,
+      envWith(kv),
+      { fetch, now: () => 1000 + 30_001 },
+    );
+
+    assert.equal(result, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, `https://us.i.posthog.com${POSTHOG_FLAGS_PATH}`);
+    assert.deepEqual(calls[0].body, {
+      api_key: "phc_test_token",
+      distinct_id: "metagraphed-worker",
+    });
+    assert.deepEqual(
+      JSON.parse(kv.store.get("feature-flag:kill-switch") as string),
+      {
+        value: true,
+        fetchedAt: 1000 + 30_001,
+      },
+    );
+  });
+
+  test("a flag absent from a well-formed response resolves to false, not the default", async () => {
+    const kv = fakeKv();
+    const fetch = fakeFetch({
+      flags: { "some-other-flag": { enabled: true } },
+    });
+
+    const result = await evaluateFeatureFlag(
+      "kill-switch",
+      "metagraphed-worker",
+      true,
+      envWith(kv),
+      { fetch, now: () => 1000 },
+    );
+
+    assert.equal(result, false);
+  });
+
+  test("a network failure falls back to the default when no cache exists, and logs", async () => {
+    const kv = fakeKv();
+    const fetch = fakeFetch({ throws: true });
+    const errors: unknown[][] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args);
+
+    try {
+      const result = await evaluateFeatureFlag(
+        "kill-switch",
+        "metagraphed-worker",
+        true,
+        envWith(kv),
+        { fetch, now: () => 1000 },
+      );
+      assert.equal(result, true);
+      assert.equal(errors.length, 1);
+      assert.match(String(errors[0][0]), /evaluate\("kill-switch"\) failed/);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test("a network failure with a stale cache falls back to the cached value, not the default", async () => {
+    const kv = fakeKv({
+      "feature-flag:kill-switch": JSON.stringify({
+        value: false,
+        fetchedAt: 1000,
+      }),
+    });
+    const fetch = fakeFetch({ throws: true });
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      const result = await evaluateFeatureFlag(
+        "kill-switch",
+        "metagraphed-worker",
+        true,
+        envWith(kv),
+        { fetch, now: () => 1000 + 30_001 },
+      );
+      assert.equal(result, false);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test("a non-2xx response is treated the same as a network failure", async () => {
+    const kv = fakeKv();
+    const fetch = fakeFetch({ ok: false, status: 500 });
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      const result = await evaluateFeatureFlag(
+        "kill-switch",
+        "metagraphed-worker",
+        true,
+        envWith(kv),
+        { fetch, now: () => 1000 },
+      );
+      assert.equal(result, true);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test("a missing METAGRAPH_CONTROL binding degrades to a live fetch every call, never throws", async () => {
+    const fetch = fakeFetch({ flags: { "kill-switch": { enabled: true } } });
+
+    const result = await evaluateFeatureFlag(
+      "kill-switch",
+      "metagraphed-worker",
+      false,
+      envWith(undefined),
+      { fetch, now: () => 1000 },
+    );
+
+    assert.equal(result, true);
+  });
+
+  test("a KV read failure is treated as a cache miss, not a thrown error", async () => {
+    const kv: FakeKv = {
+      store: new Map(),
+      async get(): Promise<unknown> {
+        throw new Error("kv unavailable");
+      },
+      async put() {},
+    };
+    const fetch = fakeFetch({ flags: { "kill-switch": { enabled: true } } });
+
+    const result = await evaluateFeatureFlag(
+      "kill-switch",
+      "metagraphed-worker",
+      false,
+      envWith(kv),
+      { fetch, now: () => 1000 },
+    );
+
+    assert.equal(result, true);
+  });
+
+  test("a KV write failure never prevents the already-resolved value from being returned", async () => {
+    const kv = fakeKv();
+    kv.put = async () => {
+      throw new Error("kv unavailable");
+    };
+    const fetch = fakeFetch({ flags: { "kill-switch": { enabled: true } } });
+
+    const result = await evaluateFeatureFlag(
+      "kill-switch",
+      "metagraphed-worker",
+      false,
+      envWith(kv),
+      { fetch, now: () => 1000 },
+    );
+
+    assert.equal(result, true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Workers-side and UI-side halves of PostHog feature flags. Both are independent and both are unblocked now (the UI half's own blocker, web analytics, shipped earlier tonight).

### Design decision (required by the issue before implementing)

Raw HTTP to PostHog's own `/flags` endpoint on every cache miss, cached in `METAGRAPH_CONTROL` KV with a 30s freshness window -- **not** a periodic flag-definition sync that re-evaluates rollout/targeting rules locally.

Every other data source in this system syncs on a schedule into KV/R2, Workers read-only (ADR 0001), and that was the first instinct here too -- it's the wrong one. PostHog's real evaluation can depend on property/cohort targeting and a percentage-rollout hash that isn't a small, stable, publicly-documented algorithm safe to reimplement: "local evaluation" is a whole SDK feature (`posthog.com/docs/feature-flags/local-evaluation`), not a spec, and `posthog-node` is exactly the thing this codebase already excludes on bundle-size grounds. Reimplementing a subset of that logic here risks a caller seeing a **different** flag state server-side than posthog-js resolves client-side for the same person -- a correctness bug worse than an extra cached network hop. Delegating evaluation to PostHog's own servers keeps this Worker correct by construction.

Verified the real response shape empirically against the live project's `/flags` endpoint before writing any code (confirmed the `{flags: {<key>: {enabled, variant, metadata...}}}` shape, not the assumption I started with).

### Workers side -- `src/feature-flags.ts`

`evaluateFeatureFlag(flagKey, distinctId, defaultValue, env, deps)`. Same raw-fetch, no-SDK posture and the same `POSTHOG_PROJECT_TOKEN` secret as `usage-telemetry.ts` (imports and reuses its `resolvePostHogHost`/`isUsageTelemetryConfigured`). Never throws -- degrades to the last-known cached value (or the caller's default) on any failure: unconfigured token, network error, non-2xx response, or a KV read/write failure. 12 tests, 100% statement/branch/line coverage on the new file (verified via diff-to-lcov cross-reference, not the misleading aggregate percentage).

### UI side -- `apps/ui/src/lib/analytics.ts`

`isFeatureEnabled(key): Promise<boolean>` waits on posthog-js's `onFeatureFlags` before resolving, rather than reading `posthog.isFeatureEnabled()` synchronously -- flags resolve asynchronously after init (a network round-trip through the `/ingest` proxy), so a synchronous read before that finishes returns `undefined`, a caller checking it immediately on mount would render the OFF state first and flash to the real one once flags arrive.

**Found and fixed a real bug while writing this module's own test**: `onFeatureFlags` fires SYNCHRONOUSLY when flags are already loaded (not just on a future async event), so `const unsubscribe = posthog.onFeatureFlags(() => { unsubscribe(); ... })` throws `ReferenceError: Cannot access 'unsubscribe' before initialization` on that path -- a genuine TDZ bug, not a hypothetical. Fixed with a `resolved` flag + post-call cleanup check that handles both the synchronous and asynchronous firing paths correctly (see the function's own comment for the exact reasoning).

## What's NOT in this PR

- **A real gated MCP tool/route.** The issue's own "prove it on one real use" was written expecting this to land alongside a genuinely new tool/route ("coordinate with whatever ships next") -- there isn't one queued right now, and retrofitting a flag onto stable, working code purely to check that box seemed like the wrong kind of churn on code that isn't otherwise changing. The infrastructure is fully tested independent of any specific gated surface (all the failure-mode/caching/fallback behavior the acceptance criteria cares about is already covered by the 12 Workers-side tests); the next new tool or route should be the one to actually use it.
- **The billing limit** on feature-flag requests -- dashboard-only, no API/CLI surface this PR can set.
- **A flag naming convention doc** (kebab-case, `mcp-`/`api-`/`ui-` prefixes) -- deferred to when a real flag exists to use as the worked example, rather than speculative documentation for a convention nothing follows yet.

Also: while researching, found 14 pre-existing PostHog flags in this project (`pricing_config`, `discord_config`, etc.) left over from a different, no-longer-active project that used to share this PostHog account. Confirmed with the user and they've already deleted them -- unrelated to this PR, just flagging why they don't appear anywhere in this diff.

## Test plan

- [x] `src/feature-flags.ts`: 12 new tests covering cache hit/miss/expiry, unconfigured-with-and-without-a-stale-cache, network failure, non-2xx response, KV read/write failure, and the `deps.fetch ?? globalThis.fetch` / `deps.now ?? Date.now` default-path fallbacks. 100% statement/branch/line coverage on the new file.
- [x] `apps/ui/src/lib/analytics.ts`: 4 new tests for `isFeatureEnabled` -- unconfigured no-op, waits for `onFeatureFlags` before resolving, unsubscribes after the first resolution, and (implicitly, since the fix was required for the second test to pass at all) the synchronous-firing TDZ case.
- [x] `npm test` (root) -- full suite green.
- [x] `npm test --workspace=apps/ui` -- full suite green (182 files, 1399 tests).
- [x] `npx tsc --noEmit` (root and `apps/ui`) / `npm run format:check` / `npm run lint` -- clean on all touched files.
- [x] Real `vite build` (`LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module`, matching CI) -- 305 KB gzipped initial client JS, unchanged, still under the 320 KB budget.

No screenshot table: `src/`, `tests/`, and `apps/ui/src/lib/**` only -- no visual change.

Closes #7762