### PR TITLE
refactor(ui): adopt mg-type-micro/mg-type-label for ad-hoc eyebrow labels (batch 7)

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/subnet-pulse-grid.tsx
+++ b/apps/ui/src/components/metagraphed/charts/subnet-pulse-grid.tsx
@@ -68,9 +68,7 @@ export function SubnetPulseGrid({ columns = 16 }: { columns?: number }) {
               />
             </TooltipTrigger>
             <TooltipContent side="top" className="text-xs">
-              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                netuid {s.netuid}
-              </div>
+              <div className="mg-type-micro text-ink-muted">netuid {s.netuid}</div>
               <div className="font-display text-sm font-semibold text-ink-strong">
                 {s.name ?? `Subnet ${s.netuid}`}
               </div>

--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -71,7 +71,7 @@ export function ValidatorSubnetHeatmap() {
           <table className="w-full min-w-[640px] text-[11px] font-mono">
             <thead>
               <tr>
-                <th className="sticky left-0 z-10 border-b border-border bg-card px-3 py-2 text-left text-[10px] uppercase tracking-widest text-ink-muted">
+                <th className="sticky left-0 z-10 border-b border-border bg-card px-3 py-2 text-left mg-type-micro text-ink-muted">
                   Validator
                 </th>
                 {netuids.map((n) => (

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -627,7 +627,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
               type="button"
               onClick={() => onScopeChange(s.key)}
               className={classNames(
-                "shrink-0 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                "shrink-0 rounded-full border px-2.5 py-1 mg-type-micro transition-colors",
                 active
                   ? "border-accent/60 bg-accent/10 text-accent"
                   : "border-border bg-paper text-ink-muted hover:text-ink-strong hover:border-ink/30",
@@ -773,9 +773,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                     onCopy={() => copyLink(n.target, n.label)}
                     onNewTab={() => openInNewTab(n.target, n.kind)}
                   />
-                  <CommandShortcut className="font-mono text-[10px] uppercase tracking-widest">
-                    {n.kind}
-                  </CommandShortcut>
+                  <CommandShortcut className="mg-type-micro">{n.kind}</CommandShortcut>
                 </CommandItem>
               );
             })}
@@ -846,9 +844,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                       onCopy={() => copyLink(target, String(title))}
                       onNewTab={() => openInNewTab(target, kind)}
                     />
-                    <CommandShortcut className="font-mono text-[10px] uppercase tracking-widest">
-                      {meta.label}
-                    </CommandShortcut>
+                    <CommandShortcut className="mg-type-micro">{meta.label}</CommandShortcut>
                   </CommandItem>
                 );
               })}
@@ -900,7 +896,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                     onCopy={() => copyLink(target, String(title))}
                     onNewTab={() => openInNewTab(target, kind || "semantic")}
                   />
-                  <CommandShortcut className="font-mono text-[10px] uppercase tracking-widest text-accent">
+                  <CommandShortcut className="mg-type-micro text-accent">
                     AI {Math.round(r.score * 100)}%
                   </CommandShortcut>
                 </CommandItem>

--- a/apps/ui/src/components/metagraphed/continue-exploring.tsx
+++ b/apps/ui/src/components/metagraphed/continue-exploring.tsx
@@ -80,7 +80,7 @@ export function ContinueExploring() {
             setVisits([]);
             setRecent([]);
           }}
-          className="font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong transition-colors inline-flex items-center gap-1"
+          className="mg-type-micro text-ink-muted hover:text-ink-strong transition-colors inline-flex items-center gap-1"
           aria-label="Clear continue-exploring history"
         >
           <X className="size-3" /> Clear
@@ -117,7 +117,7 @@ export function ContinueExploring() {
                   </span>
                 )}
                 <span className="min-w-0 flex-1">
-                  <span className="block font-mono text-[9px] uppercase tracking-widest text-ink-muted">
+                  <span className="block mg-type-micro text-ink-muted">
                     {v.kind === "subnet" ? `SN ${String(v.id).padStart(3, "0")}` : v.kind}
                   </span>
                   <span className="block truncate text-sm font-medium text-ink-strong group-hover:text-accent transition-colors">
@@ -133,7 +133,7 @@ export function ContinueExploring() {
 
       {recent.length > 0 ? (
         <div className={classNames(visits.length > 0 ? "mt-4" : "")}>
-          <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted mb-2 inline-flex items-center gap-1.5">
+          <div className="mg-type-micro text-ink-muted mb-2 inline-flex items-center gap-1.5">
             <History className="size-3" /> Recent searches
           </div>
           <ul className="flex flex-wrap gap-1.5">

--- a/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
@@ -46,9 +46,7 @@ export function EndpointCardList({
         return (
           <Panel as="div" dense key={e.id} className="min-w-0" bodyClassName="space-y-2">
             <div className="flex items-center justify-between gap-2">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                {kindLabel}
-              </span>
+              <span className="mg-type-micro text-ink-muted">{kindLabel}</span>
               <SparkLegend
                 metric="Endpoint health"
                 source="/api/v1/endpoints"

--- a/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
@@ -166,7 +166,7 @@ export function EndpointDetailDrawer({
                 formatValue={(value) => `${Math.round(value)}ms`}
               />
             ) : (
-              <div className="flex h-[88px] items-center justify-center border border-dashed border-border font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              <div className="flex h-[88px] items-center justify-center border border-dashed border-border mg-type-micro text-ink-muted">
                 Collecting latency samples — trend will grow as probes arrive
               </div>
             )}
@@ -214,7 +214,7 @@ export function EndpointDetailDrawer({
                 onClick={() => setStateFilter(id)}
                 aria-pressed={stateFilter === id}
                 className={classNames(
-                  "mg-focus-ring rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+                  "mg-focus-ring rounded border px-1.5 py-0.5 mg-type-micro",
                   stateFilter === id
                     ? "border-accent/50 bg-accent/10 text-accent-text"
                     : "border-border text-ink-muted hover:text-ink-strong",
@@ -229,7 +229,7 @@ export function EndpointDetailDrawer({
                 onClick={() => setPoolOnly((v) => !v)}
                 aria-pressed={poolOnly}
                 className={classNames(
-                  "mg-focus-ring ml-auto rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+                  "mg-focus-ring ml-auto rounded border px-1.5 py-0.5 mg-type-micro",
                   poolOnly
                     ? "border-accent/50 bg-accent/10 text-accent-text"
                     : "border-border text-ink-muted hover:text-ink-strong",

--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -39,7 +39,7 @@ export function EndpointKindTabs({ value, counts, onChange }: Props) {
             onKeyDown={onKeyDown(i)}
             className={classNames(
               // !rounded-full overrides mg-focus-ring's hardcoded 6px ring radius.
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors mg-focus-ring !rounded-full",
+              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 mg-type-micro transition-colors mg-focus-ring !rounded-full",
               active
                 ? "border-accent/60 bg-accent/15 text-ink-strong"
                 : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",

--- a/apps/ui/src/components/metagraphed/endpoint-snippet.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-snippet.tsx
@@ -62,7 +62,7 @@ export function EndpointSnippet({ rows }: { rows: EndpointSnippetRow[] }) {
             aria-selected={lang === l.id}
             onClick={() => setLang(l.id)}
             className={classNames(
-              "rounded px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider transition-colors",
+              "rounded px-2.5 py-1 mg-type-label uppercase transition-colors",
               lang === l.id ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
             )}
           >

--- a/apps/ui/src/components/metagraphed/endpoints-glance.tsx
+++ b/apps/ui/src/components/metagraphed/endpoints-glance.tsx
@@ -117,9 +117,7 @@ export function EndpointsGlance({
               <Icon className="size-3.5 shrink-0 text-ink-muted" />
               <div className="min-w-0 flex-1">
                 <div className="flex items-baseline gap-2">
-                  <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                    {b.label}
-                  </span>
+                  <span className="mg-type-micro text-ink-muted">{b.label}</span>
                   <span className="font-display text-sm font-semibold text-ink-strong tabular-nums">
                     {items.length}
                   </span>

--- a/apps/ui/src/components/metagraphed/incident-card.tsx
+++ b/apps/ui/src/components/metagraphed/incident-card.tsx
@@ -18,11 +18,7 @@ export function IncidentCard({ incident }: { incident: EndpointIncident }) {
             {i.endpoint_id ?? "—"}
           </span>
         </div>
-        <span
-          className={`font-mono text-[10px] uppercase tracking-widest ${
-            ongoing ? "text-health-down" : "text-ink-muted"
-          }`}
-        >
+        <span className={`mg-type-micro ${ongoing ? "text-health-down" : "text-ink-muted"}`}>
           {ongoing ? "ongoing" : "resolved"} · {durationLabel(i.started_at, i.ended_at)}
         </span>
       </div>

--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -108,7 +108,7 @@ export function IncidentStrip() {
             so the banner always reads as that subnet's status — never the current
             page's — and the old standalone label + trailing subnet link collapse
             into it. A net simplification (fewer elements), not another chip. */}
-        <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest">
+        <span className="shrink-0 mg-type-micro">
           {top.netuid != null ? (
             <Link
               to="/subnets/$netuid"
@@ -127,7 +127,7 @@ export function IncidentStrip() {
         </span>
         <Link
           to="/health"
-          className="shrink-0 inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest hover:text-accent"
+          className="shrink-0 inline-flex items-center gap-1 mg-type-micro hover:text-accent"
         >
           {active.length > 1 ? `All ${active.length}` : "View"}
           <ArrowRight className="size-3" />


### PR DESCRIPTION
## Summary

Continues the #7808 sweep replacing ad-hoc `font-mono text-[Npx] uppercase tracking-wid(er|est)` eyebrow-label styling with the shared `mg-type-micro`/`mg-type-label` utility classes, same heuristic as batches 1 and 6 (#7820, #7822):

- ~9-10px sizes + `uppercase` + `tracking-wid(er|est)` → `mg-type-micro`
- `text-[11px]` + `uppercase` + `tracking-wid(er|est)` → `mg-type-label uppercase`
- Left as-is: bare arbitrary sizes without the uppercase+tracking pairing

Includes two remaining sites in `incident-strip.tsx` left over from the recent severity-threshold fix (#7821) — that PR only touched the incident-filtering logic, not this file's own label styling.

## Files touched

`charts/subnet-pulse-grid.tsx`, `charts/validator-subnet-heatmap.tsx`, `command-palette-body.tsx`, `continue-exploring.tsx`, `endpoint-card-list.tsx`, `endpoint-detail-drawer.tsx`, `endpoint-kind-tabs.tsx`, `endpoint-snippet.tsx`, `endpoints-glance.tsx`, `incident-card.tsx`, `incident-strip.tsx`.

## Verification

- `tsc --noEmit` clean
- Full `eslint src`: 0 errors, only pre-existing warnings for sites intentionally left for later batches
- Full `vitest run`: 183/183 files, 1403/1403 tests passing

Part of #7808.