### PR TITLE
refactor(ui): adopt mg-type-micro/mg-type-label for ad-hoc eyebrow labels (batch 8)

### DIFF
--- a/apps/ui/src/components/metagraphed/primitives/breadcrumbs.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/breadcrumbs.tsx
@@ -30,7 +30,7 @@ export function Breadcrumbs({ pathname, crumbs, className }: BreadcrumbsProps) {
     <nav
       aria-label="Breadcrumb"
       className={classNames(
-        "flex flex-wrap items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted",
+        "flex flex-wrap items-center gap-1 mg-type-micro text-ink-muted",
         className,
       )}
     >

--- a/apps/ui/src/components/metagraphed/primitives/column-customizer.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/column-customizer.tsx
@@ -34,7 +34,7 @@ export function ColumnCustomizer({
         aria-haspopup="menu"
         aria-expanded={open}
         title="Customize visible columns"
-        className="mg-focus-ring inline-flex items-center gap-1.5 h-9 rounded border border-border bg-card px-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-ink/25 transition-colors"
+        className="mg-focus-ring inline-flex items-center gap-1.5 h-9 rounded border border-border bg-card px-2.5 mg-type-micro text-ink-muted hover:text-ink-strong hover:border-ink/25 transition-colors"
       >
         <Columns3 className="size-3" aria-hidden />
         <span className="hidden sm:inline">Columns</span>
@@ -55,9 +55,7 @@ export function ColumnCustomizer({
             className="absolute right-0 z-40 mt-1.5 w-64 rounded border border-border bg-card p-1 mg-card-glow"
           >
             <div className="flex items-center justify-between px-2 py-1.5">
-              <span className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-                Columns
-              </span>
+              <span className="mg-type-micro text-ink-muted">Columns</span>
               <button
                 type="button"
                 onClick={onReset}
@@ -87,9 +85,7 @@ export function ColumnCustomizer({
                     />
                     <span className="flex-1 truncate">{c.label}</span>
                     {c.required ? (
-                      <span className="font-mono text-[9px] uppercase tracking-widest text-ink-subtle-text">
-                        Locked
-                      </span>
+                      <span className="mg-type-micro text-ink-subtle-text">Locked</span>
                     ) : null}
                   </label>
                 );

--- a/apps/ui/src/components/metagraphed/primitives/empty-state.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/empty-state.tsx
@@ -81,7 +81,7 @@ export function EmptyState({
               href={evidenceHref}
               target="_blank"
               rel="noreferrer"
-              className="mg-focus-ring inline-flex items-center gap-1 text-[11px] font-mono uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+              className="mg-focus-ring inline-flex items-center gap-1 mg-type-label uppercase text-ink-muted hover:text-ink-strong"
             >
               {evidenceLabel}
               <ExternalLink className="size-3" aria-hidden />

--- a/apps/ui/src/components/metagraphed/primitives/filter-chip-row.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/filter-chip-row.tsx
@@ -49,9 +49,7 @@ export function FilterChipRow({ items, onRemove, onClearAll, className }: Filter
           )}
         >
           {item.icon ? <span className="text-ink-muted">{item.icon}</span> : null}
-          <span className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
-            {item.label}
-          </span>
+          <span className="mg-type-micro text-ink-muted">{item.label}</span>
           <span className="font-medium text-ink-strong">{item.value}</span>
           <X
             aria-hidden
@@ -63,7 +61,7 @@ export function FilterChipRow({ items, onRemove, onClearAll, className }: Filter
         <button
           type="button"
           onClick={onClearAll}
-          className="mg-focus-ring ml-1 rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+          className="mg-focus-ring ml-1 rounded px-1.5 py-0.5 mg-type-micro text-ink-muted hover:text-ink-strong"
         >
           Clear all
         </button>

--- a/apps/ui/src/components/metagraphed/primitives/filter-sheet.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/filter-sheet.tsx
@@ -51,7 +51,7 @@ export function FilterSheet({
         aria-haspopup="dialog"
         className={classNames(
           "inline-flex min-h-9 items-center gap-1.5 rounded border px-2.5 py-1",
-          "font-mono text-[11px] uppercase tracking-widest transition-colors",
+          "mg-type-label uppercase transition-colors",
           activeCount > 0
             ? "border-accent/40 bg-accent/10 text-accent"
             : "border-border bg-card text-ink-strong hover:border-accent/40",
@@ -87,7 +87,7 @@ export function FilterSheet({
             )}
           >
             <div className="mb-4 flex items-center justify-between border-b border-border pb-3">
-              <span className="font-mono text-[11px] uppercase tracking-widest text-ink-strong">
+              <span className="mg-type-label uppercase text-ink-strong">
                 {label}
                 {activeCount > 0 ? (
                   <span className="ml-2 text-ink-muted">· {activeCount} active</span>

--- a/apps/ui/src/components/metagraphed/primitives/filter-toolbar.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/filter-toolbar.tsx
@@ -33,7 +33,7 @@ export function FilterField({
         className,
       )}
     >
-      <span className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted inline-flex items-center gap-1.5">
+      <span className="mg-type-micro text-ink-muted inline-flex items-center gap-1.5">
         {label}
         {hint ? <span className="opacity-70">{hint}</span> : null}
       </span>

--- a/apps/ui/src/components/metagraphed/primitives/indicator.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/indicator.tsx
@@ -43,7 +43,7 @@ export function Indicator({
     >
       <span
         className={classNames(
-          "inline-flex items-center gap-1 font-mono text-[9.5px] uppercase tracking-widest text-ink-muted",
+          "inline-flex items-center gap-1 mg-type-micro text-ink-muted",
           isRow ? "self-center" : null,
         )}
       >

--- a/apps/ui/src/components/metagraphed/primitives/panel-error.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/panel-error.tsx
@@ -68,7 +68,7 @@ export function PanelError({
                 window.setTimeout(() => setCopied(false), 1400);
               });
             }}
-            className="mg-focus-ring inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+            className="mg-focus-ring inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong"
             aria-label={`Copy error id ${errorId}`}
           >
             {copied ? (

--- a/apps/ui/src/components/metagraphed/primitives/provenance-chip.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/provenance-chip.tsx
@@ -46,7 +46,7 @@ export function ProvenanceChip({ level, className }: { level?: string; className
       title={item.description}
       aria-label={`${item.label}: ${item.description}`}
       className={classNames(
-        "mg-focus-ring inline-flex items-center rounded border bg-transparent px-1.5 py-0.5 font-mono text-[9.5px] uppercase tracking-wider",
+        "mg-focus-ring inline-flex items-center rounded border bg-transparent px-1.5 py-0.5 mg-type-micro",
         item.className,
         className,
       )}

--- a/apps/ui/src/components/metagraphed/primitives/query-bar.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/query-bar.tsx
@@ -295,9 +295,7 @@ function QueryBarFilterTrigger(props: QueryBarFilterTriggerProps) {
           )}
         >
           {icon ? <span className="shrink-0 text-ink-muted">{icon}</span> : null}
-          <span className="font-mono text-[10px] uppercase tracking-widest opacity-80">
-            {label}
-          </span>
+          <span className="mg-type-micro opacity-80">{label}</span>
           <span
             className={classNames(
               "truncate max-w-[120px] font-medium",
@@ -350,16 +348,14 @@ function QueryBarFilterTrigger(props: QueryBarFilterTriggerProps) {
           </CommandList>
           {active ? (
             <div className="flex items-center justify-between border-t border-border px-2 py-1.5">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                {selected.length} selected
-              </span>
+              <span className="mg-type-micro text-ink-muted">{selected.length} selected</span>
               <button
                 type="button"
                 onClick={() => {
                   clear();
                   if (!props.multi) setOpen(false);
                 }}
-                className="mg-focus-ring rounded px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+                className="mg-focus-ring rounded px-2 py-0.5 mg-type-micro text-ink-muted hover:text-ink-strong"
               >
                 Clear
               </button>
@@ -404,7 +400,7 @@ function QueryBarMetaRow({
     <div
       className={classNames(
         "flex w-full items-center gap-2 pt-1.5",
-        "font-mono text-[10.5px] uppercase tracking-widest text-ink-muted",
+        "mg-type-micro text-ink-muted",
         className,
       )}
     >


### PR DESCRIPTION
## Summary

Continues the #7808 sweep, this time clearing the entire `primitives/` layer — the shared building blocks (breadcrumbs, filter toolbar, column customizer, empty state, indicator, panel error, provenance chip, query bar) reused across the subnets/surfaces/endpoints/providers/blocks tables. Same heuristic as prior batches (#7820, #7822, #7823):

- ~9-10.5px sizes + `uppercase` + `tracking-wid(er|est)` → `mg-type-micro`
- `text-[11px]` + `uppercase` + `tracking-wid(er|est)` → `mg-type-label uppercase`

`primitives/section-label.tsx`'s one grep match was its own doc comment describing what it replaces, not a real usage site — left untouched.

## Files touched

`breadcrumbs.tsx`, `column-customizer.tsx`, `empty-state.tsx`, `filter-chip-row.tsx`, `filter-sheet.tsx`, `filter-toolbar.tsx`, `indicator.tsx`, `panel-error.tsx`, `provenance-chip.tsx`, `query-bar.tsx`.

## Verification

- `tsc --noEmit` clean
- Full `eslint src`: 0 errors (0 remaining bare-arbitrary-text-size warnings in every touched file)
- Full `vitest run`: 183/183 files, 1403/1403 tests passing
- Verified live at `/design/primitives` (the primitives showcase route): breadcrumbs, filter-toolbar labels, and the meta-strip pager footer all render correctly, no console errors

Part of #7808.