### PR TITLE
fix(ui-kit): port SSR-safety ESLint rules, missed in the initial guardrail port

### DIFF
--- a/packages/ui-kit/eslint.config.js
+++ b/packages/ui-kit/eslint.config.js
@@ -66,6 +66,26 @@ const DESIGN_RULES = [
   },
 ];
 
+// SSR footguns -- see apps/ui/docs/ssr-safety.md. ui-kit's own components
+// only ever render inside apps/ui's TanStack Start SSR tree, so the same
+// hydration-mismatch risk applies here even though ui-kit itself has no
+// server. Ported alongside DESIGN_RULES 2026-07-24 (missed in the initial
+// guardrail port).
+const SSR_SAFETY_RULES = [
+  {
+    selector:
+      "CallExpression[callee.name='useState'] > ArrowFunctionExpression Identifier[name='localStorage']",
+    message:
+      "Reading localStorage in a useState initializer hydration-mismatches. Read inside useEffect and setState from there.",
+  },
+  {
+    selector:
+      "CallExpression[callee.name='useState'] > ArrowFunctionExpression Identifier[name='matchMedia']",
+    message:
+      "Reading matchMedia in a useState initializer hydration-mismatches. Read inside useEffect.",
+  },
+];
+
 // The primitives relocated from apps/ui (2026-07-23) authoritatively define
 // these patterns (Panel/SectionLabel don't wrap themselves in <Panel>, and
 // external-link.tsx/table-state.tsx are known, documented exceptions -- see
@@ -156,7 +176,7 @@ export default tseslint.config(
       ],
       // "warn", not "error" -- matching apps/ui's own rationale: fix
       // incrementally as files are touched, don't block unrelated PRs.
-      "no-restricted-syntax": ["warn", ...DESIGN_RULES],
+      "no-restricted-syntax": ["warn", ...DESIGN_RULES, ...SSR_SAFETY_RULES],
     },
   },
   {


### PR DESCRIPTION
## Summary

Follow-up to #7833. That PR ported apps/ui's Bone & Ink `no-restricted-syntax` design-token rules into `packages/ui-kit/eslint.config.js`, but missed the SSR-safety pair (`docs/ssr-safety.md`): a `useState(() => localStorage...)` / `useState(() => matchMedia...)` initializer hydration-mismatches. ui-kit's own components only ever render inside apps/ui's TanStack Start SSR tree, so the same risk applies to code written in ui-kit — there just wasn't a guardrail to catch it there.

No current violations (verified via grep across `packages/ui-kit/src`); this closes the enforcement gap for future ones.

## Verification

- `eslint .` in packages/ui-kit: 0 errors, 67 warnings (unchanged — no new hits, confirming no existing violations)
- `tsc --noEmit`: clean
- `prettier --check`: clean