### PR TITLE
fix(ui): reserve the site-wide incident strip for major outages only

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-strip.test.ts
+++ b/apps/ui/src/components/metagraphed/incident-strip.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { isMajorOutage } from "./incident-strip";
+import type { EndpointIncident } from "@/lib/metagraphed/types";
+
+// The site-wide banner is reserved for a proxied Bittensor RPC/WSS node fully
+// down, not the much larger stream of individual subnets' own dashboards/APIs
+// failing their content probes (data-quality drift, not a network event).
+const incident = (overrides: Partial<EndpointIncident> = {}): EndpointIncident => ({
+  id: "incident-1",
+  layer: "bittensor-base",
+  severity: "critical",
+  ...overrides,
+});
+
+describe("isMajorOutage", () => {
+  it("is true for a critical, unresolved bittensor-base incident", () => {
+    expect(isMajorOutage(incident())).toBe(true);
+  });
+
+  it("is false once the incident has ended", () => {
+    expect(isMajorOutage(incident({ ended_at: "2026-07-22T00:00:00Z" }))).toBe(false);
+  });
+
+  it("is false for a subnet's own app/API layer, even at critical severity", () => {
+    expect(isMajorOutage(incident({ layer: "subnet-app" }))).toBe(false);
+    expect(isMajorOutage(incident({ layer: "data-provider" }))).toBe(false);
+  });
+
+  it("is false for a warning/degraded bittensor-base blip", () => {
+    expect(isMajorOutage(incident({ severity: "warning" }))).toBe(false);
+  });
+});

--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -30,14 +30,26 @@ function persistDismissed(set: Set<string>) {
   }
 }
 
-function isActive(i: EndpointIncident): boolean {
+// The base Bittensor RPC/WSS layer -- the endpoints metagraphed's own proxy
+// actually routes through -- as opposed to a subnet's own dashboard/API/data
+// artifacts (`subnet-api`/`openapi`/`sse`/`data-artifact`), which fail their
+// content probes constantly and are data-quality drift, not a network event.
+const BASE_LAYER = "bittensor-base";
+
+export function isMajorOutage(i: EndpointIncident): boolean {
   if (i.ended_at) return false;
-  const state = (i.state ?? "").toLowerCase();
-  return state === "down" || state === "warn" || state === "degraded";
+  return i.layer === BASE_LAYER && i.severity === "critical";
 }
 
 /**
  * Site-wide active-incident banner for operational routes.
+ *
+ * Reserved for major, network-affecting events: a proxied Bittensor RPC/WSS
+ * node fully down (`layer: "bittensor-base"`, `severity: "critical"`) -- not
+ * the much larger and noisier stream of individual subnets' own dashboards
+ * and APIs failing their content probes, nor transient/degraded blips on an
+ * otherwise-redundant RPC pool. Those still show up in the fuller incident
+ * feed on /health; they just don't warrant interrupting every page.
  *
  * On a subnet detail page the masthead HealthPill is the sole health signal for
  * *that* subnet (#5332). Incidents scoped to the viewed netuid are therefore
@@ -60,7 +72,7 @@ export function IncidentStrip() {
     if (error || !data) return [];
     return (
       (data.data as EndpointIncident[])
-        .filter(isActive)
+        .filter(isMajorOutage)
         .filter((i) => !dismissed.has(i.id))
         // Masthead owns health for the currently viewed subnet (coerce netuid
         // so string/number API values never leave "SN1 DEGRADED" stuck on /subnets/1).

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -361,6 +361,9 @@ export interface EndpointIncident {
   message?: string;
   started_at?: string;
   ended_at?: string | null;
+  kind?: string; // subtensor-rpc | subtensor-wss | archive | subnet-api | openapi | sse | data-artifact
+  layer?: string; // bittensor-base | subnet-app | data-provider
+  severity?: string; // critical | warning | info
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

`IncidentStrip`'s filter (`isActive()`) surfaced any probe-derived incident with state down/warn/degraded, with no distinction between a proxied Bittensor RPC/WSS node fully failing and a subnet's own dashboard/API flunking its content probe. Checked live against `/api/v1/endpoint-incidents`: of 71 currently-open incidents, 66 are `subnet-api`/`data-artifact`/`openapi` kind (`layer: "subnet-app"`/`"data-provider"`) — third-party subnet dashboards/docs/data files hitting `content-mismatch`, `timeout`, `unsupported`, etc. That's data-quality drift on surfaces metagraphed doesn't operate, not an operational incident worth interrupting every `/endpoints` or `/subnets` page for.

Replaced the filter with `isMajorOutage()`:
- `layer === "bittensor-base"` — the endpoints metagraphed's own proxy actually routes through (`subtensor-rpc`/`subtensor-wss`/`archive`), per the existing server-side layer classification in `endpoint-artifacts.ts`
- `severity === "critical"` — a full `"failed"` probe result, not `"degraded"`/`"warning"`

Of the 71 open incidents right now, only 5 are `bittensor-base` layer, and all 5 are `warning`/`transient` (self-healing blips across redundant providers on netuid 0) — so with this filter the strip correctly renders nothing, matching the reported "shouldn't be there" state. A genuine full RPC/WSS outage, or something that behaves like a network halt (many base-layer endpoints going `critical` at once), still trips the banner.

`kind`/`layer`/`severity` are now explicit typed fields on `EndpointIncident` (they were previously reachable only through the index signature).

## Verification

- `tsc --noEmit` clean
- `eslint`: 0 errors (3 pre-existing bare-arbitrary-text-size warnings in the touched file, unrelated to this change)
- New `incident-strip.test.ts` unit-tests `isMajorOutage()` directly (ended incidents, non-base-layer, warning severity)
- Full `vitest run`: 183/183 files passing
- Verified live in a local dev build against production data: `/endpoints` (71 open incidents) and `/subnets/1` both render with the strip correctly absent