### PR TITLE
refactor(ui): adopt mg-type-micro/mg-type-label for all remaining ad-hoc eyebrow labels

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -167,15 +167,13 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
     <div className="space-y-4">
       {availableNetuids.length > 0 ? (
         <div className="flex flex-wrap items-center gap-2">
-          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            scope
-          </span>
+          <span className="mg-type-micro text-ink-muted">scope</span>
           <div className="inline-flex flex-wrap rounded-full border border-border/80 bg-card/80 p-1 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.45)]">
             <button
               type="button"
               onClick={() => setScope("all")}
               className={classNames(
-                "rounded-full px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.16em] transition-colors",
+                "rounded-full px-3 py-1.5 mg-type-label uppercase transition-colors",
                 scope === "all"
                   ? "bg-ink-strong text-paper shadow-[0_12px_30px_-24px_rgba(15,23,42,0.85)]"
                   : "text-ink-muted hover:text-ink-strong",
@@ -189,7 +187,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
                 type="button"
                 onClick={() => setScope(netuid)}
                 className={classNames(
-                  "rounded-full px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.16em] transition-colors",
+                  "rounded-full px-3 py-1.5 mg-type-label uppercase transition-colors",
                   scope === netuid
                     ? "bg-ink-strong text-paper shadow-[0_12px_30px_-24px_rgba(15,23,42,0.85)]"
                     : "text-ink-muted hover:text-ink-strong",
@@ -250,15 +248,11 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
 function MetricBlock({ label, value, hint }: { label: string; value: string; hint: string }) {
   return (
     <div className="min-w-0">
-      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        {label}
-      </div>
+      <div className="mg-type-micro text-ink-muted">{label}</div>
       <div className="mt-2 font-display text-xl font-semibold tracking-[-0.02em] text-ink-strong">
         {value}
       </div>
-      <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.16em] text-ink-muted">
-        {hint}
-      </div>
+      <div className="mt-1 mg-type-micro text-ink-muted">{hint}</div>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/analytics/coverage-funnel.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-funnel.tsx
@@ -72,9 +72,7 @@ export function CoverageFunnel({ className }: { className?: string }) {
       <div className="p-4">
         <div className="flex items-center justify-between mb-4">
           <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              Curation funnel
-            </div>
+            <div className="mg-type-micro text-ink-muted">Curation funnel</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               Registry depth
             </h3>
@@ -90,7 +88,7 @@ export function CoverageFunnel({ className }: { className?: string }) {
               <li key={s.key} className="space-y-1">
                 <div className="flex items-baseline justify-between text-xs">
                   <div className="flex items-baseline gap-2 min-w-0">
-                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-muted shrink-0">
+                    <span className="mg-type-micro text-ink-muted shrink-0">
                       {String(i + 1).padStart(2, "0")}
                     </span>
                     <span className="font-display font-medium text-ink-strong truncate">

--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -94,9 +94,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
     <Panel flush className="overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-border bg-paper/30">
         <div className="min-w-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Coverage matrix
-          </div>
+          <div className="mg-type-micro text-ink-muted">Coverage matrix</div>
           <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
             What each subnet is missing
           </h3>
@@ -114,7 +112,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
               type="button"
               onClick={() => setSort(o.v)}
               className={classNames(
-                "inline-flex items-center rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] transition-colors",
+                "inline-flex items-center rounded border px-2 py-0.5 mg-type-micro transition-colors",
                 sort === o.v
                   ? "border-accent/60 bg-accent/10 text-accent"
                   : "border-border text-ink-muted hover:text-ink-strong",
@@ -139,18 +137,18 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
           <table className="w-full border-collapse text-[11px] font-mono">
             <thead>
               <tr className="bg-paper/30">
-                <th className="sticky left-0 z-10 bg-paper/30 text-left px-3 py-2 text-[10px] uppercase tracking-[0.12em] text-ink-muted border-b border-border">
+                <th className="sticky left-0 z-10 bg-paper/30 text-left px-3 py-2 mg-type-micro text-ink-muted border-b border-border">
                   Subnet
                 </th>
                 {KINDS.map((k) => (
                   <th
                     key={k}
-                    className="px-2 py-2 text-center text-[10px] uppercase tracking-[0.12em] text-ink-muted border-b border-border"
+                    className="px-2 py-2 text-center mg-type-micro text-ink-muted border-b border-border"
                   >
                     {k}
                   </th>
                 ))}
-                <th className="px-2 py-2 text-right text-[10px] uppercase tracking-[0.12em] text-ink-muted border-b border-border">
+                <th className="px-2 py-2 text-right mg-type-micro text-ink-muted border-b border-border">
                   Comp
                 </th>
               </tr>
@@ -207,7 +205,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
           aria-hidden
           className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-card to-transparent md:hidden"
         />
-        <div className="pointer-events-none absolute bottom-1 right-2 rounded bg-ink-strong/70 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wide text-paper md:hidden">
+        <div className="pointer-events-none absolute bottom-1 right-2 rounded bg-ink-strong/70 px-1.5 py-0.5 mg-type-micro text-paper md:hidden">
           scroll →
         </div>
       </div>
@@ -305,9 +303,7 @@ export function CompletenessHistogram() {
     <Panel dense>
       <header className="flex items-center justify-between mb-2">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Distribution
-          </div>
+          <div className="mg-type-micro text-ink-muted">Distribution</div>
           <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
             Completeness across the registry
           </h3>

--- a/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
@@ -148,9 +148,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
     <Panel as="div" flush className={classNames("overflow-hidden", className)}>
       <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Incidents · {RANGE_LABEL[range]}
-          </div>
+          <div className="mg-type-micro text-ink-muted">Incidents · {RANGE_LABEL[range]}</div>
           <InfoTooltip label="Bars are positioned by incident start within the selected range and sized by duration. Color reflects severity. Click a row to open the host subnet or pool." />
         </div>
         <div className="flex flex-wrap items-center gap-1">
@@ -162,7 +160,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                 type="button"
                 onClick={() => setFilter(k)}
                 className={classNames(
-                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] transition-colors",
+                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-micro transition-colors",
                   active
                     ? "border-accent/60 bg-accent/10 text-accent"
                     : "border-border text-ink-muted hover:text-ink-strong hover:border-ink-muted/50",
@@ -186,7 +184,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
       ) : (
         <ul className="divide-y divide-border">
           {/* Header axis */}
-          <li className="grid grid-cols-[minmax(180px,260px)_1fr_min-content] items-center gap-3 px-4 py-1.5 bg-paper/40 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-muted">
+          <li className="grid grid-cols-[minmax(180px,260px)_1fr_min-content] items-center gap-3 px-4 py-1.5 bg-paper/40 mg-type-micro text-ink-muted">
             <span>Host</span>
             <span className="flex items-center justify-between">
               <span>-{RANGE_LABEL[range]}</span>
@@ -225,7 +223,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: r.netuid }}
-                      className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted hover:text-accent hover:border-accent/40"
+                      className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/40"
                     >
                       SN{r.netuid}
                       <ChevronRight className="size-3" aria-hidden />
@@ -237,7 +235,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                       search={(prev: Record<string, unknown>) =>
                         ({ ...prev, q: pool.name ?? pool.id }) as never
                       }
-                      className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted hover:text-accent hover:border-accent/40"
+                      className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/40"
                     >
                       pool · {pool.name ?? pool.id}
                       <ExtIcon className="size-3" aria-hidden />

--- a/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
@@ -106,9 +106,7 @@ export function NetworkPulseBand({ className }: { className?: string }) {
       <div className="p-4">
         <div className="flex items-center justify-between mb-3">
           <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              Network pulse · {RANGE_LABEL[range]}
-            </div>
+            <div className="mg-type-micro text-ink-muted">Network pulse · {RANGE_LABEL[range]}</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               ok / warn / down
             </h3>

--- a/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
@@ -44,9 +44,7 @@ export function RegistryScoreHistogram({ className }: { className?: string }) {
       <div className="p-4">
         <header className="mb-2 flex items-center justify-between">
           <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              Completeness
-            </div>
+            <div className="mg-type-micro text-ink-muted">Completeness</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               Score distribution
             </h3>
@@ -171,9 +169,7 @@ export function DimensionCoverageHeatmap({ className }: { className?: string }) 
       <div className="p-4">
         <header className="mb-4 flex items-center justify-between">
           <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              Coverage
-            </div>
+            <div className="mg-type-micro text-ink-muted">Coverage</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               Surface dimensions
             </h3>

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -147,9 +147,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
     <Panel flush className="overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-border bg-paper/30">
         <div className="min-w-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Drift matrix
-          </div>
+          <div className="mg-type-micro text-ink-muted">Drift matrix</div>
           <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
             Every tracked schema, classified by change type
           </h3>
@@ -173,7 +171,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
                 type="button"
                 onClick={() => setFilter(k)}
                 className={classNames(
-                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] transition-colors",
+                  "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-micro transition-colors",
                   active
                     ? `${tone} bg-paper`
                     : "border-border text-ink-muted hover:text-ink-strong",
@@ -309,7 +307,7 @@ function DriftTile({
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}
           className={classNames(
-            "inline-flex items-center gap-1 rounded-r border-y border-r px-1.5 -ml-px font-mono text-[9px] uppercase tracking-[0.12em] text-ink-muted hover:text-accent transition-colors",
+            "inline-flex items-center gap-1 rounded-r border-y border-r px-1.5 -ml-px mg-type-micro text-ink-muted hover:text-accent transition-colors",
             tone.fill,
           )}
           title={`Source evidence${evidence?.source ? ` · ${evidence.source}` : ""}${evidence?.recorded_at ? ` · recorded ${new Date(evidence.recorded_at).toISOString().slice(0, 10)}` : ""}`}

--- a/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
@@ -51,9 +51,7 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
       <div className="p-4">
         <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
           <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              Status mosaic · {RANGE_LABEL[range]}
-            </div>
+            <div className="mg-type-micro text-ink-muted">Status mosaic · {RANGE_LABEL[range]}</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               {rows.length} endpoint{rows.length === 1 ? "" : "s"}
             </h3>
@@ -68,7 +66,7 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
                   type="button"
                   onClick={() => setFilter(k)}
                   className={classNames(
-                    "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] transition-colors",
+                    "inline-flex items-center gap-1.5 rounded border px-2 py-0.5 mg-type-micro transition-colors",
                     active
                       ? "border-accent/60 bg-accent/10 text-accent"
                       : "border-border text-ink-muted hover:text-ink-strong hover:border-ink-muted/50",

--- a/apps/ui/src/components/metagraphed/analytics/time-range-scrub.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/time-range-scrub.tsx
@@ -43,7 +43,7 @@ export function TimeRangeScrub({
             aria-checked={on}
             onClick={() => set(o.value)}
             className={classNames(
-              "px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] rounded-sm transition-colors",
+              "px-2 py-0.5 mg-type-micro rounded-sm transition-colors",
               on ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",
             )}
           >

--- a/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
@@ -142,7 +142,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
   return (
     <Panel as="div" flush className={classNames("overflow-hidden", className)}>
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2 border-b border-border bg-paper/40">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        <div className="mg-type-micro text-ink-muted">
           Uptime by surface · {RANGE_LABEL[range]}
           {usingFallbackWindow ? <span className="text-ink-muted/60"> (7d window)</span> : null}
         </div>

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -73,9 +73,7 @@ export function WhatChangedFeed({ className, limit = 10 }: { className?: string;
       <div className="p-4">
         <div className="flex items-center justify-between mb-3">
           <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              What changed · {RANGE_LABEL[range]}
-            </div>
+            <div className="mg-type-micro text-ink-muted">What changed · {RANGE_LABEL[range]}</div>
             <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
               Recent registry signal
             </h3>
@@ -114,9 +112,7 @@ export function WhatChangedFeed({ className, limit = 10 }: { className?: string;
                     </div>
                     <div className="flex items-baseline gap-2 mt-0.5">
                       {it.detail ? (
-                        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted truncate">
-                          {it.detail}
-                        </span>
+                        <span className="mg-type-micro text-ink-muted truncate">{it.detail}</span>
                       ) : null}
                       {it.at ? (
                         <span className="font-mono text-[10px] text-ink-muted">

--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -11,7 +11,7 @@ import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import type { ChainEvent } from "@/lib/metagraphed/types";
 import { chainStreamEventMatchesFilters, useChainStream } from "@/hooks/use-chain-stream";
 
-const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+const TH = "px-4 py-2.5 mg-type-micro text-ink-muted";
 
 /** Page size for the raw all-events feed, shared by /events and /explorer. */
 export const CHAIN_EVENTS_PAGE_SIZE = 50;
@@ -125,7 +125,7 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
       {streamLabel ? (
         <span
           className={classNames(
-            "inline-flex items-center gap-1.5 rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em]",
+            "inline-flex items-center gap-1.5 rounded border px-2 py-1 mg-type-micro",
             streamStatus === "open"
               ? "border-accent/40 bg-accent/10 text-accent-text"
               : "border-border bg-surface text-ink-muted",

--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -139,9 +139,7 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
     <TooltipProvider delayDuration={150}>
       <Panel as="div" flush className="overflow-hidden">
         <div className="px-4 py-2.5 border-b border-border flex flex-wrap items-center justify-between gap-2">
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Latency heatmap · provider × kind
-          </div>
+          <div className="mg-type-micro text-ink-muted">Latency heatmap · provider × kind</div>
           <div
             className="flex flex-wrap items-center gap-2.5 text-[10px] font-mono text-ink-muted"
             role="list"
@@ -310,7 +308,7 @@ function Cell({ cell }: { cell: Cell }) {
       >
         <div className="space-y-2.5">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <h3 className="m-0 min-w-0 font-mono text-[10px] uppercase tracking-[0.22em] text-ink-muted truncate">
+            <h3 className="m-0 min-w-0 mg-type-micro text-ink-muted truncate">
               {cell.provider} · {cell.kind}
             </h3>
             <span className="font-mono text-[10px] text-ink-strong tabular-nums shrink-0">

--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
@@ -50,9 +50,7 @@ export function ValidatorDominanceChart() {
   return (
     <Panel as="div" dense>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Stake dominance · top {rows.length}
-        </span>
+        <span className="mg-type-micro text-ink-muted">Stake dominance · top {rows.length}</span>
         <span className="font-mono text-[10px] text-ink-muted">
           {coveredPct.toFixed(1)}% of network stake
         </span>
@@ -64,7 +62,7 @@ export function ValidatorDominanceChart() {
       />
       {tiles.length > 1 ? (
         <div className="mt-4 border-t border-border pt-3">
-          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          <div className="mb-2 mg-type-micro text-ink-muted">
             Concentration
             <TopShareCaption n={tiles.length} />
           </div>

--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -53,9 +53,7 @@ export function ValidatorSubnetHeatmap() {
   return (
     <Panel as="div" flush className="overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-2.5">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Validator × subnet · stake intensity
-        </div>
+        <div className="mg-type-micro text-ink-muted">Validator × subnet · stake intensity</div>
         <div className="flex flex-wrap items-center gap-2.5 font-mono text-[9.5px] text-ink-muted">
           <span>top {rows.length} validators · top 10 subnets each (server-capped)</span>
           <span className="inline-flex items-center gap-1">

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -131,9 +131,7 @@ function SharePanel({
   const allEmpty = bars.every((b) => b.value === 0);
   return (
     <Panel as="div" dense>
-      <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        {title}
-      </div>
+      <div className="mb-3 mg-type-micro text-ink-muted">{title}</div>
       {allEmpty ? (
         <p className="font-mono text-[11px] text-ink-muted">Not enough data yet.</p>
       ) : (
@@ -152,9 +150,7 @@ function pctToBar(v?: number | null): number {
 function Fact({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="min-w-0">
-      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted truncate">
-        {label}
-      </div>
+      <div className="mg-type-micro text-ink-muted truncate">{label}</div>
       <div className="mt-1 min-w-0 truncate font-display text-base font-semibold tabular-nums text-ink-strong leading-none min-[400px]:text-lg">
         {value}
       </div>
@@ -226,9 +222,7 @@ function DriftCard({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-3">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Concentration drift
-        </span>
+        <span className="mg-type-micro text-ink-muted">Concentration drift</span>
         {toggle}
       </div>
       {isLoading ? (
@@ -455,9 +449,7 @@ function RewardDriftCard({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Reward drift
-        </span>
+        <span className="mg-type-micro text-ink-muted">Reward drift</span>
         {toggle}
       </div>
       {isLoading ? (

--- a/apps/ui/src/components/metagraphed/continue-exploring.tsx
+++ b/apps/ui/src/components/metagraphed/continue-exploring.tsx
@@ -62,7 +62,7 @@ export function ContinueExploring() {
     <section className="mt-12" aria-labelledby="continue-exploring-title">
       <div className="flex items-end justify-between mb-4 gap-3">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted inline-flex items-center gap-1.5">
+          <div className="mg-type-micro text-ink-muted inline-flex items-center gap-1.5">
             <Compass className="size-3" /> Continue exploring
           </div>
           <h2

--- a/apps/ui/src/components/metagraphed/domains-rollup.tsx
+++ b/apps/ui/src/components/metagraphed/domains-rollup.tsx
@@ -43,7 +43,7 @@ export function DomainsRollup() {
 
   return (
     <section id="domains-rollup" className="scroll-mt-24">
-      <div className="hidden grid-cols-[1.4fr_0.7fr_1fr_0.9fr_1fr] gap-2 border-b border-border px-4 pb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted md:grid">
+      <div className="hidden grid-cols-[1.4fr_0.7fr_1fr_0.9fr_1fr] gap-2 border-b border-border px-4 pb-2 mg-type-micro text-ink-muted md:grid">
         <span>Domain</span>
         <span className="text-right">Subnets</span>
         <span className="text-right">Total stake</span>
@@ -123,7 +123,7 @@ function DomainRow({
             <Metric label="Entropy (normalized)" value={ratio(c?.entropy_normalized)} />
           </dl>
           <div>
-            <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            <div className="mb-2 mg-type-micro text-ink-muted">
               {domain.subnet_count} member subnet{domain.subnet_count === 1 ? "" : "s"}
             </div>
             <div className="flex flex-wrap gap-2">
@@ -159,9 +159,7 @@ function DomainRow({
 function Metric({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-ink-muted">
-        {label}
-      </div>
+      <div className="mg-type-micro text-ink-muted">{label}</div>
       <div className="mt-0.5 font-mono text-sm tabular-nums text-ink-strong">{value}</div>
     </div>
   );

--- a/apps/ui/src/components/metagraphed/download-openapi-button.tsx
+++ b/apps/ui/src/components/metagraphed/download-openapi-button.tsx
@@ -39,7 +39,7 @@ export function DownloadOpenApiButton({ url, className }: DownloadOpenApiButtonP
       aria-label="Download OpenAPI spec"
       title="Download openapi.json"
       className={classNames(
-        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-ink transition-colors hover:border-ink/30 disabled:cursor-not-allowed disabled:opacity-60",
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-4 py-2 mg-type-label uppercase text-ink transition-colors hover:border-ink/30 disabled:cursor-not-allowed disabled:opacity-60",
         className,
       )}
     >

--- a/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
@@ -99,9 +99,7 @@ export function EmissionYieldPanel() {
 
       {dist ? (
         <div>
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Per-neuron return spread
-          </div>
+          <div className="mb-3 mg-type-micro text-ink-muted">Per-neuron return spread</div>
           <div className="grid gap-3 sm:grid-cols-3">
             <StatTile
               icon={Coins}

--- a/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
+++ b/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
@@ -49,9 +49,7 @@ export function GittensorRegisteredRepos({ slug }: { slug: string }) {
   return (
     <div id="registered-repos" className="rounded-xl border border-border bg-card p-4">
       <div className="mb-3 flex items-center justify-between gap-2">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Registered repositories
-        </span>
+        <span className="mg-type-micro text-ink-muted">Registered repositories</span>
         {total ? (
           <span className="shrink-0 font-mono text-[10px] text-ink-muted tabular-nums">
             {total} total

--- a/apps/ui/src/components/metagraphed/hero-feature-row.tsx
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.tsx
@@ -56,9 +56,7 @@ function ChainThroughputCard() {
     <div className="mg-card-glow relative flex flex-col overflow-hidden rounded-2xl border border-border bg-card">
       <div className="flex items-start justify-between gap-3 px-4 pt-4">
         <div className="min-w-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted">
-            Chain throughput · 7d
-          </div>
+          <div className="mg-type-micro text-ink-muted">Chain throughput · 7d</div>
           <div className="mt-2 flex items-baseline gap-3">
             <div className="font-display text-3xl md:text-4xl font-semibold tabular-nums text-ink-strong leading-none">
               {series.length ? formatNumber(latest) : "—"}
@@ -70,9 +68,7 @@ function ChainThroughputCard() {
               </span>
             )}
           </div>
-          <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.16em] text-ink-subtle-text">
-            extrinsics · last day
-          </div>
+          <div className="mt-1 mg-type-micro text-ink-subtle-text">extrinsics · last day</div>
         </div>
       </div>
 
@@ -92,12 +88,10 @@ function ChainThroughputCard() {
       </div>
 
       <div className="mt-1 flex items-center justify-between border-t border-border px-4 py-3">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          /api/v1/chain/activity
-        </span>
+        <span className="mg-type-micro text-ink-muted">/api/v1/chain/activity</span>
         <Link
           to="/blocks"
-          className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-strong transition-colors hover:text-accent"
+          className="inline-flex items-center gap-1.5 mg-type-label uppercase text-ink-strong transition-colors hover:text-accent"
         >
           Open the block explorer
           <ArrowUpRight className="size-3" />
@@ -119,12 +113,10 @@ function LiveSubnetsCard() {
   return (
     <div className="mg-card-glow flex flex-col overflow-hidden rounded-2xl border border-border bg-card">
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted">
-          Live subnets · 7d
-        </div>
+        <div className="mg-type-micro text-ink-muted">Live subnets · 7d</div>
         <Link
           to="/subnets"
-          className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted transition-colors hover:text-accent"
+          className="inline-flex items-center gap-1 mg-type-micro text-ink-muted transition-colors hover:text-accent"
         >
           View all
           <ArrowUpRight className="size-3" />
@@ -184,9 +176,7 @@ function LiveSubnetRow({ sn }: { sn: Subnet }) {
         />
         <div className="min-w-0 flex-1">
           <div className="truncate text-ink-strong">{sn.name ?? `Subnet ${sn.netuid}`}</div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-muted">
-            SN{sn.netuid}
-          </div>
+          <div className="mg-type-micro text-ink-muted">SN{sn.netuid}</div>
         </div>
         <div className="hidden shrink-0 sm:block">
           {closes.length >= 2 ? (

--- a/apps/ui/src/components/metagraphed/hero-subnet-chips.tsx
+++ b/apps/ui/src/components/metagraphed/hero-subnet-chips.tsx
@@ -93,9 +93,7 @@ export function HeroSubnetChips({ limit = 14 }: { limit?: number }) {
             <span className="font-medium text-[12px] text-ink-strong truncate max-w-[120px]">
               {s.name ?? `Subnet ${s.netuid}`}
             </span>
-            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted">
-              SN{s.netuid}
-            </span>
+            <span className="mg-type-micro text-ink-muted">SN{s.netuid}</span>
             {/* #6423: role="img" so the label is exposed -- a plain span is
                 role="generic", whose aria-label AT is not required to announce.
                 Matches ui-kit HealthDot's treatment of this same visual. */}

--- a/apps/ui/src/components/metagraphed/leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards.tsx
@@ -64,7 +64,7 @@ export function LeaderboardsModule() {
   return (
     <section className="mt-section-gap">
       <div className="mb-8 max-w-2xl">
-        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted inline-flex items-center gap-2">
+        <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
           <span className="mg-live-dot" />
           Discover
         </div>
@@ -96,9 +96,7 @@ function BoardCard({
 }) {
   return (
     <Panel as="div" dense>
-      <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        {label}
-      </div>
+      <div className="mb-3 mg-type-micro text-ink-muted">{label}</div>
       <ol className="space-y-0.5">
         {rows.map((row, i) => (
           <li key={row.netuid}>

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -94,7 +94,7 @@ export function MetagraphTableLoader({
       {stakeBars.length > 0 ? (
         <Panel as="div" dense>
           <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            <span className="mg-type-micro text-ink-muted">
               Stake distribution · top {stakeBars.length} UIDs
             </span>
             <span className="ml-auto flex items-center gap-2">
@@ -112,7 +112,7 @@ export function MetagraphTableLoader({
 
       {/* Permit filter + sortable neuron table. */}
       <div className="flex items-center justify-between gap-3">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        <span className="mg-type-micro text-ink-muted">
           {filtered.length} of {neurons.length} neurons
         </span>
         <button

--- a/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
+++ b/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
@@ -125,9 +125,7 @@ export function NetworkDecentralizationPanel() {
 
       {/* 0-1 trust / consensus / validator-trust score spread. */}
       <div>
-        <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Trust &amp; consensus score spread
-        </div>
+        <div className="mb-3 mg-type-micro text-ink-muted">Trust &amp; consensus score spread</div>
         <div className="grid gap-3 sm:grid-cols-3">
           {model.scoreTiles.map((tile) => (
             <Tile key={tile.key} tile={tile} />

--- a/apps/ui/src/components/metagraphed/network-mood-gauge.tsx
+++ b/apps/ui/src/components/metagraphed/network-mood-gauge.tsx
@@ -48,9 +48,7 @@ export function NetworkMoodGauge() {
     >
       <Icon aria-hidden className="size-4 shrink-0" style={{ color: meta.color }} />
       <div className="min-w-0">
-        <div className="font-mono text-[9px] uppercase tracking-[0.18em] text-ink-muted">
-          Network mood
-        </div>
+        <div className="mg-type-micro text-ink-muted">Network mood</div>
         <div className="font-display text-sm font-semibold" style={{ color: meta.color }}>
           {meta.label}
         </div>

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -107,9 +107,7 @@ export function NeuronDetailCard({
         <KeyRow label="Coldkey" value={n.coldkey} />
         {n.registered_at_block != null ? (
           <div className="flex items-center justify-between gap-3">
-            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              Registered
-            </span>
+            <span className="mg-type-micro text-ink-muted">Registered</span>
             <Link
               to="/blocks/$ref"
               params={{ ref: String(n.registered_at_block) }}
@@ -127,9 +125,7 @@ export function NeuronDetailCard({
 function Fact({ label, value }: { label: string; value: string | number }) {
   return (
     <Panel as="div" dense>
-      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        {label}
-      </div>
+      <div className="mg-type-micro text-ink-muted">{label}</div>
       <div className="mt-1 font-display text-base font-semibold tabular-nums text-ink-strong leading-none">
         {value}
       </div>
@@ -140,9 +136,7 @@ function Fact({ label, value }: { label: string; value: string | number }) {
 function KeyRow({ label, value }: { label: string; value?: string }) {
   return (
     <div className="flex items-center justify-between gap-3">
-      <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        {label}
-      </span>
+      <span className="mg-type-micro text-ink-muted">{label}</span>
       {value ? (
         <span className="font-mono text-[12px] text-ink">
           <AccountAddress

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -79,9 +79,7 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          UID {uid} history
-        </span>
+        <span className="mg-type-micro text-ink-muted">UID {uid} history</span>
         {windowSelector}
       </div>
       {isLoading ? (

--- a/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
@@ -128,9 +128,7 @@ export function PageMasthead({
         <div className="mg-masthead-kpi mt-3">
           {kpis.map((k) => (
             <div key={k.label} className="min-w-0">
-              <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-ink-muted truncate">
-                {k.label}
-              </div>
+              <div className="mg-type-micro text-ink-muted truncate">{k.label}</div>
               <div className="mt-0.5 flex items-baseline gap-1.5 min-w-0">
                 <span className="font-display text-sm md:text-base font-semibold tabular-nums text-ink-strong leading-none truncate">
                   {k.value}

--- a/apps/ui/src/components/metagraphed/quick-actions-row.tsx
+++ b/apps/ui/src/components/metagraphed/quick-actions-row.tsx
@@ -83,9 +83,7 @@ export function QuickActionsRow() {
                 <ArrowUpRight aria-hidden className="mg-quick-arrow size-3.5 text-ink-subtle" />
               </div>
               <div className="space-y-1">
-                <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-                  {a.eyebrow}
-                </div>
+                <div className="mg-type-micro text-ink-muted">{a.eyebrow}</div>
                 <div className="font-display text-sm font-semibold text-ink-strong">{a.title}</div>
                 <p className="text-[12px] leading-relaxed text-ink-muted">{a.description}</p>
               </div>

--- a/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
+++ b/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
@@ -53,7 +53,7 @@ export function RecentIdentityChanges() {
           <Link
             to="/subnets/$netuid"
             params={{ netuid: c.netuid }}
-            className="shrink-0 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-accent"
+            className="shrink-0 mg-type-label uppercase text-ink-muted hover:text-accent"
           >
             SN{c.netuid}
           </Link>

--- a/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
@@ -109,7 +109,7 @@ export function RegistryLeaderboards() {
   return (
     <section id="registry-leaderboards" className="scroll-mt-24 space-y-8">
       <div className="max-w-2xl">
-        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted inline-flex items-center gap-2">
+        <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
           <span className="mg-live-dot" />
           Registry
         </div>
@@ -140,9 +140,7 @@ function BoardGroup({
 }) {
   return (
     <div className="space-y-4">
-      <h3 className="mg-section-rule font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-        {title}
-      </h3>
+      <h3 className="mg-section-rule mg-type-label uppercase text-ink-muted">{title}</h3>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {boards.map((board) => (
           <BoardCard
@@ -171,9 +169,7 @@ function BoardCard({
 }) {
   return (
     <Panel as="div" dense>
-      <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        {label}
-      </div>
+      <div className="mb-1 mg-type-micro text-ink-muted">{label}</div>
       <p className="mb-3 text-xs text-ink-subtle leading-relaxed">{blurb}</p>
       {rows.length === 0 ? (
         <p className="rounded-md border border-dashed border-border px-2 py-3 text-center text-xs text-ink-subtle">

--- a/apps/ui/src/components/metagraphed/reliability-panel.tsx
+++ b/apps/ui/src/components/metagraphed/reliability-panel.tsx
@@ -91,7 +91,7 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
   return (
     <Panel as="div" flush className="overflow-hidden">
       <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2.5">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        <div className="mg-type-micro text-ink-muted">
           Per-surface reliability · uptime · latency percentiles
         </div>
         <div role="tablist" aria-label="Reliability window" className="flex items-center gap-1">
@@ -133,7 +133,7 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
         <div className="overflow-x-auto">
           <table className="w-full font-mono text-[11px]">
             <thead>
-              <tr className="text-[10px] uppercase tracking-widest text-ink-muted">
+              <tr className="mg-type-micro text-ink-muted">
                 <th className="border-b border-border px-3 py-2 text-left">Surface</th>
                 <th className="border-b border-border px-2 py-2 text-right">Uptime</th>
                 <th className="border-b border-border px-2 py-2 text-right">p50</th>

--- a/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
@@ -41,17 +41,13 @@ export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardLi
           bodyClassName="space-y-2"
         >
           <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              Spec Version
-            </span>
+            <span className="mg-type-micro text-ink-muted">Spec Version</span>
             <span className="font-mono text-[13px] tabular-nums text-ink-strong">
               {formatNumber(row.spec_version)}
             </span>
           </div>
           <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              Block
-            </span>
+            <span className="mg-type-micro text-ink-muted">Block</span>
             <span className="font-mono text-[12px] tabular-nums">
               {row.block_number != null ? (
                 <Link
@@ -67,9 +63,7 @@ export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardLi
             </span>
           </div>
           <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              Observed
-            </span>
+            <span className="mg-type-micro text-ink-muted">Observed</span>
             <span className="font-mono text-[12px] text-ink-muted">
               {row.observed_at ? <TimeAgo at={row.observed_at} /> : "—"}
             </span>

--- a/apps/ui/src/components/metagraphed/schema-snapshot-summary.tsx
+++ b/apps/ui/src/components/metagraphed/schema-snapshot-summary.tsx
@@ -60,7 +60,7 @@ function readSnapshot(schema: SchemaInfo): SnapshotFields {
 function MetaCell({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border border-border bg-paper px-3 py-2">
-      <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted">{label}</div>
+      <div className="mg-type-micro text-ink-muted">{label}</div>
       <div className="mt-0.5 font-mono text-[12px] text-ink-strong tabular-nums truncate">
         {value}
       </div>
@@ -91,7 +91,7 @@ export function SchemaSnapshotSummary({ schema }: { schema: SchemaInfo }) {
       <div className="flex flex-wrap items-center gap-2 font-mono text-[11px]">
         <span
           className={classNames(
-            "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-widest",
+            "inline-flex items-center rounded-full border px-2 py-0.5 mg-type-micro",
             driftTone(driftStatus),
           )}
         >
@@ -110,16 +110,12 @@ export function SchemaSnapshotSummary({ schema }: { schema: SchemaInfo }) {
             <span className="text-ink-muted">{schema.previous_hash!.slice(0, 12)}</span>
             <span className="text-ink-muted">→</span>
             <span className="text-ink-strong">{schema.hash!.slice(0, 12)}</span>
-            <span className="ml-auto text-health-warn uppercase tracking-widest text-[10px]">
-              hash changed
-            </span>
+            <span className="ml-auto text-health-warn mg-type-micro">hash changed</span>
           </div>
         ) : schema.hash ? (
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-ink-strong">{schema.hash.slice(0, 12)}</span>
-            <span className="ml-auto text-ink-muted uppercase tracking-widest text-[10px]">
-              hash stable
-            </span>
+            <span className="ml-auto text-ink-muted mg-type-micro">hash stable</span>
           </div>
         ) : (
           <span className="text-ink-muted">No hash recorded for this snapshot.</span>

--- a/apps/ui/src/components/metagraphed/settings-popover.tsx
+++ b/apps/ui/src/components/metagraphed/settings-popover.tsx
@@ -121,9 +121,7 @@ function Section({
 }) {
   return (
     <div>
-      <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted mb-1.5">
-        {label}
-      </div>
+      <div className="mg-type-micro text-ink-muted mb-1.5">{label}</div>
       {children}
       {sub ? <p className="mt-1 text-[10px] text-ink-muted">{sub}</p> : null}
     </div>

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -80,9 +80,7 @@ export function ShortcutsPopover() {
         </TooltipContent>
       </Tooltip>
       <PopoverContent align="start" side="top" className="w-80 p-4">
-        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted mb-3">
-          Shortcuts
-        </div>
+        <div className="mg-type-micro text-ink-muted mb-3">Shortcuts</div>
         <ul className="space-y-1.5 text-[12px]">
           <Row label="Focus search">
             <Kbd>/</Kbd>
@@ -97,9 +95,7 @@ export function ShortcutsPopover() {
             <Kbd>Esc</Kbd>
           </Row>
         </ul>
-        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted mt-4 mb-2">
-          Go to
-        </div>
+        <div className="mg-type-micro text-ink-muted mt-4 mb-2">Go to</div>
         <ul className="space-y-1.5 text-[12px]">
           {GOTO.map((g) => (
             <Row key={g.keys} label={g.label}>
@@ -113,9 +109,7 @@ export function ShortcutsPopover() {
             block on ArrowLeft/ArrowRight -- page-scoped, unlike every other
             shortcut above, so it gets its own labeled section instead of
             reading as a global binding. */}
-        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted mt-4 mb-2">
-          On block pages
-        </div>
+        <div className="mg-type-micro text-ink-muted mt-4 mb-2">On block pages</div>
         <ul className="space-y-1.5 text-[12px]">
           <Row label="Previous / next block">
             <Kbd>←</Kbd>

--- a/apps/ui/src/components/metagraphed/status-diagnostics.tsx
+++ b/apps/ui/src/components/metagraphed/status-diagnostics.tsx
@@ -65,9 +65,7 @@ export function HealthHistoryDrilldown() {
           <div className="font-display text-sm font-semibold text-ink-strong">{date}</div>
         </div>
         <label className="ml-auto inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
-          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            date
-          </span>
+          <span className="mg-type-micro text-ink-muted">date</span>
           <input
             type="date"
             value={date}
@@ -208,7 +206,7 @@ function HealthHistoryBody({ date }: { date: string }) {
 
       <Panel flush className="overflow-x-auto">
         <table className="w-full text-left text-sm">
-          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="bg-surface/50 mg-type-micro text-ink-muted">
             <tr>
               <th className="px-3 py-2.5" aria-sort={ariaSort(sort === "netuid", order)}>
                 <SortHeader
@@ -400,7 +398,7 @@ export function SourceHealthTable() {
 
       <Panel flush className="overflow-x-auto">
         <table className="w-full text-left text-sm">
-          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="bg-surface/50 mg-type-micro text-ink-muted">
             <tr>
               <th className="px-3 py-2.5" aria-sort={ariaSort(sort === "name", order)}>
                 <SortHeader

--- a/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
@@ -77,9 +77,7 @@ export function SubnetHealthMatrix() {
                     SN{s.netuid}{" "}
                     {s.name ? <span className="text-ink-muted">· {s.name}</span> : null}
                   </div>
-                  <div className="font-mono uppercase tracking-widest text-[9px] text-ink-muted mt-0.5">
-                    {s.health ?? "unknown"}
-                  </div>
+                  <div className="mg-type-micro text-ink-muted mt-0.5">{s.health ?? "unknown"}</div>
                 </TooltipContent>
               </Tooltip>
             );
@@ -99,7 +97,7 @@ function Legend() {
     { label: "Unknown", state: "unknown" },
   ];
   return (
-    <div className="flex flex-wrap items-center gap-3 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+    <div className="flex flex-wrap items-center gap-3 mg-type-micro text-ink-muted">
       {items.map((i) => (
         <span key={i.state} className="inline-flex items-center gap-1.5">
           <span className={classNames("size-2 rounded-sm", TONE[i.state])} aria-hidden />

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -64,7 +64,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
           aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
-            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
             w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
           )}
         >
@@ -135,9 +135,7 @@ function HistoryRow({
   const display = format ? format(last) : Number.isFinite(last) ? formatNumber(last) : "—";
   return (
     <div className="flex items-center gap-3">
-      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
-        {label}
-      </span>
+      <span className="w-28 shrink-0 mg-type-label uppercase text-ink-muted">{label}</span>
       <div className="flex-1 min-w-0">
         <Sparkline values={series} color={color} width={220} height={28} formatValue={format} />
       </div>

--- a/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
@@ -175,7 +175,7 @@ function LeaseStatusCard({
 function KeySs58({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">{label}</dt>
+      <dt className="mg-type-micro text-ink-muted">{label}</dt>
       <dd className="mt-1">
         <CopyableCode value={value} className="max-w-full" />
       </dd>
@@ -210,9 +210,7 @@ function LeaseHistorySection({
 }) {
   return (
     <div>
-      <h3 className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-        Lease history
-      </h3>
+      <h3 className="mb-3 mg-type-label uppercase text-ink-muted">Lease history</h3>
       {isError ? (
         <ErrorState error={error} onRetry={onRetry} context="subnet lease history" />
       ) : isLoading ? (

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -380,14 +380,14 @@ export function SubnetMasthead({
               <span className="font-mono text-sm text-ink-muted">{profile.symbol}</span>
             ) : null}
             {profile?.subnet_type ? (
-              <span className="rounded border border-border bg-surface/40 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+              <span className="rounded border border-border bg-surface/40 px-1.5 py-0.5 mg-type-micro text-ink-muted">
                 {profile.subnet_type}
               </span>
             ) : null}
             {categories.map((c) => (
               <span
                 key={c}
-                className="rounded border border-border/60 bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted"
+                className="rounded border border-border/60 bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted"
               >
                 {c}
               </span>

--- a/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
@@ -62,7 +62,7 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
           aria-selected={i === interval}
           onClick={() => setIntervalState(i)}
           className={classNames(
-            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
             i === interval ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
           )}
         >

--- a/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
@@ -120,9 +120,7 @@ export function SubnetPriceTicker({ limit = 12 }: { limit?: number }) {
                   netuid={it.netuid}
                 />
                 <span className="font-medium text-ink-strong truncate max-w-[16ch]">{it.name}</span>
-                <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted">
-                  SN{it.netuid}
-                </span>
+                <span className="mg-type-micro text-ink-muted">SN{it.netuid}</span>
                 <span className="font-display font-semibold tabular-nums text-ink-strong">
                   {priceStr(it.price)}
                 </span>
@@ -158,7 +156,7 @@ export function SubnetPriceTicker({ limit = 12 }: { limit?: number }) {
           neither scroll with the content nor be dimmed by the scroller's edge mask. */}
       <span
         aria-hidden
-        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 inline-flex items-center gap-1 font-mono text-[9px] uppercase tracking-[0.18em] text-ink-muted bg-paper px-1.5"
+        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 inline-flex items-center gap-1 mg-type-micro text-ink-muted bg-paper px-1.5"
       >
         <Coins className="size-2.5" />
         alpha

--- a/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
@@ -59,9 +59,7 @@ function Tile({
         <Icon className="size-4" />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-          {eyebrow}
-        </div>
+        <div className="mg-type-micro text-ink-muted">{eyebrow}</div>
         <div className="truncate font-display text-[15px] font-medium text-ink-strong">{value}</div>
         {hint ? (
           <div className="truncate text-[11px] leading-snug text-ink-muted">{hint}</div>

--- a/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
@@ -56,9 +56,7 @@ function SubnetValidatorsPreviewLoader({ netuid }: { netuid: number }) {
       {sponsored ? <SponsoredValidatorCallout netuid={netuid} validator={sponsored} /> : null}
       <Panel as="div" dense>
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Top validators · by stake
-          </span>
+          <span className="mg-type-micro text-ink-muted">Top validators · by stake</span>
           <button
             type="button"
             onClick={() =>
@@ -68,7 +66,7 @@ function SubnetValidatorsPreviewLoader({ netuid }: { netuid: number }) {
                 replace: true,
               })
             }
-            className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-wider text-ink-muted transition-colors hover:text-accent"
+            className="inline-flex items-center gap-1 mg-type-micro text-ink-muted transition-colors hover:text-accent"
           >
             View all validators
             <ArrowRight className="size-3" aria-hidden />

--- a/apps/ui/src/components/metagraphed/subnets-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-highlights.tsx
@@ -73,9 +73,7 @@ function Card({
         <Icon className="size-4" />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted">
-          {eyebrow}
-        </div>
+        <div className="mg-type-micro text-ink-muted">{eyebrow}</div>
         <div className="font-display text-[15px] font-medium text-ink-strong">{value}</div>
         {hint ? <div className="text-[11px] leading-snug text-ink-muted">{hint}</div> : null}
         <div className="mt-2 -mb-0.5">

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -40,7 +40,7 @@ export function SortHeader({
       onClick={() => onSort(field)}
       aria-label={`Sort by ${label}${sortHint}`}
       className={classNames(
-        "inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest hover:text-ink-strong transition-colors",
+        "inline-flex items-center gap-1 mg-type-micro hover:text-ink-strong transition-colors",
         active ? "text-ink-strong" : "text-ink-muted",
         align === "right" && "justify-end w-full",
       )}
@@ -153,9 +153,7 @@ export function SelectFilter({
         className,
       )}
     >
-      <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-        {label}
-      </span>
+      <span className="shrink-0 mg-type-micro text-ink-muted">{label}</span>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -219,11 +217,7 @@ export function FilterChip({
         className={classNames("size-3 shrink-0", active ? "text-accent" : "text-ink-muted")}
         aria-hidden
       />
-      {label ? (
-        <span className="font-mono text-[10px] uppercase tracking-widest opacity-80 shrink-0">
-          {label}
-        </span>
-      ) : null}
+      {label ? <span className="mg-type-micro opacity-80 shrink-0">{label}</span> : null}
       <span
         className={classNames(
           "font-mono text-[11px] truncate max-w-[100px]",
@@ -265,9 +259,7 @@ export function PageSizeSelect({
 }) {
   return (
     <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
-      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-        per page
-      </span>
+      <span className="mg-type-micro text-ink-muted">per page</span>
       <select
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}

--- a/apps/ui/src/components/metagraphed/take-management-modal.tsx
+++ b/apps/ui/src/components/metagraphed/take-management-modal.tsx
@@ -215,7 +215,7 @@ function TakeAmountStep({ flow }: { flow: UseTakeFlowResult }) {
                 aria-selected={active}
                 onClick={() => flow.setDirection(d)}
                 className={classNames(
-                  "min-h-8 rounded px-4 py-1.5 font-mono text-[11px] uppercase tracking-widest transition-colors",
+                  "min-h-8 rounded px-4 py-1.5 mg-type-label uppercase transition-colors",
                   active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
                 )}
               >
@@ -226,10 +226,7 @@ function TakeAmountStep({ flow }: { flow: UseTakeFlowResult }) {
         </div>
 
         <div className="flex flex-col gap-1">
-          <span
-            aria-hidden="true"
-            className="font-mono text-[10px] uppercase tracking-widest text-ink-muted"
-          >
+          <span aria-hidden="true" className="mg-type-micro text-ink-muted">
             New take (%)
           </span>
           <SearchInput

--- a/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
@@ -58,9 +58,7 @@ export function ValidatorApyPanel({
         {rows.map((row) => (
           <Panel as="div" flush key={row.window}>
             <div className="px-4 py-3">
-              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-                Est. APY · {row.window}
-              </div>
+              <div className="mg-type-micro text-ink-muted">Est. APY · {row.window}</div>
               <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink-strong">
                 {anyLoading && row.apy == null ? "…" : formatApyPct(row.apy)}
               </div>

--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -48,7 +48,7 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
                 touch target centers against the value. `compact` folds that height
                 back into the row so it does not add vertical spacing. */}
             <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-ink-muted">
-              <span className="uppercase tracking-widest text-[10px]">coldkey</span>
+              <span className="mg-type-micro">coldkey</span>
               {/* Same AccountAddress hover-card treatment as the desktop column (#6338). */}
               <AccountAddress ss58={v.coldkey} compact fallback="—" />
             </div>

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -9,7 +9,7 @@ import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identi
 import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
-const TH_BASE = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
+const TH_BASE = "px-3 py-2 mg-type-micro text-ink-muted";
 const TD_BASE = "px-3 py-2 font-mono text-[11px]";
 const TD_NUM = `${TD_BASE} text-right tabular-nums`;
 

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -76,9 +76,7 @@ export function ValidatorGuide() {
         >
           <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
           <span className="min-w-0 flex-1">
-            <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              {HEADING}
-            </span>
+            <span className="block mg-type-micro text-ink-muted">{HEADING}</span>
             <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
               {SUBHEADING}
             </span>
@@ -112,9 +110,7 @@ export function ValidatorGuide() {
         <div className="flex items-start gap-2 px-3 py-2">
           <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
           <span className="min-w-0 flex-1">
-            <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              {HEADING}
-            </span>
+            <span className="block mg-type-micro text-ink-muted">{HEADING}</span>
             <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
               {SUBHEADING}
             </span>

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -69,7 +69,7 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
           aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
-            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            "px-2.5 py-1 mg-type-label uppercase rounded transition-colors",
             w === win ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
           )}
         >
@@ -130,9 +130,7 @@ function HistoryRow({
   const display = format ? format(last) : Number.isFinite(last) ? formatNumber(last) : "—";
   return (
     <div className="flex items-center gap-3">
-      <span className="w-28 shrink-0 font-mono text-[11px] uppercase tracking-wider text-ink-muted">
-        {label}
-      </span>
+      <span className="w-28 shrink-0 mg-type-label uppercase text-ink-muted">{label}</span>
       <div className="flex-1 min-w-0">
         <Sparkline values={series} color={color} width={220} height={28} formatValue={format} />
       </div>

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -76,7 +76,7 @@ export function ValidatorsTableLoader({
       {stakeBars.length > 0 ? (
         <Panel as="div" dense>
           <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            <span className="mg-type-micro text-ink-muted">
               Validator stake · top {stakeBars.length}
             </span>
             <span className="ml-auto flex items-center gap-2">
@@ -89,7 +89,7 @@ export function ValidatorsTableLoader({
           <BarMini data={stakeBars} />
           {stakeTiles.length > 1 ? (
             <div className="mt-4 border-t border-border pt-3">
-              <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              <div className="mb-2 mg-type-micro text-ink-muted">
                 Stake dominance
                 <TopShareCaption n={stakeTiles.length} />
               </div>

--- a/apps/ui/src/components/metagraphed/watch-alert-form.tsx
+++ b/apps/ui/src/components/metagraphed/watch-alert-form.tsx
@@ -55,7 +55,7 @@ export function Field({
 }) {
   return (
     <label className="block">
-      <span className="mb-1 block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+      <span className="mb-1 block mg-type-micro text-ink-muted">
         {label}
         {required ? <span className="text-health-down"> *</span> : null}
       </span>

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -481,7 +481,7 @@ function DeliveryStatusPill({ status }: { status: WebhookDeliveryStatus["status"
   return (
     <span
       className={classNames(
-        "inline-flex items-center rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+        "inline-flex items-center rounded border px-2 py-0.5 mg-type-micro",
         DELIVERY_TONE[status],
       )}
     >
@@ -516,7 +516,7 @@ function Field({
 }) {
   return (
     <label className={classNames("block", className)}>
-      <span className="mb-1 block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+      <span className="mb-1 block mg-type-micro text-ink-muted">
         {label}
         {required ? <span className="text-health-down"> *</span> : null}
       </span>
@@ -529,9 +529,7 @@ function Field({
 function Row({ label, value }: { label: string; value: string }) {
   return (
     <div className="grid grid-cols-[auto_1fr] gap-3">
-      <dt className="whitespace-nowrap font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-        {label}
-      </dt>
+      <dt className="whitespace-nowrap mg-type-micro text-ink-muted">{label}</dt>
       <dd className="min-w-0 truncate text-ink">{value}</dd>
     </div>
   );

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -113,9 +113,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
       <div className="grid gap-4 md:grid-cols-2">
         {/* Validator vs miner split. */}
         <Panel as="div" dense>
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Validator / miner split
-          </div>
+          <div className="mb-3 mg-type-micro text-ink-muted">Validator / miner split</div>
           {splitBars.length ? (
             <BarMini data={splitBars} />
           ) : (
@@ -309,9 +307,7 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-3">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          Yield drift
-        </span>
+        <span className="mg-type-micro text-ink-muted">Yield drift</span>
         {toggle}
       </div>
       {isLoading ? (

--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -176,7 +176,7 @@ export function YourPositionsPanel({ address }: { address: string }) {
       {/* Desktop table */}
       <Panel as="div" flush className="hidden overflow-x-auto md:block">
         <table className="w-full text-sm">
-          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+          <thead className="bg-surface/50 mg-type-micro text-ink-muted">
             <tr>
               <th className="px-3 py-2.5 text-left">Subnet</th>
               <th className="px-3 py-2.5 text-left">Source</th>
@@ -275,7 +275,7 @@ function SourceBadge({ source }: { source: "owned" | "delegated" }) {
   return (
     <span
       className={classNames(
-        "inline-flex items-center rounded border px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider",
+        "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro",
         source === "owned"
           ? "border-accent/40 bg-accent-surface text-accent-text"
           : "border-border bg-surface/40 text-ink-muted",

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -219,7 +219,7 @@ function ErrorComponent({ error, reset }: { error: Error; reset: () => void }) {
     <div className="min-h-screen bg-paper px-4 py-8 text-ink-strong">
       <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-5xl items-center">
         <main className="w-full rounded-xl border border-health-down/30 bg-card p-4 md:p-8">
-          <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-health-down">
+          <div className="flex flex-wrap items-center gap-2 mg-type-micro text-health-down">
             <ServerCrash className="size-4" /> Route error
             <span className="rounded border border-border bg-paper px-1.5 py-0.5 text-ink-muted">
               {pathname}

--- a/apps/ui/src/routes/about.tsx
+++ b/apps/ui/src/routes/about.tsx
@@ -180,9 +180,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 function Term({ name, desc }: { name: string; desc: string }) {
   return (
     <div className="grid grid-cols-[auto_1fr] gap-3 items-baseline">
-      <dt className="font-mono text-[11px] uppercase tracking-widest text-ink-strong whitespace-nowrap">
-        {name}
-      </dt>
+      <dt className="mg-type-label uppercase text-ink-strong whitespace-nowrap">{name}</dt>
       <dd className="text-sm text-ink-muted">{desc}</dd>
     </div>
   );

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -253,13 +253,13 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             </ActionBar>
             <a
               href="#history"
-              className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent-text transition-colors hover:bg-accent/15"
+              className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 mg-type-label uppercase text-accent-text transition-colors hover:bg-accent/15"
             >
               View activity
             </a>
             <a
               href="#call"
-              className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted transition-colors hover:border-ink/20 hover:text-ink-strong"
+              className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 mg-type-label uppercase text-ink-muted transition-colors hover:border-ink/20 hover:text-ink-strong"
             >
               API endpoints
             </a>
@@ -371,9 +371,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
                 key={entry.kind}
                 className="rounded-2xl border border-border/80 bg-card/95 px-4 py-3 mg-card-glow"
               >
-                <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-                  event kind
-                </div>
+                <div className="mg-type-micro text-ink-muted">event kind</div>
                 <div className="mt-2 flex items-end justify-between gap-3">
                   <span className="min-w-0 truncate font-mono text-[12px] text-ink-strong">
                     {entry.kind}
@@ -498,7 +496,7 @@ function SectionBadge({
   return (
     <span
       className={classNames(
-        "inline-flex items-center rounded-full border px-3 py-1 font-mono text-[10px] uppercase tracking-[0.18em]",
+        "inline-flex items-center rounded-full border px-3 py-1 mg-type-micro",
         tone === "accent"
           ? "border-accent/30 bg-accent/10 text-accent"
           : "border-border bg-card text-ink-muted",
@@ -509,7 +507,7 @@ function SectionBadge({
   );
 }
 
-const TH = "px-4 py-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+const TH = "px-4 py-3 mg-type-micro text-ink-muted";
 
 function AccountFeedSectionSkeleton({
   id,
@@ -1234,9 +1232,7 @@ function DelegationSide({
 }) {
   return (
     <div>
-      <h3 className="mb-2 whitespace-nowrap font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-        {label}
-      </h3>
+      <h3 className="mb-2 whitespace-nowrap mg-type-label uppercase text-ink-muted">{label}</h3>
       {unavailable ? (
         <TableState
           variant="error"
@@ -1349,7 +1345,7 @@ function EntityLabelCard({ label }: { label: AccountEntityLabel }) {
         <Tag className="h-3.5 w-3.5 shrink-0 text-accent" />
         <span className="min-w-0 truncate font-semibold text-ink">{label.name ?? "Unnamed"}</span>
         {label.category ? (
-          <span className="shrink-0 whitespace-nowrap rounded border border-border/70 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-ink-muted">
+          <span className="shrink-0 whitespace-nowrap rounded border border-border/70 px-1.5 py-0.5 mg-type-micro text-ink-muted">
             {label.category}
           </span>
         ) : null}
@@ -1416,7 +1412,7 @@ function AccountEntitiesSection({ ss58 }: { ss58: string }) {
 
       {ties.length > 0 ? (
         <>
-          <h3 className="mb-2 whitespace-nowrap font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          <h3 className="mb-2 whitespace-nowrap mg-type-label uppercase text-ink-muted">
             Ownership
           </h3>
           <DataPanel>
@@ -1625,9 +1621,7 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
 
       {bars.length > 0 ? (
         <div className="mb-4 rounded-2xl border border-border/80 bg-card/95 px-4 py-4 mg-card-glow">
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            gross flow by subnet (τ)
-          </div>
+          <div className="mb-3 mg-type-micro text-ink-muted">gross flow by subnet (τ)</div>
           <BarMini data={bars} showValue={false} />
         </div>
       ) : null}
@@ -2447,9 +2441,7 @@ function AccountFootprintSection({
     >
       {staked.length > 0 ? (
         <div className="mb-4 rounded-2xl border border-border/80 bg-card/95 px-4 py-4 mg-card-glow">
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            stake by subnet (τ)
-          </div>
+          <div className="mb-3 mg-type-micro text-ink-muted">stake by subnet (τ)</div>
           <BarMini data={staked} showValue={false} />
         </div>
       ) : null}
@@ -2821,9 +2813,7 @@ function AccountHeroAside({
     <div className="w-[20rem] rounded-2xl border border-border/80 bg-card/95 p-4 mg-card-glow">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted">
-            account signal
-          </div>
+          <div className="mg-type-micro text-ink-muted">account signal</div>
           <div className="mt-2 font-display text-xl font-semibold text-ink-strong">
             Indexed footprint
           </div>
@@ -2874,9 +2864,7 @@ function HeroAsideRow({
         <Icon className="size-4" />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          {label}
-        </div>
+        <div className="mg-type-micro text-ink-muted">{label}</div>
         <div className="mt-1 flex items-baseline gap-2">
           <span className="truncate font-display text-lg font-semibold tabular-nums text-ink-strong">
             {value}

--- a/apps/ui/src/routes/accounts.index.tsx
+++ b/apps/ui/src/routes/accounts.index.tsx
@@ -58,10 +58,7 @@ function AccountsPage() {
         }
       />
       <form onSubmit={submit} className="mx-auto w-full max-w-2xl">
-        <label
-          htmlFor="ss58"
-          className="mb-2 block font-mono text-[10px] uppercase tracking-widest text-ink-muted"
-        >
+        <label htmlFor="ss58" className="mb-2 block mg-type-micro text-ink-muted">
           Account address (ss58)
         </label>
         <div className="flex flex-col gap-2 sm:flex-row">
@@ -98,9 +95,7 @@ function AccountsPage() {
         className="mx-auto mt-10 w-full max-w-2xl rounded-lg border border-border bg-card p-4"
         data-testid="top-active-accounts-section"
       >
-        <h2 className="mb-1 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Most active accounts
-        </h2>
+        <h2 className="mb-1 mg-type-label uppercase text-ink-muted">Most active accounts</h2>
         <p className="mb-4 font-mono text-[11px] text-ink-muted">
           Ranked by extrinsics signed on-chain in the last {TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS} days —
           jump straight to an account below.

--- a/apps/ui/src/routes/delegate.tsx
+++ b/apps/ui/src/routes/delegate.tsx
@@ -23,7 +23,7 @@ function DelegatePage() {
       {/* Hero */}
       <section className="mg-hero-slab relative pt-12 pb-8 md:pt-16 md:pb-10">
         <div className="max-w-3xl">
-          <div className="mg-fade-in font-mono text-[10px] uppercase tracking-[0.22em] text-ink-muted inline-flex items-center gap-2">
+          <div className="mg-fade-in mg-type-micro text-ink-muted inline-flex items-center gap-2">
             <span className="mg-live-dot" />
             Partner validators · {PARTNER_ORG.name}
           </div>
@@ -60,7 +60,7 @@ function DelegatePage() {
       <section className="mt-10">
         <div className="mb-4 flex items-baseline justify-between">
           <h2 className="font-display text-xl font-semibold text-ink-strong">Supported subnets</h2>
-          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          <span className="mg-type-micro text-ink-muted">
             {PARTNER_VALIDATORS.length} live · more rolling out
           </span>
         </div>
@@ -75,7 +75,7 @@ function DelegatePage() {
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+                    <div className="mg-type-micro text-ink-muted">
                       SN{p.netuid} · {p.subnetName}
                     </div>
                     <div className="mt-1 font-display text-lg font-semibold text-ink-strong">
@@ -83,7 +83,7 @@ function DelegatePage() {
                     </div>
                   </div>
                   <span
-                    className={`shrink-0 rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest ${
+                    className={`shrink-0 rounded-full border px-2 py-0.5 mg-type-micro ${
                       p.live ? "border-health-ok/40 text-health-ok" : "border-border text-ink-muted"
                     }`}
                   >
@@ -117,7 +117,7 @@ function TrustCell({ icon, title, body }: { icon: React.ReactNode; title: string
         <span className="text-accent" aria-hidden>
           {icon}
         </span>
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em]">{title}</span>
+        <span className="mg-type-micro">{title}</span>
       </div>
       <p className="mt-1.5 text-[12px] text-ink-muted leading-relaxed">{body}</p>
     </div>

--- a/apps/ui/src/routes/design.primitives.tsx
+++ b/apps/ui/src/routes/design.primitives.tsx
@@ -146,7 +146,7 @@ function PrimitivesPreview() {
             </FilterField>
           </FilterToolbar>
         </div>
-        <p className="mt-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <p className="mt-2 mg-type-micro text-ink-muted">
           density={density} · visible=
           {cols.visible.join(",")}
         </p>
@@ -239,7 +239,7 @@ function PrimitivesPreview() {
         </div>
       </Section>
 
-      <p className="mt-10 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+      <p className="mt-10 mg-type-micro text-ink-muted">
         Applied on: /subnets grid cards · /endpoints card list
       </p>
     </div>

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -1058,7 +1058,7 @@ function EndpointsTable() {
                   : "Showing all endpoint records"
               }
               className={classNames(
-                "mg-focus-ring inline-flex h-8 items-center gap-1.5 rounded px-2 font-mono text-[10px] uppercase tracking-widest",
+                "mg-focus-ring inline-flex h-8 items-center gap-1.5 rounded px-2 mg-type-micro",
                 search.callable ? "text-accent-text" : "text-ink-muted hover:text-ink-strong",
               )}
             >

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -164,7 +164,7 @@ function ExplorerPage() {
   );
 }
 
-const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+const TH = "px-4 py-2.5 mg-type-micro text-ink-muted";
 
 /**
  * One labeled mini-sparkline cell for a daily series. Aligns `days` labels to
@@ -188,9 +188,7 @@ function MiniSeries({
   return (
     <div>
       <div className="mb-1.5 flex items-baseline justify-between gap-2">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-          {label}
-        </span>
+        <span className="mg-type-micro text-ink-muted">{label}</span>
         <span className="font-mono text-[11px] tabular-nums text-ink-strong">
           {latest == null ? "—" : formatValue(latest)}
         </span>
@@ -240,9 +238,7 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Call mix
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Call mix</h2>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(calls.total_extrinsics)} calls
         </span>
@@ -295,7 +291,7 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
 
           {functions.length > 0 ? (
             <div className="border-t border-border pt-3">
-              <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              <div className="mb-2 mg-type-micro text-ink-muted">
                 {selected ? `${selected} functions` : "Function breakdown"}
               </div>
               <BarMini
@@ -332,9 +328,7 @@ function PalletEventMixSection({ stats }: { stats: ChainEventsStats }) {
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Pallet event mix
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Pallet event mix</h2>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(stats.groups)} groups · {formatNumber(stats.window_blocks)} blocks
         </span>
@@ -383,9 +377,7 @@ function StakeFlowMetric({
     tone === "ok" ? "text-health-ok" : tone === "down" ? "text-health-down" : "text-ink-strong";
   return (
     <div>
-      <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-        {label}
-      </div>
+      <div className="mg-type-micro text-ink-muted">{label}</div>
       <div className={`mt-0.5 font-mono text-sm tabular-nums ${valueClass}`}>{value}</div>
     </div>
   );
@@ -411,9 +403,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Stake flow
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Stake flow</h2>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(flow.subnet_count)} subnets
         </span>
@@ -444,9 +434,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
 
       {inflows.length > 0 ? (
         <div>
-          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Top net inflows
-          </div>
+          <div className="mb-2 mg-type-micro text-ink-muted">Top net inflows</div>
           <ul className="space-y-1.5">
             {inflows.map((s) => {
               const pct = Math.max(2, Math.round((Math.max(0, s.net_flow_tao) / cap) * 100));
@@ -513,9 +501,7 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Stake moves
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Stake moves</h2>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(moves.subnet_count)} subnets
         </span>
@@ -531,9 +517,7 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
 
       {busiest.length > 0 ? (
         <div>
-          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Busiest subnets
-          </div>
+          <div className="mb-2 mg-type-micro text-ink-muted">Busiest subnets</div>
           <ul className="space-y-1.5">
             {busiest.map((s) => {
               const pct = Math.max(2, Math.round((s.movements / cap) * 100));
@@ -590,9 +574,7 @@ function NetworkOperationsSection({
 }) {
   return (
     <section>
-      <h2 className="mb-6 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-        Network operations
-      </h2>
+      <h2 className="mb-6 mg-type-label uppercase text-ink-muted">Network operations</h2>
       <div className="grid gap-6 lg:grid-cols-2">
         <ChainServingLeaderboard board={serving} />
         <ChainPrometheusLeaderboard board={prometheus} />
@@ -607,9 +589,7 @@ function ChainServingLeaderboard({ board }: { board: ChainServing }) {
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Axon serving
-        </h3>
+        <h3 className="mg-type-label uppercase text-ink-muted">Axon serving</h3>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(board.subnet_count)} subnets
         </span>
@@ -678,9 +658,7 @@ function ChainPrometheusLeaderboard({ board }: { board: ChainPrometheus }) {
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Prometheus telemetry
-        </h3>
+        <h3 className="mg-type-label uppercase text-ink-muted">Prometheus telemetry</h3>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(board.subnet_count)} subnets
         </span>
@@ -754,9 +732,7 @@ function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <div>
-          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-            Axon churn leaderboard
-          </h2>
+          <h2 className="mg-type-label uppercase text-ink-muted">Axon churn leaderboard</h2>
           <p className="mt-1 font-mono text-[11px] text-ink-muted">
             {formatNumber(churn.network.removals)} axon teardowns across{" "}
             {formatNumber(churn.network.distinct_removers)} removers network-wide
@@ -822,9 +798,7 @@ function NetworkIdleStakeSection({ idleStake }: { idleStake: ChainIdleStake }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <div>
-          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-            Idle stake
-          </h2>
+          <h2 className="mg-type-label uppercase text-ink-muted">Idle stake</h2>
           <p className="mt-1 font-mono text-[11px] text-ink-muted">
             Stake delegated to hotkeys currently earning zero dividends
           </p>
@@ -910,9 +884,7 @@ function NetworkRegistrationsSection({ registrations }: { registrations: ChainRe
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Network registrations
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Network registrations</h2>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(registrations.subnet_count)} subnets
         </span>
@@ -1007,9 +979,7 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Validator turnover
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Validator turnover</h2>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(turnover.subnet_count)} subnets
         </span>
@@ -1037,9 +1007,7 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
 
       {volatile.length > 0 ? (
         <div>
-          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Most volatile subnets
-          </div>
+          <div className="mb-2 mg-type-micro text-ink-muted">Most volatile subnets</div>
           <ul className="space-y-1.5">
             {volatile.map((s) => {
               const pct = Math.max(
@@ -1098,9 +1066,7 @@ function EconomicsTrendsSection({ trends }: { trends: EconomicsTrends }) {
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Network economics trend
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Network economics trend</h2>
         <span className="font-mono text-[11px] text-ink-muted">{trends.day_count} days</span>
       </div>
       {chrono.length > 0 ? (
@@ -1175,9 +1141,7 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
   return (
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Transfers leaderboard
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Transfers leaderboard</h2>
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(transfers.transfer_count)} transfers
         </span>
@@ -1195,9 +1159,7 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
 
       <div className="grid gap-6 lg:grid-cols-2">
         <div>
-          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Top senders
-          </div>
+          <div className="mb-2 mg-type-micro text-ink-muted">Top senders</div>
           {transfers.top_senders.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="w-full text-left text-sm">
@@ -1241,9 +1203,7 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
         </div>
 
         <div>
-          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            Top receivers
-          </div>
+          <div className="mb-2 mg-type-micro text-ink-muted">Top receivers</div>
           {transfers.top_receivers.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="w-full text-left text-sm">
@@ -1482,9 +1442,7 @@ function ExplorerDashboard() {
           {/* daily activity series */}
           <Panel className="min-w-0">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-              <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-                Daily activity
-              </h2>
+              <h2 className="mg-type-label uppercase text-ink-muted">Daily activity</h2>
               <span className="font-mono text-[11px] text-ink-muted">
                 {activity.day_count} days
               </span>
@@ -1537,9 +1495,7 @@ function ExplorerDashboard() {
 
             {/* top signers */}
             <Panel className="min-w-0">
-              <h2 className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-                Most active accounts
-              </h2>
+              <h2 className="mb-4 mg-type-label uppercase text-ink-muted">Most active accounts</h2>
               {signers.signers.length > 0 ? (
                 <ExplorerLeaderboardTableShell
                   leaderboardId={EXPLORER_LEADERBOARD_IDS.activeAccounts}
@@ -1610,9 +1566,7 @@ function ExplorerDashboard() {
         <div className="grid gap-6 lg:grid-cols-2">
           <Panel className="min-w-0">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-              <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-                Daily fees &amp; tips
-              </h2>
+              <h2 className="mg-type-label uppercase text-ink-muted">Daily fees &amp; tips</h2>
               <span className="font-mono text-[11px] text-ink-muted">{fees.day_count} days</span>
             </div>
             {feeChrono.length > 0 ? (
@@ -1652,9 +1606,7 @@ function ExplorerDashboard() {
           </Panel>
           <Panel className="min-w-0">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-              <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-                Top fee payers
-              </h2>
+              <h2 className="mg-type-label uppercase text-ink-muted">Top fee payers</h2>
               <span className="font-mono text-[11px] text-ink-muted">
                 {fees.top_fee_payers.length} accounts
               </span>
@@ -1722,7 +1674,7 @@ function ExplorerDashboard() {
           <Panel className="min-w-0">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
               <div>
-                <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+                <h2 className="mg-type-label uppercase text-ink-muted">
                   Stake-transfer leaderboard
                 </h2>
                 <p className="mt-1 font-mono text-[11px] text-ink-muted">
@@ -1813,9 +1765,7 @@ function ExplorerDashboard() {
         <>
           <Panel className="min-w-0 lg:col-span-2">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
-              <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-                Network weight-setters
-              </h2>
+              <h2 className="mg-type-label uppercase text-ink-muted">Network weight-setters</h2>
               <span className="font-mono text-[11px] text-ink-muted">
                 {formatNumber(weightSetters.distinct_setters)} validators
               </span>
@@ -1895,9 +1845,7 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
         <div>
-          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-            Transfer pairs
-          </h2>
+          <h2 className="mg-type-label uppercase text-ink-muted">Transfer pairs</h2>
           {pairs ? (
             <p className="mt-1 font-mono text-[11px] text-ink-muted">
               {formatNumber(pairs.unique_pairs)} sender→receiver corridors ·{" "}
@@ -2022,9 +1970,7 @@ function ChainEventsFeedSection() {
   return (
     <Panel className="mt-10">
       <div className="mb-4">
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Chain events
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Chain events</h2>
         <p className="mt-1 font-mono text-[11px] text-ink-muted">
           Browse individual pallet events newest-first — distinct from aggregate activity stats.
         </p>

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -134,9 +134,7 @@ function FeesTrendCard() {
       <div className="p-4 sm:p-6">
         <div className="mb-2 flex items-baseline justify-between gap-2">
           <div className="flex items-baseline gap-2">
-            <h2 className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-              Fees, last 7d
-            </h2>
+            <h2 className="mg-type-micro text-ink-muted">Fees, last 7d</h2>
             <span className="font-mono text-[11px] text-ink-muted">{fees.day_count} days</span>
           </div>
           <span className="font-mono text-[11px] tabular-nums text-ink-strong">

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -619,9 +619,7 @@ function OpenGapsSection() {
 
       {missingSet.size > 0 ? (
         <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-accent/30 bg-primary-soft/40 px-3 py-2 font-mono text-[11px] text-ink-strong">
-          <span className="uppercase tracking-widest text-[10px] text-ink-muted">
-            filtered by missing kind:
-          </span>
+          <span className="mg-type-micro text-ink-muted">filtered by missing kind:</span>
           {Array.from(missingSet).map((k) => (
             <span
               key={k}
@@ -636,7 +634,7 @@ function OpenGapsSection() {
           <button
             type="button"
             onClick={() => setSearch({ missing: "" })}
-            className="ml-auto inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2 py-0.5 text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
+            className="ml-auto inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2 py-0.5 mg-type-micro text-ink-muted hover:text-ink-strong"
           >
             <X className="size-3" /> clear
           </button>
@@ -820,7 +818,7 @@ function GapRow({
           <Link
             to="/subnets/$netuid"
             params={{ netuid: gap.netuid }}
-            className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted hover:text-accent hover:border-accent/40"
+            className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/40"
           >
             open
           </Link>
@@ -829,7 +827,7 @@ function GapRow({
           href={`${GITHUB_REPO}/issues/new?title=${encodeURIComponent(`gap: ${gap.title ?? gap.id}`)}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted hover:text-accent hover:border-accent/40"
+          className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-micro text-ink-muted hover:text-accent hover:border-accent/40"
         >
           file
         </a>

--- a/apps/ui/src/routes/graphql.explorer.tsx
+++ b/apps/ui/src/routes/graphql.explorer.tsx
@@ -35,7 +35,7 @@ function GraphqlExplorerPage() {
       <Link
         to="/docs/$"
         params={{ _splat: "graphql" }}
-        className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted transition-colors hover:text-ink-strong"
+        className="inline-flex items-center gap-1.5 mg-type-label uppercase text-ink-muted transition-colors hover:text-ink-strong"
       >
         <ArrowLeft aria-hidden className="size-3.5" />
         GraphQL docs

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -495,9 +495,7 @@ function BoardCard({ title, children }: { title: string; children: React.ReactNo
   return (
     <Panel as="div" flush>
       <div className="p-4">
-        <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-ink-muted mb-3">
-          {title}
-        </div>
+        <div className="mg-type-micro text-ink-muted mb-3">{title}</div>
         {children}
       </div>
     </Panel>
@@ -693,9 +691,7 @@ function Incidents({ interval }: { interval: number | false }) {
     <div className="space-y-4">
       <Panel as="div" dense bodyClassName="flex items-center gap-4">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-ink-muted">
-            Incidents · 14d
-          </div>
+          <div className="mg-type-micro text-ink-muted">Incidents · 14d</div>
           <div className="font-display text-2xl font-semibold text-ink-strong tabular-nums leading-none mt-1">
             {rows.length}
           </div>

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -219,9 +219,7 @@ function OverviewPage() {
                   </div>
                 </AsyncPanel>
                 <div className="lg:col-span-12">
-                  <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-                    Enrichment queue
-                  </div>
+                  <div className="mb-3 mg-type-micro text-ink-muted">Enrichment queue</div>
                   <AsyncPanel
                     context="enrichment queue"
                     fallback={<Skeleton className="h-64 w-full" />}
@@ -293,9 +291,7 @@ function OverviewPage() {
               description="Every list and detail view in this app is also a documented API route. Same data, same envelope."
             />
             <Panel as="div" className="max-w-2xl">
-              <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted mb-2">
-                Try it
-              </div>
+              <div className="mg-type-micro text-ink-muted mb-2">Try it</div>
               <CopyableCode
                 value={`curl ${API_BASE}/api/v1/subnets`}
                 className="w-full text-[12px]"
@@ -334,9 +330,7 @@ function OverviewPage() {
       <AccentBand pattern className="mt-20">
         <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
           <div className="max-w-xl">
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-strong/70 mb-2">
-              All registry data is public
-            </div>
+            <div className="mg-type-micro text-ink-strong/70 mb-2">All registry data is public</div>
             <h2 className="font-display text-2xl md:text-3xl font-semibold text-ink-strong tracking-tight">
               Browse the full Bittensor registry.
             </h2>
@@ -432,7 +426,7 @@ function HomeHero() {
               <span className="min-w-0 flex-1 truncate">
                 Search subnets, validators, endpoints, accounts…
               </span>
-              <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+              <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted">
                 ⌘K
               </kbd>
             </button>
@@ -503,7 +497,7 @@ function SectionHeader({
   if (inline) {
     return (
       <div>
-        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted inline-flex items-center gap-2">
+        <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
           {live ? <span className="mg-live-dot" /> : null}
           {eyebrow}
         </div>
@@ -515,7 +509,7 @@ function SectionHeader({
   }
   return (
     <div className="mb-8 max-w-2xl">
-      <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted inline-flex items-center gap-2">
+      <div className="mg-type-micro text-ink-muted inline-flex items-center gap-2">
         {live ? <span className="mg-live-dot" /> : null}
         {eyebrow}
       </div>
@@ -572,11 +566,9 @@ function TrackedGrid() {
           to={item.to}
           className="mg-hover-lift group rounded-xl border border-border bg-card p-6 flex flex-col"
         >
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            {item.label}
-          </div>
+          <div className="mg-type-micro text-ink-muted">{item.label}</div>
           <p className="mt-3 text-sm text-ink-strong leading-relaxed flex-1">{item.desc}</p>
-          <span className="mt-4 inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted group-hover:text-accent transition-colors">
+          <span className="mt-4 inline-flex items-center gap-1 mg-type-micro text-ink-muted group-hover:text-accent transition-colors">
             Explore
             <ArrowUpRight className="size-3 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
           </span>
@@ -606,7 +598,7 @@ function LivePerformance() {
     <AccentBand className="mt-20">
       <div className="mb-8 flex items-end justify-between">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-strong/70 inline-flex items-center gap-2">
+          <div className="mg-type-micro text-ink-strong/70 inline-flex items-center gap-2">
             <span className="mg-live-dot" />
             Live performance
           </div>
@@ -665,9 +657,7 @@ function PerfCard({
     <Panel as="div" flush>
       <div className="p-4">
         <div className="flex items-baseline justify-between mb-3">
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            {label}
-          </div>
+          <div className="mg-type-micro text-ink-muted">{label}</div>
           <div className="font-mono text-[10px] text-ink-muted">{hint}</div>
         </div>
         <div
@@ -775,9 +765,7 @@ function PilotCardFallback({
     >
       <div className="flex items-center justify-between">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            {subtitle}
-          </div>
+          <div className="mg-type-micro text-ink-muted">{subtitle}</div>
           <div className="mt-1 font-display text-lg font-semibold text-ink-strong">{title}</div>
         </div>
         <CurationChip level="adapter-backed" />
@@ -816,9 +804,7 @@ function PilotCard({
     >
       <div className="flex items-center justify-between mb-4">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
-            {subtitle}
-          </div>
+          <div className="mg-type-micro text-ink-muted">{subtitle}</div>
           <div className="mt-1 font-display text-lg font-semibold text-ink-strong">{title}</div>
         </div>
         <CurationChip level="adapter-backed" />
@@ -827,9 +813,7 @@ function PilotCard({
         <dl className="grid grid-cols-2 gap-2">
           {metricEntries.map(([k, v]) => (
             <div key={k} className="rounded-md border border-border bg-surface/40 px-3 py-2">
-              <dt className="font-mono text-[9px] uppercase tracking-[0.16em] text-ink-muted truncate">
-                {k}
-              </dt>
+              <dt className="mg-type-micro text-ink-muted truncate">{k}</dt>
               <dd className="font-mono text-[12px] text-ink-strong truncate">
                 {typeof v === "object" ? JSON.stringify(v) : String(v)}
               </dd>
@@ -896,7 +880,7 @@ function SubnetPreviewTable() {
     <Panel as="div" flush className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-left text-sm">
-          <thead className="bg-surface/40 text-[10px] font-mono uppercase tracking-[0.18em] text-ink-muted">
+          <thead className="bg-surface/40 mg-type-micro text-ink-muted">
             <tr>
               <th className="px-4 py-3 font-medium">UID</th>
               <th className="px-4 py-3 font-medium">Name</th>
@@ -981,7 +965,7 @@ function SubnetPreviewTable() {
 
 function PoweredByFooter() {
   return (
-    <div className="mt-12 border-t border-border pt-6 flex flex-wrap items-center justify-between gap-2 text-[10px] font-mono uppercase tracking-[0.18em] text-ink-muted">
+    <div className="mt-12 border-t border-border pt-6 flex flex-wrap items-center justify-between gap-2 mg-type-micro text-ink-muted">
       <span className="inline-flex items-center gap-2">
         <FileCode2 className="size-3" />
         Powered by Cloudflare Workers · Static Assets · R2

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -60,9 +60,9 @@ export const Route = createFileRoute("/leaderboards")({
 
 const TH = "px-4 py-2.5 mg-type-micro text-[10px] text-ink-muted";
 const WINDOW_BTN_ACTIVE =
-  "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent-text";
+  "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 mg-type-label uppercase text-accent-text";
 const WINDOW_BTN =
-  "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30";
+  "rounded-full border border-border bg-card px-3 py-1 mg-type-label uppercase text-ink-muted hover:border-ink/30";
 
 // Shaped to each board's own layout -- title, one description line, the
 // 3-tile StatTile row, and a table-shaped placeholder -- so the loading
@@ -129,9 +129,7 @@ function LeaderboardsPage() {
         }
       />
       <div className="flex flex-wrap items-center justify-end gap-2">
-        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Window
-        </span>
+        <span className="mg-type-label uppercase text-ink-muted">Window</span>
         {(["7d", "30d"] as const).map((w) => (
           <button
             key={w}
@@ -268,9 +266,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
   return (
     <div className="space-y-8">
       <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Weight-setting activity
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Weight-setting activity</h2>
         <p className="mt-1 text-sm text-ink-muted">
           Validator consensus effort ranked by subnet — raw WeightsSet events over the selected
           window.
@@ -316,9 +312,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
       ) : (
         <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
-            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-              Per-subnet rankings
-            </span>
+            <span className="mg-type-label uppercase text-ink-muted">Per-subnet rankings</span>
             <span className="font-mono text-[11px] text-ink-muted">
               {formatNumber(board.subnet_count)} subnets
               {board.observed_at ? (
@@ -452,9 +446,7 @@ function EmissionsLeaderboard() {
   return (
     <div className="space-y-8">
       <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Top emitters
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Top emitters</h2>
         <p className="mt-1 text-sm text-ink-muted">
           Subnets ranked by their share of network emissions — from the live economics snapshot.
         </p>
@@ -494,9 +486,7 @@ function EmissionsLeaderboard() {
       ) : (
         <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
-            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-              Per-subnet rankings
-            </span>
+            <span className="mg-type-label uppercase text-ink-muted">Per-subnet rankings</span>
             <span className="font-mono text-[11px] text-ink-muted">
               top {top.length} of {formatNumber(ranked.length)} subnets
             </span>
@@ -591,9 +581,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
   return (
     <div className="space-y-8">
       <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Deregistrations
-        </h2>
+        <h2 className="mg-type-label uppercase text-ink-muted">Deregistrations</h2>
         <p className="mt-1 text-sm text-ink-muted">
           Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
           window.
@@ -635,9 +623,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
       ) : (
         <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
-            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-              Per-subnet rankings
-            </span>
+            <span className="mg-type-label uppercase text-ink-muted">Per-subnet rankings</span>
             <span className="font-mono text-[11px] text-ink-muted">
               {formatNumber(board.subnet_count)} subnets
               {board.observed_at ? (

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -221,7 +221,7 @@ function SchemasHero() {
           <Link
             to="/docs/$"
             params={{ _splat: "api-reference" }}
-            className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent-text transition-colors hover:bg-accent/15"
+            className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 mg-type-label uppercase text-accent-text transition-colors hover:bg-accent/15"
           >
             Browse reference
           </Link>

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -501,7 +501,7 @@ function SurfaceRow({ surface, ongoing }: { surface: GlobalIncidentSurface; ongo
     <li className="flex items-center gap-3 rounded border border-border bg-card px-3 py-2.5">
       <span
         className={classNames(
-          "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-widest shrink-0",
+          "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro shrink-0",
           ongoing
             ? "border-health-down/40 bg-health-down/5 text-health-down"
             : "border-border bg-paper text-ink-muted",

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1279,7 +1279,7 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-3">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+        <span className="mg-type-micro text-ink-muted">
           {events.length} event{events.length === 1 ? "" : "s"}
         </span>
         <RealtimeFreshness at={data.meta?.generated_at} />
@@ -1693,10 +1693,8 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
     <div className="mt-6 min-w-0" data-weight-setters-leaderboard>
       <Panel flush className="overflow-hidden">
         <div className="flex flex-nowrap items-center justify-between gap-3 border-b border-border px-4 py-3">
-          <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted sm:hidden">
-            Weight-setters
-          </span>
-          <span className="hidden shrink-0 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted sm:inline">
+          <span className="shrink-0 mg-type-micro text-ink-muted sm:hidden">Weight-setters</span>
+          <span className="hidden shrink-0 mg-type-micro text-ink-muted sm:inline">
             Weight-setters · per-validator breakdown
           </span>
           <span className="shrink-0 font-mono text-[10px] text-ink-muted whitespace-nowrap">

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -194,7 +194,7 @@ function SubnetPerformanceTable({
               </td>
               <td className="px-3 py-2 text-center">
                 {s.validator_permit ? (
-                  <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                  <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 mg-type-micro text-accent-text">
                     Yes
                   </span>
                 ) : (


### PR DESCRIPTION
## Summary

Completes the #7808 sweep in a single PR: converts every remaining ad-hoc `font-mono text-[Npx] uppercase tracking-X` eyebrow-label site (218 sites across 78 files) to the shared `mg-type-micro`/`mg-type-label` utility classes, using the same heuristic as every prior batch (#7820, #7822, #7823, #7826, #7827):

- ~9-10.5px sizes + `uppercase` + `tracking-wid(er|est)` or an equivalent arbitrary `tracking-[0.NNem]` → `mg-type-micro`
- `text-[11px]` + `uppercase` + `tracking-X` → `mg-type-label uppercase`

This also catches a second variant this issue's earlier batches missed: `tracking-[0.1Xem]` arbitrary values (0.12em-0.22em) — functionally identical to `tracking-wide/wider/widest` (0.025em/0.05em/0.1em) but a bespoke tightening on top, matching `mg-type-micro`'s own 0.18em and `mg-type-label`'s 0.14em — which weren't matched by the narrower `tracking-wid(er|est)` name search used earlier.

Applied via a small Python script operating token-by-token on double-quoted class strings (strip `font-mono`, the specific `text-[Npx]`, `uppercase`, and the `tracking-*` token; insert the replacement at the first removed token's position; leave every other class untouched) — the same transformation done by hand in every prior batch, mechanized once the shape of the site was proven consistent across ~200 sites. Dry-ran it over every matched site and reviewed the full diff before applying. One template-literal site (`delegate.tsx`) that the script's plain-string regex doesn't reach was fixed by hand.

Left as-is: bare arbitrary sizes with no uppercase+tracking pairing (tabular/numeric formatting has no `mg-type-*` equivalent), and `primitives/section-label.tsx`'s one grep hit, which is its own doc comment describing what it replaces, not a usage site.

## Verification

- `tsc --noEmit` clean
- Full `eslint src`: 0 errors (1509 pre-existing warnings, all legitimate skips outside this heuristic)
- Full `vitest run`: 183/183 files, 1403/1403 tests passing
- Spot-checked live in a local dev build against production data — homepage, `/explorer`, `/leaderboards`, `/subnets/1` — all render correctly, 0 console errors

Closes #7808.