### PR TITLE
refactor(ui): adopt mg-type-micro/mg-type-label for ad-hoc eyebrow labels (batch 6)

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -71,7 +71,7 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
           aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
-            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
             w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
           )}
         >
@@ -140,9 +140,7 @@ function HistoryRow({
   const display = format ? format(last) : Number.isFinite(last) ? formatNumber(last) : "—";
   return (
     <div className="flex items-center gap-3">
-      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
-        {label}
-      </span>
+      <span className="w-28 shrink-0 mg-type-label uppercase text-ink-muted">{label}</span>
       <div className="flex-1 min-w-0">
         <Sparkline values={series} color={color} width={220} height={28} formatValue={format} />
       </div>

--- a/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
@@ -255,7 +255,7 @@ export function EnrichmentQueueTable({ limit = 12 }: { limit?: number }) {
   return (
     <Panel as="div" flush className="overflow-x-auto">
       <table className="w-full text-left text-sm">
-        <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+        <thead className="bg-surface/50 mg-type-micro text-ink-muted">
           <tr>
             <th className="px-3 py-2.5" aria-sort={ariaSort(sort === "rank", order)}>
               <SortHeader
@@ -325,7 +325,7 @@ function QueueRow({ row }: { row: CoverageDepthQueueRow }) {
         {row.severity ? (
           <span
             className={classNames(
-              "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-widest",
+              "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro",
               tone,
             )}
           >

--- a/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
@@ -222,9 +222,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
       {hasIncidents ? (
         <div className="border-t border-border bg-paper/30 px-4 py-2">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
-            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              Downtime windows
-            </span>
+            <span className="mg-type-micro text-ink-muted">Downtime windows</span>
             <div
               className="ml-auto flex flex-wrap items-center gap-1.5"
               role="group"
@@ -241,7 +239,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
                     aria-pressed={active}
                     aria-label={`${f.label} incidents (${count}). Click to ${active ? "hide" : "show"}.`}
                     className={classNames(
-                      "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                      "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 mg-type-micro transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
                       active
                         ? "border-border bg-card text-ink-strong"
                         : "border-border/60 bg-paper/40 text-ink-muted/60 opacity-60",
@@ -289,7 +287,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs text-[11px] leading-relaxed">
-                    <div className="font-mono text-[10px] uppercase tracking-widest text-primary-foreground/80">
+                    <div className="mg-type-micro text-primary-foreground/80">
                       {sev} · {dur}
                     </div>
                     <div className="mt-1 break-all">{i.surface_id}</div>

--- a/apps/ui/src/components/metagraphed/api-source-footer.tsx
+++ b/apps/ui/src/components/metagraphed/api-source-footer.tsx
@@ -13,7 +13,7 @@ export function ApiSourceFooter({ paths, artifacts }: { paths: string[]; artifac
   return (
     <footer className="mt-10 border-t border-border pt-4 text-[11px] text-ink-muted">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        <span className="font-mono uppercase tracking-widest text-[10px]">data sources</span>
+        <span className="mg-type-micro">data sources</span>
         {paths.map((p) => (
           <div key={p} className="flex min-w-0 max-w-full items-center gap-1.5">
             <ExternalLink
@@ -28,7 +28,7 @@ export function ApiSourceFooter({ paths, artifacts }: { paths: string[]; artifac
       </div>
       {artifacts && artifacts.length > 0 ? (
         <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
-          <span className="font-mono uppercase tracking-widest text-[10px]">artifacts</span>
+          <span className="mg-type-micro">artifacts</span>
           {artifacts.map((p) => (
             <ExternalLink
               key={p}

--- a/apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx
@@ -48,7 +48,7 @@ export function CadenceHeatmap({ rows }: { rows: Block[] }) {
         </span>
       }
       action={
-        <div className="flex items-center gap-3 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <div className="flex items-center gap-3 mg-type-micro text-ink-muted">
           {mean != null ? <span>mean {humaniseSeconds(mean)}</span> : null}
           <span className={slow ? "text-health-warn-text" : ""}>slow {slow}</span>
           <span className={stalled ? "text-health-down" : ""}>stalled {stalled}</span>
@@ -105,7 +105,7 @@ function Legend() {
     { label: ">48s", cls: "bg-health-down/80" },
   ];
   return (
-    <div className="mt-3 flex items-center gap-3 border-t border-border/60 pt-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+    <div className="mt-3 flex items-center gap-3 border-t border-border/60 pt-2.5 mg-type-micro text-ink-muted">
       <span>faster</span>
       <div className="flex items-center gap-1">
         {items.map((i) => (

--- a/apps/ui/src/components/metagraphed/blocks/chain-walk-ribbon.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/chain-walk-ribbon.tsx
@@ -161,7 +161,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
               <span className="font-mono text-[11px] text-ink-muted">—</span>
             )}
           </div>
-          <div className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted shrink-0">
+          <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted shrink-0">
             <Kbd>←</Kbd>
             <Kbd>→</Kbd>
             <span className="hidden sm:inline">to walk</span>

--- a/apps/ui/src/components/metagraphed/blocks/neighbor-compare.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/neighbor-compare.tsx
@@ -102,7 +102,7 @@ function DeltaChip({
         : "text-health-down";
   return (
     <div className="rounded border border-border/60 bg-paper px-2 py-1.5">
-      <div className="text-[9px] uppercase tracking-widest text-ink-subtle">{label}</div>
+      <div className="mg-type-micro text-ink-subtle">{label}</div>
       <div className="mt-0.5 flex items-baseline justify-between gap-2">
         <span className="text-ink-strong">
           {loading ? "…" : value != null ? formatNumber(value) : "—"}

--- a/apps/ui/src/components/metagraphed/blocks/runtime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/runtime-timeline.tsx
@@ -32,7 +32,7 @@ export function RuntimeTimeline() {
       action={
         current != null ? (
           <span
-            className="mg-chip h-6 border-accent/40 text-accent-text px-2 text-[10px] font-mono uppercase tracking-widest"
+            className="mg-chip h-6 border-accent/40 text-accent-text px-2 mg-type-micro"
             title="Current runtime spec"
           >
             v{current}

--- a/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
@@ -83,7 +83,7 @@ export function ShortcutsDialog({ blockRef }: { blockRef: string }) {
             type="button"
             autoFocus
             onClick={() => setOpen(false)}
-            className="mg-focus-ring rounded px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+            className="mg-focus-ring rounded px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong"
           >
             Esc
           </button>

--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -109,9 +109,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
     <Panel as="div" flush className="overflow-hidden">
       <div className="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-border bg-paper/30">
         <div className="flex items-center gap-1.5 min-w-0">
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            Registry activity
-          </span>
+          <span className="mg-type-micro text-ink-muted">Registry activity</span>
           <InfoTooltip label="Daily probe samples and recorded incidents — not GitHub commits. Drives the registry's freshness signal." />
         </div>
         <span className="font-mono text-[10px] text-ink-muted">


### PR DESCRIPTION
## Summary

Continues the #7808 sweep replacing ad-hoc `font-mono text-[Npx] uppercase tracking-wid(er|est)` eyebrow-label styling with the shared `mg-type-micro`/`mg-type-label` utility classes, same heuristic as the prior batch (#7820):

- ~9-10px sizes + `uppercase` + `tracking-wid(er|est)` → `mg-type-micro`
- `text-[11px]` + `uppercase` + `tracking-wid(er|est)` → `mg-type-label uppercase`
- Applies regardless of element role (span, div, th, button) since the swap only touches font-family/size/case/tracking
- Left as-is: bare arbitrary sizes without the uppercase+tracking pairing (tabular/numeric formatting)

## Files touched

`account-position-history-chart.tsx`, `analytics/registry-depth.tsx`, `analytics/uptime-timeline.tsx`, `api-source-footer.tsx`, `blocks/cadence-heatmap.tsx`, `blocks/chain-walk-ribbon.tsx`, `blocks/neighbor-compare.tsx`, `blocks/runtime-timeline.tsx`, `blocks/shortcuts-dialog.tsx`, `charts/activity-heatmap.tsx`.

## Verification

- `tsc --noEmit` clean
- Full `eslint src`: 0 errors, only pre-existing warnings for the much larger set of sites intentionally left for later batches
- Full `vitest run`: 182/182 files, 1399/1399 tests passing

Part of #7808.