### PR TITLE
refactor(ui): adopt mg-type-micro/mg-type-label for ad-hoc eyebrow labels (batch 9)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -288,7 +288,7 @@ export function AppShell({
                     <div className="max-w-shell-max mx-auto px-4 h-9 flex items-center">
                       <Link
                         to={parent.to}
-                        className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink-strong transition-colors font-mono uppercase tracking-widest text-[10px]"
+                        className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink-strong transition-colors mg-type-micro"
                       >
                         <ChevronLeft className="size-3" />
                         {parent.label}
@@ -308,7 +308,7 @@ export function AppShell({
                           <Link
                             to={c.to}
                             className={classNames(
-                              "truncate hover:text-ink-strong transition-colors font-mono uppercase tracking-widest text-[10px]",
+                              "truncate hover:text-ink-strong transition-colors mg-type-micro",
                               i === crumbs.length - 1 && "text-ink-strong",
                             )}
                           >
@@ -367,9 +367,7 @@ export function AppShell({
                 <WalletConnectButton />
               </div>
               <div className="mt-auto border-t border-border pt-3">
-                <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted mb-1.5">
-                  API base
-                </div>
+                <div className="mg-type-micro text-ink-muted mb-1.5">API base</div>
                 <ApiBaseRow />
               </div>
             </SheetContent>
@@ -637,9 +635,7 @@ function EndpointHealthPill() {
 function FooterCol({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div>
-      <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong mb-3">
-        {title}
-      </div>
+      <div className="mg-type-micro text-ink-strong mb-3">{title}</div>
       <div className="flex flex-col gap-2">{children}</div>
     </div>
   );

--- a/apps/ui/src/components/metagraphed/incident-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/incident-timeline.tsx
@@ -52,7 +52,7 @@ export function IncidentTimeline({ netuid }: { netuid: number }) {
                   <div className="truncate text-ink-strong" title={inc.surface_id}>
                     {shortSurfaceId(inc.surface_id, netuid)}
                   </div>
-                  <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+                  <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 mg-type-micro text-ink-muted">
                     {inc.started_at ? (
                       <span>
                         started <TimeAgo at={inc.started_at} />
@@ -64,7 +64,7 @@ export function IncidentTimeline({ netuid }: { netuid: number }) {
                 </div>
                 <span
                   className={classNames(
-                    "shrink-0 rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider",
+                    "shrink-0 rounded-full border px-2 py-0.5 mg-type-micro",
                     open
                       ? "border-health-down/40 bg-health-down/10 text-health-down"
                       : "border-border bg-surface/40 text-ink-muted",

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -120,7 +120,7 @@ export function MetagraphTableLoader({
           onClick={() => setPermitOnly((v) => !v)}
           aria-pressed={permitOnly}
           className={classNames(
-            "inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider transition-colors",
+            "inline-flex items-center gap-1.5 rounded border px-2.5 py-1 mg-type-label uppercase transition-colors",
             permitOnly
               ? "border-accent/40 bg-accent-surface text-accent-text"
               : "border-border bg-surface/40 text-ink-muted hover:text-ink-strong",

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
@@ -247,7 +247,7 @@ export function MegaPanelBody({
               className="w-full rounded-md border border-border bg-card pl-8 pr-3 py-1.5 text-sm placeholder:text-ink-muted focus:outline-none focus:border-accent/60 focus:ring-2 focus:ring-accent/20"
             />
           </div>
-          <div className="hidden md:flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <div className="hidden md:flex items-center gap-2 mg-type-micro text-ink-muted">
             <span>type to jump</span>
             <span aria-hidden>·</span>
             <span>↑↓ move</span>
@@ -421,9 +421,7 @@ export function MegaPanelBody({
           <div className="grid grid-cols-2 gap-2">
             {snapshot.tiles.map((s) => (
               <div key={s.label} className="rounded-md border border-border bg-paper p-2.5">
-                <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
-                  {s.label}
-                </div>
+                <div className="mg-type-micro text-ink-muted">{s.label}</div>
                 <div className="mt-0.5 mg-num text-lg font-semibold text-ink-strong">{s.value}</div>
               </div>
             ))}

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -503,7 +503,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                             {n.hint}
                           </span>
                         </span>
-                        <span className="shrink-0 rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-widest text-accent/80">
+                        <span className="shrink-0 rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 mg-type-micro text-accent/80">
                           {n.badge}
                         </span>
                       </button>

--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -75,7 +75,7 @@ export function NetworkSwitcher() {
         <button
           type="button"
           aria-label={`Network: ${network.label}`}
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-ink hover:border-ink/30 transition-colors min-h-11"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 mg-type-micro text-ink hover:border-ink/30 transition-colors min-h-11"
           title={`Network: ${network.label} · ${base}`}
         >
           <Globe2 className="size-3 text-ink-muted" />
@@ -229,9 +229,7 @@ export function NetworkSwitcher() {
           ) : null}
         </div>
 
-        <p className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">
-          Unofficial registry · public read-only data
-        </p>
+        <p className="mg-type-micro text-ink-muted">Unofficial registry · public read-only data</p>
       </ClampedPopoverContent>
     </Popover>
   );

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -46,19 +46,17 @@ export function NeuronDetailCard({
     <div className="space-y-4 rounded-xl border border-border bg-surface/30 p-4">
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
         <div className="flex items-baseline gap-2">
-          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Neuron
-          </span>
+          <span className="mg-type-micro text-ink-muted">Neuron</span>
           <span className="font-display text-lg font-semibold tabular-nums text-ink-strong leading-none">
             UID {n.uid}
           </span>
           {n.validator_permit ? (
-            <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+            <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
               Validator
             </span>
           ) : null}
           {n.active === false ? (
-            <span className="inline-flex items-center rounded border border-border px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-ink-muted">
+            <span className="inline-flex items-center rounded border border-border px-1.5 py-0.5 mg-type-micro text-ink-muted">
               Inactive
             </span>
           ) : null}
@@ -70,7 +68,7 @@ export function NeuronDetailCard({
               type="button"
               onClick={onClose}
               aria-label="Close neuron detail"
-              className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-ink-muted hover:text-ink-strong"
+              className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 mg-type-micro text-ink-muted hover:text-ink-strong"
             >
               <X className="size-3" aria-hidden /> Close
             </button>

--- a/apps/ui/src/components/metagraphed/neuron-format.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-format.tsx
@@ -37,7 +37,7 @@ export function scoreStr(v?: number | null): string {
 export function SponsoredBadge() {
   return (
     <span
-      className="inline-flex items-center rounded border border-ink-muted/40 bg-surface px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wider text-ink-muted"
+      className="inline-flex items-center rounded border border-ink-muted/40 bg-surface px-1.5 py-0.5 mg-type-micro text-ink-muted"
       title="Sponsored placement — this validator paid for visibility here. It is not ranked or endorsed; see the validator directory's own stake/trust/APY columns for objective standing."
     >
       Sponsored

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -66,7 +66,7 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
           aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
-            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
             w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
           )}
         >
@@ -160,9 +160,7 @@ function HistoryRow({
     last == null ? "—" : format ? format(last) : Number.isFinite(last) ? formatNumber(last) : "—";
   return (
     <div className="flex items-center gap-3">
-      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
-        {label}
-      </span>
+      <span className="w-28 shrink-0 mg-type-label uppercase text-ink-muted">{label}</span>
       <div className="flex-1 min-w-0">
         <Sparkline
           values={series}

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -274,7 +274,7 @@ export function NeuronTable({
                   )}
                   <td className="px-3 py-2.5 text-center">
                     {n.validator_permit ? (
-                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                      <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
                         Validator
                       </span>
                     ) : (
@@ -315,7 +315,7 @@ export function NeuronTable({
           href={csvUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-surface/40 px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider text-ink-muted transition-colors hover:border-ink/30 hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-surface/40 px-2.5 py-1 mg-type-label uppercase text-ink-muted transition-colors hover:border-ink/30 hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           onClick={(e) => e.stopPropagation()}
         >
           <Download className="size-3" aria-hidden />
@@ -363,7 +363,7 @@ function NeuronCard({
           )}
         </div>
         {n.validator_permit ? (
-          <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+          <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
             Validator
           </span>
         ) : null}


### PR DESCRIPTION
## Summary

Continues the #7808 sweep, same heuristic as prior batches:

- ~9-10.5px sizes + `uppercase` + `tracking-wid(er|est)` (or an equivalent arbitrary `tracking-[0.1Xem]`) → `mg-type-micro`
- `text-[11px]` + `uppercase` + `tracking-wid(er|est)` → `mg-type-label uppercase`

Also caught `neuron-detail-card.tsx`'s one `tracking-[0.18em]` site — functionally identical to `tracking-widest` (0.18em is `mg-type-micro`'s own tracking value) but expressed as an arbitrary value, so it wasn't matched by the narrower `tracking-wid(er|est)` grep used in earlier batches.

## Files touched

`app-shell.tsx`, `incident-timeline.tsx`, `metagraph-panel.tsx`, `nav-mega-menu-content.tsx`, `nav-omnibox.tsx`, `network-switcher.tsx`, `neuron-detail-card.tsx`, `neuron-format.tsx`, `neuron-history-chart.tsx`, `neuron-table.tsx`.

## Verification

- `tsc --noEmit` clean
- Full `eslint src`: 0 errors, only pre-existing warnings for sites intentionally left for later batches
- Full `vitest run`: 183/183 files, 1403/1403 tests passing

Part of #7808.