### PR TITLE
fix(data-api): stop health-checks-sync aborting on surface_key conflicts

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -6611,7 +6611,14 @@ test("health-checks-sync silently skips a row missing a required field, no error
 
 test("health-checks-sync bulk-inserts surface_checks and upserts surface_status", async () => {
   const res = await postHealthChecks(
-    { probed: [probedRow(), probedRow({ surface_id: "sn-2-other-api" })] },
+    {
+      probed: [
+        probedRow(),
+        // Distinct surface_key too -- two DIFFERENT surfaces, not a rename
+        // pair (METAGRAPHED-B dedupes id/key collisions; tests below).
+        probedRow({ surface_id: "sn-2-other-api", surface_key: "srf-def456" }),
+      ],
+    },
     { secret: HEALTH_CHECKS_SYNC_SECRET },
   );
   expect(res.status).toBe(200);
@@ -6648,6 +6655,97 @@ test("health-checks-sync defaults every optional field to null/0 when absent", a
     /INSERT INTO surface_status\b/.test(c.text),
   );
   expect(statusInsert.values).toContain(0); // consecutive_failures default
+});
+
+// METAGRAPHED-B regression block: a stale surface_status row holding one of
+// the batch's surface_keys under a different surface_id (a rename's leftover),
+// or an id/key collision INSIDE one batch, violated the partial unique index
+// idx_surface_status_key_unique (or "cannot affect row a second time") and
+// aborted the whole single-transaction mirror write on every probe run.
+test("REGRESSION (METAGRAPHED-B): evicts a stale surface_key holder before the surface_status upsert", async () => {
+  const res = await postHealthChecks(
+    { probed: [probedRow()] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const deleteIdx = sqlCalls.findIndex((c) =>
+    /DELETE FROM surface_status s\b[\s\S]*USING \(VALUES/.test(c.text),
+  );
+  const statusInsertIdx = sqlCalls.findIndex((c) =>
+    /INSERT INTO surface_status\b/.test(c.text),
+  );
+  expect(deleteIdx).toBeGreaterThan(-1);
+  // The eviction must run BEFORE the upsert, inside the same transaction.
+  expect(deleteIdx).toBeLessThan(statusInsertIdx);
+  expect(sqlCalls[deleteIdx].text).toMatch(
+    /s\.surface_key = incoming\.surface_key[\s\S]*s\.surface_id <> incoming\.surface_id/,
+  );
+  expect(sqlCalls[deleteIdx].values).toEqual([
+    "srf-abc123",
+    "sn-1-example-api",
+  ]);
+});
+
+test("REGRESSION (METAGRAPHED-B): two batch rows sharing a surface_key collapse to the later row", async () => {
+  // A mid-migration rename probed under both ids in one run: old id + new id,
+  // same surface_key. One INSERT carrying both would violate the key index.
+  const res = await postHealthChecks(
+    {
+      probed: [
+        probedRow({ surface_id: "sn-1-old-id", status: "failed" }),
+        probedRow({ surface_id: "sn-1-new-id", status: "ok" }),
+      ],
+    },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // surface_checks keeps BOTH probes (no key constraint there); the status
+  // upsert keeps only the later row.
+  expect(body).toEqual({ ok: true, checks_written: 2, status_written: 1 });
+  const statusInsert = sqlCalls.find((c) =>
+    /INSERT INTO surface_status\b/.test(c.text),
+  );
+  expect(statusInsert.values).toContain("sn-1-new-id");
+  expect(statusInsert.values).not.toContain("sn-1-old-id");
+});
+
+test("REGRESSION (METAGRAPHED-B): a duplicate surface_id within one batch collapses to the later row", async () => {
+  const res = await postHealthChecks(
+    {
+      probed: [
+        probedRow({ status: "failed", surface_key: null }),
+        probedRow({ status: "ok", surface_key: null }),
+      ],
+    },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, checks_written: 2, status_written: 1 });
+  const statusInsert = sqlCalls.find((c) =>
+    /INSERT INTO surface_status\b/.test(c.text),
+  );
+  expect(statusInsert.values).toContain("ok");
+  expect(statusInsert.values).not.toContain("failed");
+});
+
+test("METAGRAPHED-B: keyless rows skip the eviction query and are all kept", async () => {
+  // The unique index is partial (surface_key IS NOT NULL), so keyless rows
+  // can't collide on it -- no DELETE should be issued for an all-null batch.
+  const res = await postHealthChecks(
+    {
+      probed: [
+        probedRow({ surface_key: null }),
+        probedRow({ surface_id: "sn-2-other-api", surface_key: null }),
+      ],
+    },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, checks_written: 2, status_written: 2 });
+  expect(queryText()).not.toMatch(/DELETE FROM surface_status/);
 });
 
 test("health-checks-sync maps a DB failure to a clean 502 instead of throwing", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2494,10 +2494,12 @@ async function handleSubnetIdentitySync(request, env) {
 // surface_checks/surface_status so the Postgres tier can eventually take
 // over the read side. surface_status uses ON CONFLICT (surface_id) only
 // (not D1's dual surface_key/surface_id conflict targets -- Postgres allows
-// one conflict target per INSERT): a surface rename mid-migration can
-// briefly fail this route's UPSERT on the surface_key unique index rather
-// than silently duplicate a row, which is an acceptable degrade for a
-// mirror that isn't yet the read source of truth.
+// one conflict target per INSERT), so the handler compensates for the
+// surface_key unique index (idx_surface_status_key_unique) itself: it dedupes
+// the batch and evicts stale key-holders before the upsert (METAGRAPHED-B).
+// The original "a rename can briefly fail this route, acceptable degrade"
+// stance was wrong in practice -- one stale key-holder row aborted the WHOLE
+// single-transaction mirror write on every 15-min probe run, permanently.
 const HEALTH_CHECKS_SYNC_TOKEN_HEADER = "x-health-checks-sync-token";
 // One probe run today is ~150-200 surfaces; generous headroom.
 const HEALTH_CHECKS_SYNC_MAX_BODY_BYTES = 2_000_000;
@@ -2600,6 +2602,28 @@ async function handleHealthChecksSync(request, env) {
       : 0,
     updated_at: row.checked_at_ms,
   }));
+  // METAGRAPHED-B: the ON CONFLICT (surface_id) upsert below tolerates only
+  // ONE row per surface_id in a single INSERT ("cannot affect row a second
+  // time") and one live row per surface_key (idx_surface_status_key_unique,
+  // deploy/postgres/schema.sql). A batch carrying the same surface twice, or
+  // two ids sharing a key, aborted the whole transaction -- and with it the
+  // surface_checks insert -- on every probe run. Later row wins, matching the
+  // upsert's own last-write semantics; keyless rows are all kept (the index
+  // is partial on surface_key IS NOT NULL).
+  const lastRowWins = (rows, keyOf) => {
+    const byKey = new Map();
+    const keyless = [];
+    for (const row of rows) {
+      const key = keyOf(row);
+      if (key === null) keyless.push(row);
+      else byKey.set(key, row);
+    }
+    return [...keyless, ...byKey.values()];
+  };
+  const dedupedStatusRows = lastRowWins(
+    lastRowWins(statusRows, (row) => row.surface_id),
+    (row) => row.surface_key,
+  );
 
   try {
     return await sql.begin(async (sql) => {
@@ -2619,9 +2643,32 @@ async function handleHealthChecksSync(request, env) {
           "checked_at",
         )}
         ON CONFLICT (surface_id, checked_at) DO NOTHING`;
+      // METAGRAPHED-B: evict any stale row still holding one of this batch's
+      // surface_keys under a DIFFERENT surface_id -- a surface rename leaves
+      // the old id's row behind, and idx_surface_status_key_unique then
+      // rejects the new id's insert (the upsert's conflict target is
+      // surface_id, so the key collision surfaces as a hard error, not an
+      // update). Scalar positional binds via a VALUES join -- this Worker's
+      // fetch_types:false Hyperdrive setting breaks postgres.js's bound-array
+      // ANY($1) serialization (see the neurons-sync prune query's comment).
+      const keyedRows = dedupedStatusRows.filter(
+        (row) => row.surface_key !== null,
+      );
+      if (keyedRows.length) {
+        const valuesSql = keyedRows
+          .map((_, i) => `($${i * 2 + 1}::text, $${i * 2 + 2}::text)`)
+          .join(", ");
+        await sql.unsafe(
+          `DELETE FROM surface_status s
+           USING (VALUES ${valuesSql}) AS incoming(surface_key, surface_id)
+           WHERE s.surface_key = incoming.surface_key
+             AND s.surface_id <> incoming.surface_id`,
+          keyedRows.flatMap((row) => [row.surface_key, row.surface_id]),
+        );
+      }
       await sql`
         INSERT INTO surface_status ${sql(
-          statusRows,
+          dedupedStatusRows,
           "surface_id",
           "surface_key",
           "netuid",
@@ -2654,7 +2701,7 @@ async function handleHealthChecksSync(request, env) {
       return writeJson({
         ok: true,
         checks_written: checkRows.length,
-        status_written: statusRows.length,
+        status_written: dedupedStatusRows.length,
       });
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

Every 15-minute probe run's `POST /api/v1/internal/health-checks-sync` Postgres mirror write has been failing since 2026-07-22 (Sentry METAGRAPHED-B, 104+ events): the `surface_status` upsert conflicts on `(surface_id)` only, while the table also carries the partial unique index `idx_surface_status_key_unique` on `surface_key` (`deploy/postgres/schema.sql:682`). A stale row holding an incoming `surface_key` under a different `surface_id` (a rename's leftover), or two batch rows sharing a key, violated the index — and because `surface_checks` + `surface_status` share one transaction, the entire mirror write aborted. The Postgres tier received no health data at all while this fired. The route's header comment had called this a "brief… acceptable degrade"; in practice it was a permanent, total outage of the mirror.

## Fix

- Dedupe the probed batch before the upsert: later row wins per `surface_id` (the upsert cannot affect one row twice) and per non-null `surface_key`; keyless rows are all kept (the index is partial on `surface_key IS NOT NULL`).
- Inside the transaction, before the upsert, evict any stale `surface_status` row holding one of the batch's keys under a different `surface_id` — via a `VALUES`-join with scalar positional binds, matching the neurons-sync prune's documented workaround for `fetch_types:false` breaking bound-array `ANY($1)` serialization.
- `status_written` now reports the deduped row count.

## Validation

- `npx vitest run tests/data-api.test.mjs` — 533/534 pass; the one failure is the pre-existing `account-balances-sync` row-cap timeout flake, which fails identically on unmodified `main` on this machine (unrelated route; separate fix to follow).
- New regression tests: stale key-holder eviction ordering + bind values, rename-pair collapse within one batch, duplicate `surface_id` collapse, keyless batch issuing no DELETE.
- `npm run lint`, `npm run format:check`, `npm run typecheck` — clean.

Fixes METAGRAPHED-B
Closes #7828