### PR TITLE
build(typescript): Phase 3 straggler — convert contracts.mjs to .ts

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -79,7 +79,7 @@ import {
   PRIMARY_DOMAIN,
   buildApiIndexArtifact,
   buildContractsArtifact,
-} from "../src/contracts.mjs";
+} from "../src/contracts.ts";
 import {
   MCP_SERVER_INFO,
   MCP_REGISTRY_META,

--- a/scripts/build-network-registry.ts
+++ b/scripts/build-network-registry.ts
@@ -15,7 +15,7 @@
 import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import {
   artifactOutputPath,
   backfilledIdentityUrl,

--- a/scripts/openapi-components.ts
+++ b/scripts/openapi-components.ts
@@ -1,4 +1,4 @@
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { buildApiComponentBundle } from "./bundle-schemas.ts";
 import { buildTimestamp } from "./lib.ts";
 

--- a/scripts/probes-smoke.ts
+++ b/scripts/probes-smoke.ts
@@ -23,7 +23,7 @@ import {
   rollupSubnetStatus,
   type ProbeSurface,
 } from "../src/health-probe-core.ts";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 
 type Row = Record<string, unknown>;
 

--- a/scripts/r2-manifest.ts
+++ b/scripts/r2-manifest.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, stat } from "node:fs/promises";
 import {

--- a/scripts/refresh-economics.ts
+++ b/scripts/refresh-economics.ts
@@ -24,7 +24,7 @@ import {
   stableStringify,
 } from "./lib.ts";
 import { loadAlphaPriceHistoryByNetuid } from "./lib/load-alpha-price-history.ts";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
 import { shouldPublishEconomics } from "./economics-floor.ts";
 import { initSentry, endSessionAndFlush } from "./observability.ts";

--- a/scripts/smoke-live-api.ts
+++ b/scripts/smoke-live-api.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { API_ROUTES } from "../src/contracts.mjs";
+import { API_ROUTES } from "../src/contracts.ts";
 import { MCP_TOOLS } from "../src/mcp-server.mjs";
 
 // Live production response bodies (API envelopes, MCP JSON-RPC results) --

--- a/scripts/snapshot-adapters.ts
+++ b/scripts/snapshot-adapters.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { pathToFileURL } from "node:url";
 import {
   buildTimestamp,

--- a/scripts/snapshot-openapi.ts
+++ b/scripts/snapshot-openapi.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from "node:fs";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import {
   artifactFilePath,
   artifactOutputPath,

--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -6,7 +6,7 @@ import {
   API_ROUTES,
   CONTRACT_VERSION,
   compileRoutePattern,
-} from "../src/contracts.mjs";
+} from "../src/contracts.ts";
 import { handleRequest } from "../workers/api.mjs";
 import {
   createLocalArtifactEnv,

--- a/scripts/validate-committed-seed.ts
+++ b/scripts/validate-committed-seed.ts
@@ -24,7 +24,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
-import { API_ROUTES } from "../src/contracts.mjs";
+import { API_ROUTES } from "../src/contracts.ts";
 import { handleRequest } from "../workers/api.mjs";
 import {
   ARTIFACT_STORAGE_TIERS,

--- a/scripts/validate-docs.ts
+++ b/scripts/validate-docs.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { API_ROUTES, PUBLIC_ARTIFACTS } from "../src/contracts.mjs";
+import { API_ROUTES, PUBLIC_ARTIFACTS } from "../src/contracts.ts";
 import { repoRoot } from "./lib.ts";
 
 // --- Cadence prose guard (ADR 0007) -------------------------------------------

--- a/scripts/validate-openapi-examples.ts
+++ b/scripts/validate-openapi-examples.ts
@@ -8,7 +8,7 @@
 import { Ajv2020, type Schema, type ValidateFunction } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
 import path from "node:path";
-import { API_ROUTES } from "../src/contracts.mjs";
+import { API_ROUTES } from "../src/contracts.ts";
 import { readJson, repoRoot } from "./lib.ts";
 
 // ajv-formats' default export resolves to the CJS module namespace rather than

--- a/scripts/validate-openapi.ts
+++ b/scripts/validate-openapi.ts
@@ -4,7 +4,7 @@ import {
   API_ROUTES,
   CONTRACT_VERSION,
   PRIMARY_DOMAIN,
-} from "../src/contracts.mjs";
+} from "../src/contracts.ts";
 import { readJson, repoRoot } from "./lib.ts";
 
 // The OpenAPI document + api-index are generated JSON, deep-traversed only to

--- a/scripts/validate-schema-enums.ts
+++ b/scripts/validate-schema-enums.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { QUERY_ENUMS } from "../src/contracts.mjs";
+import { QUERY_ENUMS } from "../src/contracts.ts";
 import { readJson, repoRoot } from "./lib.ts";
 
 const schemaBundle = await readJson(

--- a/scripts/validate-schemas.ts
+++ b/scripts/validate-schemas.ts
@@ -2,7 +2,7 @@ import { Ajv2020, type ErrorObject } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { PUBLIC_ARTIFACTS } from "../src/contracts.mjs";
+import { PUBLIC_ARTIFACTS } from "../src/contracts.ts";
 import {
   listJsonFiles,
   listJsonFilesRecursive,

--- a/scripts/worker-test.ts
+++ b/scripts/worker-test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "./lib.ts";
 

--- a/src/adapter-candidates-mcp.ts
+++ b/src/adapter-candidates-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const ADAPTER_CANDIDATES_ARTIFACT =
   "/metagraph/review/adapter-candidates.json";

--- a/src/agent-tool-specs.ts
+++ b/src/agent-tool-specs.ts
@@ -10,7 +10,7 @@
 //
 // Execution is uniform: every tool is run by forwarding the model's tool call
 // to the MCP endpoint as a JSON-RPC `tools/call` (see buildAgentToolsIndex).
-import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
+import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.ts";
 import { MCP_SERVER_INFO, listToolDefinitions } from "./mcp-server.mjs";
 
 const ORIGIN = `https://${PRIMARY_DOMAIN}`;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -3,6 +3,30 @@ import { ROUTE_CSV_EXAMPLES } from "./csv-route-examples.ts";
 import { DOMAIN_TAGS } from "./domain-tags.ts";
 import { sampleFromSchema } from "./openapi-sample.ts";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+interface QueryParameterSpec {
+  name: string;
+  description?: string;
+  schema: unknown;
+}
+
+interface QueryCollectionSpec {
+  collection?: string | null;
+  csvResponse?: boolean;
+  filterNames?: string[];
+  parameters: QueryParameterSpec[];
+}
+
+type QueryParametersInput = QueryParameterSpec[] | QueryCollectionSpec;
+
+interface RetirementInfo {
+  code: string;
+  http_status: number;
+  message: string;
+}
+
 export const CONTRACT_VERSION = "2026-07-03.2";
 export const SCHEMA_VERSION = 1;
 // The API + artifacts are served from the api subdomain; the bare apex
@@ -4336,7 +4360,7 @@ export const API_ROUTES = [
   ),
 ];
 
-export function buildContractsArtifact(generatedAt) {
+export function buildContractsArtifact(generatedAt: string) {
   return {
     schema_version: SCHEMA_VERSION,
     contract_version: CONTRACT_VERSION,
@@ -4372,7 +4396,10 @@ export function buildContractsArtifact(generatedAt) {
   };
 }
 
-export function buildApiIndexArtifact(generatedAt, contractsArtifact) {
+export function buildApiIndexArtifact(
+  generatedAt: string,
+  contractsArtifact: ReturnType<typeof buildContractsArtifact>,
+) {
   return {
     schema_version: SCHEMA_VERSION,
     contract_version: CONTRACT_VERSION,
@@ -4415,14 +4442,17 @@ export function buildApiIndexArtifact(generatedAt, contractsArtifact) {
   };
 }
 
-export function buildOpenApiArtifact(generatedAt, componentSchemas) {
+export function buildOpenApiArtifact(
+  generatedAt: string,
+  componentSchemas: Row | null,
+) {
   if (!componentSchemas) {
     throw new Error(
       "buildOpenApiArtifact requires canonical component schemas from schemas/api-components.schema.json",
     );
   }
 
-  const paths = {};
+  const paths: Row = {};
   for (const entry of API_ROUTES) {
     const openApiPath = entry.path;
     const responseSchema = {
@@ -4599,8 +4629,12 @@ const FIXTURE_DETAIL_OPENAPI_EXAMPLE = {
   },
 };
 
-function openApiExampleForRoute(entry, responseSchema, componentSchemas) {
-  const example = sampleFromSchema(responseSchema, componentSchemas);
+function openApiExampleForRoute(
+  entry: (typeof API_ROUTES)[number],
+  responseSchema: Row,
+  componentSchemas: Row,
+) {
+  const example = sampleFromSchema(responseSchema, componentSchemas) as Row;
   if (entry.id !== "fixture-detail") {
     return example;
   }
@@ -4618,7 +4652,7 @@ function openApiExampleForRoute(entry, responseSchema, componentSchemas) {
   };
 }
 
-export function artifactPathFromTemplate(template, params = {}) {
+export function artifactPathFromTemplate(template: string, params: Row = {}) {
   return (
     template
       .replace("{netuid}", String(params.netuid ?? ""))
@@ -4638,7 +4672,7 @@ export function artifactPathFromTemplate(template, params = {}) {
   );
 }
 
-export function compileRoutePattern(pathTemplate) {
+export function compileRoutePattern(pathTemplate: string) {
   const tokenized = pathTemplate
     .replace(/\{netuid\}/g, "__METAGRAPH_NETUID__")
     .replace(/\{uid\}/g, "__METAGRAPH_UID__")
@@ -4680,7 +4714,13 @@ export function compileRoutePattern(pathTemplate) {
   return new RegExp(`^${pattern}\\/?$`);
 }
 
-function artifact(id, pathValue, description, schemaRef, options = {}) {
+function artifact(
+  id: string,
+  pathValue: string,
+  description: string,
+  schemaRef: string | null,
+  options: { status?: string; retirement?: RetirementInfo | null } = {},
+) {
   const { status = ARTIFACT_STATUS_LIVE, retirement = null } = options;
   return {
     id,
@@ -4695,7 +4735,7 @@ function artifact(id, pathValue, description, schemaRef, options = {}) {
   };
 }
 
-function artifactContentType(pathValue) {
+function artifactContentType(pathValue: string) {
   if (pathValue.endsWith(".d.ts")) {
     return "text/plain; charset=utf-8";
   }
@@ -4703,15 +4743,15 @@ function artifactContentType(pathValue) {
 }
 
 function route(
-  id,
-  method,
-  pathValue,
-  artifactPath,
-  description,
-  cache,
-  tags,
-  queryParameters = [],
-  pathParameters = [],
+  id: string,
+  method: string,
+  pathValue: string,
+  artifactPath: string,
+  description: string,
+  cache: string,
+  tags: string[],
+  queryParameters: QueryParametersInput = [],
+  pathParameters: Row[] = [],
 ) {
   const querySpec = normalizeQueryParameters(queryParameters);
   return {
@@ -4730,7 +4770,7 @@ function route(
   };
 }
 
-function queryCollection(dataKey, options = {}) {
+function queryCollection(dataKey: string, options: Row = {}) {
   return {
     data_key: dataKey,
     filters: options.filters || {},
@@ -4750,12 +4790,12 @@ function queryCollection(dataKey, options = {}) {
   };
 }
 
-function enumSchema(values) {
+function enumSchema(values: readonly string[]) {
   return { type: "string", enum: values };
 }
 
-function listQuery(collection, options = {}) {
-  const config = API_QUERY_COLLECTIONS[collection];
+function listQuery(collection: string, options: { exclude?: string[] } = {}) {
+  const config = (API_QUERY_COLLECTIONS as Record<string, Row>)[collection];
   /* v8 ignore next 3 -- developer config invariant validated by OpenAPI/schema checks */
   if (!config) {
     throw new Error(`Unknown API query collection: ${collection}`);
@@ -4770,7 +4810,7 @@ function listQuery(collection, options = {}) {
       ? [{ name: "q", schema: searchTextSchema }]
       : [];
   // Each numeric range field F → a `min_F` + `max_F` inclusive-bound parameter.
-  const rangeParameters = config.range_filters.flatMap((field) => [
+  const rangeParameters = config.range_filters.flatMap((field: string) => [
     { name: `min_${field}`, schema: { type: "number" } },
     { name: `max_${field}`, schema: { type: "number" } },
   ]);
@@ -4813,12 +4853,18 @@ function listQuery(collection, options = {}) {
 // query parameters the collection itself doesn't own — e.g. the incidents route's
 // `window` scope (#6571). The extra parameters lead, then the standard list-query
 // params, so `window` still reads first in the OpenAPI parameter list.
-function listQueryWith(collection, extraParameters) {
+function listQueryWith(
+  collection: string,
+  extraParameters: QueryParameterSpec[],
+) {
   const spec = listQuery(collection);
   return { ...spec, parameters: [...extraParameters, ...spec.parameters] };
 }
 
-function csvListQuery(collection, options = {}) {
+function csvListQuery(
+  collection: string,
+  options: { exclude?: string[] } = {},
+) {
   const spec = listQuery(collection, options);
   return {
     ...spec,
@@ -4835,7 +4881,7 @@ function csvListQuery(collection, options = {}) {
   };
 }
 
-function csvRouteQuery(parameters = []) {
+function csvRouteQuery(parameters: QueryParameterSpec[] = []) {
   return {
     collection: null,
     filterNames: [],
@@ -4852,7 +4898,7 @@ function csvRouteQuery(parameters = []) {
   };
 }
 
-function csvExampleForRoute(entry) {
+function csvExampleForRoute(entry: (typeof API_ROUTES)[number]) {
   const supplemental = ROUTE_CSV_EXAMPLES[entry.id];
   if (supplemental) return supplemental;
   if (entry.id === "subnet-movers") {
@@ -4977,14 +5023,14 @@ function csvExampleForRoute(entry) {
   return "netuid,name\r\n7,Allways";
 }
 
-function csvResponseDescriptionForRoute(entry) {
+function csvResponseDescriptionForRoute(entry: (typeof API_ROUTES)[number]) {
   if (entry.query_collection) {
     return "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.";
   }
   return "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.";
 }
 
-function normalizeQueryParameters(queryParameters) {
+function normalizeQueryParameters(queryParameters: QueryParametersInput) {
   if (Array.isArray(queryParameters)) {
     return { collection: null, filterNames: [], parameters: queryParameters };
   }
@@ -4996,7 +5042,7 @@ function normalizeQueryParameters(queryParameters) {
   };
 }
 
-function schemaRefForArtifactPath(artifactPath) {
+function schemaRefForArtifactPath(artifactPath: string) {
   const contract = PUBLIC_ARTIFACTS.find((entry) =>
     pathTemplatesMatch(entry.path, artifactPath),
   );
@@ -5013,7 +5059,7 @@ function schemaRefForArtifactPath(artifactPath) {
   return contract.schema_ref;
 }
 
-function pathTemplatesMatch(contractPath, artifactPath) {
+function pathTemplatesMatch(contractPath: string, artifactPath: string) {
   if (contractPath === artifactPath) {
     return true;
   }

--- a/src/curation-mcp.ts
+++ b/src/curation-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const CURATION_ARTIFACT = "/metagraph/curation.json";
 

--- a/src/endpoint-incidents-mcp.ts
+++ b/src/endpoint-incidents-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const ENDPOINT_INCIDENTS_ARTIFACT = "/metagraph/endpoint-incidents.json";
 

--- a/src/endpoint-pools-mcp.ts
+++ b/src/endpoint-pools-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 
 export const ENDPOINT_POOLS_ARTIFACT = "/metagraph/endpoint-pools.json";
 

--- a/src/enrichment-evidence-mcp.ts
+++ b/src/enrichment-evidence-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const ENRICHMENT_EVIDENCE_ARTIFACT =
   "/metagraph/review/enrichment-evidence.json";

--- a/src/enrichment-queue-mcp.ts
+++ b/src/enrichment-queue-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const ENRICHMENT_QUEUE_ARTIFACT =
   "/metagraph/review/enrichment-queue.json";

--- a/src/evidence-mcp.ts
+++ b/src/evidence-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 
 export const EVIDENCE_LEDGER_ARTIFACT = "/metagraph/evidence-ledger.json";
 

--- a/src/gaps-mcp.ts
+++ b/src/gaps-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const GAPS_ARTIFACT = "/metagraph/gaps.json";
 

--- a/src/health-history-mcp.ts
+++ b/src/health-history-mcp.ts
@@ -4,7 +4,7 @@
 
 import { DAY_PATTERN } from "../workers/request-params.ts";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 const HEALTH_SURFACE_SORT_FIELDS =
   API_QUERY_COLLECTIONS["health-surfaces"].sort_fields;

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -72,7 +72,7 @@ import {
   listSubscribableMcpResourceClasses,
   parseSubnetStatusResourceUri,
 } from "./subnet-status-subscribe.ts";
-import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.mjs";
+import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.ts";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
   GET_ECONOMICS_MCP_TOOL,

--- a/src/network-economics.ts
+++ b/src/network-economics.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import { resolveLiveEconomics } from "./health-serving.ts";
 
 const ECONOMICS_SORT_FIELDS = API_QUERY_COLLECTIONS.economics.sort_fields;

--- a/src/profile-completeness-mcp.ts
+++ b/src/profile-completeness-mcp.ts
@@ -5,7 +5,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const PROFILE_COMPLETENESS_ARTIFACT =
   "/metagraph/review/profile-completeness.json";

--- a/src/profiles-mcp.ts
+++ b/src/profiles-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 const PROFILES_SORT_FIELDS = API_QUERY_COLLECTIONS.profiles.sort_fields;
 const NULLABLE_STRING = { type: ["string", "null"] };

--- a/src/provider-endpoints-mcp.ts
+++ b/src/provider-endpoints-mcp.ts
@@ -5,7 +5,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const PROVIDER_SLUG_PATTERN = /^[a-z0-9-]+$/;
 

--- a/src/providers-mcp.ts
+++ b/src/providers-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const PROVIDERS_ARTIFACT = "/metagraph/providers.json";
 

--- a/src/review-enrichment-targets-mcp.ts
+++ b/src/review-enrichment-targets-mcp.ts
@@ -5,7 +5,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const REVIEW_ENRICHMENT_TARGETS_ARTIFACT =
   "/metagraph/review/enrichment-targets.json";

--- a/src/review-gaps-mcp.ts
+++ b/src/review-gaps-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const REVIEW_GAPS_ARTIFACT = "/metagraph/review/gap-priorities.json";
 

--- a/src/rpc-pools-mcp.ts
+++ b/src/rpc-pools-mcp.ts
@@ -9,7 +9,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
 import { overlayRpcPoolEligibility } from "./health-serving.ts";
 

--- a/src/search-index-mcp.ts
+++ b/src/search-index-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 
 export const SEARCH_INDEX_ARTIFACT = "/metagraph/search-index.json";
 

--- a/src/search-mcp.ts
+++ b/src/search-mcp.ts
@@ -6,7 +6,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 
 export const SEARCH_ARTIFACT = "/metagraph/search.json";
 

--- a/src/source-snapshots-mcp.ts
+++ b/src/source-snapshots-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 
 export const SOURCE_SNAPSHOTS_ARTIFACT = "/metagraph/source-snapshots.json";
 

--- a/src/subnet-endpoints-mcp.ts
+++ b/src/subnet-endpoints-mcp.ts
@@ -5,7 +5,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;

--- a/src/subnet-evidence-mcp.ts
+++ b/src/subnet-evidence-mcp.ts
@@ -5,7 +5,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 
 const CLAIM_SORT_FIELDS = API_QUERY_COLLECTIONS.claims.sort_fields;
 

--- a/src/surfaces-mcp.ts
+++ b/src/surfaces-mcp.ts
@@ -4,7 +4,7 @@
 
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 
 export const SURFACES_ARTIFACT = "/metagraph/surfaces.json";
 

--- a/tests/account-entities-handler.test.ts
+++ b/tests/account-entities-handler.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import {
   handleAccount,

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -11,7 +11,7 @@ import {
   handleSubnetStakeFlow,
 } from "../workers/request-handlers/entities.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 
 // Edge-cache coverage for the D1-backed analytics routes (audit #6). These four

--- a/tests/analytics-live.test.ts
+++ b/tests/analytics-live.test.ts
@@ -20,7 +20,7 @@ import {
   parseUptimeWindow,
   profilesProjectionFromRows,
 } from "../src/analytics-live.ts";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import type { Row } from "./row-type.ts";
 

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -13,7 +13,7 @@ import {
   writeSubnetSnapshot,
 } from "../src/health-prober.ts";
 import { handleRequest, handleScheduled } from "../workers/api.mjs";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../workers/api.mjs";
 import workerDefault from "../workers/api.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
-import { API_ROUTES, compileRoutePattern } from "../src/contracts.mjs";
+import { API_ROUTES, compileRoutePattern } from "../src/contracts.ts";
 import * as workerConfig from "../workers/config.ts";
 import { type AnyFn, type Row } from "./row-type.ts";
 import type { RpcEndpoint } from "../workers/request-handlers/rpc-proxy.ts";
@@ -1599,7 +1599,7 @@ describe("registry list CSV export", () => {
         (param: Row) => param.name === "format",
       );
       assert.ok(formatParam, `${id} should expose a format parameter`);
-      assert.deepEqual(formatParam.schema.enum, ["json", "csv"]);
+      assert.deepEqual((formatParam.schema as Row).enum, ["json", "csv"]);
     }
   });
 

--- a/tests/artifact-tiering-explicit.test.ts
+++ b/tests/artifact-tiering-explicit.test.ts
@@ -9,7 +9,7 @@
 // time instead of in a production refresh.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { PUBLIC_ARTIFACTS } from "../src/contracts.mjs";
+import { PUBLIC_ARTIFACTS } from "../src/contracts.ts";
 import {
   DUAL_PATTERNS,
   R2_ONLY_PATTERNS,

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -33,7 +33,7 @@ import {
   CONTRACT_VERSION,
   API_ROUTES,
   PRIMARY_DOMAIN,
-} from "../src/contracts.mjs";
+} from "../src/contracts.ts";
 import { handleRequest } from "../workers/api.mjs";
 import type { Row } from "./row-type.ts";
 

--- a/tests/chain-performance-handler.test.ts
+++ b/tests/chain-performance-handler.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import { handleChainPerformance } from "../workers/request-handlers/entities.mjs";
 import type { Row } from "./row-type.ts";

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import addFormatsPlugin from "ajv-formats";
 import { composeCompareData, handleRequest } from "../workers/api.mjs";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import { Ajv2020 } from "ajv/dist/2020.js";

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -15,7 +15,7 @@ import {
   buildContractsArtifact,
   buildOpenApiArtifact,
   compileRoutePattern,
-} from "../src/contracts.mjs";
+} from "../src/contracts.ts";
 import { RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN } from "../workers/config.ts";
 import { evaluateArtifactBudgets } from "../scripts/artifact-budgets.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
@@ -73,8 +73,8 @@ describe("artifact lifecycle status (#6358)", () => {
       "health-summary",
     ]);
     for (const entry of retired) {
-      assert.equal(entry.retirement.http_status, 410);
-      assert.match(entry.retirement.message, /retired/i);
+      assert.equal(entry.retirement!.http_status, 410);
+      assert.match(entry.retirement!.message, /retired/i);
       // The description tells a human reader too, not just the machine field.
       assert.match(entry.description, /retired/i);
     }
@@ -206,7 +206,10 @@ describe("public contract registry", () => {
   test("builds contracts, API index, and OpenAPI from one route table", async () => {
     const generatedAt = "1970-01-01T00:00:00.000Z";
     const contracts = buildContractsArtifact(generatedAt) as Row;
-    const apiIndex = buildApiIndexArtifact(generatedAt, contracts) as Row;
+    const apiIndex = buildApiIndexArtifact(
+      generatedAt,
+      contracts as unknown as ReturnType<typeof buildContractsArtifact>,
+    ) as Row;
     const openapi = buildOpenApiArtifact(
       generatedAt,
       await loadOpenApiComponentSchemas(generatedAt),

--- a/tests/discovery-artifacts.test.ts
+++ b/tests/discovery-artifacts.test.ts
@@ -10,7 +10,7 @@ import { describe, test } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
 import { repoRoot, loadSubnets } from "../scripts/lib.ts";
-import { PRIMARY_DOMAIN } from "../src/contracts.mjs";
+import { PRIMARY_DOMAIN } from "../src/contracts.ts";
 import { MCP_REGISTRY_NAME, MCP_SERVER_INFO } from "../src/mcp-server.mjs";
 import { mcpServerCardResponse } from "../workers/request-handlers/discovery.ts";
 import { mockEnv, type Row } from "./row-type.ts";

--- a/tests/identity-history-csv.test.ts
+++ b/tests/identity-history-csv.test.ts
@@ -7,7 +7,7 @@
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import {
   handleSubnetIdentityHistory,

--- a/tests/invariants-contracts.test.ts
+++ b/tests/invariants-contracts.test.ts
@@ -15,7 +15,7 @@ import {
   buildContractsArtifact,
   buildOpenApiArtifact,
   compileRoutePattern,
-} from "../src/contracts.mjs";
+} from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import type { Row } from "./row-type.ts";
 
@@ -45,7 +45,7 @@ describe("contracts — route ⇄ artifact mapping invariants", () => {
       assert.match(dataRef, /^#\/components\/schemas\/\w+$/);
       const componentName = dataRef.split("/").pop();
       assert.ok(
-        openapi.components.schemas[componentName],
+        (openapi.components.schemas as Row)[componentName],
         `route ${route.id} data schema ${componentName} is not a defined component`,
       );
     }

--- a/tests/list-query.test.ts
+++ b/tests/list-query.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
+import { API_QUERY_COLLECTIONS } from "../src/contracts.ts";
 import {
   applyQueryFilters,
   canonicalListSearch,

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -34,7 +34,7 @@ import { CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT } from "../src/chain-weight-setters.
 import { CHAIN_SERVING_LIMIT_DEFAULT } from "../src/chain-serving.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -8,7 +8,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { MOVERS_WINDOWS } from "../src/movers.ts";
 import { unsupportedWindowMessage } from "../src/neuron-history.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";

--- a/tests/responses-contract-version.test.ts
+++ b/tests/responses-contract-version.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { contractStaleness, contractVersion } from "../workers/responses.ts";
 import { mockEnv } from "./row-type.ts";
 

--- a/tests/smoke-route-substitution.test.ts
+++ b/tests/smoke-route-substitution.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { API_ROUTES } from "../src/contracts.mjs";
+import { API_ROUTES } from "../src/contracts.ts";
 import {
   apiRouteUrl,
   fixtureSurfaceIdFromIndex,

--- a/tests/subnet-concentration-history-csv.test.ts
+++ b/tests/subnet-concentration-history-csv.test.ts
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import {
   canonicalSubnetConcentrationHistoryCachePath,

--- a/tests/subnet-hyperparams-history-csv.test.ts
+++ b/tests/subnet-hyperparams-history-csv.test.ts
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import { handleSubnetHyperparamsHistory } from "../workers/request-handlers/entities.mjs";
 import type { Row } from "./row-type.ts";

--- a/tests/subnet-idle-stake-handler.test.ts
+++ b/tests/subnet-idle-stake-handler.test.ts
@@ -8,7 +8,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import {
   handleChainIdleStake,

--- a/tests/subnet-performance-history-csv.test.ts
+++ b/tests/subnet-performance-history-csv.test.ts
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import {
   canonicalSubnetPerformanceHistoryCachePath,

--- a/tests/subnet-yield-csv.test.ts
+++ b/tests/subnet-yield-csv.test.ts
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import {
   canonicalSubnetYieldCachePath,

--- a/tests/subnet-yield-history-csv.test.ts
+++ b/tests/subnet-yield-history-csv.test.ts
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.ts";
 import {
   canonicalSubnetYieldHistoryCachePath,

--- a/tests/worker-runtime.test.ts
+++ b/tests/worker-runtime.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import worker, { handleRequest } from "../workers/api.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import { jsonBody, type Row } from "./row-type.ts";

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -5,7 +5,7 @@ import {
   PUBLIC_ARTIFACTS,
   artifactPathFromTemplate,
   compileRoutePattern,
-} from "../src/contracts.mjs";
+} from "../src/contracts.ts";
 import {
   isUsageTelemetryConfigured,
   recordExceptionEvent,

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -3,7 +3,7 @@
 // (issue #510, de-monolith) as a leaf module: it imports only contract/config
 // constants and nothing from api.mjs, so every request-handler module can share
 // these without an import cycle.
-import { CACHE_SECONDS, CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CACHE_SECONDS, CONTRACT_VERSION } from "../src/contracts.ts";
 import { JSON_CONTENT_TYPE } from "./config.ts";
 
 export type CacheProfile = "short" | "standard" | "static";

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -7,7 +7,7 @@
 import {
   API_QUERY_COLLECTIONS,
   SEARCH_TEXT_MAX_LENGTH,
-} from "../src/contracts.mjs";
+} from "../src/contracts.ts";
 import { linkHeader } from "./http.ts";
 import { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT } from "./request-params.ts";
 

--- a/workers/request-handlers/discovery.ts
+++ b/workers/request-handlers/discovery.ts
@@ -1,4 +1,4 @@
-import { CACHE_SECONDS, PRIMARY_DOMAIN } from "../../src/contracts.mjs";
+import { CACHE_SECONDS, PRIMARY_DOMAIN } from "../../src/contracts.ts";
 import { errorResponse, ifNoneMatchSatisfied, weakEtag } from "../http.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
 import { contractVersion, publishedAt } from "../responses.ts";

--- a/workers/responses.ts
+++ b/workers/responses.ts
@@ -3,7 +3,7 @@
 // Extracted from workers/api.mjs (issue #510, de-monolith). Depends only on the
 // http + storage leaf modules and the contract version; it calls nothing back
 // into api.mjs, so there is no import cycle.
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.ts";
 import type { CacheProfile } from "./http.ts";
 import { latestPointer } from "./storage.ts";


### PR DESCRIPTION
## Summary
Part of the TS migration epic (#7510). Converts `src/contracts.mjs` (5041 lines) to `.ts` — the largest remaining Phase 3 file (per #7516) — and updates the import specifier in all 72 files that reference it (scripts/, src/*-mcp.ts, tests/, workers/).

The file is mostly declarative route/schema data (`API_ROUTES`, `PUBLIC_ARTIFACTS`, `API_QUERY_COLLECTIONS`) built by ~20 small constructor functions (`route()`, `artifact()`, `listQuery()`, `enumSchema()`, etc.). Typing those constructors' parameters lets TypeScript infer the shape of every table entry rather than needing per-entry annotations across the ~2500-line `API_ROUTES` array.

This PR is independent of #7835 (the `entities.mjs` conversion) — based on fresh `main`, does not depend on it merging first, and doesn't touch `entities.mjs`/`entities.ts` itself (only fixes the `contracts.mjs` → `.ts` specifier in files that happen to import both).

## Test plan
- [x] `npx tsc --noEmit` clean (repo-wide)
- [x] `npx eslint .` clean (repo-wide)
- [x] `npx prettier --check` clean on all touched files
- [x] `npx vitest run` on all 25 directly-affected test files: 1414/1414 passing
- [ ] CI green