### PR TITLE
refactor(ui): adopt mg-type-micro/mg-type-label for ad-hoc eyebrow labels (batch 1)

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -78,7 +78,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
     <Panel as="div" flush className="overflow-hidden">
       {/* Header */}
       <div className="flex flex-wrap items-center gap-3 border-b border-border bg-paper/40 px-4 py-2.5">
-        <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <div className="flex items-center gap-2 mg-type-micro text-ink-muted">
           <span
             className="inline-flex size-1.5 rounded-full bg-health-warn animate-pulse"
             aria-hidden
@@ -104,7 +104,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
                 aria-selected={on}
                 onClick={() => setScope(v)}
                 className={classNames(
-                  "rounded px-2 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                  "rounded px-2 py-1 mg-type-micro transition-colors",
                   on ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
                 )}
               >
@@ -137,7 +137,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
             <button
               type="button"
               onClick={() => setShowAllDrift((v) => !v)}
-              className="flex w-full items-center justify-center gap-1 border-t border-border/60 px-4 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:bg-surface hover:text-ink-strong"
+              className="flex w-full items-center justify-center gap-1 border-t border-border/60 px-4 py-2 mg-type-micro text-ink-muted hover:bg-surface hover:text-ink-strong"
             >
               {showAllDrift ? "Show recent only" : `Show all ${drifting.length} drifting`}
             </button>
@@ -148,7 +148,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
       {/* Stable list (toggled) */}
       {visibleStable.length > 0 ? (
         <div className="border-t border-border bg-paper/30">
-          <div className="px-4 pt-3 pb-1.5 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
+          <div className="px-4 pt-3 pb-1.5 mg-type-micro text-ink-muted">
             stable · {visibleStable.length}
           </div>
           <ul className="divide-y divide-border/40">
@@ -190,12 +190,12 @@ function DriftRow({ schema, onClick }: { schema: SchemaInfo; onClick: () => void
               {label}
             </span>
             {schema.netuid != null ? (
-              <span className="shrink-0 rounded-full border border-border bg-paper px-1.5 py-0.5 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
+              <span className="shrink-0 rounded-full border border-border bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted">
                 SN{schema.netuid}
               </span>
             ) : null}
             {schema.drift_status ? (
-              <span className="shrink-0 rounded-full border border-health-warn/30 bg-health-warn/10 px-1.5 py-0.5 font-mono text-[9.5px] uppercase tracking-widest text-health-warn">
+              <span className="shrink-0 rounded-full border border-health-warn/30 bg-health-warn/10 px-1.5 py-0.5 mg-type-micro text-health-warn">
                 {schema.drift_status}
               </span>
             ) : null}
@@ -238,9 +238,7 @@ function StableRow({ schema, onClick }: { schema: SchemaInfo; onClick: () => voi
           {label}
         </span>
         {schema.netuid != null ? (
-          <span className="shrink-0 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted/70">
-            SN{schema.netuid}
-          </span>
+          <span className="shrink-0 mg-type-micro text-ink-muted/70">SN{schema.netuid}</span>
         ) : null}
         <ChevronRight className="ml-auto size-3.5 text-ink-muted opacity-0 transition-opacity group-hover:opacity-60" />
       </button>

--- a/apps/ui/src/components/metagraphed/api-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/api-drawer.tsx
@@ -103,7 +103,7 @@ export function ApiDrawer() {
                 type="button"
                 onClick={() => setActivePath(s.path)}
                 className={classNames(
-                  "rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                  "rounded-full border px-2.5 py-1 mg-type-micro transition-colors",
                   activePath === s.path
                     ? "border-accent/60 bg-accent/10 text-ink-strong"
                     : "border-border text-ink-muted hover:text-ink-strong",
@@ -160,12 +160,10 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
   return (
     <div className="p-4 space-y-4">
       <section className="space-y-2">
-        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-          Request
-        </div>
+        <div className="mg-type-micro text-ink-muted">Request</div>
         <Panel as="div" flush>
           <div className="p-3 font-mono text-[12px] text-ink-strong break-all flex items-start gap-2">
-            <span className="shrink-0 rounded bg-curation-verified/15 text-curation-verified px-1.5 py-0.5 text-[10px] uppercase tracking-widest">
+            <span className="shrink-0 rounded bg-curation-verified/15 text-curation-verified px-1.5 py-0.5 mg-type-micro">
               GET
             </span>
             <span className="min-w-0 flex-1">{fullUrl}</span>
@@ -188,7 +186,7 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
 
       <section className="space-y-2">
         <div className="flex items-center justify-between">
-          <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          <div className="mg-type-micro text-ink-muted">
             Response
             {data?.meta?.cache ? ` · ${data.meta.cache}` : null}
           </div>
@@ -196,7 +194,7 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
             type="button"
             onClick={() => refetch()}
             disabled={isFetching}
-            className="font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong disabled:opacity-50 inline-flex items-center gap-1"
+            className="mg-type-micro text-ink-muted hover:text-ink-strong disabled:opacity-50 inline-flex items-center gap-1"
           >
             {isFetching ? <Loader2 className="size-3 animate-spin" /> : null}
             refetch

--- a/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
@@ -96,14 +96,10 @@ export function EconomicsMini({ netuid }: Props) {
         >
           <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1.5 px-4 py-2.5 border-b border-border bg-paper/30">
             <div className="flex items-center gap-3 min-w-0">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Alpha price
-              </span>
+              <span className="mg-type-micro text-ink-muted">Alpha price</span>
               <span className="font-display text-base font-semibold tabular-nums text-ink-strong">
                 {price != null ? `${price.toFixed(6)}` : "—"}
-                <span className="ml-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                  TAO
-                </span>
+                <span className="ml-1 mg-type-micro text-ink-muted">TAO</span>
               </span>
             </div>
             {ratio != null ? (
@@ -124,17 +120,13 @@ export function EconomicsMini({ netuid }: Props) {
               />
               <div className="grid flex-1 grid-cols-2 gap-3">
                 <div className="min-w-0">
-                  <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-                    Alpha in pool
-                  </div>
+                  <div className="mg-type-micro text-ink-muted">Alpha in pool</div>
                   <div className="mt-1 break-words font-display text-lg font-semibold tabular-nums text-ink-strong">
                     {formatNumber(inP)}
                   </div>
                 </div>
                 <div className="min-w-0">
-                  <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-                    Alpha out pool
-                  </div>
+                  <div className="mg-type-micro text-ink-muted">Alpha out pool</div>
                   <div className="mt-1 break-words font-display text-lg font-semibold tabular-nums text-ink-strong">
                     {formatNumber(outP)}
                   </div>
@@ -150,7 +142,7 @@ export function EconomicsMini({ netuid }: Props) {
       </DialogTrigger>
       <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto bg-card p-0">
         <DialogHeader className="border-b border-border bg-paper/40 p-4 pr-12">
-          <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          <div className="flex items-center gap-2 mg-type-micro text-ink-muted">
             <BarChart3 className="size-3.5 text-accent" /> Subnet {netuid} economics
           </div>
           <DialogTitle className="font-display text-2xl text-ink-strong">
@@ -205,7 +197,7 @@ function EconomicsDrilldown({
         />
       </div>
       <div className="mt-4 rounded-xl border border-border bg-paper/30 p-4">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2 mg-type-micro text-ink-muted">
           <span>Pool composition</span>
           <span>SN{netuid}</span>
         </div>
@@ -237,7 +229,7 @@ function DeltaTile({ label, value, tip }: { label: string; value: string; tip?: 
       title={tip}
       aria-label={tip ? `${label}: ${value}. ${tip}` : `${label}: ${value}`}
     >
-      <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">{label}</div>
+      <div className="mg-type-micro text-ink-muted">{label}</div>
       <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong">
         {value}
       </div>
@@ -257,9 +249,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
     <Panel as="div" flush className="overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1.5 border-b border-border bg-paper/30 px-4 py-2.5">
         <div className="flex items-center gap-3 min-w-0">
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            No alpha pool registered
-          </span>
+          <span className="mg-type-micro text-ink-muted">No alpha pool registered</span>
           <span className="font-display text-base font-semibold tabular-nums text-ink-strong">
             SN{netuid}
           </span>
@@ -269,7 +259,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
       {uptime.length > 1 ? (
         <div className="grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)] divide-x divide-border">
           <div className="p-3">
-            <div className="mb-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            <div className="mb-1 mg-type-micro text-ink-muted">
               Uptime trend · {uptime.length} days
             </div>
             <div className="h-[88px] w-full">
@@ -285,9 +275,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
           </div>
           <div className="grid grid-rows-1 divide-y divide-border">
             <div className="p-3">
-              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Latest uptime
-              </div>
+              <div className="mg-type-micro text-ink-muted">Latest uptime</div>
               <div className="mt-1 font-display text-lg font-semibold tabular-nums text-ink-strong">
                 {lastUp != null ? `${lastUp.toFixed(2)}%` : "—"}
               </div>

--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -169,13 +169,13 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
           >
             <thead>
               <tr>
-                <th className="sticky left-0 z-10 bg-card text-left px-3 py-2 text-[10px] uppercase tracking-widest text-ink-muted border-b border-border">
+                <th className="sticky left-0 z-10 bg-card text-left px-3 py-2 mg-type-micro text-ink-muted border-b border-border">
                   Provider
                 </th>
                 {kinds.map((k) => (
                   <th
                     key={k}
-                    className="px-2 py-2 text-[10px] uppercase tracking-widest text-ink-muted border-b border-border"
+                    className="px-2 py-2 mg-type-micro text-ink-muted border-b border-border"
                   >
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -343,7 +343,7 @@ function Cell({ cell }: { cell: Cell }) {
                     category: KIND_TO_CATEGORY[cell.kind] ?? "all",
                   } as never
                 }
-                className="sm:ml-auto inline-flex items-center gap-1 rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-accent hover:border-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
+                className="sm:ml-auto inline-flex items-center gap-1 rounded border border-border bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
                 aria-label={`Open endpoints filtered to ${cell.provider} ${cell.kind}`}
               >
                 <Filter className="size-3" /> filter endpoints
@@ -407,7 +407,7 @@ function Cell({ cell }: { cell: Cell }) {
 function ChipGroup({ label, id, children }: { label: string; id: string; children: ReactNode }) {
   return (
     <div>
-      <div id={id} className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted mb-1">
+      <div id={id} className="mg-type-micro text-ink-muted mb-1">
         {label}
       </div>
       <div className="flex flex-wrap gap-1.5" role="list" aria-labelledby={id}>
@@ -421,7 +421,7 @@ function CellStat({ label, value, color }: { label: string; value: number; color
   return (
     <div className="rounded border border-border bg-paper px-2 py-1 text-center" role="listitem">
       <div className={classNames("tabular-nums text-[12px] font-semibold", color)}>{value}</div>
-      <div className="uppercase tracking-widest text-[9px] text-ink-muted">{label}</div>
+      <div className="mg-type-micro text-ink-muted">{label}</div>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -213,7 +213,7 @@ function DriftCard({ netuid }: { netuid: number }) {
           aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
-            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
             w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
           )}
         >
@@ -294,7 +294,7 @@ function DriftRow({
   const last = series[series.length - 1];
   return (
     <div className="grid grid-cols-1 gap-1 min-[400px]:grid-cols-[minmax(0,7rem)_1fr_auto] min-[400px]:items-center min-[400px]:gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-wider text-ink-muted">{label}</span>
+      <span className="mg-type-label uppercase text-ink-muted">{label}</span>
       <div className="min-w-0">
         <Sparkline
           values={series}
@@ -442,7 +442,7 @@ function RewardDriftCard({ netuid }: { netuid: number }) {
           aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
-            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
             w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
           )}
         >
@@ -534,7 +534,7 @@ export function DistributionPanel({ netuid }: { netuid: number }) {
             type="button"
             onClick={() => setView(t.id)}
             className={classNames(
-              "px-3 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+              "px-3 py-1 mg-type-label uppercase rounded transition-colors",
               view === t.id ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
             )}
           >

--- a/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
@@ -50,14 +50,12 @@ export function EndpointComparePanel({
           <span className="font-display text-[12px] font-medium text-ink-strong">
             Compare — {endpoints.length} endpoint{endpoints.length === 1 ? "" : "s"}
           </span>
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            side-by-side
-          </span>
+          <span className="mg-type-micro text-ink-muted">side-by-side</span>
         </div>
         <button
           type="button"
           onClick={onClear}
-          className="mg-focus-ring rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+          className="mg-focus-ring rounded px-1.5 py-0.5 mg-type-micro text-ink-muted hover:text-ink-strong"
         >
           Clear all
         </button>
@@ -191,9 +189,7 @@ function CompareColumn({
           </span>
         </Field>
         <Field label="Access">
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            {ELIGIBILITY_LABEL[eligibility]}
-          </span>
+          <span className="mg-type-micro text-ink-muted">{ELIGIBILITY_LABEL[eligibility]}</span>
         </Field>
         <Field label="Incidents (retained)">
           <span
@@ -211,7 +207,7 @@ function CompareColumn({
           </span>
         </Field>
         <Field label="Region · Kind">
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          <span className="mg-type-micro text-ink-muted">
             {endpoint.region ?? "global"} · {endpoint.kind ?? "endpoint"}
           </span>
         </Field>
@@ -232,7 +228,7 @@ function CompareColumn({
               formatValue={(v) => `${Math.round(v)}ms`}
             />
           ) : (
-            <div className="flex h-full items-center justify-center font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            <div className="flex h-full items-center justify-center mg-type-micro text-ink-muted">
               Collecting samples…
             </div>
           )}

--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -70,7 +70,7 @@ export function EndpointList({
       <Panel as="div" flush className="hidden md:block overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
-            <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <thead className="bg-surface/50 mg-type-micro text-ink-muted">
               <tr>
                 {showNetuid ? <th className="px-4 py-2.5 text-left w-16">SN</th> : null}
                 <th className="px-4 py-2.5 text-left">Resource</th>
@@ -113,7 +113,7 @@ export function EndpointList({
       <div className="md:hidden space-y-4">
         {groups.map((g) => (
           <div key={g.category}>
-            <div className="px-1 mb-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted flex items-center justify-between">
+            <div className="px-1 mb-1.5 mg-type-micro text-ink-muted flex items-center justify-between">
               <span>{CATEGORY_LABEL[g.category]}</span>
               <span className="tabular-nums">{g.items.length}</span>
             </div>
@@ -154,10 +154,7 @@ function GroupBlock({
   return (
     <>
       <tr className={classNames("bg-surface/30", !isFirst && "border-t border-border")}>
-        <td
-          colSpan={colSpan}
-          className="px-4 py-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted"
-        >
+        <td colSpan={colSpan} className="px-4 py-1.5 mg-type-micro text-ink-muted">
           <span className="text-ink-strong">{CATEGORY_LABEL[category]}</span>
           <span className="ml-2 tabular-nums">· {items.length}</span>
         </td>
@@ -320,9 +317,7 @@ function MobileCard({
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 mb-1">
-            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              {e.kind ?? "endpoint"}
-            </span>
+            <span className="mg-type-micro text-ink-muted">{e.kind ?? "endpoint"}</span>
             {showNetuid && e.netuid != null ? (
               <Link
                 to="/subnets/$netuid"
@@ -341,9 +336,7 @@ function MobileCard({
       <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 border-t border-border pt-2 text-[11px]">
         {showProvider ? (
           <>
-            <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              Provider
-            </dt>
+            <dt className="mg-type-micro text-ink-muted">Provider</dt>
             <dd className="text-right">
               {e.provider ? (
                 <Link
@@ -366,11 +359,11 @@ function MobileCard({
             </dd>
           </>
         ) : null}
-        <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">Latency</dt>
+        <dt className="mg-type-micro text-ink-muted">Latency</dt>
         <dd className="text-right font-mono text-ink tabular-nums">
           {e.latency_ms != null ? `${e.latency_ms}ms` : "—"}
         </dd>
-        <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">Probed</dt>
+        <dt className="mg-type-micro text-ink-muted">Probed</dt>
         <dd className="text-right font-mono text-ink-muted">
           <TimeAgo at={e.last_probed_at} />
         </dd>
@@ -380,7 +373,7 @@ function MobileCard({
           <button
             type="button"
             onClick={() => copy(e.url!)}
-            className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 text-[10px] font-mono uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-accent/40"
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong hover:border-accent/40"
           >
             <CopyIconToggle copied={copied} /> copy
           </button>
@@ -389,7 +382,7 @@ function MobileCard({
               href={safeUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 text-[10px] font-mono uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-accent/40"
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong hover:border-accent/40"
             >
               open <ExternalLinkIcon className="size-3" />
             </a>

--- a/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
@@ -156,13 +156,13 @@ export function EndpointOperationalList({
                   <Link
                     to="/subnets/$netuid"
                     params={{ netuid: group.netuid }}
-                    className="mg-focus-ring font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-accent-text"
+                    className="mg-focus-ring mg-type-micro text-ink-muted hover:text-accent-text"
                   >
                     Open subnet →
                   </Link>
                 ) : null}
               </div>
-              <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <div className="flex items-center gap-2 mg-type-micro text-ink-muted">
                 {okCount ? <span className="text-health-ok">{okCount} live</span> : null}
                 {warnCount ? <span className="text-health-warn-text">{warnCount} warn</span> : null}
                 {downCount ? <span className="text-health-down">{downCount} down</span> : null}
@@ -200,7 +200,7 @@ export function EndpointOperationalList({
                       />
                       {onToggleCompare ? (
                         <label
-                          className="absolute left-2 top-2 z-10 flex items-center gap-1 rounded border border-border bg-paper/85 px-1 py-0.5 font-mono text-[9px] uppercase tracking-widest text-ink-muted backdrop-blur hover:text-ink-strong"
+                          className="absolute left-2 top-2 z-10 flex items-center gap-1 rounded border border-border bg-paper/85 px-1 py-0.5 mg-type-micro text-ink-muted backdrop-blur hover:text-ink-strong"
                           onClick={(e) => e.stopPropagation()}
                           title={
                             compareIds?.has(endpoint.id)
@@ -253,7 +253,7 @@ export function EndpointOperationalList({
                         >
                           {/* Headline: kind chip + URL as h4 */}
                           <div className="min-w-0">
-                            <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                            <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 mg-type-micro text-ink-muted">
                               <span className="text-ink-strong">{endpoint.kind ?? "endpoint"}</span>
                               <span className="text-ink-subtle-text" aria-hidden>
                                 ·
@@ -335,9 +335,7 @@ export function EndpointOperationalList({
                                   : "—"}
                               </span>
                               {endpoint.latency_ms != null ? (
-                                <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                                  ms
-                                </span>
+                                <span className="mg-type-micro text-ink-muted">ms</span>
                               ) : null}
                             </div>
                             <div className="mt-1.5 h-[18px]">

--- a/apps/ui/src/components/metagraphed/entity-hover-card.tsx
+++ b/apps/ui/src/components/metagraphed/entity-hover-card.tsx
@@ -102,7 +102,7 @@ function SubnetMiniProfile({ netuid }: { netuid: number }) {
           netuid={netuid}
         />
         <div className="min-w-0 flex-1">
-          <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
+          <div className="mg-type-micro text-ink-muted">
             SN{netuid}
             {s.symbol ? ` · ${s.symbol}` : ""}
           </div>
@@ -157,9 +157,7 @@ function ProviderMiniProfile({ slug }: { slug: string }) {
           repoUrl={p.repo}
         />
         <div className="min-w-0 flex-1">
-          <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
-            {p.kind ?? "provider"}
-          </div>
+          <div className="mg-type-micro text-ink-muted">{p.kind ?? "provider"}</div>
           <div className="font-display text-sm font-semibold text-ink-strong truncate">
             {p.name ?? slug}
           </div>
@@ -187,7 +185,7 @@ function AccountMiniProfile({ ss58 }: { ss58: string }) {
   return (
     <div className="space-y-2">
       <div className="min-w-0">
-        <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">account</div>
+        <div className="mg-type-micro text-ink-muted">account</div>
         <div className="font-mono text-[10px] text-ink-muted truncate">{ss58}</div>
       </div>
       <dl className="grid grid-cols-2 gap-2 pt-1">
@@ -206,7 +204,7 @@ function AccountMiniProfile({ ss58 }: { ss58: string }) {
 function Mini({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="rounded border border-border/60 bg-paper/40 px-2 py-1">
-      <dt className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">{label}</dt>
+      <dt className="mg-type-micro text-ink-muted">{label}</dt>
       <dd className="font-mono text-[12px] text-ink-strong truncate">{value}</dd>
     </div>
   );
@@ -222,9 +220,5 @@ function Loading() {
   );
 }
 function Failed() {
-  return (
-    <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-      Preview unavailable
-    </div>
-  );
+  return <div className="mg-type-micro text-ink-muted">Preview unavailable</div>;
 }

--- a/apps/ui/src/components/metagraphed/move-stake-destination-input.tsx
+++ b/apps/ui/src/components/metagraphed/move-stake-destination-input.tsx
@@ -75,9 +75,7 @@ export function MoveStakeDestinationInput({
       </div>
 
       <div className="flex flex-col gap-1">
-        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-          Destination hotkey
-        </span>
+        <span className="mg-type-micro text-ink-muted">Destination hotkey</span>
         <SearchInput
           value={destinationHotkeyInput}
           onChange={onDestinationHotkeyChange}
@@ -87,9 +85,7 @@ export function MoveStakeDestinationInput({
       </div>
 
       <div className="flex flex-col gap-1">
-        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-          Destination subnet
-        </span>
+        <span className="mg-type-micro text-ink-muted">Destination subnet</span>
         <select
           value={destinationNetuidInput}
           onChange={(e) => onDestinationNetuidChange(e.target.value)}
@@ -106,9 +102,7 @@ export function MoveStakeDestinationInput({
 
       <div className="flex flex-wrap items-end gap-3">
         <div className="flex flex-col gap-1">
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            Amount (α)
-          </span>
+          <span className="mg-type-micro text-ink-muted">Amount (α)</span>
           <SearchInput
             value={amountInput}
             onChange={onAmountInputChange}
@@ -121,7 +115,7 @@ export function MoveStakeDestinationInput({
           type="button"
           onClick={onApplyMax}
           disabled={maxAmountInput == null}
-          className="min-h-8 rounded border border-border bg-card px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
+          className="min-h-8 rounded border border-border bg-card px-3 py-1.5 mg-type-label uppercase text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
         >
           Max
         </button>

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -155,12 +155,10 @@ export function NeuronTable({
       </ul>
       <div className="hidden overflow-x-auto md:block">
         <table className="w-full text-sm">
-          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="bg-surface/50 mg-type-micro text-ink-muted">
             <tr>
               {col("uid", "UID", "left")}
-              <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
-                Hotkey
-              </th>
+              <th className="px-3 py-2.5 text-left mg-type-micro">Hotkey</th>
               {col("stake_tao", "Stake τ")}
               {col("emission_tao", "Emission τ")}
               {isValidator ? (
@@ -168,9 +166,7 @@ export function NeuronTable({
                   {col("dividends", "Dividends")}
                   {col("validator_trust", "Val Trust")}
                   {col("take", "Take")}
-                  <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
-                    Est. APY
-                  </th>
+                  <th className="px-3 py-2.5 text-right mg-type-micro">Est. APY</th>
                 </>
               ) : (
                 <>
@@ -179,13 +175,9 @@ export function NeuronTable({
                   {col("consensus", "Consensus")}
                 </>
               )}
-              <th className="px-3 py-2.5 text-center font-mono text-[10px] uppercase tracking-widest">
-                Permit
-              </th>
+              <th className="px-3 py-2.5 text-center mg-type-micro">Permit</th>
               {isValidator ? (
-                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
-                  Delegate
-                </th>
+                <th className="px-3 py-2.5 text-right mg-type-micro">Delegate</th>
               ) : null}
             </tr>
           </thead>
@@ -315,7 +307,7 @@ export function NeuronTable({
           </tbody>
         </table>
       </div>
-      <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 flex flex-wrap items-center justify-between gap-2 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+      <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 flex flex-wrap items-center justify-between gap-2 mg-type-micro text-ink-muted">
         <span>
           {sorted.length} {sorted.length === 1 ? "neuron" : "neurons"} · subnet {netuid}
         </span>
@@ -357,7 +349,7 @@ function NeuronCard({
     <li className={classNames("min-w-0 space-y-2 p-3", active && "bg-accent-surface")}>
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 font-mono text-[12px] tabular-nums text-ink-strong">
-          <span className="text-[10px] uppercase tracking-widest text-ink-muted">UID</span>
+          <span className="mg-type-micro text-ink-muted">UID</span>
           {onSelect ? (
             <button
               type="button"

--- a/apps/ui/src/components/metagraphed/operational-panel.tsx
+++ b/apps/ui/src/components/metagraphed/operational-panel.tsx
@@ -177,15 +177,13 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
 
           {!filter.isAll ? (
             <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-border bg-paper/40">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Filtering resources
-              </span>
+              <span className="mg-type-micro text-ink-muted">Filtering resources</span>
               {(["ok", "warn", "down", "unknown"] as Severity[])
                 .filter((s) => filter.isActive(s))
                 .map((s) => (
                   <span
                     key={s}
-                    className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-strong"
+                    className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2 py-0.5 mg-type-micro text-ink-strong"
                   >
                     {s}
                   </span>
@@ -193,7 +191,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
               <button
                 type="button"
                 onClick={filter.reset}
-                className="ml-auto inline-flex items-center gap-1 rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+                className="ml-auto inline-flex items-center gap-1 rounded border border-border bg-card px-1.5 py-0.5 mg-type-micro text-ink-muted hover:text-ink-strong"
               >
                 <X className="size-3" /> clear
               </button>
@@ -205,7 +203,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
           {endpoints.length > 0 ? (
             <div className="border-b border-border px-4 py-3">
               <div className="mb-2 flex items-center justify-between gap-2">
-                <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                <span className="inline-flex items-center gap-1.5 mg-type-micro text-ink-muted">
                   Endpoint mosaic · {endpoints.length}
                   <InfoTooltip label="One cell per tracked endpoint, colored by the last probe result: ok (2xx within latency budget), warn (slow / intermittent 5xx), down (consecutive failures), or unknown (no probe in window). Source: /api/v1/subnets/{netuid}/endpoints joined with /health. Stale snapshots still render — check the panel's `updated` stamp." />
                 </span>
@@ -250,9 +248,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
             <div className="min-w-0 border-b lg:border-b-0 lg:border-r border-border">
               <div className="flex items-center justify-between gap-2 border-b border-border bg-paper/40 px-4 py-2">
                 <div>
-                  <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
-                    Health trend
-                  </div>
+                  <div className="mg-type-micro text-ink-strong">Health trend</div>
                   <div className="font-mono text-[9.5px] text-ink-muted/80">
                     uptime &amp; latency over the selected window, with incident markers
                     {healthRes?.meta?.generated_at
@@ -266,9 +262,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
             </div>
             <div className="min-w-0 p-4 space-y-3">
               <div className="flex items-center justify-between">
-                <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                  Recent incidents
-                </span>
+                <span className="mg-type-micro text-ink-muted">Recent incidents</span>
                 <a
                   href="#incidents"
                   onClick={(e) => {
@@ -277,7 +271,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                       .getElementById("incidents")
                       ?.scrollIntoView({ behavior: "smooth", block: "start" });
                   }}
-                  className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-accent"
+                  className="inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-accent"
                 >
                   all <ArrowRight className="size-3" />
                 </a>
@@ -290,9 +284,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                 />
               ) : incidents.length === 0 ? (
                 <div className="rounded-lg border border-dashed border-border bg-paper/40 px-3 py-6 text-center">
-                  <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                    Clean history
-                  </div>
+                  <div className="mg-type-micro text-ink-muted">Clean history</div>
                   <div className="mt-1 text-[11px] text-ink-muted">
                     No incidents recorded for this subnet.
                   </div>
@@ -325,7 +317,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                         </div>
                         <span
                           className={classNames(
-                            "shrink-0 rounded-full border px-1.5 py-0.5 font-mono text-[9.5px] uppercase tracking-wider",
+                            "shrink-0 rounded-full border px-1.5 py-0.5 mg-type-micro",
                             open
                               ? "border-health-down/40 bg-health-down/10 text-health-down"
                               : "border-border bg-paper text-ink-muted",
@@ -432,9 +424,7 @@ function Stat({
           tabIndex={0}
           className="px-3 py-2.5 min-w-0 focus:outline-none focus-visible:bg-surface/40"
         >
-          <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate">
-            {label}
-          </div>
+          <div className="mg-type-micro text-ink-muted truncate">{label}</div>
           <div
             className={classNames(
               "mt-1 font-display text-base font-semibold tabular-nums leading-tight truncate",

--- a/apps/ui/src/components/metagraphed/resource-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/resource-explorer.tsx
@@ -83,13 +83,11 @@ export function ResourceExplorer({ netuid }: { netuid: number }) {
     >
       {!filter.isAll ? (
         <div className="mb-2 flex flex-wrap items-center gap-2 rounded-md border border-border bg-paper/40 px-2.5 py-1.5">
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            Filter
-          </span>
+          <span className="mg-type-micro text-ink-muted">Filter</span>
           {ALL_SEVERITIES.filter((s) => filter.isActive(s)).map((s) => (
             <span
               key={s}
-              className="rounded-full border border-border bg-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-strong"
+              className="rounded-full border border-border bg-card px-2 py-0.5 mg-type-micro text-ink-strong"
             >
               {s}
             </span>
@@ -97,7 +95,7 @@ export function ResourceExplorer({ netuid }: { netuid: number }) {
           <button
             type="button"
             onClick={filter.reset}
-            className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+            className="ml-auto inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-ink-strong"
           >
             <X className="size-3" /> clear
           </button>
@@ -348,7 +346,7 @@ function EndpointsView({
   return (
     <div>
       <div className="flex items-center justify-between px-4 py-2 bg-paper/40 border-b border-border">
-        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <span className="mg-type-micro text-ink-muted">
           {rows.length} endpoint{rows.length === 1 ? "" : "s"} · {ordered.length} kind
           {ordered.length === 1 ? "" : "s"}
           {hidden > 0 ? ` · ${hidden} hidden` : ""}
@@ -357,7 +355,7 @@ function EndpointsView({
           to="/subnets/$netuid"
           params={{ netuid }}
           search={{ tab: "endpoints" }}
-          className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-accent"
+          className="inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-accent"
         >
           full table <ArrowRight className="size-3" />
         </Link>
@@ -366,9 +364,7 @@ function EndpointsView({
         {ordered.map((g) => (
           <li key={g.kind}>
             <div className="flex items-center gap-2 px-4 py-1.5 bg-surface/30">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
-                {KIND_LABEL[g.kind] ?? g.kind}
-              </span>
+              <span className="mg-type-micro text-ink-strong">{KIND_LABEL[g.kind] ?? g.kind}</span>
               <span className="font-mono text-[10px] text-ink-muted tabular-nums">
                 {g.items.length}
               </span>
@@ -566,7 +562,7 @@ function SurfacesView({
   return (
     <div>
       <div className="flex items-center justify-between px-4 py-2 bg-paper/40 border-b border-border">
-        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <span className="mg-type-micro text-ink-muted">
           {rows.length} surface{rows.length === 1 ? "" : "s"} · {ordered.length} kind
           {ordered.length === 1 ? "" : "s"}
           {hidden > 0 ? ` · ${hidden} hidden` : ""}
@@ -575,7 +571,7 @@ function SurfacesView({
           to="/subnets/$netuid"
           params={{ netuid }}
           search={{ tab: "surfaces" }}
-          className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-accent"
+          className="inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-accent"
         >
           full list <ArrowRight className="size-3" />
         </Link>
@@ -584,9 +580,7 @@ function SurfacesView({
         {ordered.map(([kind, items]) => (
           <li key={kind}>
             <div className="flex items-center gap-2 px-4 py-1.5 bg-surface/30">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
-                {kind}
-              </span>
+              <span className="mg-type-micro text-ink-strong">{kind}</span>
               <span className="font-mono text-[10px] text-ink-muted tabular-nums">
                 {items.length}
               </span>

--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -66,12 +66,12 @@ export function ProxyHero() {
   return (
     <div className="rounded-lg border border-accent/30 bg-accent-surface p-4">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="inline-flex items-center gap-1.5 rounded border border-health-ok/40 bg-health-ok/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-health-ok">
+        <span className="inline-flex items-center gap-1.5 rounded border border-health-ok/40 bg-health-ok/10 px-1.5 py-0.5 mg-type-micro text-health-ok">
           <span className="size-1.5 rounded-full bg-health-ok" />
           Live
         </span>
         <span className="mg-label">Load-balanced reverse proxy</span>
-        <span className="rounded border border-accent/30 bg-accent/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent-text">
+        <span className="rounded border border-accent/30 bg-accent/10 px-1.5 py-0.5 mg-type-micro text-accent-text">
           {label}
         </span>
       </div>
@@ -149,7 +149,7 @@ function UsageStat({
     >
       <div className="flex items-center gap-1.5 text-ink-muted">
         <Icon className="size-3" aria-hidden />
-        <span className="font-mono text-[10px] uppercase tracking-widest">{eyebrow}</span>
+        <span className="mg-type-micro">{eyebrow}</span>
       </div>
       <div className="mt-1 font-mono text-lg font-semibold text-ink-strong">{value}</div>
       {hint ? <div className="font-mono text-[10px] text-ink-muted">{hint}</div> : null}
@@ -187,7 +187,7 @@ export function ProxyUsagePanel() {
               type="button"
               onClick={() => navigate({ search: (prev) => ({ ...prev, window: w }) })}
               className={classNames(
-                "rounded px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                "rounded px-2 py-0.5 mg-type-micro transition-colors",
                 window === w ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",
               )}
             >
@@ -268,7 +268,7 @@ export function ProxyUsagePanel() {
                 <caption className="px-3 pt-2 text-left mg-label">
                   Per-endpoint distribution
                 </caption>
-                <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+                <thead className="bg-surface/50 mg-type-micro text-ink-muted">
                   <tr>
                     <th className="px-3 py-2 text-left">Endpoint</th>
                     <th className="px-3 py-2 text-left">Provider</th>

--- a/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
@@ -94,7 +94,7 @@ function DriftBody({
       <DialogHeader>
         <DialogTitle className="flex flex-wrap items-center gap-2">
           <span>{schema.name ?? schema.id}</span>
-          <span className="inline-flex items-center rounded-full border border-health-warn/40 bg-health-warn/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-health-warn">
+          <span className="inline-flex items-center rounded-full border border-health-warn/40 bg-health-warn/10 px-2 py-0.5 mg-type-micro text-health-warn">
             drift
           </span>
           {schema.netuid != null ? (
@@ -130,7 +130,7 @@ function DriftBody({
               onOpenInExplorer(schema.id);
               onClose();
             }}
-            className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-primary-soft px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent-text hover:bg-primary-soft/80"
+            className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-primary-soft px-3 py-1.5 mg-type-label uppercase text-accent-text hover:bg-primary-soft/80"
           >
             open in explorer
           </button>
@@ -138,7 +138,7 @@ function DriftBody({
         <button
           type="button"
           onClick={onClose}
-          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3 py-1.5 mg-type-label uppercase text-ink-muted hover:text-ink-strong"
         >
           close
         </button>
@@ -181,14 +181,14 @@ function EvidenceSection({
 
   return (
     <div className="rounded-lg border border-border bg-card/60 p-3">
-      <div className="mb-2 flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+      <div className="mb-2 flex items-center gap-2 mg-type-micro text-ink-muted">
         evidence &amp; sources
         <InfoTooltip label="Where the snapshot diff was derived from. Open or copy these to verify the change against the source." />
       </div>
       <ul className="space-y-1.5">
         {links.map((l) => (
           <li key={l.href} className="flex items-center gap-2 font-mono text-[11px] text-ink">
-            <span className="shrink-0 rounded border border-border bg-paper px-1.5 py-0.5 text-[9.5px] uppercase tracking-widest text-ink-muted">
+            <span className="shrink-0 rounded border border-border bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted">
               {l.label}
             </span>
             {l.href.startsWith("http") ? (

--- a/apps/ui/src/components/metagraphed/stake-amount-input.tsx
+++ b/apps/ui/src/components/metagraphed/stake-amount-input.tsx
@@ -132,7 +132,7 @@ export function StakeAmountInput({
               aria-selected={active}
               onClick={() => onActionChange(a)}
               className={classNames(
-                "min-h-8 rounded px-4 py-1.5 font-mono text-[11px] uppercase tracking-widest transition-colors",
+                "min-h-8 rounded px-4 py-1.5 mg-type-label uppercase transition-colors",
                 active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
               )}
             >
@@ -144,10 +144,7 @@ export function StakeAmountInput({
 
       <div className="flex flex-wrap items-end gap-3">
         <div className="flex flex-col gap-1">
-          <span
-            aria-hidden="true"
-            className="font-mono text-[10px] uppercase tracking-widest text-ink-muted"
-          >
+          <span aria-hidden="true" className="mg-type-micro text-ink-muted">
             Amount ({unitSymbol(unit)})
           </span>
           <SearchInput
@@ -161,9 +158,7 @@ export function StakeAmountInput({
 
         {showUnitToggle ? (
           <div className="flex flex-col gap-1">
-            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              Unit
-            </span>
+            <span className="mg-type-micro text-ink-muted">Unit</span>
             <div
               role="tablist"
               aria-label="TAO or alpha"
@@ -179,7 +174,7 @@ export function StakeAmountInput({
                     aria-selected={active}
                     onClick={() => onUnitChange(u)}
                     className={classNames(
-                      "min-h-8 rounded px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest transition-colors",
+                      "min-h-8 rounded px-3 py-1.5 mg-type-label uppercase transition-colors",
                       active
                         ? "bg-surface text-ink-strong"
                         : "text-ink-muted hover:text-ink-strong",
@@ -198,7 +193,7 @@ export function StakeAmountInput({
             type="button"
             onClick={onApplyMaxStake}
             disabled={maxStakeRao == null}
-            className="min-h-8 rounded border border-border bg-card px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
+            className="min-h-8 rounded border border-border bg-card px-3 py-1.5 mg-type-label uppercase text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
           >
             Max{maxStakeRao != null ? ` (${raoToTao(maxStakeRao)} τ)` : ""}
           </button>
@@ -207,7 +202,7 @@ export function StakeAmountInput({
             type="button"
             onClick={onApplyMaxUnstake}
             disabled={unstakeMax.disabled}
-            className="min-h-8 rounded border border-border bg-card px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
+            className="min-h-8 rounded border border-border bg-card px-3 py-1.5 mg-type-label uppercase text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
           >
             Max
           </button>

--- a/apps/ui/src/components/metagraphed/states/registry-empty.tsx
+++ b/apps/ui/src/components/metagraphed/states/registry-empty.tsx
@@ -101,7 +101,7 @@ export function RegistryEmpty({
             <h3 className="font-display text-base font-semibold text-ink-strong">{title}</h3>
             <span
               className={classNames(
-                "inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-widest",
+                "inline-flex items-center rounded-full border px-2 py-0.5 mg-type-micro",
                 tone.badge,
               )}
             >
@@ -121,18 +121,14 @@ export function RegistryEmpty({
 
           {freshnessHint ? (
             <p className="text-[11px] leading-relaxed text-ink-muted/80">
-              <span className="font-mono text-[9.5px] uppercase tracking-widest opacity-70">
-                how freshness works ·{" "}
-              </span>
+              <span className="mg-type-micro opacity-70">how freshness works · </span>
               {freshnessHint}
             </p>
           ) : null}
 
           {evidenceHref ? (
             <p className="text-[11px] text-ink-muted">
-              <span className="font-mono text-[9.5px] uppercase tracking-widest opacity-70">
-                where to verify ·{" "}
-              </span>
+              <span className="mg-type-micro opacity-70">where to verify · </span>
               <a
                 href={evidenceHref}
                 target="_blank"
@@ -159,7 +155,7 @@ export function RegistryEmpty({
 
 function ActionButton({ action, variant }: { action: ActionLink; variant: RegistryEmptyVariant }) {
   const base =
-    "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-mono text-[10.5px] uppercase tracking-widest transition-colors";
+    "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 mg-type-label uppercase transition-colors";
   const primary = action.primary
     ? "border-accent/40 bg-primary-soft text-accent hover:bg-primary-soft/80"
     : "border-border bg-paper text-ink-muted hover:text-ink-strong hover:border-ink/30";

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
@@ -117,7 +117,7 @@ export function SubnetCompareDrawer({ netuid }: { netuid: number }) {
                   setPeer(null);
                   setDraft("");
                 }}
-                className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+                className="ml-auto inline-flex items-center gap-1 mg-type-micro text-ink-muted hover:text-ink-strong"
               >
                 <X className="size-3" /> clear
               </button>
@@ -142,7 +142,7 @@ export function SubnetCompareDrawer({ netuid }: { netuid: number }) {
           onClick={() => setPeer(null)}
           title="Clear comparison"
           aria-label={`Clear comparison with SN${String(peer).padStart(3, "0")}`}
-          className="inline-flex items-center gap-1 rounded-full border border-accent/40 bg-primary-soft px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-accent hover:border-accent/60 mg-focus-ring"
+          className="inline-flex items-center gap-1 rounded-full border border-accent/40 bg-primary-soft px-2 py-1 mg-type-micro text-accent hover:border-accent/60 mg-focus-ring"
         >
           <X className="size-3" /> clear
         </button>
@@ -199,7 +199,7 @@ function CompareBody({ base, peer }: { base: number; peer: number }) {
       </header>
 
       {loading ? (
-        <div className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <div className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center mg-type-micro text-ink-muted">
           Loading…
         </div>
       ) : null}
@@ -242,7 +242,7 @@ function CompareBody({ base, peer }: { base: number; peer: number }) {
       />
 
       <Panel flush className="overflow-hidden">
-        <div className="border-b border-border px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <div className="border-b border-border px-3 py-2 mg-type-micro text-ink-muted">
           Top providers
         </div>
         <div className="grid grid-cols-2 divide-x divide-border">
@@ -258,9 +258,7 @@ function Header({ label, name, netuid }: { label: string; name?: string; netuid:
   return (
     <Panel as="div" flush>
       <div className="px-2.5 py-2">
-        <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-          {label}
-        </div>
+        <div className="mg-type-micro text-ink-muted">{label}</div>
         <div className="mt-0.5 truncate font-display text-sm font-semibold text-ink-strong">
           {name ?? `Subnet ${netuid}`}
         </div>
@@ -292,7 +290,7 @@ function DiffRow({
         highlight ? "border-accent/60" : "border-border",
       )}
     >
-      <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">{title}</div>
+      <div className="mg-type-micro text-ink-muted">{title}</div>
       <div className="mt-1 grid grid-cols-[1fr_auto_1fr] items-baseline gap-3">
         <span className="font-display text-sm font-semibold tabular-nums text-ink-strong">
           {baseValue}
@@ -332,7 +330,7 @@ function ProviderColumn({
             <span className="font-mono text-[10px] tabular-nums text-ink-muted">
               {r.count}
               {unique ? (
-                <span className="ml-1 rounded border border-accent/40 px-1 text-[9px] uppercase tracking-widest text-accent">
+                <span className="ml-1 rounded border border-accent/40 px-1 mg-type-micro text-accent">
                   only
                 </span>
               ) : null}

--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -119,15 +119,9 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
           <table className="w-full text-left text-sm">
             <thead className="bg-surface/40">
               <tr>
-                <th className="px-4 py-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                  Hotkey
-                </th>
-                <th className="px-4 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                  Locked mass
-                </th>
-                <th className="px-4 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                  Conviction
-                </th>
+                <th className="px-4 py-2.5 mg-type-micro text-ink-muted">Hotkey</th>
+                <th className="px-4 py-2.5 text-right mg-type-micro text-ink-muted">Locked mass</th>
+                <th className="px-4 py-2.5 text-right mg-type-micro text-ink-muted">Conviction</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
@@ -158,7 +152,7 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
                           {entry.is_owner ? (
                             <span
                               className={classNames(
-                                "shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted",
+                                "shrink-0 rounded border border-border px-1.5 py-0.5 mg-type-micro text-ink-muted",
                               )}
                             >
                               owner

--- a/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
@@ -75,7 +75,7 @@ function RetryNotice({
       <button
         type="button"
         onClick={onRetry}
-        className="mt-3 rounded border border-border bg-card px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest text-ink hover:border-ink/30"
+        className="mt-3 rounded border border-border bg-card px-2.5 py-1 mg-type-label uppercase text-ink hover:border-ink/30"
       >
         Retry
       </button>
@@ -129,7 +129,7 @@ function LeaseStatusCard({
     <Panel as="div" dense bodyClassName="space-y-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent-text">
+          <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 mg-type-micro text-accent-text">
             Leased
           </span>
           <span className="font-mono text-[11px] text-ink-muted">lease #{lease.lease_id}</span>
@@ -234,8 +234,8 @@ function LeaseHistorySection({
                   <span
                     className={
                       ev.event_kind === "SubnetLeaseTerminated"
-                        ? "rounded-full border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted"
-                        : "rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent-text"
+                        ? "rounded-full border border-border px-2 py-0.5 mg-type-micro text-ink-muted"
+                        : "rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 mg-type-micro text-accent-text"
                     }
                   >
                     {ev.event_kind === "SubnetLeaseTerminated"

--- a/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
@@ -60,7 +60,7 @@ function Stat({ field, trailing }: { field: Field; trailing?: React.ReactNode })
         <TooltipTrigger asChild>
           <div
             tabIndex={0}
-            className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate cursor-help focus:outline-none"
+            className="mg-type-micro text-ink-muted truncate cursor-help focus:outline-none"
           >
             {field.label}
           </div>
@@ -87,9 +87,7 @@ function Stat({ field, trailing }: { field: Field; trailing?: React.ReactNode })
           ) : null}
         </Tooltip>
         {field.unit && hasValue ? (
-          <span className="shrink-0 font-mono text-[9px] uppercase tracking-widest text-ink-muted">
-            {field.unit}
-          </span>
+          <span className="shrink-0 mg-type-micro text-ink-muted">{field.unit}</span>
         ) : null}
         {trailing}
       </div>
@@ -263,7 +261,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                     centerSub="in"
                   />
                   <div className="min-w-0">
-                    <div className="flex items-center gap-1.5 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
+                    <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted">
                       Pool composition
                       <InfoTooltip label="Alpha In ÷ (Alpha In + Alpha Out) from the latest on-chain AMM reserves snapshot, taken from /api/v1/economics. Tile shows a `stale` chip when the snapshot is older than the refresh budget; numbers still render from the last known values." />
                     </div>
@@ -308,7 +306,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                     centerSub="endpoints"
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
+                    <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted">
                       Endpoint topology
                       <InfoTooltip label="Distribution of tracked public endpoints by kind. Only verified surfaces from /api/v1/subnets/{netuid}/endpoints are counted — candidate (unverified) leads are excluded. `unknown` slots indicate the last probe could not classify the endpoint; if the snapshot is stale, values still render from the last known probe." />
                     </div>
@@ -320,7 +318,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
               )}
             </div>
             <div className="p-4">
-              <div className="flex items-center gap-1.5 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
+              <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted">
                 Top providers
                 <InfoTooltip label="Ranked by count of verified surfaces this provider operates for this subnet, joined from /api/v1/providers. Candidate (unverified) leads are excluded. If provider attribution is stale, ranking still renders from the last published snapshot." />
               </div>
@@ -366,9 +364,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
         {/* Ownership + curation */}
         <div className="grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
           <div className="p-4 space-y-2">
-            <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-              Ownership
-            </div>
+            <div className="mg-type-micro text-ink-muted">Ownership</div>
             {(() => {
               // econ is a plain (non-suspense) query — same hydration gate as
               // the other econ-derived conditionals in this component.
@@ -378,17 +374,13 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                 <>
                   {coldkey ? (
                     <div className="flex items-center gap-2 min-w-0">
-                      <span className="w-16 shrink-0 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-                        Coldkey
-                      </span>
+                      <span className="w-16 shrink-0 mg-type-micro text-ink-muted">Coldkey</span>
                       <KeyChip value={coldkey} label="coldkey" className="min-w-0" />
                     </div>
                   ) : null}
                   {hotkey ? (
                     <div className="flex items-center gap-2 min-w-0">
-                      <span className="w-16 shrink-0 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-                        Hotkey
-                      </span>
+                      <span className="w-16 shrink-0 mg-type-micro text-ink-muted">Hotkey</span>
                       <KeyChip value={hotkey} label="hotkey" className="min-w-0" />
                     </div>
                   ) : null}
@@ -401,9 +393,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
 
           <div className="p-4 space-y-2.5">
             <div className="flex items-center justify-between">
-              <span className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-                Registry curation
-              </span>
+              <span className="mg-type-micro text-ink-muted">Registry curation</span>
               <CurationChip level={profile?.curation_level} />
             </div>
             {completenessPct != null ? (
@@ -465,9 +455,7 @@ function Meta({ label, value, hint }: { label: string; value: string; hint: stri
           tabIndex={0}
           className="px-3 py-2 min-w-0 focus:outline-none focus-visible:bg-surface/40"
         >
-          <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate">
-            {label}
-          </div>
+          <div className="mg-type-micro text-ink-muted truncate">{label}</div>
           <div className="mt-1 font-display text-sm font-semibold tabular-nums text-ink-strong truncate">
             {value}
           </div>

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -30,7 +30,7 @@ export function SubnetsCompareDrawer() {
         >
           {/* Dock */}
           <div className="flex flex-wrap items-center gap-2 px-3 py-2">
-            <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            <span className="inline-flex items-center gap-1.5 mg-type-micro text-ink-muted">
               <BarChart3 className="size-3 text-accent" />
               Compare
               <span className="text-ink-strong tabular-nums">
@@ -62,7 +62,7 @@ export function SubnetsCompareDrawer() {
                 onClick={() => setExpanded((v) => !v)}
                 disabled={selected.length < 2}
                 className={classNames(
-                  "inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                  "inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-paper px-3 mg-type-micro transition-colors",
                   selected.length < 2
                     ? "opacity-50 cursor-not-allowed"
                     : "hover:border-accent/60 hover:text-accent text-ink-strong",
@@ -73,7 +73,7 @@ export function SubnetsCompareDrawer() {
               <button
                 type="button"
                 onClick={clear}
-                className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-paper px-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong transition-colors"
+                className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-paper px-2.5 mg-type-micro text-ink-muted hover:text-ink-strong transition-colors"
               >
                 Clear
               </button>
@@ -217,7 +217,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
         <button
           type="button"
           onClick={() => refetch()}
-          className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest text-ink-strong hover:border-accent/60 hover:text-accent transition-colors"
+          className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 mg-type-micro text-ink-strong hover:border-accent/60 hover:text-accent transition-colors"
         >
           Retry
         </button>
@@ -230,13 +230,13 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
       <table className="min-w-full text-[12px]">
         <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
           <tr>
-            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted backdrop-blur">
+            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left mg-type-micro text-ink-muted backdrop-blur">
               Metric
             </th>
             {netuids.map((n) => (
               <th
                 key={n}
-                className="min-w-[6rem] whitespace-nowrap px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-strong"
+                className="min-w-[6rem] whitespace-nowrap px-3 py-2 text-left mg-type-micro text-ink-strong"
               >
                 SN{n}
               </th>
@@ -246,7 +246,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
         <tbody className="divide-y divide-border">
           {rows.map((row) => (
             <tr key={row.label}>
-              <td className="sticky left-0 z-[1] bg-card px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <td className="sticky left-0 z-[1] bg-card px-3 py-2 mg-type-micro text-ink-muted">
                 {row.label}
               </td>
               {netuids.map((n) => (

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -34,7 +34,7 @@ export function ValidatorsCompareDrawer() {
         >
           {/* Dock */}
           <div className="flex flex-wrap items-center gap-2 px-3 py-2">
-            <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            <span className="inline-flex items-center gap-1.5 mg-type-micro text-ink-muted">
               <BarChart3 className="size-3 text-accent" />
               Compare
               <span className="text-ink-strong tabular-nums">
@@ -70,7 +70,7 @@ export function ValidatorsCompareDrawer() {
                 onClick={() => setExpanded((v) => !v)}
                 disabled={selected.length < 2}
                 className={classNames(
-                  "inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                  "inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-paper px-3 mg-type-micro transition-colors",
                   selected.length < 2
                     ? "opacity-50 cursor-not-allowed"
                     : "hover:border-accent/60 hover:text-accent text-ink-strong",
@@ -81,7 +81,7 @@ export function ValidatorsCompareDrawer() {
               <button
                 type="button"
                 onClick={clear}
-                className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-paper px-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong transition-colors"
+                className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-paper px-2.5 mg-type-micro text-ink-muted hover:text-ink-strong transition-colors"
               >
                 Clear
               </button>
@@ -200,7 +200,7 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
         <button
           type="button"
           onClick={() => refetch()}
-          className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest text-ink-strong hover:border-accent/60 hover:text-accent transition-colors"
+          className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 mg-type-micro text-ink-strong hover:border-accent/60 hover:text-accent transition-colors"
         >
           Retry
         </button>
@@ -213,14 +213,14 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
       <table className="min-w-full text-[12px]">
         <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
           <tr>
-            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted backdrop-blur">
+            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left mg-type-micro text-ink-muted backdrop-blur">
               Metric
             </th>
             {hotkeys.map((hotkey) => (
               <th
                 key={hotkey}
                 title={hotkey}
-                className="min-w-[8rem] whitespace-nowrap px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-strong"
+                className="min-w-[8rem] whitespace-nowrap px-3 py-2 text-left mg-type-micro text-ink-strong"
               >
                 {shortHash(hotkey) ?? hotkey}
               </th>
@@ -230,7 +230,7 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
         <tbody className="divide-y divide-border">
           {rows.map((row) => (
             <tr key={row.label}>
-              <td className="sticky left-0 z-[1] bg-card px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <td className="sticky left-0 z-[1] bg-card px-3 py-2 mg-type-micro text-ink-muted">
                 {row.label}
               </td>
               {hotkeys.map((hotkey) => (

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -163,13 +163,11 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                   )}
                 </div>
                 {n.role === "validator" ? (
-                  <span className="shrink-0 inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                  <span className="shrink-0 inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
                     Validator
                   </span>
                 ) : (
-                  <span className="shrink-0 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
-                    Miner
-                  </span>
+                  <span className="shrink-0 mg-type-micro text-ink-muted">Miner</span>
                 )}
               </div>
               <div className="mt-2 flex items-center justify-between gap-2 font-mono text-[11px] tabular-nums">
@@ -185,7 +183,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
         </div>
         <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm">
-            <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <thead className="bg-surface/50 mg-type-micro text-ink-muted">
               <tr>
                 <th className="px-3 py-2.5 text-left">UID</th>
                 <th className="px-3 py-2.5 text-left">Hotkey</th>
@@ -221,13 +219,11 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                   </td>
                   <td className="px-3 py-2.5">
                     {n.role === "validator" ? (
-                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
                         Validator
                       </span>
                     ) : (
-                      <span className="font-mono text-[10px] uppercase tracking-wider text-ink-muted">
-                        Miner
-                      </span>
+                      <span className="mg-type-micro text-ink-muted">Miner</span>
                     )}
                   </td>
                   <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
@@ -247,7 +243,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
             </tbody>
           </table>
         </div>
-        <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+        <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 mg-type-micro text-ink-muted">
           top {ranked.length} of {neurons.length} by yield · subnet {netuid}
         </div>
       </Panel>
@@ -300,7 +296,7 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
           aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
-            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
             w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
           )}
         >
@@ -348,7 +344,7 @@ function DriftRow({ label, series, color }: { label: string; series: number[]; c
   const last = series[series.length - 1];
   return (
     <div className="grid grid-cols-1 gap-1 min-[400px]:grid-cols-[minmax(0,7rem)_1fr_auto] min-[400px]:items-center min-[400px]:gap-3">
-      <span className="font-mono text-[11px] uppercase tracking-wider text-ink-muted">{label}</span>
+      <span className="mg-type-label uppercase text-ink-muted">{label}</span>
       <div className="min-w-0">
         <Sparkline
           values={series}

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -553,7 +553,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                   ? "Loading raw events…"
                   : `${formatNumber(chainEvents.length)} raw pallet events`}
               </span>
-              <span className="font-mono text-[10px] uppercase tracking-wider">
+              <span className="mg-type-micro">
                 <span className="group-open:hidden">Show</span>
                 <span className="hidden group-open:inline">Hide</span>
               </span>
@@ -635,7 +635,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           <details className="group rounded border border-border bg-card">
             <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[11px] font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
               <span>API &amp; artifact URLs</span>
-              <span className="font-mono text-[10px] uppercase tracking-wider">
+              <span className="mg-type-micro">
                 <span className="group-open:hidden">Show</span>
                 <span className="hidden group-open:inline">Hide</span>
               </span>
@@ -835,7 +835,7 @@ function GroupedEvents({
                 </span>
                 {success != null ? (
                   <span
-                    className={`hidden sm:inline font-mono text-[10px] uppercase tracking-wider ${success ? "text-health-ok" : "text-health-down"}`}
+                    className={`hidden sm:inline mg-type-micro ${success ? "text-health-ok" : "text-health-down"}`}
                   >
                     {success ? "success" : "failed"}
                   </span>
@@ -859,7 +859,7 @@ function GroupedEvents({
                 <div className="border-t border-border bg-surface/20 px-3 py-2">
                   <table className="w-full text-left text-sm">
                     <thead>
-                      <tr className="text-[10px] uppercase tracking-wider text-ink-muted">
+                      <tr className="mg-type-micro text-ink-muted">
                         <th className="px-2 py-1.5 font-normal">Kind</th>
                         {showHotkeyCol ? <th className="px-2 py-1.5 font-normal">Hotkey</th> : null}
                         <th className="px-2 py-1.5 text-right font-normal">Amount</th>
@@ -1007,7 +1007,7 @@ function FieldRow({
 }) {
   return (
     <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-      <dt className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted sm:w-40 sm:shrink-0">
+      <dt className="inline-flex items-center gap-1 mg-type-micro text-ink-muted sm:w-40 sm:shrink-0">
         <span>{label}</span>
         {hint ? <InfoTooltip label={hint} /> : null}
       </dt>

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -312,7 +312,7 @@ function BlocksTable() {
           <QueryBar.Divider />
           <QueryBar.Utility className="ml-auto">
             <span
-              className="hidden sm:inline font-mono text-[10px] uppercase tracking-widest text-ink-muted"
+              className="hidden sm:inline mg-type-micro text-ink-muted"
               title="Blocks are always listed newest first"
             >
               ↓ Newest
@@ -327,9 +327,7 @@ function BlocksTable() {
         <FilterSheet label="Filters" activeCount={secondaryFilterCount}>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <label className="flex flex-col gap-1.5">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Spec version
-              </span>
+              <span className="mg-type-micro text-ink-muted">Spec version</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -343,9 +341,7 @@ function BlocksTable() {
             </label>
             <div className="hidden sm:block" aria-hidden />
             <label className="flex flex-col gap-1.5">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Block from
-              </span>
+              <span className="mg-type-micro text-ink-muted">Block from</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -358,9 +354,7 @@ function BlocksTable() {
               />
             </label>
             <label className="flex flex-col gap-1.5">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Block to
-              </span>
+              <span className="mg-type-micro text-ink-muted">Block to</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -373,9 +367,7 @@ function BlocksTable() {
               />
             </label>
             <label className="flex flex-col gap-1.5">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Min extrinsics
-              </span>
+              <span className="mg-type-micro text-ink-muted">Min extrinsics</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -388,9 +380,7 @@ function BlocksTable() {
               />
             </label>
             <label className="flex flex-col gap-1.5">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Min events
-              </span>
+              <span className="mg-type-micro text-ink-muted">Min events</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -417,7 +407,7 @@ function BlocksTable() {
                     offset: 0,
                   })
                 }
-                className="rounded border border-border bg-card px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-accent/40 hover:text-ink-strong transition-colors"
+                className="rounded border border-border bg-card px-2.5 py-1 mg-type-label uppercase text-ink-muted hover:border-accent/40 hover:text-ink-strong transition-colors"
               >
                 Clear numeric filters
               </button>

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1405,8 +1405,8 @@ function ExplorerDashboard() {
             onClick={() => navigate({ search: { window: w } })}
             className={
               w === win
-                ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent-text"
-                : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
+                ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 mg-type-label uppercase text-accent-text"
+                : "rounded-full border border-border bg-card px-3 py-1 mg-type-label uppercase text-ink-muted hover:border-ink/30"
             }
           >
             {w}
@@ -1468,8 +1468,8 @@ function ExplorerDashboard() {
             onKeyDown={explorerTabKeyDown(i)}
             className={
               tab === t.id
-                ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent-text"
-                : "rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+                ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 mg-type-label uppercase text-accent-text"
+                : "rounded-full border border-border bg-card px-3.5 py-1.5 mg-type-label uppercase text-ink-muted hover:border-ink/30 hover:text-ink-strong"
             }
           >
             {t.label}
@@ -1914,8 +1914,8 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
               onClick={() => setSort(s)}
               className={
                 s === sort
-                  ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent-text"
-                  : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
+                  ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 mg-type-label uppercase text-accent-text"
+                  : "rounded-full border border-border bg-card px-3 py-1 mg-type-label uppercase text-ink-muted hover:border-ink/30"
               }
             >
               {s}

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -447,7 +447,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                     {p.authority ? (
                       <span
                         className={classNames(
-                          "shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider",
+                          "shrink-0 rounded border px-1.5 py-0.5 mg-type-micro",
                           authorityTone(p.authority),
                         )}
                       >
@@ -531,7 +531,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                         {p.authority ? (
                           <span
                             className={classNames(
-                              "font-mono text-[10px] uppercase tracking-wider rounded border px-1.5 py-0.5",
+                              "mg-type-micro rounded border px-1.5 py-0.5",
                               authorityTone(p.authority),
                             )}
                           >
@@ -625,7 +625,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                     {p.authority ? (
                       <span
                         className={classNames(
-                          "font-mono text-[10px] uppercase tracking-wider rounded border px-1.5 py-0.5 shrink-0",
+                          "mg-type-micro rounded border px-1.5 py-0.5 shrink-0",
                           authorityTone(p.authority),
                         )}
                       >
@@ -696,7 +696,7 @@ function ProviderCountsRow({
 function ProviderCardStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex flex-col">
-      <span className="font-mono text-[9px] uppercase tracking-wider text-ink-muted">{label}</span>
+      <span className="mg-type-micro text-ink-muted">{label}</span>
       <span className="font-mono text-[13px] tabular-nums text-ink-strong">{value}</span>
     </div>
   );
@@ -705,7 +705,7 @@ function ProviderCardStat({ label, value }: { label: string; value: string }) {
 function CountTile({ icon, label, value }: { icon?: ReactNode; label: string; value: number }) {
   return (
     <div className="flex flex-col">
-      <span className="inline-flex items-center gap-1 font-mono text-[9px] uppercase tracking-wider text-ink-muted">
+      <span className="inline-flex items-center gap-1 mg-type-micro text-ink-muted">
         {icon}
         {label}
       </span>


### PR DESCRIPTION
## Summary

Sweeps `apps/ui/src` for ad-hoc `font-mono text-[Npx] uppercase tracking-wid(er|est)` eyebrow-label styling and swaps it for the shared `mg-type-micro` / `mg-type-label` utility classes (`styles.css`), following the same conversion heuristic used across earlier Phase 11 batches:

- Bare arbitrary sizes in the ~9-10px range (`text-[9px]`/`[9.5px]`/`[10px]`/`[10.5px]`) + `uppercase` + `tracking-wid(er|est)` → `mg-type-micro`
- `text-[11px]` + `uppercase` + `tracking-wid(er|est)` → `mg-type-label uppercase` (the 11px utility doesn't force uppercase, so it's kept as an explicit adjacent class)
- Applies regardless of the element's role (span, div, th/td, thead, dt, button, `<a>`, badge/pill) since the swap only touches font-family/size/case/tracking, never color/border/background/shape
- Left as-is: bare arbitrary sizes with no `uppercase`+tracking pairing (pure numeric/tabular formatting), which have no `mg-type-*` equivalent

This is the first of several PRs against #7808 (~1633 flagged sites total, the large majority of which are legitimate bespoke formatting outside this heuristic's scope — see per-batch commit messages for exact per-file counts).

## Files touched

`neuron-table.tsx`, `charts/economics-mini.tsx`, `endpoint-list.tsx`, `operational-panel.tsx`, `resource-explorer.tsx`, `subnet-profile-panel.tsx`, `yield-panel.tsx`, `analytics/drift-activity.tsx`, `subnet-compare-drawer.tsx`, `subnets-compare-drawer.tsx`, `validators-compare-drawer.tsx`, `routes/blocks.index.tsx`, `charts/latency-heatmap.tsx`, `endpoint-compare-panel.tsx`, `endpoint-operational-list.tsx`, `entity-hover-card.tsx`, `rpc-proxy.tsx`, `schema-drift-detail.tsx`, `api-drawer.tsx`, `concentration-panel.tsx`, `move-stake-destination-input.tsx`, `stake-amount-input.tsx`, `states/registry-empty.tsx`, `subnet-conviction-leaderboard.tsx`, `subnet-lease-panel.tsx`, `routes/blocks.$ref.tsx`, `routes/explorer.tsx`, `routes/providers.index.tsx`.

## Verification

- `tsc --noEmit` clean
- Full `eslint src`: 0 errors, only pre-existing `no-restricted-syntax` warnings for the (much larger) set of sites intentionally left unconverted
- Full `vitest run`: 182/182 files, 1399/1399 tests passing
- Rebased cleanly onto latest `main` (post #7809/#7810/hotfix merges)

Part of #7808.