### PR TITLE
refactor(ui): wrap ad-hoc card shells in Panel primitive (#7809)

### DIFF
--- a/apps/ui/eslint.config.js
+++ b/apps/ui/eslint.config.js
@@ -51,8 +51,20 @@ const BASE_DESIGN_RULES = [
 // showcase.
 const PRIMITIVE_STEER_RULES = [
   {
+    // Scoped to plain `<div>`/`<section>` className literals only -- an
+    // unscoped `Literal[value=/regex/]` (the original form of this rule)
+    // matched the same rounded/border/bg-card substrings on buttons, `<a>`/
+    // `<Link>` nav pills, `<input>` fields, and existing styled components
+    // (e.g. `<StatTile className="rounded-2xl border-border/80 bg-card/95 ...">`,
+    // which already owns its own card rendering) -- none of those are the
+    // hand-rolled content-shell divs this rule exists to catch. Also excludes
+    // `mg-card-glow`/`mg-card-glow-accent` (packages/ui-kit/src/styles.css)
+    // matches -- that's a real, already-documented soft-elevation variant for
+    // detail-page panels (#6398), not drift; <Panel> has no glow variant to
+    // migrate it to. A 2026-07-23 audit found the unscoped selector's false
+    // positives outnumbered genuine hits roughly 3-to-1.
     selector:
-      "Literal[value=/\\brounded\\b.*\\bborder\\b.*\\bbg-card\\b|\\bborder\\b.*\\bbg-card\\b.*\\brounded\\b/]",
+      "JSXOpeningElement[name.name=/^(?:div|section)$/] JSXAttribute[name.name='className'] Literal[value=/\\brounded\\b.*\\bborder\\b.*\\bbg-card\\b|\\bborder\\b.*\\bbg-card\\b.*\\brounded\\b/][value!=/mg-card-glow/]",
     message:
       "Wrap card shells in <Panel> from '@/components/metagraphed/primitives' instead of re-authoring rounded/border/bg-card by hand.",
   },

--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { accountPositionHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { AccountPositionHistoryPoint } from "@/lib/metagraphed/types";
@@ -93,7 +94,7 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
           description="Daily snapshots will appear here once enough chain history has accumulated for this position."
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <Panel as="div" dense bodyClassName="space-y-3">
           {series.stake.length > 0 ? (
             <HistoryRow
               label="Staked"
@@ -118,7 +119,7 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
               format={yieldStr}
             />
           ) : null}
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/analytics/coverage-funnel.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-funnel.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { coverageQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import { InfoTooltip } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { Coverage } from "@/lib/metagraphed/types";
 
 interface Step {
@@ -67,71 +68,73 @@ export function CoverageFunnel({ className }: { className?: string }) {
   const max = Math.max(1, ...steps.map((s) => s.value));
 
   return (
-    <div className={classNames("rounded-lg border border-border bg-card p-5", className)}>
-      <div className="flex items-center justify-between mb-4">
-        <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Curation funnel
+    <Panel as="div" flush className={className}>
+      <div className="p-5">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              Curation funnel
+            </div>
+            <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
+              Registry depth
+            </h3>
           </div>
-          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
-            Registry depth
-          </h3>
+          <InfoTooltip label="Each step's bar is scaled to the largest step; the % shows conversion from the previous step." />
         </div>
-        <InfoTooltip label="Each step's bar is scaled to the largest step; the % shows conversion from the previous step." />
-      </div>
-      <ol className="space-y-3">
-        {steps.map((s, i) => {
-          const prev = i === 0 ? null : steps[i - 1]!.value;
-          const conv = prev && prev > 0 ? (s.value / prev) * 100 : null;
-          const width = (s.value / max) * 100;
-          return (
-            <li key={s.key} className="space-y-1">
-              <div className="flex items-baseline justify-between text-xs">
-                <div className="flex items-baseline gap-2 min-w-0">
-                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-muted shrink-0">
-                    {String(i + 1).padStart(2, "0")}
-                  </span>
-                  <span className="font-display font-medium text-ink-strong truncate">
-                    {s.label}
-                  </span>
-                  <span className="font-mono text-[10px] text-ink-muted truncate">{s.hint}</span>
-                </div>
-                <div className="flex items-baseline gap-2 shrink-0 tabular-nums">
-                  {conv != null ? (
-                    <span
-                      className={classNames(
-                        "font-mono text-[10px]",
-                        conv >= 90
-                          ? "text-health-ok"
-                          : conv >= 50
-                            ? "text-ink-muted"
-                            : "text-health-warn",
-                      )}
-                      title={`${conv.toFixed(1)}% of previous step`}
-                    >
-                      {conv.toFixed(0)}%
+        <ol className="space-y-3">
+          {steps.map((s, i) => {
+            const prev = i === 0 ? null : steps[i - 1]!.value;
+            const conv = prev && prev > 0 ? (s.value / prev) * 100 : null;
+            const width = (s.value / max) * 100;
+            return (
+              <li key={s.key} className="space-y-1">
+                <div className="flex items-baseline justify-between text-xs">
+                  <div className="flex items-baseline gap-2 min-w-0">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-muted shrink-0">
+                      {String(i + 1).padStart(2, "0")}
                     </span>
-                  ) : null}
-                  <span className="font-display text-sm font-semibold text-ink-strong">
-                    {formatNumber(s.value)}
-                  </span>
+                    <span className="font-display font-medium text-ink-strong truncate">
+                      {s.label}
+                    </span>
+                    <span className="font-mono text-[10px] text-ink-muted truncate">{s.hint}</span>
+                  </div>
+                  <div className="flex items-baseline gap-2 shrink-0 tabular-nums">
+                    {conv != null ? (
+                      <span
+                        className={classNames(
+                          "font-mono text-[10px]",
+                          conv >= 90
+                            ? "text-health-ok"
+                            : conv >= 50
+                              ? "text-ink-muted"
+                              : "text-health-warn",
+                        )}
+                        title={`${conv.toFixed(1)}% of previous step`}
+                      >
+                        {conv.toFixed(0)}%
+                      </span>
+                    ) : null}
+                    <span className="font-display text-sm font-semibold text-ink-strong">
+                      {formatNumber(s.value)}
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div className="h-1.5 rounded-full bg-border/40 overflow-hidden" aria-hidden>
-                <div
-                  className={classNames(
-                    "h-full rounded-full transition-all duration-500",
-                    s.tone === "accent" && "bg-accent",
-                    s.tone === "warn" && "bg-health-warn",
-                    s.tone === "default" && "bg-ink-muted/60",
-                  )}
-                  style={{ width: `${width}%` }}
-                />
-              </div>
-            </li>
-          );
-        })}
-      </ol>
-    </div>
+                <div className="h-1.5 rounded-full bg-border/40 overflow-hidden" aria-hidden>
+                  <div
+                    className={classNames(
+                      "h-full rounded-full transition-all duration-500",
+                      s.tone === "accent" && "bg-accent",
+                      s.tone === "warn" && "bg-health-warn",
+                      s.tone === "default" && "bg-ink-muted/60",
+                    )}
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { reviewProfileCompletenessQuery, subnetsQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { InfoTooltip } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { Subnet } from "@/lib/metagraphed/types";
 
 const KINDS = [
@@ -90,7 +91,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
   }, [rows]);
 
   return (
-    <section className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel flush className="overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-border bg-paper/30">
         <div className="min-w-0">
           <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
@@ -220,7 +221,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
         </div>
         <div>showing top {rows.length} subnets</div>
       </footer>
-    </section>
+    </Panel>
   );
 }
 
@@ -301,7 +302,7 @@ export function CompletenessHistogram() {
   const colW = innerW / buckets.length;
 
   return (
-    <section className="rounded-xl border border-border bg-card p-4">
+    <Panel dense>
       <header className="flex items-center justify-between mb-2">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
@@ -388,7 +389,7 @@ export function CompletenessHistogram() {
         {rows.length} subnets bucketed in 10% bins. Median (p50) marks the middle of the registry;
         long tail to the right is the goal.
       </p>
-    </section>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -5,6 +5,7 @@ import type { SchemaInfo } from "@/lib/metagraphed/types";
 import { classNames } from "@/lib/metagraphed/format";
 import { TimeAgo } from "@jsonbored/ui-kit";
 import { StateBlock } from "@/components/metagraphed/states/state-block";
+import { Panel } from "@/components/metagraphed/primitives";
 
 interface Props {
   schemas: SchemaInfo[];
@@ -74,7 +75,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
     });
 
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel as="div" flush className="overflow-hidden">
       {/* Header */}
       <div className="flex flex-wrap items-center gap-3 border-b border-border bg-paper/40 px-4 py-2.5">
         <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
@@ -161,7 +162,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
       <div className="border-t border-border px-4 py-2 font-mono text-[10px] text-ink-muted">
         click a drifting row for change details · stable rows open in the explorer below
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
@@ -6,6 +6,7 @@ import { endpointIncidentsQuery, endpointsQuery, rpcPoolsQuery } from "@/lib/met
 import { classNames, durationLabel } from "@/lib/metagraphed/format";
 import { TimeAgo, InfoTooltip } from "@jsonbored/ui-kit";
 import { EmptyState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { useTimeRange, RANGE_HOURS, RANGE_LABEL } from "./time-range-context";
 import type { Endpoint, EndpointIncident, HealthState, RpcPool } from "@/lib/metagraphed/types";
 
@@ -144,9 +145,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
   }, [pools]);
 
   return (
-    <div
-      className={classNames("rounded-xl border border-border bg-card overflow-hidden", className)}
-    >
+    <Panel as="div" flush className={classNames("overflow-hidden", className)}>
       <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">
           <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
@@ -250,7 +249,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
           })}
         </ul>
       )}
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
@@ -9,6 +9,7 @@ import {
 import { classNames } from "@/lib/metagraphed/format";
 import type { EndpointIncident } from "@/lib/metagraphed/types";
 import { InfoTooltip } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import {
   useTimeRange,
   RANGE_HOURS,
@@ -101,94 +102,103 @@ export function NetworkPulseBand({ className }: { className?: string }) {
   const colW = W / renderedCount;
 
   return (
-    <div className={classNames("rounded-lg border border-border bg-card p-5", className)}>
-      <div className="flex items-center justify-between mb-3">
-        <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Network pulse · {RANGE_LABEL[range]}
+    <Panel as="div" flush className={className}>
+      <div className="p-5">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              Network pulse · {RANGE_LABEL[range]}
+            </div>
+            <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
+              ok / warn / down
+            </h3>
           </div>
-          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
-            ok / warn / down
-          </h3>
+          <div className="flex items-center gap-2">
+            <Legend swatch="bg-health-ok" label="ok" />
+            <Legend swatch="bg-health-warn" label="warn" />
+            <Legend swatch="bg-health-down" label="down" />
+            <InfoTooltip label="For 7d/30d each bar is the real sample-weighted daily uptime from /api/v1/health/trends (down = 1 − uptime); 1h/24h fall back to the live current ok/warn/down snapshot. Markers indicate incident starts per bucket." />
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Legend swatch="bg-health-ok" label="ok" />
-          <Legend swatch="bg-health-warn" label="warn" />
-          <Legend swatch="bg-health-down" label="down" />
-          <InfoTooltip label="For 7d/30d each bar is the real sample-weighted daily uptime from /api/v1/health/trends (down = 1 − uptime); 1h/24h fall back to the live current ok/warn/down snapshot. Markers indicate incident starts per bucket." />
+        <svg
+          width="100%"
+          height={H + 16}
+          viewBox={`0 0 ${W} ${H + 16}`}
+          preserveAspectRatio="none"
+          className="block w-full"
+          role="img"
+          aria-label={`Network status distribution over ${RANGE_LABEL[range]}`}
+        >
+          {buckets.map((b, i) => {
+            const x = i * colW;
+            const okH = b.ok * H;
+            const warnH = b.warn * H;
+            const downH = b.down * H;
+            const day = usingTrend ? trendDays.slice(-renderedCount)[i] : undefined;
+            const title = day
+              ? `${day.date} · ${(day.uptime_ratio * 100).toFixed(1)}% uptime · ${day.subnet_count} subnets`
+              : `${(b.ok * 100).toFixed(1)}% ok · ${(b.down * 100).toFixed(1)}% down (current snapshot)`;
+            return (
+              <g key={i}>
+                <title>{title}</title>
+                <rect
+                  x={x + 0.5}
+                  y={H - okH}
+                  width={colW - 1}
+                  height={okH}
+                  fill="var(--health-ok)"
+                  opacity={0.85}
+                />
+                <rect
+                  x={x + 0.5}
+                  y={H - okH - warnH}
+                  width={colW - 1}
+                  height={warnH}
+                  fill="var(--health-warn)"
+                  opacity={0.85}
+                />
+                <rect
+                  x={x + 0.5}
+                  y={0}
+                  width={colW - 1}
+                  height={downH}
+                  fill="var(--health-down)"
+                  opacity={0.85}
+                />
+              </g>
+            );
+          })}
+          {Array.from(incidentBucket.entries()).map(([bucket, count]) => {
+            const x = bucket * colW + colW / 2;
+            const hoursAgo = Math.round(
+              (renderedCount - 1 - bucket) * (RANGE_HOURS[range] / renderedCount),
+            );
+            return (
+              <g key={bucket}>
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={H}
+                  y2={H + 8}
+                  stroke="var(--health-down)"
+                  strokeWidth={1.5}
+                />
+                <circle cx={x} cy={H + 11} r={3} fill="var(--health-down)" opacity={0.9}>
+                  <title>{`${count} incident${count > 1 ? "s" : ""} ~${hoursAgo}h ago`}</title>
+                </circle>
+              </g>
+            );
+          })}
+        </svg>
+        <div className="mt-2 flex items-center justify-between font-mono text-[10px] text-ink-muted">
+          <span>-{RANGE_LABEL[range]}</span>
+          <span>
+            {usingTrend ? "daily uptime · incident markers" : "current snapshot · incident markers"}
+          </span>
+          <span>now</span>
         </div>
       </div>
-      <svg
-        width="100%"
-        height={H + 16}
-        viewBox={`0 0 ${W} ${H + 16}`}
-        preserveAspectRatio="none"
-        className="block w-full"
-        role="img"
-        aria-label={`Network status distribution over ${RANGE_LABEL[range]}`}
-      >
-        {buckets.map((b, i) => {
-          const x = i * colW;
-          const okH = b.ok * H;
-          const warnH = b.warn * H;
-          const downH = b.down * H;
-          const day = usingTrend ? trendDays.slice(-renderedCount)[i] : undefined;
-          const title = day
-            ? `${day.date} · ${(day.uptime_ratio * 100).toFixed(1)}% uptime · ${day.subnet_count} subnets`
-            : `${(b.ok * 100).toFixed(1)}% ok · ${(b.down * 100).toFixed(1)}% down (current snapshot)`;
-          return (
-            <g key={i}>
-              <title>{title}</title>
-              <rect
-                x={x + 0.5}
-                y={H - okH}
-                width={colW - 1}
-                height={okH}
-                fill="var(--health-ok)"
-                opacity={0.85}
-              />
-              <rect
-                x={x + 0.5}
-                y={H - okH - warnH}
-                width={colW - 1}
-                height={warnH}
-                fill="var(--health-warn)"
-                opacity={0.85}
-              />
-              <rect
-                x={x + 0.5}
-                y={0}
-                width={colW - 1}
-                height={downH}
-                fill="var(--health-down)"
-                opacity={0.85}
-              />
-            </g>
-          );
-        })}
-        {Array.from(incidentBucket.entries()).map(([bucket, count]) => {
-          const x = bucket * colW + colW / 2;
-          const hoursAgo = Math.round(
-            (renderedCount - 1 - bucket) * (RANGE_HOURS[range] / renderedCount),
-          );
-          return (
-            <g key={bucket}>
-              <line x1={x} x2={x} y1={H} y2={H + 8} stroke="var(--health-down)" strokeWidth={1.5} />
-              <circle cx={x} cy={H + 11} r={3} fill="var(--health-down)" opacity={0.9}>
-                <title>{`${count} incident${count > 1 ? "s" : ""} ~${hoursAgo}h ago`}</title>
-              </circle>
-            </g>
-          );
-        })}
-      </svg>
-      <div className="mt-2 flex items-center justify-between font-mono text-[10px] text-ink-muted">
-        <span>-{RANGE_LABEL[range]}</span>
-        <span>
-          {usingTrend ? "daily uptime · incident markers" : "current snapshot · incident markers"}
-        </span>
-        <span>now</span>
-      </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
@@ -5,6 +5,7 @@ import { registrySummaryQuery, coverageDepthQuery } from "@/lib/metagraphed/quer
 import { classNames } from "@/lib/metagraphed/format";
 import { InfoTooltip, TableState, BarMini, type BarMiniDatum } from "@jsonbored/ui-kit";
 import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { CoverageDepthQueueRow } from "@/lib/metagraphed/types";
 
 /* ------------------------------------------------------------------ *
@@ -39,75 +40,77 @@ export function RegistryScoreHistogram({ className }: { className?: string }) {
   const scored = cov.scored_subnet_count;
 
   return (
-    <div className={classNames("rounded-lg border border-border bg-card p-5", className)}>
-      <header className="mb-2 flex items-center justify-between">
-        <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Completeness
+    <Panel as="div" flush className={className}>
+      <div className="p-5">
+        <header className="mb-2 flex items-center justify-between">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              Completeness
+            </div>
+            <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
+              Score distribution
+            </h3>
           </div>
-          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
-            Score distribution
-          </h3>
-        </div>
-        <div className="flex items-center gap-3 font-mono text-[10px] text-ink-muted">
-          {cov.median_score != null ? <Stat label="p50" value={`${cov.median_score}`} /> : null}
-          {cov.average_score != null ? <Stat label="μ" value={`${cov.average_score}`} /> : null}
-          <InfoTooltip label="Per-subnet completeness_score (0–100) bucketed by /api/v1/registry/summary. The rightmost bin (100) is the fully-complete set." />
-        </div>
-      </header>
-      <svg
-        width="100%"
-        viewBox={`0 0 ${W} ${H}`}
-        preserveAspectRatio="none"
-        className="block w-full"
-        role="img"
-        aria-label="Registry completeness score distribution"
-      >
-        {bins.map((b, i) => {
-          const x = PAD + i * colW;
-          const h = (b.value / max) * innerH;
-          const isFull = b.key === "100";
-          return (
-            <g key={b.key}>
-              <title>{`${b.label}: ${b.value} subnets`}</title>
-              <rect
-                x={x + 2}
-                y={PAD + innerH - h}
-                width={colW - 4}
-                height={h}
-                fill={isFull ? "var(--health-ok)" : "var(--accent)"}
-                opacity={isFull ? 0.85 : 0.75}
-                rx={1.5}
-              />
-              <text
-                x={x + colW / 2}
-                y={PAD + innerH - h - 4}
-                textAnchor="middle"
-                fontFamily="ui-monospace, monospace"
-                fontSize={9}
-                fill="var(--ink-strong)"
-              >
-                {b.value || ""}
-              </text>
-              <text
-                x={x + colW / 2}
-                y={H - 6}
-                textAnchor="middle"
-                fontFamily="ui-monospace, monospace"
-                fontSize={9}
-                fill="var(--ink-muted)"
-              >
-                {b.label}
-              </text>
-            </g>
-          );
-        })}
-      </svg>
-      <p className="mt-1 font-mono text-[10px] text-ink-muted">
-        {scored != null ? `${scored} subnets scored.` : ""} Each bin is a completeness band; the
-        goal is to push the registry rightward.
-      </p>
-    </div>
+          <div className="flex items-center gap-3 font-mono text-[10px] text-ink-muted">
+            {cov.median_score != null ? <Stat label="p50" value={`${cov.median_score}`} /> : null}
+            {cov.average_score != null ? <Stat label="μ" value={`${cov.average_score}`} /> : null}
+            <InfoTooltip label="Per-subnet completeness_score (0–100) bucketed by /api/v1/registry/summary. The rightmost bin (100) is the fully-complete set." />
+          </div>
+        </header>
+        <svg
+          width="100%"
+          viewBox={`0 0 ${W} ${H}`}
+          preserveAspectRatio="none"
+          className="block w-full"
+          role="img"
+          aria-label="Registry completeness score distribution"
+        >
+          {bins.map((b, i) => {
+            const x = PAD + i * colW;
+            const h = (b.value / max) * innerH;
+            const isFull = b.key === "100";
+            return (
+              <g key={b.key}>
+                <title>{`${b.label}: ${b.value} subnets`}</title>
+                <rect
+                  x={x + 2}
+                  y={PAD + innerH - h}
+                  width={colW - 4}
+                  height={h}
+                  fill={isFull ? "var(--health-ok)" : "var(--accent)"}
+                  opacity={isFull ? 0.85 : 0.75}
+                  rx={1.5}
+                />
+                <text
+                  x={x + colW / 2}
+                  y={PAD + innerH - h - 4}
+                  textAnchor="middle"
+                  fontFamily="ui-monospace, monospace"
+                  fontSize={9}
+                  fill="var(--ink-strong)"
+                >
+                  {b.value || ""}
+                </text>
+                <text
+                  x={x + colW / 2}
+                  y={H - 6}
+                  textAnchor="middle"
+                  fontFamily="ui-monospace, monospace"
+                  fontSize={9}
+                  fill="var(--ink-muted)"
+                >
+                  {b.label}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+        <p className="mt-1 font-mono text-[10px] text-ink-muted">
+          {scored != null ? `${scored} subnets scored.` : ""} Each bin is a completeness band; the
+          goal is to push the registry rightward.
+        </p>
+      </div>
+    </Panel>
   );
 }
 
@@ -164,29 +167,31 @@ export function DimensionCoverageHeatmap({ className }: { className?: string }) 
   const subnetCount = res.data.subnet_count;
 
   return (
-    <div className={classNames("rounded-lg border border-border bg-card p-5", className)}>
-      <header className="mb-4 flex items-center justify-between">
-        <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Coverage
+    <Panel as="div" flush className={className}>
+      <div className="p-5">
+        <header className="mb-4 flex items-center justify-between">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              Coverage
+            </div>
+            <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
+              Surface dimensions
+            </h3>
           </div>
-          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
-            Surface dimensions
-          </h3>
+          <InfoTooltip label="Share of subnets with at least one surface of each kind, registry-wide (/api/v1/registry/summary). Green ≥75%, amber/red are the enrichment frontier." />
+        </header>
+        <BarMini data={data} max={100} showValue />
+        <div className="mt-3 flex items-center justify-between font-mono text-[10px] text-ink-muted">
+          <span>% of {subnetCount ?? "all"} subnets covered</span>
+          <span className="inline-flex items-center gap-2">
+            <Swatch color="var(--health-ok)" label="≥75" />
+            <Swatch color="var(--chart-3)" label="≥40" />
+            <Swatch color="var(--health-warn)" label="≥15" />
+            <Swatch color="var(--health-down)" label="<15" />
+          </span>
         </div>
-        <InfoTooltip label="Share of subnets with at least one surface of each kind, registry-wide (/api/v1/registry/summary). Green ≥75%, amber/red are the enrichment frontier." />
-      </header>
-      <BarMini data={data} max={100} showValue />
-      <div className="mt-3 flex items-center justify-between font-mono text-[10px] text-ink-muted">
-        <span>% of {subnetCount ?? "all"} subnets covered</span>
-        <span className="inline-flex items-center gap-2">
-          <Swatch color="var(--health-ok)" label="≥75" />
-          <Swatch color="var(--chart-3)" label="≥40" />
-          <Swatch color="var(--health-warn)" label="≥15" />
-          <Swatch color="var(--health-down)" label="<15" />
-        </span>
       </div>
-    </div>
+    </Panel>
   );
 }
 
@@ -248,7 +253,7 @@ export function EnrichmentQueueTable({ limit = 12 }: { limit?: number }) {
   }
 
   return (
-    <div className="overflow-x-auto rounded-lg border border-border bg-card">
+    <Panel as="div" flush className="overflow-x-auto">
       <table className="w-full text-left text-sm">
         <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
           <tr>
@@ -295,7 +300,7 @@ export function EnrichmentQueueTable({ limit = 12 }: { limit?: number }) {
           ))}
         </tbody>
       </table>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -13,6 +13,7 @@ import { schemasQuery, evidenceQuery } from "@/lib/metagraphed/queries";
 import { normalizeDriftStatus } from "@/lib/metagraphed/schema-drift";
 import { classNames } from "@/lib/metagraphed/format";
 import { TimeAgo, InfoTooltip, safeExternalUrl } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { SchemaInfo, EvidenceItem } from "@/lib/metagraphed/types";
 
 type DriftKind = "breaking" | "additive" | "new" | "unchanged" | "unknown";
@@ -143,7 +144,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
   };
 
   return (
-    <section className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel flush className="overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-border bg-paper/30">
         <div className="min-w-0">
           <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
@@ -241,7 +242,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
           <Pin className="size-3" aria-hidden /> click a tile to inspect snapshot &amp; diff
         </div>
       </footer>
-    </section>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { endpointsQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { InfoTooltip } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import { useTimeRange, RANGE_HOURS, RANGE_LABEL } from "./time-range-context";
 import type { Endpoint, HealthState } from "@/lib/metagraphed/types";
 
@@ -46,86 +47,88 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
     filter === "all" ? endpoints : endpoints.filter((e) => (e.health ?? "unknown") === filter);
 
   return (
-    <div className={classNames("rounded-lg border border-border bg-card p-5", className)}>
-      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
-        <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Status mosaic · {RANGE_LABEL[range]}
+    <Panel as="div" flush className={className}>
+      <div className="p-5">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              Status mosaic · {RANGE_LABEL[range]}
+            </div>
+            <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
+              {rows.length} endpoint{rows.length === 1 ? "" : "s"}
+            </h3>
           </div>
-          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
-            {rows.length} endpoint{rows.length === 1 ? "" : "s"}
-          </h3>
+          <div className="flex flex-wrap items-center gap-1">
+            {(["all", "ok", "warn", "down", "unknown"] as const).map((k) => {
+              const active = filter === k;
+              const n = k === "all" ? endpoints.length : (counts[k] ?? 0);
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => setFilter(k)}
+                  className={classNames(
+                    "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] transition-colors",
+                    active
+                      ? "border-accent/60 bg-accent/10 text-accent"
+                      : "border-border text-ink-muted hover:text-ink-strong hover:border-ink-muted/50",
+                  )}
+                  aria-pressed={active}
+                >
+                  {k !== "all" ? (
+                    <span
+                      className={classNames("inline-block size-1.5 rounded-sm", TONE[k])}
+                      aria-hidden
+                    />
+                  ) : null}
+                  {k} <span className="text-ink-muted/80 tabular-nums">{n}</span>
+                </button>
+              );
+            })}
+            <InfoTooltip label="One tile per monitored endpoint, colored by latest probe state. Click a tile to open the host subnet." />
+          </div>
         </div>
-        <div className="flex flex-wrap items-center gap-1">
-          {(["all", "ok", "warn", "down", "unknown"] as const).map((k) => {
-            const active = filter === k;
-            const n = k === "all" ? endpoints.length : (counts[k] ?? 0);
-            return (
-              <button
-                key={k}
-                type="button"
-                onClick={() => setFilter(k)}
+        <div
+          className="grid gap-[3px]"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(14px, 1fr))" }}
+          role="list"
+        >
+          {rows.map((e) => {
+            const state = (e.health ?? "unknown") as HealthState;
+            const tile = (
+              <span
                 className={classNames(
-                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] transition-colors",
-                  active
-                    ? "border-accent/60 bg-accent/10 text-accent"
-                    : "border-border text-ink-muted hover:text-ink-strong hover:border-ink-muted/50",
+                  "block aspect-square rounded-[2px] transition-transform hover:scale-110 hover:ring-1 hover:ring-accent/60",
+                  TONE[state] ?? TONE.unknown,
                 )}
-                aria-pressed={active}
-              >
-                {k !== "all" ? (
-                  <span
-                    className={classNames("inline-block size-1.5 rounded-sm", TONE[k])}
-                    aria-hidden
-                  />
-                ) : null}
-                {k} <span className="text-ink-muted/80 tabular-nums">{n}</span>
-              </button>
+                title={`${e.kind ?? "endpoint"} · ${e.provider ?? e.provider_slug ?? "—"} · ${state}${
+                  e.latency_ms != null ? ` · ${e.latency_ms}ms` : ""
+                }${e.netuid != null ? ` · SN${e.netuid}` : ""}`}
+              />
+            );
+            return (
+              <span key={e.id} role="listitem">
+                {e.netuid != null ? (
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: e.netuid }}
+                    className="block focus:outline-none focus-visible:ring-1 focus-visible:ring-accent rounded-[2px]"
+                  >
+                    {tile}
+                  </Link>
+                ) : (
+                  tile
+                )}
+              </span>
             );
           })}
-          <InfoTooltip label="One tile per monitored endpoint, colored by latest probe state. Click a tile to open the host subnet." />
+          {rows.length === 0 ? (
+            <div className="col-span-full py-6 text-center font-mono text-[10px] text-ink-muted">
+              No endpoints match this filter.
+            </div>
+          ) : null}
         </div>
       </div>
-      <div
-        className="grid gap-[3px]"
-        style={{ gridTemplateColumns: "repeat(auto-fill, minmax(14px, 1fr))" }}
-        role="list"
-      >
-        {rows.map((e) => {
-          const state = (e.health ?? "unknown") as HealthState;
-          const tile = (
-            <span
-              className={classNames(
-                "block aspect-square rounded-[2px] transition-transform hover:scale-110 hover:ring-1 hover:ring-accent/60",
-                TONE[state] ?? TONE.unknown,
-              )}
-              title={`${e.kind ?? "endpoint"} · ${e.provider ?? e.provider_slug ?? "—"} · ${state}${
-                e.latency_ms != null ? ` · ${e.latency_ms}ms` : ""
-              }${e.netuid != null ? ` · SN${e.netuid}` : ""}`}
-            />
-          );
-          return (
-            <span key={e.id} role="listitem">
-              {e.netuid != null ? (
-                <Link
-                  to="/subnets/$netuid"
-                  params={{ netuid: e.netuid }}
-                  className="block focus:outline-none focus-visible:ring-1 focus-visible:ring-accent rounded-[2px]"
-                >
-                  {tile}
-                </Link>
-              ) : (
-                tile
-              )}
-            </span>
-          );
-        })}
-        {rows.length === 0 ? (
-          <div className="col-span-full py-6 text-center font-mono text-[10px] text-ink-muted">
-            No endpoints match this filter.
-          </div>
-        ) : null}
-      </div>
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
@@ -9,6 +9,7 @@ import {
 import { classNames, durationLabel, formatNumber, formatRelative } from "@/lib/metagraphed/format";
 import { formatFreshness } from "@/lib/metagraphed/freshness";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { Tooltip, TooltipContent, TooltipTrigger, InfoTooltip, TimeAgo } from "@jsonbored/ui-kit";
 import { useTimeRange, RANGE_LABEL } from "./time-range-context";
 import type { FlatSurfaceIncident, HealthTrendSurface } from "@/lib/metagraphed/types";
@@ -109,21 +110,21 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
 
   if (isError) {
     return (
-      <div className="rounded-xl border border-border bg-card p-6">
+      <Panel as="div">
         <ErrorState error={error} onRetry={() => refetch()} context="uptime timeline" />
-      </div>
+      </Panel>
     );
   }
 
   if (surfaces.length === 0) {
     return (
-      <div className="rounded-xl border border-border bg-card p-6">
+      <Panel as="div">
         <EmptyState
           title="No trend data"
           description="Per-surface uptime &amp; latency will appear here once the prober has collected enough samples for this subnet."
           lastChecked={trendsAt}
         />
-      </div>
+      </Panel>
     );
   }
 
@@ -139,9 +140,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
   const hasIncidents = incidents.length > 0;
 
   return (
-    <div
-      className={classNames("rounded-xl border border-border bg-card overflow-hidden", className)}
-    >
+    <Panel as="div" flush className={classNames("overflow-hidden", className)}>
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2 border-b border-border bg-paper/40">
         <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Uptime by surface · {RANGE_LABEL[range]}
@@ -312,6 +311,6 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
           </div>
         </div>
       ) : null}
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { AlertTriangle, GitBranch, Radio, Sparkles } from "lucide-react";
 import { changelogQuery, endpointIncidentsQuery } from "@/lib/metagraphed/queries";
 import { TimeAgo } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import { classNames } from "@/lib/metagraphed/format";
 import type { EndpointIncident } from "@/lib/metagraphed/types";
 import { useTimeRange, RANGE_HOURS, RANGE_LABEL } from "./time-range-context";
@@ -68,66 +69,68 @@ export function WhatChangedFeed({ className, limit = 10 }: { className?: string;
   }, [cRes.data, iRes.data, cutoff, limit]);
 
   return (
-    <div className={classNames("rounded-lg border border-border bg-card p-5", className)}>
-      <div className="flex items-center justify-between mb-3">
-        <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            What changed · {RANGE_LABEL[range]}
+    <Panel as="div" flush className={className}>
+      <div className="p-5">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              What changed · {RANGE_LABEL[range]}
+            </div>
+            <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
+              Recent registry signal
+            </h3>
           </div>
-          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
-            Recent registry signal
-          </h3>
+          <span className="inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted">
+            <Sparkles className="size-3" aria-hidden />
+            live
+          </span>
         </div>
-        <span className="inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted">
-          <Sparkles className="size-3" aria-hidden />
-          live
-        </span>
+        {items.length === 0 ? (
+          <div className="flex items-center gap-2 py-6 text-xs text-ink-muted">
+            <Radio className="size-3.5" aria-hidden />
+            Nothing notable in the last {RANGE_LABEL[range]}.
+          </div>
+        ) : (
+          <ol className="space-y-2.5">
+            {items.map((it) => {
+              const Icon = KIND_ICON[it.kind];
+              return (
+                <li key={it.id} className="flex items-start gap-2.5 group">
+                  <span
+                    className={classNames(
+                      "mt-0.5 inline-flex size-5 items-center justify-center rounded border shrink-0",
+                      it.tone === "accent" && "border-accent/40 text-accent",
+                      it.tone === "warn" && "border-health-warn/40 text-health-warn",
+                      it.tone === "down" && "border-health-down/40 text-health-down",
+                      it.tone === "default" && "border-border text-ink-muted",
+                    )}
+                    aria-hidden
+                  >
+                    <Icon className="size-3" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-xs font-medium text-ink-strong truncate group-hover:text-accent transition-colors">
+                      {it.title}
+                    </div>
+                    <div className="flex items-baseline gap-2 mt-0.5">
+                      {it.detail ? (
+                        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted truncate">
+                          {it.detail}
+                        </span>
+                      ) : null}
+                      {it.at ? (
+                        <span className="font-mono text-[10px] text-ink-muted">
+                          <TimeAgo at={it.at} />
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
       </div>
-      {items.length === 0 ? (
-        <div className="flex items-center gap-2 py-6 text-xs text-ink-muted">
-          <Radio className="size-3.5" aria-hidden />
-          Nothing notable in the last {RANGE_LABEL[range]}.
-        </div>
-      ) : (
-        <ol className="space-y-2.5">
-          {items.map((it) => {
-            const Icon = KIND_ICON[it.kind];
-            return (
-              <li key={it.id} className="flex items-start gap-2.5 group">
-                <span
-                  className={classNames(
-                    "mt-0.5 inline-flex size-5 items-center justify-center rounded border shrink-0",
-                    it.tone === "accent" && "border-accent/40 text-accent",
-                    it.tone === "warn" && "border-health-warn/40 text-health-warn",
-                    it.tone === "down" && "border-health-down/40 text-health-down",
-                    it.tone === "default" && "border-border text-ink-muted",
-                  )}
-                  aria-hidden
-                >
-                  <Icon className="size-3" />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <div className="text-xs font-medium text-ink-strong truncate group-hover:text-accent transition-colors">
-                    {it.title}
-                  </div>
-                  <div className="flex items-baseline gap-2 mt-0.5">
-                    {it.detail ? (
-                      <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted truncate">
-                        {it.detail}
-                      </span>
-                    ) : null}
-                    {it.at ? (
-                      <span className="font-mono text-[10px] text-ink-muted">
-                        <TimeAgo at={it.at} />
-                      </span>
-                    ) : null}
-                  </div>
-                </div>
-              </li>
-            );
-          })}
-        </ol>
-      )}
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/api-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/api-drawer.tsx
@@ -18,6 +18,7 @@ import {
   safeExternalUrl,
 } from "@jsonbored/ui-kit";
 import { classNames } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 
 /** Header trigger button. Hidden when no page has registered an API source. */
 export function ApiDrawerTrigger() {
@@ -162,21 +163,23 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
         <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
           Request
         </div>
-        <div className="rounded border border-border bg-card p-3 font-mono text-[12px] text-ink-strong break-all flex items-start gap-2">
-          <span className="shrink-0 rounded bg-curation-verified/15 text-curation-verified px-1.5 py-0.5 text-[10px] uppercase tracking-widest">
-            GET
-          </span>
-          <span className="min-w-0 flex-1">{fullUrl}</span>
-          <a
-            href={safeExternalUrl(fullUrl)}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Open raw"
-            className="text-ink-muted hover:text-ink-strong"
-          >
-            <ExternalLinkIcon className="size-3.5" />
-          </a>
-        </div>
+        <Panel as="div" flush>
+          <div className="p-3 font-mono text-[12px] text-ink-strong break-all flex items-start gap-2">
+            <span className="shrink-0 rounded bg-curation-verified/15 text-curation-verified px-1.5 py-0.5 text-[10px] uppercase tracking-widest">
+              GET
+            </span>
+            <span className="min-w-0 flex-1">{fullUrl}</span>
+            <a
+              href={safeExternalUrl(fullUrl)}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open raw"
+              className="text-ink-muted hover:text-ink-strong"
+            >
+              <ExternalLinkIcon className="size-3.5" />
+            </a>
+          </div>
+        </Panel>
         <div className="flex flex-wrap gap-1.5">
           <CopyableCode value={fullUrl} label="url" />
           <CopyableCode value={curl} label="curl" />
@@ -200,9 +203,13 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
           </button>
         </div>
         {isLoading ? (
-          <div className="rounded border border-border bg-card p-4 text-[12px] text-ink-muted inline-flex items-center gap-2">
+          <Panel
+            as="div"
+            dense
+            bodyClassName="text-[12px] text-ink-muted inline-flex items-center gap-2"
+          >
             <Loader2 className="size-3.5 animate-spin" /> Loading…
-          </div>
+          </Panel>
         ) : error ? (
           <div className="rounded border border-health-down/40 bg-health-down/5 p-3 text-[12px] text-health-down">
             <div className="font-medium">Request failed</div>

--- a/apps/ui/src/components/metagraphed/api-keys-manager.tsx
+++ b/apps/ui/src/components/metagraphed/api-keys-manager.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiFetch, ApiError } from "@/lib/metagraphed/client";
 import { SectionHeading, CopyableCode } from "@jsonbored/ui-kit";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { useWallet } from "@/hooks/use-wallet";
 import { useApiSession } from "@/hooks/use-api-session";
 
@@ -58,7 +59,7 @@ export function ApiKeysManager() {
         title="API keys"
         intro="Real fullnode RPC access -- not just the keyless read-only proxy. Requires a wallet-signed login; no invite code."
       />
-      <div className="rounded border border-border bg-card p-4">
+      <Panel as="div" dense>
         {walletStatus !== "connected" || !wallet ? (
           <EmptyState
             title="Connect your wallet"
@@ -77,7 +78,7 @@ export function ApiKeysManager() {
             onSignIn={apiSession.signIn}
           />
         )}
-      </div>
+      </Panel>
     </section>
   );
 }

--- a/apps/ui/src/components/metagraphed/blocks/chain-walk-ribbon.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/chain-walk-ribbon.tsx
@@ -5,7 +5,7 @@ import { InfoTooltip, Kbd, Sparkline } from "@jsonbored/ui-kit";
 import { BLOCK_TERM_HINTS } from "@/lib/metagraphed/section-hints";
 import { blocksQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds, classNames } from "@/lib/metagraphed/format";
-import { ChartSkeleton } from "@/components/metagraphed/primitives";
+import { ChartSkeleton, Panel } from "@/components/metagraphed/primitives";
 import { useIsMobile } from "@/hooks/use-mobile";
 import type { Block } from "@/lib/metagraphed/types";
 
@@ -62,7 +62,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
   const next = current.next_block_number;
 
   return (
-    <div className="rounded border border-border bg-card p-3">
+    <Panel as="div" dense>
       <div className="flex items-stretch gap-2">
         {/* Prev arrow */}
         <ArrowBtn
@@ -168,7 +168,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
           </div>
         </div>
       ) : null}
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Kbd } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 
 const SHORTCUTS: Array<{ keys: string[]; label: string }> = [
   { keys: ["J", "←"], label: "Previous block" },
@@ -73,7 +74,7 @@ export function ShortcutsDialog({ blockRef }: { blockRef: string }) {
         if (e.target === e.currentTarget) setOpen(false);
       }}
     >
-      <div className="w-full max-w-md rounded border border-border bg-card">
+      <Panel as="div" flush className="w-full max-w-md">
         <div className="flex items-center justify-between border-b border-border px-4 py-3">
           <h2 id="mg-shortcut-title" className="mg-type-micro text-ink-muted">
             Keyboard shortcuts
@@ -99,7 +100,7 @@ export function ShortcutsDialog({ blockRef }: { blockRef: string }) {
             </div>
           ))}
         </dl>
-      </div>
+      </Panel>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { ResetFiltersButton, SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
@@ -206,9 +207,11 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
   );
 
   const cards = events.map((event) => (
-    <div
+    <Panel
+      as="div"
+      dense
       key={`${event.block_number}-${event.event_index}-card`}
-      className="rounded border border-border bg-card p-3 min-h-11"
+      className="min-h-11"
     >
       <div className="font-mono text-[11px] text-ink-strong">
         {extrinsicCall(event.pallet, event.method)}
@@ -227,7 +230,7 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
         )}
         <TimeAgo at={event.observed_at} />
       </div>
-    </div>
+    </Panel>
   ));
 
   if (isPending) return <Skeleton className="h-56 w-full" />;

--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -6,6 +6,7 @@ import {
   flattenSurfaceIncidents,
 } from "@/lib/metagraphed/queries";
 import { Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { Tooltip, TooltipContent, TooltipTrigger, InfoTooltip } from "@jsonbored/ui-kit";
 import { useHydrated } from "@/hooks/use-hydrated";
 
@@ -105,7 +106,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
   if (!hydrated || tLoading) return <Skeleton className="h-44 w-full" />;
 
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel as="div" flush className="overflow-hidden">
       <div className="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-border bg-paper/30">
         <div className="flex items-center gap-1.5 min-w-0">
           <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
@@ -166,7 +167,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
           <span>more</span>
         </div>
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
@@ -4,6 +4,7 @@ import { BarChart3, Maximize2 } from "lucide-react";
 import { economicsQuery, subnetUptimeQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import {
   Dialog,
   DialogContent,
@@ -253,7 +254,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
   const uptime = dailyUptimeSeries(surfaces);
   const lastUp = uptime[uptime.length - 1];
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-card">
+    <Panel as="div" flush className="overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1.5 border-b border-border bg-paper/30 px-4 py-2.5">
         <div className="flex items-center gap-3 min-w-0">
           <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
@@ -299,6 +300,6 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
           probes.
         </div>
       )}
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -12,6 +12,7 @@ import {
 } from "@jsonbored/ui-kit";
 import type { Endpoint } from "@/lib/metagraphed/types";
 import { classNames } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 
 // Map heatmap "kind" buckets onto /endpoints `category` query values so chip
 // clicks land on a pre-filtered view rather than the unfiltered list. The
@@ -128,15 +129,15 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
 
   if (providers.length === 0) {
     return (
-      <div className="rounded border border-border bg-card p-4 text-xs text-ink-muted">
+      <Panel as="div" dense bodyClassName="text-xs text-ink-muted">
         No endpoint latency data yet.
-      </div>
+      </Panel>
     );
   }
 
   return (
     <TooltipProvider delayDuration={150}>
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <Panel as="div" flush className="overflow-hidden">
         <div className="px-4 py-2.5 border-b border-border flex flex-wrap items-center justify-between gap-2">
           <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Latency heatmap · provider × kind
@@ -226,7 +227,7 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
             </tbody>
           </table>
         </div>
-      </div>
+      </Panel>
     </TooltipProvider>
   );
 }

--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { BarMini, TreemapMini, type TreemapMiniDatum } from "@jsonbored/ui-kit";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { EmptyState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { TopShareCaption } from "@/components/metagraphed/top-share-caption";
 import {
   VALIDATOR_DOMINANCE_TOP_N,
@@ -47,7 +48,7 @@ export function ValidatorDominanceChart() {
   const coveredPct = rows.reduce((sum, r) => sum + r.share, 0) * 100;
 
   return (
-    <div className="rounded-xl border border-border bg-card p-4">
+    <Panel as="div" dense>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
         <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Stake dominance · top {rows.length}
@@ -74,6 +75,6 @@ export function ValidatorDominanceChart() {
           />
         </div>
       ) : null}
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -6,6 +6,7 @@ import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { classNames } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 
 // #3495: validator (row) × subnet (column) participation matrix from the global
 // validators payload, cells shaded by relative stake. Pure consumer of
@@ -43,14 +44,14 @@ export function ValidatorSubnetHeatmap() {
 
   if (rows.length === 0 || netuids.length === 0) {
     return (
-      <div className="rounded border border-border bg-card p-4 text-xs text-ink-muted">
+      <Panel as="div" dense bodyClassName="text-xs text-ink-muted">
         No validator participation data yet.
-      </div>
+      </Panel>
     );
   }
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-card">
+    <Panel as="div" flush className="overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-2.5">
         <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Validator × subnet · stake intensity
@@ -132,6 +133,6 @@ export function ValidatorSubnetHeatmap() {
           </table>
         </TooltipProvider>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -11,6 +11,7 @@ import { StatTile, BarMini, Sparkline } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
 import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
+import { Panel } from "@/components/metagraphed/primitives";
 import type {
   ConcentrationMetrics,
   ConcentrationHistoryPoint,
@@ -96,7 +97,7 @@ export function ConcentrationLoader({ netuid }: { netuid: number }) {
       </div>
 
       {/* Holders / entity context strip. */}
-      <div className="rounded-xl border border-border bg-card p-4 grid grid-cols-2 gap-3 min-[400px]:grid-cols-4">
+      <Panel as="div" dense bodyClassName="grid grid-cols-2 gap-3 min-[400px]:grid-cols-4">
         <Fact label="Stake holders" value={stake?.holders ?? "—"} />
         <Fact label="Emission holders" value={emission?.holders ?? "—"} />
         <Fact label="Entities" value={c.entity_count ?? "—"} />
@@ -104,7 +105,7 @@ export function ConcentrationLoader({ netuid }: { netuid: number }) {
           label="UIDs / entity"
           value={c.uids_per_entity != null ? c.uids_per_entity.toFixed(2) : "—"}
         />
-      </div>
+      </Panel>
 
       {/* Gini drift over a window. */}
       <DriftCard netuid={netuid} />
@@ -129,7 +130,7 @@ function SharePanel({
   ];
   const allEmpty = bars.every((b) => b.value === 0);
   return (
-    <div className="rounded-xl border border-border bg-card p-4">
+    <Panel as="div" dense>
       <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
         {title}
       </div>
@@ -138,7 +139,7 @@ function SharePanel({
       ) : (
         <BarMini data={bars} max={100} />
       )}
-    </div>
+    </Panel>
   );
 }
 
@@ -240,7 +241,7 @@ function DriftCard({ netuid }: { netuid: number }) {
           description="Daily concentration snapshots will appear here once enough chain history has accumulated."
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <Panel as="div" dense bodyClassName="space-y-3">
           {series.stakeGini.length > 0 ? (
             <DriftRow
               label="Stake Gini"
@@ -273,7 +274,7 @@ function DriftCard({ netuid }: { netuid: number }) {
               format={(v) => `${(v * 100).toFixed(1)}%`}
             />
           ) : null}
-        </div>
+        </Panel>
       )}
     </div>
   );
@@ -377,12 +378,12 @@ function PerformanceLoader({ netuid }: { netuid: number }) {
       </div>
 
       {/* Score spread — 0-1 trust / consensus / validator-trust medians. */}
-      <div className="rounded-xl border border-border bg-card p-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <Panel as="div" dense bodyClassName="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <Fact label="Trust median" value={numStr(p.trust?.p50)} />
         <Fact label="Consensus median" value={numStr(p.consensus?.p50)} />
         <Fact label="Val-trust median" value={numStr(p.validator_trust?.p50)} />
         <Fact label="Active neurons" value={p.active_count ?? p.neuron_count ?? "—"} />
-      </div>
+      </Panel>
 
       {/* Reward-Gini drift over a window. */}
       <RewardDriftCard netuid={netuid} />
@@ -469,7 +470,7 @@ function RewardDriftCard({ netuid }: { netuid: number }) {
           description="Daily reward-distribution snapshots will appear here once enough chain history has accumulated."
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <Panel as="div" dense bodyClassName="space-y-3">
           {series.incentiveGini.length > 0 ? (
             <DriftRow
               label="Incentive Gini"
@@ -502,7 +503,7 @@ function RewardDriftCard({ netuid }: { netuid: number }) {
               format={(v) => `${(v * 100).toFixed(1)}%`}
             />
           ) : null}
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -15,6 +15,7 @@ import {
   RealtimeFreshness,
   type SparklinePoint,
 } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import { stakeMovesTileModel } from "@/lib/metagraphed/stake-moves-tile";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile";
@@ -27,9 +28,9 @@ import { stakeTransfersTileModel } from "@/lib/metagraphed/stake-transfers-tile"
 
 function Notice({ children }: { children: string }) {
   return (
-    <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
+    <Panel as="div" dense bodyClassName="text-xs text-ink-muted">
       {children}
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
@@ -9,6 +9,7 @@ import {
 } from "@jsonbored/ui-kit";
 
 import { resolveEndpointCard } from "@/components/metagraphed/endpoint-card-fields";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { Endpoint, Provider, Subnet } from "@/lib/metagraphed/types";
 
 export interface EndpointCardListProps {
@@ -43,7 +44,7 @@ export function EndpointCardList({
           subnetById,
         );
         return (
-          <div key={e.id} className="min-w-0 rounded border border-border bg-card p-3 space-y-2">
+          <Panel as="div" dense key={e.id} className="min-w-0" bodyClassName="space-y-2">
             <div className="flex items-center justify-between gap-2">
               <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
                 {kindLabel}
@@ -132,7 +133,7 @@ export function EndpointCardList({
                 probed <TimeAgo at={e.last_probed_at} />
               </span>
             </SparkLegend>
-          </div>
+          </Panel>
         );
       })}
     </div>

--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -15,6 +15,7 @@ import {
   Sparkline,
 } from "@jsonbored/ui-kit";
 import { useCopy } from "@/hooks/use-copy";
+import { Panel } from "@/components/metagraphed/primitives";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames } from "@/lib/metagraphed/format";
 import {
@@ -66,7 +67,7 @@ export function EndpointList({
   return (
     <TooltipProvider delayDuration={150}>
       {/* Desktop */}
-      <div className="hidden md:block rounded-xl border border-border bg-card overflow-hidden">
+      <Panel as="div" flush className="hidden md:block overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
@@ -106,7 +107,7 @@ export function EndpointList({
             </tbody>
           </table>
         </div>
-      </div>
+      </Panel>
 
       {/* Mobile */}
       <div className="md:hidden space-y-4">

--- a/apps/ui/src/components/metagraphed/endpoints-glance.tsx
+++ b/apps/ui/src/components/metagraphed/endpoints-glance.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { ChevronDown, ChevronUp, Radio, Database, AlertOctagon } from "lucide-react";
 import { HealthDot } from "@jsonbored/ui-kit";
 import { EmptyState, RECOVERY } from "./states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { classNames } from "@/lib/metagraphed/format";
 import { useIsMobile } from "@/hooks/use-mobile";
 import type { Endpoint } from "@/lib/metagraphed/types";
@@ -105,7 +106,7 @@ export function EndpointsGlance({
   };
 
   return (
-    <div className="rounded-lg border border-border bg-card">
+    <Panel as="div" flush>
       <ul className="divide-y divide-border">
         {BUCKETS.map((b) => {
           const items = endpoints.filter(b.match);
@@ -164,6 +165,6 @@ export function EndpointsGlance({
           <div className="p-3">{fullList()}</div>
         </div>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/endpoints-priority-strip.tsx
+++ b/apps/ui/src/components/metagraphed/endpoints-priority-strip.tsx
@@ -4,7 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { AlertTriangle, TrendingUp, Timer } from "lucide-react";
 import { endpointsQuery, endpointIncidentsQuery } from "@/lib/metagraphed/queries";
 import type { Endpoint } from "@/lib/metagraphed/types";
-import { Chip } from "@/components/metagraphed/primitives";
+import { Chip, Panel } from "@/components/metagraphed/primitives";
 import { HealthDot } from "@jsonbored/ui-kit";
 
 interface Item {
@@ -97,7 +97,7 @@ export function EndpointsPriorityStrip() {
 function PriorityCard({ item }: { item: Item }) {
   const Icon = item.icon;
   const body = (
-    <div className="mg-hover-lift rounded border border-border bg-card p-3 h-full">
+    <Panel as="div" dense interactive className="h-full">
       <div className="flex items-center justify-between gap-2">
         <span className="mg-label inline-flex items-center gap-1.5">
           <Icon className="size-3" aria-hidden />
@@ -133,7 +133,7 @@ function PriorityCard({ item }: { item: Item }) {
           <Chip tone="muted">Nothing to review</Chip>
         </div>
       )}
-    </div>
+    </Panel>
   );
   if (!item.href) return body;
   return (

--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -4,6 +4,7 @@ import { apiFetch } from "@/lib/metagraphed/client";
 import { metagraphedQueryKey } from "@/lib/metagraphed/queries";
 import { ExternalLink, HoverPreview, TimeAgo } from "@jsonbored/ui-kit";
 import { EmptyState, ErrorState, Skeleton } from "./states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { formatRelative } from "@/lib/metagraphed/format";
 import type { ApiMeta, EvidenceItem } from "@/lib/metagraphed/types";
 
@@ -145,7 +146,7 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
       </div>
 
       {sortedGroups.map(([source, items]) => (
-        <div key={source} className="rounded border border-border bg-card p-3">
+        <Panel as="div" dense key={source}>
           <div className="flex items-center justify-between mb-2 gap-3">
             <span className="mg-label">{source}</span>
             <span className="flex items-center gap-2 font-mono text-[10px] text-ink-muted">
@@ -197,7 +198,7 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
               <li className="text-[11px] text-ink-muted self-center">+{items.length - 24} more</li>
             ) : null}
           </ul>
-        </div>
+        </Panel>
       ))}
 
       <div className="flex items-center justify-between gap-3 pt-1">

--- a/apps/ui/src/components/metagraphed/global-error-boundary.tsx
+++ b/apps/ui/src/components/metagraphed/global-error-boundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { AlertTriangle, Copy, Home, RefreshCw } from "lucide-react";
 import { reportError } from "@/lib/error-reporting";
+import { Panel } from "@/components/metagraphed/primitives";
 
 interface Props {
   children: ReactNode;
@@ -90,12 +91,12 @@ export class GlobalErrorBoundary extends Component<Props, State> {
               overview, or copy the error details for a bug report.
             </p>
 
-            <div className="mt-6 rounded-xl border border-border bg-card p-4">
+            <Panel as="div" dense className="mt-6">
               <div className="mg-label">Error message</div>
               <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-paper p-2 font-mono text-[12px] text-ink">
                 {message || "Unknown error"}
               </pre>
-            </div>
+            </Panel>
 
             <div className="mt-6 flex flex-wrap gap-2">
               <button

--- a/apps/ui/src/components/metagraphed/graphiql-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { ClientOnly } from "@tanstack/react-router";
 import { classNames } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 
 const GraphiqlExplorerBody = lazy(() =>
   import("./graphiql-explorer-body").then((m) => ({ default: m.GraphiqlExplorerBody })),
@@ -41,13 +42,15 @@ export function GraphiqlExplorer({
 
 function ExplorerFallback({ heightClassName }: { heightClassName: string }) {
   return (
-    <div
+    <Panel
+      as="div"
+      flush
       className={classNames(
-        "flex items-center justify-center rounded-lg border border-border bg-card font-mono text-xs text-ink-muted",
+        "flex items-center justify-center font-mono text-xs text-ink-muted",
         heightClassName,
       )}
     >
       Loading explorer…
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/integrability-board.tsx
+++ b/apps/ui/src/components/metagraphed/integrability-board.tsx
@@ -3,6 +3,7 @@ import { Gauge, Layers, CheckCircle2 } from "lucide-react";
 import { StatTile, BarMini, type BarMiniDatum } from "@jsonbored/ui-kit";
 import { coverageQuery } from "@/lib/metagraphed/queries";
 import type { Coverage } from "@/lib/metagraphed/types";
+import { Panel } from "@/components/metagraphed/primitives";
 
 // Fixed bucket order for the score distribution (the API keys are unordered).
 const SCORE_BUCKETS = ["0-24", "25-49", "50-74", "75-99", "100"];
@@ -69,7 +70,7 @@ export function IntegrabilityBoard() {
 
       <div className="grid gap-6 md:grid-cols-2">
         {dimensionData.length > 0 ? (
-          <div className="rounded border border-border bg-card p-3">
+          <Panel as="div" dense>
             <div className="mb-2 flex items-baseline justify-between">
               <h3 className="font-display text-sm font-semibold text-ink-strong">
                 Coverage by dimension
@@ -80,11 +81,11 @@ export function IntegrabilityBoard() {
             <p className="mt-2 text-[11px] text-ink-muted">
               Lowest-coverage dimensions first — the biggest gaps to fill.
             </p>
-          </div>
+          </Panel>
         ) : null}
 
         {distribution.length > 0 ? (
-          <div className="rounded border border-border bg-card p-3">
+          <Panel as="div" dense>
             <div className="mb-2 flex items-baseline justify-between">
               <h3 className="font-display text-sm font-semibold text-ink-strong">
                 Completeness scores
@@ -95,7 +96,7 @@ export function IntegrabilityBoard() {
             <p className="mt-2 text-[11px] text-ink-muted">
               How subnet completeness scores are distributed across the registry.
             </p>
-          </div>
+          </Panel>
         ) : null}
       </div>
     </div>

--- a/apps/ui/src/components/metagraphed/leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { leaderboardsQuery } from "@/lib/metagraphed/queries";
 import { BrandIcon } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { LeaderboardBoardKey, LeaderboardRow } from "@/lib/metagraphed/types";
 
 // #1111: surface the five live, D1-computed registry leaderboards
@@ -94,7 +95,7 @@ function BoardCard({
   metric: (row: LeaderboardRow) => string | null;
 }) {
   return (
-    <div className="rounded-xl border border-border bg-card p-4">
+    <Panel as="div" dense>
       <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
         {label}
       </div>
@@ -128,6 +129,6 @@ function BoardCard({
           </li>
         ))}
       </ol>
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -6,6 +6,7 @@ import { TableState, RealtimeFreshness, StatTile, BarMini } from "@jsonbored/ui-
 import { NeuronTable } from "@/components/metagraphed/neuron-table";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { classNames } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
 const TOP_N = 12;
@@ -91,7 +92,7 @@ export function MetagraphTableLoader({
 
       {/* Stake distribution across the leading UIDs. */}
       {stakeBars.length > 0 ? (
-        <div className="rounded-xl border border-border bg-card p-4">
+        <Panel as="div" dense>
           <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Stake distribution · top {stakeBars.length} UIDs
@@ -104,7 +105,7 @@ export function MetagraphTableLoader({
             </span>
           </div>
           <BarMini data={stakeBars} />
-        </div>
+        </Panel>
       ) : (
         <div className="flex items-center justify-end">{freshness}</div>
       )}

--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -5,6 +5,7 @@ import { ClampedPopoverContent } from "./clamped-popover-content";
 import { useApiBase, useNetwork } from "@/hooks/use-api-base";
 import { CHAIN_NETWORKS, LOCAL_DEV, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { classNames } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 
 interface Reach {
   ok: boolean;
@@ -122,28 +123,32 @@ export function NetworkSwitcher() {
               );
             })}
             <li>
-              <div className="rounded border border-dashed border-border bg-card px-2 py-2">
-                <div className="flex items-center gap-2">
-                  <TerminalSquare className="size-3.5 text-ink-muted shrink-0" />
-                  <span className="text-[12px] font-medium text-ink-strong">{LOCAL_DEV.label}</span>
+              <Panel as="div" flush className="border-dashed">
+                <div className="px-2 py-2">
+                  <div className="flex items-center gap-2">
+                    <TerminalSquare className="size-3.5 text-ink-muted shrink-0" />
+                    <span className="text-[12px] font-medium text-ink-strong">
+                      {LOCAL_DEV.label}
+                    </span>
+                  </div>
+                  <span className="mt-0.5 block text-[10px] text-ink-muted">
+                    {LOCAL_DEV.description}
+                  </span>
+                  <div className="mt-1 flex items-center justify-between gap-2">
+                    <code className="font-mono text-[10px] text-ink-muted truncate">
+                      {LOCAL_DEV.rpc}
+                    </code>
+                    <a
+                      href={LOCAL_DEV.guideUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-[10px] text-ink-muted hover:text-ink-strong underline underline-offset-2 shrink-0"
+                    >
+                      setup →
+                    </a>
+                  </div>
                 </div>
-                <span className="mt-0.5 block text-[10px] text-ink-muted">
-                  {LOCAL_DEV.description}
-                </span>
-                <div className="mt-1 flex items-center justify-between gap-2">
-                  <code className="font-mono text-[10px] text-ink-muted truncate">
-                    {LOCAL_DEV.rpc}
-                  </code>
-                  <a
-                    href={LOCAL_DEV.guideUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-[10px] text-ink-muted hover:text-ink-strong underline underline-offset-2 shrink-0"
-                  >
-                    setup →
-                  </a>
-                </div>
-              </div>
+              </Panel>
             </li>
           </ul>
         </div>

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "@/components/metagraphed/states";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 
 function scoreStr(v?: number | null): string {
   if (v == null || !Number.isFinite(v)) return "—";
@@ -103,7 +104,7 @@ export function NeuronDetailCard({
         <Fact label="Dividends" value={scoreStr(n.dividends)} />
       </div>
 
-      <div className="rounded-lg border border-border bg-card p-4 space-y-2.5">
+      <Panel as="div" dense bodyClassName="space-y-2.5">
         <KeyRow label="Hotkey" value={n.hotkey} />
         <KeyRow label="Coldkey" value={n.coldkey} />
         {n.registered_at_block != null ? (
@@ -120,21 +121,21 @@ export function NeuronDetailCard({
             </Link>
           </div>
         ) : null}
-      </div>
+      </Panel>
     </div>
   );
 }
 
 function Fact({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="rounded-lg border border-border bg-card p-3">
+    <Panel as="div" dense>
       <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
         {label}
       </div>
       <div className="mt-1 font-display text-base font-semibold tabular-nums text-ink-strong leading-none">
         {value}
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetNeuronHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetNeuronHistoryPoint } from "@/lib/metagraphed/types";
 
@@ -93,7 +94,7 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
           description="Daily snapshots for this neuron will appear here once enough chain history has accumulated."
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <Panel as="div" dense bodyClassName="space-y-3">
           {series.stake.length > 0 ? (
             <HistoryRow
               label="Stake"
@@ -137,7 +138,7 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
           {series.rank.length > 0 ? (
             <HistoryRow label="Rank" series={series.rank} color="var(--chart-6)" />
           ) : null}
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -7,6 +7,7 @@ import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import { Panel } from "@/components/metagraphed/primitives";
 import { taoCompact, scoreStr, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import {
   annualizedDelegatorApyPct,
@@ -135,7 +136,7 @@ export function NeuronTable({
   );
 
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel as="div" flush className="overflow-hidden">
       {/* Mobile card fallback (#6335): the 8-10 column table is unreadable on a
           narrow viewport, so mirror ValidatorCardList's per-row cards (one per
           neuron, each metric labelled by its field). The desktop table below is
@@ -329,7 +330,7 @@ export function NeuronTable({
           Download CSV
         </a>
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/operational-panel.tsx
+++ b/apps/ui/src/components/metagraphed/operational-panel.tsx
@@ -21,6 +21,7 @@ import { TimeRangeScrub } from "@/components/metagraphed/analytics/time-range-sc
 import { Tooltip, TooltipContent, TooltipTrigger, TimeAgo, InfoTooltip } from "@jsonbored/ui-kit";
 import { PanelShell } from "@/components/metagraphed/panel-shell";
 import { ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import { formatFreshness } from "@/lib/metagraphed/freshness";
 import { useSubnetFilter, type Severity } from "@/components/metagraphed/subnet-filter-context";
@@ -94,7 +95,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
       {healthQ.error ? (
         <ErrorState error={healthQ.error} onRetry={retryOperational} context="operational status" />
       ) : (
-        <div className="rounded-xl border border-border bg-card overflow-hidden">
+        <Panel as="div" flush className="overflow-hidden">
           {/* Status ribbon */}
           <div className="grid grid-cols-2 md:grid-cols-4 divide-x divide-border border-b border-border">
             <Stat
@@ -339,7 +340,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
               )}
             </div>
           </div>
-        </div>
+        </Panel>
       )}
     </PanelShell>
   );

--- a/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
+++ b/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { chainIdentityHistoryQuery } from "@/lib/metagraphed/queries";
 import { EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { TimeAgo } from "@jsonbored/ui-kit";
 
 // #3474: homepage widget — the live network-wide feed of recent subnet-identity
@@ -11,9 +12,9 @@ import { TimeAgo } from "@jsonbored/ui-kit";
 
 function Notice({ children }: { children: string }) {
   return (
-    <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
+    <Panel as="div" dense bodyClassName="text-xs text-ink-muted">
       {children}
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { leaderboardsQuery } from "@/lib/metagraphed/queries";
 import { BrandIcon } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { LeaderboardBoardKey, LeaderboardRow } from "@/lib/metagraphed/types";
 
 // #6995: surface the registry's own D1-computed leaderboards on /leaderboards.
@@ -169,7 +170,7 @@ function BoardCard({
   metric: (row: LeaderboardRow) => string | null;
 }) {
   return (
-    <div className="rounded-xl border border-border bg-card p-4">
+    <Panel as="div" dense>
       <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
         {label}
       </div>
@@ -210,6 +211,6 @@ function BoardCard({
           ))}
         </ol>
       )}
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/reliability-panel.tsx
+++ b/apps/ui/src/components/metagraphed/reliability-panel.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { SurfaceLatencyPercentiles, SurfaceSla } from "@/lib/metagraphed/types";
 
 // #1114: per-surface reliability — uptime SLA + latency percentiles (p50/p95/p99)
@@ -88,7 +89,7 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
   const errorObj = pctErrorObj ?? slaErrorObj;
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-card">
+    <Panel as="div" flush className="overflow-hidden">
       <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2.5">
         <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Per-surface reliability · uptime · latency percentiles
@@ -176,6 +177,6 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
           </table>
         </div>
       )}
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/resource-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/resource-explorer.tsx
@@ -26,6 +26,7 @@ import {
   safeExternalUrl,
 } from "@jsonbored/ui-kit";
 import { PanelShell } from "@/components/metagraphed/panel-shell";
+import { Panel } from "@/components/metagraphed/primitives";
 import { useCopy } from "@/hooks/use-copy";
 import { useHydrated } from "@/hooks/use-hydrated";
 import { classNames } from "@/lib/metagraphed/format";
@@ -102,7 +103,7 @@ export function ResourceExplorer({ netuid }: { netuid: number }) {
           </button>
         </div>
       ) : null}
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <Panel as="div" flush className="overflow-hidden">
         {seg === "endpoints" ? (
           <Suspense fallback={<Skeleton className="h-40 w-full" />}>
             <EndpointsView netuid={netuid} filter={filter} />
@@ -120,7 +121,7 @@ export function ResourceExplorer({ netuid }: { netuid: number }) {
             </Suspense>
           </div>
         ) : null}
-      </div>
+      </Panel>
     </PanelShell>
   );
 }

--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -6,6 +6,7 @@ import { useNetwork } from "@/hooks/use-api-base";
 import { rpcUsageQuery } from "@/lib/metagraphed/queries";
 import { CopyButton, TimeAgo } from "@jsonbored/ui-kit";
 import { EmptyState, StaleBanner } from "./states";
+import { Panel } from "./primitives";
 import { classNames, formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import type { RpcUsage } from "@/lib/metagraphed/types";
 
@@ -83,11 +84,13 @@ export function ProxyHero() {
         single point of failure.
       </p>
 
-      <div className="mt-4 flex items-center gap-2 rounded border border-border bg-card px-3 py-2">
-        <span className="mg-label">POST</span>
-        <code className="flex-1 truncate font-mono text-[13px] text-ink-strong">{proxyUrl}</code>
-        <CopyButton value={proxyUrl} label="proxy URL" />
-      </div>
+      <Panel as="div" flush className="mt-4">
+        <div className="flex items-center gap-2 px-3 py-2">
+          <span className="mg-label">POST</span>
+          <code className="flex-1 truncate font-mono text-[13px] text-ink-strong">{proxyUrl}</code>
+          <CopyButton value={proxyUrl} label="proxy URL" />
+        </div>
+      </Panel>
 
       <div className="mt-2 rounded border border-border bg-paper">
         <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
@@ -260,7 +263,7 @@ export function ProxyUsagePanel() {
           ) : null}
 
           {usage.endpoints.length > 0 ? (
-            <div className="rounded border border-border bg-card overflow-x-auto">
+            <Panel as="div" flush className="overflow-x-auto">
               <table className="w-full text-sm">
                 <caption className="px-3 pt-2 text-left mg-label">
                   Per-endpoint distribution
@@ -303,7 +306,7 @@ export function ProxyUsagePanel() {
                   })}
                 </tbody>
               </table>
-            </div>
+            </Panel>
           ) : null}
         </>
       )}

--- a/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { TimeAgo } from "@jsonbored/ui-kit";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { RuntimeTransition } from "@/lib/metagraphed/types";
 
 /**
@@ -32,9 +33,12 @@ export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardLi
   return (
     <div className={className}>
       {rows.map((row) => (
-        <div
+        <Panel
+          as="div"
+          dense
           key={`${row.spec_version}-${row.block_number}`}
-          className="min-w-0 space-y-2 rounded-lg border border-border bg-card p-3"
+          className="min-w-0"
+          bodyClassName="space-y-2"
         >
           <div className="flex items-baseline justify-between gap-2">
             <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
@@ -70,7 +74,7 @@ export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardLi
               {row.observed_at ? <TimeAgo at={row.observed_at} /> : "—"}
             </span>
           </div>
-        </div>
+        </Panel>
       ))}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/schema-drift.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift.tsx
@@ -6,6 +6,7 @@ import { API_BASE } from "@/lib/metagraphed/config";
 import { classNames } from "@/lib/metagraphed/format";
 import { TimeAgo, CopyableCode } from "@jsonbored/ui-kit";
 import { EmptyState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 
 function driftTone(status?: string): string {
   switch (status) {
@@ -60,7 +61,7 @@ export function SchemaDriftSummary({ netuid, compact }: { netuid: number; compac
 
   if (compact) {
     return (
-      <div className="rounded border border-border bg-card p-3">
+      <Panel as="div" dense>
         <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
           <div className="flex items-center gap-2">
             <GitCompare className="size-3.5 text-ink-muted" />
@@ -103,7 +104,7 @@ export function SchemaDriftSummary({ netuid, compact }: { netuid: number; compac
             ) : null}
           </ul>
         ) : null}
-      </div>
+      </Panel>
     );
   }
 

--- a/apps/ui/src/components/metagraphed/status-diagnostics.tsx
+++ b/apps/ui/src/components/metagraphed/status-diagnostics.tsx
@@ -367,7 +367,10 @@ export function SourceHealthTable() {
 
   return (
     <div className="space-y-3">
-      <Panel dense bodyClassName="flex flex-wrap items-center gap-4 font-mono text-[12px] tabular-nums">
+      <Panel
+        dense
+        bodyClassName="flex flex-wrap items-center gap-4 font-mono text-[12px] tabular-nums"
+      >
         <span className="text-health-ok">{summary.status_counts.ok ?? 0} ok</span>
         <span className="text-health-warn">{summary.status_counts.degraded ?? 0} degraded</span>
         <span className="text-health-down">{summary.status_counts.failed ?? 0} failed</span>

--- a/apps/ui/src/components/metagraphed/status-diagnostics.tsx
+++ b/apps/ui/src/components/metagraphed/status-diagnostics.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { HealthHistorySurface, SourceHealthProvider } from "@/lib/metagraphed/types";
 
 /* ================================================================== *
@@ -58,7 +59,7 @@ export function HealthHistoryDrilldown() {
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-3 rounded border border-border bg-card p-3">
+      <Panel dense bodyClassName="flex flex-wrap items-center gap-3">
         <div>
           <div className="mg-label">Probe date</div>
           <div className="font-display text-sm font-semibold text-ink-strong">{date}</div>
@@ -76,7 +77,7 @@ export function HealthHistoryDrilldown() {
             aria-label="Probe history date"
           />
         </label>
-      </div>
+      </Panel>
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-48 w-full" />}>
           <HealthHistoryBody date={date} />
@@ -164,7 +165,7 @@ function HealthHistoryBody({ date }: { date: string }) {
   return (
     <div className="space-y-3">
       <div className="grid gap-3 md:grid-cols-2">
-        <div className="rounded border border-border bg-card p-3">
+        <Panel as="div" dense>
           <div className="mg-label mb-1">Status counts</div>
           <div className="flex items-center gap-4 font-mono text-[12px] tabular-nums">
             <span className="text-health-ok">{okCount} ok</span>
@@ -172,11 +173,11 @@ function HealthHistoryBody({ date }: { date: string }) {
             <span className="text-health-down">{failed} failed</span>
             <span className="text-ink-muted">{summary.surface_count ?? rows.length} probed</span>
           </div>
-        </div>
-        <div className="rounded border border-border bg-card p-3">
+        </Panel>
+        <Panel as="div" dense>
           <div className="mg-label mb-1.5">Classification mix</div>
           <BarMini data={classData} showValue />
-        </div>
+        </Panel>
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
@@ -205,7 +206,7 @@ function HealthHistoryBody({ date }: { date: string }) {
         </span>
       </div>
 
-      <div className="overflow-x-auto rounded-lg border border-border bg-card">
+      <Panel flush className="overflow-x-auto">
         <table className="w-full text-left text-sm">
           <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
             <tr>
@@ -268,7 +269,7 @@ function HealthHistoryBody({ date }: { date: string }) {
             ))}
           </tbody>
         </table>
-      </div>
+      </Panel>
     </div>
   );
 }
@@ -366,7 +367,7 @@ export function SourceHealthTable() {
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-4 rounded border border-border bg-card p-3 font-mono text-[12px] tabular-nums">
+      <Panel dense bodyClassName="flex flex-wrap items-center gap-4 font-mono text-[12px] tabular-nums">
         <span className="text-health-ok">{summary.status_counts.ok ?? 0} ok</span>
         <span className="text-health-warn">{summary.status_counts.degraded ?? 0} degraded</span>
         <span className="text-health-down">{summary.status_counts.failed ?? 0} failed</span>
@@ -375,7 +376,7 @@ export function SourceHealthTable() {
           {summary.provider_count ?? rows.length} providers · {summary.endpoint_count ?? 0}{" "}
           endpoints
         </span>
-      </div>
+      </Panel>
 
       <div className="flex flex-wrap items-center gap-2">
         <SelectFilter
@@ -394,7 +395,7 @@ export function SourceHealthTable() {
         </span>
       </div>
 
-      <div className="overflow-x-auto rounded-lg border border-border bg-card">
+      <Panel flush className="overflow-x-auto">
         <table className="w-full text-left text-sm">
           <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
             <tr>
@@ -460,7 +461,7 @@ export function SourceHealthTable() {
             ))}
           </tbody>
         </table>
-      </div>
+      </Panel>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import type { Endpoint } from "@/lib/metagraphed/types";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { Panel } from "@/components/metagraphed/primitives";
 
 /**
  * Side-by-side compare drawer. The chosen peer netuid is persisted in the
@@ -240,7 +241,7 @@ function CompareBody({ base, peer }: { base: number; peer: number }) {
         delta={null}
       />
 
-      <section className="rounded-lg border border-border bg-card overflow-hidden">
+      <Panel flush className="overflow-hidden">
         <div className="border-b border-border px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
           Top providers
         </div>
@@ -248,22 +249,26 @@ function CompareBody({ base, peer }: { base: number; peer: number }) {
           <ProviderColumn rows={baseProviders} other={peerProviders} />
           <ProviderColumn rows={peerProviders} other={baseProviders} />
         </div>
-      </section>
+      </Panel>
     </div>
   );
 }
 
 function Header({ label, name, netuid }: { label: string; name?: string; netuid: number }) {
   return (
-    <div className="rounded border border-border bg-card px-2.5 py-2">
-      <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">{label}</div>
-      <div className="mt-0.5 truncate font-display text-sm font-semibold text-ink-strong">
-        {name ?? `Subnet ${netuid}`}
+    <Panel as="div" flush>
+      <div className="px-2.5 py-2">
+        <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
+          {label}
+        </div>
+        <div className="mt-0.5 truncate font-display text-sm font-semibold text-ink-strong">
+          {name ?? `Subnet ${netuid}`}
+        </div>
+        <div className="font-mono text-[10px] text-ink-muted">
+          netuid {String(netuid).padStart(3, "0")}
+        </div>
       </div>
-      <div className="font-mono text-[10px] text-ink-muted">
-        netuid {String(netuid).padStart(3, "0")}
-      </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Crown, Swords } from "lucide-react";
 import { subnetConvictionQuery } from "@/lib/metagraphed/queries";
 import { CopyableCode } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import {
   rowGapPct,
@@ -113,7 +114,7 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
           {data.maturity_rate != null ? ` · maturity_rate ${formatNumber(data.maturity_rate)}` : ""}
         </p>
       ) : null}
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <Panel as="div" flush className="overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
             <thead className="bg-surface/40">
@@ -194,7 +195,7 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
             </tbody>
           </table>
         </div>
-      </div>
+      </Panel>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
@@ -86,7 +87,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
           description="Daily snapshots will appear here once enough chain history has accumulated for this subnet."
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <Panel as="div" dense bodyClassName="space-y-3">
           {series.neurons.length > 0 ? (
             <HistoryRow label="Neurons" series={series.neurons} color="var(--accent)" />
           ) : null}
@@ -113,7 +114,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
               format={formatTao}
             />
           ) : null}
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
@@ -3,6 +3,7 @@ import { subnetLeaseHistoryQuery, subnetLeaseQuery } from "@/lib/metagraphed/que
 import type { SubnetLeaseEvent, SubnetLeaseTerms } from "@/lib/metagraphed/types";
 import { CopyableCode, StatTile, TimeAgo } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 
 /**
@@ -125,7 +126,7 @@ function LeaseStatusCard({
   }
 
   return (
-    <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+    <Panel as="div" dense bodyClassName="space-y-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent-text">
@@ -167,7 +168,7 @@ function LeaseStatusCard({
         <KeySs58 label="Coldkey" value={lease.coldkey} />
         <KeySs58 label="Hotkey" value={lease.hotkey} />
       </dl>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -28,6 +28,7 @@ import {
   Sparkline,
 } from "@jsonbored/ui-kit";
 import { StaleBanner } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import {
   subnetEndpointsQuery,
   subnetDeregistrationsQuery,
@@ -474,7 +475,11 @@ export function SubnetMasthead({
           leaving empty column slots — grid tracks are shared across every
           row, but flex lines size independently (same pattern as the
           flex-wrap strip in operational-panel.tsx). */}
-      <div className="mt-5 flex flex-wrap divide-x divide-border rounded-xl border border-border bg-card overflow-hidden [&>*]:grow [&>*]:basis-[150px] [&>*]:min-w-[150px]">
+      <Panel
+        as="div"
+        flush
+        className="mt-5 flex flex-wrap divide-x divide-border overflow-hidden [&>*]:grow [&>*]:basis-[150px] [&>*]:min-w-[150px]"
+      >
         <StatWithSpark
           label="Netuid"
           value={String(netuid).padStart(3, "0")}
@@ -650,7 +655,7 @@ export function SubnetMasthead({
           updatedAt={generatedAt}
           viz={<DotRow dots={sourceKinds} />}
         />
-      </div>
+      </Panel>
     </header>
   );
 }

--- a/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetOhlcQuery } from "@/lib/metagraphed/queries";
 import { CandlestickMini, type CandlestickDatum } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { classNames, formatTao } from "@/lib/metagraphed/format";
 
 const INTERVALS = ["1h", "1d"] as const;
@@ -95,7 +96,7 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
           description="OHLC candles are built from executed stake/unstake trades -- once this subnet has trading activity in the selected interval, candles will appear here."
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card p-4">
+        <Panel as="div" dense>
           <CandlestickMini
             data={candles}
             width={640}
@@ -110,7 +111,7 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
               {formatTao(data!.candles[data!.candles.length - 1]!.volume_tao)}
             </span>
           </div>
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
@@ -2,6 +2,7 @@ import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { GitMerge, ArrowRight } from "lucide-react";
 import { useHydrated } from "@/hooks/use-hydrated";
+import { Panel } from "@/components/metagraphed/primitives";
 import {
   economicsQuery,
   lineageQuery,
@@ -194,7 +195,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
       info="Joined from /api/v1/lineage · /api/v1/economics · /api/v1/subnets/{netuid}/profile"
       tone="ink"
     >
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <Panel as="div" flush className="overflow-hidden">
         {/* Chain identity row */}
         <div className="grid grid-cols-2 md:grid-cols-4 divide-x divide-border border-b border-border">
           <Meta
@@ -451,7 +452,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
             </div>
           </div>
         </div>
-      </div>
+      </Panel>
     </SectionAnchor>
   );
 }

--- a/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
@@ -6,6 +6,7 @@ import { CopyButton } from "@jsonbored/ui-kit";
 import { subnetValidatorsQuery } from "@/lib/metagraphed/queries";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { SponsoredValidatorCallout } from "@/components/metagraphed/sponsored-validator-callout";
@@ -53,7 +54,7 @@ function SubnetValidatorsPreviewLoader({ netuid }: { netuid: number }) {
   return (
     <div className="mt-6 space-y-3">
       {sponsored ? <SponsoredValidatorCallout netuid={netuid} validator={sponsored} /> : null}
-      <div className="rounded-xl border border-border bg-card p-4">
+      <Panel as="div" dense>
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Top validators · by stake
@@ -78,7 +79,7 @@ function SubnetValidatorsPreviewLoader({ netuid }: { netuid: number }) {
             <ValidatorPreviewRow key={v.uid} netuid={netuid} validator={v} />
           ))}
         </ul>
-      </div>
+      </Panel>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { MethodologyCallout } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
 import {
   apyFromRewardsPer1000,
@@ -55,17 +56,19 @@ export function ValidatorApyPanel({
     <div className="space-y-3">
       <div className="grid gap-3 sm:grid-cols-3">
         {rows.map((row) => (
-          <div key={row.window} className="rounded-xl border border-border bg-card px-4 py-3">
-            <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              Est. APY · {row.window}
+          <Panel as="div" flush key={row.window}>
+            <div className="px-4 py-3">
+              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Est. APY · {row.window}
+              </div>
+              <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink-strong">
+                {anyLoading && row.apy == null ? "…" : formatApyPct(row.apy)}
+              </div>
+              <p className="mt-1 text-[10px] leading-relaxed text-ink-muted">
+                Net of take · daily neuron_daily rollup
+              </p>
             </div>
-            <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink-strong">
-              {anyLoading && row.apy == null ? "…" : formatApyPct(row.apy)}
-            </div>
-            <p className="mt-1 text-[10px] leading-relaxed text-ink-muted">
-              Net of take · daily neuron_daily rollup
-            </p>
-          </div>
+          </Panel>
         ))}
       </div>
       {!anyLoading && !anyValue ? (

--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -5,6 +5,7 @@ import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-form
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { ValidatorCompareToggle } from "@/components/metagraphed/validators-compare-drawer";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
+import { Panel } from "@/components/metagraphed/primitives";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
 export interface ValidatorCardListProps {
@@ -26,10 +27,7 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
       {validators.map((v) => {
         const f = resolveValidatorCard(v);
         return (
-          <div
-            key={v.hotkey}
-            className="min-w-0 space-y-2 rounded-lg border border-border bg-card p-3"
-          >
+          <Panel as="div" dense key={v.hotkey} className="min-w-0" bodyClassName="space-y-2">
             <div className="flex min-w-0 items-center gap-1.5">
               {v.featured ? <SponsoredBadge /> : null}
               <Link
@@ -63,7 +61,7 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
               <Stat label="Total emission" value={taoCompact(v.total_emission_tao)} />
               <Stat label="Est. APY" value={f.apyLabel} />
             </dl>
-          </div>
+          </Panel>
         );
       })}
     </div>

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { ValidatorHistoryPoint } from "@/lib/metagraphed/types";
@@ -91,7 +92,7 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
           description="Daily snapshots will appear here once enough chain history has accumulated for this validator."
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <Panel as="div" dense bodyClassName="space-y-3">
           {series.stake.length > 0 ? (
             <HistoryRow
               label="Staked"
@@ -108,7 +109,7 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
               format={rewardsStr}
             />
           ) : null}
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -8,6 +8,7 @@ import {
   SelectFilter,
 } from "@/components/metagraphed/table-controls";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
+import { Panel } from "@/components/metagraphed/primitives";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { validatorNominatorsQuery } from "@/lib/metagraphed/queries";
 import type { ValidatorNominatorEntry } from "@/lib/metagraphed/types";
@@ -156,7 +157,7 @@ export function ValidatorNominatorsTable({ queryOptions, search, setSearch }: Pr
 
 function NominatorCard({ n }: { n: ValidatorNominatorEntry }) {
   return (
-    <div className="block rounded border border-border bg-card p-3 min-h-11">
+    <Panel as="div" dense className="block min-h-11">
       <div className="flex items-center justify-between gap-2">
         <CopyableCode value={n.coldkey} className="max-w-[70%]" />
         <span className="font-mono text-[11px] text-ink-muted shrink-0">
@@ -168,6 +169,6 @@ function NominatorCard({ n }: { n: ValidatorNominatorEntry }) {
         <span>gross {taoCompact(n.gross_staked_tao)}</span>
         <span>{formatNumber(n.event_count)} events</span>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -12,6 +12,7 @@ import { NeuronTable } from "@/components/metagraphed/neuron-table";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { SponsoredValidatorCallout } from "@/components/metagraphed/sponsored-validator-callout";
 import { TopShareCaption } from "@/components/metagraphed/top-share-caption";
+import { Panel } from "@/components/metagraphed/primitives";
 
 const TOP_N = 10;
 
@@ -73,7 +74,7 @@ export function ValidatorsTableLoader({
     <div className="space-y-4">
       {sponsored ? <SponsoredValidatorCallout netuid={netuid} validator={sponsored} /> : null}
       {stakeBars.length > 0 ? (
-        <div className="rounded-xl border border-border bg-card p-4">
+        <Panel as="div" dense>
           <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
               Validator stake · top {stakeBars.length}
@@ -99,7 +100,7 @@ export function ValidatorsTableLoader({
               />
             </div>
           ) : null}
-        </div>
+        </Panel>
       ) : (
         <div className="flex items-center justify-end">{freshness}</div>
       )}

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -5,6 +5,7 @@ import { classNames } from "@/lib/metagraphed/format";
 import { CopyableCode, SectionHeading } from "@jsonbored/ui-kit";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { SettingsSummaryStrip } from "@/components/metagraphed/settings-summary-strip";
+import { Panel } from "@/components/metagraphed/primitives";
 import { CHANGE_KINDS } from "@/lib/metagraphed/settings-summary";
 import type {
   WebhookDeliveryStatus,
@@ -341,7 +342,7 @@ function LookupSubscriptionSection() {
       ) : null}
 
       {result ? (
-        <div className="mt-3 space-y-3 rounded border border-border bg-card p-4">
+        <Panel as="div" dense className="mt-3" bodyClassName="space-y-3">
           <div className="flex flex-wrap items-center gap-2">
             <DeliveryStatusPill status={result.delivery.status} />
             <span
@@ -376,7 +377,7 @@ function LookupSubscriptionSection() {
               after {result.delivery.last_failure.attempts ?? "?"} attempt(s).
             </div>
           ) : null}
-        </div>
+        </Panel>
       ) : null}
     </section>
   );

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -14,6 +14,7 @@ import {
 } from "@jsonbored/ui-kit";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
@@ -111,7 +112,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
 
       <div className="grid gap-4 md:grid-cols-2">
         {/* Validator vs miner split. */}
-        <div className="rounded-xl border border-border bg-card p-4">
+        <Panel as="div" dense>
           <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Validator / miner split
           </div>
@@ -120,7 +121,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
           ) : (
             <p className="font-mono text-[11px] text-ink-muted">Not enough data yet.</p>
           )}
-        </div>
+        </Panel>
 
         {/* Yield percentile spread — container-query layout (#3934). */}
         <YieldPercentileStrip
@@ -132,7 +133,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
       </div>
 
       {/* Per-UID yield leaderboard (top yielders). */}
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <Panel as="div" flush className="overflow-hidden">
         {/* < md: a 7-column table squeezes Yield/vs-median off an undiscoverable
             horizontal scroll, so narrow viewports get a stacked card per UID
             instead — mirrors the cards/table split the explorer stake-transfer
@@ -249,7 +250,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
         <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
           top {ranked.length} of {neurons.length} by yield · subnet {netuid}
         </div>
-      </div>
+      </Panel>
 
       {/* Daily yield-distribution drift. */}
       <YieldDriftCard netuid={netuid} />
@@ -327,7 +328,7 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
           description="Daily yield-distribution snapshots will appear here once enough chain history has accumulated."
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <Panel as="div" dense bodyClassName="space-y-3">
           {series.subnet.length > 0 ? (
             <DriftRow label="Subnet yield" series={series.subnet} color="var(--accent)" />
           ) : null}
@@ -337,7 +338,7 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
           {series.p90.length > 0 ? (
             <DriftRow label="p90 yield" series={series.p90} color="var(--health-warn)" />
           ) : null}
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -12,6 +12,7 @@ import {
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { MoveStakeModal } from "@/components/metagraphed/move-stake-modal";
 import { EmptyState } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -173,7 +174,7 @@ export function YourPositionsPanel({ address }: { address: string }) {
       </div>
 
       {/* Desktop table */}
-      <div className="hidden overflow-x-auto rounded-xl border border-border bg-card md:block">
+      <Panel as="div" flush className="hidden overflow-x-auto md:block">
         <table className="w-full text-sm">
           <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
             <tr>
@@ -228,12 +229,12 @@ export function YourPositionsPanel({ address }: { address: string }) {
             ))}
           </tbody>
         </table>
-      </div>
+      </Panel>
 
       {/* Mobile cards */}
       <div className="space-y-3 md:hidden">
         {positions.map((p, i) => (
-          <div key={p.key} className="space-y-2 rounded-lg border border-border bg-card p-3">
+          <Panel as="div" dense bodyClassName="space-y-2" key={p.key}>
             <div className="flex items-center justify-between gap-2">
               <Link
                 to="/subnets/$netuid"
@@ -263,7 +264,7 @@ export function YourPositionsPanel({ address }: { address: string }) {
                 positionSpotTao={p.spotTao}
               />
             </div>
-          </div>
+          </Panel>
         ))}
       </div>
     </div>

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -28,6 +28,7 @@ import { THEME_BOOTSTRAP_SCRIPT } from "@/lib/theme";
 import { DENSITY_BOOTSTRAP_SCRIPT } from "@/lib/density";
 import { HEALTH_PALETTE_BOOTSTRAP_SCRIPT } from "@/lib/health-palette";
 import { GlobalErrorBoundary } from "@/components/metagraphed/global-error-boundary";
+import { Panel } from "@/components/metagraphed/primitives";
 import {
   mountBlankScreenWatchdog,
   PRE_HYDRATION_RECOVERY_SCRIPT,
@@ -89,7 +90,7 @@ function NotFoundComponent() {
           </p>
 
           {/* Attempted URL + copy */}
-          <div className="mt-6 rounded-xl border border-border bg-card p-3">
+          <Panel as="div" dense className="mt-6">
             <div className="flex items-center gap-2 mg-label">
               <AlertTriangle className="size-3.5 text-health-warn" /> Attempted URL
             </div>
@@ -112,7 +113,7 @@ function NotFoundComponent() {
                 {copied ? "Copied" : "Copy URL"}
               </button>
             </div>
-          </div>
+          </Panel>
 
           {/* Search */}
           <form onSubmit={onSubmit} className="mt-4" role="search" aria-label="Find a subnet">

--- a/apps/ui/src/routes/about.tsx
+++ b/apps/ui/src/routes/about.tsx
@@ -11,7 +11,7 @@ import {
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { CopyableCode, ExternalLink } from "@jsonbored/ui-kit";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import { PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { API_BASE, GITHUB_REPO } from "@/lib/metagraphed/config";
 import { coverageQuery, freshnessQuery, healthQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
@@ -241,7 +241,7 @@ function AtAGlance() {
     },
   ];
   return (
-    <div className="rounded-xl border border-border bg-card p-4">
+    <Panel as="div" dense>
       <div className="mg-label mb-3 inline-flex items-center gap-2">
         <span className="mg-live-dot" /> At a glance
       </div>
@@ -286,6 +286,6 @@ function AtAGlance() {
           → Registry gaps
         </Link>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/routes/agents.tsx
+++ b/apps/ui/src/routes/agents.tsx
@@ -21,7 +21,7 @@ import {
   McpToolsList,
   SectionHeading,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { AskBox } from "@/components/metagraphed/ask-box";
 import { SearchBox } from "@/components/metagraphed/search-box";
 import { Skeleton } from "@/components/metagraphed/states";
@@ -174,21 +174,20 @@ function AgentsBody() {
           />
           <div className="space-y-2.5">
             {SDKS.map((sdk) => (
-              <div
-                key={sdk.lang}
-                className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3"
-              >
-                <Package className="size-4 shrink-0 text-ink-muted" aria-hidden />
-                <div className="min-w-0 flex-1">
-                  <code className="block overflow-x-auto whitespace-nowrap font-mono text-[12px] text-ink-strong">
-                    {sdk.install}
-                  </code>
-                  <ExternalLink href={sdk.url} className="font-mono text-[10px] text-ink-muted">
-                    {sdk.lang} · {sdk.pkg}
-                  </ExternalLink>
+              <Panel as="div" flush key={sdk.lang}>
+                <div className="flex items-center gap-3 px-4 py-3">
+                  <Package className="size-4 shrink-0 text-ink-muted" aria-hidden />
+                  <div className="min-w-0 flex-1">
+                    <code className="block overflow-x-auto whitespace-nowrap font-mono text-[12px] text-ink-strong">
+                      {sdk.install}
+                    </code>
+                    <ExternalLink href={sdk.url} className="font-mono text-[10px] text-ink-muted">
+                      {sdk.lang} · {sdk.pkg}
+                    </ExternalLink>
+                  </div>
+                  <CopyButton value={sdk.install} label={`${sdk.lang} install`} compact />
                 </div>
-                <CopyButton value={sdk.install} label={`${sdk.lang} install`} compact />
-              </div>
+              </Panel>
             ))}
           </div>
         </div>
@@ -255,7 +254,7 @@ function AgentsBody() {
         <SectionHeading title="Try it" intro="No key, no account — hit any surface with curl." />
         <div className="space-y-2.5">
           {QUICKSTART.map((q) => (
-            <div key={q.label} className="rounded-lg border border-border bg-card">
+            <Panel as="div" flush key={q.label}>
               <div className="flex items-center justify-between border-b border-border px-4 py-2">
                 <span className="mg-label">{q.label}</span>
                 <CopyButton value={q.cmd} label={q.label} compact />
@@ -263,7 +262,7 @@ function AgentsBody() {
               <pre className="overflow-x-auto px-4 py-3 font-mono text-[11px] leading-relaxed text-ink">
                 {q.cmd}
               </pre>
-            </div>
+            </Panel>
           ))}
         </div>
       </section>

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -18,7 +18,7 @@ import { PalletMethodBreakdown } from "@/components/metagraphed/blocks/pallet-me
 import { ShortcutsDialog } from "@/components/metagraphed/blocks/shortcuts-dialog";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
@@ -432,7 +432,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
               description="This block has no indexed extrinsics (or the poller window for this shard is still catching up)."
             />
           ) : (
-            <div className="overflow-x-auto rounded border border-border bg-card">
+            <Panel as="div" flush className="overflow-x-auto">
               <table className="w-full text-left text-sm">
                 <thead className="bg-surface/40">
                   <tr>
@@ -497,7 +497,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                   })}
                 </tbody>
               </table>
-            </div>
+            </Panel>
           )}
         </SectionAnchor>
 
@@ -577,7 +577,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                   description="This block has no decoded pallet events indexed yet, or the all-events backfill hasn't reached it."
                 />
               ) : (
-                <div className="overflow-x-auto rounded border border-border bg-card">
+                <Panel as="div" flush className="overflow-x-auto">
                   <table className="w-full text-left text-sm">
                     <thead className="bg-surface/40">
                       <tr>
@@ -620,7 +620,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                       ))}
                     </tbody>
                   </table>
-                </div>
+                </Panel>
               )}
             </div>
           </details>
@@ -777,7 +777,7 @@ function GroupedEvents({
   };
 
   return (
-    <div className="rounded border border-border bg-card">
+    <Panel as="div" flush>
       <div className="flex items-center justify-between border-b border-border px-3 py-2">
         <span className="mg-label">
           {groups.length} extrinsic{groups.length === 1 ? "" : "s"} · {events.length} event
@@ -903,7 +903,7 @@ function GroupedEvents({
           );
         })}
       </ul>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1742,7 +1742,7 @@ function ExplorerDashboard() {
                 cards/table split ListShell uses for paginated lists). */}
                 <div className="md:hidden space-y-2">
                   {stakeTransfers.subnets.map((s) => (
-                    <div key={s.netuid} className="rounded border border-border bg-card p-3">
+                    <Panel as="div" dense key={s.netuid}>
                       <div className="flex items-center justify-between gap-2">
                         <Link
                           to="/subnets/$netuid"
@@ -1761,7 +1761,7 @@ function ExplorerDashboard() {
                         <span>{formatNumber(s.transfers)} transfers</span>
                         <span>{formatNumber(s.distinct_senders)} senders</span>
                       </div>
-                    </div>
+                    </Panel>
                   ))}
                 </div>
                 <ExplorerLeaderboardTableShell

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -16,7 +16,7 @@ import {
   StatTile,
   TableState,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -367,7 +367,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
 
       <SectionAnchor id="events" title="Emitted events" tone="accent">
         {events.length > 0 ? (
-          <div className="overflow-x-auto rounded border border-border bg-card">
+          <Panel as="div" flush className="overflow-x-auto">
             <table className="w-full text-left text-sm">
               <thead className="bg-surface/40">
                 <tr>
@@ -416,7 +416,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                 ))}
               </tbody>
             </table>
-          </div>
+          </Panel>
         ) : (
           <EmptyState
             title="No emitted events"
@@ -482,7 +482,7 @@ function renderCallArgs(
       return <p className="text-sm text-ink-muted">No call args were indexed.</p>;
     }
     return (
-      <div className="overflow-x-auto rounded border border-border bg-card">
+      <Panel as="div" flush className="overflow-x-auto">
         <table className="w-full text-left text-sm">
           <thead className="bg-surface/40">
             <tr>
@@ -503,7 +503,7 @@ function renderCallArgs(
             ))}
           </tbody>
         </table>
-      </div>
+      </Panel>
     );
   }
 
@@ -513,7 +513,7 @@ function renderCallArgs(
       return <p className="text-sm text-ink-muted">No call args were indexed.</p>;
     }
     return (
-      <div className="overflow-x-auto rounded border border-border bg-card">
+      <Panel as="div" flush className="overflow-x-auto">
         <table className="w-full text-left text-sm">
           <thead className="bg-surface/40">
             <tr>
@@ -534,7 +534,7 @@ function renderCallArgs(
             ))}
           </tbody>
         </table>
-      </div>
+      </Panel>
     );
   }
 

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -26,7 +26,7 @@ import {
   DownloadCsvButton,
   Sparkline,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, PagerFooter } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, PagerFooter, Panel } from "@/components/metagraphed/primitives";
 import { chainFeesQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { activeFilterCount, filterToggleLabel } from "@/lib/metagraphed/filter-disclosure";
@@ -130,28 +130,30 @@ function FeesTrendCard() {
   const latest = values.length > 0 ? values[values.length - 1]! : null;
 
   return (
-    <section className="mb-6 rounded-lg border border-border bg-card p-4 sm:p-5">
-      <div className="mb-2 flex items-baseline justify-between gap-2">
-        <div className="flex items-baseline gap-2">
-          <h2 className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Fees, last 7d
-          </h2>
-          <span className="font-mono text-[11px] text-ink-muted">{fees.day_count} days</span>
+    <Panel as="section" flush className="mb-6">
+      <div className="p-4 sm:p-5">
+        <div className="mb-2 flex items-baseline justify-between gap-2">
+          <div className="flex items-baseline gap-2">
+            <h2 className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              Fees, last 7d
+            </h2>
+            <span className="font-mono text-[11px] text-ink-muted">{fees.day_count} days</span>
+          </div>
+          <span className="font-mono text-[11px] tabular-nums text-ink-strong">
+            {latest == null ? "—" : formatTao(latest)}
+          </span>
         </div>
-        <span className="font-mono text-[11px] tabular-nums text-ink-strong">
-          {latest == null ? "—" : formatTao(latest)}
-        </span>
+        <Sparkline
+          values={values}
+          points={feeChrono.map((d) => ({ t: d.day, v: d.total_fee_tao }))}
+          width={640}
+          height={48}
+          color="var(--accent)"
+          ariaLabel="Daily total fees"
+          formatValue={formatTao}
+        />
       </div>
-      <Sparkline
-        values={values}
-        points={feeChrono.map((d) => ({ t: d.day, v: d.total_fee_tao }))}
-        width={640}
-        height={48}
-        color="var(--accent)"
-        ariaLabel="Daily total fees"
-        formatValue={formatTao}
-      />
-    </section>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -17,7 +17,7 @@ import {
   MiniStack,
   MiniRadial,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import { X, Search } from "lucide-react";
 import { IntegrabilityBoard } from "@/components/metagraphed/integrability-board";
@@ -260,7 +260,11 @@ function GapsKpiStrip() {
   const above75 = completeness.filter((r) => (r.completeness ?? 0) >= 0.75).length;
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-5 divide-x divide-border rounded-xl border border-border bg-card overflow-hidden">
+    <Panel
+      as="div"
+      flush
+      className="grid grid-cols-2 md:grid-cols-5 divide-x divide-border overflow-hidden"
+    >
       <StatWithSpark
         label="Open gaps"
         value={gaps.length}
@@ -321,7 +325,7 @@ function GapsKpiStrip() {
         full="Items the enrichment pipeline has flagged for human review or re-probe."
         updatedAt={queueRes.meta?.generated_at}
       />
-    </div>
+    </Panel>
   );
 }
 
@@ -992,7 +996,7 @@ function EnrichmentQueue() {
       />
     );
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel as="div" flush className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
@@ -1027,7 +1031,7 @@ function EnrichmentQueue() {
           </tbody>
         </table>
       </div>
-    </div>
+    </Panel>
   );
 }
 
@@ -1048,7 +1052,7 @@ function EnrichmentTargets() {
       />
     );
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel as="div" flush className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
@@ -1091,7 +1095,7 @@ function EnrichmentTargets() {
           </tbody>
         </table>
       </div>
-    </div>
+    </Panel>
   );
 }
 
@@ -1113,7 +1117,7 @@ function EnrichmentEvidence() {
       />
     );
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel as="div" flush className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
@@ -1160,7 +1164,7 @@ function EnrichmentEvidence() {
           </tbody>
         </table>
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -9,7 +9,7 @@ import { RefreshCw, Pause, Play, ChevronDown, ChevronRight, ArrowUpRight } from 
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { StaleBanner } from "@/components/metagraphed/states";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { IncidentCard } from "@/components/metagraphed/incident-card";
 import {
   HealthPill,
@@ -493,12 +493,14 @@ function StatusBoard({ interval }: { interval: number | false }) {
 
 function BoardCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-xl border border-border bg-card p-5">
-      <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-ink-muted mb-3">
-        {title}
+    <Panel as="div" flush>
+      <div className="p-5">
+        <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-ink-muted mb-3">
+          {title}
+        </div>
+        {children}
       </div>
-      {children}
-    </div>
+    </Panel>
   );
 }
 
@@ -540,7 +542,7 @@ function SourceHealth({ interval }: { interval: number | false }) {
     );
   }
   return (
-    <div className="rounded-xl border border-border bg-card overflow-x-auto">
+    <Panel as="div" flush className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead className="mg-type-micro bg-surface-2/60 text-[10px] text-ink-muted">
           <tr>
@@ -563,7 +565,7 @@ function SourceHealth({ interval }: { interval: number | false }) {
           ))}
         </tbody>
       </table>
-    </div>
+    </Panel>
   );
 }
 
@@ -689,7 +691,7 @@ function Incidents({ interval }: { interval: number | false }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-4 rounded-xl border border-border bg-card p-4">
+      <Panel as="div" dense bodyClassName="flex items-center gap-4">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-ink-muted">
             Incidents · 14d
@@ -706,7 +708,7 @@ function Incidents({ interval }: { interval: number | false }) {
           ariaLabel="Incidents over time"
           className="ml-auto"
         />
-      </div>
+      </Panel>
 
       <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
         {FILTER_OPTIONS.map((opt) => (

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -6,7 +6,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, ErrorState, Skeleton, StatUnavailable } from "@/components/metagraphed/states";
 import { statPhase, type StatPhase } from "@/lib/metagraphed/stat-phase";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { AsyncPanel } from "@/components/metagraphed/primitives";
+import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
 import {
   AccentBand,
   BrandIcon,
@@ -292,7 +292,7 @@ function OverviewPage() {
               title="Public, read-only, JSON-Schema canonical."
               description="Every list and detail view in this app is also a documented API route. Same data, same envelope."
             />
-            <div className="rounded-xl border border-border bg-card p-6 max-w-2xl">
+            <Panel as="div" className="max-w-2xl">
               <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted mb-2">
                 Try it
               </div>
@@ -314,7 +314,7 @@ function OverviewPage() {
                   OpenAPI spec
                 </a>
               </div>
-            </div>
+            </Panel>
           </section>
 
           <div className="mt-section-gap flex justify-center">
@@ -662,36 +662,38 @@ function PerfCard({
 }) {
   const hasSeries = phase === "ready" && !!series && series.length > 1;
   return (
-    <div className="rounded-xl border border-border bg-card p-5">
-      <div className="flex items-baseline justify-between mb-3">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          {label}
+    <Panel as="div" flush>
+      <div className="p-5">
+        <div className="flex items-baseline justify-between mb-3">
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            {label}
+          </div>
+          <div className="font-mono text-[10px] text-ink-muted">{hint}</div>
         </div>
-        <div className="font-mono text-[10px] text-ink-muted">{hint}</div>
-      </div>
-      <div
-        className={`font-display text-3xl md:text-4xl font-semibold leading-none tabular-nums ${accent ? "text-accent" : "text-ink-strong"}`}
-      >
-        {phase === "pending" ? (
-          <Skeleton className="h-9 w-24" />
-        ) : phase === "error" ? (
-          <StatUnavailable iconClassName="size-4" />
-        ) : (
-          value
-        )}
-      </div>
-      {hasSeries ? (
-        <div className="mt-4">
-          <Sparkline
-            values={series}
-            width={520}
-            height={56}
-            color={accent ? "var(--accent)" : "var(--ink-strong)"}
-            ariaLabel={label}
-          />
+        <div
+          className={`font-display text-3xl md:text-4xl font-semibold leading-none tabular-nums ${accent ? "text-accent" : "text-ink-strong"}`}
+        >
+          {phase === "pending" ? (
+            <Skeleton className="h-9 w-24" />
+          ) : phase === "error" ? (
+            <StatUnavailable iconClassName="size-4" />
+          ) : (
+            value
+          )}
         </div>
-      ) : null}
-    </div>
+        {hasSeries ? (
+          <div className="mt-4">
+            <Sparkline
+              values={series}
+              width={520}
+              height={56}
+              color={accent ? "var(--accent)" : "var(--ink-strong)"}
+              ariaLabel={label}
+            />
+          </div>
+        ) : null}
+      </div>
+    </Panel>
   );
 }
 
@@ -848,13 +850,13 @@ function PilotCard({
 
 function TableSkeleton() {
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel as="div" flush className="overflow-hidden">
       {Array.from({ length: 8 }).map((_, i) => (
         <div key={i} className="border-b border-border last:border-b-0 px-4 py-3">
           <Skeleton className="h-4 w-full" />
         </div>
       ))}
-    </div>
+    </Panel>
   );
 }
 
@@ -891,7 +893,7 @@ function SubnetPreviewTable() {
   const total = coverage?.netuids_active ?? coverage?.netuids_total;
 
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <Panel as="div" flush className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-left text-sm">
           <thead className="bg-surface/40 text-[10px] font-mono uppercase tracking-[0.18em] text-ink-muted">
@@ -973,7 +975,7 @@ function SubnetPreviewTable() {
           refresh
         </button>
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -7,7 +7,7 @@ import { ChevronDown, Download, Scale, UserMinus, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { RegistryLeaderboards } from "@/components/metagraphed/registry-leaderboards";
 import {
   BrandIcon,
@@ -314,7 +314,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
           lastChecked={board.observed_at ?? undefined}
         />
       ) : (
-        <section className="rounded-lg border border-border bg-card">
+        <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
             <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
               Per-subnet rankings
@@ -338,7 +338,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
               const subnet = subnetById.get(row.netuid);
               const name = subnet?.name ?? `Subnet ${row.netuid}`;
               return (
-                <div key={row.netuid} className="rounded border border-border bg-card p-3">
+                <Panel as="div" dense key={row.netuid}>
                   <div className="flex items-center justify-between gap-2">
                     <Link
                       to="/subnets/$netuid"
@@ -367,7 +367,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                     <span>{formatNumber(row.weight_sets)} weight-sets</span>
                     <span>{formatNumber(row.distinct_setters)} setters</span>
                   </div>
-                </div>
+                </Panel>
               );
             })}
           </div>
@@ -422,7 +422,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
               </tbody>
             </table>
           </div>
-        </section>
+        </Panel>
       )}
     </div>
   );
@@ -492,7 +492,7 @@ function EmissionsLeaderboard() {
           description="The economics snapshot has no per-subnet emission share for this network yet."
         />
       ) : (
-        <section className="rounded-lg border border-border bg-card">
+        <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
             <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
               Per-subnet rankings
@@ -506,7 +506,7 @@ function EmissionsLeaderboard() {
               const subnet = subnetById.get(row.netuid);
               const name = subnet?.name ?? row.name ?? `Subnet ${row.netuid}`;
               return (
-                <div key={row.netuid} className="rounded border border-border bg-card p-3">
+                <Panel as="div" dense key={row.netuid}>
                   <div className="flex items-center justify-between gap-2">
                     <Link
                       to="/subnets/$netuid"
@@ -529,7 +529,7 @@ function EmissionsLeaderboard() {
                       {pct(row.emission_share)}
                     </span>
                   </div>
-                </div>
+                </Panel>
               );
             })}
           </div>
@@ -576,7 +576,7 @@ function EmissionsLeaderboard() {
               </tbody>
             </table>
           </div>
-        </section>
+        </Panel>
       )}
     </div>
   );
@@ -633,7 +633,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
           lastChecked={board.observed_at ?? undefined}
         />
       ) : (
-        <section className="rounded-lg border border-border bg-card">
+        <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
             <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
               Per-subnet rankings
@@ -654,7 +654,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
               const subnet = subnetById.get(row.netuid);
               const name = subnet?.name ?? `Subnet ${row.netuid}`;
               return (
-                <div key={row.netuid} className="rounded border border-border bg-card p-3">
+                <Panel as="div" dense key={row.netuid}>
                   <div className="flex items-center justify-between gap-2">
                     <Link
                       to="/subnets/$netuid"
@@ -683,7 +683,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
                     <span>{formatNumber(row.deregistrations)} deregistrations</span>
                     <span>{formatNumber(row.distinct_deregistered_hotkeys)} hotkeys</span>
                   </div>
-                </div>
+                </Panel>
               );
             })}
           </div>
@@ -740,7 +740,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
               </tbody>
             </table>
           </div>
-        </section>
+        </Panel>
       )}
     </div>
   );

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, StaleBanner, RECOVERY } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   BrandIcon,
@@ -420,7 +421,7 @@ function BreakdownCard({ title, data }: { title: string; data: Record<string, nu
   if (entries.length === 0) return null;
   const max = Math.max(...entries.map((e) => e[1]));
   return (
-    <section className="rounded-lg border border-border bg-card p-4">
+    <Panel dense>
       <h3 className="font-display text-xs font-semibold uppercase tracking-wider text-ink-strong mb-2">
         {title}
       </h3>
@@ -440,7 +441,7 @@ function BreakdownCard({ title, data }: { title: string; data: Record<string, nu
           </li>
         ))}
       </ul>
-    </section>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -7,6 +7,7 @@ import { Globe, Github, BookOpen, Radio, Layers, Network } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner } from "@/components/metagraphed/states";
+import { Panel } from "@/components/metagraphed/primitives";
 import {
   AsyncPanel,
   FilterChipRow,
@@ -148,10 +149,7 @@ function ProvidersSkeleton() {
   return (
     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {Array.from({ length: 6 }).map((_, i) => (
-        <div
-          key={i}
-          className="rounded-lg border border-border bg-card p-4 animate-pulse h-[180px]"
-        >
+        <Panel as="div" dense className="animate-pulse h-[180px]" key={i}>
           <div className="flex items-start gap-3">
             <div className="size-9 rounded bg-surface" />
             <div className="flex-1 space-y-2">
@@ -161,7 +159,7 @@ function ProvidersSkeleton() {
             </div>
           </div>
           <div className="mt-4 h-8 rounded bg-surface" />
-        </div>
+        </Panel>
       ))}
     </div>
   );
@@ -731,7 +729,12 @@ function SourceHealthRollup() {
   const summary = useSuspenseQuery(sourceHealthProvidersQuery()).data.data.summary;
   const status = summary.status_counts;
   return (
-    <div className="mt-3 flex flex-wrap items-center gap-4 rounded border border-border bg-card p-3 font-mono text-[12px] tabular-nums">
+    <Panel
+      as="div"
+      dense
+      className="mt-3"
+      bodyClassName="flex flex-wrap items-center gap-4 font-mono text-[12px] tabular-nums"
+    >
       <span className="mg-label">Source health</span>
       <span className="text-health-ok">{status.ok ?? 0} ok</span>
       <span className="text-health-warn">{status.degraded ?? 0} degraded</span>
@@ -740,7 +743,7 @@ function SourceHealthRollup() {
       <span className="ml-auto text-ink-muted">
         {summary.provider_count ?? 0} providers · {summary.endpoint_count ?? 0} endpoints
       </span>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/routes/runtime.index.tsx
+++ b/apps/ui/src/routes/runtime.index.tsx
@@ -5,7 +5,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
 import { ShareButton, DownloadCsvButton, ActionBar, TableState, TimeAgo } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import {
   RuntimeUpgradeCardList,
   orderRuntimeUpgradesNewestFirst,
@@ -83,7 +83,7 @@ function RuntimeContent() {
         />
       ) : (
         <>
-          <div className="hidden md:block rounded-xl border border-border bg-card overflow-hidden">
+          <Panel as="div" flush className="hidden md:block overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead className="mg-type-micro bg-surface/50 text-[10px] text-ink-muted">
@@ -125,7 +125,7 @@ function RuntimeContent() {
                 </tbody>
               </table>
             </div>
-          </div>
+          </Panel>
           <RuntimeUpgradeCardList rows={rows} className="grid gap-3 sm:grid-cols-2 md:hidden" />
         </>
       )}
@@ -161,10 +161,12 @@ function PageHeroKpis({ history }: { history: RuntimeVersionHistory }) {
 
 function KpiTile({ label, value, hint }: { label: string; value: ReactNode; hint?: ReactNode }) {
   return (
-    <div className="rounded-xl border border-border bg-card px-4 py-3">
-      <div className="mg-type-micro text-[10px] text-ink-muted">{label}</div>
-      <div className="mt-1 font-mono text-lg text-ink-strong tabular-nums">{value}</div>
-      {hint ? <div className="mt-0.5 text-xs text-ink-muted">{hint}</div> : null}
-    </div>
+    <Panel as="div" flush>
+      <div className="px-4 py-3">
+        <div className="mg-type-micro text-[10px] text-ink-muted">{label}</div>
+        <div className="mt-1 font-mono text-lg text-ink-strong tabular-nums">{value}</div>
+        {hint ? <div className="mt-0.5 text-xs text-ink-muted">{hint}</div> : null}
+      </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -459,7 +459,7 @@ function SchemaExplorer() {
         </aside>
 
         {/* Right viewer */}
-        <section className="rounded-xl border border-border bg-card overflow-hidden min-h-[480px]">
+        <Panel as="section" flush className="overflow-hidden min-h-[480px]">
           {selected ? (
             <SchemaViewer schema={selected} />
           ) : (
@@ -470,7 +470,7 @@ function SchemaExplorer() {
               />
             </div>
           )}
-        </section>
+        </Panel>
       </div>
     </div>
   );

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -391,7 +391,7 @@ function RecentIncidents() {
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-3 rounded border border-border bg-card p-3">
+      <Panel as="div" dense bodyClassName="flex flex-wrap items-center gap-3">
         <div>
           <div className="mg-label">
             {ongoingCount > 0 ? "Active now" : "Downtime events · " + window}
@@ -429,7 +429,7 @@ function RecentIncidents() {
             </button>
           ))}
         </div>
-      </div>
+      </Panel>
 
       {surfaces.length === 0 ? (
         <EmptyState title="No sustained downtime in this window" />

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -23,6 +23,7 @@ import {
   AsyncPanel,
   CopyLinkButton,
   MobileCollapse,
+  Panel,
   ResponsiveTable,
 } from "@/components/metagraphed/primitives";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -753,7 +754,7 @@ function SubnetLineageSection({ netuid }: { netuid: number }) {
       subtitle={`Paired across networks — ${selfNetwork} ↔ ${counterpartNetwork}.`}
       info="Cross-network lineage links the testnet and mainnet deployments of the same subnet, matched by chain name or source repo."
     >
-      <section className="rounded-lg border border-border bg-card p-4 flex flex-wrap items-center justify-between gap-3">
+      <Panel dense bodyClassName="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
           <span className="mg-label">{counterpartNetwork} counterpart</span>
           <span className="font-display text-sm font-semibold text-ink-strong">
@@ -766,7 +767,7 @@ function SubnetLineageSection({ netuid }: { netuid: number }) {
             matched by {matchedBy}
           </span>
         ) : null}
-      </section>
+      </Panel>
     </SectionAnchor>
   );
 }
@@ -1431,7 +1432,7 @@ function AgentReadinessCard({
 }) {
   const tone = SERVICE_READINESS_TONE[tier ?? ""] ?? "text-ink-muted border-border";
   return (
-    <div className="rounded-lg border border-border bg-card p-4">
+    <Panel dense>
       <div className="flex flex-wrap items-center gap-3">
         <div>
           <div className="mg-label">Integration readiness</div>
@@ -1471,7 +1472,7 @@ function AgentReadinessCard({
           </ul>
         </div>
       ) : null}
-    </div>
+    </Panel>
   );
 }
 
@@ -1660,14 +1661,18 @@ function WeightsSummaryLoader({ netuid }: { netuid: number }) {
     // AccountWeightSettingSection (accounts.$ss58.tsx) already uses for its
     // sibling weight-setting KPI strip -- divide-y/divide-x swap with it so
     // the stacked cells still get a separator line at mobile.
-    <div className="mb-4 grid grid-cols-1 divide-y divide-border overflow-hidden rounded-xl border border-border bg-card sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+    <Panel
+      as="div"
+      flush
+      className="mb-4 grid grid-cols-1 divide-y divide-border overflow-hidden sm:grid-cols-3 sm:divide-x sm:divide-y-0"
+    >
       {cells.map((c) => (
         <div key={c.label} className="px-4 py-3">
           <div className="mg-type-micro text-[10px] text-ink-muted">{c.label}</div>
           <div className="mt-0.5 font-mono text-lg tabular-nums text-ink-strong">{c.value}</div>
         </div>
       ))}
-    </div>
+    </Panel>
   );
 }
 
@@ -1689,7 +1694,7 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
   const windowLabel = d.window ?? "30d";
   return (
     <div className="mt-6 min-w-0" data-weight-setters-leaderboard>
-      <div className="overflow-hidden rounded-xl border border-border bg-card">
+      <Panel flush className="overflow-hidden">
         <div className="flex flex-nowrap items-center justify-between gap-3 border-b border-border px-4 py-3">
           <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted sm:hidden">
             Weight-setters
@@ -1733,7 +1738,7 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
             </tbody>
           </table>
         </ResponsiveTable>
-      </div>
+      </Panel>
     </div>
   );
 }
@@ -1864,7 +1869,7 @@ function GapsList({ netuid }: { netuid: number }) {
     );
   }
   return (
-    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+    <Panel dense bodyClassName="space-y-3">
       {missing.length > 0 ? (
         <div>
           <div className="mg-label mb-1">Missing kinds</div>
@@ -1890,7 +1895,7 @@ function GapsList({ netuid }: { netuid: number }) {
       <div className="border-t border-border pt-2 text-[11px] text-ink-muted">
         Help close these gaps by opening a PR against the public registry repo.
       </div>
-    </div>
+    </Panel>
   );
 }
 
@@ -2178,7 +2183,7 @@ function HyperparamGroupsTable({ h }: { h: SubnetHyperparameters }) {
   return (
     <div className="space-y-6">
       {HYPERPARAM_GROUPS.map((group) => (
-        <div key={group.title} className="rounded-xl border border-border bg-card">
+        <Panel as="div" flush key={group.title}>
           <div className="border-b border-border px-4 py-2.5">
             <h3 className="font-display text-sm font-semibold text-ink-strong">{group.title}</h3>
           </div>
@@ -2190,7 +2195,7 @@ function HyperparamGroupsTable({ h }: { h: SubnetHyperparameters }) {
               </div>
             ))}
           </div>
-        </div>
+        </Panel>
       ))}
     </div>
   );

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -16,6 +16,7 @@ import {
   ProvenanceChip,
   QueryBar,
   QueryProgress,
+  Panel,
   ReadinessGauge,
   StatusBadge,
   StickyToolbar,
@@ -1507,7 +1508,7 @@ const HEALTH_TEXT: Record<string, string> = {
 
 function SubnetMatrix({ rows }: { rows: Subnet[] }) {
   return (
-    <div className="rounded border border-border bg-card p-4">
+    <Panel as="div" dense>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div className="mg-type-micro text-[10px] text-ink-muted">
           Health matrix · {rows.length} subnets
@@ -1541,7 +1542,7 @@ function SubnetMatrix({ rows }: { rows: Subnet[] }) {
           </EntityHoverCard>
         ))}
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -6,6 +6,7 @@ import {
   AsyncPanel,
   FilterChipRow,
   FilterSheet,
+  Panel,
   QueryBar,
   QueryProgress,
   PageMasthead,
@@ -467,7 +468,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
   };
 
   const cardFor = (s: Surface) => (
-    <div key={s.id} className="rounded border border-border bg-card p-3 min-h-11">
+    <Panel as="div" dense key={s.id} className="min-h-11">
       <div className="flex items-center justify-between gap-2">
         <span className="mg-label">{s.kind ?? "surface"}</span>
         <div className="flex items-center gap-1.5">
@@ -513,7 +514,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
           <TimeAgo at={s.last_verified_at} fallback="never verified" />
         </SparkLegend>
       </div>
-    </div>
+    </Panel>
   );
 
   // The user-selectable grid view renders the cards at every breakpoint, so it

--- a/apps/ui/src/routes/tools.ss58.tsx
+++ b/apps/ui/src/routes/tools.ss58.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { CheckCircle2, XCircle, AlertTriangle } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyableCode } from "@jsonbored/ui-kit";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import { PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { decodeSs58, DEFAULT_SS58_FORMAT } from "@/lib/metagraphed/ss58";
 import { classNames } from "@/lib/metagraphed/format";
 
@@ -136,24 +136,27 @@ function Ss58ToolPage() {
           </ResultCard>
         ) : null}
 
-        <section className="rounded-lg border border-border bg-card p-5 text-[13px] leading-relaxed text-ink-muted">
-          <h2 className="mb-2 font-display text-sm font-semibold text-ink-strong">
-            How this works
-          </h2>
-          <p>
-            An SS58 address is{" "}
-            <code className="font-mono text-ink-strong">
-              base58(prefix || public_key || checksum)
-            </code>{" "}
-            — a network-prefix byte, the 32-byte sr25519/ed25519 public key, and a 2-byte checksum
-            (the first 2 bytes of a blake2b-512 hash over{" "}
-            <code className="font-mono text-ink-strong">"SS58PRE" || prefix || public_key</code>),
-            all base58-encoded. The same public key produces a different address string per network
-            — Bittensor's hotkeys and coldkeys use prefix 42 (&quot;generic Substrate&quot;), the
-            same prefix several other chains without a dedicated allocation also use. Decoding and
-            checksum verification happen entirely client-side; this page makes no network requests.
-          </p>
-        </section>
+        <Panel as="section" flush bodyClassName="text-[13px] leading-relaxed text-ink-muted">
+          <div className="p-5">
+            <h2 className="mb-2 font-display text-sm font-semibold text-ink-strong">
+              How this works
+            </h2>
+            <p>
+              An SS58 address is{" "}
+              <code className="font-mono text-ink-strong">
+                base58(prefix || public_key || checksum)
+              </code>{" "}
+              — a network-prefix byte, the 32-byte sr25519/ed25519 public key, and a 2-byte checksum
+              (the first 2 bytes of a blake2b-512 hash over{" "}
+              <code className="font-mono text-ink-strong">"SS58PRE" || prefix || public_key</code>),
+              all base58-encoded. The same public key produces a different address string per
+              network — Bittensor's hotkeys and coldkeys use prefix 42 (&quot;generic
+              Substrate&quot;), the same prefix several other chains without a dedicated allocation
+              also use. Decoding and checksum verification happen entirely client-side; this page
+              makes no network requests.
+            </p>
+          </div>
+        </Panel>
       </div>
     </AppShell>
   );


### PR DESCRIPTION
## Summary

Sweeps `apps/ui/src` for the remaining ad-hoc `rounded border border-border bg-card` card shells and wraps them in the `Panel` primitive (`components/metagraphed/primitives/panel.tsx`), following the same conversion heuristics used in the earlier Phase 11 batches:

- `p-3`/`p-4` → `dense`; no padding / p-6 → default; asymmetric or non-token padding (e.g. `p-5`, `px-4 py-3`) → `flush` + a literal inner padded div (avoids relying on cascade order between `mg-panel-pad-flush` and a utility padding class)
- Extra layout classes alongside a padding token → `bodyClassName`; classes affecting the outer box (margin, sizing, `overflow-hidden`) → `className`
- Rounded-radius variance (`rounded-md`/`-lg`/`-xl`/`-2xl` → `rounded`) is accepted as normalization toward Panel's fixed radius

Also tightened the `no-restricted-syntax` Panel-shell guardrail in `eslint.config.js`: the old selector (`Literal[value=/regex/]`) matched buttons/links/inputs/existing-styled-components and `mg-card-glow`-tagged divs with zero AST context. It's now scoped to plain `<div>`/`<section>` className literals only, cutting the flagged count from 357 to a genuine ~0 (see below).

## What's left as-is (deliberate skips)

A residual ~31 sites across 26 files are **not** converted, each for a structural reason Panel can't accommodate:
- `role="tablist"`/`"radiogroup"` segmented controls
- `bg-card/NN` translucent variants (a distinct visual treatment from Panel's opaque `bg-card`)
- Elements needing `id`, `aria-label`, `data-testid`, `role`, or `aria-live` — Panel has no rest-props spread, so it can't forward arbitrary HTML attributes
- Tone-mismatched borders (Panel's tone enum has no "ok" tone, and `warn`/`down` also tint the background, which some components deliberately avoid)

These are still flagged by the (now-correctly-scoped) lint rule as warnings, which is intentional — they're a visible worklist, not a bug.

## Verification

- `tsc --noEmit`, full `eslint src` (0 errors, only pre-existing warnings from unrelated rules), full `vitest run` (1399/1399 passing) after every batch and after rebasing onto latest `main`
- Spot-checked in a live browser: homepage, `/schemas` (contracts list + schema explorer + right viewer), `/tools/ss58` (methodology section), `/surfaces` (table + grid card view), `/explorer` (Stake tab, mobile stake-transfers card list), `/extrinsics` (fees trend card) — all render with correct padding/radius/content, 0 console errors

Part of #7809.