### PR TITLE
test(data-api): unflake the account-balances row-cap test

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -5994,11 +5994,15 @@ test("account-balances-sync rejects a body over the byte cap (413)", async () =>
 });
 
 test("account-balances-sync rejects more rows than the per-request cap (413)", async () => {
-  const rows = Array.from({ length: 1_000_001 }, (_, i) =>
-    accountBalanceRow({ ss58: `5Whale${i}` }),
-  );
-  const res = await postAccountBalances(rows, {
+  // #7830: materializing 1,000,001 full accountBalanceRow objects (plus the
+  // ~180MB JSON.stringify) blew vitest's default 5s timeout on a loaded
+  // machine. The handler checks the row cap straight after JSON.parse and
+  // BEFORE any per-row shape validation (deliberately -- the cap exists so a
+  // hostile payload never pays for O(n) validation), so the smallest
+  // parseable element exercises the identical 413 branch at ~2MB.
+  const res = await postAccountBalances(null, {
     secret: ACCOUNT_BALANCES_SYNC_SECRET,
+    raw: "[0" + ",0".repeat(1_000_000) + "]",
   });
   expect(res.status).toBe(413);
 });


### PR DESCRIPTION
## Summary

The "account-balances-sync rejects more rows than the per-request cap (413)" test materialized 1,000,001 full `accountBalanceRow` objects and JSON.stringify'd a ~180MB body, blowing vitest's default 5s `testTimeout` on a loaded machine (verified failing on unmodified `main` locally on 2026-07-23; CI machines were fast enough to pass). The handler checks `ACCOUNT_BALANCES_SYNC_MAX_ROWS` immediately after `JSON.parse` and before any per-row shape validation — deliberately, so a hostile payload never pays for O(n) validation — so the fixture can be a cheaply built raw body of 1,000,001 minimal parseable elements (`[0,0,…]`, ~2MB) while exercising the identical 413 branch. Assertion semantics unchanged.

## Validation

- `npx vitest run tests/data-api.test.mjs -t "rejects more rows than the per-request cap"` — passes in 46ms (previously 5.6s+ / timeout under load).
- Full `npx vitest run tests/data-api.test.mjs` — 530/530 pass.
- `npx prettier --check tests/data-api.test.mjs` — clean.

Closes #7830