### PR TITLE
build(typescript): Phase 3 completion — convert graphql.mjs + mcp-server.mjs to .ts

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -84,7 +84,7 @@ import {
   MCP_SERVER_INFO,
   MCP_REGISTRY_META,
   listToolDefinitions,
-} from "../src/mcp-server.mjs";
+} from "../src/mcp-server.ts";
 import { buildDatasetExports } from "./datasets.ts";
 import {
   buildChangelog,

--- a/scripts/smoke-live-api.ts
+++ b/scripts/smoke-live-api.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { API_ROUTES } from "../src/contracts.ts";
-import { MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_TOOLS } from "../src/mcp-server.ts";
 
 // Live production response bodies (API envelopes, MCP JSON-RPC results) --
 // every field below is read for assertion/reporting only, and an unexpected

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -13,7 +13,7 @@ import {
   MCP_SERVER_VERSION,
   MCP_TOOLS,
   listToolDefinitions,
-} from "../src/mcp-server.mjs";
+} from "../src/mcp-server.ts";
 import {
   buildAnthropicToolSpecs,
   buildOpenAIToolSpecs,

--- a/src/agent-tool-specs.ts
+++ b/src/agent-tool-specs.ts
@@ -11,7 +11,7 @@
 // Execution is uniform: every tool is run by forwarding the model's tool call
 // to the MCP endpoint as a JSON-RPC `tools/call` (see buildAgentToolsIndex).
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.ts";
-import { MCP_SERVER_INFO, listToolDefinitions } from "./mcp-server.mjs";
+import { MCP_SERVER_INFO, listToolDefinitions } from "./mcp-server.ts";
 
 const ORIGIN = `https://${PRIMARY_DOMAIN}`;
 const MCP_ENDPOINT = `${ORIGIN}/mcp`;

--- a/src/data-api-mcp.ts
+++ b/src/data-api-mcp.ts
@@ -50,7 +50,7 @@ function eventCountFromDataApi(data: unknown): unknown {
 
 export interface DataApiMcpContext {
   env: Env;
-  clientIp?: string;
+  clientIp?: string | null;
 }
 
 export async function dataApiFetchJson(

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -465,6 +465,36 @@ import {
 } from "./chain-transfer-pairs.ts";
 import { loadBulkHealthTrends } from "./bulk-health-trends.ts";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+// The MCP loaders' ctx parameter requires a readArtifact field, but every
+// call site in this file supplies readArtifact through the loaders' own deps
+// override (`read = deps.readArtifact ?? ctx.readArtifact`), so ctx.readArtifact
+// is never dereferenced here. This cast bridges that gap without weakening the
+// loaders' own signatures.
+const mcpCtx = (context: GqlContext) =>
+  context as GqlContext & {
+    readArtifact: (env: Env, path: string) => ReturnType<typeof readArtifact>;
+  };
+
+// The contextValue handleGraphQLRequest passes to execute() (env + a
+// per-request memo Map + the raw Request), plus the extra fields the
+// graphql-ws subscription path stamps on (clientIp/graphqlWsConnection) and
+// the Sentry hook. Kept loose (all optional except env) because different
+// entry points populate different subsets.
+interface GqlContext {
+  env: Env;
+  cache: Map<string, unknown>;
+  request?: Request;
+  clientIp?: string | null;
+  graphqlWsConnection?: unknown;
+  chainFirehose?: unknown;
+  reportError?: (err: unknown) => void;
+}
+
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
 export const GRAPHQL_MAX_BODY_BYTES = 64 * 1024;
@@ -4141,8 +4171,12 @@ export const schema = buildSchema(SDL);
 // whichever Durable Object drives the graphql-ws server (workers/chain-firehose-hub.mjs)
 // -- see GRAPHQL_SUBSCRIPTION_CONTEXT_KEY below.
 export const GRAPHQL_SUBSCRIPTION_CONTEXT_KEY = "chainFirehose";
-schema.getSubscriptionType().getFields().chainEvents.subscribe =
-  async function* chainEventsSubscribe(_source, args, context) {
+schema.getSubscriptionType()!.getFields().chainEvents.subscribe =
+  async function* chainEventsSubscribe(
+    _source: unknown,
+    args: Row,
+    context: Row,
+  ) {
     const hub = context?.[GRAPHQL_SUBSCRIPTION_CONTEXT_KEY];
     if (!hub) {
       throw new GraphQLError(
@@ -4377,13 +4411,16 @@ export const FIELD_COMPLEXITY = {
   evm_address_mapping: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
-function fieldComplexity(fieldName) {
-  return FIELD_COMPLEXITY[fieldName] ?? DEFAULT_FIELD_COMPLEXITY;
+function fieldComplexity(fieldName: string) {
+  return (
+    (FIELD_COMPLEXITY as Record<string, number>)[fieldName] ??
+    DEFAULT_FIELD_COMPLEXITY
+  );
 }
 
 // --- Validation rules ---
 
-function buildFragmentMap(documentNode) {
+function buildFragmentMap(documentNode: Row) {
   const fragments = new Map();
   for (const def of documentNode.definitions) {
     if (def.kind === "FragmentDefinition") {
@@ -4401,7 +4438,7 @@ function buildFragmentMap(documentNode) {
 // stays enabled over POST, matching the documented contract. Sibling data fields
 // in the same operation are still measured, so a mixed query stays bounded.
 const INTROSPECTION_ROOT_FIELDS = new Set(["__schema", "__type"]);
-function isIntrospectionRootField(sel) {
+function isIntrospectionRootField(sel: Row) {
   return sel.kind === "Field" && INTROSPECTION_ROOT_FIELDS.has(sel.name?.value);
 }
 
@@ -4416,7 +4453,13 @@ function isIntrospectionRootField(sel) {
 // are likewise transparent: a type condition is not a nesting level or an extra
 // field. Counting them would over-measure a query relative to its equivalent
 // inlined or named-fragment form, wrongly rejecting valid queries.
-function selectionDepth(selectionSet, fragments, visited, memo, max) {
+function selectionDepth(
+  selectionSet: Row,
+  fragments: Map<string, Row>,
+  visited: Set<string>,
+  memo: Map<string, number>,
+  max: number,
+) {
   let deepest = 0;
   for (const sel of selectionSet.selections) {
     if (isIntrospectionRootField(sel)) continue; // schema-only: depth 0
@@ -4426,7 +4469,7 @@ function selectionDepth(selectionSet, fragments, visited, memo, max) {
       const frag = fragments.get(fragName);
       if (frag && !visited.has(fragName)) {
         if (memo.has(fragName)) {
-          depth = memo.get(fragName);
+          depth = memo.get(fragName)!;
         } else {
           depth = selectionDepth(
             frag.selectionSet,
@@ -4451,10 +4494,10 @@ function selectionDepth(selectionSet, fragments, visited, memo, max) {
   return deepest;
 }
 
-export function maxDepthRule(max) {
-  return (context) => ({
+export function maxDepthRule(max: number) {
+  return (context: Row) => ({
     Document: {
-      leave(node) {
+      leave(node: Row) {
         const fragments = buildFragmentMap(node);
         for (const def of node.definitions) {
           if (def.kind === "OperationDefinition") {
@@ -4480,7 +4523,13 @@ export function maxDepthRule(max) {
   });
 }
 
-function selectionComplexity(selectionSet, fragments, visited, memo, max) {
+function selectionComplexity(
+  selectionSet: Row,
+  fragments: Map<string, Row>,
+  visited: Set<string>,
+  memo: Map<string, number>,
+  max: number,
+) {
   let count = 0;
   for (const sel of selectionSet.selections) {
     if (isIntrospectionRootField(sel)) continue; // schema-only: no complexity cost
@@ -4489,7 +4538,7 @@ function selectionComplexity(selectionSet, fragments, visited, memo, max) {
       const frag = fragments.get(fragName);
       if (frag && !visited.has(fragName)) {
         if (memo.has(fragName)) {
-          count += memo.get(fragName);
+          count += memo.get(fragName)!;
         } else {
           const fragCount = selectionComplexity(
             frag.selectionSet,
@@ -4529,10 +4578,10 @@ function selectionComplexity(selectionSet, fragments, visited, memo, max) {
   return count;
 }
 
-export function maxComplexityRule(max) {
-  return (context) => ({
+export function maxComplexityRule(max: number) {
+  return (context: Row) => ({
     Document: {
-      leave(node) {
+      leave(node: Row) {
         const fragments = buildFragmentMap(node);
         for (const def of node.definitions) {
           if (def.kind === "OperationDefinition") {
@@ -4565,7 +4614,12 @@ export function maxComplexityRule(max) {
 export const DEFAULT_PAGE_LIMIT = 20;
 export const MAX_PAGE_LIMIT = 100;
 
-function paginate(items, limit, cursor, keyFn) {
+function paginate(
+  items: Row[],
+  limit: unknown,
+  cursor: unknown,
+  keyFn: (row: Row) => unknown,
+) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to
   // 1. An explicit `limit: 0` reaching `Math.max(1, …)` would return a single
   // result, which reads to an agent as "this registry knows one subnet" (the same
@@ -4576,7 +4630,7 @@ function paginate(items, limit, cursor, keyFn) {
       : DEFAULT_PAGE_LIMIT;
   let start = 0;
   if (cursor) {
-    const idx = items.findIndex((item) => String(keyFn(item)) === cursor);
+    const idx = items.findIndex((item: Row) => String(keyFn(item)) === cursor);
     if (idx >= 0) start = idx + 1;
   }
   const page = items.slice(start, start + safeLimit);
@@ -4607,25 +4661,34 @@ const LIVE_ECONOMICS_KEY = "live:economics";
 // Resolve an async value at most once per query: a page of subnets each pulling
 // a relationship shares one read of each registry artifact (and one live health
 // snapshot). The promise is cached so concurrent thunks collapse onto one read.
-function once(context, key, load) {
+function once(
+  context: GqlContext,
+  key: string,
+  load: AnyFn,
+): Promise<Row | null> {
   let pending = context.cache.get(key);
   if (!pending) {
     pending = load();
     context.cache.set(key, pending);
   }
-  return pending;
+  return pending as Promise<Row | null>;
 }
 
 // Artifact data, or null when cold/absent — resolvers degrade to empty shapes
 // rather than erroring, like the REST handlers.
-function loadArtifact(context, path) {
+function loadArtifact(context: GqlContext, path: string) {
   return once(context, path, () =>
     readArtifact(context.env, path).then((res) => (res.ok ? res.data : null)),
   );
 }
 
 // Rows under `key`, filtered to one subnet when `netuid` is given.
-async function loadRows(context, path, key, netuid) {
+async function loadRows(
+  context: GqlContext,
+  path: string,
+  key: string,
+  netuid?: number | null,
+) {
   const data = await loadArtifact(context, path);
   const rows = data?.[key];
   if (!Array.isArray(rows)) return [];
@@ -4635,16 +4698,22 @@ async function loadRows(context, path, key, netuid) {
 // Live operational health (KV health:current → Postgres tier) — the build no
 // longer publishes static health, so this mirrors the REST /api/v1/health
 // source. Null when the live store is cold.
-function loadLiveHealth(context) {
+function loadLiveHealth(context: GqlContext) {
   return once(context, LIVE_HEALTH_KEY, () =>
-    resolveLiveHealth({ readHealthKv, env: context.env }),
+    resolveLiveHealth({
+      readHealthKv: readHealthKv as (
+        env: Env,
+        key: string,
+      ) => Promise<Row | null>,
+      env: context.env,
+    }),
   );
 }
 
 // Economics blob, preferring the fresh KV tier over the committed R2 artifact —
 // the same source REST (/api/v1/economics, registry leaderboards) serves, so the
 // GraphQL rows and opportunity boards never lag it. Null when both are cold.
-function loadEconomics(context) {
+function loadEconomics(context: GqlContext) {
   return once(context, LIVE_ECONOMICS_KEY, async () => {
     const live = await resolveLiveEconomics({
       readHealthKv,
@@ -4659,16 +4728,19 @@ function loadEconomics(context) {
 
 // Cron snapshot freshness stamp (KV health:meta) — the same observed_at REST
 // compare stamps its envelope with. Null when the live store is cold.
-function loadObservedAt(context) {
+function loadObservedAt(context: GqlContext): Promise<string | null> {
   return once(context, KV_HEALTH_META, async () => {
-    const meta = await readHealthKv(context.env, KV_HEALTH_META);
+    const meta = (await readHealthKv(
+      context.env,
+      KV_HEALTH_META,
+    )) as Row | null;
     return meta?.last_run_at || null;
-  });
+  }) as Promise<string | null>;
 }
 
 // Economics subnet rows for compare, reusing the live-preferring economics memo
 // (same source the `economics` root + opportunity boards serve).
-async function loadEconomicsRows(context) {
+async function loadEconomicsRows(context: GqlContext) {
   const data = await loadEconomics(context);
   return Array.isArray(data?.subnets) ? data.subnets : [];
 }
@@ -4680,8 +4752,12 @@ async function loadEconomicsRows(context) {
 // handleCompare's health dimension uses for its own internal compare-health
 // forward (workers/request-handlers/analytics-routes.mjs) rather than
 // forwarding the caller's request unchanged.
-function postgresTierRequest(context, pathname, params) {
-  const pgUrl = new URL(context.request.url);
+function postgresTierRequest(
+  context: GqlContext,
+  pathname: string,
+  params?: Row,
+) {
+  const pgUrl = new URL((context.request as Request).url);
   pgUrl.pathname = pathname;
   pgUrl.search = params ? params.toString() : "";
   return new Request(pgUrl);
@@ -4696,7 +4772,10 @@ function postgresTierRequest(context, pathname, params) {
 // reimplemented here rather than imported since mcp-server.mjs already
 // imports this file's handleGraphQLRequest and importing back would be
 // circular.
-async function fetchAllEventsTier(context, pathname) {
+async function fetchAllEventsTier(
+  context: GqlContext,
+  pathname: string,
+): Promise<Row | null> {
   const dataApi = context.env?.DATA_API;
   if (!dataApi?.fetch) {
     throw new GraphQLError(
@@ -4716,7 +4795,7 @@ async function fetchAllEventsTier(context, pathname) {
       `The chain-events tier returned an error (status ${response.status}). Try again shortly.`,
     );
   }
-  return response.json();
+  return response.json() as Promise<Row | null>;
 }
 
 // --- Node builders (attach lazy relationship resolvers to artifact rows) ---
@@ -4727,16 +4806,18 @@ async function fetchAllEventsTier(context, pathname) {
 // straight off the row, relationships resolve on demand through the shared memo.
 // `prefetch` lets the single-subnet path serve surfaces/endpoints from the
 // detail artifact it already read; economics + health are not in that artifact.
-function subnetNode(identity, prefetch = {}) {
+function subnetNode(identity: Row, prefetch: Row = {}) {
   const netuid = identity.netuid;
-  const bundledOr = (rows, load) =>
+  const bundledOr = (rows: Row[] | undefined, load: AnyFn) =>
     rows !== undefined
       ? () => rows ?? []
-      : (_args, context) => load(context, netuid);
+      : (_args: unknown, context: GqlContext) => load(context, netuid);
   return {
     ...identity,
-    health: (_args, context) => loadSubnetHealth(context, netuid),
-    economics: (_args, context) => loadSubnetEconomics(context, netuid),
+    health: (_args: unknown, context: GqlContext) =>
+      loadSubnetHealth(context, netuid),
+    economics: (_args: unknown, context: GqlContext) =>
+      loadSubnetEconomics(context, netuid),
     surfaces: bundledOr(prefetch.surfaces, loadSubnetSurfaces),
     endpoints: bundledOr(prefetch.endpoints, loadSubnetEndpoints),
   };
@@ -4747,7 +4828,7 @@ function subnetNode(identity, prefetch = {}) {
 // exists in this schema yet) -- stringify it here rather than letting
 // graphql-js' default String serializer coerce the object via `String(...)`
 // (which would silently produce "[object Object]").
-function extrinsicNode(extrinsic) {
+function extrinsicNode(extrinsic: Row) {
   if (!extrinsic) return null;
   return {
     ...extrinsic,
@@ -4767,7 +4848,7 @@ function extrinsicNode(extrinsic) {
 // fields ValidatorSubnet declares, and graphql-js' default field resolver
 // reads them straight off each row, the same technique this file's other node
 // builders use for rows with more columns than any one GraphQL type exposes.
-function validatorNode(validator) {
+function validatorNode(validator: Row) {
   return {
     ...validator,
     featured: validator.featured === true,
@@ -4781,7 +4862,7 @@ function validatorNode(validator) {
 // zeroed aggregate), but a malformed Postgres-tier response body degrades to
 // `{}` -- merged here with the cold-safe base the same way accountSummaryNode
 // normalizes a bad upstream body into the schema-stable zero card.
-function validatorDetailNode(data, hotkey) {
+function validatorDetailNode(data: Row, hotkey: string) {
   const base = buildValidatorDetail([], hotkey);
   const raw = data && typeof data === "object" ? data : {};
   return validatorNode({
@@ -4802,7 +4883,7 @@ function validatorDetailNode(data, hotkey) {
 // malformed extrinsic-detail body, so a bad upstream body still resolves to
 // the same schema-stable zero shape as a genuinely cold store, not a
 // Non-Null-field error.
-function accountSummaryNode(data, ss58) {
+function accountSummaryNode(data: Row, ss58: string) {
   return {
     ss58: data.ss58 ?? ss58,
     event_count: data.event_count ?? 0,
@@ -4819,13 +4900,15 @@ function accountSummaryNode(data, ss58) {
   };
 }
 
-function providerNode(provider) {
+function providerNode(provider: Row) {
   const netuids = provider?.netuids || [];
   return {
     ...provider,
     netuids,
-    subnets: (_args, context) => loadProviderSubnets(context, netuids),
-    endpoints: (_args, context) => loadProviderEndpoints(context, provider.id),
+    subnets: (_args: unknown, context: GqlContext) =>
+      loadProviderSubnets(context, netuids),
+    endpoints: (_args: unknown, context: GqlContext) =>
+      loadProviderEndpoints(context, provider.id),
   };
 }
 
@@ -4837,10 +4920,10 @@ function providerNode(provider) {
 // artifact (the loader's not_found throw) degrades to an empty list rather than
 // erroring the parent query -- the same schema-stable convention Subnet.endpoints
 // and the provider node's own cold-artifact paths follow.
-async function loadProviderEndpoints(context, slug) {
+async function loadProviderEndpoints(context: GqlContext, slug: string) {
   try {
     const result = await loadProviderEndpointsList(
-      context,
+      mcpCtx(context),
       { slug },
       { readArtifact },
     );
@@ -4850,31 +4933,31 @@ async function loadProviderEndpoints(context, slug) {
   }
 }
 
-async function loadSubnetHealth(context, netuid) {
+async function loadSubnetHealth(context: GqlContext, netuid: number) {
   return subnetBadgeStatus(await loadLiveHealth(context), netuid);
 }
 
-async function loadSubnetEconomics(context, netuid) {
+async function loadSubnetEconomics(context: GqlContext, netuid: number) {
   const data = await loadEconomics(context);
-  return data?.subnets?.find((row) => row?.netuid === netuid) ?? null;
+  return data?.subnets?.find((row: Row) => row?.netuid === netuid) ?? null;
 }
 
-function loadSubnetSurfaces(context, netuid) {
+function loadSubnetSurfaces(context: GqlContext, netuid: number) {
   return loadRows(context, ARTIFACT.surfaces, "surfaces", netuid);
 }
 
-function loadSubnetEndpoints(context, netuid) {
+function loadSubnetEndpoints(context: GqlContext, netuid: number) {
   return loadRows(context, ARTIFACT.endpoints, "endpoints", netuid);
 }
 
-async function loadProviderSubnets(context, netuids) {
+async function loadProviderSubnets(context: GqlContext, netuids: number[]) {
   if (!netuids.length) return [];
   const rows = await loadRows(context, ARTIFACT.subnets, "subnets");
   const byNetuid = new Map(rows.map((row) => [row.netuid, row]));
   return netuids
-    .map((netuid) => byNetuid.get(netuid))
+    .map((netuid: number) => byNetuid.get(netuid))
     .filter(Boolean)
-    .map((row) => subnetNode(row));
+    .map((row: Row) => subnetNode(row));
 }
 
 // --- Resolvers ---
@@ -4884,8 +4967,8 @@ async function loadProviderSubnets(context, netuids) {
 // contracts subnets.arrayFilters.domain). Unrecognized values simply match zero
 // rows; GraphQL does not 400 on bad filter tokens.
 function matchesSubnetListFilters(
-  row,
-  { status, subnet_type, domain, coverage_level, curation_level } = {},
+  row: Row,
+  { status, subnet_type, domain, coverage_level, curation_level }: Row = {},
 ) {
   for (const [key, raw] of [
     ["status", status],
@@ -4916,10 +4999,10 @@ function matchesSubnetListFilters(
 // node-wraps rows; `resultKey` is the list field's name (economics uses
 // `subnets`, the rest use `items`).
 async function listPage(
-  context,
-  path,
-  key,
-  { limit, cursor, keyFn, netuid, map, resultKey = "items", filterFn },
+  context: GqlContext,
+  path: string,
+  key: string,
+  { limit, cursor, keyFn, netuid, map, resultKey = "items", filterFn }: Row,
 ) {
   let all = await loadRows(context, path, key, netuid);
   if (filterFn) {
@@ -4946,7 +5029,7 @@ const VALID_PROVIDER_ID = /^[A-Za-z0-9._:-]+$/;
 // itself is live chain RPC, not the Postgres tier, reusing loadAddressMapping's
 // own KV cache/TTL, matching REST's /evm/address/{h160} handler exactly; ss58 is
 // null on an unresolved mapping (schema-stable), never a GraphQL error.
-function resolveEvmAddressMapping(h160, context) {
+function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
     throw new GraphQLError("h160 must be a 20-byte 0x-prefixed hex address.", {
       extensions: { code: "BAD_USER_INPUT" },
@@ -4966,8 +5049,8 @@ const rootValue = {
       curation_level,
       limit,
       cursor,
-    },
-    context,
+    }: Row,
+    context: GqlContext,
   ) {
     const hasCategoricalFilters =
       status != null ||
@@ -4979,10 +5062,10 @@ const rootValue = {
       limit,
       cursor,
       netuid,
-      keyFn: (s) => s.netuid,
+      keyFn: (s: Row) => s.netuid,
       map: subnetNode,
       filterFn: hasCategoricalFilters
-        ? (row) =>
+        ? (row: Row) =>
             matchesSubnetListFilters(row, {
               status,
               subnet_type,
@@ -4994,7 +5077,7 @@ const rootValue = {
     });
   },
 
-  async subnet({ netuid }, context) {
+  async subnet({ netuid }: Row, context: GqlContext) {
     const data = await loadArtifact(
       context,
       `/metagraph/subnets/${netuid}.json`,
@@ -5019,20 +5102,20 @@ const rootValue = {
     });
   },
 
-  async subnet_hyperparameters({ netuid }, context) {
+  async subnet_hyperparameters({ netuid }: Row, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_SUBNET_HYPERPARAMS_SOURCE) -> buildSubnetHyperparams
     // fallback contract handleSubnetHyperparams uses. The D1 write path is retired, so a
     // cold tier is an expected steady state, not an error: it yields a schema-stable card
     // with hyperparameters:null rather than a GraphQL error or a 404.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/subnets/${netuid}/hyperparameters`,
         ),
         "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
-      )) ?? buildSubnetHyperparams(null, netuid);
+      )) as Row | null) ?? buildSubnetHyperparams(null, netuid);
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5045,7 +5128,10 @@ const rootValue = {
     };
   },
 
-  async subnet_hyperparameters_history({ netuid, limit, offset }, context) {
+  async subnet_hyperparameters_history(
+    { netuid, limit, offset }: Row,
+    context: GqlContext,
+  ) {
     // Same FEED_PAGINATION bounds parsePagination applies for REST, so a GraphQL
     // caller cannot request a wider page than the route allows.
     const safeLimit = clampLimit(limit, FEED_PAGINATION);
@@ -5054,7 +5140,7 @@ const rootValue = {
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5062,7 +5148,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildSubnetHyperparamsHistory([], netuid, {
         limit: safeLimit,
         offset: safeOffset,
@@ -5082,14 +5168,17 @@ const rootValue = {
   // #7169: the three composed subnet routes that had no GraphQL mirror. Each
   // reuses exactly what REST/MCP already call, so the three surfaces can't
   // drift.
-  async subnet_metagraph({ netuid, validator_permit }, context) {
+  async subnet_metagraph(
+    { netuid, validator_permit }: Row,
+    context: GqlContext,
+  ) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetMetagraph
     // fallback contract get_subnet_metagraph uses; a subnet with no indexed
     // neurons is a schema-stable empty metagraph, never a GraphQL error.
     const params = new URLSearchParams();
     if (validator_permit) params.set("validator_permit", "true");
     return (
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5097,11 +5186,11 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildSubnetMetagraph([], netuid)
+      )) as Row | null) ?? buildSubnetMetagraph([], netuid)
     );
   },
 
-  async subnet_overview({ netuid }, context) {
+  async subnet_overview({ netuid }: Row, context: GqlContext) {
     // Same baked-overview + overlayOverviewHealth composition the REST
     // "subnet-overview" case and the get_subnet MCP tool perform. An
     // un-baked netuid resolves to null rather than a GraphQL error.
@@ -5114,17 +5203,18 @@ const rootValue = {
     return overlayOverviewHealth(overview, live, netuid) || overview;
   },
 
-  async subnet_profile({ netuid }, context) {
+  async subnet_profile({ netuid }: Row, context: GqlContext) {
     // Reuse loadSubnetProfile (the loader get_subnet_profile already calls)
     // unchanged; its deps.readArtifact is invoked as (ctx, path) -- exactly
     // loadArtifact's shape -- so the read shares the request-scoped once()
     // cache. Its only throw is an invalid netuid, which becomes BAD_USER_INPUT
     // (mirroring REST's invalid_params 400); an un-baked profile is null.
     try {
-      return await loadSubnetProfile(context, netuid, {
-        readArtifact: loadArtifact,
+      return await loadSubnetProfile(mcpCtx(context), netuid, {
+        readArtifact: loadArtifact as AnyFn,
       });
-    } catch (err) {
+    } catch (rawErr) {
+      const err = rawErr as Row;
       if (err?.profilesMcp) {
         throw new GraphQLError(err.message, {
           extensions: { code: "BAD_USER_INPUT" },
@@ -5137,11 +5227,14 @@ const rootValue = {
   // #6991: five registry-meta routes that had an MCP tool but no GraphQL
   // field. Each reads the same baked artifact (and applies the same overlay /
   // builder) its MCP tool does, so REST, MCP, and GraphQL can't drift.
-  async candidates({ netuid, kind, provider, state, limit, cursor }, context) {
+  async candidates(
+    { netuid, kind, provider, state, limit, cursor }: Row,
+    context: GqlContext,
+  ) {
     const data = await loadArtifact(context, "/metagraph/candidates.json");
     const all = Array.isArray(data?.candidates) ? data.candidates : [];
     const filtered = all.filter(
-      (c) =>
+      (c: Row) =>
         (netuid == null || c.netuid === netuid) &&
         (kind == null || c.kind === kind) &&
         (provider == null || c.provider === provider) &&
@@ -5151,16 +5244,16 @@ const rootValue = {
       filtered,
       limit,
       cursor,
-      (c) => c.id ?? c.key,
+      (c: Row) => c.id ?? c.key,
     );
     return { items: page, total, next_cursor: nextCursor };
   },
 
-  fixtures(_args, context) {
+  fixtures(_args: unknown, context: GqlContext) {
     return loadArtifact(context, "/metagraph/fixtures.json");
   },
 
-  async agent_catalog({ netuid }, context) {
+  async agent_catalog({ netuid }: Row, context: GqlContext) {
     const live = await loadLiveHealth(context);
     if (netuid == null) {
       const index = await loadArtifact(
@@ -5176,15 +5269,18 @@ const rootValue = {
     return detail && (overlayCatalogDetail(detail, live, netuid) || detail);
   },
 
-  async freshness(_args, context) {
+  async freshness(_args: unknown, context: GqlContext) {
     // Same baked-artifact + live KV meta merge loadFreshness performs for MCP.
     const base = await loadArtifact(context, "/metagraph/freshness.json");
     if (!base) return null;
-    const meta = await readHealthKv(context.env, KV_HEALTH_META);
+    const meta = (await readHealthKv(
+      context.env,
+      KV_HEALTH_META,
+    )) as Row | null;
     return mergeFreshness(base, meta) ?? base;
   },
 
-  async top_holders({ sort, limit }, context) {
+  async top_holders({ sort, limit }: Row, context: GqlContext) {
     // Same allowlist REST enforces -- an unknown sort is BAD_USER_INPUT rather
     // than silently falling back, mirroring the route's invalid_query 400.
     if (sort != null && !TOP_HOLDERS_SORTS.includes(sort)) {
@@ -5205,24 +5301,25 @@ const rootValue = {
       limit: String(safeLimit),
     });
     return (
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/accounts/top-holders", params),
         "METAGRAPH_TOP_HOLDERS_SOURCE",
-      )) ?? buildTopHoldersList([], { sort: safeSort, limit: safeLimit })
+      )) as Row | null) ??
+      buildTopHoldersList([], { sort: safeSort, limit: safeLimit })
     );
   },
 
-  async subnet_trajectory({ netuid }, context) {
+  async subnet_trajectory({ netuid }: Row, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_SUBNET_SNAPSHOTS_SOURCE) -> loadSubnetTrajectory
     // fallback contract handleTrajectory uses; a subnet with no daily snapshots is
     // a schema-stable empty trajectory, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, `/api/v1/subnets/${netuid}/trajectory`),
         "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-      )) ?? (await loadSubnetTrajectory(netuid));
+      )) as Row | null) ?? (await loadSubnetTrajectory(netuid));
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5233,11 +5330,11 @@ const rootValue = {
       // dropping windows with no comparable prior point (null delta).
       deltas: Object.entries(data.deltas ?? {})
         .filter(([, delta]) => delta != null)
-        .map(([window, delta]) => ({ window, ...delta })),
+        .map(([window, delta]) => ({ window, ...(delta as Row) })),
     };
   },
 
-  async subnet_registrations({ netuid, window }, context) {
+  async subnet_registrations({ netuid, window }: Row, context: GqlContext) {
     // Same 7d/30d window validation handleSubnetRegistrations uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_REGISTRATIONS_WINDOW;
@@ -5254,7 +5351,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5262,7 +5359,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetRegistrations(null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetRegistrations(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5274,7 +5372,7 @@ const rootValue = {
     };
   },
 
-  async subnet_deregistrations({ netuid, window }, context) {
+  async subnet_deregistrations({ netuid, window }: Row, context: GqlContext) {
     // Same 7d/30d window validation handleSubnetDeregistrations uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW;
@@ -5291,7 +5389,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5299,7 +5397,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetDeregistrations(null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetDeregistrations(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5311,7 +5410,7 @@ const rootValue = {
     };
   },
 
-  async subnet_serving({ netuid, window }, context) {
+  async subnet_serving({ netuid, window }: Row, context: GqlContext) {
     // Same 7d/30d window validation handleSubnetServing uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_SERVING_WINDOW;
@@ -5328,7 +5427,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5336,7 +5435,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetServing(null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetServing(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5348,7 +5448,7 @@ const rootValue = {
     };
   },
 
-  async subnet_axon_removals({ netuid, window }, context) {
+  async subnet_axon_removals({ netuid, window }: Row, context: GqlContext) {
     // Same 7d/30d window validation handleSubnetAxonRemovals uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
@@ -5365,7 +5465,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5373,7 +5473,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetAxonRemovals(null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetAxonRemovals(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5385,7 +5486,10 @@ const rootValue = {
     };
   },
 
-  async subnet_identity_history({ netuid, limit, offset, cursor }, context) {
+  async subnet_identity_history(
+    { netuid, limit, offset, cursor }: Row,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5403,7 +5507,7 @@ const rootValue = {
     // the schema-stable empty timeline (entry_count 0), never a GraphQL
     // error and never a live D1 read.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5411,7 +5515,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildSubnetIdentityHistory([], netuid, {
         limit: safeLimit,
         offset: safeOffset,
@@ -5428,7 +5532,7 @@ const rootValue = {
     };
   },
 
-  async chain_identity_history({ limit }, context) {
+  async chain_identity_history({ limit }: Row, context: GqlContext) {
     // Same FEED_PAGINATION clamp REST applies. This chain-wide feed is
     // limit-only (no offset/cursor) -- the network view returns the most-recent
     // changes across every subnet in one pass.
@@ -5439,11 +5543,11 @@ const rootValue = {
     // (2026-07-16), so a Postgres miss/outage degrades to a schema-stable
     // empty feed (count 0), never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/identity-history", params),
         "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-      )) ?? buildChainIdentityHistory([], { limit: safeLimit });
+      )) as Row | null) ?? buildChainIdentityHistory([], { limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
       count: data.count ?? 0,
@@ -5452,7 +5556,7 @@ const rootValue = {
     };
   },
 
-  async subnet_performance({ netuid }, context) {
+  async subnet_performance({ netuid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5463,7 +5567,7 @@ const rootValue = {
     // use: a subnet with no neurons is a schema-stable zeroed card (metric
     // blocks null), never a GraphQL error. No window — current snapshot only.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5471,7 +5575,7 @@ const rootValue = {
           new URLSearchParams(),
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildSubnetPerformance([], netuid);
+      )) as Row | null) ?? buildSubnetPerformance([], netuid);
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5487,7 +5591,7 @@ const rootValue = {
     };
   },
 
-  async subnet_concentration({ netuid }, context) {
+  async subnet_concentration({ netuid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5498,7 +5602,7 @@ const rootValue = {
     // use: a subnet with no neurons is a schema-stable zeroed card (metric blocks
     // null), never a GraphQL error. No window -- current snapshot only.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5506,7 +5610,7 @@ const rootValue = {
           new URLSearchParams(),
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildConcentration([], netuid);
+      )) as Row | null) ?? buildConcentration([], netuid);
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5522,7 +5626,10 @@ const rootValue = {
     };
   },
 
-  async subnet_performance_history({ netuid, window }, context) {
+  async subnet_performance_history(
+    { netuid, window }: Row,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5543,7 +5650,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5551,7 +5658,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildSubnetPerformanceHistory([], netuid, {
         window: windowParam,
         capped: false,
@@ -5565,7 +5672,7 @@ const rootValue = {
     };
   },
 
-  async subnet_yield_history({ netuid, window }, context) {
+  async subnet_yield_history({ netuid, window }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5586,7 +5693,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5594,7 +5701,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildSubnetYieldHistory([], netuid, {
         window: windowParam,
         capped: false,
@@ -5608,7 +5715,10 @@ const rootValue = {
     };
   },
 
-  async subnet_concentration_history({ netuid, window }, context) {
+  async subnet_concentration_history(
+    { netuid, window }: Row,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5629,7 +5739,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5637,7 +5747,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildConcentrationHistory([], netuid, {
         window: windowParam,
         capped: false,
@@ -5651,7 +5761,7 @@ const rootValue = {
     };
   },
 
-  async neuron({ netuid, uid }, context) {
+  async neuron({ netuid, uid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5666,14 +5776,14 @@ const rootValue = {
     // cold fallback contract handleNeuron / MCP get_neuron use: an absent UID
     // is a schema-stable card with neuron:null, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/subnets/${netuid}/neurons/${uid}`,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildNeuronDetail(null, netuid);
+      )) as Row | null) ?? buildNeuronDetail(null, netuid);
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5683,7 +5793,7 @@ const rootValue = {
     };
   },
 
-  async neuron_history({ netuid, uid, window }, context) {
+  async neuron_history({ netuid, uid, window }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5696,12 +5806,14 @@ const rootValue = {
     }
     // Same parseHistoryWindow REST's handleNeuronHistory uses, so accepted
     // window labels (7d/30d/90d/1y/all, default 30d) match exactly.
-    const { label, error } = parseHistoryWindow(window);
-    if (error) {
+    const windowResult = parseHistoryWindow(window);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildNeuronHistory([])
@@ -5709,7 +5821,7 @@ const rootValue = {
     // UID with no neuron_daily rows in the window is a schema-stable
     // empty-points card, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5717,7 +5829,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildNeuronHistory([], netuid, uid, { window: label });
+      )) as Row | null) ??
+      buildNeuronHistory([], netuid, uid, { window: label });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5728,13 +5841,13 @@ const rootValue = {
     };
   },
 
-  async subnet_yield({ netuid }, context) {
+  async subnet_yield({ netuid }: Row, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetYield cold
     // fallback contract handleSubnetYield uses: a subnet with no neurons is a
     // schema-stable zeroed card, never a GraphQL error. No window param — the
     // route reads the CURRENT metagraph snapshot.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5742,7 +5855,7 @@ const rootValue = {
           new URLSearchParams(),
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildSubnetYield([], netuid);
+      )) as Row | null) ?? buildSubnetYield([], netuid);
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5765,7 +5878,7 @@ const rootValue = {
     };
   },
 
-  async subnet_weights({ netuid, window }, context) {
+  async subnet_weights({ netuid, window }: Row, context: GqlContext) {
     // Same 7d/30d window validation handleSubnetWeights uses -- an unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_WEIGHTS_WINDOW;
@@ -5782,7 +5895,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5790,7 +5903,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetWeights(null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetWeights(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5802,7 +5916,7 @@ const rootValue = {
     };
   },
 
-  async subnet_stake_moves({ netuid, window }, context) {
+  async subnet_stake_moves({ netuid, window }: Row, context: GqlContext) {
     // Same 7d/30d window validation handleSubnetStakeMoves uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_STAKE_MOVES_WINDOW;
@@ -5819,7 +5933,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5827,7 +5941,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetStakeMoves(null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetStakeMoves(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5839,7 +5954,7 @@ const rootValue = {
     };
   },
 
-  async subnet_stake_transfers({ netuid, window }, context) {
+  async subnet_stake_transfers({ netuid, window }: Row, context: GqlContext) {
     // Same 7d/30d window validation handleSubnetStakeTransfers uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
@@ -5856,7 +5971,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5864,7 +5979,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetStakeTransfers(null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetStakeTransfers(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5876,7 +5992,7 @@ const rootValue = {
     };
   },
 
-  async subnet_idle_stake({ netuid }, context) {
+  async subnet_idle_stake({ netuid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5887,11 +6003,11 @@ const rootValue = {
     // tool use; a subnet with no neurons is a schema-stable zeroed card, never a
     // GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, `/api/v1/subnets/${netuid}/idle-stake`),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildSubnetIdleStake([], netuid);
+      )) as Row | null) ?? buildSubnetIdleStake([], netuid);
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5902,7 +6018,10 @@ const rootValue = {
     };
   },
 
-  async subnet_stake_flow({ netuid, window, direction }, context) {
+  async subnet_stake_flow(
+    { netuid, window, direction }: Row,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5942,7 +6061,8 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      tier?.data ?? buildStakeFlow([], netuid, { window: windowParam });
+      (tier?.data as Row | undefined) ??
+      buildStakeFlow([], netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5956,8 +6076,8 @@ const rootValue = {
   },
 
   async subnet_events(
-    { netuid, kind, block_start, block_end, limit, offset },
-    context,
+    { netuid, kind, block_start, block_end, limit, offset }: Row,
+    context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
@@ -5983,7 +6103,7 @@ const rootValue = {
     // list passes through whole; graphql's default resolver reads each AccountEvent
     // field, matching account_events' shaped rows.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -5991,7 +6111,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildSubnetEvents([], netuid, {
         limit: safeLimit,
         offset: safeOffset,
@@ -6008,7 +6128,7 @@ const rootValue = {
     };
   },
 
-  async subnet_history({ netuid, window }, context) {
+  async subnet_history({ netuid, window }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6016,19 +6136,21 @@ const rootValue = {
     }
     // Same parseHistoryWindow handleSubnetHistory + loadSubnetHistory (MCP) use,
     // so accepted window labels (7d/30d/90d/1y/all, default 30d) match exactly.
-    const { label, error } = parseHistoryWindow(window);
-    if (error) {
+    const windowResult = parseHistoryWindow(window);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetHistory([])
     // empty-series fallback handleSubnetHistory uses; a subnet with no daily
     // rollup is a schema-stable point_count:0 series, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -6036,7 +6158,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildSubnetHistory([], netuid, { window: label });
+      )) as Row | null) ?? buildSubnetHistory([], netuid, { window: label });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6046,7 +6168,7 @@ const rootValue = {
     };
   },
 
-  async subnet_prometheus({ netuid, window }, context) {
+  async subnet_prometheus({ netuid, window }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6069,7 +6191,7 @@ const rootValue = {
     // uses; a subnet with no PrometheusServed events is a schema-stable zeroed
     // card, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -6077,7 +6199,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetPrometheus(null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetPrometheus(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6089,7 +6212,7 @@ const rootValue = {
     };
   },
 
-  async subnet_weight_setters({ netuid, window }, context) {
+  async subnet_weight_setters({ netuid, window }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6110,7 +6233,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -6118,7 +6241,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildSubnetWeightSetters([], null, netuid, { window: windowParam });
+      )) as Row | null) ??
+      buildSubnetWeightSetters([], null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6131,16 +6255,16 @@ const rootValue = {
     };
   },
 
-  providers({ limit, cursor }, context) {
+  providers({ limit, cursor }: Row, context: GqlContext) {
     return listPage(context, ARTIFACT.providers, "providers", {
       limit,
       cursor,
-      keyFn: (p) => p.id,
+      keyFn: (p: Row) => p.id,
       map: providerNode,
     });
   },
 
-  async provider({ id }, context) {
+  async provider({ id }: Row, context: GqlContext) {
     if (typeof id !== "string" || !VALID_PROVIDER_ID.test(id)) return null;
     const data = await loadArtifact(context, `/metagraph/providers/${id}.json`);
     if (!data) return null;
@@ -6153,10 +6277,11 @@ const rootValue = {
   // loader miss (not_found / cold R2 / unavailable) resolves to null
   // (schema-stable), matching provider's cold/absent convention -- never a
   // GraphQL error for an unregistered slug.
-  async adapter({ slug }, context) {
+  async adapter({ slug }: Row, context: GqlContext) {
     try {
-      return await loadAdapter(context, { slug }, { readArtifact });
-    } catch (err) {
+      return await loadAdapter(mcpCtx(context), { slug }, { readArtifact });
+    } catch (rawErr) {
+      const err = rawErr as Row;
       if (err?.toolError && err.code === "invalid_params") {
         throw new GraphQLError(err.message, {
           extensions: { code: "BAD_USER_INPUT" },
@@ -6167,14 +6292,14 @@ const rootValue = {
     }
   },
 
-  async economics({ limit, cursor }, context) {
+  async economics({ limit, cursor }: Row, context: GqlContext) {
     // Live-preferring source (not the static-only listPage), paginated like it.
     const data = await loadEconomics(context);
     const { page, total, nextCursor } = paginate(
       data?.subnets || [],
       limit,
       cursor,
-      (s) => s.netuid,
+      (s: Row) => s.netuid,
     );
     return {
       subnets: page,
@@ -6184,21 +6309,21 @@ const rootValue = {
     };
   },
 
-  surfaces({ netuid, limit, cursor }, context) {
+  surfaces({ netuid, limit, cursor }: Row, context: GqlContext) {
     return listPage(context, ARTIFACT.surfaces, "surfaces", {
       limit,
       cursor,
       netuid,
-      keyFn: (s) => s.id ?? s.key,
+      keyFn: (s: Row) => s.id ?? s.key,
     });
   },
 
-  endpoints({ netuid, limit, cursor }, context) {
+  endpoints({ netuid, limit, cursor }: Row, context: GqlContext) {
     return listPage(context, ARTIFACT.endpoints, "endpoints", {
       limit,
       cursor,
       netuid,
-      keyFn: (e) => e.id ?? e.surface_id,
+      keyFn: (e: Row) => e.id ?? e.surface_id,
     });
   },
 
@@ -6210,22 +6335,26 @@ const rootValue = {
   // executor surfaces as a normal GraphQL error, matching every other field's
   // "an unsupported filter/sort is a GraphQL error, not a silently substituted
   // default" convention.
-  endpoint_pools(args, context) {
-    return loadEndpointPoolsList(context, args, { readArtifact });
+  endpoint_pools(args: Row, context: GqlContext) {
+    return loadEndpointPoolsList(mcpCtx(context), args, { readArtifact });
   },
 
-  rpc_pools(args, context) {
+  rpc_pools(args: Row, context: GqlContext) {
     // rpc-pools' loader additionally reads ctx.readHealthKv for its live
     // 15-minute cron eligibility overlay (rpc-pools-mcp.ts) -- graphql.mjs's
     // own context has no such property, so it's supplied here from the same
     // module-level import loadLiveHealth/loadEconomics already use.
-    return loadRpcPoolsList({ ...context, readHealthKv }, args, {
-      readArtifact,
-    });
+    return loadRpcPoolsList(
+      { ...context, readHealthKv } as unknown as Parameters<
+        typeof loadRpcPoolsList
+      >[0],
+      args,
+      { readArtifact },
+    );
   },
 
-  endpoint_incidents(args, context) {
-    return loadEndpointIncidentsList(context, args, { readArtifact });
+  endpoint_incidents(args: Row, context: GqlContext) {
+    return loadEndpointIncidentsList(mcpCtx(context), args, { readArtifact });
   },
 
   // #6986: reuse list_source_snapshots' own loader unchanged. It validates its
@@ -6234,8 +6363,8 @@ const rootValue = {
   // as a normal GraphQL error, matching every other field's "an unsupported
   // filter/sort is a GraphQL error, not a silently substituted default"
   // convention.
-  source_snapshots(args, context) {
-    return loadSourceSnapshotsList(context, args, { readArtifact });
+  source_snapshots(args: Row, context: GqlContext) {
+    return loadSourceSnapshotsList(mcpCtx(context), args, { readArtifact });
   },
 
   // #7171: reuse list_gaps / list_evidence loaders unchanged. Each validates
@@ -6243,12 +6372,12 @@ const rootValue = {
   // error, matching source_snapshots' "unsupported filter/sort is a GraphQL
   // error, not a silently substituted default" convention. A cold/absent
   // artifact is likewise a GraphQL error (matching REST/MCP not_found).
-  gaps(args, context) {
-    return loadGapsList(context, args, { readArtifact });
+  gaps(args: Row, context: GqlContext) {
+    return loadGapsList(mcpCtx(context), args, { readArtifact });
   },
 
-  evidence(args, context) {
-    return loadEvidenceList(context, args, { readArtifact });
+  evidence(args: Row, context: GqlContext) {
+    return loadEvidenceList(mcpCtx(context), args, { readArtifact });
   },
 
   // #6992: reuse list_profiles' own loader unchanged. Its readOptionalArtifact
@@ -6256,20 +6385,20 @@ const rootValue = {
   // (not a throw) -- this file's own loadArtifact(context, path) already has
   // exactly that shape (readArtifact(context.env, path), null if not ok), so
   // it's reused directly rather than adding a redundant wrapper.
-  profiles(args, context) {
-    return loadProfilesList(context, args, {
-      readOptionalArtifact: loadArtifact,
+  profiles(args: Row, context: GqlContext) {
+    return loadProfilesList(mcpCtx(context), args, {
+      readOptionalArtifact: loadArtifact as AnyFn,
     });
   },
 
-  registry_summary(_args, context) {
+  registry_summary(_args: unknown, context: GqlContext) {
     // Same baked artifact the REST route + registry_summary MCP tool read.
     // Degrades to null when cold instead of erroring, matching every other
     // artifact-backed resolver here.
     return loadArtifact(context, "/metagraph/registry-summary.json");
   },
 
-  async saved_query({ id, params }, context) {
+  async saved_query({ id, params }: Row, context: GqlContext) {
     // #7642: the same maintainer-curated template executor the REST route and
     // run_saved_query MCP tool share (src/saved-queries.ts) -- template
     // lookup, param coercion/validation, and execution are all its. Its
@@ -6278,7 +6407,8 @@ const rootValue = {
     // other executor failure surfaces as a normal GraphQL error.
     try {
       return await runSavedQuery(context.env, id, params ?? {});
-    } catch (err) {
+    } catch (rawErr) {
+      const err = rawErr as Row;
       if (
         err?.toolError &&
         (err.code === "not_found" || err.code === "invalid_params")
@@ -6291,17 +6421,17 @@ const rootValue = {
     }
   },
 
-  source_health(_args, context) {
+  source_health(_args: unknown, context: GqlContext) {
     // Same baked artifact the REST route + get_source_health MCP tool read.
     return loadArtifact(context, "/metagraph/source-health.json");
   },
 
-  lineage(_args, context) {
+  lineage(_args: unknown, context: GqlContext) {
     // Same baked artifact the REST route + get_lineage MCP tool read.
     return loadArtifact(context, "/metagraph/lineage.json");
   },
 
-  async rpc_endpoints(_args, context) {
+  async rpc_endpoints(_args: unknown, context: GqlContext) {
     // Same baked catalog the REST route + list_rpc_endpoints MCP tool read,
     // with the same live overlay: the 15-minute cron RPC-pool KV snapshot
     // replaces the stale build-time health/latency (mergeRpcEndpoints). With no
@@ -6311,8 +6441,11 @@ const rootValue = {
       context,
       "/metagraph/rpc-endpoints.json",
     );
-    const pool = await readHealthKv(context.env, KV_HEALTH_RPC_POOL);
-    return pool ? mergeRpcEndpoints(staticData, pool) : staticData;
+    const pool = (await readHealthKv(
+      context.env,
+      KV_HEALTH_RPC_POOL,
+    )) as Row | null;
+    return pool ? mergeRpcEndpoints(staticData ?? {}, pool) : staticData;
   },
 
   // #7170: reuse get_changelog's/get_contracts's own loaders unchanged (the same
@@ -6321,19 +6454,19 @@ const rootValue = {
   // pass. A cold/absent artifact makes the loader throw, which the graphql
   // executor surfaces as a normal GraphQL error, matching REST's 404 and the
   // source_snapshots convention for a missing artifact.
-  changelog(_args, context) {
-    return loadChangelog(context, { readArtifact });
+  changelog(_args: unknown, context: GqlContext) {
+    return loadChangelog(mcpCtx(context), { readArtifact });
   },
 
-  contracts(_args, context) {
-    return loadContracts(context, { readArtifact });
+  contracts(_args: unknown, context: GqlContext) {
+    return loadContracts(mcpCtx(context), { readArtifact });
   },
 
   // #7431: reuse get_build's own loader unchanged (the same baked artifact read
   // REST and MCP already use). A cold/absent artifact makes the loader throw,
   // which the graphql executor surfaces as a normal GraphQL error.
-  build(_args, context) {
-    return loadBuildSummary(context, { readArtifact });
+  build(_args: unknown, context: GqlContext) {
+    return loadBuildSummary(mcpCtx(context), { readArtifact });
   },
 
   // #7170: reuse get_health_history's own loader unchanged. It takes deps as
@@ -6343,8 +6476,10 @@ const rootValue = {
   // and throws invalid_params on a bad one / not_found on a missing snapshot;
   // that throw becomes a GraphQL error, matching every other field's "an
   // unsupported filter/sort is a GraphQL error, not a silent default".
-  health_history(args, context) {
-    return loadHealthHistory(context, args, { readArtifact: loadArtifact });
+  health_history(args: Row, context: GqlContext) {
+    return loadHealthHistory(context, args, {
+      readArtifact: loadArtifact as AnyFn,
+    });
   },
 
   // #7167: reuse each review-family list_* MCP loader unchanged. Each validates
@@ -6354,31 +6489,33 @@ const rootValue = {
   // filter/sort is a GraphQL error, not a silently substituted default"
   // convention. A cold/missing artifact is also a GraphQL error (matches
   // REST 404 / MCP not_found); an empty filtered page is a success with total 0.
-  review_adapter_candidates(args, context) {
-    return loadAdapterCandidatesList(context, args, { readArtifact });
+  review_adapter_candidates(args: Row, context: GqlContext) {
+    return loadAdapterCandidatesList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_evidence(args, context) {
-    return loadEnrichmentEvidenceList(context, args, { readArtifact });
+  review_enrichment_evidence(args: Row, context: GqlContext) {
+    return loadEnrichmentEvidenceList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_queue(args, context) {
-    return loadEnrichmentQueueList(context, args, { readArtifact });
+  review_enrichment_queue(args: Row, context: GqlContext) {
+    return loadEnrichmentQueueList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_targets(args, context) {
-    return loadReviewEnrichmentTargetsList(context, args, { readArtifact });
+  review_enrichment_targets(args: Row, context: GqlContext) {
+    return loadReviewEnrichmentTargetsList(mcpCtx(context), args, {
+      readArtifact,
+    });
   },
 
-  review_gaps(args, context) {
-    return loadReviewGapsList(context, args, { readArtifact });
+  review_gaps(args: Row, context: GqlContext) {
+    return loadReviewGapsList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_profile_completeness(args, context) {
-    return loadProfileCompletenessList(context, args, { readArtifact });
+  review_profile_completeness(args: Row, context: GqlContext) {
+    return loadProfileCompletenessList(mcpCtx(context), args, { readArtifact });
   },
 
-  async health(_args, context) {
+  async health(_args: unknown, context: GqlContext) {
     const snapshot = await loadLiveHealth(context);
     const result = snapshot ? buildGlobalHealth(snapshot, {}) : null;
     if (!result) return null;
@@ -6394,7 +6531,7 @@ const rootValue = {
     };
   },
 
-  async opportunity_boards({ limit }, context) {
+  async opportunity_boards({ limit }: Row, context: GqlContext) {
     const data = await loadEconomics(context);
     const rows = Array.isArray(data?.subnets) ? data.subnets : [];
     // Reuse the live economics tier + the leaderboard ranking, so the boards
@@ -6406,7 +6543,7 @@ const rootValue = {
       economicsRows: rows,
       subnetMeta: new Map(),
     });
-    const boards = ranked.boards;
+    const boards = ranked.boards as Row;
     return {
       observed_at: ranked.observed_at,
       with_economics_count: rows.length,
@@ -6422,7 +6559,7 @@ const rootValue = {
     };
   },
 
-  async compare({ netuids, dimensions }, context) {
+  async compare({ netuids, dimensions }: Row, context: GqlContext) {
     // Reuse the REST/MCP shared parsers so the GraphQL contract matches
     // /api/v1/compare and the compare_subnets MCP tool exactly (distinctness +
     // range + the dimension whitelist), then the shared loader composes the rows.
@@ -6446,40 +6583,42 @@ const rootValue = {
       : [];
     return loadCompareSubnets({
       profiles,
-      economicsRows: parsedDimensions.includes("economics")
+      economicsRows: parsedDimensions!.includes("economics")
         ? await loadEconomicsRows(context)
         : [],
       netuids: parsedNetuids,
-      dimensions: parsedDimensions,
+      dimensions: parsedDimensions!,
       observedAt: await loadObservedAt(context),
     });
   },
 
-  async incidents({ window }, context) {
+  async incidents({ window }: Row, context: GqlContext) {
     // Reuse the exact analyticsWindow parse/validate REST's handleGlobalIncidents
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL BAD_USER_INPUT
     // error, not a silent empty result. analyticsWindow reads only the ?window param.
-    const windowUrl = new URL(context.request.url);
+    const windowUrl = new URL((context.request as Request).url);
     windowUrl.search = "";
     if (window != null) windowUrl.searchParams.set("window", window);
-    const { label, days, error } = analyticsWindow(windowUrl);
-    if (error) {
+    const windowResult = analyticsWindow(windowUrl);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     // Same METAGRAPH_HEALTH_SOURCE Postgres tier -> loadGlobalIncidentsLedger D1
     // fallback contract handleGlobalIncidents uses; the ledger is schema-stable on
     // a cold/retired tier (empty surfaces + zeroed summary), never a GraphQL error.
     const params = new URLSearchParams();
     params.set("window", label);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/incidents", params),
         "METAGRAPH_HEALTH_SOURCE",
-      )) ??
-      (await loadGlobalIncidentsLedger(context.env, { label, days })).data;
+      )) as Row | null) ??
+      (await loadGlobalIncidentsLedger(context.env, { label })).data;
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,
@@ -6495,33 +6634,33 @@ const rootValue = {
   // Identical window validation (7d/30d -> BAD_USER_INPUT), Postgres-tier ->
   // retired-D1 fallback, and schema-stable cold-tier degradation; nothing
   // re-derived. Distinct from endpoint_incidents (the active endpoint feed).
-  async global_incidents({ window }, context) {
+  async global_incidents({ window }: Row, context: GqlContext) {
     return rootValue.incidents({ window }, context);
   },
 
-  search({ limit, cursor }, context) {
+  search({ limit, cursor }: Row, context: GqlContext) {
     // Same baked search artifact + list-window the REST route serves, paged
     // through the shared listPage helper the other artifact lists use.
     return listPage(context, ARTIFACT.search, "documents", {
       limit,
       cursor,
       resultKey: "documents",
-      keyFn: (d) => d.id,
+      keyFn: (d: Row) => d.id,
     });
   },
 
-  search_index({ limit, cursor }, context) {
+  search_index({ limit, cursor }: Row, context: GqlContext) {
     // The slim companion: identical documents minus the per-document token
     // blobs, served from its own artifact exactly as REST serves it.
     return listPage(context, ARTIFACT.searchIndex, "documents", {
       limit,
       cursor,
       resultKey: "documents",
-      keyFn: (d) => d.id,
+      keyFn: (d: Row) => d.id,
     });
   },
 
-  async domains(_args, context) {
+  async domains(_args: unknown, context: GqlContext) {
     // Composed live from the subnets index + economics tier (no static file),
     // via the same buildDomainOverview the REST route calls.
     const [subnetRows, economicsRows] = await Promise.all([
@@ -6531,7 +6670,7 @@ const rootValue = {
     return buildDomainOverview(subnetRows, economicsRows);
   },
 
-  async domain_summary({ tag }, context) {
+  async domain_summary({ tag }: Row, context: GqlContext) {
     // The same fixed 14-tag enum ?domain= validates on subnets -- an unknown
     // tag is a GraphQL BAD_USER_INPUT error, not an empty rollup.
     if (!DOMAIN_TAGS.includes(tag)) {
@@ -6546,7 +6685,7 @@ const rootValue = {
     return buildDomainSummary(tag, subnetRows, economicsRows);
   },
 
-  async compare_validators({ hotkeys, netuid }, context) {
+  async compare_validators({ hotkeys, netuid }: Row, context: GqlContext) {
     // Same parse/validate contract the REST route + compare_validators MCP
     // tool share: 1..COMPARE_VALIDATORS_MAX distinct SS58 addresses.
     const parsed = parseCompareHotkeyList(hotkeys);
@@ -6569,52 +6708,52 @@ const rootValue = {
     const details = [];
     for (const hotkey of parsed) {
       details.push(
-        (await tryPostgresTier(
+        ((await tryPostgresTier(
           context.env,
           postgresTierRequest(
             context,
             `/api/v1/validators/${encodeURIComponent(hotkey)}`,
           ),
           "METAGRAPH_NEURONS_SOURCE",
-        )) ?? buildValidatorDetail([], hotkey),
+        )) as Row | null) ?? buildValidatorDetail([], hotkey),
       );
     }
     return composeValidatorComparison(details, { netuid: netuid ?? null });
   },
 
-  async agent_resources(_args, context) {
+  async agent_resources(_args: unknown, context: GqlContext) {
     // Same baked artifact the REST route + get_agent_resources MCP tool read.
     // The MCP tool raises not_found when it is absent; GraphQL degrades to
     // null instead, matching every other artifact-backed resolver here.
     return loadArtifact(context, AGENT_RESOURCES_ARTIFACT);
   },
 
-  async curation(_args, context) {
+  async curation(_args: unknown, context: GqlContext) {
     // Same baked artifact the REST /api/v1/curation route + list_curation MCP
     // tool read; opaque-JSON passthrough degrading to null on cold.
     return loadArtifact(context, CURATION_ARTIFACT);
   },
 
-  async coverage(_args, context) {
+  async coverage(_args: unknown, context: GqlContext) {
     // Same baked artifact the REST /api/v1/coverage route + get_coverage MCP
     // tool read; GraphQL degrades to null when cold, like agent_resources.
     return loadArtifact(context, "/metagraph/coverage.json");
   },
 
-  schemas(_args, context) {
+  schemas(_args: unknown, context: GqlContext) {
     // #7866: the same baked schema-index artifact the REST /api/v1/schemas
     // route + list_schemas MCP tool read; opaque-JSON passthrough degrading to
     // null when cold, like coverage/curation above.
     return loadArtifact(context, "/metagraph/schemas/index.json");
   },
 
-  async coverage_depth(_args, context) {
+  async coverage_depth(_args: unknown, context: GqlContext) {
     // Raw passthrough of the /api/v1/coverage-depth artifact (the same one the
     // list_enrichment_targets MCP tool shapes); degrades to null when cold.
     return loadArtifact(context, "/metagraph/coverage-depth.json");
   },
 
-  async subnet_volume({ netuid }, context) {
+  async subnet_volume({ netuid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6636,7 +6775,9 @@ const rootValue = {
       postgresTierRequest(context, `/api/v1/subnets/${netuid}/volume`),
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
-    const data = tier?.data ?? buildAlphaVolume([], netuid, { marketCapTao });
+    const data =
+      (tier?.data as Row | undefined) ??
+      buildAlphaVolume([], netuid, { marketCapTao });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6656,7 +6797,7 @@ const rootValue = {
     };
   },
 
-  async subnet_ohlc({ netuid, interval, days }, context) {
+  async subnet_ohlc({ netuid, interval, days }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6687,15 +6828,12 @@ const rootValue = {
     params.set("interval", intervalParam);
     params.set("days", String(daysParam));
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, `/api/v1/subnets/${netuid}/ohlc`, params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
-      buildSubnetOhlc([], netuid, {
-        interval: intervalParam,
-        days: daysParam,
-      });
+      )) as Row | null) ??
+      buildSubnetOhlc([], netuid, { interval: intervalParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6705,7 +6843,10 @@ const rootValue = {
     };
   },
 
-  async subnet_stake_quote({ netuid, amount, direction }, context) {
+  async subnet_stake_quote(
+    { netuid, amount, direction }: Row,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6739,7 +6880,7 @@ const rootValue = {
     return { schema_version: 1, ...result.quote };
   },
 
-  async subnet_validators({ netuid }, context) {
+  async subnet_validators({ netuid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6749,11 +6890,11 @@ const rootValue = {
     // empty-snapshot fallback the REST route and list_subnet_validators share.
     // REST takes no filter params here, so neither does this mirror.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, `/api/v1/subnets/${netuid}/validators`),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildSubnetValidators([], netuid);
+      )) as Row | null) ?? buildSubnetValidators([], netuid);
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6764,20 +6905,25 @@ const rootValue = {
     };
   },
 
-  async subnet_health_percentiles({ netuid, window }, context) {
+  async subnet_health_percentiles(
+    { netuid, window }: Row,
+    context: GqlContext,
+  ) {
     // Reuse the exact analyticsWindow parse/validate REST's percentiles handler
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
     // BAD_USER_INPUT error, not a silent empty result, matching
     // subnet_health_incidents.
-    const windowUrl = new URL(context.request.url);
+    const windowUrl = new URL((context.request as Request).url);
     windowUrl.search = "";
     if (window != null) windowUrl.searchParams.set("window", window);
-    const { label, error } = analyticsWindow(windowUrl);
-    if (error) {
+    const windowResult = analyticsWindow(windowUrl);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadSubnetPercentiles
     // fallback the REST route and the get_subnet_health_percentiles MCP tool
     // share -- the tier owns the percentile computation, so nothing is
@@ -6786,7 +6932,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", label);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -6794,7 +6940,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_HEALTH_SOURCE",
-      )) ??
+      )) as Row | null) ??
       (await loadSubnetPercentiles(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
@@ -6809,7 +6955,10 @@ const rootValue = {
     };
   },
 
-  async subnet_event_summary({ netuid, window, limit }, context) {
+  async subnet_event_summary(
+    { netuid, window, limit }: Row,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6839,7 +6988,7 @@ const rootValue = {
     params.set("window", windowParam);
     params.set("limit", String(limitParam));
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -6847,7 +6996,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildSubnetEventSummary([], [], netuid, {
         window: windowParam,
         limit: limitParam,
@@ -6868,7 +7017,7 @@ const rootValue = {
     };
   },
 
-  async subnet_gaps({ netuid }, context) {
+  async subnet_gaps({ netuid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6881,7 +7030,7 @@ const rootValue = {
     return loadArtifact(context, `/metagraph/review/gaps/${netuid}.json`);
   },
 
-  async subnet_evidence({ netuid }, context) {
+  async subnet_evidence({ netuid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6892,7 +7041,7 @@ const rootValue = {
     return loadArtifact(context, `/metagraph/evidence/${netuid}.json`);
   },
 
-  async subnet_candidates({ netuid }, context) {
+  async subnet_candidates({ netuid }: Row, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -6905,19 +7054,21 @@ const rootValue = {
     return loadArtifact(context, `/metagraph/candidates/${netuid}.json`);
   },
 
-  async subnet_health_incidents({ netuid, window }, context) {
+  async subnet_health_incidents({ netuid, window }: Row, context: GqlContext) {
     // Reuse the exact analyticsWindow parse/validate REST's handleHealthIncidents
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
     // BAD_USER_INPUT error, not a silent empty result.
-    const windowUrl = new URL(context.request.url);
+    const windowUrl = new URL((context.request as Request).url);
     windowUrl.search = "";
     if (window != null) windowUrl.searchParams.set("window", window);
-    const { label, error } = analyticsWindow(windowUrl);
-    if (error) {
+    const windowResult = analyticsWindow(windowUrl);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadSubnetIncidents D1
     // fallback contract handleHealthIncidents and the get_subnet_health_incidents
     // MCP tool share -- the tier owns the gap-island incident reconstruction, so
@@ -6926,7 +7077,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", label);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -6934,7 +7085,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_HEALTH_SOURCE",
-      )) ??
+      )) as Row | null) ??
       (await loadSubnetIncidents(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
@@ -6959,8 +7110,8 @@ const rootValue = {
       call_module: callModule,
       call_function: callFunction,
       success,
-    },
-    context,
+    }: Row,
+    context: GqlContext,
   ) {
     if (block != null && (!Number.isInteger(block) || block < 0)) {
       throw new GraphQLError("block must be a non-negative integer.", {
@@ -6979,11 +7130,11 @@ const rootValue = {
     if (callFunction) params.set("call_function", callFunction);
     if (success != null) params.set("success", String(success));
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/extrinsics", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildExtrinsicFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -7002,11 +7153,11 @@ const rootValue = {
   // schema-stable empty feed, never a GraphQL error — matching extrinsics'
   // cold-empty convention. Distinct from Subscription.chainEvents.
   async chain_events(
-    { pallet, method, block, extrinsic, cursor, before, limit },
-    context,
+    { pallet, method, block, extrinsic, cursor, before, limit }: Row,
+    context: GqlContext,
   ) {
     try {
-      const data = await loadChainEventsFeed(context, {
+      const data = await loadChainEventsFeed(mcpCtx(context), {
         pallet,
         method,
         block,
@@ -7021,7 +7172,7 @@ const rootValue = {
         count: data.count,
         next_before: data.next_before,
         next_cursor: data.next_cursor,
-        events: data.events.map((event) => ({
+        events: (data.events as Row[]).map((event) => ({
           block_number: event.block_number ?? null,
           event_index: event.event_index ?? null,
           pallet: event.pallet ?? null,
@@ -7032,7 +7183,8 @@ const rootValue = {
           observed_at: event.observed_at ?? null,
         })),
       };
-    } catch (err) {
+    } catch (rawErr) {
+      const err = rawErr as Row;
       if (err?.toolError && err.code === "invalid_params") {
         throw new GraphQLError(err.message, {
           extensions: { code: "BAD_USER_INPUT" },
@@ -7053,11 +7205,12 @@ const rootValue = {
   // (the same 1000-default/positive-integer/1-5000-cap validation MCP's
   // get_chain_activity applies) then loadChainActivity — both relocated to
   // data-api-mcp.ts beside loadChainEventsFeed.
-  async chain_events_stats({ blocks }, context) {
+  async chain_events_stats({ blocks }: Row, context: GqlContext) {
     let window;
     try {
       window = optionalBlocksWindow({ blocks });
-    } catch (err) {
+    } catch (rawErr) {
+      const err = rawErr as Row;
       // optionalBlocksWindow's only failure is invalid_params (a non-positive
       // or non-integer blocks) — surface it as BAD_USER_INPUT, mirroring how
       // chain_events maps the sibling feed's invalid-filter error.
@@ -7066,7 +7219,7 @@ const rootValue = {
       });
     }
     try {
-      return await loadChainActivity(context, window);
+      return await loadChainActivity(mcpCtx(context), window);
     } catch {
       // A cold/unbound/rate-limited tier degrades to a schema-stable empty
       // aggregate (echoing the validated window), never a GraphQL error —
@@ -7076,8 +7229,8 @@ const rootValue = {
   },
 
   async sudo(
-    { limit, offset, cursor, block, call_function: callFunction, success },
-    context,
+    { limit, offset, cursor, block, call_function: callFunction, success }: Row,
+    context: GqlContext,
   ) {
     // The Sudo governance feed is the /extrinsics feed with call_module fixed
     // to Sudo by the route itself, so it takes no signer/call_module args and
@@ -7097,11 +7250,11 @@ const rootValue = {
     if (callFunction) params.set("call_function", callFunction);
     if (success != null) params.set("success", String(success));
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/sudo", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildExtrinsicFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -7114,16 +7267,16 @@ const rootValue = {
     };
   },
 
-  async extrinsic({ ref }, context) {
+  async extrinsic({ ref }: Row, context: GqlContext) {
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/extrinsics/${encodeURIComponent(ref)}`,
         ),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ?? buildExtrinsic(undefined, ref);
+      )) as Row | null) ?? buildExtrinsic(undefined, ref);
     return {
       ref: data.ref ?? ref,
       extrinsic: extrinsicNode(data.extrinsic),
@@ -7131,8 +7284,8 @@ const rootValue = {
   },
 
   async governance_config_changes(
-    { limit, offset, cursor, block, call_function: callFunction, success },
-    context,
+    { limit, offset, cursor, block, call_function: callFunction, success }: Row,
+    context: GqlContext,
   ) {
     if (block != null && (!Number.isInteger(block) || block < 0)) {
       throw new GraphQLError("block must be a non-negative integer.", {
@@ -7153,7 +7306,7 @@ const rootValue = {
     // itself (see SUDO_GOVERNANCE_ROUTES in workers/data-api.mjs) -- no filter
     // logic duplicated here; the REST route and MCP tool share this exact path.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -7161,7 +7314,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildExtrinsicFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -7174,7 +7327,7 @@ const rootValue = {
     };
   },
 
-  async blocks({ limit, offset, cursor }, context) {
+  async blocks({ limit, offset, cursor }: Row, context: GqlContext) {
     const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
     const safeOffset = clampOffset(offset);
     const params = new URLSearchParams();
@@ -7185,11 +7338,11 @@ const rootValue = {
     // production, so the Postgres tier being cold is the expected steady state —
     // fall back to the same pure builder REST uses, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/blocks", params),
         "METAGRAPH_BLOCKS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildBlockFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -7202,18 +7355,18 @@ const rootValue = {
     };
   },
 
-  async blocks_summary(_args, context) {
+  async blocks_summary(_args: unknown, context: GqlContext) {
     // #5664: same tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) -> buildBlocksSummary([])
     // fallback contract handleBlocksSummary uses. blocks' D1 write path is retired
     // (#4909) so a cold Postgres tier is the steady state -- the empty builder
     // shape (block_count 0, every aggregate null) satisfies the non-null
     // BlocksSummary! contract, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/blocks/summary"),
         "METAGRAPH_BLOCKS_SOURCE",
-      )) ?? buildBlocksSummary([]);
+      )) as Row | null) ?? buildBlocksSummary([]);
     return {
       schema_version: data.schema_version ?? 1,
       block_count: data.block_count ?? 0,
@@ -7230,18 +7383,18 @@ const rootValue = {
     };
   },
 
-  async runtime(_args, context) {
+  async runtime(_args: unknown, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) -> buildRuntimeVersionHistory([])
     // fallback contract GET /api/v1/runtime and the get_runtime MCP tool use; blocks'
     // D1 write path is retired (#4909) so a cold Postgres tier is the steady state --
     // the empty builder shape (transition_count 0, current_spec_version null) satisfies
     // the non-null RuntimeVersionHistory! contract, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/runtime"),
         "METAGRAPH_BLOCKS_SOURCE",
-      )) ?? buildRuntimeVersionHistory([]);
+      )) as Row | null) ?? buildRuntimeVersionHistory([]);
     return {
       schema_version: data.schema_version ?? 1,
       transitions: data.transitions || [],
@@ -7252,16 +7405,16 @@ const rootValue = {
     };
   },
 
-  async block({ ref }, context) {
+  async block({ ref }: Row, context: GqlContext) {
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/blocks/${encodeURIComponent(ref)}`,
         ),
         "METAGRAPH_BLOCKS_SOURCE",
-      )) ?? buildBlock(undefined, ref);
+      )) as Row | null) ?? buildBlock(undefined, ref);
     return {
       ref: data.ref ?? ref,
       block: data.block ?? null,
@@ -7274,7 +7427,7 @@ const rootValue = {
   // Postgres tier + schema-stable fallback builder REST and MCP already use. The
   // /blocks/:ref/{extrinsics,events} routes wrap their body in `{ data }` (unlike
   // the flat /blocks/:ref route), so the tier result is destructured accordingly.
-  async block_extrinsics({ ref, limit, offset }, context) {
+  async block_extrinsics({ ref, limit, offset }: Row, context: GqlContext) {
     const safeLimit = Number.isFinite(limit)
       ? Math.max(1, Math.min(100, Math.floor(limit)))
       : 50;
@@ -7284,7 +7437,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
-    const { data } = (await tryPostgresTier(
+    const { data } = ((await tryPostgresTier(
       context.env,
       postgresTierRequest(
         context,
@@ -7292,7 +7445,7 @@ const rootValue = {
         params,
       ),
       "METAGRAPH_EXTRINSICS_SOURCE",
-    )) ?? {
+    )) as Row | null) ?? {
       data: buildBlockExtrinsics([], ref, null, {
         limit: safeLimit,
         offset: safeOffset,
@@ -7301,7 +7454,7 @@ const rootValue = {
     return data;
   },
 
-  async block_events({ ref, limit, offset }, context) {
+  async block_events({ ref, limit, offset }: Row, context: GqlContext) {
     const safeLimit = Number.isFinite(limit)
       ? Math.max(1, Math.min(1000, Math.floor(limit)))
       : 100;
@@ -7311,7 +7464,7 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
-    const { data } = (await tryPostgresTier(
+    const { data } = ((await tryPostgresTier(
       context.env,
       postgresTierRequest(
         context,
@@ -7319,7 +7472,7 @@ const rootValue = {
         params,
       ),
       "METAGRAPH_EXTRINSICS_SOURCE",
-    )) ?? {
+    )) as Row | null) ?? {
       data: buildBlockEvents([], ref, null, {
         limit: safeLimit,
         offset: safeOffset,
@@ -7331,11 +7484,11 @@ const rootValue = {
   // Reuses loadBlockChainEvents unchanged (the get_block_chain_events tool's own
   // loader); it throws invalid_params on a bad block_number and tier_unavailable
   // where the all-events Worker is absent -- both surface as normal GraphQL errors.
-  block_chain_events({ block_number: blockNumber }, context) {
-    return loadBlockChainEvents(context, blockNumber);
+  block_chain_events({ block_number: blockNumber }: Row, context: GqlContext) {
+    return loadBlockChainEvents(mcpCtx(context), blockNumber);
   },
 
-  async validators({ sort, limit, cursor }, context) {
+  async validators({ sort, limit, cursor }: Row, context: GqlContext) {
     const requestedSort = sort ?? DEFAULT_GLOBAL_VALIDATOR_SORT;
     if (!GLOBAL_VALIDATOR_SORTS.includes(requestedSort)) {
       throw new GraphQLError(
@@ -7349,22 +7502,22 @@ const rootValue = {
     params.set("sort", requestedSort);
     params.set("limit", String(GLOBAL_VALIDATOR_LIMIT_MAX));
     const data = overlayFeaturedValidators(
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/validators", params),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ??
+      )) as Row | null) ??
         buildGlobalValidators([], {
           sort: requestedSort,
           limit: GLOBAL_VALIDATOR_LIMIT_MAX,
         }),
-    );
+    )! as Row;
     const nodes = (data.validators || []).map(validatorNode);
     const { page, total, nextCursor } = paginate(
       nodes,
       limit,
       cursor,
-      (v) => v.hotkey,
+      (v: Row) => v.hotkey,
     );
     return {
       items: page,
@@ -7376,7 +7529,10 @@ const rootValue = {
     };
   },
 
-  async validator_nominators({ hotkey, window, sort, coldkey }, context) {
+  async validator_nominators(
+    { hotkey, window, sort, coldkey }: Row,
+    context: GqlContext,
+  ) {
     // Same window/sort allow-lists handleValidatorNominators validates against --
     // an unsupported value is a GraphQL BAD_USER_INPUT error, not a silently
     // substituted default. `sort` is optional: omitted resolves to
@@ -7417,7 +7573,7 @@ const rootValue = {
     // retirement: the `account_events` D1 table is dropped in production, so the
     // fallback goes straight to the pure builder with no rows, never a live D1 query.
     const data =
-      (
+      ((
         await tryPostgresTier(
           context.env,
           postgresTierRequest(
@@ -7427,7 +7583,7 @@ const rootValue = {
           ),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )
-      )?.data ??
+      )?.data as Row | undefined) ??
       buildValidatorNominators([], hotkey, {
         window: requestedWindow,
         sort: sort ?? undefined,
@@ -7444,7 +7600,7 @@ const rootValue = {
     };
   },
 
-  async validator({ hotkey }, context) {
+  async validator({ hotkey }: Row, context: GqlContext) {
     const data = await tryPostgresTier(
       context.env,
       postgresTierRequest(
@@ -7453,18 +7609,20 @@ const rootValue = {
       ),
       "METAGRAPH_NEURONS_SOURCE",
     );
-    return validatorDetailNode(data, hotkey);
+    return validatorDetailNode(data as Row, hotkey);
   },
 
-  async validator_history({ hotkey, window }, context) {
+  async validator_history({ hotkey, window }: Row, context: GqlContext) {
     // Same parseHistoryWindow REST's handleValidatorHistory uses, so accepted
     // window labels (7d/30d/90d/1y/all, default 30d) match exactly.
-    const { label, error } = parseHistoryWindow(window);
-    if (error) {
+    const windowResult = parseHistoryWindow(window);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildValidatorHistory
@@ -7472,7 +7630,7 @@ const rootValue = {
     // neuron_daily rows in the window is a schema-stable empty-points card,
     // never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -7480,7 +7638,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildValidatorHistory([], hotkey, { window: label });
+      )) as Row | null) ?? buildValidatorHistory([], hotkey, { window: label });
     return {
       schema_version: data.schema_version ?? 1,
       hotkey: data.hotkey ?? hotkey,
@@ -7490,7 +7648,10 @@ const rootValue = {
     };
   },
 
-  async account_position_history({ ss58, netuid, window }, context) {
+  async account_position_history(
+    { ss58, netuid, window }: Row,
+    context: GqlContext,
+  ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7503,12 +7664,14 @@ const rootValue = {
     }
     // Same parseHistoryWindow the REST position-history handler uses, so
     // accepted window labels (7d/30d/90d/1y/all, default 30d) match exactly.
-    const { label, error } = parseHistoryWindow(window);
-    if (error) {
+    const windowResult = parseHistoryWindow(window);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildAccountPositionHistory
@@ -7516,7 +7679,7 @@ const rootValue = {
     // rows for the subnet in the window is a schema-stable empty-points card,
     // never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -7524,7 +7687,8 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildAccountPositionHistory([], ss58, netuid, { window: label });
+      )) as Row | null) ??
+      buildAccountPositionHistory([], ss58, netuid, { window: label });
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,
@@ -7535,7 +7699,7 @@ const rootValue = {
     };
   },
 
-  async accounts({ sort, limit }, context) {
+  async accounts({ sort, limit }: Row, context: GqlContext) {
     const requestedSort = sort ?? DEFAULT_ACCOUNTS_LIST_SORT;
     if (!ACCOUNTS_LIST_SORTS.includes(requestedSort)) {
       throw new GraphQLError(
@@ -7551,11 +7715,11 @@ const rootValue = {
     params.set("sort", requestedSort);
     params.set("limit", String(safeLimit));
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/accounts", params),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildAccountsList([], {
         sort: requestedSort,
         limit: safeLimit,
@@ -7569,25 +7733,25 @@ const rootValue = {
     };
   },
 
-  async account({ ss58 }, context) {
+  async account({ ss58 }: Row, context: GqlContext) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/accounts/${encodeURIComponent(ss58)}`,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildAccountSummary(ss58, {});
+      )) as Row | null) ?? buildAccountSummary(ss58, {});
     return accountSummaryNode(data, ss58);
   },
 
-  async account_prometheus({ ss58, window }, context) {
+  async account_prometheus({ ss58, window }: Row, context: GqlContext) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7617,7 +7781,8 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      pg?.data ?? buildAccountPrometheus([], ss58, { window: requestedWindow });
+      (pg?.data as Row | undefined) ??
+      buildAccountPrometheus([], ss58, { window: requestedWindow });
     return {
       schema_version: data.schema_version ?? 1,
       address: data.address ?? ss58,
@@ -7630,7 +7795,10 @@ const rootValue = {
     };
   },
 
-  async account_stake_flow({ ss58, window, direction }, context) {
+  async account_stake_flow(
+    { ss58, window, direction }: Row,
+    context: GqlContext,
+  ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7668,7 +7836,8 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      pg?.data ?? buildAccountStakeFlow([], ss58, { window: requestedWindow });
+      (pg?.data as Row | undefined) ??
+      buildAccountStakeFlow([], ss58, { window: requestedWindow });
     return {
       schema_version: data.schema_version ?? 1,
       address: data.address ?? ss58,
@@ -7688,7 +7857,7 @@ const rootValue = {
     };
   },
 
-  async account_portfolio({ ss58 }, context) {
+  async account_portfolio({ ss58 }: Row, context: GqlContext) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7699,14 +7868,14 @@ const rootValue = {
     // body is flat (like `account`'s own), not the { data, generatedAt } envelope
     // the account-event-footprint family uses.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/accounts/${encodeURIComponent(ss58)}/portfolio`,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildAccountPortfolio([], ss58);
+      )) as Row | null) ?? buildAccountPortfolio([], ss58);
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,
@@ -7723,7 +7892,7 @@ const rootValue = {
     };
   },
 
-  async account_positions({ ss58 }, context) {
+  async account_positions({ ss58 }: Row, context: GqlContext) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7735,14 +7904,14 @@ const rootValue = {
     // body (like account_portfolio's), not the { data, generatedAt } envelope
     // the account-event-footprint family uses.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/accounts/${encodeURIComponent(ss58)}/positions`,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildAccountPositions([], new Map(), ss58);
+      )) as Row | null) ?? buildAccountPositions([], new Map(), ss58);
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,
@@ -7753,7 +7922,7 @@ const rootValue = {
     };
   },
 
-  async account_subnets({ ss58 }, context) {
+  async account_subnets({ ss58 }: Row, context: GqlContext) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7765,14 +7934,14 @@ const rootValue = {
     // not the { data, generatedAt } envelope the account-event footprint family
     // uses. An unregistered address is a schema-stable empty card, never null.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/accounts/${encodeURIComponent(ss58)}/subnets`,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildAccountSubnets([], ss58);
+      )) as Row | null) ?? buildAccountSubnets([], ss58);
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,
@@ -7781,7 +7950,7 @@ const rootValue = {
     };
   },
 
-  async account_registrations({ ss58, window }, context) {
+  async account_registrations({ ss58, window }: Row, context: GqlContext) {
     // Same SS58 + window validation handleAccountRegistrations (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -7813,7 +7982,7 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      tier?.data ??
+      (tier?.data as Row | undefined) ??
       buildAccountRegistrations([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -7823,7 +7992,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s) => ({
+      subnets: (data.subnets ?? []).map((s: Row) => ({
         netuid: s.netuid,
         registrations: s.registrations,
         first_registered_at: s.first_registered_at ?? null,
@@ -7832,7 +8001,7 @@ const rootValue = {
     };
   },
 
-  async account_deregistrations({ ss58, window }, context) {
+  async account_deregistrations({ ss58, window }: Row, context: GqlContext) {
     // Same SS58 + window validation handleAccountDeregistrations (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -7864,7 +8033,7 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      tier?.data ??
+      (tier?.data as Row | undefined) ??
       buildAccountDeregistrations([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -7874,7 +8043,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s) => ({
+      subnets: (data.subnets ?? []).map((s: Row) => ({
         netuid: s.netuid,
         deregistrations: s.deregistrations,
         first_deregistered_at: s.first_deregistered_at ?? null,
@@ -7883,7 +8052,7 @@ const rootValue = {
     };
   },
 
-  async account_serving({ ss58, window }, context) {
+  async account_serving({ ss58, window }: Row, context: GqlContext) {
     // Same SS58 + window validation handleAccountServing (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -7915,7 +8084,8 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      tier?.data ?? buildAccountServing([], ss58, { window: windowParam });
+      (tier?.data as Row | undefined) ??
+      buildAccountServing([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       address: data.address ?? ss58,
@@ -7924,7 +8094,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s) => ({
+      subnets: (data.subnets ?? []).map((s: Row) => ({
         netuid: s.netuid,
         announcements: s.announcements,
         first_served_at: s.first_served_at ?? null,
@@ -7933,7 +8103,7 @@ const rootValue = {
     };
   },
 
-  async account_axon_removals({ ss58, window }, context) {
+  async account_axon_removals({ ss58, window }: Row, context: GqlContext) {
     // Same SS58 + window validation handleAccountAxonRemovals (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -7965,7 +8135,8 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      tier?.data ?? buildAccountAxonRemovals([], ss58, { window: windowParam });
+      (tier?.data as Row | undefined) ??
+      buildAccountAxonRemovals([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       address: data.address ?? ss58,
@@ -7974,7 +8145,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s) => ({
+      subnets: (data.subnets ?? []).map((s: Row) => ({
         netuid: s.netuid,
         removals: s.removals,
         first_removed_at: s.first_removed_at ?? null,
@@ -7983,7 +8154,7 @@ const rootValue = {
     };
   },
 
-  async account_stake_moves({ ss58, window }, context) {
+  async account_stake_moves({ ss58, window }: Row, context: GqlContext) {
     // Same SS58 + window validation handleAccountStakeMoves (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -8015,7 +8186,8 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      tier?.data ?? buildAccountStakeMoves([], ss58, { window: windowParam });
+      (tier?.data as Row | undefined) ??
+      buildAccountStakeMoves([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       address: data.address ?? ss58,
@@ -8024,7 +8196,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s) => ({
+      subnets: (data.subnets ?? []).map((s: Row) => ({
         netuid: s.netuid,
         movements: s.movements,
         first_moved_at: s.first_moved_at ?? null,
@@ -8034,7 +8206,7 @@ const rootValue = {
     };
   },
 
-  async account_weight_setters({ ss58, window }, context) {
+  async account_weight_setters({ ss58, window }: Row, context: GqlContext) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -8065,7 +8237,7 @@ const rootValue = {
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
     const data =
-      pg?.data ??
+      (pg?.data as Row | undefined) ??
       buildAccountWeightSetters([], ss58, { window: requestedWindow });
     return {
       schema_version: data.schema_version ?? 1,
@@ -8079,7 +8251,7 @@ const rootValue = {
     };
   },
 
-  async account_entities({ ss58 }, context) {
+  async account_entities({ ss58 }: Row, context: GqlContext) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -8105,7 +8277,7 @@ const rootValue = {
     const data = ownershipData ?? buildAccountEntities(ss58, { entities: [] });
     const labels = labelsForSs58(
       entityLabelsIndex(
-        entitiesArtifact.ok ? entitiesArtifact.data?.entities : [],
+        entitiesArtifact.ok ? (entitiesArtifact.data as Row)?.entities : [],
       ),
       ss58,
     );
@@ -8118,7 +8290,7 @@ const rootValue = {
     };
   },
 
-  async account_identity({ ss58 }, context) {
+  async account_identity({ ss58 }: Row, context: GqlContext) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty card.
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
@@ -8132,14 +8304,14 @@ const rootValue = {
     // every field null, never a GraphQL error -- a Postgres miss/outage
     // degrades to that exact same schema-stable shape, never a live D1 read.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/accounts/${encodeURIComponent(ss58)}/identity`,
         ),
         "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
-      )) ?? buildAccountIdentity(null, ss58);
+      )) as Row | null) ?? buildAccountIdentity(null, ss58);
     return {
       schema_version: data.schema_version ?? 1,
       account: data.account ?? ss58,
@@ -8155,7 +8327,10 @@ const rootValue = {
     };
   },
 
-  async account_identity_history({ ss58, limit, offset, cursor }, context) {
+  async account_identity_history(
+    { ss58, limit, offset, cursor }: Row,
+    context: GqlContext,
+  ) {
     // Same SS58 validation every account_* resolver uses -- a malformed
     // address is a GraphQL BAD_USER_INPUT error, not a silent empty timeline.
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
@@ -8173,7 +8348,7 @@ const rootValue = {
     if (offset != null) params.set("offset", String(offset));
     if (cursor != null) params.set("cursor", cursor);
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -8181,7 +8356,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildAccountIdentityHistory([], ss58, {
         limit,
         offset,
@@ -8194,7 +8369,7 @@ const rootValue = {
       limit: data.limit ?? null,
       offset: data.offset ?? null,
       next_cursor: data.next_cursor ?? null,
-      entries: (data.entries ?? []).map((e) => ({
+      entries: (data.entries ?? []).map((e: Row) => ({
         observed_at: e.observed_at ?? null,
         name: e.name ?? null,
         url: e.url ?? null,
@@ -8208,7 +8383,10 @@ const rootValue = {
     };
   },
 
-  async account_counterparties({ ss58, counterparty, limit }, context) {
+  async account_counterparties(
+    { ss58, counterparty, limit }: Row,
+    context: GqlContext,
+  ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty card.
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
@@ -8248,7 +8426,7 @@ const rootValue = {
       ),
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     );
-    let data = tier;
+    let data = tier as Row | null;
     if (data == null) {
       if (counterparty != null) {
         const rel = buildCounterpartyRelationship([], ss58, counterparty, {
@@ -8278,7 +8456,7 @@ const rootValue = {
       scan_capped: data.scan_capped ?? false,
       total_sent_tao: data.total_sent_tao ?? 0,
       total_received_tao: data.total_received_tao ?? 0,
-      counterparties: (data.counterparties ?? []).map((c) => ({
+      counterparties: (data.counterparties ?? []).map((c: Row) => ({
         address: c.address,
         sent_tao: c.sent_tao ?? 0,
         received_tao: c.received_tao ?? 0,
@@ -8302,7 +8480,7 @@ const rootValue = {
             first_seen_at: rel.first_seen_at ?? null,
             last_seen_at: rel.last_seen_at ?? null,
             limit: rel.limit ?? 0,
-            transfers: (rel.transfers ?? []).map((t) => ({
+            transfers: (rel.transfers ?? []).map((t: Row) => ({
               block_number: t.block_number ?? null,
               event_index: t.event_index ?? null,
               netuid: t.netuid ?? null,
@@ -8318,8 +8496,8 @@ const rootValue = {
   },
 
   async account_transfers(
-    { ss58, limit, offset, cursor, direction, block_start, block_end },
-    context,
+    { ss58, limit, offset, cursor, direction, block_start, block_end }: Row,
+    context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
@@ -8346,7 +8524,7 @@ const rootValue = {
     // retired (#4772), so a tier miss resolves through buildAccountTransfers over
     // an empty scan -- a schema-stable empty feed, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -8354,7 +8532,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildAccountTransfers([], ss58, {
         limit: safeLimit,
         offset: safeOffset,
@@ -8367,7 +8545,7 @@ const rootValue = {
       limit: data.limit ?? safeLimit,
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
-      transfers: (data.transfers ?? []).map((t) => ({
+      transfers: (data.transfers ?? []).map((t: Row) => ({
         block_number: t.block_number ?? null,
         event_index: t.event_index ?? null,
         from: t.from ?? null,
@@ -8380,8 +8558,8 @@ const rootValue = {
   },
 
   async account_extrinsics(
-    { ss58, limit, offset, cursor, block_start, block_end },
-    context,
+    { ss58, limit, offset, cursor, block_start, block_end }: Row,
+    context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
@@ -8407,7 +8585,7 @@ const rootValue = {
     // (#4772), so a tier miss resolves through buildAccountExtrinsics over an
     // empty scan -- a schema-stable empty feed, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -8415,7 +8593,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildAccountExtrinsics([], ss58, {
         limit: safeLimit,
         offset: safeOffset,
@@ -8435,8 +8613,8 @@ const rootValue = {
   },
 
   async account_events(
-    { ss58, kind, netuid, block_start, block_end, limit, offset, cursor },
-    context,
+    { ss58, kind, netuid, block_start, block_end, limit, offset, cursor }: Row,
+    context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
@@ -8464,7 +8642,7 @@ const rootValue = {
     // retired (#4772), so a tier miss resolves through buildAccountEvents over an
     // empty scan -- a schema-stable empty feed, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -8472,7 +8650,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildAccountEvents([], ss58, {
         limit: safeLimit,
         offset: safeOffset,
@@ -8485,7 +8663,7 @@ const rootValue = {
       limit: data.limit ?? safeLimit,
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
-      events: (data.events ?? []).map((e) => ({
+      events: (data.events ?? []).map((e: Row) => ({
         block_number: e.block_number ?? null,
         event_index: e.event_index ?? null,
         event_kind: e.event_kind ?? null,
@@ -8502,8 +8680,8 @@ const rootValue = {
   },
 
   async account_history(
-    { ss58, netuid, from, to, limit, offset, cursor },
-    context,
+    { ss58, netuid, from, to, limit, offset, cursor }: Row,
+    context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty series.
@@ -8554,7 +8732,7 @@ const rootValue = {
       cursor: cursor ?? undefined,
     };
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -8562,7 +8740,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? (await loadAccountHistory(ss58, historyOptions));
+      )) as Row | null) ?? (await loadAccountHistory(ss58, historyOptions));
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,
@@ -8570,7 +8748,7 @@ const rootValue = {
       limit: data.limit ?? safeLimit,
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
-      days: (data.days ?? []).map((d) => ({
+      days: (data.days ?? []).map((d: Row) => ({
         day: d.day ?? null,
         netuid: d.netuid ?? null,
         event_count: d.event_count ?? null,
@@ -8581,31 +8759,28 @@ const rootValue = {
     };
   },
 
-  async economics_trends({ window }, context) {
+  async economics_trends({ window }: Row, context: GqlContext) {
     // Same parseHistoryWindow REST uses, so accepted window labels and the
     // resulting { label, days } stay identical between REST and GraphQL.
-    const { label, days, error } = parseHistoryWindow(window);
-    if (error) {
+    const windowResult = parseHistoryWindow(window);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same tier
     // and fallback contract REST's handleEconomicsTrends uses.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/economics/trends", params),
         "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-      )) ??
-      (
-        await loadEconomicsTrends({
-          windowLabel: label,
-          windowDays: days,
-        })
-      ).data;
+      )) as Row | null) ??
+      (await loadEconomicsTrends({ windowLabel: label })).data;
     // Normalized the same way blocks/validators/accounts are (schema-stable,
     // never a GraphQL error), so a malformed/partial Postgres-tier body still
     // satisfies the non-null EconomicsTrends! contract.
@@ -8617,7 +8792,7 @@ const rootValue = {
     };
   },
 
-  async subnet_movers({ window, sort, limit }, context) {
+  async subnet_movers({ window, sort, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_MOVERS_WINDOW;
     if (!Object.hasOwn(MOVERS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -8651,11 +8826,11 @@ const rootValue = {
     // handleSubnetMovers uses -- a cold/absent tier yields a schema-stable
     // empty leaderboard, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/subnets/movers", params),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildMovers([], [], {
         window: requestedWindow,
         startDate: null,
@@ -8691,7 +8866,7 @@ const rootValue = {
     };
   },
 
-  async chain_turnover({ window, limit }, context) {
+  async chain_turnover({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_TURNOVER_WINDOW;
     if (!Object.hasOwn(CHAIN_TURNOVER_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -8713,11 +8888,11 @@ const rootValue = {
     // store yields the schema-stable empty/non-comparable envelope, never a
     // GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/turnover", params),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainTurnover([], {
         window: requestedWindow,
         startDate: null,
@@ -8744,19 +8919,21 @@ const rootValue = {
     };
   },
 
-  async chain_activity({ window }, context) {
+  async chain_activity({ window }: Row, context: GqlContext) {
     // Reuse the exact analyticsWindow parse/validate REST's handleChainActivity
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
     // BAD_USER_INPUT error, not a silent empty result.
-    const windowUrl = new URL(context.request.url);
+    const windowUrl = new URL((context.request as Request).url);
     windowUrl.search = "";
     if (window != null) windowUrl.searchParams.set("window", window);
-    const { label, error } = analyticsWindow(windowUrl);
-    if (error) {
+    const windowResult = analyticsWindow(windowUrl);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // Same tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE) -> buildChainActivity
@@ -8764,17 +8941,17 @@ const rootValue = {
     // rollup (no logic duplicated here), and a cold store yields a schema-stable
     // empty series.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/activity", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ?? buildChainActivity({ window: label });
+      )) as Row | null) ?? buildChainActivity({ window: label });
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,
       observed_at: data.observed_at ?? null,
       day_count: data.day_count ?? 0,
-      days: (data.days ?? []).map((d) => ({
+      days: (data.days ?? []).map((d: Row) => ({
         day: d.day,
         block_count: d.block_count ?? 0,
         extrinsic_count: d.extrinsic_count ?? 0,
@@ -8787,21 +8964,23 @@ const rootValue = {
   },
 
   async chain_calls(
-    { window, group_by: groupBy, limit, call_module: callModule },
-    context,
+    { window, group_by: groupBy, limit, call_module: callModule }: Row,
+    context: GqlContext,
   ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleChainCalls
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
     // BAD_USER_INPUT error, not a silent empty result.
-    const windowUrl = new URL(context.request.url);
+    const windowUrl = new URL((context.request as Request).url);
     windowUrl.search = "";
     if (window != null) windowUrl.searchParams.set("window", window);
-    const { label, error } = analyticsWindow(windowUrl);
-    if (error) {
+    const windowResult = analyticsWindow(windowUrl);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     const requestedGroupBy = groupBy ?? "module";
     if (
       requestedGroupBy !== "module" &&
@@ -8827,11 +9006,12 @@ const rootValue = {
     // handleChainCalls uses; the tier owns the call-mix aggregation (no logic
     // duplicated here), and a cold store yields a schema-stable empty breakdown.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/calls", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ?? buildChainCalls({ window: label, groupBy: requestedGroupBy });
+      )) as Row | null) ??
+      buildChainCalls({ window: label, groupBy: requestedGroupBy });
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,
@@ -8839,7 +9019,7 @@ const rootValue = {
       observed_at: data.observed_at ?? null,
       total_extrinsics: data.total_extrinsics ?? 0,
       call_count: data.call_count ?? 0,
-      calls: (data.calls ?? []).map((c) => ({
+      calls: (data.calls ?? []).map((c: Row) => ({
         call_module: c.call_module,
         call_function: c.call_function ?? null,
         count: c.count ?? 0,
@@ -8848,19 +9028,24 @@ const rootValue = {
     };
   },
 
-  async chain_fees({ window, limit, call_module: callModule }, context) {
+  async chain_fees(
+    { window, limit, call_module: callModule }: Row,
+    context: GqlContext,
+  ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleChainFees
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
     // BAD_USER_INPUT error, not a silent empty result.
-    const windowUrl = new URL(context.request.url);
+    const windowUrl = new URL((context.request as Request).url);
     windowUrl.search = "";
     if (window != null) windowUrl.searchParams.set("window", window);
-    const { label, error } = analyticsWindow(windowUrl);
-    if (error) {
+    const windowResult = analyticsWindow(windowUrl);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     if (callModule != null && callModule.length > 100) {
       throw new GraphQLError("call_module must be at most 100 characters.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -8875,17 +9060,17 @@ const rootValue = {
     // handleChainFees uses; the tier owns the daily/median/payer aggregation (no
     // logic duplicated here), and a cold store yields a schema-stable empty series.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/fees", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ?? buildChainFees({ window: label });
+      )) as Row | null) ?? buildChainFees({ window: label });
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,
       observed_at: data.observed_at ?? null,
       day_count: data.day_count ?? 0,
-      daily: (data.daily ?? []).map((d) => ({
+      daily: (data.daily ?? []).map((d: Row) => ({
         day: d.day,
         extrinsic_count: d.extrinsic_count ?? 0,
         total_fee_tao: d.total_fee_tao ?? null,
@@ -8895,7 +9080,7 @@ const rootValue = {
         avg_tip_tao: d.avg_tip_tao ?? null,
         median_tip_tao: d.median_tip_tao ?? null,
       })),
-      top_fee_payers: (data.top_fee_payers ?? []).map((p) => ({
+      top_fee_payers: (data.top_fee_payers ?? []).map((p: Row) => ({
         signer: p.signer,
         total_fee_tao: p.total_fee_tao ?? null,
         total_tip_tao: p.total_tip_tao ?? null,
@@ -8904,7 +9089,7 @@ const rootValue = {
     };
   },
 
-  async chain_weights({ window, limit }, context) {
+  async chain_weights({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_WEIGHTS_WINDOW;
     if (!Object.hasOwn(CHAIN_WEIGHTS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -8925,15 +9110,15 @@ const rootValue = {
     // the `account_events` D1 table is dropped in production, so the fallback goes
     // straight to the pure builder with no rows, never a live D1 query.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/weights", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainWeights([], {
         window: requestedWindow,
         limit: safeLimit,
-        networkDistinct: null,
+        networkDistinct: undefined,
       });
     return {
       schema_version: data.schema_version ?? 1,
@@ -8950,7 +9135,7 @@ const rootValue = {
     };
   },
 
-  async chain_serving({ window, limit }, context) {
+  async chain_serving({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_SERVING_WINDOW;
     if (!Object.hasOwn(CHAIN_SERVING_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -8971,11 +9156,11 @@ const rootValue = {
     // schema-stable zeroed card contract REST's chainServing route uses, never
     // a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/serving", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainServing([], { window: requestedWindow, limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
@@ -8992,7 +9177,7 @@ const rootValue = {
     };
   },
 
-  async chain_axon_removals({ window, limit }, context) {
+  async chain_axon_removals({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
     if (!Object.hasOwn(CHAIN_AXON_REMOVALS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9013,11 +9198,11 @@ const rootValue = {
     // schema-stable zeroed card contract REST's handleChainAxonRemovals uses,
     // never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/axon-removals", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainAxonRemovals([], { window: requestedWindow, limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
@@ -9034,7 +9219,7 @@ const rootValue = {
     };
   },
 
-  async chain_deregistrations({ window, limit }, context) {
+  async chain_deregistrations({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW;
     if (!Object.hasOwn(CHAIN_DEREGISTRATIONS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9058,11 +9243,11 @@ const rootValue = {
     // schema-stable zeroed card contract REST's handleChainDeregistrations
     // uses, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/deregistrations", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainDeregistrations([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -9082,7 +9267,7 @@ const rootValue = {
     };
   },
 
-  async chain_registrations({ window, limit }, context) {
+  async chain_registrations({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_REGISTRATIONS_WINDOW;
     if (!Object.hasOwn(CHAIN_REGISTRATIONS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9103,11 +9288,11 @@ const rootValue = {
     // schema-stable zeroed card contract REST's handleChainRegistrations uses,
     // never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/registrations", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainRegistrations([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -9127,7 +9312,7 @@ const rootValue = {
     };
   },
 
-  async chain_prometheus({ window, limit }, context) {
+  async chain_prometheus({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_PROMETHEUS_WINDOW;
     if (!Object.hasOwn(CHAIN_PROMETHEUS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9148,11 +9333,11 @@ const rootValue = {
     // schema-stable zeroed card contract REST's handleChainPrometheus uses,
     // never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/prometheus", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainPrometheus([], { window: requestedWindow, limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
@@ -9170,21 +9355,23 @@ const rootValue = {
   },
 
   async chain_signers(
-    { window, limit, sort, call_module: callModule },
-    context,
+    { window, limit, sort, call_module: callModule }: Row,
+    context: GqlContext,
   ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleChainSigners
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
     // BAD_USER_INPUT error, not a silent empty leaderboard.
-    const windowUrl = new URL(context.request.url);
+    const windowUrl = new URL((context.request as Request).url);
     windowUrl.search = "";
     if (window != null) windowUrl.searchParams.set("window", window);
-    const { label, error } = analyticsWindow(windowUrl);
-    if (error) {
+    const windowResult = analyticsWindow(windowUrl);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     // Same CHAIN_SIGNERS_SORTS allow-list REST validates against; sort is
     // optional (null -> the loader's tx_count default), so only a non-null
     // value is checked.
@@ -9220,7 +9407,7 @@ const rootValue = {
       "METAGRAPH_EXTRINSICS_SOURCE",
     );
     const data =
-      tier ??
+      (tier as Row | null) ??
       buildChainSigners({
         window: label,
         sort,
@@ -9233,7 +9420,7 @@ const rootValue = {
       sort: data.sort ?? CHAIN_SIGNERS_SORTS[0],
       observed_at: data.observed_at ?? null,
       signer_count: data.signer_count ?? 0,
-      signers: (data.signers ?? []).map((entry) => ({
+      signers: (data.signers ?? []).map((entry: Row) => ({
         signer: entry.signer,
         tx_count: entry.tx_count ?? 0,
         total_fee_tao: entry.total_fee_tao ?? null,
@@ -9243,7 +9430,7 @@ const rootValue = {
     };
   },
 
-  async chain_weight_setters({ window, limit }, context) {
+  async chain_weight_setters({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW;
     if (!Object.hasOwn(CHAIN_WEIGHT_SETTERS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9262,11 +9449,11 @@ const rootValue = {
     // and the table is dropped in production, so a D1 query here would
     // always miss. Postgres → schema-stable empty stub, never a live D1 read.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/weights/setters", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainWeightSetters([], null, {
         window: requestedWindow,
         limit: safeLimit,
@@ -9282,7 +9469,7 @@ const rootValue = {
     };
   },
 
-  async chain_alpha_volume({ limit }, context) {
+  async chain_alpha_volume({ limit }: Row, context: GqlContext) {
     const safeLimit = clampLimit(limit, {
       defaultLimit: CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
       maxLimit: CHAIN_ALPHA_VOLUME_LIMIT_MAX,
@@ -9296,11 +9483,11 @@ const rootValue = {
     // retirement: the `account_events` D1 table is dropped in production, so the
     // fallback goes straight to the pure builder with no rows, never a live D1 query.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/alpha-volume", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? buildChainAlphaVolume([], { limit: safeLimit });
+      )) as Row | null) ?? buildChainAlphaVolume([], { limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? "24h",
@@ -9324,17 +9511,17 @@ const rootValue = {
     };
   },
 
-  async chain_idle_stake(_args, context) {
+  async chain_idle_stake(_args: unknown, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildChainIdleStake([])
     // cold fallback contract handleChainIdleStake / MCP get_chain_idle_stake
     // use: a cold/absent tier yields a schema-stable empty ranking, never a
     // GraphQL error. No window/limit args -- current snapshot only.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/idle-stake"),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildChainIdleStake([]);
+      )) as Row | null) ?? buildChainIdleStake([]);
     return {
       schema_version: data.schema_version ?? 1,
       captured_at: data.captured_at ?? null,
@@ -9344,7 +9531,7 @@ const rootValue = {
     };
   },
 
-  async chain_stake_flow({ window, limit }, context) {
+  async chain_stake_flow({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_FLOW_WINDOW;
     if (!Object.hasOwn(CHAIN_STAKE_FLOW_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9363,11 +9550,11 @@ const rootValue = {
     // buildChainStakeFlow empty-card fallback REST's handleChainStakeFlow
     // uses. #4909 D1 retirement: never a live D1 read.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/stake-flow", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainStakeFlow([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -9393,7 +9580,7 @@ const rootValue = {
     };
   },
 
-  async chain_stake_moves({ window, limit }, context) {
+  async chain_stake_moves({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_MOVES_WINDOW;
     if (!Object.hasOwn(CHAIN_STAKE_MOVES_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9412,11 +9599,11 @@ const rootValue = {
     // buildChainStakeMoves empty-card fallback REST's handleChainStakeMoves
     // uses. #4909 D1 retirement: never a live D1 read.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/stake-moves", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainStakeMoves([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -9436,7 +9623,7 @@ const rootValue = {
     };
   },
 
-  async chain_stake_transfers({ window, limit }, context) {
+  async chain_stake_transfers({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW;
     if (!Object.hasOwn(CHAIN_STAKE_TRANSFERS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9458,11 +9645,11 @@ const rootValue = {
     // buildChainStakeTransfers empty-card fallback REST's
     // handleChainStakeTransfers uses. #4909 D1 retirement: never a live D1 read.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/stake-transfers", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainStakeTransfers([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -9482,7 +9669,10 @@ const rootValue = {
     };
   },
 
-  async chain_transfer_pairs({ window, sort, limit }, context) {
+  async chain_transfer_pairs(
+    { window, sort, limit }: Row,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW;
     if (!Object.hasOwn(CHAIN_TRANSFER_PAIR_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9510,11 +9700,11 @@ const rootValue = {
     // buildChainTransferPairs empty-card fallback REST uses, including the KV
     // health:meta observed_at stamp. #4909 D1 retirement: never a live D1 read.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/transfer-pairs", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainTransferPairs({
         window: requestedWindow,
         sort,
@@ -9536,7 +9726,7 @@ const rootValue = {
     };
   },
 
-  async chain_transfers({ window, limit }, context) {
+  async chain_transfers({ window, limit }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_CHAIN_TRANSFER_WINDOW;
     if (!Object.hasOwn(CHAIN_TRANSFER_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9556,11 +9746,11 @@ const rootValue = {
     // uses, including the KV health:meta observed_at stamp. #4909 D1
     // retirement: never a live D1 read.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/transfers", params),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      )) as Row | null) ??
       buildChainTransfers({
         window: requestedWindow,
         observedAt: await loadObservedAt(context),
@@ -9582,17 +9772,17 @@ const rootValue = {
     };
   },
 
-  async health_trends(_args, context) {
+  async health_trends(_args: unknown, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadBulkHealthTrends
     // fallback contract REST's handleBulkHealthTrends and the get_health_trends
     // MCP tool share -- a cold store yields both windows zeroed, never a
     // GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/health/trends"),
         "METAGRAPH_HEALTH_SOURCE",
-      )) ??
+      )) as Row | null) ??
       (
         await loadBulkHealthTrends({
           observedAt: await loadObservedAt(context),
@@ -9606,7 +9796,7 @@ const rootValue = {
     };
   },
 
-  async subnet_health_trends({ netuid }, context) {
+  async subnet_health_trends({ netuid }: Row, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadSubnetHealthTrends D1
     // fallback contract REST's handleHealthTrends and the
     // get_subnet_health_trends MCP tool share -- the route takes no window arg
@@ -9615,11 +9805,11 @@ const rootValue = {
     // tier owns the per-surface uptime/latency aggregation; nothing is
     // duplicated here.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, `/api/v1/subnets/${netuid}/health/trends`),
         "METAGRAPH_HEALTH_SOURCE",
-      )) ??
+      )) as Row | null) ??
       (await loadSubnetHealthTrends(netuid, {
         observedAt: await loadObservedAt(context),
       }));
@@ -9632,7 +9822,7 @@ const rootValue = {
     };
   },
 
-  async subnet_health({ netuid }, context) {
+  async subnet_health({ netuid }: Row, context: GqlContext) {
     // Same non-negative netuid gate the other per-subnet resolvers use --
     // GraphQL Int coercion rejects non-integers at parse time; a negative
     // netuid is a BAD_USER_INPUT error, not a silent card.
@@ -9649,7 +9839,13 @@ const rootValue = {
     // it resolves to the identical schema-stable "unknown" card the MCP tool
     // returns on a cold store -- never a GraphQL error. Nothing is re-derived.
     const [live, reliability] = await Promise.all([
-      resolveLiveHealth({ readHealthKv, env: context.env }),
+      resolveLiveHealth({
+        readHealthKv: readHealthKv as (
+          env: Env,
+          key: string,
+        ) => Promise<Row | null>,
+        env: context.env,
+      }),
       loadSubnetReliability(),
     ]);
     const overlaid = overlaySubnetHealth(null, live, netuid);
@@ -9667,7 +9863,10 @@ const rootValue = {
     };
   },
 
-  async subnet_uptime({ netuid, window, min_samples: minSamples }, context) {
+  async subnet_uptime(
+    { netuid, window, min_samples: minSamples }: Row,
+    context: GqlContext,
+  ) {
     // Same 90d/1y window validation handleUptime / get_subnet_uptime use -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     // parseUptimeWindow(undefined) → "90d"; a supplied bad value → null.
@@ -9694,7 +9893,7 @@ const rootValue = {
     // surfaces card, never a GraphQL error. The tier owns the
     // surface_uptime_daily aggregation; nothing is duplicated here.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -9702,12 +9901,11 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_HEALTH_SOURCE",
-      )) ??
-      (await loadSubnetUptime(netuid, {
+      )) as Row | null) ??
+      ((await loadSubnetUptime(netuid, {
         window: windowParam,
         observedAt: await loadObservedAt(context),
-        minSamples: sampleFloor,
-      }));
+      })) as Row);
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -9719,7 +9917,7 @@ const rootValue = {
     };
   },
 
-  async rpc_usage({ window }, context) {
+  async rpc_usage({ window }: Row, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_ANALYTICS_WINDOW;
     if (!Object.hasOwn(ANALYTICS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -9733,11 +9931,11 @@ const rootValue = {
     // contract REST's handleRpcUsage and the get_rpc_usage MCP tool share -- a
     // cold store yields a schema-stable zeroed card, never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/rpc/usage", params),
         "METAGRAPH_RPC_USAGE_SOURCE",
-      )) ??
+      )) as Row | null) ??
       (await loadRpcUsage({
         window: requestedWindow,
         observedAt: await loadObservedAt(context),
@@ -9771,7 +9969,7 @@ const rootValue = {
     };
   },
 
-  async registry_leaderboards({ board, limit }, context) {
+  async registry_leaderboards({ board, limit }: Row, context: GqlContext) {
     // Same board allowlist handleLeaderboards enforces -- an unknown board is a
     // GraphQL BAD_USER_INPUT error, mirroring REST's invalid_query 400 rather
     // than silently resolving to an empty board.
@@ -9813,7 +10011,7 @@ const rootValue = {
     };
   },
 
-  async chain_performance(_args, context) {
+  async chain_performance(_args: unknown, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildChainPerformance([])
     // cold fallback contract handleChainPerformance / MCP get_chain_performance
     // use: a cold/absent tier yields a schema-stable zeroed card (every metric
@@ -9821,11 +10019,11 @@ const rootValue = {
     // against an EMPTY param allowlist, so there is no window/limit arg to
     // mirror -- current snapshot only.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/performance"),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildChainPerformance([]);
+      )) as Row | null) ?? buildChainPerformance([]);
     return {
       schema_version: data.schema_version ?? 1,
       subnet_count: data.subnet_count ?? 0,
@@ -9841,16 +10039,16 @@ const rootValue = {
     };
   },
 
-  async chain_yield(_args, context) {
+  async chain_yield(_args: unknown, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildChainYield([])
     // fallback contract handleChainYield uses -- a cold/absent tier yields a
     // schema-stable zeroed card (every aggregate null), never a GraphQL error.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/yield"),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildChainYield([]);
+      )) as Row | null) ?? buildChainYield([]);
     const distribution = data.distribution ?? null;
     return {
       schema_version: data.schema_version ?? 1,
@@ -9880,7 +10078,7 @@ const rootValue = {
     };
   },
 
-  async chain_concentration(_args, context) {
+  async chain_concentration(_args: unknown, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildChainConcentration([])
     // cold fallback contract handleChainConcentration / MCP get_chain_concentration
     // use: a cold/absent tier yields a schema-stable zeroed card (every metric
@@ -9889,11 +10087,11 @@ const rootValue = {
     // param allowlist, so there is no window/limit arg to mirror -- current
     // snapshot only.
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/chain/concentration"),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildChainConcentration([]);
+      )) as Row | null) ?? buildChainConcentration([]);
     return {
       schema_version: data.schema_version ?? 1,
       subnet_count: data.subnet_count ?? 0,
@@ -9909,7 +10107,7 @@ const rootValue = {
     };
   },
 
-  async subnet_recycled({ netuid }, context) {
+  async subnet_recycled({ netuid }: Row, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -9924,7 +10122,7 @@ const rootValue = {
     return loadSubnetRecycled(context.env, netuid);
   },
 
-  async subnet_burn({ netuid }, context) {
+  async subnet_burn({ netuid }: Row, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -9939,7 +10137,7 @@ const rootValue = {
     return loadSubnetBurn(context.env, netuid);
   },
 
-  async subnet_turnover({ netuid, window }, context) {
+  async subnet_turnover({ netuid, window }: Row, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError("netuid must be a u16 subnet id (0-65535).", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -9947,12 +10145,14 @@ const rootValue = {
     }
     // Same parseHistoryWindow the REST turnover handler uses, so accepted
     // window labels (7d/30d/90d/1y/all, default 30d) match exactly.
-    const { label, error } = parseHistoryWindow(window);
-    if (error) {
+    const windowResult = parseHistoryWindow(window);
+    if ("error" in windowResult) {
+      const { error } = windowResult;
       throw new GraphQLError(error.message, {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildTurnover([]) empty-card
@@ -9961,7 +10161,7 @@ const rootValue = {
     // never a GraphQL error. Mirrors the default scorecard (REST's ?changes=true
     // detail is omitted).
     const data =
-      (await tryPostgresTier(
+      ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
@@ -9969,7 +10169,7 @@ const rootValue = {
           params,
         ),
         "METAGRAPH_NEURONS_SOURCE",
-      )) ?? buildTurnover([], netuid, { window: label });
+      )) as Row | null) ?? buildTurnover([], netuid, { window: label });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -9990,7 +10190,7 @@ const rootValue = {
     };
   },
 
-  async subnet_ownership_history({ netuid }, context) {
+  async subnet_ownership_history({ netuid }: Row, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -10011,7 +10211,7 @@ const rootValue = {
     };
   },
 
-  async subnet_conviction({ netuid }, context) {
+  async subnet_conviction({ netuid }: Row, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -10034,7 +10234,7 @@ const rootValue = {
     };
   },
 
-  async subnet_lease_history({ netuid }, context) {
+  async subnet_lease_history({ netuid }: Row, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -10053,7 +10253,7 @@ const rootValue = {
     };
   },
 
-  async subnet_lease({ netuid }, context) {
+  async subnet_lease({ netuid }: Row, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -10067,7 +10267,7 @@ const rootValue = {
     return loadSubnetLease(context.env, netuid);
   },
 
-  async account_balance({ ss58 }, context) {
+  async account_balance({ ss58 }: Row, context: GqlContext) {
     if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -10081,7 +10281,7 @@ const rootValue = {
     return loadAccountBalance(context.env, ss58);
   },
 
-  async account_root_claim({ ss58 }, context) {
+  async account_root_claim({ ss58 }: Row, context: GqlContext) {
     if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -10093,7 +10293,7 @@ const rootValue = {
     return loadAccountRootClaim(context.env, ss58);
   },
 
-  async account_children({ ss58 }, context) {
+  async account_children({ ss58 }: Row, context: GqlContext) {
     if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -10107,7 +10307,7 @@ const rootValue = {
     return loadAccountChildren(context.env, ss58);
   },
 
-  async account_parents({ ss58 }, context) {
+  async account_parents({ ss58 }: Row, context: GqlContext) {
     if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -10121,7 +10321,7 @@ const rootValue = {
     return loadAccountParents(context.env, ss58);
   },
 
-  async sudo_key(_args, context) {
+  async sudo_key(_args: unknown, context: GqlContext) {
     // Live chain RPC, not the Postgres tier -- reuses loadSudoKey's own KV
     // cache/TTL, matching REST's sudo/key handler exactly. hotkey stays null
     // on RPC failure or a renounced sudo (schema-stable), never a GraphQL
@@ -10130,7 +10330,7 @@ const rootValue = {
     return loadSudoKey(context.env);
   },
 
-  async network_parameters(_args, context) {
+  async network_parameters(_args: unknown, context: GqlContext) {
     // Live chain RPC, not the Postgres tier -- reuses loadNetworkParameters'
     // own KV cache/TTL, matching REST's /network/parameters handler exactly.
     // Each field stays independently null on its own RPC failure
@@ -10139,7 +10339,7 @@ const rootValue = {
     // needed for those.
     return loadNetworkParameters(context.env);
   },
-  async network_randomness(_args, context) {
+  async network_randomness(_args: unknown, context: GqlContext) {
     // Live chain RPC, not the Postgres tier -- reuses loadRandomnessStatus'
     // own KV cache/TTL, matching REST's /network/randomness handler exactly.
     // Each round field stays independently null on RPC failure (schema-stable),
@@ -10150,16 +10350,16 @@ const rootValue = {
   // -- a thin delegate so MCP tool names and GraphQL fields line up. Identical
   // loader, KV cache/TTL, and independently-null RPC-failure behavior; nothing
   // re-implemented.
-  async randomness_status(_args, context) {
+  async randomness_status(_args: unknown, context: GqlContext) {
     return rootValue.network_randomness(_args, context);
   },
-  async evm_address({ h160 }, context) {
+  async evm_address({ h160 }: Row, context: GqlContext) {
     return resolveEvmAddressMapping(h160, context);
   },
   // Same resolver as evm_address, under the get_evm_address_mapping tool name so
   // MCP and GraphQL agree; delegating rather than duplicating keeps the two
   // fields from ever drifting apart.
-  async evm_address_mapping({ h160 }, context) {
+  async evm_address_mapping({ h160 }: Row, context: GqlContext) {
     return resolveEvmAddressMapping(h160, context);
   },
 };
@@ -10175,7 +10375,12 @@ const SDL_CONTENT_TYPE = "application/graphql; charset=utf-8";
 // REST route -- this file had no such header at all before. Required (every
 // call site below already has one), not optional -- no path should ever
 // produce an error response with no category.
-const graphqlError = (message, status, code, extraHeaders = {}) =>
+const graphqlError = (
+  message: string,
+  status: number,
+  code: string,
+  extraHeaders: Row = {},
+) =>
   new Response(JSON.stringify({ errors: [{ message }] }), {
     status,
     headers: graphqlHeaders({
@@ -10193,7 +10398,7 @@ const graphqlHeaders = (extra = {}) => ({
 
 // --- Handler ---
 
-async function readLimitedJson(request) {
+async function readLimitedJson(request: Request) {
   const declaredLength = request.headers.get("content-length");
   if (declaredLength !== null) {
     const length = Number(declaredLength);
@@ -10266,8 +10471,8 @@ async function readLimitedJson(request) {
   }
 }
 
-function utf8ByteLength(value) {
-  return new TextEncoder().encode(value).byteLength;
+function utf8ByteLength(value: unknown) {
+  return new TextEncoder().encode(value as string).byteLength;
 }
 
 // GET publishes the schema document so the shape is discoverable without a
@@ -10284,7 +10489,7 @@ function sdlResponse() {
   });
 }
 
-export async function handleGraphQLRequest(request, env) {
+export async function handleGraphQLRequest(request: Request, env: Env) {
   if (request.method === "GET") {
     return sdlResponse();
   }
@@ -10335,7 +10540,7 @@ export async function handleGraphQLRequest(request, env) {
     document = parse(query);
   } catch (err) {
     return new Response(
-      JSON.stringify({ errors: [{ message: err.message }] }),
+      JSON.stringify({ errors: [{ message: (err as Error).message }] }),
       {
         status: 400,
         headers: graphqlHeaders({

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -52,7 +52,7 @@ import {
   handleRpcProxyRequest,
   graphqlRateLimited,
 } from "../workers/request-handlers/rpc-proxy.ts";
-import { handleGraphQLRequest } from "./graphql.mjs";
+import { handleGraphQLRequest } from "./graphql.ts";
 import {
   isValidSubscriptionId,
   subscriptionStorageKey,
@@ -687,6 +687,39 @@ import {
 } from "./validator-nominators.ts";
 import { buildValidatorHistory } from "./validator-history.ts";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+// Bridges McpCtx (readArtifact optional -- direct-call tests omit it) to the
+// per-domain loader ctx interfaces that declare readArtifact required; every
+// wrapped call site passes its own readArtifact via the loader's deps override
+// or runs where buildMcpContext injected the real reader.
+const asMcpLoaderCtx = (ctx: McpCtx) =>
+  ctx as McpCtx & {
+    readArtifact: (env: Env, path: string) => Promise<never>;
+  };
+
+// The per-request context buildMcpContext assembles for every tool handler:
+// env + domain + optional session/telemetry plumbing, plus the artifact/KV
+// readers the fetch entry injects (kept loose since direct-call tests build
+// partial contexts).
+interface McpCtx {
+  env: Env;
+  domain?: string;
+  sessionId?: string | null;
+  clientIp?: string | null;
+  readArtifact?: AnyFn;
+  readHealthKv?: AnyFn;
+  executionCtx?: { waitUntil?: (p: Promise<unknown>) => void };
+  recordUsageEvent?: AnyFn;
+  chainSignersCache?: Map<string, unknown>;
+  recordMcpToolCallEvent?: AnyFn;
+  recordMcpInitializeEvent?: AnyFn;
+  recordExceptionEvent?: AnyFn;
+}
+
 // Protocol versions we understand, newest first. We echo the client's requested
 // version when it is one of these, otherwise we answer with our latest. We meet
 // the 2025-11-25 requirements for a tools-only, stateless, no-auth Streamable
@@ -723,7 +756,7 @@ const STAKE_PREVIEW_IMPACT_MAX_PCT = 5;
 // `ok` flag) purely from a computed stake quote's price impact — the one signal
 // the preview already carries that reflects how much this size moves the pool.
 // Additive over get_subnet_stake_quote's numbers; adds no execution capability.
-function computeStakePreviewAdvisory(quote) {
+function computeStakePreviewAdvisory(quote: Row) {
   const impact = quote.price_impact_pct;
   const warnings = [];
   if (impact >= STAKE_PREVIEW_IMPACT_MAX_PCT) {
@@ -1060,15 +1093,18 @@ const RPC_INTERNAL_ERROR = -32603;
 
 // A tool-level failure: surfaced to the client as a successful tools/call result
 // with isError:true (per MCP), not as a transport JSON-RPC error.
-function toolError(code, message) {
-  const error = new Error(message);
+function toolError(code: string, message: string) {
+  const error = new Error(message) as Error & {
+    toolError: boolean;
+    code: string;
+  };
   error.toolError = true;
   error.code = code;
   return error;
 }
 
-async function loadArtifactData(ctx, artifactPath) {
-  const result = await ctx.readArtifact(ctx.env, artifactPath);
+async function loadArtifactData(ctx: McpCtx, artifactPath: string) {
+  const result = await ctx.readArtifact!(ctx.env, artifactPath);
   if (!result || !result.ok) {
     const code = result?.code || "artifact_unavailable";
     if (code === "artifact_not_found") {
@@ -1087,14 +1123,17 @@ async function loadArtifactData(ctx, artifactPath) {
   return result.data;
 }
 
-async function loadOptionalArtifact(ctx, artifactPath) {
-  const result = await ctx.readArtifact(ctx.env, artifactPath);
+async function loadOptionalArtifact(ctx: McpCtx, artifactPath: string) {
+  const result = await ctx.readArtifact!(ctx.env, artifactPath);
   return result?.ok ? result.data : null;
 }
 
 // Resolve a catalogued surface by current id, stable surface_key, or deprecated
 // surface_id alias — same resolution verify_integration uses (#358, #1005).
-async function findCataloguedSurface(ctx, surfaceId) {
+async function findCataloguedSurface(
+  ctx: McpCtx,
+  surfaceId: string,
+): Promise<Row | null> {
   const catalog = await loadOptionalArtifact(
     ctx,
     "/metagraph/operational-surfaces.json",
@@ -1105,10 +1144,10 @@ async function findCataloguedSurface(ctx, surfaceId) {
     const aliases = await loadOptionalArtifact(ctx, SURFACE_ALIASES_PATH);
     surface = findSurface(surfaces, surfaceId, aliases);
   }
-  return surface;
+  return surface as Row | null;
 }
 
-async function resolveArtifactSurfaceId(ctx, surfaceId) {
+async function resolveArtifactSurfaceId(ctx: McpCtx, surfaceId: string) {
   const surface = await findCataloguedSurface(ctx, surfaceId);
   return surface?.surface_id ?? surfaceId;
 }
@@ -1117,13 +1156,13 @@ async function resolveArtifactSurfaceId(ctx, surfaceId) {
 // surface_status), so MCP tools serve live health like the REST routes do —
 // never a build-time value. Returns null when no live source is available
 // (caller renders `unknown`). Mirrors workers/api.mjs liveHealthOverlay.
-function mcpLiveHealth(ctx) {
+function mcpLiveHealth(ctx: McpCtx) {
   return resolveLiveHealth({ readHealthKv: ctx.readHealthKv, env: ctx.env });
 }
 
 // Live contract version (env override → default), matching the REST resolver so
 // the economics KV freshness/contract gate behaves the same over MCP.
-function mcpContractVersion(ctx) {
+function mcpContractVersion(ctx: McpCtx) {
   return ctx.env?.METAGRAPH_CONTRACT_VERSION || CONTRACT_VERSION;
 }
 
@@ -1134,7 +1173,7 @@ function mcpContractVersion(ctx) {
 // workers/data-api.mjs's extrinsics routes parse. The host in the URL is
 // never dispatched to (DATA_API.fetch resolves the binding directly, the
 // same convention src/data-api-mcp.ts's dataApiFetchJson already uses).
-function mcpExtrinsicsListRequest(args) {
+function mcpExtrinsicsListRequest(args: Row) {
   const params = new URLSearchParams();
   const block = optionalNonNegativeInt(args, "block");
   if (block != null) params.set("block", String(block));
@@ -1171,7 +1210,7 @@ function mcpExtrinsicsListRequest(args) {
 // derives call_module from the pathname itself for these two routes, not a
 // query param -- see its PATH_TO_CALL_MODULE-style mapping), so passing the
 // correct fixed pathname is what selects the filter, nothing else needed.
-function mcpFixedCallModuleFeedRequest(pathname, args) {
+function mcpFixedCallModuleFeedRequest(pathname: string, args: Row) {
   const params = new URLSearchParams();
   const block = optionalNonNegativeInt(args, "block");
   if (block != null) params.set("block", String(block));
@@ -1195,7 +1234,7 @@ function mcpFixedCallModuleFeedRequest(pathname, args) {
   return new Request(`https://d${pathname}${qs ? `?${qs}` : ""}`);
 }
 
-function mcpExtrinsicDetailRequest(ref) {
+function mcpExtrinsicDetailRequest(ref: string) {
   return new Request(`https://d/api/v1/extrinsics/${encodeURIComponent(ref)}`);
 }
 
@@ -1206,7 +1245,10 @@ function mcpExtrinsicDetailRequest(ref) {
 // same METAGRAPH_SUBNET_IDENTITY_SOURCE flag, so get_subnet_identity_history
 // and GET /api/v1/subnets/{netuid}/identity-history never diverge on which
 // tier answered.
-function mcpSubnetIdentityHistoryRequest(netuid, { limit, offset, cursor }) {
+function mcpSubnetIdentityHistoryRequest(
+  netuid: number,
+  { limit, offset, cursor }: Row,
+) {
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
   if (offset != null) params.set("offset", String(offset));
@@ -1222,7 +1264,7 @@ function mcpSubnetIdentityHistoryRequest(netuid, { limit, offset, cursor }) {
 // mirrors REST's handleChainIdentityHistory (also gated on
 // METAGRAPH_SUBNET_IDENTITY_SOURCE, the one flag covering both the per-subnet
 // and network-wide subnet_identity_history reads).
-function mcpChainIdentityHistoryRequest({ limit }) {
+function mcpChainIdentityHistoryRequest({ limit }: Row) {
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
   const qs = params.toString();
@@ -1234,7 +1276,7 @@ function mcpChainIdentityHistoryRequest({ limit }) {
 // Synthetic GET /api/v1/accounts/{ss58}/identity request, forwarded UNCHANGED
 // to DATA_API via tryPostgresTier -- mirrors REST's handleAccountIdentity,
 // same METAGRAPH_ACCOUNT_IDENTITY_SOURCE flag, no query params.
-function mcpAccountIdentityRequest(ss58) {
+function mcpAccountIdentityRequest(ss58: string) {
   return new Request(
     `https://d/api/v1/accounts/${encodeURIComponent(ss58)}/identity`,
   );
@@ -1246,7 +1288,7 @@ function mcpAccountIdentityRequest(ss58) {
 // METAGRAPH_NEURONS_SOURCE flag (entities.mjs's handleSubnetConcentration
 // et al. all call tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")),
 // so one shared pathname+params builder covers all of them.
-function mcpNeuronsTierRequest(pathname, params = {}) {
+function mcpNeuronsTierRequest(pathname: string, params: Row = {}) {
   const qs = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (value != null) qs.set(key, String(value));
@@ -1260,7 +1302,7 @@ function mcpNeuronsTierRequest(pathname, params = {}) {
 // subscriptions/{id} route uses), best-effort: a list/get hiccup or a store
 // without `list` (local dev KV mock) degrades to "ok" rather than failing
 // the whole lookup.
-async function readMcpWebhookDeliveryStatus(env, id) {
+async function readMcpWebhookDeliveryStatus(env: Env, id: unknown) {
   try {
     if (typeof env.METAGRAPH_CONTROL.list !== "function") {
       return summarizeDeliveryRecords([]);
@@ -1272,11 +1314,11 @@ async function readMcpWebhookDeliveryStatus(env, id) {
     const records = await Promise.all(
       keys
         .slice(0, WEBHOOK_REDELIVERY_LIST_LIMIT)
-        .map((entry) =>
+        .map((entry: Row) =>
           env.METAGRAPH_CONTROL.get(entry.name, { type: "json" }),
         ),
     );
-    return summarizeDeliveryRecords(records);
+    return summarizeDeliveryRecords(records as Row[]);
   } catch {
     return summarizeDeliveryRecords([]);
   }
@@ -1286,7 +1328,10 @@ async function readMcpWebhookDeliveryStatus(env, id) {
 // limit/offset/cursor contract as mcpSubnetIdentityHistoryRequest above --
 // mirrors REST's handleAccountIdentityHistory, same
 // METAGRAPH_ACCOUNT_IDENTITY_SOURCE flag as get_account_identity.
-function mcpAccountIdentityHistoryRequest(ss58, { limit, offset, cursor }) {
+function mcpAccountIdentityHistoryRequest(
+  ss58: string,
+  { limit, offset, cursor }: Row,
+) {
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
   if (offset != null) params.set("offset", String(offset));
@@ -1299,7 +1344,7 @@ function mcpAccountIdentityHistoryRequest(ss58, { limit, offset, cursor }) {
 
 // One subnet's economics: live KV tier (KV-primary), else the committed R2
 // snapshot — the precedence /api/v1/economics uses. A missing row → economics:null.
-async function loadSubnetEconomics(ctx, netuid) {
+async function loadSubnetEconomics(ctx: McpCtx, netuid: number) {
   const live = await resolveLiveEconomics({
     readHealthKv: ctx.readHealthKv,
     env: ctx.env,
@@ -1312,7 +1357,8 @@ async function loadSubnetEconomics(ctx, netuid) {
     source: live?.source || "r2-fallback",
     captured_at: blob?.captured_at ?? null,
     summary: blob?.summary ?? null,
-    economics: blob?.subnets?.find((row) => row?.netuid === netuid) ?? null,
+    economics:
+      blob?.subnets?.find((row: Row) => row?.netuid === netuid) ?? null,
   };
 }
 
@@ -1332,7 +1378,7 @@ async function loadSubnetEconomics(ctx, netuid) {
 // all-events tier has no per-table tryPostgresTier flag (unlike
 // account_events-backed routes such as get_subnet_ohlc), so this reaches
 // DATA_API unconditionally, same as list_chain_events above.
-async function loadSubnetOwnershipHistory(ctx, netuid) {
+async function loadSubnetOwnershipHistory(ctx: McpCtx, netuid: number) {
   await requireDataTierRateLimit(ctx);
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
@@ -1360,7 +1406,7 @@ async function loadSubnetOwnershipHistory(ctx, netuid) {
         "Try again shortly.",
     );
   }
-  const data = await response.json();
+  const data = (await response.json()) as Row | null;
   return {
     schema_version: data?.schema_version ?? 1,
     netuid,
@@ -1375,7 +1421,7 @@ async function loadSubnetOwnershipHistory(ctx, netuid) {
 // already does both the subnet_locks read AND the live UnlockRate/
 // MaturityRate RPC lookup and returns the fully-rolled-forward result, so
 // this just proxies -- no duplicate logic here.
-async function loadSubnetConviction(ctx, netuid) {
+async function loadSubnetConviction(ctx: McpCtx, netuid: number) {
   await requireDataTierRateLimit(ctx);
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
@@ -1403,7 +1449,7 @@ async function loadSubnetConviction(ctx, netuid) {
         "Try again shortly.",
     );
   }
-  const data = await response.json();
+  const data = (await response.json()) as Row | null;
   return {
     schema_version: data?.schema_version ?? 1,
     netuid,
@@ -1419,7 +1465,7 @@ async function loadSubnetConviction(ctx, netuid) {
 // Mirrors loadSubnetOwnershipHistory above (#6719): same DATA_API-direct
 // proxy shape, a different Postgres-tier route (account_events, not
 // chain_events).
-async function loadSubnetLeaseHistory(ctx, netuid) {
+async function loadSubnetLeaseHistory(ctx: McpCtx, netuid: number) {
   await requireDataTierRateLimit(ctx);
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
@@ -1447,7 +1493,7 @@ async function loadSubnetLeaseHistory(ctx, netuid) {
         "Try again shortly.",
     );
   }
-  const data = await response.json();
+  const data = (await response.json()) as Row | null;
   return {
     schema_version: data?.schema_version ?? 1,
     netuid,
@@ -1456,7 +1502,7 @@ async function loadSubnetLeaseHistory(ctx, netuid) {
   };
 }
 
-async function requireDataTierRateLimit(ctx) {
+async function requireDataTierRateLimit(ctx: McpCtx) {
   if (!ctx.env?.DATA_RATE_LIMITER?.limit) return;
   const { success } = await ctx.env.DATA_RATE_LIMITER.limit({
     key: `data:${ctx.clientIp}`,
@@ -1469,11 +1515,11 @@ async function requireDataTierRateLimit(ctx) {
   }
 }
 
-function chainSignersCacheKey({ label, limit, callModule, sort }) {
+function chainSignersCacheKey({ label, limit, callModule, sort }: Row) {
   return JSON.stringify([label, limit, callModule || "", sort]);
 }
 
-async function loadMcpChainSigners(ctx, options) {
+async function loadMcpChainSigners(ctx: McpCtx, options: Row) {
   ctx.chainSignersCache ||= new Map();
   const key = chainSignersCacheKey(options);
   if (!ctx.chainSignersCache.has(key)) {
@@ -1495,8 +1541,8 @@ async function loadMcpChainSigners(ctx, options) {
           }),
           rows: [],
         }))
-        .catch((error) => {
-          ctx.chainSignersCache.delete(key);
+        .catch((error: unknown) => {
+          ctx.chainSignersCache!.delete(key);
           throw error;
         }),
     );
@@ -1504,7 +1550,7 @@ async function loadMcpChainSigners(ctx, options) {
   return ctx.chainSignersCache.get(key);
 }
 
-async function mcpObservedAt(ctx) {
+async function mcpObservedAt(ctx: McpCtx) {
   if (!ctx.readHealthKv) return null;
   const meta = await ctx.readHealthKv(ctx.env, KV_HEALTH_META);
   return meta?.last_run_at || null;
@@ -1513,19 +1559,19 @@ async function mcpObservedAt(ctx) {
 // Resolve + validate a history window arg (7d|30d|90d|1y|all) the way the REST
 // /history routes do, mapping a bad value to a clean tool error. Returns the
 // parsed {label, days} (days is null for the unbounded `all` window).
-function requireHistoryWindow(args) {
-  const { label, days, error } = parseHistoryWindow(args?.window);
-  if (error) {
-    throw toolError("invalid_params", error.message);
+function requireHistoryWindow(args: Row) {
+  const parsed = parseHistoryWindow(args?.window);
+  if ("error" in parsed) {
+    throw toolError("invalid_params", parsed.error.message);
   }
-  return { label, days };
+  return { label: parsed.label, days: parsed.days };
 }
 
 // One subnet's per-day aggregate history — mirrors handleSubnetHistory. Tries
 // the Postgres tier first (METAGRAPH_NEURONS_SOURCE); the neuron_daily D1
 // table was retired (#4772), so buildSubnetHistory([]) yields the
 // schema-stable point_count:0 payload the same way a cold/absent D1 used to.
-async function loadSubnetHistory(ctx, netuid, { label }) {
+async function loadSubnetHistory(ctx: McpCtx, netuid: number, { label }: Row) {
   return (
     (await tryPostgresTier(
       ctx.env,
@@ -1544,9 +1590,9 @@ async function loadSubnetHistory(ctx, netuid, { label }) {
 // tool and GET /api/v1/subnets/{netuid}/identity-history never diverge on
 // which tier answered.
 async function loadSubnetIdentityHistoryTool(
-  ctx,
-  netuid,
-  { limit, offset, cursor },
+  ctx: McpCtx,
+  netuid: number,
+  { limit, offset, cursor }: Row,
 ) {
   return (
     (await tryPostgresTier(
@@ -1562,7 +1608,12 @@ async function loadSubnetIdentityHistoryTool(
 // Postgres tier first (METAGRAPH_NEURONS_SOURCE); the neuron_daily D1 table
 // was retired (#4772), so buildNeuronHistory([]) yields the schema-stable
 // point_count:0 payload the same way a cold/absent D1 used to.
-async function loadNeuronHistory(ctx, netuid, uid, { label }) {
+async function loadNeuronHistory(
+  ctx: McpCtx,
+  netuid: number,
+  uid: number,
+  { label }: Row,
+) {
   return (
     (await tryPostgresTier(
       ctx.env,
@@ -1582,7 +1633,11 @@ async function loadNeuronHistory(ctx, netuid, uid, { label }) {
 // artifact is optional (a provider may have no endpoints artifact), so a missing
 // one degrades to endpoints:null rather than failing the whole call. The detail
 // artifact missing is a real not_found (loadArtifactData maps it).
-async function loadProviderDetail(ctx, slug, includeEndpoints) {
+async function loadProviderDetail(
+  ctx: McpCtx,
+  slug: string,
+  includeEndpoints: boolean,
+) {
   const detail = await loadArtifactData(
     ctx,
     `/metagraph/providers/${slug}.json`,
@@ -1599,14 +1654,14 @@ async function loadProviderDetail(ctx, slug, includeEndpoints) {
 // freshness artifact overlaid with the live 15-minute prober's last_run_at
 // (mergeFreshness) so the surface-health source reads `current` like the REST
 // route. With no live meta the committed artifact passes through unchanged.
-async function loadFreshness(ctx) {
+async function loadFreshness(ctx: McpCtx) {
   const base = await loadArtifactData(ctx, "/metagraph/freshness.json");
   if (!ctx.readHealthKv) return base;
   const meta = await ctx.readHealthKv(ctx.env, KV_HEALTH_META);
   return mergeFreshness(base, meta) ?? base;
 }
 
-async function loadEconomicsSubnetRows(ctx) {
+async function loadEconomicsSubnetRows(ctx: McpCtx) {
   const live = await resolveLiveEconomics({
     readHealthKv: ctx.readHealthKv,
     env: ctx.env,
@@ -1620,7 +1675,7 @@ async function loadEconomicsSubnetRows(ctx) {
 // AI-dependent tools (semantic_search, ask) need the VECTORIZE + AI bindings and
 // the kill-switch on. In a cold/CI env they degrade to a graceful isError result
 // pointing at the keyword fallback, never a transport error.
-function requireAi(ctx) {
+function requireAi(ctx: McpCtx) {
   if (!aiEnabled(ctx.env)) {
     throw toolError(
       "ai_unavailable",
@@ -1630,11 +1685,11 @@ function requireAi(ctx) {
   }
 }
 
-function mcpAiClientKey(ctx, scope) {
+function mcpAiClientKey(ctx: McpCtx, scope: string) {
   return `${scope}:${ctx.clientIp || "anon"}`;
 }
 
-async function requireAiRateLimit(ctx, scope) {
+async function requireAiRateLimit(ctx: McpCtx, scope: string) {
   if (await withinRateLimit(ctx.env, mcpAiClientKey(ctx, scope))) return;
   throw toolError(
     "rate_limited",
@@ -1644,12 +1699,13 @@ async function requireAiRateLimit(ctx, scope) {
 
 // Run an ai-search call, mapping its input-validation errors to tool errors so
 // they surface as a clean isError result instead of a thrown transport error.
-async function runAi(fn) {
+async function runAi(fn: AnyFn) {
   try {
     return await fn();
-  } catch (error) {
+  } catch (rawError) {
+    const error = rawError as Row;
     if (error?.aiInput) throw toolError("invalid_params", error.message);
-    throw error;
+    throw rawError;
   }
 }
 
@@ -1657,7 +1713,7 @@ async function runAi(fn) {
 // `subnet` string (numeric, curated slug, or chain native_slug). Slug lookup
 // joins the committed index curated-slug-first, then native_slug — the same
 // precedence the REST resolver uses (see lookupSubnetNetuid, #331).
-async function resolveNetuid(ctx, args) {
+async function resolveNetuid(ctx: McpCtx, args: Row) {
   if (Number.isInteger(args?.netuid) && args.netuid >= 0) return args.netuid;
   const ref = typeof args?.subnet === "string" ? args.subnet.trim() : "";
   if (ref === "") {
@@ -1672,10 +1728,10 @@ async function resolveNetuid(ctx, args) {
   const key = ref.toLowerCase();
   const match =
     subnets.find(
-      (s) => typeof s.slug === "string" && s.slug.toLowerCase() === key,
+      (s: Row) => typeof s.slug === "string" && s.slug.toLowerCase() === key,
     ) ||
     subnets.find(
-      (s) =>
+      (s: Row) =>
         typeof s.native_slug === "string" &&
         s.native_slug.toLowerCase() === key,
     );
@@ -1691,13 +1747,18 @@ async function resolveNetuid(ctx, args) {
 // Rank subnets relevant to a free-form task. Uses semantic (intent) ranking when
 // the AI layer is available, else keyword overlap over the enriched search index
 // (categories + service_kinds). Returns the discovery mode + ordered candidates.
-async function rankSubnetsForTask(ctx, task, poolSize, callableByNetuid) {
+async function rankSubnetsForTask(
+  ctx: McpCtx,
+  task: string,
+  poolSize: number,
+  callableByNetuid: Map<number, unknown>,
+) {
   // Only subnets exposing callable services can perform a task, so apply the
   // callability filter BEFORE truncating to the pool. Otherwise a callable
   // subnet ranked behind `poolSize` non-callable matches is cut from the pool
   // and the tool falsely reports "no callable subnet matched". (Mirrors the
   // filter-before-slice order in find_subnets_by_capability.)
-  const isCallable = (netuid) => callableByNetuid.has(netuid);
+  const isCallable = (netuid: number) => callableByNetuid.has(netuid);
   if (aiEnabled(ctx.env)) {
     try {
       const out = await semanticSearch(ctx.env, task, {
@@ -1705,12 +1766,12 @@ async function rankSubnetsForTask(ctx, task, poolSize, callableByNetuid) {
       });
       const ranked = (out.results || [])
         .filter(
-          (r) =>
+          (r: Row) =>
             r.type === "subnet" &&
             Number.isInteger(r.netuid) &&
             isCallable(r.netuid),
         )
-        .map((r) => ({ netuid: r.netuid, relevance: r.score }));
+        .map((r: Row) => ({ netuid: r.netuid, relevance: r.score }));
       // Only commit to semantic mode when it yields callable hits; a pool of
       // purely non-callable matches falls through to keyword discovery.
       if (ranked.length > 0) return { mode: "semantic", ranked };
@@ -1722,18 +1783,18 @@ async function rankSubnetsForTask(ctx, task, poolSize, callableByNetuid) {
   const terms = queryTerms(task);
   const docs = Array.isArray(index.documents) ? index.documents : [];
   const ranked = docs
-    .filter((doc) => doc.type === "subnet")
-    .map((doc) => ({
+    .filter((doc: Row) => doc.type === "subnet")
+    .map((doc: Row) => ({
       netuid: doc.netuid,
       relevance: scoreDocument(doc, terms),
     }))
-    .filter((entry) => entry.relevance > 0 && isCallable(entry.netuid))
-    .sort((a, b) => b.relevance - a.relevance || a.netuid - b.netuid)
+    .filter((entry: Row) => entry.relevance > 0 && isCallable(entry.netuid))
+    .sort((a: Row, b: Row) => b.relevance - a.relevance || a.netuid - b.netuid)
     .slice(0, poolSize);
   return { mode: "keyword", ranked };
 }
 
-function validateToolArguments(tool, args) {
+function validateToolArguments(tool: Row, args: Row) {
   if (args === undefined || args === null) return {};
   if (
     typeof args !== "object" ||
@@ -1751,7 +1812,7 @@ function validateToolArguments(tool, args) {
   return args;
 }
 
-function requireNonNegativeInt(args, key) {
+function requireNonNegativeInt(args: Row, key: string) {
   const value = args?.[key];
   if (!Number.isInteger(value) || value < 0) {
     throw toolError(
@@ -1762,7 +1823,7 @@ function requireNonNegativeInt(args, key) {
   return value;
 }
 
-function optionalNonNegativeInt(args, key) {
+function optionalNonNegativeInt(args: Row, key: string) {
   const value = args?.[key];
   if (value === undefined || value === null) return null;
   if (!Number.isInteger(value) || value < 0) {
@@ -1776,7 +1837,7 @@ function optionalNonNegativeInt(args, key) {
 
 // Like optionalNonNegativeInt but for a decimal quantity (e.g. a TAO amount),
 // where a fractional value is valid.
-function optionalNonNegativeNumber(args, key) {
+function optionalNonNegativeNumber(args: Row, key: string) {
   const value = args?.[key];
   if (value === undefined || value === null) return null;
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
@@ -1790,7 +1851,7 @@ function optionalNonNegativeNumber(args, key) {
 
 // Like optionalNonNegativeInt, but 0 is invalid (a "cap the list to zero rows"
 // argument reads as a misuse, not a legitimate empty-result request).
-function optionalPositiveInt(args, key) {
+function optionalPositiveInt(args: Row, key: string) {
   const value = args?.[key];
   if (value === undefined || value === null) return null;
   if (!Number.isInteger(value) || value < 1) {
@@ -1802,11 +1863,11 @@ function optionalPositiveInt(args, key) {
   return value;
 }
 
-function requireNetuid(args) {
+function requireNetuid(args: Row) {
   return requireNonNegativeInt(args, "netuid");
 }
 
-function optionalBoolean(args, key) {
+function optionalBoolean(args: Row, key: string) {
   const value = args?.[key];
   if (value === undefined || value === null) return false;
   if (typeof value !== "boolean") {
@@ -1819,7 +1880,7 @@ function optionalBoolean(args, key) {
 // filter arg must distinguish "not provided, don't filter" (null) from an
 // explicit true/false, or an absent filter would wrongly narrow to only the
 // false-valued rows.
-function optionalNullableBoolean(args, key) {
+function optionalNullableBoolean(args: Row, key: string) {
   const value = args?.[key];
   if (value === undefined || value === null) return null;
   if (typeof value !== "boolean") {
@@ -1828,7 +1889,7 @@ function optionalNullableBoolean(args, key) {
   return value;
 }
 
-function optionalSuccessFilter(args) {
+function optionalSuccessFilter(args: Row) {
   const value = args?.success;
   if (value === undefined || value === null) return undefined;
   if (value === true) return true;
@@ -1839,7 +1900,7 @@ function optionalSuccessFilter(args) {
   );
 }
 
-function requireString(args, key) {
+function requireString(args: Row, key: string) {
   const value = args?.[key];
   if (typeof value !== "string" || value.trim() === "") {
     throw toolError(
@@ -1852,7 +1913,7 @@ function requireString(args, key) {
 
 // A trimmed optional string, or null when absent/blank — for free-form filters
 // like the account-events `kind`, where an enum would wrongly reject valid values.
-function optionalString(args, key) {
+function optionalString(args: Row, key: string) {
   const value = args?.[key];
   if (value === undefined || value === null || value === "") return null;
   if (typeof value !== "string" || value.trim() === "") {
@@ -1865,7 +1926,7 @@ function optionalString(args, key) {
 }
 
 // Optional YYYY-MM-DD day bound — mirrors parseDateRange() on REST history routes.
-function optionalDayArg(args, key) {
+function optionalDayArg(args: Row, key: string) {
   const value = optionalString(args, key);
   if (value === null) return null;
   if (!DAY_PATTERN.test(value)) {
@@ -1883,9 +1944,9 @@ function optionalDayArg(args, key) {
 
 // Reject unknown event-kind filters before D1, parity with the REST event feeds
 // (handleSubnetEvents / handleAccountEvents) so a typo cannot force a scan.
-function requireKnownEventKind(kind) {
+function requireKnownEventKind(kind: unknown) {
   if (kind == null) return;
-  if (!INGESTED_EVENT_KINDS.includes(kind)) {
+  if (!INGESTED_EVENT_KINDS.includes(kind as string)) {
     throw toolError(
       "invalid_params",
       `"${kind}" is not a supported event kind. Supported: ${INGESTED_EVENT_KINDS.join(", ")}.`,
@@ -1895,7 +1956,7 @@ function requireKnownEventKind(kind) {
 
 // Require a bare SS58 address (hotkey or coldkey) — the same shape the REST
 // account routes accept, from the shared SS58_ADDRESS_PATTERN.
-function requireSs58(args) {
+function requireSs58(args: Row) {
   const value = requireString(args, "ss58");
   if (!SS58_ADDRESS_PATTERN.test(value)) {
     throw toolError(
@@ -1913,7 +1974,7 @@ const SS58_PATTERN_SOURCE = SS58_ADDRESS_PATTERN.source;
 // A validator identity is the same SS58 shape as an account, just a different
 // argument name (a hotkey the caller already knows, not one they're looking
 // up) -- same runtime pattern check as requireSs58, distinct error text.
-function requireHotkey(args) {
+function requireHotkey(args: Row) {
   const value = requireString(args, "hotkey");
   if (!SS58_ADDRESS_PATTERN.test(value)) {
     throw toolError(
@@ -1935,7 +1996,7 @@ function requireHotkey(args) {
 // src/data-api-mcp.ts (exported optionalBlocksWindow, #7432) beside its
 // loadChainActivity loader — shared with GraphQL's chain_events_stats field.
 
-function clampLimit(value, fallback, max) {
+function clampLimit(value: unknown, fallback: number, max: number) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to
   // 1. tools/call does not enforce the inputSchema `minimum`, so an explicit
   // limit:0 reaches here; `Math.max(1, …)` would return a single result, which
@@ -1962,7 +2023,7 @@ function semanticTypeSchema() {
 // bespoke `offset` handling (floor + clamp to 0, no throw): tools/call does not
 // enforce the inputSchema `minimum`, so a bad cursor degrades to the first page
 // instead of erroring.
-function resolveCursor(args) {
+function resolveCursor(args: Row) {
   return Number.isFinite(args?.cursor)
     ? Math.max(0, Math.floor(args.cursor))
     : 0;
@@ -1979,7 +2040,10 @@ function resolveCursor(args) {
 // present cursor as paging on its own. The caller pre-resolves both bounds (limit
 // clamped, cursor a non-negative integer), so validateListQuery inside
 // applyQueryFilters cannot fail here and always returns a pagination envelope.
-function cursorWindow(rows, { collection, dataKey, limit, cursor }) {
+function cursorWindow(
+  rows: Row[],
+  { collection, dataKey, limit, cursor }: Row,
+) {
   const url = new URL("https://mcp.internal/list");
   if (limit != null) {
     url.searchParams.set("limit", String(limit));
@@ -1992,7 +2056,7 @@ function cursorWindow(rows, { collection, dataKey, limit, cursor }) {
     url,
     collection,
     [],
-  );
+  ) as { data: Row; meta: Row };
   const {
     total,
     returned,
@@ -2013,7 +2077,12 @@ function cursorWindow(rows, { collection, dataKey, limit, cursor }) {
 // pagination envelope, and the mapped page. Both search tools page 1-50/10 over
 // the ranked match set (windowed via applyQueryFilters, so `cursor`/`next_cursor`
 // match the REST list contract).
-function searchResponse(label, matched, args, mapResult) {
+function searchResponse(
+  label: Row,
+  matched: Row[],
+  args: Row,
+  mapResult: AnyFn,
+) {
   const { page, total, returned, limit, cursor, next_cursor } = cursorWindow(
     matched,
     {
@@ -2052,7 +2121,7 @@ const LIST_SUBNETS_ORDERS = ["asc", "desc"];
  * @param {string} field - one of LIST_SUBNETS_SORT_FIELDS
  * @returns {number|string|null}
  */
-function subnetSortValue(subnet, field) {
+function subnetSortValue(subnet: Row, field: string) {
   const value = subnet[field];
   return typeof value === "number" || typeof value === "string" ? value : null;
 }
@@ -2067,7 +2136,7 @@ function subnetSortValue(subnet, field) {
  * @param {"asc"|"desc"} order - sort direction
  * @returns {object[]}
  */
-function sortSubnets(rows, field, order) {
+function sortSubnets(rows: Row[], field: string, order: unknown) {
   const dir = order === "desc" ? -1 : 1;
   return [...rows].sort((a, b) => {
     const av = subnetSortValue(a, field);
@@ -2080,7 +2149,9 @@ function sortSubnets(rows, field, order) {
     // mirrors compareValues in workers/list-query.mjs (bare localeCompare), the
     // shared sort convention for the REST list endpoints.
     const cmp =
-      typeof av === "number" ? av - bv : String(av).localeCompare(String(bv));
+      typeof av === "number"
+        ? av - (bv as number)
+        : String(av).localeCompare(String(bv));
     return cmp !== 0 ? cmp * dir : a.netuid - b.netuid;
   });
 }
@@ -2116,14 +2187,14 @@ const LIST_SUBNETS_RANGE_BOUNDS = [
 // non-numeric cannot satisfy a bound, so it is excluded once any bound on that
 // field is set — identical to rangeFilterRows in workers/list-query.mjs. Only
 // finite numeric args count (tools/call does not enforce inputSchema types).
-function rangeFilterSubnets(rows, args) {
+function rangeFilterSubnets(rows: Row[], args: Row) {
   const bounds = LIST_SUBNETS_RANGE_BOUNDS.filter(({ arg }) =>
     Number.isFinite(args?.[arg]),
   ).map(({ field, op, arg }) => ({ field, op, limit: args[arg] }));
   if (bounds.length === 0) {
     return rows;
   }
-  return rows.filter((row) =>
+  return rows.filter((row: Row) =>
     bounds.every(({ field, op, limit }) => {
       const value = row[field];
       if (typeof value !== "number") {
@@ -2148,7 +2219,7 @@ const LIST_SUBNETS_CATEGORICAL = [
 // `domain` tests the union of curated + derived categories; the rest are scalar.
 // Shared by inclusion and exclusion so `status=` and `not_status=` stay exact
 // complements.
-function subnetCategoricalMatch(subnet, field, value) {
+function subnetCategoricalMatch(subnet: Row, field: string, value: unknown) {
   if (field === "domain") {
     const tags = [
       ...(Array.isArray(subnet.categories) ? subnet.categories : []),
@@ -2156,7 +2227,7 @@ function subnetCategoricalMatch(subnet, field, value) {
         ? subnet.derived_categories
         : []),
     ].map((tag) => String(tag).toLowerCase());
-    return tags.includes(value);
+    return tags.includes(value as string);
   }
   return String(subnet[field] ?? "").toLowerCase() === value;
 }
@@ -2164,9 +2235,9 @@ function subnetCategoricalMatch(subnet, field, value) {
 // Apply the categorical filters: keep rows matching every `field=v` and matching
 // none of the `not_field=v` exclusions (case-insensitive). A row missing the
 // field never matches, so it survives an exclusion but fails an inclusion.
-function categoricalFilterSubnets(rows, args) {
-  const includes = [];
-  const excludes = [];
+function categoricalFilterSubnets(rows: Row[], args: Row) {
+  const includes: { field: string; value: string }[] = [];
+  const excludes: { field: string; value: string }[] = [];
   for (const arg of LIST_SUBNETS_CATEGORICAL) {
     const inc = typeof args?.[arg] === "string" ? args[arg].trim() : "";
     if (inc) includes.push({ field: arg, value: inc.toLowerCase() });
@@ -2178,7 +2249,7 @@ function categoricalFilterSubnets(rows, args) {
     return rows;
   }
   return rows.filter(
-    (subnet) =>
+    (subnet: Row) =>
       includes.every(({ field, value }) =>
         subnetCategoricalMatch(subnet, field, value),
       ) &&
@@ -2190,7 +2261,7 @@ function categoricalFilterSubnets(rows, args) {
 
 // A search.json document → keywordScore shape: title/slug are identity; subtitle
 // and tokens (which already fold in categories/service kinds) are recall-only.
-function scoreDocument(doc, terms) {
+function scoreDocument(doc: Row, terms: string[]) {
   return keywordScore(
     {
       name: doc.title,
@@ -2211,7 +2282,7 @@ const COVERAGE_DEPTH_TIERS = [
 ];
 const COVERAGE_DEPTH_SEVERITIES = ["hard", "missing-data", "needs-review"];
 
-function optionalEnum(args, key, allowed) {
+function optionalEnum(args: Row, key: string, allowed: readonly string[]) {
   const value = args?.[key];
   if (value === undefined || value === null || value === "") return null;
   if (typeof value !== "string" || !allowed.includes(value)) {
@@ -2223,7 +2294,7 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function optionalGapCode(args) {
+function optionalGapCode(args: Row) {
   const value = args?.gap_code;
   if (value === undefined || value === null || value === "") return null;
   if (typeof value !== "string" || !/^[a-z0-9-]+$/.test(value)) {
@@ -2235,7 +2306,7 @@ function optionalGapCode(args) {
   return value;
 }
 
-function coverageDepthTarget(row, rank = null) {
+function coverageDepthTarget(row: Row, rank = null) {
   return {
     rank,
     netuid: row.netuid,
@@ -2247,7 +2318,7 @@ function coverageDepthTarget(row, rank = null) {
     agent_status: row.agent_status,
     blocker_level: row.blocker_level,
     top_gap_codes: row.top_gap_codes || [],
-    top_gaps: (row.top_gaps || []).map((gap) => ({
+    top_gaps: (row.top_gaps || []).map((gap: Row) => ({
       code: gap.code,
       severity: gap.severity,
       field: gap.field,
@@ -2272,12 +2343,12 @@ function coverageDepthTarget(row, rank = null) {
   };
 }
 
-function coverageDepthMatches(row, { tier, severity, gapCode }) {
+function coverageDepthMatches(row: Row, { tier, severity, gapCode }: Row) {
   if (tier && row.tier !== tier) return false;
   if (gapCode && !(row.top_gap_codes || []).includes(gapCode)) return false;
   if (
     severity &&
-    !(row.top_gaps || []).some((gap) => gap.severity === severity)
+    !(row.top_gaps || []).some((gap: Row) => gap.severity === severity)
   ) {
     return false;
   }
@@ -2322,16 +2393,18 @@ export const MCP_TOOLS = [
       required: ["query"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const query = requireString(args, "query");
       const index = await loadArtifactData(ctx, "/metagraph/search.json");
       const terms = queryTerms(query);
       const docs = Array.isArray(index.documents) ? index.documents : [];
       const matched = docs
-        .filter((doc) => doc.type === "subnet")
-        .map((doc) => ({ doc, score: scoreDocument(doc, terms) }))
-        .filter((entry) => entry.score > 0)
-        .sort((a, b) => b.score - a.score || a.doc.netuid - b.doc.netuid);
+        .filter((doc: Row) => doc.type === "subnet")
+        .map((doc: Row) => ({ doc, score: scoreDocument(doc, terms) }))
+        .filter((entry: Row) => entry.score > 0)
+        .sort(
+          (a: Row, b: Row) => b.score - a.score || a.doc.netuid - b.doc.netuid,
+        );
       return searchResponse({ query }, matched, args, ({ doc }) => ({
         netuid: doc.netuid,
         slug: doc.slug,
@@ -2526,7 +2599,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const index = await loadArtifactData(ctx, "/metagraph/subnets.json");
       const all = Array.isArray(index.subnets) ? index.subnets : [];
       // Categorical inclusion (status/subnet_type/domain) and exclusion
@@ -2545,7 +2618,7 @@ export const MCP_TOOLS = [
           limit: clampLimit(args?.limit, 50, 100),
           cursor: resolveCursor(args),
         });
-      const subnets = page.map((subnet) => ({
+      const subnets = page.map((subnet: Row) => ({
         netuid: subnet.netuid,
         slug: subnet.slug ?? null,
         title: subnet.name ?? null,
@@ -2609,7 +2682,7 @@ export const MCP_TOOLS = [
       required: ["capability"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const capability = requireString(args, "capability");
       const staticCatalog = await loadArtifactData(
         ctx,
@@ -2620,7 +2693,7 @@ export const MCP_TOOLS = [
       const terms = queryTerms(capability);
       const subnets = Array.isArray(catalog.subnets) ? catalog.subnets : [];
       const matched = subnets
-        .map((subnet) => ({
+        .map((subnet: Row) => ({
           subnet,
           score: keywordScore(
             {
@@ -2636,9 +2709,11 @@ export const MCP_TOOLS = [
             terms,
           ),
         }))
-        .filter((entry) => entry.score > 0 && entry.subnet.callable_count > 0)
+        .filter(
+          (entry: Row) => entry.score > 0 && entry.subnet.callable_count > 0,
+        )
         .sort(
-          (a, b) =>
+          (a: Row, b: Row) =>
             b.score - a.score ||
             (b.subnet.integration_readiness || 0) -
               (a.subnet.integration_readiness || 0) ||
@@ -2669,7 +2744,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const overview = await loadArtifactData(
         ctx,
@@ -2698,7 +2773,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const detail = await loadArtifactData(
         ctx,
@@ -2746,7 +2821,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const topValidatorsLimit =
         optionalPositiveInt(args, "top_validators_limit") ?? 10;
@@ -2793,7 +2868,7 @@ export const MCP_TOOLS = [
       // list_subnet_validators' own limit post-filter (the loader already
       // ranks by stake_tao DESC, so slicing after is a no-op re-sort) --
       // mirrored here rather than exported, since it's three lines.
-      const slicedValidators = (validators?.validators ?? []).slice(
+      const slicedValidators = ((validators?.validators ?? []) as Row[]).slice(
         0,
         topValidatorsLimit,
       );
@@ -2814,7 +2889,7 @@ export const MCP_TOOLS = [
   },
   {
     ...GET_NETWORK_HEALTH_MCP_TOOL,
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadGlobalOperationalHealth(
         { env: ctx.env, readHealthKv: ctx.readHealthKv },
         { contractVersion: () => mcpContractVersion(ctx) },
@@ -2823,12 +2898,13 @@ export const MCP_TOOLS = [
   },
   {
     ...GET_HEALTH_HISTORY_MCP_TOOL,
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       try {
         return await loadHealthHistory(ctx, args, {
-          readArtifact: loadArtifactData,
+          readArtifact: loadArtifactData as AnyFn,
         });
-      } catch (err) {
+      } catch (rawErr) {
+        const err = rawErr as Row;
         if (err?.healthHistoryMcp) {
           throw toolError(err.code, err.message);
         }
@@ -2850,7 +2926,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const [live, reliability] = await Promise.all([
         mcpLiveHealth(ctx),
@@ -2889,7 +2965,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -2918,7 +2994,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       const postgres = await tryPostgresTier(
         ctx.env,
         mcpNeuronsTierRequest("/api/v1/health/trends"),
@@ -2954,13 +3030,13 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed;
+      const { label } = parsed!;
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -3002,13 +3078,13 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed;
+      const { label } = parsed!;
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -3042,7 +3118,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadSubnetEconomics(ctx, netuid);
     },
@@ -3080,7 +3156,7 @@ export const MCP_TOOLS = [
       required: ["netuid", "amount"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const amount = args?.amount;
       const direction = optionalString(args, "direction") ?? "stake";
@@ -3183,7 +3259,7 @@ export const MCP_TOOLS = [
       ],
       additionalProperties: true,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const amount = args?.amount;
       const direction = optionalString(args, "direction") ?? "stake";
@@ -3230,13 +3306,14 @@ export const MCP_TOOLS = [
   },
   {
     ...GET_ECONOMICS_MCP_TOOL,
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       try {
-        return await loadNetworkEconomics(ctx, args, {
+        return await loadNetworkEconomics(asMcpLoaderCtx(ctx), args, {
           contractVersion: mcpContractVersion,
           readOptionalArtifact: loadOptionalArtifact,
         });
-      } catch (err) {
+      } catch (rawErr) {
+        const err = rawErr as Row;
         if (err?.networkEconomics) {
           throw toolError(err.code, err.message);
         }
@@ -3261,7 +3338,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -3291,23 +3368,24 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const parsed = parseEconomicsTrendsWindow(args?.window);
       if (args?.window !== undefined && parsed === null) {
-        const { error } = parseHistoryWindow(args.window);
-        throw toolError("invalid_params", error.message);
+        const reparsed = parseHistoryWindow(args.window);
+        const message =
+          "error" in reparsed
+            ? reparsed.error.message
+            : "window is not supported.";
+        throw toolError("invalid_params", message);
       }
-      const { label, days } = parsed;
+      const { label } = parsed!;
       const postgres = await tryPostgresTier(
         ctx.env,
         mcpNeuronsTierRequest("/api/v1/economics/trends", { window: label }),
         "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
       );
       if (postgres) return postgres;
-      const { data } = await loadEconomicsTrends({
-        windowLabel: label,
-        windowDays: days,
-      });
+      const { data } = await loadEconomicsTrends({ windowLabel: label });
       return data;
     },
   },
@@ -3328,7 +3406,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -3359,7 +3437,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -3388,7 +3466,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -3415,7 +3493,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -3442,7 +3520,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -3466,7 +3544,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -3501,7 +3579,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       // Mirrors REST's handleChainIdentityHistory: same tryPostgresTier
       // contract, same METAGRAPH_SUBNET_IDENTITY_SOURCE flag as the REST
       // route (#4832), so this tool and GET /api/v1/chain/identity-history
@@ -3533,7 +3611,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -3573,7 +3651,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_TURNOVER_WINDOW;
       if (!Object.hasOwn(CHAIN_TURNOVER_WINDOWS, window)) {
@@ -3632,7 +3710,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_FLOW_WINDOW;
       if (!Object.hasOwn(CHAIN_STAKE_FLOW_WINDOWS, window)) {
@@ -3688,7 +3766,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const limit = clampLimit(
         args?.limit,
         CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
@@ -3733,7 +3811,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_WEIGHTS_WINDOW;
       if (!Object.hasOwn(CHAIN_WEIGHTS_WINDOWS, window)) {
@@ -3759,7 +3837,7 @@ export const MCP_TOOLS = [
         buildChainWeights([], {
           window,
           limit,
-          networkDistinct: null,
+          networkDistinct: undefined,
         })
       );
     },
@@ -3793,7 +3871,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW;
       if (!Object.hasOwn(CHAIN_WEIGHT_SETTERS_WINDOWS, window)) {
@@ -3853,7 +3931,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_MOVES_WINDOW;
       if (!Object.hasOwn(CHAIN_STAKE_MOVES_WINDOWS, window)) {
@@ -3913,7 +3991,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW;
       if (!Object.hasOwn(CHAIN_STAKE_TRANSFERS_WINDOWS, window)) {
@@ -3973,7 +4051,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
       if (!Object.hasOwn(CHAIN_AXON_REMOVALS_WINDOWS, window)) {
@@ -4034,7 +4112,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_SERVING_WINDOW;
       if (!Object.hasOwn(CHAIN_SERVING_WINDOWS, window)) {
@@ -4095,7 +4173,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_PROMETHEUS_WINDOW;
       if (!Object.hasOwn(CHAIN_PROMETHEUS_WINDOWS, window)) {
@@ -4138,7 +4216,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       // Mirrors REST's handleBlocksSummary: try Postgres first, fall back to
       // the schema-stable zeroed card now that blocks' D1 write path is
       // retired (#4772) and the table is dropped in production.
@@ -4173,10 +4251,10 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const parsed = parseConcentrationHistoryWindow(args?.window);
-      if (parsed.error) {
+      if ("error" in parsed) {
         throw toolError("invalid_params", parsed.error.message);
       }
       return (
@@ -4226,7 +4304,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const { label } = requireHistoryWindow(args);
       const changes = optionalBoolean(args, "changes");
@@ -4270,7 +4348,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -4304,13 +4382,13 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const parsed = parseSubnetYieldHistoryWindow(args?.window);
-      if (args?.window !== undefined && parsed.error) {
+      if (args?.window !== undefined && "error" in parsed && parsed.error) {
         throw toolError("invalid_params", parsed.error.message);
       }
-      const { label } = parsed;
+      const { label } = parsed as { label: string };
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -4355,7 +4433,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_STAKE_FLOW_WINDOW;
@@ -4420,7 +4498,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
@@ -4474,7 +4552,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_WEIGHTS_WINDOW;
@@ -4519,7 +4597,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW;
@@ -4563,7 +4641,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_REGISTRATIONS_WINDOW;
@@ -4607,7 +4685,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_STAKE_MOVES_WINDOW;
@@ -4652,7 +4730,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
@@ -4697,7 +4775,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
@@ -4743,7 +4821,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_SERVING_WINDOW;
@@ -4789,7 +4867,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_PROMETHEUS_WINDOW;
@@ -4833,7 +4911,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW;
@@ -4876,13 +4954,13 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const parsed = parseSubnetPerformanceHistoryWindow(args?.window);
-      if (args?.window !== undefined && parsed.error) {
+      if (args?.window !== undefined && "error" in parsed && parsed.error) {
         throw toolError("invalid_params", parsed.error.message);
       }
-      const { label } = parsed;
+      const { label } = parsed as { label: string };
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -4931,7 +5009,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window = optionalString(args, "window") ?? DEFAULT_MOVERS_WINDOW;
       if (!Object.hasOwn(MOVERS_WINDOWS, window)) {
         throw toolError(
@@ -5000,7 +5078,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const window = parseUptimeWindow(args?.window);
       if (args?.window !== undefined && window === null) {
@@ -5011,16 +5089,15 @@ export const MCP_TOOLS = [
         (await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/uptime`, {
-            window,
+            window: window as string,
             min_samples: minSamples,
           }),
           "METAGRAPH_HEALTH_SOURCE",
         )) ??
-        (await loadSubnetUptime(netuid, {
-          window,
+        ((await loadSubnetUptime(netuid, {
+          window: window ?? undefined,
           observedAt: await mcpObservedAt(ctx),
-          minSamples,
-        }))
+        })) as Row)
       );
     },
   },
@@ -5051,7 +5128,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const board = optionalEnum(args, "board", LEADERBOARD_BOARDS);
       const limit = clampLimit(args?.limit, 20, 100);
       const profiles =
@@ -5088,7 +5165,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const domain = optionalEnum(args, "domain", DOMAIN_TAGS);
       // A cold/missing subnets index degrades to an empty rollup (like
       // loadEconomicsSubnetRows' own graceful fallback below), not a thrown
@@ -5105,12 +5182,13 @@ export const MCP_TOOLS = [
   },
   {
     ...LIST_PROFILES_MCP_TOOL,
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       try {
-        return await loadProfilesList(ctx, args, {
+        return await loadProfilesList(asMcpLoaderCtx(ctx), args, {
           readOptionalArtifact: loadOptionalArtifact,
         });
-      } catch (err) {
+      } catch (rawErr) {
+        const err = rawErr as Row;
         if (err?.profilesMcp) {
           throw toolError(err.code, err.message);
         }
@@ -5120,13 +5198,14 @@ export const MCP_TOOLS = [
   },
   {
     ...GET_SUBNET_PROFILE_MCP_TOOL,
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       try {
-        return await loadSubnetProfile(ctx, netuid, {
+        return await loadSubnetProfile(asMcpLoaderCtx(ctx), netuid, {
           readArtifact: loadArtifactData,
         });
-      } catch (err) {
+      } catch (rawErr) {
+        const err = rawErr as Row;
         if (err?.profilesMcp) {
           throw toolError(err.code, err.message);
         }
@@ -5163,7 +5242,7 @@ export const MCP_TOOLS = [
       required: ["netuids"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuids = parseCompareNetuidList(args?.netuids);
       if (!netuids) {
         throw toolError(
@@ -5171,7 +5250,7 @@ export const MCP_TOOLS = [
           "netuids must be a non-empty array of 1-128 distinct subnet ids.",
         );
       }
-      const dimensions = parseCompareDimensionList(args?.dimensions);
+      const dimensions = parseCompareDimensionList(args?.dimensions)!;
       if (args?.dimensions !== undefined && dimensions === null) {
         throw toolError(
           "invalid_params",
@@ -5207,7 +5286,7 @@ export const MCP_TOOLS = [
             economicsRows: dimensions.includes("economics")
               ? economicsRows
               : null,
-            healthRows: postgres.rows,
+            healthRows: postgres.rows as Row[],
             observedAt,
           });
         }
@@ -5239,12 +5318,12 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label, days } = parseAnalyticsWindow(args?.window ?? "7d");
+      const { label } = parsed!;
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -5253,7 +5332,6 @@ export const MCP_TOOLS = [
         )) ??
         (await loadGlobalIncidents({
           windowLabel: label,
-          windowDays: days,
           observedAt: await mcpObservedAt(ctx),
         }))
       );
@@ -5281,7 +5359,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       // validator_permit is validated for REST-parity but, like the D1 filter it
       // used to bound, has nothing left to filter now that neurons is retired
@@ -5332,7 +5410,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const limit = optionalPositiveInt(args, "limit");
       const minStakeTao = optionalNonNegativeNumber(args, "min_stake_tao");
@@ -5352,13 +5430,14 @@ export const MCP_TOOLS = [
       }
       // The loader already ranks by stake_tao DESC, so a limit after the
       // min_stake_tao floor keeps the highest-stake survivors — no re-sort.
-      const filtered =
+      const filtered = (
         minStakeTao === null
           ? data.validators
-          : data.validators.filter(
-              (v) =>
+          : (data.validators as Row[]).filter(
+              (v: Row) =>
                 typeof v.stake_tao === "number" && v.stake_tao >= minStakeTao,
-            );
+            )
+      ) as Row[];
       const validators = limit === null ? filtered : filtered.slice(0, limit);
       return { ...data, validator_count: validators.length, validators };
     },
@@ -5393,7 +5472,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const sort =
         optionalEnum(args, "sort", GLOBAL_VALIDATOR_SORTS) ??
         DEFAULT_GLOBAL_VALIDATOR_SORT;
@@ -5433,7 +5512,7 @@ export const MCP_TOOLS = [
       required: ["hotkey"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const hotkey = requireHotkey(args);
       return (
         (await tryPostgresTier(
@@ -5483,7 +5562,7 @@ export const MCP_TOOLS = [
       required: ["hotkeys"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const hotkeys = parseCompareHotkeyList(args?.hotkeys);
       if (!hotkeys) {
         throw toolError(
@@ -5534,7 +5613,7 @@ export const MCP_TOOLS = [
       required: ["id"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const id = requireString(args, "id");
       if (!isValidSubscriptionId(id)) {
         throw toolError(
@@ -5561,7 +5640,7 @@ export const MCP_TOOLS = [
         throw toolError("not_found", `No such subscription: ${id}.`);
       }
       return {
-        ...publicSubscriptionView(record),
+        ...publicSubscriptionView(record as Row),
         delivery: await readMcpWebhookDeliveryStatus(ctx.env, id),
       };
     },
@@ -5589,7 +5668,7 @@ export const MCP_TOOLS = [
       required: ["id", "owner_token"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const id = requireString(args, "id");
       const ownerToken = requireString(args, "owner_token");
       if (!ctx.env.DATA_API) {
@@ -5616,8 +5695,8 @@ export const MCP_TOOLS = [
       if (!upstream.ok) {
         throw toolError(
           upstream.status === 404 ? "not_found" : "alert_trigger_error",
-          typeof body?.error === "string"
-            ? body.error
+          typeof (body as Row | null)?.error === "string"
+            ? ((body as Row).error as string)
             : "The alert triggers tier returned an error.",
         );
       }
@@ -5670,7 +5749,7 @@ export const MCP_TOOLS = [
       required: ["hotkey"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const hotkey = requireHotkey(args);
       const window =
         optionalEnum(args, "window", Object.keys(NOMINATOR_WINDOWS)) ??
@@ -5736,7 +5815,7 @@ export const MCP_TOOLS = [
       required: ["hotkey"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const hotkey = requireHotkey(args);
       const { label } = requireHistoryWindow(args);
       return (
@@ -5771,7 +5850,7 @@ export const MCP_TOOLS = [
       required: ["netuid", "uid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       // uid is validated for REST-parity but, like the D1 filter it used to
       // bound, has nothing left to look up now that neurons is retired
@@ -5810,7 +5889,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadSubnetHistory(ctx, netuid, requireHistoryWindow(args));
     },
@@ -5849,7 +5928,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadSubnetIdentityHistoryTool(ctx, netuid, {
         limit: args?.limit,
@@ -5886,7 +5965,7 @@ export const MCP_TOOLS = [
       required: ["netuid", "uid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const uid = requireNonNegativeInt(args, "uid");
       return loadNeuronHistory(ctx, netuid, uid, requireHistoryWindow(args));
@@ -5947,7 +6026,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const kind = optionalString(args, "kind");
       requireKnownEventKind(kind);
@@ -5999,7 +6078,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -6043,7 +6122,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = optionalNonNegativeInt(args, "offset") ?? 0;
@@ -6084,7 +6163,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const netEconomics = await loadSubnetEconomics(ctx, netuid);
       const marketCapTao =
@@ -6135,7 +6214,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const interval =
         optionalString(args, "interval") ?? OHLC_INTERVAL_DEFAULT;
@@ -6189,7 +6268,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadSubnetOwnershipHistory(ctx, netuid);
     },
@@ -6217,7 +6296,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadSubnetConviction(ctx, netuid);
     },
@@ -6238,7 +6317,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       if (!isU16Netuid(netuid)) {
         throw toolError(
@@ -6277,7 +6356,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       if (!isU16Netuid(netuid)) {
         throw toolError(
@@ -6321,7 +6400,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       if (!isU16Netuid(netuid)) {
         throw toolError(
@@ -6364,7 +6443,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadSubnetLeaseHistory(ctx, netuid);
     },
@@ -6394,7 +6473,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const data =
         (await tryPostgresTier(
@@ -6404,11 +6483,11 @@ export const MCP_TOOLS = [
         )) ?? buildAccountSummary(ss58, {});
       // Community-contributable entity labels (#6739), same REST-parity join
       // as workers/request-handlers/entities.mjs's own handleAccount.
-      const entitiesArtifact = await ctx.readArtifact(
+      const entitiesArtifact = (await ctx.readArtifact!(
         ctx.env,
         ENTITY_LABELS_ARTIFACT,
-      );
-      data.labels = labelsForSs58(
+      )) as Row | null;
+      (data as Row).labels = labelsForSs58(
         entityLabelsIndex(
           entitiesArtifact?.ok ? entitiesArtifact.data?.entities : [],
         ),
@@ -6440,10 +6519,10 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const [entitiesArtifact, ownershipData] = await Promise.all([
-        ctx.readArtifact(ctx.env, ENTITY_LABELS_ARTIFACT),
+        ctx.readArtifact!(ctx.env, ENTITY_LABELS_ARTIFACT),
         tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/entities`),
@@ -6452,7 +6531,7 @@ export const MCP_TOOLS = [
       ]);
       const data =
         ownershipData ?? buildAccountEntities(ss58, { entities: [] });
-      data.labels = labelsForSs58(
+      (data as Row).labels = labelsForSs58(
         entityLabelsIndex(
           entitiesArtifact?.ok ? entitiesArtifact.data?.entities : [],
         ),
@@ -6483,7 +6562,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       if (!isFinneySs58Address(ss58)) {
         throw toolError(
@@ -6529,7 +6608,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       if (!isFinneySs58Address(ss58)) {
         throw toolError(
@@ -6576,7 +6655,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       if (!isFinneySs58Address(ss58)) {
         throw toolError(
@@ -6621,7 +6700,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       if (!isFinneySs58Address(ss58)) {
         throw toolError(
@@ -6710,7 +6789,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const kind = optionalString(args, "kind");
       requireKnownEventKind(kind);
@@ -6770,7 +6849,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       return (
         (await tryPostgresTier(
@@ -6804,7 +6883,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       return (
         (await tryPostgresTier(
@@ -6841,7 +6920,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       return (
         (await tryPostgresTier(
@@ -6887,7 +6966,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const recentEventsLimit = clampLimit(args?.recent_events_limit, 10, 1000);
       // balance is a live RPC call (its own rate limiter + address-network
@@ -6978,7 +7057,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       return (
         (await tryPostgresTier(
@@ -7024,7 +7103,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = optionalNonNegativeInt(args, "offset") ?? 0;
@@ -7069,7 +7148,7 @@ export const MCP_TOOLS = [
       required: ["ss58", "netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const netuid = requireNetuid(args);
       const { label } = requireHistoryWindow(args);
@@ -7131,7 +7210,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_STAKE_FLOW_WINDOW;
@@ -7196,7 +7275,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW;
@@ -7249,7 +7328,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_AXON_REMOVAL_WINDOW;
@@ -7303,7 +7382,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_PROMETHEUS_WINDOW;
@@ -7356,7 +7435,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_REGISTRATION_WINDOW;
@@ -7408,7 +7487,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW;
@@ -7462,7 +7541,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const window = optionalString(args, "window") ?? DEFAULT_SERVING_WINDOW;
       if (!Object.hasOwn(SERVING_WINDOWS, window)) {
@@ -7515,7 +7594,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_ACCOUNT_DEREGISTRATION_WINDOW;
@@ -7596,7 +7675,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const netuid = optionalNonNegativeInt(args, "netuid") ?? undefined;
       const from = optionalDayArg(args, "from");
@@ -7675,7 +7754,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       // block_start/block_end/cursor are validated for REST-parity and forwarded
       // to the Postgres tier below; the D1 fallback (buildAccountExtrinsics([]))
@@ -7767,7 +7846,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const direction = optionalString(args, "direction");
       // block_start/block_end/cursor are validated for REST-parity and forwarded to
@@ -7845,7 +7924,7 @@ export const MCP_TOOLS = [
       required: ["ss58"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const counterparty = optionalString(args, "counterparty");
       if (counterparty != null) {
@@ -7984,7 +8063,7 @@ export const MCP_TOOLS = [
       required: [],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       // Every filter below is validated for REST-parity and, now that the
       // Postgres tier can be flipped on, forwarded to it below -- only the
       // buildBlockFeed([]) D1 fallback ignores them (nothing left to filter
@@ -8052,7 +8131,7 @@ export const MCP_TOOLS = [
       required: ["ref"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ref = requireString(args, "ref");
       // Mirrors REST's handleBlock: try Postgres first, fall back to the
       // schema-stable block:null shape now that blocks' D1 write path is
@@ -8099,7 +8178,7 @@ export const MCP_TOOLS = [
       required: ["ref"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ref = requireString(args, "ref");
       const limit = clampLimit(args?.limit, 50, 100);
       const offset = Number.isFinite(args?.offset)
@@ -8156,7 +8235,7 @@ export const MCP_TOOLS = [
       required: ["ref"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ref = requireString(args, "ref");
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = Number.isFinite(args?.offset)
@@ -8276,7 +8355,7 @@ export const MCP_TOOLS = [
       required: [],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       // Validated for REST-parity but, like the D1 filters they used to bound, have
       // nothing left to filter now that extrinsics is retired (#4772) --
       // buildExtrinsicFeed([]) below never sees them.
@@ -8336,7 +8415,7 @@ export const MCP_TOOLS = [
       required: ["ref"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ref = requireString(args, "ref");
       // Mirrors REST's handleExtrinsic: try Postgres first (#4694), fall back to
       // the schema-stable empty detail now that extrinsics' D1 write path is
@@ -8413,7 +8492,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -8440,7 +8519,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadSudoKey(ctx.env);
     },
   },
@@ -8458,7 +8537,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadNetworkParameters(ctx.env);
     },
   },
@@ -8478,7 +8557,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadRandomnessStatus(ctx.env);
     },
   },
@@ -8545,7 +8624,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -8578,7 +8657,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
       // table is dropped in production, so a D1 query here would always miss.
       return (
@@ -8616,7 +8695,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const sort =
         optionalEnum(args, "sort", ACCOUNTS_LIST_SORTS) ??
         DEFAULT_ACCOUNTS_LIST_SORT;
@@ -8663,7 +8742,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const sort =
         optionalEnum(args, "sort", TOP_HOLDERS_SORTS) ??
         DEFAULT_TOP_HOLDERS_SORT;
@@ -8706,7 +8785,7 @@ export const MCP_TOOLS = [
       required: ["block_number"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const blockNumber = requireNonNegativeInt(args, "block_number");
       return loadBlockChainEvents(ctx, blockNumber);
     },
@@ -8744,7 +8823,7 @@ export const MCP_TOOLS = [
       required: ["ref"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const ref = requireString(args, "ref");
       const cursor = optionalString(args, "cursor");
       return loadExtrinsicChainEvents(ctx, ref, {
@@ -8778,7 +8857,7 @@ export const MCP_TOOLS = [
       required: [],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const blocks = optionalBlocksWindow(args);
       return loadChainActivity(ctx, blocks);
     },
@@ -8846,7 +8925,7 @@ export const MCP_TOOLS = [
       required: [],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       return loadChainEventsFeed(ctx, {
         pallet: optionalString(args, "pallet"),
         method: optionalString(args, "method"),
@@ -8897,12 +8976,12 @@ export const MCP_TOOLS = [
       required: [],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed;
+      const { label } = parsed!;
       const groupBy =
         optionalEnum(args, "group_by", ["module", "module_function"]) ||
         "module";
@@ -8971,12 +9050,12 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label, days } = parsed;
+      const { label, days } = parsed!;
       const sort =
         optionalEnum(args, "sort", CHAIN_SIGNERS_SORTS) || "tx_count";
       const limit = clampLimit(args?.limit, 50, 100);
@@ -8998,14 +9077,14 @@ export const MCP_TOOLS = [
         "METAGRAPH_EXTRINSICS_SOURCE",
       );
       if (postgres) return postgres;
-      const { data } = await loadMcpChainSigners(ctx, {
+      const { data } = (await loadMcpChainSigners(ctx, {
         label,
         days,
         observedAt: await mcpObservedAt(ctx),
         limit,
         callModule,
         sort,
-      });
+      })) as { data: Row };
       return data;
     },
   },
@@ -9039,12 +9118,12 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed;
+      const { label } = parsed!;
       const limit = clampLimit(args?.limit, 25, 100);
       const callModule = optionalString(args, "call_module");
       if (callModule != null && callModule.length > 100) {
@@ -9099,12 +9178,12 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed;
+      const { label } = parsed!;
       const limit = clampLimit(
         args?.limit,
         CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
@@ -9156,7 +9235,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW;
       if (!Object.hasOwn(CHAIN_DEREGISTRATIONS_WINDOWS, window)) {
@@ -9212,7 +9291,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_TRANSFER_WINDOW;
       if (!Object.hasOwn(CHAIN_TRANSFER_WINDOWS, window)) {
@@ -9282,7 +9361,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW;
       if (!Object.hasOwn(CHAIN_TRANSFER_PAIR_WINDOWS, window)) {
@@ -9338,12 +9417,12 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed;
+      const { label } = parsed!;
       // #4909 D1 retirement: extrinsics'/blocks' D1 write path is retired
       // (#4772) and the tables are dropped in production, so a D1 query here
       // would always miss. Postgres → schema-stable empty stub, never a live
@@ -9375,7 +9454,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const staticDetail = await loadArtifactData(
         ctx,
@@ -9416,7 +9495,7 @@ export const MCP_TOOLS = [
       required: ["surface_id"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const surfaceId = requireString(args, "surface_id");
       // surface_id is part of an R2 key path; reject anything that could escape
       // the schemas/ namespace.
@@ -9452,7 +9531,7 @@ export const MCP_TOOLS = [
       required: ["surface_id"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const surfaceId = requireString(args, "surface_id");
       // surface_id is part of an R2 key path; reject anything that could escape
       // the fixtures/ namespace.
@@ -9496,7 +9575,7 @@ export const MCP_TOOLS = [
       required: ["slug"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const slug = requireString(args, "slug");
       // slug is part of an R2 key path; reject anything that could escape the
       // providers/ namespace.
@@ -9512,20 +9591,20 @@ export const MCP_TOOLS = [
   },
   {
     ...LIST_PROVIDERS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadProvidersList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadProvidersList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_SURFACES_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadSurfacesList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSurfacesList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_CANDIDATES_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadCandidatesList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadCandidatesList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -9603,7 +9682,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
       const layer = optionalEnum(args, "layer", QUERY_ENUMS.endpointLayer);
       const netuid = optionalNonNegativeInt(args, "netuid");
@@ -9637,7 +9716,7 @@ export const MCP_TOOLS = [
       // must see live values, not the baked ones.
       if (
         Array.isArray(data?.endpoints) &&
-        data.endpoints.some((endpoint) => endpoint?.surface_id)
+        data.endpoints.some((endpoint: Row) => endpoint?.surface_id)
       ) {
         const overlaid = overlayArtifactEndpoints(
           data,
@@ -9647,7 +9726,7 @@ export const MCP_TOOLS = [
       }
       const all = Array.isArray(data.endpoints) ? data.endpoints : [];
       const filtered = all.filter(
-        (e) =>
+        (e: Row) =>
           (kind === null || e.kind === kind) &&
           (layer === null || e.layer === layer) &&
           (netuid === null || e.netuid === netuid) &&
@@ -9681,8 +9760,8 @@ export const MCP_TOOLS = [
   },
   {
     ...LIST_EVIDENCE_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadEvidenceList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadEvidenceList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -9698,7 +9777,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       const staticData = await loadArtifactData(
         ctx,
         "/metagraph/rpc-endpoints.json",
@@ -9714,20 +9793,20 @@ export const MCP_TOOLS = [
   },
   {
     ...LIST_SOURCE_SNAPSHOTS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadSourceSnapshotsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSourceSnapshotsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_PROFILE_COMPLETENESS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadProfileCompletenessList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadProfileCompletenessList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_RPC_POOLS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadRpcPoolsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadRpcPoolsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -9747,7 +9826,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const data = await loadArtifactData(
         ctx,
@@ -9756,7 +9835,7 @@ export const MCP_TOOLS = [
       // Live per-endpoint health overlay, same rule as list_endpoints above.
       if (
         Array.isArray(data?.endpoints) &&
-        data.endpoints.some((endpoint) => endpoint?.surface_id)
+        data.endpoints.some((endpoint: Row) => endpoint?.surface_id)
       ) {
         const overlaid = overlayArtifactEndpoints(
           data,
@@ -9769,8 +9848,8 @@ export const MCP_TOOLS = [
   },
   {
     ...LIST_SUBNET_ENDPOINTS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadSubnetEndpointsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSubnetEndpointsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -9790,15 +9869,15 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadArtifactData(ctx, `/metagraph/candidates/${netuid}.json`);
     },
   },
   {
     ...LIST_SUBNET_CANDIDATES_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadSubnetCandidatesList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSubnetCandidatesList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -9817,15 +9896,15 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadArtifactData(ctx, `/metagraph/evidence/${netuid}.json`);
     },
   },
   {
     ...LIST_SUBNET_EVIDENCE_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadSubnetEvidenceList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSubnetEvidenceList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -9845,7 +9924,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       return loadArtifactData(ctx, `/metagraph/surfaces/${netuid}.json`);
     },
@@ -9863,7 +9942,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/fixtures.json");
     },
   },
@@ -9881,80 +9960,80 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/schemas/index.json");
     },
   },
   {
     ...LIST_SEARCH_INDEX_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadSearchIndexList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSearchIndexList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_SEARCH_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadSearchList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSearchList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_CURATION_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadCurationList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadCurationList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_GAPS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadGapsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadGapsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ENRICHMENT_QUEUE_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadEnrichmentQueueList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadEnrichmentQueueList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ADAPTER_CANDIDATES_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadAdapterCandidatesList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadAdapterCandidatesList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ENRICHMENT_EVIDENCE_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadEnrichmentEvidenceList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadEnrichmentEvidenceList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_REVIEW_GAPS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadReviewGapsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadReviewGapsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadReviewEnrichmentTargetsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadReviewEnrichmentTargetsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ENDPOINT_POOLS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadEndpointPoolsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadEndpointPoolsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadEndpointIncidentsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadEndpointIncidentsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadProviderEndpointsList(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadProviderEndpointsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -9970,7 +10049,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/lineage.json");
     },
   },
@@ -9989,14 +10068,14 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadFreshness(ctx);
     },
   },
   {
     ...GET_CONTRACTS_MCP_TOOL,
-    async handler(_args, ctx) {
-      return loadContracts(ctx);
+    async handler(_args: unknown, ctx: McpCtx) {
+      return loadContracts(asMcpLoaderCtx(ctx));
     },
   },
   {
@@ -10013,27 +10092,26 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/source-health.json");
     },
   },
   {
     ...GET_CHANGELOG_MCP_TOOL,
-    async handler(_args, ctx) {
-      return loadChangelog(ctx);
+    async handler(_args: unknown, ctx: McpCtx) {
+      return loadChangelog(asMcpLoaderCtx(ctx));
     },
   },
   {
     ...GET_FEED_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadFeedItems(ctx, args, {
+    async handler(args: Row, ctx: McpCtx) {
+      return loadFeedItems(asMcpLoaderCtx(ctx), args, {
         // Same cross-subnet incident ledger + wiring get_global_incidents uses
         // (mcpObservedAt), widest window (30d) -- get_feed's own since/until
         // narrow further from there.
         async loadIncidents() {
           return loadGlobalIncidents({
             windowLabel: "30d",
-            windowDays: 30,
             observedAt: await mcpObservedAt(ctx),
           });
         },
@@ -10042,14 +10120,14 @@ export const MCP_TOOLS = [
   },
   {
     ...GET_BUILD_MCP_TOOL,
-    async handler(_args, ctx) {
-      return loadBuildSummary(ctx);
+    async handler(_args: unknown, ctx: McpCtx) {
+      return loadBuildSummary(asMcpLoaderCtx(ctx));
     },
   },
   {
     ...GET_ADAPTER_MCP_TOOL,
-    async handler(args, ctx) {
-      return loadAdapter(ctx, args);
+    async handler(args: Row, ctx: McpCtx) {
+      return loadAdapter(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -10070,7 +10148,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const live = await mcpLiveHealth(ctx);
       if (args?.netuid === undefined || args?.netuid === null) {
         const index = await loadArtifactData(
@@ -10089,8 +10167,8 @@ export const MCP_TOOLS = [
   },
   {
     ...GET_AGENT_RESOURCES_MCP_TOOL,
-    async handler(_args, ctx) {
-      return loadAgentResources(ctx);
+    async handler(_args: unknown, ctx: McpCtx) {
+      return loadAgentResources(asMcpLoaderCtx(ctx));
     },
   },
   {
@@ -10116,12 +10194,12 @@ export const MCP_TOOLS = [
       required: [],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label } = parsed;
+      const { label } = parsed!;
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -10154,7 +10232,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const limit = clampLimit(args?.limit, 3, 10);
       const poolData = await loadArtifactData(ctx, "/metagraph/rpc/pools.json");
       const liveRpcPool = ctx.readHealthKv
@@ -10167,9 +10245,12 @@ export const MCP_TOOLS = [
       // Pool map keys ("0"/"1"/"2") are pool indices, NOT networks — and the
       // same physical endpoint can appear in more than one pool. Dedupe by
       // endpoint id, keeping the best-scored instance.
-      const bestById = new Map();
+      const bestById = new Map<string, Row>();
       for (const pool of Object.values(pools)) {
-        const overlaid = overlayRpcPoolEligibility(pool, liveRpcPool);
+        const overlaid = overlayRpcPoolEligibility(
+          pool as Row,
+          liveRpcPool,
+        ) as Row;
         for (const endpoint of overlaid.endpoints || []) {
           if (!endpoint.pool_eligible) continue;
           const existing = bestById.get(endpoint.id);
@@ -10239,7 +10320,7 @@ export const MCP_TOOLS = [
       required: ["method"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       if (typeof args?.method !== "string" || !args.method) {
         throw toolError(
           "invalid_params",
@@ -10277,7 +10358,7 @@ export const MCP_TOOLS = [
           method: "POST",
           headers: {
             "content-type": "application/json",
-            "cf-connecting-ip": ctx.clientIp,
+            "cf-connecting-ip": ctx.clientIp ?? "",
           },
           body: JSON.stringify(rpcRequestBody),
         },
@@ -10300,14 +10381,20 @@ export const MCP_TOOLS = [
         // handleRpcProxyRequest's every error path goes through workers/http.ts's
         // errorResponse(), which always populates error.code/error.message -- no
         // "malformed error body" case exists to guess a fallback for.
-        throw toolError(payload.error.code, payload.error.message);
+        throw toolError(
+          (payload as Row).error.code,
+          (payload as Row).error.message,
+        );
       }
       return {
         network,
         method: args.method,
-        jsonrpc: payload?.jsonrpc ?? "2.0",
-        result: payload && "result" in payload ? payload.result : null,
-        error: payload?.error ?? null,
+        jsonrpc: (payload as Row | null)?.jsonrpc ?? "2.0",
+        result:
+          payload && "result" in (payload as Row)
+            ? (payload as Row).result
+            : null,
+        error: (payload as Row | null)?.error ?? null,
         endpoint_id: response.headers.get("x-metagraph-rpc-endpoint-id"),
         provider: response.headers.get("x-metagraph-rpc-provider"),
         cache: response.headers.get("x-metagraph-rpc-cache"),
@@ -10364,7 +10451,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: true,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const query = requireString(args, "query");
       if (
         args?.variables !== undefined &&
@@ -10386,7 +10473,7 @@ export const MCP_TOOLS = [
         method: "POST",
         headers: {
           "content-type": "application/json",
-          "cf-connecting-ip": ctx.clientIp,
+          "cf-connecting-ip": ctx.clientIp ?? "",
         },
         body: JSON.stringify({ query, variables: args?.variables }),
       });
@@ -10411,8 +10498,8 @@ export const MCP_TOOLS = [
       // Both are surfaced to the agent as { data, errors } rather than thrown,
       // so it can read partial data and the error detail together.
       return {
-        data: payload?.data ?? null,
-        errors: payload?.errors ?? [],
+        data: (payload as Row | null)?.data ?? null,
+        errors: (payload as Row | null)?.errors ?? [],
       };
     },
   },
@@ -10428,14 +10515,14 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/registry-summary.json");
     },
   },
   {
     ...GET_COVERAGE_MCP_TOOL,
-    async handler(_args, ctx) {
-      return loadRegistryCoverage(ctx);
+    async handler(_args: unknown, ctx: McpCtx) {
+      return loadRegistryCoverage(asMcpLoaderCtx(ctx));
     },
   },
   {
@@ -10451,7 +10538,7 @@ export const MCP_TOOLS = [
       properties: {},
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/coverage-depth.json");
     },
   },
@@ -10499,7 +10586,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const limit = clampLimit(args?.limit, 10, 50);
       const tier = optionalEnum(args, "tier", COVERAGE_DEPTH_TIERS);
       const severity = optionalEnum(
@@ -10517,7 +10604,7 @@ export const MCP_TOOLS = [
         "/metagraph/coverage-depth.json",
       );
       const rows = Array.isArray(scorecard.rows) ? scorecard.rows : [];
-      const rowsByNetuid = new Map(rows.map((row) => [row.netuid, row]));
+      const rowsByNetuid = new Map(rows.map((row: Row) => [row.netuid, row]));
       const queue = Array.isArray(scorecard.ranked_queue)
         ? scorecard.ranked_queue
         : [];
@@ -10533,19 +10620,19 @@ export const MCP_TOOLS = [
         candidates = [{ row, rank: null }];
       } else {
         candidates = queue
-          .map((entry) => ({
+          .map((entry: Row) => ({
             row: rowsByNetuid.get(entry.netuid) || entry,
             rank: entry.rank ?? null,
           }))
-          .filter((entry) => Number.isInteger(entry.row?.netuid));
+          .filter((entry: Row) => Number.isInteger(entry.row?.netuid));
       }
       const filters = { tier, severity, gap_code: gapCode, netuid };
       const targets = candidates
-        .filter(({ row }) =>
+        .filter(({ row }: Row) =>
           coverageDepthMatches(row, { tier, severity, gapCode }),
         )
         .slice(0, limit)
-        .map(({ row, rank }) => coverageDepthTarget(row, rank));
+        .map(({ row, rank }: Row) => coverageDepthTarget(row, rank));
       return {
         generated_at: scorecard.generated_at || null,
         coverage_depth_version: scorecard.coverage_depth_version || null,
@@ -10580,7 +10667,7 @@ export const MCP_TOOLS = [
       required: ["netuid"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const gaps = await loadOptionalArtifact(
         ctx,
@@ -10629,7 +10716,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const board = optionalEnum(args, "board", ECONOMIC_LEADERBOARD_BOARDS);
       const limit = clampLimit(args?.limit, 10, 100);
       const economics = await loadArtifactData(
@@ -10648,9 +10735,10 @@ export const MCP_TOOLS = [
         economicsRows: rows,
         subnetMeta: new Map(),
       });
-      const boards = {};
+      const boards: Row = {};
+      const rankedBoards = ranked.boards as Row;
       for (const key of ECONOMIC_LEADERBOARD_BOARDS) {
-        if (ranked.boards[key]) boards[key] = ranked.boards[key];
+        if (rankedBoards[key]) boards[key] = rankedBoards[key];
       }
       return {
         board: board || null,
@@ -10690,7 +10778,7 @@ export const MCP_TOOLS = [
       required: ["query"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       requireAi(ctx);
       const query = requireString(args, "query");
       await requireAiRateLimit(ctx, "semantic");
@@ -10724,7 +10812,7 @@ export const MCP_TOOLS = [
       required: ["question"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       requireAi(ctx);
       const question = requireString(args, "question");
       await requireAiRateLimit(ctx, "ask");
@@ -10765,7 +10853,7 @@ export const MCP_TOOLS = [
       required: ["task"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const task = requireString(args, "task");
       const limit = clampLimit(args?.limit, 5, 20);
       const live = await mcpLiveHealth(ctx);
@@ -10777,8 +10865,10 @@ export const MCP_TOOLS = [
       // result's `health` reflects the current cron-probed status, not the
       // build-time "unknown" stub baked into the artifact.
       const overlaidCatalog = overlayCatalogIndex(catalog, live) || catalog;
-      const byNetuid = new Map(
-        (overlaidCatalog.subnets || []).map((entry) => [entry.netuid, entry]),
+      const byNetuid = new Map<number, Row>(
+        (overlaidCatalog.subnets || []).map(
+          (entry: Row) => [entry.netuid, entry] as [number, Row],
+        ),
       );
       const { mode, ranked } = await rankSubnetsForTask(
         ctx,
@@ -10843,7 +10933,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const netuid = await resolveNetuid(ctx, args);
       const staticDetail = await loadArtifactData(
         ctx,
@@ -10853,54 +10943,56 @@ export const MCP_TOOLS = [
       const detail =
         overlayCatalogDetail(staticDetail, live, netuid) || staticDetail;
       const services = Array.isArray(detail.services) ? detail.services : [];
-      const callable = services.filter((s) => s.eligibility?.callable);
-      const steps = (callable.length > 0 ? callable : services).map((s) => ({
-        surface_id: s.surface_id,
-        kind: s.kind,
-        capability: s.capability,
-        base_url: s.base_url,
-        callable: Boolean(s.eligibility?.callable),
-        auth: {
-          required: Boolean(s.auth_required),
-          schemes: Array.isArray(s.auth_schemes) ? s.auth_schemes : [],
-        },
-        // Ready-to-run curl/Python/TS for a first call (issue #351).
-        // Regenerate from base_url + auth so cleartext credential guards stay
-        // current even when reading older catalogs with stored snippets.
-        snippets: generateServiceSnippets(s) || s.snippets || null,
-        schema: s.schema_artifact
-          ? {
-              available: true,
-              fetch_with: `get_api_schema with surface_id ${
-                s.schema_source?.surface_id || s.surface_id
-              }`,
-              schema_url: s.schema_url || null,
-            }
-          : { available: false, schema_url: s.schema_url || null },
-        fixture: s.fixture
-          ? {
-              available: true,
-              fetch_with: `get_fixture with surface_id ${s.surface_id}`,
-              artifact_path: s.fixture.artifact_path,
-              captured_at: s.fixture.captured_at,
-              response_status: s.fixture.response?.status ?? null,
-              content_type: s.fixture.response?.content_type ?? null,
-            }
-          : {
-              available: false,
-              status: s.fixture_status?.status || "missing",
-              reason:
-                s.fixture_status?.reason || "no captured fixture available",
-            },
-        health: {
-          status: s.health?.status ?? "unknown",
-          stale: s.health?.stale ?? false,
-          observed_by: s.health?.observed_by ?? null,
-        },
-      }));
+      const callable = services.filter((s: Row) => s.eligibility?.callable);
+      const steps = (callable.length > 0 ? callable : services).map(
+        (s: Row) => ({
+          surface_id: s.surface_id,
+          kind: s.kind,
+          capability: s.capability,
+          base_url: s.base_url,
+          callable: Boolean(s.eligibility?.callable),
+          auth: {
+            required: Boolean(s.auth_required),
+            schemes: Array.isArray(s.auth_schemes) ? s.auth_schemes : [],
+          },
+          // Ready-to-run curl/Python/TS for a first call (issue #351).
+          // Regenerate from base_url + auth so cleartext credential guards stay
+          // current even when reading older catalogs with stored snippets.
+          snippets: generateServiceSnippets(s) || s.snippets || null,
+          schema: s.schema_artifact
+            ? {
+                available: true,
+                fetch_with: `get_api_schema with surface_id ${
+                  s.schema_source?.surface_id || s.surface_id
+                }`,
+                schema_url: s.schema_url || null,
+              }
+            : { available: false, schema_url: s.schema_url || null },
+          fixture: s.fixture
+            ? {
+                available: true,
+                fetch_with: `get_fixture with surface_id ${s.surface_id}`,
+                artifact_path: s.fixture.artifact_path,
+                captured_at: s.fixture.captured_at,
+                response_status: s.fixture.response?.status ?? null,
+                content_type: s.fixture.response?.content_type ?? null,
+              }
+            : {
+                available: false,
+                status: s.fixture_status?.status || "missing",
+                reason:
+                  s.fixture_status?.reason || "no captured fixture available",
+              },
+          health: {
+            status: s.health?.status ?? "unknown",
+            stale: s.health?.stale ?? false,
+            observed_by: s.health?.observed_by ?? null,
+          },
+        }),
+      );
       const isCallable = callable.length > 0;
-      const schemaStep = steps.find((s) => s.schema.available);
-      const fixtureStep = steps.find((s) => s.fixture.available);
+      const schemaStep = steps.find((s: Row) => s.schema.available);
+      const fixtureStep = steps.find((s: Row) => s.fixture.available);
       return {
         netuid,
         name: detail.name,
@@ -10946,7 +11038,7 @@ export const MCP_TOOLS = [
       },
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       const catalog = await loadArtifactData(
         ctx,
         "/metagraph/operational-surfaces.json",
@@ -11035,7 +11127,7 @@ export const MCP_TOOLS = [
       required: ["surface_id"],
       additionalProperties: false,
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       if (typeof args?.surface_id !== "string" || !args.surface_id) {
         throw toolError("invalid_params", "surface_id is required.");
       }
@@ -11168,7 +11260,9 @@ export const MCP_TOOLS = [
             );
           }
           const suppliedNames = Object.keys(args.credential);
-          const missing = names.filter((n) => !suppliedNames.includes(n));
+          const missing = names.filter(
+            (n: unknown) => !suppliedNames.includes(n as string),
+          );
           const unexpected = suppliedNames.filter((n) => !names.includes(n));
           if (missing.length > 0 || unexpected.length > 0) {
             throw toolError(
@@ -11254,7 +11348,7 @@ export const MCP_TOOLS = [
             "This surface has no captured schema, so path/method execution is not available for it -- omit path/method to call its single declared url instead.",
           );
         }
-        const match = matchSchemaOperation(
+        const match: Row | null = matchSchemaOperation(
           schema.document,
           args.path,
           normalizedMethod,
@@ -11337,19 +11431,24 @@ export const MCP_TOOLS = [
       if (credentialPlacement?.location === "body" && !requestContentType) {
         requestContentType = "application/json";
       }
-      const result = await callSubnetSurface(surface, {
-        query:
-          args.query && typeof args.query === "object" ? args.query : undefined,
-        path: hasPath ? args.path : undefined,
-        method: hasPath ? normalizedMethod : undefined,
-        body: requestBody,
-        contentType: requestContentType,
-        credential: credentialPlacement,
-        fetchImpl: globalThis.fetch,
-        isUnsafeUrl: workerResolvedUrlSafetyGuard({
+      const result = await callSubnetSurface(
+        surface as unknown as Parameters<typeof callSubnetSurface>[0],
+        {
+          query:
+            args.query && typeof args.query === "object"
+              ? args.query
+              : undefined,
+          path: hasPath ? args.path : undefined,
+          method: hasPath ? normalizedMethod : undefined,
+          body: requestBody,
+          contentType: requestContentType,
+          credential: credentialPlacement,
           fetchImpl: globalThis.fetch,
-        }),
-      });
+          isUnsafeUrl: workerResolvedUrlSafetyGuard({
+            fetchImpl: globalThis.fetch,
+          }),
+        },
+      );
       if (!result.ok) {
         if (
           result.unsafe_url ||
@@ -11430,7 +11529,7 @@ export const MCP_TOOLS = [
         data: {},
       },
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       if (typeof args?.query_id !== "string" || !args.query_id) {
         throw toolError("invalid_params", "Argument `query_id` is required.");
       }
@@ -11481,7 +11580,7 @@ export const MCP_TOOLS = [
         args: { type: "object" },
       },
     },
-    async handler(args) {
+    async handler(args: Row) {
       if (
         typeof args?.to !== "string" ||
         !/^0x[0-9a-fA-F]{40}$/.test(args.to)
@@ -11541,7 +11640,7 @@ export const MCP_TOOLS = [
         queried_at: { type: ["string", "null"] },
       },
     },
-    async handler(args, ctx) {
+    async handler(args: Row, ctx: McpCtx) {
       if (typeof args?.h160 !== "string" || !H160_PATTERN.test(args.h160)) {
         throw toolError(
           "invalid_params",
@@ -15664,8 +15763,9 @@ const TOOL_OUTPUT_SCHEMAS = {
 };
 
 export function listToolDefinitions() {
-  return MCP_TOOLS.map((tool) => {
-    const outputSchema = tool.outputSchema || TOOL_OUTPUT_SCHEMAS[tool.name];
+  return MCP_TOOLS.map((tool: Row) => {
+    const outputSchema =
+      tool.outputSchema || (TOOL_OUTPUT_SCHEMAS as Row)[tool.name];
     return {
       name: tool.name,
       title: tool.title,
@@ -15802,20 +15902,26 @@ const FIXED_RESOURCES = [
 // no change signal, so subscribing to one would accept silently and then
 // never fire. Checked in the resources/subscribe dispatch case below.
 // #6034: also metagraph://subnet/{netuid}/status (predicate, not a fixed set).
-function isSubscribableResourceUri(uri) {
+function isSubscribableResourceUri(uri: string) {
   return isSubscribableMcpResourceUri(uri);
 }
 
 const RESOURCE_PAGE_SIZE = 100;
 
-function resourceEntry(uri, name, title, description, mimeType) {
+function resourceEntry(
+  uri: string,
+  name: string,
+  title: string,
+  description: string,
+  mimeType: string,
+) {
   return { uri, name, title, description, mimeType };
 }
 
 // Build the full ordered resource list from the registry indexes — the same
 // artifacts the tools read, so resources never drift from tools. A missing index
 // degrades gracefully (that section is omitted rather than erroring the list).
-async function listAllResources(ctx) {
+async function listAllResources(ctx: McpCtx) {
   const out = FIXED_RESOURCES.map((r) =>
     resourceEntry(r.uri, r.name, r.title, r.description, r.mimeType),
   );
@@ -15876,23 +15982,23 @@ async function listAllResources(ctx) {
   return out;
 }
 
-function decodeResourceCursor(cursor) {
+function decodeResourceCursor(cursor: unknown) {
   if (cursor == null) return 0;
   const n = Number.parseInt(String(cursor), 10);
   return Number.isInteger(n) && n >= 0 ? n : 0;
 }
 
-async function listResources(params, ctx) {
+async function listResources(params: Row, ctx: McpCtx) {
   const all = await listAllResources(ctx);
   const start = decodeResourceCursor(params?.cursor);
   const page = all.slice(start, start + RESOURCE_PAGE_SIZE);
   const next = start + RESOURCE_PAGE_SIZE;
-  const result = { resources: page };
+  const result: Row = { resources: page };
   if (next < all.length) result.nextCursor = String(next);
   return result;
 }
 
-function parseResourceUri(uri) {
+function parseResourceUri(uri: string) {
   if (typeof uri !== "string" || !uri.startsWith("metagraph://")) return null;
   const rest = uri.slice("metagraph://".length);
   const slash = rest.indexOf("/");
@@ -15904,7 +16010,7 @@ function parseResourceUri(uri) {
 
 // Map a metagraph:// URI to its backing artifact path, validating each id so it
 // cannot escape its R2 namespace (the id is part of the R2 key).
-function resourceArtifactPath(uri) {
+function resourceArtifactPath(uri: string) {
   const fixed = FIXED_RESOURCES.find((r) => r.uri === uri);
   if (fixed) return fixed.artifact;
   const parsed = parseResourceUri(uri);
@@ -15930,7 +16036,7 @@ function resourceArtifactPath(uri) {
 // (binding absent in local/CI, or genuinely no chain event has landed since
 // the hub last cold-started) -- a subscribed client's first resources/read
 // after subscribing is a normal, expected case, not a fault.
-async function readLiveChainStreamResource(ctx) {
+async function readLiveChainStreamResource(ctx: McpCtx) {
   if (!ctx.env.CHAIN_FIREHOSE_HUB) {
     return {
       table: null,
@@ -15947,7 +16053,7 @@ async function readLiveChainStreamResource(ctx) {
   return payload ?? { table: null, message: "no chain event observed yet" };
 }
 
-async function readSubnetStatusResource(ctx, netuid) {
+async function readSubnetStatusResource(ctx: McpCtx, netuid: number) {
   const [live, reliability] = await Promise.all([
     mcpLiveHealth(ctx),
     loadSubnetReliability(),
@@ -15967,7 +16073,7 @@ async function readSubnetStatusResource(ctx, netuid) {
   };
 }
 
-async function readResource(params, ctx) {
+async function readResource(params: Row, ctx: McpCtx) {
   const uri = params?.uri;
   if (uri === MCP_CHAIN_STREAM_RESOURCE_URI) {
     const data = await readLiveChainStreamResource(ctx);
@@ -16010,7 +16116,7 @@ async function readResource(params, ctx) {
 // mirroring the lesson from this session's graphql-ws fix
 // (validateChainEventsSubscribePayload) -- a hand-rolled second validation
 // path is exactly how a security guarantee quietly drifts from the first.
-async function subscribeResource(params, ctx) {
+async function subscribeResource(params: Row, ctx: McpCtx) {
   const uri = params?.uri;
   if (typeof uri !== "string" || !isSubscribableResourceUri(uri)) {
     throw toolError(
@@ -16050,7 +16156,7 @@ async function subscribeResource(params, ctx) {
   return {};
 }
 
-async function unsubscribeResource(params, ctx) {
+async function unsubscribeResource(params: Row, ctx: McpCtx) {
   const uri = params?.uri;
   if (typeof uri !== "string") {
     throw toolError("invalid_params", "Missing required field: uri.");
@@ -16095,7 +16201,7 @@ export const MCP_PROMPTS = [
         required: true,
       },
     ],
-    build: (a) =>
+    build: (a: Row) =>
       `Integrate with Bittensor subnet ${a.netuid} using the metagraphed tools, in order:\n` +
       `1. get_subnet { netuid: ${a.netuid} } — identity + surface overview.\n` +
       `2. list_subnet_apis { netuid: ${a.netuid} } — callable services with base URL, auth, schema URL, health.\n` +
@@ -16115,7 +16221,7 @@ export const MCP_PROMPTS = [
         required: true,
       },
     ],
-    build: (a) =>
+    build: (a: Row) =>
       `Find Bittensor subnets that can do: "${a.task}". Use the metagraphed tools:\n` +
       `1. find_subnet_for_task { task: ${JSON.stringify(a.task)} } — goal-matched callable subnets.\n` +
       `2. semantic_search { q: ${JSON.stringify(a.task)} } — broader meaning-based discovery if needed.\n` +
@@ -16130,7 +16236,7 @@ export const MCP_PROMPTS = [
     arguments: [
       { name: "netuid", description: "The subnet netuid.", required: true },
     ],
-    build: (a) =>
+    build: (a: Row) =>
       `Assess operational health + fallbacks for subnet ${a.netuid}:\n` +
       `1. get_subnet_health { netuid: ${a.netuid} } — per-surface status, latency, reliability.\n` +
       `2. get_best_rpc_endpoint {} — a live-healthy Bittensor base-layer RPC endpoint to fall back to.\n` +
@@ -16149,7 +16255,7 @@ export function listPromptDefinitions() {
   }));
 }
 
-function getPrompt(params) {
+function getPrompt(params: Row) {
   const prompt = PROMPTS_BY_NAME.get(params?.name);
   if (!prompt) {
     throw toolError(
@@ -16174,8 +16280,8 @@ function getPrompt(params) {
   };
 }
 
-function negotiateProtocol(requested) {
-  return MCP_PROTOCOL_VERSIONS.includes(requested)
+function negotiateProtocol(requested: unknown) {
+  return MCP_PROTOCOL_VERSIONS.includes(requested as string)
     ? requested
     : MCP_LATEST_PROTOCOL;
 }
@@ -16196,7 +16302,7 @@ function negotiateProtocol(requested) {
 // but only after recordMcpToolCallEvent (src/usage-telemetry.ts) redacts and
 // size-caps them; see that module's header comment for why (no SDK
 // instrument() wrapper here, so no default redaction pipeline either).
-async function callTool(params, ctx) {
+async function callTool(params: Row, ctx: McpCtx) {
   const startedAt = Date.now();
   const result = await dispatchTool(params, ctx);
   const durationMs = Date.now() - startedAt;
@@ -16232,7 +16338,7 @@ async function callTool(params, ctx) {
  * @param {object} ctx
  * @param {object} event
  */
-function scheduleToolUsageEvent(ctx, event) {
+function scheduleToolUsageEvent(ctx: McpCtx, event: Row) {
   try {
     if (!isUsageTelemetryConfigured(ctx?.env)) return;
     const record = ctx?.recordUsageEvent ?? recordUsageEvent;
@@ -16243,7 +16349,7 @@ function scheduleToolUsageEvent(ctx, event) {
   }
 }
 
-function scheduleMcpToolCallEvent(ctx, event) {
+function scheduleMcpToolCallEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordMcpToolCallEvent ?? recordMcpToolCallEvent;
     const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
@@ -16253,7 +16359,7 @@ function scheduleMcpToolCallEvent(ctx, event) {
   }
 }
 
-function scheduleMcpInitializeEvent(ctx, event) {
+function scheduleMcpInitializeEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordMcpInitializeEvent ?? recordMcpInitializeEvent;
     const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
@@ -16266,7 +16372,7 @@ function scheduleMcpInitializeEvent(ctx, event) {
 // metagraphed#7758: PostHog $exception capture, parallel-run alongside the
 // existing Sentry.captureException at the same site below. Same
 // waitUntil/no-throw discipline as the schedulers above.
-function scheduleExceptionEvent(ctx, event) {
+function scheduleExceptionEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordExceptionEvent ?? recordExceptionEvent;
     const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
@@ -16276,7 +16382,7 @@ function scheduleExceptionEvent(ctx, event) {
   }
 }
 
-async function dispatchTool(params, ctx) {
+async function dispatchTool(params: Row, ctx: McpCtx) {
   const name = params?.name;
   const tool = typeof name === "string" ? TOOLS_BY_NAME.get(name) : undefined;
   if (!tool) {
@@ -16306,7 +16412,8 @@ async function dispatchTool(params, ctx) {
       structuredContent: data,
       isError: false,
     };
-  } catch (error) {
+  } catch (rawError) {
+    const error = rawError as Row;
     if (error?.toolError) {
       return {
         content: [{ type: "text", text: `${error.code}: ${error.message}` }],
@@ -16355,7 +16462,7 @@ async function dispatchTool(params, ctx) {
 
 // Dispatch a single JSON-RPC message. Returns the response object for requests,
 // or null for notifications (no id).
-async function dispatchMessage(message, ctx) {
+async function dispatchMessage(message: Row, ctx: McpCtx) {
   const isNotification =
     message === null ||
     typeof message !== "object" ||
@@ -16437,7 +16544,8 @@ async function dispatchMessage(message, ctx) {
           ? null
           : rpcError(id, RPC_METHOD_NOT_FOUND, `Unknown method: ${method}`);
     }
-  } catch (error) {
+  } catch (rawError) {
+    const error = rawError as Row;
     if (isNotification) return null;
     // A toolError thrown by a protocol method (resources/read, prompts/get) is a
     // bad-params condition, not an internal fault — surface it as -32602.
@@ -16450,16 +16558,16 @@ async function dispatchMessage(message, ctx) {
   }
 }
 
-function rpcResult(id, result) {
+function rpcResult(id: unknown, result: Row) {
   return { jsonrpc: JSONRPC_VERSION, id, result };
 }
 
-function rpcError(id, code, message) {
+function rpcError(id: unknown, code: number, message: string) {
   return { jsonrpc: JSONRPC_VERSION, id, error: { code, message } };
 }
 
 // Build the MCP processing context from the Worker request + injected deps.
-function buildContext(request, env, deps) {
+function buildContext(request: Request, env: Env, deps: Row) {
   let domain;
   try {
     domain = new URL(request.url).host || PRIMARY_DOMAIN;
@@ -16495,18 +16603,22 @@ const MCP_HEADERS = {
   "cache-control": "no-store",
 };
 
-function jsonResponse(payload, status = 200, headers = {}) {
+function jsonResponse(
+  payload: unknown,
+  status: number = 200,
+  headers: Row = {},
+) {
   return new Response(JSON.stringify(payload), {
     status,
     headers: { ...MCP_HEADERS, ...headers },
   });
 }
 
-function mcpClientKey(request) {
+function mcpClientKey(request: Request) {
   return resolveClientIp(request);
 }
 
-async function enforceMcpRateLimit(request, env) {
+async function enforceMcpRateLimit(request: Request, env: Env) {
   const limiter = env.MCP_RATE_LIMITER || env.RPC_RATE_LIMITER;
   if (!limiter?.limit) return null;
 
@@ -16548,7 +16660,7 @@ function bodyTooLargeResponse() {
 // than a shared helper since the two files' error-response shapes
 // (JSON-RPC vs GraphQL) differ enough that a shared abstraction would need
 // to take a response-builder callback for no real reuse benefit.
-async function readLimitedMcpBody(request) {
+async function readLimitedMcpBody(request: Request) {
   const declaredLength = Number(request.headers.get("content-length") || 0);
   if (Number.isFinite(declaredLength) && declaredLength > MAX_MCP_BODY_BYTES) {
     return { error: bodyTooLargeResponse() };
@@ -16600,7 +16712,7 @@ async function readLimitedMcpBody(request) {
 // only ever produces a response for a header that IS present and unrecognized
 // (which also correctly rejects a garbage value on `initialize` itself, since
 // a compliant client would never send one there).
-function validateMcpProtocolVersionHeader(request) {
+function validateMcpProtocolVersionHeader(request: Request) {
   const header = request.headers.get("mcp-protocol-version");
   if (!header || MCP_PROTOCOL_VERSIONS.includes(header)) return null;
   return jsonResponse(
@@ -16621,7 +16733,10 @@ function validateMcpProtocolVersionHeader(request) {
 // requiring the header this mints, and all three necessarily come after an
 // initialize. Batched/legacy-array requests predate the 2025-06-18 session
 // concept and are left alone.
-function mintMcpSessionHeaderIfNeeded(body, response) {
+function mintMcpSessionHeaderIfNeeded(
+  body: Row | null,
+  response: Row | null,
+): Record<string, string> {
   if (Array.isArray(body) || body?.method !== "initialize") return {};
   if (!response || response.error) return {};
   return { "mcp-session-id": crypto.randomUUID() };
@@ -16639,7 +16754,7 @@ const MCP_STREAM_HUB_UNAVAILABLE_RESPONSE = new Response(null, {
 // bounded-duration stream rather than an indefinite hold, and why it is a
 // separate Durable Object from the realtime chain firehose. Every other MCP
 // method is POST-only and stateless; this is the one GET route.
-async function handleMcpStreamRequest(request, env) {
+async function handleMcpStreamRequest(request: Request, env: Env) {
   const versionError = validateMcpProtocolVersionHeader(request);
   if (versionError) return versionError;
 
@@ -16694,7 +16809,7 @@ async function handleMcpStreamRequest(request, env) {
 // DELETE /mcp -- explicit client-initiated session termination (spec-
 // optional; supporting it lets a well-behaved client release its
 // McpSessionHub promptly instead of waiting out MCP_SESSION_IDLE_TTL_MS).
-async function handleMcpTerminateRequest(request, env) {
+async function handleMcpTerminateRequest(request: Request, env: Env) {
   const rawSessionId = request.headers.get("mcp-session-id");
   if (!isValidMcpSessionId(rawSessionId)) {
     return jsonResponse(
@@ -16737,7 +16852,11 @@ async function handleMcpTerminateRequest(request, env) {
 // artifact/KV readers from workers/api.mjs. POST carries the stateless
 // JSON-RPC 2.0 envelope; GET opens the SSE push stream; DELETE terminates a
 // session (see the two handlers above for both).
-export async function handleMcpRequest(request, env = {}, deps = {}) {
+export async function handleMcpRequest(
+  request: Request,
+  env: Env = {} as unknown as Env,
+  deps: Row = {},
+) {
   const rateLimitResponse = await enforceMcpRateLimit(request, env);
   if (rateLimitResponse) return rateLimitResponse;
 

--- a/tests/404-gen-call-subnet-surface-verify.test.ts
+++ b/tests/404-gen-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-17-404-gen-health";
@@ -110,7 +110,7 @@ describe("SN17 404-GEN call_subnet_surface verification (#7033)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/adapter-candidates-mcp.test.ts
+++ b/tests/adapter-candidates-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   adapterCandidatesQueryUrl,
   loadAdapterCandidatesList,
 } from "../src/adapter-candidates-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
 

--- a/tests/adapters-mcp.test.ts
+++ b/tests/adapters-mcp.test.ts
@@ -10,7 +10,7 @@ import {
   loadAdapter,
   parseAdapterSlug,
 } from "../src/adapters-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
 

--- a/tests/adtao-call-subnet-surface-verify.test.ts
+++ b/tests/adtao-call-subnet-surface-verify.test.ts
@@ -21,7 +21,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const registry: Row = JSON.parse(
@@ -140,7 +140,7 @@ for (const { id, url, kind, body } of CASES) {
               },
             }),
           }),
-          {},
+          {} as unknown as Env,
           deps,
         );
         const result = ((await response.json()) as Row).result;

--- a/tests/affine-call-subnet-surface-verify.test.ts
+++ b/tests/affine-call-subnet-surface-verify.test.ts
@@ -39,7 +39,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const NETUID = 120;
@@ -95,7 +95,7 @@ async function callThroughMcpTool(surface: Row, spec: Row) {
           },
         }),
       }),
-      {},
+      {} as unknown as Env,
       deps,
     );
     return ((await httpResponse.json()) as Row).result;

--- a/tests/agent-resources-mcp.test.ts
+++ b/tests/agent-resources-mcp.test.ts
@@ -9,7 +9,7 @@ import {
   agentResourcesToolError,
   loadAgentResources,
 } from "../src/agent-resources-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
 

--- a/tests/albedo-call-subnet-surface-verify.test.ts
+++ b/tests/albedo-call-subnet-surface-verify.test.ts
@@ -21,7 +21,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const NETUID = 97;
@@ -127,7 +127,7 @@ function verifySurface({
               },
             }),
           }),
-          {},
+          {} as unknown as Env,
           deps,
         );
         const result = ((await response.json()) as Row).result;

--- a/tests/allways-call-subnet-surface-verify.test.ts
+++ b/tests/allways-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "allways-api-health";
@@ -110,7 +110,7 @@ describe("SN7 Allways call_subnet_surface verification (#7023)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/almanac-call-subnet-surface-verify.test.ts
+++ b/tests/almanac-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-41-almanac-subnet-api";
@@ -110,7 +110,7 @@ describe("SN41 Almanac call_subnet_surface verification (#7055)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/alpharidge-ai-call-subnet-surface-verify.test.ts
+++ b/tests/alpharidge-ai-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-45-talisman-health";
@@ -112,7 +112,7 @@ describe("SN45 SN45 call_subnet_surface verification (#7059)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/apex-call-subnet-surface-verify.test.ts
+++ b/tests/apex-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-1-apex-healthcheck-ready";
@@ -113,7 +113,7 @@ describe("SN1 SN1 call_subnet_surface verification (#7017)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/astrid-call-subnet-surface-verify.test.ts
+++ b/tests/astrid-call-subnet-surface-verify.test.ts
@@ -27,7 +27,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const NETUID = 127;
@@ -83,7 +83,7 @@ async function callThroughMcpTool(surface: Row, spec: Row) {
           },
         }),
       }),
-      {},
+      {} as unknown as Env,
       deps,
     );
     return ((await httpResponse.json()) as Row).result;

--- a/tests/aurelius-call-subnet-surface-verify.test.ts
+++ b/tests/aurelius-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-37-aurelius-subnet-api";
@@ -115,7 +115,7 @@ describe("SN37 Aurelius call_subnet_surface verification (#7052)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/basilica-call-subnet-surface-verify.test.ts
+++ b/tests/basilica-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-39-basilica-subnet-api";
@@ -112,7 +112,7 @@ describe("SN39 Basilica call_subnet_surface verification (#7053)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/bitads-call-subnet-surface-verify.test.ts
+++ b/tests/bitads-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-16-taomarketcap-subnet-api";
@@ -124,7 +124,7 @@ describe("SN16 BitAds call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/bitcast-call-subnet-surface-verify.test.ts
+++ b/tests/bitcast-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-93-bitcast-health";
@@ -110,7 +110,7 @@ describe("SN93 SN93 call_subnet_surface verification (#7105)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/bitsota-call-subnet-surface-verify.test.ts
+++ b/tests/bitsota-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-94-bitsota-healthz";
@@ -110,7 +110,7 @@ describe("SN94 SN94 call_subnet_surface verification (#7106)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/blockmachine-call-subnet-surface-verify.test.ts
+++ b/tests/blockmachine-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-19-blockmachine-health";
@@ -112,7 +112,7 @@ describe("SN19 SN19 call_subnet_surface verification (#7035)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/build-mcp.test.ts
+++ b/tests/build-mcp.test.ts
@@ -9,7 +9,7 @@ import {
   buildToolError,
   loadBuildSummary,
 } from "../src/build-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/cacheon-call-subnet-surface-verify.test.ts
+++ b/tests/cacheon-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-14-cacheon-evaluations";
@@ -110,7 +110,7 @@ describe("SN14 SN14 call_subnet_surface verification (#7030)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -9,7 +9,7 @@
 // validation, error-code mapping) end-to-end through the real JSON-RPC path.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 import type { Row } from "./row-type.ts";
 
@@ -388,7 +388,7 @@ async function callTool(args: Row, fetchImpl?: typeof fetch) {
           params: { name: "call_subnet_surface", arguments: args },
         }),
       }),
-      {},
+      {} as unknown as Env,
       deps,
     );
     return ((await response.json()) as Row).result;
@@ -1426,7 +1426,7 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
               },
             }),
           }),
-          { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" },
+          { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" } as unknown as Env,
           {
             ...deps,
             executionCtx: { waitUntil: (p: Row) => p },
@@ -1475,7 +1475,7 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
             },
           }),
         }),
-        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" },
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" } as unknown as Env,
         {
           ...deps,
           executionCtx: { waitUntil: (p: Row) => p },

--- a/tests/call-subnet-surface-sn116.test.ts
+++ b/tests/call-subnet-surface-sn116.test.ts
@@ -15,7 +15,7 @@
 // is caught.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 // The SN116 TaoMarketCap surface exactly as the build emits it into
@@ -93,7 +93,7 @@ async function callSn116Surface(surfaceId: string) {
           },
         }),
       }),
-      {},
+      {} as unknown as Env,
       deps,
     );
     return ((await response.json()) as Row).result;

--- a/tests/call-subnet-surface-sn91.test.ts
+++ b/tests/call-subnet-surface-sn91.test.ts
@@ -12,7 +12,7 @@
 // regression in the tool or in the surface's registry config is caught.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 // The SN91 health surface exactly as the build emits it into
@@ -78,7 +78,7 @@ async function callSn91Surface(surfaceId: string) {
           },
         }),
       }),
-      {},
+      {} as unknown as Env,
       deps,
     );
     return ((await response.json()) as Row).result;

--- a/tests/candidates-mcp.test.ts
+++ b/tests/candidates-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   candidatesQueryUrl,
   loadCandidatesList,
 } from "../src/candidates-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 type CandidatesCtx = Parameters<typeof loadCandidatesList>[0];
@@ -396,7 +396,7 @@ describe("candidates-mcp (#7889)", () => {
   test("MCP server exports wire list_candidates with new filters", () => {
     assert.match(MCP_INSTRUCTIONS, /list_candidates/);
     assert.match(LIST_CANDIDATES_INSTRUCTIONS, /id\/confidence/);
-    const tool = MCP_TOOLS.find((t) => t.name === "list_candidates");
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_candidates");
     assert.ok(tool);
     assert.equal(tool.name, LIST_CANDIDATES_MCP_TOOL.name);
     assert.equal(tool.title, "List unpromoted candidate surfaces");

--- a/tests/changelog-mcp.test.ts
+++ b/tests/changelog-mcp.test.ts
@@ -9,7 +9,7 @@ import {
   changelogToolError,
   loadChangelog,
 } from "../src/changelog-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/chutes-call-subnet-surface-verify.test.ts
+++ b/tests/chutes-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-64-chutes-health";
@@ -110,7 +110,7 @@ describe("SN64 SN64 call_subnet_surface verification (#7077)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/cliqueai-call-subnet-surface-verify.test.ts
+++ b/tests/cliqueai-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-83-taomarketcap-subnet-api";
@@ -126,7 +126,7 @@ describe("SN83 CliqueAI call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/coldint-call-subnet-surface-verify.test.ts
+++ b/tests/coldint-call-subnet-surface-verify.test.ts
@@ -26,7 +26,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-29-coldint-competitions-api";
@@ -122,7 +122,7 @@ describe("SN29 Coldint call_subnet_surface verification (#7045)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/compelle-call-subnet-surface-verify.test.ts
+++ b/tests/compelle-call-subnet-surface-verify.test.ts
@@ -24,7 +24,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-82-compelle-health";
@@ -137,7 +137,7 @@ describe("SN82 Compelle call_subnet_surface verification (#7095)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/compute-horde-call-subnet-surface-verify.test.ts
+++ b/tests/compute-horde-call-subnet-surface-verify.test.ts
@@ -18,7 +18,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-12-compute-horde-grafana-openapi";
@@ -130,7 +130,7 @@ describe("SN12 Compute Horde call_subnet_surface verification (#7028)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/connitoai-call-subnet-surface-verify.test.ts
+++ b/tests/connitoai-call-subnet-surface-verify.test.ts
@@ -30,7 +30,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const registry = JSON.parse(
   readFileSync(
@@ -177,7 +177,7 @@ for (const { id, url, kind, schemaUrl, body } of CASES) {
               },
             }),
           }),
-          {},
+          {} as unknown as Env,
           deps,
         );
         const result = ((await response.json()) as Row).result;

--- a/tests/contracts-mcp.test.ts
+++ b/tests/contracts-mcp.test.ts
@@ -9,7 +9,7 @@ import {
   contractsToolError,
   loadContracts,
 } from "../src/contracts-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/curation-mcp.test.ts
+++ b/tests/curation-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   curationQueryUrl,
   loadCurationList,
 } from "../src/curation-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/desearch-call-subnet-surface-verify.test.ts
+++ b/tests/desearch-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-22-desearch-health";
 
@@ -112,7 +112,7 @@ describe("SN22 Desearch call_subnet_surface verification (#7038)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/discovery-artifacts.test.ts
+++ b/tests/discovery-artifacts.test.ts
@@ -11,7 +11,7 @@ import { Ajv2020 } from "ajv/dist/2020.js";
 import addFormatsPlugin from "ajv-formats";
 import { repoRoot, loadSubnets } from "../scripts/lib.ts";
 import { PRIMARY_DOMAIN } from "../src/contracts.ts";
-import { MCP_REGISTRY_NAME, MCP_SERVER_INFO } from "../src/mcp-server.mjs";
+import { MCP_REGISTRY_NAME, MCP_SERVER_INFO } from "../src/mcp-server.ts";
 import { mcpServerCardResponse } from "../workers/request-handlers/discovery.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/djinn-call-subnet-surface-verify.test.ts
+++ b/tests/djinn-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-103-djinn-health";
 
@@ -110,7 +110,7 @@ describe("SN103 SN103 call_subnet_surface verification (#7115)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/docs-content-drift.test.ts
+++ b/tests/docs-content-drift.test.ts
@@ -16,7 +16,7 @@ import {
   GRAPHQL_MAX_DEPTH,
   GRAPHQL_MAX_QUERY_BYTES,
   MAX_PAGE_LIMIT,
-} from "../src/graphql.mjs";
+} from "../src/graphql.ts";
 import {
   DENIED_RPC_PREFIXES,
   MAX_RPC_BODY_BYTES,
@@ -68,7 +68,7 @@ function wranglerRateLimit(name: string) {
   return { limit: Number(match[1]), period: Number(match[2]) };
 }
 
-describe("content/docs/graphql.mdx matches src/graphql.mjs", () => {
+describe("content/docs/graphql.mdx matches src/graphql.ts", () => {
   test("limits table", () => {
     assert.equal(
       tableValue(graphqlDocs, "Max depth"),

--- a/tests/dojo-call-subnet-surface-verify.test.ts
+++ b/tests/dojo-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-52-taomarketcap-subnet-api";
 const NETUID = 52;
@@ -124,7 +124,7 @@ describe("SN52 Dojo call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/dsperse-call-subnet-surface-verify.test.ts
+++ b/tests/dsperse-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-2-dsperse-circuit-list";
@@ -110,7 +110,7 @@ describe("SN2 SN2 call_subnet_surface verification (#7018)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/eirel-call-subnet-surface-verify.test.ts
+++ b/tests/eirel-call-subnet-surface-verify.test.ts
@@ -30,7 +30,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-36-eirel-metagraph-status";
 
@@ -141,7 +141,7 @@ describe("SN36 (Eirel) call_subnet_surface verification (#7051)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/endpoint-incidents-mcp.test.ts
+++ b/tests/endpoint-incidents-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   endpointIncidentsQueryUrl,
   loadEndpointIncidentsList,
 } from "../src/endpoint-incidents-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/endpoint-pools-mcp.test.ts
+++ b/tests/endpoint-pools-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   endpointPoolsQueryUrl,
   loadEndpointPoolsList,
 } from "../src/endpoint-pools-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/endure-network-call-subnet-surface-verify.test.ts
+++ b/tests/endure-network-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-30-taomarketcap-subnet-api";
 const NETUID = 30;
@@ -126,7 +126,7 @@ describe("SN30 Endure Network call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/eni-call-subnet-surface-verify.test.ts
+++ b/tests/eni-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-101-taomarketcap-subnet-api";
 const NETUID = 101;
@@ -124,7 +124,7 @@ describe("SN101 eni call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/enrichment-evidence-mcp.test.ts
+++ b/tests/enrichment-evidence-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   enrichmentEvidenceQueryUrl,
   loadEnrichmentEvidenceList,
 } from "../src/enrichment-evidence-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/enrichment-queue-mcp.test.ts
+++ b/tests/enrichment-queue-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   enrichmentQueueQueryUrl,
   loadEnrichmentQueueList,
 } from "../src/enrichment-queue-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/evidence-mcp.test.ts
+++ b/tests/evidence-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   evidenceQueryUrl,
   loadEvidenceList,
 } from "../src/evidence-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 

--- a/tests/forevermoney-call-subnet-surface-verify.test.ts
+++ b/tests/forevermoney-call-subnet-surface-verify.test.ts
@@ -25,7 +25,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 98;
 

--- a/tests/gaps-mcp.test.ts
+++ b/tests/gaps-mcp.test.ts
@@ -11,7 +11,7 @@ import {
   gapsQueryUrl,
   loadGapsList,
 } from "../src/gaps-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 type GapsCtx = Parameters<typeof loadGapsList>[0];

--- a/tests/global-operational-health.test.ts
+++ b/tests/global-operational-health.test.ts
@@ -8,7 +8,7 @@ import {
   loadGlobalOperationalHealth,
   unknownGlobalHealth,
 } from "../src/global-operational-health.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 type LoadCtx = Parameters<typeof loadGlobalOperationalHealth>[0];

--- a/tests/grail-call-subnet-surface-verify.test.ts
+++ b/tests/grail-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-81-grail-grafana-openapi";
 const OPENAPI_URL = "https://grail-grafana.tplr.ai/public/openapi3.json";
@@ -115,7 +115,7 @@ describe("SN81 Grail call_subnet_surface verification (#7094)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/graphql-sentry-and-error-code.test.ts
+++ b/tests/graphql-sentry-and-error-code.test.ts
@@ -37,7 +37,7 @@ const {
   handleGraphQLRequest,
   GRAPHQL_MAX_BODY_BYTES,
   GRAPHQL_MAX_QUERY_BYTES,
-} = await import("../src/graphql.mjs");
+} = await import("../src/graphql.ts");
 
 afterEach(() => {
   captureException.mockClear();
@@ -52,7 +52,7 @@ async function gql(query: string, env: Row = emptyEnv) {
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ query }),
   });
-  const res = await handleGraphQLRequest(req, env);
+  const res = await handleGraphQLRequest(req, env as unknown as Env);
   return { res, body: (await res.json()) as Row };
 }
 
@@ -249,7 +249,7 @@ test("every transport-level rejection carries its own error code, none reach Sen
   ];
 
   for (const { name, req, status, code } of cases) {
-    const res = await handleGraphQLRequest(req(), emptyEnv);
+    const res = await handleGraphQLRequest(req(), emptyEnv as unknown as Env);
     assert.equal(res.status, status, `${name}: status`);
     assert.equal(
       res.headers.get("x-metagraph-error-code"),

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -20,7 +20,7 @@ import {
   maxComplexityRule,
   maxDepthRule,
   schema as chainEventsSchema,
-} from "../src/graphql.mjs";
+} from "../src/graphql.ts";
 import { LEADERBOARD_BOARDS } from "../src/health-serving.ts";
 import { CHAIN_PROMETHEUS_WINDOWS } from "../src/chain-prometheus.ts";
 import { CHAIN_SIGNERS_SORTS } from "../src/chain-query-loaders.ts";
@@ -35,18 +35,19 @@ import {
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
 } from "../src/kv-keys.ts";
+import type { AnyFn, Row } from "./row-type.ts";
 
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
-const emptyEnv = {};
+const emptyEnv: Row = {};
 
-async function gql(query, env = emptyEnv, extras = {}) {
+async function gql(query: string, env: Row = emptyEnv, extras: Row = {}) {
   const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ query, ...extras }),
   });
-  const res = await handleGraphQLRequest(req, env);
-  return { status: res.status, body: await res.json() };
+  const res = await handleGraphQLRequest(req, env as unknown as Env);
+  return { status: res.status, body: (await res.json()) as Row };
 }
 
 // Inject synthetic artifacts (R2) and optional live KV tiers (health:current,
@@ -54,11 +55,11 @@ async function gql(query, env = emptyEnv, extras = {}) {
 // `kvReads` record per-key access counts so tests can prove per-request read
 // memoization. GraphQL source paths are R2-only; fixtures are keyed by full
 // artifact path, e.g. "/metagraph/subnets.json". `kv` maps KV keys to values.
-function fixtureEnv(fixtures = {}, { reads, kv, kvReads } = {}) {
-  const env = {
+function fixtureEnv(fixtures: Row = {}, { reads, kv, kvReads }: Row = {}) {
+  const env: Row = {
     METAGRAPH_R2_LATEST_PREFIX: "latest/",
     METAGRAPH_ARCHIVE: {
-      async get(key) {
+      async get(key: string) {
         if (reads) reads.set(key, (reads.get(key) || 0) + 1);
         const path = "/metagraph/" + key.replace(/^latest\//, "");
         const data = fixtures[path];
@@ -74,7 +75,7 @@ function fixtureEnv(fixtures = {}, { reads, kv, kvReads } = {}) {
   };
   if (kv) {
     env.METAGRAPH_CONTROL = {
-      async get(key) {
+      async get(key: string) {
         if (kvReads) kvReads.set(key, (kvReads.get(key) || 0) + 1);
         return Object.hasOwn(kv, key) ? kv[key] : null;
       },
@@ -86,7 +87,7 @@ function fixtureEnv(fixtures = {}, { reads, kv, kvReads } = {}) {
 describe("handleGraphQLRequest — method guard", () => {
   test("GET publishes the SDL document (discoverability)", async () => {
     const req = new Request("https://api.metagraph.sh/api/v1/graphql");
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 200);
     assert.match(res.headers.get("content-type") || "", /application\/graphql/);
     assert.equal(res.headers.get("allow"), "GET, POST");
@@ -102,9 +103,9 @@ describe("handleGraphQLRequest — method guard", () => {
     const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
       method: "PUT",
     });
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 405);
-    const body = await res.json();
+    const body = (await res.json()) as Row;
     assert.ok(body.errors[0].message.includes("POST"));
     assert.equal(res.headers.get("allow"), "GET, POST");
   });
@@ -117,7 +118,7 @@ describe("handleRequest — GraphQL routing", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ query: "{ __typename }" }),
     });
-    const res = await handleRequest(req, emptyEnv, {});
+    const res = await handleRequest(req, emptyEnv as unknown as Env, {});
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("allow"), null);
     assert.deepEqual(await res.json(), { data: { __typename: "Query" } });
@@ -128,7 +129,7 @@ describe("handleRequest — GraphQL routing", () => {
       new Request("https://api.metagraph.sh/api/v1/graphql", {
         method: "OPTIONS",
       }),
-      emptyEnv,
+      emptyEnv as unknown as Env,
       {},
     );
     assert.equal(res.status, 204);
@@ -141,7 +142,7 @@ describe("handleRequest — GraphQL routing", () => {
   test("GET /api/v1/graphql through the router returns the SDL", async () => {
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/graphql"),
-      emptyEnv,
+      emptyEnv as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -157,9 +158,9 @@ describe("handleGraphQLRequest — request validation", () => {
       headers: { "content-type": "application/json" },
       body: "not json",
     });
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 400);
-    const body = await res.json();
+    const body = (await res.json()) as Row;
     assert.ok(body.errors[0].message.includes("JSON"));
   });
 
@@ -172,9 +173,9 @@ describe("handleGraphQLRequest — request validation", () => {
       },
       body: JSON.stringify({ query: "{ __typename }" }),
     });
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 413);
-    const body = await res.json();
+    const body = (await res.json()) as Row;
     assert.ok(body.errors[0].message.includes("body"));
   });
 
@@ -184,10 +185,10 @@ describe("handleGraphQLRequest — request validation", () => {
       headers: { "content-type": "application/json" },
       body: new Blob([" ".repeat(GRAPHQL_MAX_BODY_BYTES + 1)]).stream(),
       duplex: "half",
-    });
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    } as unknown as RequestInit);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 413);
-    const body = await res.json();
+    const body = (await res.json()) as Row;
     assert.ok(body.errors[0].message.includes("body"));
   });
 
@@ -199,14 +200,14 @@ describe("handleGraphQLRequest — request validation", () => {
         query: `# ${"x".repeat(GRAPHQL_MAX_QUERY_BYTES)}\n{ __typename }`,
       }),
     });
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 413);
-    const body = await res.json();
+    const body = (await res.json()) as Row;
     assert.ok(body.errors[0].message.includes("query"));
   });
 
   test("missing query field returns 400", async () => {
-    const { status, body } = await gql(undefined);
+    const { status, body } = await gql(undefined as unknown as string);
     assert.equal(status, 400);
     assert.ok(body.errors[0].message.includes("query"));
   });
@@ -245,7 +246,7 @@ describe("handleGraphQLRequest — validation rules", () => {
     const { status, body } = await gql(deep);
     assert.equal(status, 400);
     const ext = body.errors.find(
-      (e) => e.extensions?.code === "DEPTH_LIMIT_EXCEEDED",
+      (e: Row) => e.extensions?.code === "DEPTH_LIMIT_EXCEEDED",
     );
     assert.ok(
       ext,
@@ -279,7 +280,9 @@ describe("handleGraphQLRequest — validation rules", () => {
     );
     assert.equal(status, 400);
     assert.ok(
-      body.errors.find((e) => e.extensions?.code === "DEPTH_LIMIT_EXCEEDED"),
+      body.errors.find(
+        (e: Row) => e.extensions?.code === "DEPTH_LIMIT_EXCEEDED",
+      ),
       `expected DEPTH_LIMIT_EXCEEDED, got: ${JSON.stringify(body.errors)}`,
     );
   });
@@ -295,7 +298,7 @@ describe("handleGraphQLRequest — validation rules", () => {
     const { status, body } = await gql(q);
     assert.equal(status, 400);
     const ext = body.errors.find(
-      (e) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
+      (e: Row) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
     );
     assert.ok(
       ext,
@@ -315,7 +318,7 @@ describe("handleGraphQLRequest — validation rules", () => {
     const { status, body } = await gql(q);
     assert.equal(status, 400);
     const ext = body.errors.find(
-      (e) => e.extensions?.code === "DEPTH_LIMIT_EXCEEDED",
+      (e: Row) => e.extensions?.code === "DEPTH_LIMIT_EXCEEDED",
     );
     assert.ok(
       ext,
@@ -332,7 +335,7 @@ describe("handleGraphQLRequest — validation rules", () => {
     const { status, body } = await gql(q);
     assert.equal(status, 400);
     const ext = body.errors.find(
-      (e) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
+      (e: Row) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
     );
     assert.ok(
       ext,
@@ -364,7 +367,7 @@ describe("handleGraphQLRequest — validation rules", () => {
     assert.equal(over.status, 400);
     assert.ok(
       over.body.errors.find(
-        (e) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
+        (e: Row) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
       ),
     );
   });
@@ -399,7 +402,7 @@ describe("handleGraphQLRequest — validation rules", () => {
     const { status, body } = await gql(`{ ${fields} }`);
     assert.equal(status, 400);
     const ext = body.errors.find(
-      (e) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
+      (e: Row) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
     );
     assert.ok(
       ext,
@@ -420,7 +423,7 @@ describe("handleGraphQLRequest — introspection", () => {
       '{ __type(name: "Subnet") { fields { name } } }',
     );
     assert.equal(status, 200);
-    const names = body.data.__type.fields.map((f) => f.name);
+    const names = body.data.__type.fields.map((f: Row) => f.name);
     assert.ok(names.includes("netuid"), `expected netuid, got: ${names}`);
     assert.ok(names.includes("name"), `expected name, got: ${names}`);
   });
@@ -476,7 +479,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       "{ subnets { items { netuid name slug } total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnets.total, 2);
@@ -496,7 +499,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       "{ subnets(limit: 2) { items { netuid } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnets.items.length, 2);
@@ -517,7 +520,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     for (const limit of [0, -5]) {
       const { status, body } = await gql(
         `{ subnets(limit: ${limit}) { items { netuid } total } }`,
-        env,
+        env as unknown as Env,
       );
       assert.equal(status, 200);
       assert.equal(body.data.subnets.items.length, 3, `limit:${limit}`);
@@ -537,7 +540,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       "{ subnets(netuid: 2) { items { netuid name } total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnets.total, 1);
@@ -556,12 +559,12 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       '{ subnets(status: "Active") { items { netuid } total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnets.total, 2);
     assert.deepEqual(
-      body.data.subnets.items.map((row) => row.netuid),
+      body.data.subnets.items.map((row: Row) => row.netuid),
       [1, 3],
     );
   });
@@ -577,7 +580,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       '{ subnets(status: "active") { items { netuid } total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnets.total, 1);
@@ -611,7 +614,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       '{ subnets(domain: "training") { items { netuid } total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnets.total, 1);
@@ -628,7 +631,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       "{ subnet(netuid: 7) { netuid name slug } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnet.netuid, 7);
@@ -666,7 +669,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
         gap_count
         first_party
       } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const s = body.data.subnet;
@@ -686,7 +689,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       "{ providers { items { id netuids } total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.providers.items[0].netuids, []);
@@ -698,7 +701,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       '{ provider(id: "acme-1.0") { id name } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.provider.name, "Acme");
@@ -721,7 +724,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     for (const id of ["../subnets", "../../economics", "a/b", "foo bar", ""]) {
       const { status, body } = await gql(
         `{ provider(id: ${JSON.stringify(id)}) { id name } }`,
-        env,
+        env as unknown as Env,
       );
       assert.equal(status, 200, id);
       assert.equal(body.data.provider, null, id);
@@ -739,7 +742,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       "{ economics { total subnets { netuid name emission_share miner_count } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.economics.total, 1);
@@ -769,7 +772,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
           total_root_value_tao total_alpha_value_tao total_network_value_tao
           subnet_count
         } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.economics.summary, {
@@ -788,7 +791,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     });
     const { status, body } = await gql(
       "{ economics { summary { subnet_count } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.economics.summary, null);
@@ -796,7 +799,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
 });
 
 describe("handleGraphQLRequest — error envelope is never cacheable", () => {
-  const post = (env) =>
+  const post = (env: Row) =>
     handleGraphQLRequest(
       new Request("https://api.metagraph.sh/api/v1/graphql", {
         method: "POST",
@@ -805,12 +808,12 @@ describe("handleGraphQLRequest — error envelope is never cacheable", () => {
           query: "{ subnets { items { netuid } total } }",
         }),
       }),
-      env,
+      env as unknown as Env,
     );
 
   test("a clean POST keeps the success cache directive", async () => {
     const res = await post(emptyEnv);
-    const body = await res.json();
+    const body = (await res.json()) as Row;
     assert.equal(res.status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(
@@ -835,7 +838,7 @@ describe("handleGraphQLRequest — error envelope is never cacheable", () => {
       },
     };
     const res = await post(env);
-    const body = await res.json();
+    const body = (await res.json()) as Row;
     assert.equal(res.status, 200);
     assert.ok(body.errors?.length > 0);
     assert.equal(res.headers.get("cache-control"), "no-store");
@@ -887,7 +890,7 @@ describe("handleGraphQLRequest — coverage edge cases", () => {
     });
     const { status, body } = await gql(
       '{ subnets(cursor: "999") { items { netuid } total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnets.items.length, 2);
@@ -920,7 +923,7 @@ describe("handleGraphQLRequest — coverage edge cases", () => {
     });
     const { status, body } = await gql(
       '{ provider(id: "acme") { netuids } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.provider.netuids, [1, 7]);
@@ -932,12 +935,12 @@ describe("handleGraphQLRequest — coverage edge cases", () => {
 // limiter binding. A counting limiter that allows the first N keyed hits and
 // denies the rest models the Cloudflare binding closely enough to prove the
 // gate fires on /api/v1/graphql.
-function countingRateLimiterEnv(limit, extra = {}) {
-  const counts = new Map();
+function countingRateLimiterEnv(limit: number, extra: Row = {}): Row {
+  const counts = new Map<string, number>();
   return {
     ...extra,
     RPC_RATE_LIMITER: {
-      limit({ key }) {
+      limit({ key }: { key: string }) {
         const next = (counts.get(key) || 0) + 1;
         counts.set(key, next);
         return Promise.resolve({ success: next <= limit });
@@ -946,14 +949,14 @@ function countingRateLimiterEnv(limit, extra = {}) {
   };
 }
 
-const gqlPost = (env, headers = {}) =>
+const gqlPost = (env: Row, headers = {}) =>
   handleRequest(
     new Request("https://api.metagraph.sh/api/v1/graphql", {
       method: "POST",
       headers: { "content-type": "application/json", ...headers },
       body: JSON.stringify({ query: "{ __typename }" }),
     }),
-    env,
+    env as unknown as Env,
     {},
   );
 
@@ -997,7 +1000,7 @@ describe("handleRequest — GraphQL rate limiting (#security)", () => {
       new Request("https://api.metagraph.sh/api/v1/graphql", {
         headers: { upgrade: "websocket" },
       }),
-      env,
+      env as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -1007,7 +1010,7 @@ describe("handleRequest — GraphQL rate limiting (#security)", () => {
 
 describe("client IP resolution — x-forwarded-for is not trusted (#security)", () => {
   test("resolveClientIp ignores x-forwarded-for, uses cf-connecting-ip only", () => {
-    const sameCf = (xff) =>
+    const sameCf = (xff: string) =>
       resolveClientIp(
         new Request("https://api.metagraph.sh/api/v1/graphql", {
           method: "POST",
@@ -1087,7 +1090,7 @@ describe("graphql — broadened Subnet + nested relationships", () => {
           surfaces { id kind status }
           endpoints { id kind status }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const s = body.data.subnet;
@@ -1124,7 +1127,7 @@ describe("graphql — broadened Subnet + nested relationships", () => {
     );
     const { status, body } = await gql(
       "{ subnet(netuid: 7) { netuid health { status ok_count surface_count } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnet.health.status, "ok");
@@ -1164,7 +1167,7 @@ describe("graphql — broadened Subnet + nested relationships", () => {
     );
     const { status, body } = await gql(
       "{ subnets { items { netuid economics { emission_share } health { status } } total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnets.total, 2);
@@ -1190,7 +1193,7 @@ describe("graphql — broadened Subnet + nested relationships", () => {
     });
     const { status, body } = await gql(
       '{ provider(id: "acme") { id netuids subnets { netuid name } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.provider.netuids, [2, 1]);
@@ -1213,7 +1216,7 @@ describe("graphql — broadened Subnet + nested relationships", () => {
     });
     const { status, body } = await gql(
       '{ provider(id: "acme") { id endpoints { id kind status netuid } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.provider.endpoints.length, 2);
@@ -1235,7 +1238,7 @@ describe("graphql — broadened Subnet + nested relationships", () => {
     });
     const { status, body } = await gql(
       '{ provider(id: "acme") { id endpoints { id } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.provider.endpoints, []);
@@ -1255,15 +1258,17 @@ describe("graphql — surfaces / endpoints / health roots", () => {
     });
     const filtered = await gql(
       "{ surfaces(netuid: 1) { items { id netuid } total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
     assert.equal(filtered.body.data.surfaces.total, 2);
-    assert.ok(filtered.body.data.surfaces.items.every((s) => s.netuid === 1));
+    assert.ok(
+      filtered.body.data.surfaces.items.every((s: Row) => s.netuid === 1),
+    );
 
     const paged = await gql(
       "{ surfaces(limit: 1) { items { id } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(paged.body.data.surfaces.items.length, 1);
     assert.equal(paged.body.data.surfaces.total, 3);
@@ -1281,7 +1286,7 @@ describe("graphql — surfaces / endpoints / health roots", () => {
     });
     const { status, body } = await gql(
       "{ endpoints(netuid: 6) { items { id status netuid } total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.endpoints.total, 1);
@@ -1299,13 +1304,13 @@ describe("graphql — surfaces / endpoints / health roots", () => {
     });
     const first = await gql(
       "{ endpoints(limit: 1) { items { status } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(first.body.data.endpoints.total, 2);
     assert.equal(first.body.data.endpoints.next_cursor, "x1");
     const second = await gql(
       '{ endpoints(limit: 1, cursor: "x1") { items { id } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(second.body.data.endpoints.items[0].id, "e2");
   });
@@ -1327,7 +1332,7 @@ describe("graphql — surfaces / endpoints / health roots", () => {
     );
     const { status, body } = await gql(
       "{ health { status ok_count surface_count health_source subnets { netuid status } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.health.status, "degraded");
@@ -1406,7 +1411,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     const env = fixtureEnv({ "/metagraph/endpoint-pools.json": POOLS_BLOB });
     const filtered = await gql(
       '{ endpoint_pools(kind: "archive") { pools total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
     assert.equal(filtered.body.data.endpoint_pools.total, 1);
@@ -1417,7 +1422,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
 
     const paged = await gql(
       "{ endpoint_pools(limit: 1) { pools total returned next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(paged.body.data.endpoint_pools.pools.length, 1);
     assert.equal(paged.body.data.endpoint_pools.total, 3);
@@ -1429,7 +1434,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     const env = fixtureEnv({ "/metagraph/endpoint-pools.json": POOLS_BLOB });
     const { body } = await gql(
       '{ endpoint_pools(kind: "bogus") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
   });
@@ -1444,7 +1449,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     const env = fixtureEnv({ "/metagraph/rpc/pools.json": POOLS_BLOB });
     const { status, body } = await gql(
       '{ rpc_pools(sort: "eligible_count", order: "desc") { pools total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.rpc_pools.total, 3);
@@ -1465,7 +1470,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     );
     const { body } = await gql(
       "{ rpc_pools { source operational_observed_at } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.data.rpc_pools.source, "live-cron-prober");
     assert.equal(
@@ -1478,7 +1483,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     const env = fixtureEnv({ "/metagraph/rpc/pools.json": POOLS_BLOB });
     const { body } = await gql(
       "{ rpc_pools { source operational_observed_at } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.data.rpc_pools.source, null);
     assert.equal(body.data.rpc_pools.operational_observed_at, null);
@@ -1490,7 +1495,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     });
     const { status, body } = await gql(
       '{ endpoint_incidents(severity: "critical") { incidents total summary } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.endpoint_incidents.total, 1);
@@ -1499,7 +1504,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
 
     const byNetuid = await gql(
       "{ endpoint_incidents(netuid: 31) { incidents total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(byNetuid.body.data.endpoint_incidents.total, 1);
     assert.equal(
@@ -1514,14 +1519,18 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     });
     const { body } = await gql(
       '{ endpoint_incidents(severity: "bogus") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
   });
 
   test("FIELD_COMPLEXITY weights all three new fields like their sibling relationship fields", () => {
     for (const field of ["endpoint_pools", "rpc_pools", "endpoint_incidents"]) {
-      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+      assert.equal(
+        (FIELD_COMPLEXITY as Row)[field],
+        5,
+        `${field} should be weighted`,
+      );
     }
   });
 });
@@ -1558,7 +1567,7 @@ describe("graphql — source_snapshots", () => {
     });
     const filtered = await gql(
       '{ source_snapshots(q: "chain") { sources total generated_at } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
     assert.equal(filtered.body.data.source_snapshots.total, 1);
@@ -1573,7 +1582,7 @@ describe("graphql — source_snapshots", () => {
 
     const paged = await gql(
       "{ source_snapshots(limit: 1) { sources total returned next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(paged.body.data.source_snapshots.sources.length, 1);
     assert.equal(paged.body.data.source_snapshots.total, 2);
@@ -1587,7 +1596,7 @@ describe("graphql — source_snapshots", () => {
     });
     const { status, body } = await gql(
       '{ source_snapshots(sort: "record_count", order: "desc") { sources summary schema_version } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.source_snapshots.sources[0].id, "chain-events");
@@ -1601,7 +1610,7 @@ describe("graphql — source_snapshots", () => {
     });
     const { body } = await gql(
       '{ source_snapshots(sort: "bogus") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
   });
@@ -1636,7 +1645,7 @@ describe("graphql — changelog", () => {
     const env = fixtureEnv({ "/metagraph/changelog.json": CHANGELOG_BLOB });
     const { status, body } = await gql(
       "{ changelog { generated_at source notes summary artifacts subnets coverage_delta } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const changelog = body.data.changelog;
@@ -1685,7 +1694,7 @@ describe("graphql — contracts", () => {
     const env = fixtureEnv({ "/metagraph/contracts.json": CONTRACTS_BLOB });
     const { status, body } = await gql(
       "{ contracts { schema_version contract_version generated_at name base_path primary_domain openapi_url type_definitions_url notes artifacts } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const contracts = body.data.contracts;
@@ -1736,7 +1745,7 @@ describe("graphql — build", () => {
     const env = fixtureEnv({ "/metagraph/build-summary.json": BUILD_BLOB });
     const { status, body } = await gql(
       "{ build { schema_version contract_version generated_at published_at artifact_count artifact_size_bytes subnet_count surface_count provider_count artifacts coverage artifact_budget_summary } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const build = body.data.build;
@@ -1792,7 +1801,7 @@ describe("graphql — health_history", () => {
     });
     const { status, body } = await gql(
       '{ health_history(date: "2026-07-01") { date summary surfaces total returned limit cursor next_cursor } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const history = body.data.health_history;
@@ -1803,7 +1812,7 @@ describe("graphql — health_history", () => {
 
     const paged = await gql(
       '{ health_history(date: "2026-07-01", limit: 1) { surfaces total returned next_cursor } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(paged.body.data.health_history.surfaces.length, 1);
     assert.equal(paged.body.data.health_history.total, 2);
@@ -1817,7 +1826,7 @@ describe("graphql — health_history", () => {
     });
     const filtered = await gql(
       '{ health_history(date: "2026-07-01", netuid: 1) { total surfaces } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(filtered.body.data.health_history.total, 1);
     assert.equal(
@@ -1827,7 +1836,7 @@ describe("graphql — health_history", () => {
 
     const sorted = await gql(
       '{ health_history(date: "2026-07-01", sort: "latency_ms", order: "desc") { surfaces sort order } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(sorted.body.data.health_history.surfaces[0].netuid, 1);
     assert.equal(sorted.body.data.health_history.sort, "latency_ms");
@@ -1840,7 +1849,7 @@ describe("graphql — health_history", () => {
     });
     const { body } = await gql(
       '{ health_history(date: "not-a-day") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
     assert.equal(body.data, null);
@@ -1852,7 +1861,7 @@ describe("graphql — health_history", () => {
     });
     const { body } = await gql(
       '{ health_history(date: "2026-07-01", status: "alive") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
   });
@@ -1863,7 +1872,7 @@ describe("graphql — health_history", () => {
     });
     const { body } = await gql(
       '{ health_history(date: "2026-07-02") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
     assert.equal(body.data, null);
@@ -1909,7 +1918,7 @@ describe("graphql — profiles", () => {
     const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
     const filtered = await gql(
       "{ profiles(netuid: 7) { profiles total captured_at } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
     assert.equal(filtered.body.data.profiles.total, 1);
@@ -1921,7 +1930,7 @@ describe("graphql — profiles", () => {
 
     const paged = await gql(
       "{ profiles(limit: 1) { profiles total returned next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(paged.body.data.profiles.profiles.length, 1);
     assert.equal(paged.body.data.profiles.total, 2);
@@ -1933,14 +1942,14 @@ describe("graphql — profiles", () => {
     const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
     const searched = await gql(
       '{ profiles(q: "alpha") { profiles total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(searched.body.data.profiles.total, 1);
     assert.equal(searched.body.data.profiles.profiles[0].slug, "alpha");
 
     const sorted = await gql(
       '{ profiles(sort: "completeness_score", order: "desc") { profiles } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(sorted.body.data.profiles.profiles[0].slug, "allways");
   });
@@ -1949,7 +1958,7 @@ describe("graphql — profiles", () => {
     const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
     const { body } = await gql(
       '{ profiles(curation_level: "bogus") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
   });
@@ -1968,7 +1977,7 @@ describe("graphql — profiles", () => {
 // #6977: block-scoped extrinsics/events/chain-events lists mirror the same
 // Postgres tier + schema-stable fallback the block/extrinsics feeds already use.
 describe("graphql — block_extrinsics / block_events / block_chain_events (#6977)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -2009,7 +2018,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
     };
     const { status, body } = await gql(
       '{ block_extrinsics(ref: "9", limit: 10, offset: 2) { block_number extrinsic_count extrinsics } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.block_extrinsics.block_number, 9);
@@ -2050,7 +2059,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
     };
     const { status, body } = await gql(
       '{ block_events(ref: "9", limit: 20, offset: 3) { block_number event_count events } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.block_events.event_count, 1);
@@ -2072,7 +2081,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
     };
     const { status, body } = await gql(
       "{ block_chain_events(block_number: 9) { block_number event_count events } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.block_chain_events.block_number, 9);
@@ -2083,7 +2092,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
   test("block_chain_events: an absent all-events tier is a GraphQL error, not null-degrade", async () => {
     const { body } = await gql(
       "{ block_chain_events(block_number: 9) { event_count } }",
-      emptyEnv,
+      emptyEnv as unknown as Env,
     );
     assert.ok(
       body.errors?.length,
@@ -2098,7 +2107,11 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
       "block_events",
       "block_chain_events",
     ]) {
-      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+      assert.equal(
+        (FIELD_COMPLEXITY as Row)[field],
+        5,
+        `${field} should be weighted`,
+      );
     }
   });
 });
@@ -2247,7 +2260,7 @@ describe("graphql — review_* contributor-review family", () => {
     const env = reviewEnv();
     const filtered = await gql(
       "{ review_adapter_candidates(netuid: 7) { candidates total generated_at } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
     assert.equal(filtered.body.data.review_adapter_candidates.total, 1);
@@ -2262,7 +2275,7 @@ describe("graphql — review_* contributor-review family", () => {
 
     const paged = await gql(
       "{ review_adapter_candidates(limit: 1) { candidates total returned next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(
       paged.body.data.review_adapter_candidates.candidates.length,
@@ -2277,7 +2290,7 @@ describe("graphql — review_* contributor-review family", () => {
     const env = reviewEnv();
     const filtered = await gql(
       '{ review_enrichment_evidence(lane: "direct-submission") { entries total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(filtered.body.data.review_enrichment_evidence.total, 1);
     assert.equal(
@@ -2287,7 +2300,7 @@ describe("graphql — review_* contributor-review family", () => {
 
     const sorted = await gql(
       '{ review_enrichment_evidence(sort: "priority_score", order: "asc") { entries } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(
       sorted.body.data.review_enrichment_evidence.entries[0].netuid,
@@ -2299,7 +2312,7 @@ describe("graphql — review_* contributor-review family", () => {
     const env = reviewEnv();
     const { body } = await gql(
       '{ review_enrichment_queue(curation_level: "maintainer-reviewed") { queue total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.data.review_enrichment_queue.total, 1);
     assert.equal(body.data.review_enrichment_queue.queue[0].netuid, 12);
@@ -2309,7 +2322,7 @@ describe("graphql — review_* contributor-review family", () => {
     const env = reviewEnv();
     const { body } = await gql(
       '{ review_enrichment_targets(target_type: "surface-candidate") { targets total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.data.review_enrichment_targets.total, 1);
     assert.equal(body.data.review_enrichment_targets.targets[0].netuid, 7);
@@ -2319,7 +2332,7 @@ describe("graphql — review_* contributor-review family", () => {
     const env = reviewEnv();
     const { body } = await gql(
       '{ review_gaps(missing_kinds: "openapi") { priorities total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.data.review_gaps.total, 1);
     assert.equal(body.data.review_gaps.priorities[0].netuid, 7);
@@ -2329,7 +2342,7 @@ describe("graphql — review_* contributor-review family", () => {
     const env = reviewEnv();
     const { body } = await gql(
       '{ review_profile_completeness(identity_level: "partial") { profiles total summary } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.data.review_profile_completeness.total, 1);
     assert.equal(body.data.review_profile_completeness.profiles[0].netuid, 7);
@@ -2343,7 +2356,7 @@ describe("graphql — review_* contributor-review family", () => {
     const env = reviewEnv();
     const { body } = await gql(
       '{ review_adapter_candidates(curation_level: "bogus") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
   });
@@ -2351,7 +2364,7 @@ describe("graphql — review_* contributor-review family", () => {
   test("surfaces a cold/missing review artifact as a GraphQL error, matching REST/MCP", async () => {
     const { body } = await gql(
       "{ review_adapter_candidates { total } }",
-      emptyEnv,
+      emptyEnv as unknown as Env,
     );
     assert.ok(body.errors?.length);
     assert.equal(body.data, null);
@@ -2419,12 +2432,12 @@ describe("graphql — economics pagination", () => {
     );
     const { status, body } = await gql(
       "{ economics { subnets { netuid alpha_market_cap_tao } total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.economics.total, 2);
     assert.deepEqual(
-      body.data.economics.subnets.map((s) => s.netuid),
+      body.data.economics.subnets.map((s: Row) => s.netuid),
       [1, 2],
     );
     assert.equal(body.data.economics.subnets[0].alpha_market_cap_tao, null);
@@ -2516,17 +2529,17 @@ describe("graphql — opportunity boards (reuse the leaderboard ranking)", () =>
     assert.equal(b.highest_emission[0].netuid, 2);
     // Cheapest open registration first (the closed subnet is excluded).
     assert.equal(b.cheapest_registration[0].netuid, 3);
-    assert.ok(b.cheapest_registration.every((e) => e.netuid !== 2));
+    assert.ok(b.cheapest_registration.every((e: Row) => e.netuid !== 2));
     // Most validator headroom first.
     assert.equal(b.validator_headroom[0].netuid, 3);
     // #7227: biggest 1d gainers; netuid 2's negative change is dropped.
     assert.deepEqual(
-      b.biggest_alpha_gain_1d.map((e) => e.netuid),
+      b.biggest_alpha_gain_1d.map((e: Row) => e.netuid),
       [3, 1],
     );
     assert.equal(b.biggest_alpha_gain_1d[0].alpha_price_change_1d, 40);
     assert.deepEqual(
-      b.biggest_alpha_gain_7d.map((e) => e.netuid),
+      b.biggest_alpha_gain_7d.map((e: Row) => e.netuid),
       [2, 3, 1],
     );
   });
@@ -2539,7 +2552,7 @@ describe("graphql — opportunity boards (reuse the leaderboard ranking)", () =>
           biggest_alpha_gain_1d { netuid }
           biggest_alpha_gain_7d { netuid }
         } }`,
-      emptyEnv,
+      emptyEnv as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.opportunity_boards.with_economics_count, 0);
@@ -2562,7 +2575,11 @@ describe("graphql — complexity weights keep the guard meaningful", () => {
       "health",
       "opportunity_boards",
     ]) {
-      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+      assert.equal(
+        (FIELD_COMPLEXITY as Row)[field],
+        5,
+        `${field} should be weighted`,
+      );
     }
   });
 
@@ -2586,7 +2603,7 @@ describe("graphql — complexity weights keep the guard meaningful", () => {
           endpoints { id kind status }
           economics { emission_share open_slots }
       } }`,
-      emptyEnv,
+      emptyEnv as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnet, null); // cold store, but the query was accepted
@@ -2602,12 +2619,12 @@ describe("graphql — complexity weights keep the guard meaningful", () => {
           health { status ok_count failed_count degraded_count unknown_count surface_count avg_latency_ms }
           surfaces { id key kind status url provider name }
       } } }`,
-      emptyEnv,
+      emptyEnv as unknown as Env,
     );
     assert.equal(status, 400);
     assert.ok(
       body.errors.find(
-        (e) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
+        (e: Row) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
       ),
     );
   });
@@ -2637,16 +2654,16 @@ describe("graphql — resolver branch coverage", () => {
     });
     const { status, body } = await gql(
       "{ subnets { items { netuid surfaces { id } endpoints { id } } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const item = body.data.subnets.items[0];
     assert.deepEqual(
-      item.surfaces.map((s) => s.id),
+      item.surfaces.map((s: Row) => s.id),
       ["s1"],
     );
     assert.deepEqual(
-      item.endpoints.map((e) => e.id),
+      item.endpoints.map((e: Row) => e.id),
       ["e1"],
     );
   });
@@ -2661,7 +2678,7 @@ describe("graphql — resolver branch coverage", () => {
     });
     const { status, body } = await gql(
       "{ subnet(netuid: 3) { surfaces { id } endpoints { id } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet.surfaces, []);
@@ -2677,7 +2694,7 @@ describe("graphql — resolver branch coverage", () => {
     });
     const { status, body } = await gql(
       "{ subnet(netuid: 5) { economics { emission_share } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.subnet.economics, null);
@@ -2691,7 +2708,7 @@ describe("graphql — resolver branch coverage", () => {
     });
     const { status, body } = await gql(
       '{ provider(id: "solo") { subnets { netuid } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.provider.subnets, []);
@@ -2708,7 +2725,7 @@ describe("graphql — resolver branch coverage", () => {
     });
     const { status, body } = await gql(
       "{ providers(limit: 1) { items { id } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.providers.total, 2);
@@ -2726,7 +2743,7 @@ describe("graphql — resolver branch coverage", () => {
     });
     const first = await gql(
       "{ surfaces(limit: 1) { items { kind } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(first.body.data.surfaces.total, 2);
     assert.equal(first.body.data.surfaces.next_cursor, "k1");
@@ -2738,24 +2755,26 @@ describe("graphql — resolver branch coverage", () => {
       headers: { "content-type": "application/json", "content-length": "-1" },
       body: JSON.stringify({ query: "{ __typename }" }),
     });
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 400);
-    assert.ok((await res.json()).errors[0].message.includes("Content-Length"));
+    assert.ok(
+      ((await res.json()) as Row).errors[0].message.includes("Content-Length"),
+    );
   });
 
   test("a POST with no body returns a missing-query error", async () => {
     const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
       method: "POST",
     });
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 400);
-    assert.ok((await res.json()).errors[0].message.includes("query"));
+    assert.ok(((await res.json()) as Row).errors[0].message.includes("query"));
   });
 
   test("OPTIONS /mcp advertises GET, POST, DELETE, OPTIONS (the sibling CORS branch, #4983 MCP half)", async () => {
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/mcp", { method: "OPTIONS" }),
-      emptyEnv,
+      emptyEnv as unknown as Env,
       {},
     );
     assert.equal(res.status, 204);
@@ -2768,7 +2787,7 @@ describe("graphql — resolver branch coverage", () => {
   test("OPTIONS /api/v1/ask advertises POST, OPTIONS (the other CORS operand)", async () => {
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/ask", { method: "OPTIONS" }),
-      emptyEnv,
+      emptyEnv as unknown as Env,
       {},
     );
     assert.equal(res.status, 204);
@@ -2783,7 +2802,7 @@ describe("graphql — resolver branch coverage", () => {
       new Request("https://api.metagraph.sh/api/v1/subnets", {
         method: "OPTIONS",
       }),
-      emptyEnv,
+      emptyEnv as unknown as Env,
       {},
     );
     assert.equal(res.status, 204);
@@ -2803,7 +2822,7 @@ describe("graphql — resolver branch coverage", () => {
       },
       body: payload,
     });
-    const res = await handleGraphQLRequest(req, emptyEnv);
+    const res = await handleGraphQLRequest(req, emptyEnv as unknown as Env);
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { data: { __typename: "Query" } });
   });
@@ -2853,7 +2872,7 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
             health { ok_count }
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const c = body.data.compare;
@@ -2881,7 +2900,7 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
       `{ compare(netuids: [1], dimensions: ["structure"]) {
           dimensions subnets { structure { surface_count } economics { emission_share } }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.compare.dimensions, ["structure"]);
@@ -2898,7 +2917,7 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
     );
     const { body } = await gql(
       `{ compare(netuids: [1], dimensions: ["structure"]) { observed_at } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.data.compare.observed_at, "2026-06-23T00:00:00.000Z");
   });
@@ -2917,7 +2936,7 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
       `{ compare(netuids: [1], dimensions: ["health"]) {
           subnets { netuid health { surface_count ok_count avg_latency_ms } }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.compare.subnets[0].health, null);
@@ -2930,7 +2949,7 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
     };
     const { status, body } = await gql(
       `{ compare(netuids: [1], dimensions: ["health"]) { subnets { health { ok_count } } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.compare.subnets[0].health, null);
@@ -2945,7 +2964,7 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
     };
     const { status, body } = await gql(
       `{ compare(netuids: [1], dimensions: ["health"]) { subnets { health { ok_count } } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.compare.subnets[0].health, null);
@@ -2955,11 +2974,13 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
     const empty = await gql("{ compare(netuids: []) { schema_version } }");
     assert.equal(empty.status, 200);
     assert.ok(
-      empty.body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+      empty.body.errors.find(
+        (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
+      ),
     );
     const neg = await gql("{ compare(netuids: [-1]) { schema_version } }");
     assert.ok(
-      neg.body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+      neg.body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
     );
   });
 
@@ -2967,7 +2988,9 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
     const { body } = await gql(
       '{ compare(netuids: [1], dimensions: ["bogus"]) { schema_version } }',
     );
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("cold store: no profiles/economics artifacts → found:false, empty rows", async () => {
@@ -2991,7 +3014,7 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
 });
 
 describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -3037,7 +3060,7 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     };
     const { status, body } = await gql(
       "{ sudo { items { block_number call_module call_args success } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.sudo.total, 1);
@@ -3052,11 +3075,11 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
   });
 
   test("sudo: hits /api/v1/sudo and forwards filters, never signer/call_module", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3071,25 +3094,25 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     };
     await gql(
       `{ sudo(limit: 5, offset: 2, block: 42, call_function: "sudo", success: true) { total } }`,
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.pathname, "/api/v1/sudo");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl.searchParams.get("offset"), "2");
-    assert.equal(capturedUrl.searchParams.get("block"), "42");
-    assert.equal(capturedUrl.searchParams.get("call_function"), "sudo");
-    assert.equal(capturedUrl.searchParams.get("success"), "true");
+    assert.equal(capturedUrl!.pathname, "/api/v1/sudo");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("offset"), "2");
+    assert.equal(capturedUrl!.searchParams.get("block"), "42");
+    assert.equal(capturedUrl!.searchParams.get("call_function"), "sudo");
+    assert.equal(capturedUrl!.searchParams.get("success"), "true");
     // The route fixes call_module=Sudo, so the field exposes neither arg.
-    assert.equal(capturedUrl.searchParams.get("call_module"), null);
-    assert.equal(capturedUrl.searchParams.get("signer"), null);
+    assert.equal(capturedUrl!.searchParams.get("call_module"), null);
+    assert.equal(capturedUrl!.searchParams.get("signer"), null);
   });
 
   test("sudo: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3103,7 +3126,7 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
       },
     };
     await gql(`{ sudo(cursor: "abc123") { total } }`, env);
-    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
   });
 
   test("sudo: a negative block filter is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
@@ -3119,7 +3142,9 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     };
     const { status, body } = await gql("{ sudo(block: -1) { total } }", env);
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -3131,7 +3156,7 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     };
     const { status, body } = await gql(
       "{ sudo { items { call_module } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.sudo, {
@@ -3143,7 +3168,7 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
 });
 
 describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -3189,7 +3214,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     };
     const { status, body } = await gql(
       "{ extrinsics { items { block_number call_module call_args success } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.extrinsics.total, 1);
@@ -3204,11 +3229,11 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 
   test("extrinsics: filter args are forwarded as query params to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3223,26 +3248,26 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     };
     await gql(
       `{ extrinsics(limit: 5, block: 42, signer: "5Signer", call_module: "SubtensorModule", call_function: "register", success: true) { total } }`,
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.pathname, "/api/v1/extrinsics");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl.searchParams.get("block"), "42");
-    assert.equal(capturedUrl.searchParams.get("signer"), "5Signer");
+    assert.equal(capturedUrl!.pathname, "/api/v1/extrinsics");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("block"), "42");
+    assert.equal(capturedUrl!.searchParams.get("signer"), "5Signer");
     assert.equal(
-      capturedUrl.searchParams.get("call_module"),
+      capturedUrl!.searchParams.get("call_module"),
       "SubtensorModule",
     );
-    assert.equal(capturedUrl.searchParams.get("call_function"), "register");
-    assert.equal(capturedUrl.searchParams.get("success"), "true");
+    assert.equal(capturedUrl!.searchParams.get("call_function"), "register");
+    assert.equal(capturedUrl!.searchParams.get("success"), "true");
   });
 
   test("extrinsics: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3256,7 +3281,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
       },
     };
     await gql(`{ extrinsics(cursor: "abc123") { total } }`, env);
-    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
   });
 
   test("extrinsics: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -3266,7 +3291,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     };
     const { status, body } = await gql(
       "{ extrinsics { items { call_module } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.extrinsics, {
@@ -3284,7 +3309,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     };
     const { status, body } = await gql(
       `{ extrinsic(ref: "${ref}") { ref extrinsic { call_module } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.extrinsic.ref, ref);
@@ -3304,10 +3329,12 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     };
     const { status, body } = await gql(
       "{ extrinsics(block: -1) { total } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -3350,7 +3377,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     };
     const { status, body } = await gql(
       `{ extrinsic(ref: "${ref}") { ref extrinsic { call_module call_function } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.extrinsic.ref, ref);
@@ -3365,7 +3392,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
 });
 
 describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -3411,7 +3438,7 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
     };
     const { status, body } = await gql(
       "{ governance_config_changes { items { block_number call_module call_function call_args success } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.governance_config_changes.total, 1);
@@ -3435,7 +3462,7 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
     };
     const { status, body } = await gql(
       "{ governance_config_changes { items { call_module } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.governance_config_changes, {
@@ -3446,11 +3473,11 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
   });
 
   test("governance_config_changes: filter args are forwarded to the /governance/config-changes path (loader reuse, no signer/call_module)", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3465,28 +3492,28 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
     };
     await gql(
       `{ governance_config_changes(limit: 5, block: 42, call_function: "sudo_set_tempo", success: true) { total } }`,
-      env,
+      env as unknown as Env,
     );
     // The worker fixes call_module=AdminUtils by path, so the resolver hits the
     // governance route (not /extrinsics) and never forwards signer/call_module.
-    assert.equal(capturedUrl.pathname, "/api/v1/governance/config-changes");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl.searchParams.get("block"), "42");
+    assert.equal(capturedUrl!.pathname, "/api/v1/governance/config-changes");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("block"), "42");
     assert.equal(
-      capturedUrl.searchParams.get("call_function"),
+      capturedUrl!.searchParams.get("call_function"),
       "sudo_set_tempo",
     );
-    assert.equal(capturedUrl.searchParams.get("success"), "true");
-    assert.equal(capturedUrl.searchParams.get("signer"), null);
-    assert.equal(capturedUrl.searchParams.get("call_module"), null);
+    assert.equal(capturedUrl!.searchParams.get("success"), "true");
+    assert.equal(capturedUrl!.searchParams.get("signer"), null);
+    assert.equal(capturedUrl!.searchParams.get("call_module"), null);
   });
 
   test("governance_config_changes: a cursor arg is forwarded as a query param", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3500,7 +3527,7 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
       },
     };
     await gql(`{ governance_config_changes(cursor: "abc123") { total } }`, env);
-    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
   });
 
   test("governance_config_changes: rejects a negative block with BAD_USER_INPUT", async () => {
@@ -3517,7 +3544,7 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
 });
 
 describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -3560,7 +3587,7 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     };
     const { status, body } = await gql(
       "{ blocks { items { block_number block_hash extrinsic_count event_count } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.blocks.total, 1);
@@ -3572,11 +3599,11 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
   });
 
   test("blocks: limit/offset/cursor are forwarded as query params to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_BLOCKS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3591,12 +3618,12 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     };
     await gql(
       `{ blocks(limit: 5, offset: 10, cursor: "abc123") { total } }`,
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.pathname, "/api/v1/blocks");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl.searchParams.get("offset"), "10");
-    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+    assert.equal(capturedUrl!.pathname, "/api/v1/blocks");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
+    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
   });
 
   test("blocks: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -3606,7 +3633,7 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     };
     const { status, body } = await gql(
       "{ blocks { items { block_number } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.blocks, {
@@ -3641,7 +3668,7 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     };
     const { status, body } = await gql(
       `{ block(ref: "${ref}") { ref block { block_number spec_version } prev_block_number next_block_number } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.block.ref, ref);
@@ -3653,11 +3680,11 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
 
   test("block: resolves a Postgres-tier row by 0x block hash", async () => {
     const ref = `0x${"b".repeat(64)}`;
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_BLOCKS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3680,10 +3707,10 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     };
     const { status, body } = await gql(
       `{ block(ref: "${ref}") { ref block { block_number block_hash } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, `/api/v1/blocks/${ref}`);
+    assert.equal(capturedUrl!.pathname, `/api/v1/blocks/${ref}`);
     assert.equal(body.data.block.block.block_number, 123);
     assert.equal(body.data.block.block.block_hash, ref);
   });
@@ -3709,7 +3736,7 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     };
     const { status, body } = await gql(
       `{ block(ref: "${ref}") { ref block { block_number } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.block.ref, ref);
@@ -3723,7 +3750,7 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
 });
 
 describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -3792,7 +3819,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     };
     const { status, body } = await gql(
       '{ validators(sort: "total_stake", limit: 5) { items { hotkey featured coldkey nominator_count realized_return_1d realized_return_1w realized_return_1m captured_at block_number subnets { netuid uid stake_tao } } total sort captured_at block_number } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.validators.total, 1);
@@ -3814,11 +3841,11 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
   });
 
   test("validators: sort is forwarded to the Postgres tier; limit is always the REST max window", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3833,17 +3860,17 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
       },
     };
     await gql('{ validators(sort: "uid_count", limit: 5) { total } }', env);
-    assert.equal(capturedUrl.pathname, "/api/v1/validators");
-    assert.equal(capturedUrl.searchParams.get("sort"), "uid_count");
-    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+    assert.equal(capturedUrl!.pathname, "/api/v1/validators");
+    assert.equal(capturedUrl!.searchParams.get("sort"), "uid_count");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("validators: an omitted GraphQL limit still fetches the REST max window from the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -3858,8 +3885,8 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
       },
     };
     await gql("{ validators { total } }", env);
-    assert.equal(capturedUrl.searchParams.get("sort"), "subnet_count");
-    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+    assert.equal(capturedUrl!.searchParams.get("sort"), "subnet_count");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("validators: paginate with a hotkey cursor", async () => {
@@ -3893,7 +3920,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     };
     const first = await gql(
       "{ validators(limit: 1) { items { hotkey } total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(first.status, 200);
     assert.equal(first.body.data.validators.total, 2);
@@ -3902,7 +3929,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
 
     const second = await gql(
       '{ validators(limit: 1, cursor: "5Alpha") { items { hotkey } next_cursor } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(second.status, 200);
     assert.equal(second.body.data.validators.items[0].hotkey, "5Beta");
@@ -3916,7 +3943,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     };
     const { status, body } = await gql(
       "{ validators { items { hotkey } total sort captured_at block_number } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.validators, {
@@ -3941,10 +3968,12 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     };
     const { status, body } = await gql(
       '{ validators(sort: "not_a_real_sort") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -3998,7 +4027,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     };
     const { status, body } = await gql(
       '{ validator(hotkey: "5Validator") { hotkey subnet_count captured_at block_number subnets { netuid stake_tao } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.validator.hotkey, "5Validator");
@@ -4018,7 +4047,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
     };
     const { status, body } = await gql(
       '{ validator(hotkey: "5NoRows") { hotkey featured subnet_count total_stake_tao captured_at block_number subnets { netuid } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -4041,7 +4070,7 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
 
 describe("graphql — account_position_history (#5889, Postgres-tier + empty-points fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -4098,7 +4127,7 @@ describe("graphql — account_position_history (#5889, Postgres-tier + empty-poi
           ss58 netuid window point_count
           points { snapshot_date captured_at uid coldkey role active stake_tao emission_tao rank trust incentive dividends yield }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -4117,7 +4146,9 @@ describe("graphql — account_position_history (#5889, Postgres-tier + empty-poi
     );
     assert.equal(status, 200);
     assert.equal(body.data, null);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("an out-of-range netuid is BAD_USER_INPUT", async () => {
@@ -4126,15 +4157,17 @@ describe("graphql — account_position_history (#5889, Postgres-tier + empty-poi
     );
     assert.equal(status, 200);
     assert.equal(body.data, null);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -4142,11 +4175,11 @@ describe("graphql — account_position_history (#5889, Postgres-tier + empty-poi
     };
     await gql(
       `{ account_position_history(ss58: "${SS58}", netuid: 5, window: "7d") { window } }`,
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
     assert.ok(
-      capturedUrl.pathname.endsWith(`/accounts/${SS58}/subnets/5/history`),
+      capturedUrl!.pathname.endsWith(`/accounts/${SS58}/subnets/5/history`),
     );
   });
 
@@ -4159,7 +4192,7 @@ describe("graphql — account_position_history (#5889, Postgres-tier + empty-poi
       `{ account_position_history(ss58: "${SS58}", netuid: 3, window: "30d") {
           schema_version ss58 netuid window point_count points { snapshot_date }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -4179,12 +4212,14 @@ describe("graphql — account_position_history (#5889, Postgres-tier + empty-poi
     );
     assert.equal(status, 200);
     assert.equal(body.data, null);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 });
 
 describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
   const EMPTY = {
@@ -4243,7 +4278,7 @@ describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallbac
     };
     const { status, body } = await gql(
       `{ subnet_turnover(netuid: 5, window: "90d") { ${ALL_FIELDS} } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -4257,19 +4292,19 @@ describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallbac
   });
 
   test("window + netuid are forwarded to the Postgres tier route", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql(`{ subnet_turnover(netuid: 7, window: "7d") { window } }`, env);
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/7/turnover"));
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/7/turnover"));
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -4279,7 +4314,7 @@ describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallbac
     };
     const { status, body } = await gql(
       `{ subnet_turnover(netuid: 1, window: "30d") { ${ALL_FIELDS} } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -4292,7 +4327,9 @@ describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallbac
     );
     assert.equal(status, 200);
     assert.equal(body.data, null);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("an out-of-range netuid is BAD_USER_INPUT", async () => {
@@ -4301,7 +4338,9 @@ describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallbac
     );
     assert.equal(status, 200);
     assert.equal(body.data, null);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 });
 
@@ -4311,7 +4350,7 @@ describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallbac
 // unlike subnet_turnover above), mirroring MCP's get_subnet_ownership_history/
 // get_subnet_conviction/get_subnet_lease_history proxies byte-for-byte.
 describe("graphql — subnet_ownership_history / subnet_conviction / subnet_lease_history", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -4336,7 +4375,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     };
     const { status, body } = await gql(
       "{ subnet_ownership_history(netuid: 7) { schema_version netuid count ownership_changes } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -4371,7 +4410,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     };
     const { status, body } = await gql(
       "{ subnet_conviction(netuid: 7) { schema_version netuid queried_at_block unlock_rate maturity_rate king count leaderboard } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -4405,7 +4444,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     };
     const { status, body } = await gql(
       "{ subnet_lease_history(netuid: 9) { schema_version netuid count lease_events } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -4428,7 +4467,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     };
     const { body } = await gql(
       "{ subnet_ownership_history(netuid: 4) { count ownership_changes } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.data.subnet_ownership_history.count, 0);
     assert.deepEqual(body.data.subnet_ownership_history.ownership_changes, []);
@@ -4442,7 +4481,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
 
     const ownership = await gql(
       "{ subnet_ownership_history(netuid: 4) { schema_version netuid count ownership_changes } }",
-      env,
+      env as unknown as Env,
     );
     assert.deepEqual(ownership.body.data.subnet_ownership_history, {
       schema_version: 1,
@@ -4453,7 +4492,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
 
     const conviction = await gql(
       "{ subnet_conviction(netuid: 4) { schema_version netuid queried_at_block unlock_rate maturity_rate king count leaderboard } }",
-      env,
+      env as unknown as Env,
     );
     assert.deepEqual(conviction.body.data.subnet_conviction, {
       schema_version: 1,
@@ -4468,7 +4507,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
 
     const leaseHistory = await gql(
       "{ subnet_lease_history(netuid: 4) { schema_version netuid count lease_events } }",
-      env,
+      env as unknown as Env,
     );
     assert.deepEqual(leaseHistory.body.data.subnet_lease_history, {
       schema_version: 1,
@@ -4490,7 +4529,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     const env = { DATA_API: dataApi(new Response("err", { status: 502 })) };
     const { body } = await gql(
       "{ subnet_conviction(netuid: 7) { count } }",
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
     assert.equal(body.data, null);
@@ -4506,7 +4545,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     };
     const { body } = await gql(
       "{ subnet_lease_history(netuid: 9) { count } }",
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors?.length);
     assert.equal(body.data, null);
@@ -4518,7 +4557,11 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
       "subnet_conviction",
       "subnet_lease_history",
     ]) {
-      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+      assert.equal(
+        (FIELD_COMPLEXITY as Row)[field],
+        5,
+        `${field} should be weighted`,
+      );
     }
   });
 
@@ -4552,7 +4595,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
       // the whole response, not just this field.
       assert.equal(body.data, null, `${field} should null the response`);
       assert.ok(
-        body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+        body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
         `${field} should be BAD_USER_INPUT`,
       );
       assert.equal(called, false, `${field} should never reach DATA_API`);
@@ -4564,7 +4607,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
 // event log) -- same schema-stable-null-on-RPC-failure shape as
 // subnet_recycled/subnet_burn above, reusing loadSubnetLease unchanged.
 describe("graphql — subnet_lease (#6719, live chain RPC via subnet-lease.ts)", () => {
-  function withFetchStub(stub, fn) {
+  function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
     return Promise.resolve(fn()).finally(() => {
@@ -4623,7 +4666,7 @@ describe("graphql — subnet_lease (#6719, live chain RPC via subnet-lease.ts)",
         assert.equal(status, 200);
         assert.equal(body.data.subnet_lease, null);
         assert.ok(
-          body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+          body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
         );
         assert.equal(called, false);
       },
@@ -4635,7 +4678,9 @@ describe("graphql — subnet_lease (#6719, live chain RPC via subnet-lease.ts)",
       "{ subnet_lease(netuid: -1) { leased } }",
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("subnet_lease is weighted like its live-RPC siblings", () => {
@@ -4648,7 +4693,7 @@ describe("graphql — subnet_lease (#6719, live chain RPC via subnet-lease.ts)",
 });
 
 describe("graphql — validator_history (#5710, Postgres-tier + empty-points fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -4695,7 +4740,7 @@ describe("graphql — validator_history (#5710, Postgres-tier + empty-points fal
           hotkey window point_count
           points { snapshot_date subnet_count total_stake_tao total_emission_tao rewards_per_1000_tao }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.validator_history;
@@ -4714,11 +4759,11 @@ describe("graphql — validator_history (#5710, Postgres-tier + empty-points fal
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -4726,10 +4771,10 @@ describe("graphql — validator_history (#5710, Postgres-tier + empty-points fal
     };
     await gql(
       '{ validator_history(hotkey: "5Validator", window: "7d") { window } }',
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
-    assert.ok(capturedUrl.pathname.endsWith("/validators/5Validator/history"));
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
+    assert.ok(capturedUrl!.pathname.endsWith("/validators/5Validator/history"));
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -4741,7 +4786,7 @@ describe("graphql — validator_history (#5710, Postgres-tier + empty-points fal
       `{ validator_history(hotkey: "5Validator", window: "30d") {
           schema_version hotkey window point_count points { snapshot_date }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.validator_history, {
@@ -4809,11 +4854,11 @@ describe("graphql — subnet_trajectory (#5887, Postgres-tier + D1-live fallback
   });
 
   test("resolves Postgres-tier data and flattens the window-keyed deltas map to a labelled list", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -4839,7 +4884,7 @@ describe("graphql — subnet_trajectory (#5887, Postgres-tier + D1-live fallback
     };
     const { status, body } = await gql(trajectoryQuery, env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/subnets/3/trajectory");
+    assert.equal(capturedUrl!.pathname, "/api/v1/subnets/3/trajectory");
     assert.equal(body.data.subnet_trajectory.point_count, 2);
     assert.equal(body.data.subnet_trajectory.points[0].date, "2026-07-01");
     assert.equal(body.data.subnet_trajectory.points[1].completeness_score, 60);
@@ -4893,7 +4938,7 @@ describe("graphql — subnet_trajectory (#5887, Postgres-tier + D1-live fallback
 });
 
 describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty timeline fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -4953,7 +4998,7 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
             github_repo subnet_url discord logo_url identity_hash
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.subnet_identity_history;
@@ -4995,7 +5040,7 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
           netuid entry_count limit
           entries { block_number observed_at subnet_name symbol identity_hash }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -5007,11 +5052,11 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
   });
 
   test("pagination args are forwarded to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -5019,12 +5064,12 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
     };
     await gql(
       '{ subnet_identity_history(netuid: 3, limit: 25, offset: 10, cursor: "abc") { entry_count } }',
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.searchParams.get("limit"), "25");
-    assert.equal(capturedUrl.searchParams.get("offset"), "10");
-    assert.equal(capturedUrl.searchParams.get("cursor"), "abc");
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/identity-history"));
+    assert.equal(capturedUrl!.searchParams.get("limit"), "25");
+    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
+    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc");
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/identity-history"));
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -5036,7 +5081,7 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
       `{ subnet_identity_history(netuid: 9) {
           schema_version netuid entry_count limit offset next_cursor entries { subnet_name }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_identity_history, {
@@ -5065,7 +5110,7 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
 });
 
 describe("graphql — chain_identity_history (#5878, Postgres-tier + empty-feed fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -5129,7 +5174,7 @@ describe("graphql — chain_identity_history (#5878, Postgres-tier + empty-feed 
           schema_version count subnet_count
           changes { netuid block_number observed_at subnet_name symbol identity_hash }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.chain_identity_history;
@@ -5151,7 +5196,7 @@ describe("graphql — chain_identity_history (#5878, Postgres-tier + empty-feed 
       `{ chain_identity_history {
           schema_version count subnet_count changes { netuid }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.chain_identity_history, {
@@ -5217,7 +5262,7 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
     };
     const { status, body } = await gql(
       '{ accounts(sort: "total_stake", limit: 5) { items { hotkey coldkey subnet_count total_stake_tao stake_dominance latest_captured_at latest_block_number subnets { netuid uid stake_tao emission_tao } } total sort captured_at block_number } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.accounts.total, 1);
@@ -5237,11 +5282,11 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
   });
 
   test("accounts: sort and limit args are forwarded as query params to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -5256,17 +5301,17 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
       },
     };
     await gql('{ accounts(sort: "uid_count", limit: 5) { total } }', env);
-    assert.equal(capturedUrl.pathname, "/api/v1/accounts");
-    assert.equal(capturedUrl.searchParams.get("sort"), "uid_count");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/accounts");
+    assert.equal(capturedUrl!.searchParams.get("sort"), "uid_count");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
   });
 
   test("accounts: an omitted sort/limit forwards the defaults to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -5281,8 +5326,8 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
       },
     };
     await gql("{ accounts { total } }", env);
-    assert.equal(capturedUrl.searchParams.get("sort"), "total_stake");
-    assert.equal(capturedUrl.searchParams.get("limit"), "20");
+    assert.equal(capturedUrl!.searchParams.get("sort"), "total_stake");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "20");
   });
 
   test("accounts: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -5292,7 +5337,7 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
     };
     const { status, body } = await gql(
       "{ accounts { items { hotkey } total sort captured_at block_number } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.accounts, {
@@ -5317,10 +5362,12 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
     };
     const { status, body } = await gql(
       '{ accounts(sort: "not_a_real_sort") { total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -5338,10 +5385,12 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
     };
     const { status, body } = await gql(
       '{ account(ss58: "not-a-valid-address") { ss58 } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     // `account` is a nullable field (unlike `validators`/`accounts`), so the
     // thrown error nulls out just this field, not the whole `data` object.
     assert.equal(body.data.account, null);
@@ -5408,7 +5457,7 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
     };
     const { status, body } = await gql(
       `{ account(ss58: "${SS58}") { ss58 event_count subnet_count first_block last_block event_kinds { kind count } registrations { netuid stake_tao validator_permit active } recent_events { block_number event_kind } activity { tx_count last_tx_block total_fee_tao modules_called { call_module count } } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.account.ss58, SS58);
@@ -5440,7 +5489,7 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
     };
     const { status, body } = await gql(
       `{ account(ss58: "${SS58}") { ss58 event_count subnet_count event_scan_capped first_block last_block event_kinds { kind } registrations { netuid } recent_events { block_number } activity { tx_count modules_called { call_module } } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account, {
@@ -5466,7 +5515,7 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
 describe("graphql — account_prometheus (#5703, Postgres-tier { data, generatedAt } + zeroed-card fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_prometheus${argsClause} {
       schema_version address window total_announcements subnet_count concentration dominant_netuid
       subnets { netuid announcements first_announced_at last_announced_at }
@@ -5524,7 +5573,7 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
     };
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", window: "7d")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const p = body.data.account_prometheus;
@@ -5539,11 +5588,11 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             data: { schema_version: 1, address: SS58, subnets: [] },
@@ -5553,8 +5602,8 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
       },
     };
     await gql(query(`(ss58: "${SS58}", window: "90d")`), env);
-    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/prometheus`);
-    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/prometheus`);
+    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed footprint", async () => {
@@ -5610,10 +5659,12 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
     };
     const { status, body } = await gql(
       query('(ss58: "not-a-valid-address")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -5636,7 +5687,7 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
 describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generatedAt } + zeroed-card fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_stake_flow${argsClause} {
       schema_version address window total_staked_tao total_unstaked_tao
       net_flow_tao gross_flow_tao flow_ratio direction stake_events unstake_events
@@ -5720,7 +5771,7 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
     };
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", window: "7d")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const f = body.data.account_stake_flow;
@@ -5736,11 +5787,11 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
   });
 
   test("window and direction are forwarded as query params to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             data: { schema_version: 1, address: SS58, subnets: [] },
@@ -5750,9 +5801,9 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
       },
     };
     await gql(query(`(ss58: "${SS58}", window: "90d", direction: "in")`), env);
-    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/stake-flow`);
-    assert.equal(capturedUrl.searchParams.get("window"), "90d");
-    assert.equal(capturedUrl.searchParams.get("direction"), "in");
+    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/stake-flow`);
+    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
+    assert.equal(capturedUrl!.searchParams.get("direction"), "in");
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
@@ -5822,10 +5873,12 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
     };
     const { status, body } = await gql(
       query('(ss58: "not-a-valid-address")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -5858,7 +5911,7 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
 describe("graphql — account_portfolio (#5702, Postgres-tier flat body + zeroed-card fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_portfolio${argsClause} {
       schema_version ss58 captured_at subnet_count position_count validator_count
       miner_count total_stake_tao total_emission_tao overall_yield
@@ -5947,11 +6000,11 @@ describe("graphql — account_portfolio (#5702, Postgres-tier flat body + zeroed
   });
 
   test("ss58 is forwarded on the Postgres-tier request path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -5962,7 +6015,7 @@ describe("graphql — account_portfolio (#5702, Postgres-tier flat body + zeroed
       },
     };
     await gql(query(`(ss58: "${SS58}")`), env);
-    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/portfolio`);
+    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/portfolio`);
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty card", async () => {
@@ -6001,10 +6054,12 @@ describe("graphql — account_portfolio (#5702, Postgres-tier flat body + zeroed
     };
     const { status, body } = await gql(
       query('(ss58: "not-a-valid-address")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -6017,7 +6072,7 @@ describe("graphql — account_portfolio (#5702, Postgres-tier flat body + zeroed
 describe("graphql — account_positions (#6324, Postgres-tier flat body + empty-card fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_positions${argsClause} {
       schema_version ss58 captured_at position_count total_stake_tao
       positions { hotkey netuid share_fraction stake_tao }
@@ -6080,11 +6135,11 @@ describe("graphql — account_positions (#6324, Postgres-tier flat body + empty-
   });
 
   test("ss58 is forwarded on the Postgres-tier request path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -6095,7 +6150,7 @@ describe("graphql — account_positions (#6324, Postgres-tier flat body + empty-
       },
     };
     await gql(query(`(ss58: "${SS58}")`), env);
-    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/positions`);
+    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/positions`);
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty card", async () => {
@@ -6128,10 +6183,12 @@ describe("graphql — account_positions (#6324, Postgres-tier flat body + empty-
     };
     const { status, body } = await gql(
       query('(ss58: "not-a-valid-address")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -6144,7 +6201,7 @@ describe("graphql — account_positions (#6324, Postgres-tier flat body + empty-
 describe("graphql — account_subnets (#5894, Postgres-tier flat body + empty-card fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_subnets${argsClause} {
       schema_version ss58 subnet_count
       subnets { netuid uid stake_tao validator_permit active }
@@ -6204,11 +6261,11 @@ describe("graphql — account_subnets (#5894, Postgres-tier flat body + empty-ca
   });
 
   test("ss58 is forwarded on the Postgres-tier request path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -6220,7 +6277,7 @@ describe("graphql — account_subnets (#5894, Postgres-tier flat body + empty-ca
       },
     };
     await gql(query(`(ss58: "${SS58}")`), env);
-    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/subnets`);
+    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/subnets`);
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty footprint", async () => {
@@ -6251,10 +6308,12 @@ describe("graphql — account_subnets (#5894, Postgres-tier flat body + empty-ca
     };
     const { status, body } = await gql(
       query('(ss58: "not-a-valid-address")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -6267,7 +6326,7 @@ describe("graphql — account_subnets (#5894, Postgres-tier flat body + empty-ca
 describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_extrinsics${argsClause} {
       schema_version ss58 extrinsic_count limit offset next_cursor
       extrinsics { block_number extrinsic_index call_module call_function call_args success fee_tao }
@@ -6336,11 +6395,11 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
   });
 
   test("ss58 + pagination/block-range args are forwarded on the Postgres-tier request path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -6358,14 +6417,14 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
       query(
         `(ss58: "${SS58}", limit: 5, offset: 10, cursor: "abc123", block_start: 100, block_end: 200)`,
       ),
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/extrinsics`);
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl.searchParams.get("offset"), "10");
-    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
-    assert.equal(capturedUrl.searchParams.get("block_start"), "100");
-    assert.equal(capturedUrl.searchParams.get("block_end"), "200");
+    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/extrinsics`);
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
+    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
+    assert.equal(capturedUrl!.searchParams.get("block_start"), "100");
+    assert.equal(capturedUrl!.searchParams.get("block_end"), "200");
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -6399,10 +6458,12 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
     };
     const { status, body } = await gql(
       query('(ss58: "not-a-valid-address")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -6422,14 +6483,14 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
 // -- using graphql-js's real subscribe() function (not a hand-rolled
 // simulation) against a minimal fake hub, exactly the shape
 // ChainFirehoseHub actually provides via context.
-function fakeChainFirehose(pushAfterSubscribe) {
-  const subscriptions = [];
+function fakeChainFirehose(pushAfterSubscribe?: AnyFn) {
+  const subscriptions: Row[] = [];
   return {
-    subscribeChainEvents(topics) {
-      const pending = [];
-      let waitingResolve = null;
+    subscribeChainEvents(topics: unknown, _clientIp?: unknown) {
+      const pending: unknown[] = [];
+      let waitingResolve: AnyFn | null = null;
       const repeater = {
-        push(value) {
+        push(value: unknown) {
           if (waitingResolve) {
             const resolve = waitingResolve;
             waitingResolve = null;
@@ -6453,7 +6514,7 @@ function fakeChainFirehose(pushAfterSubscribe) {
       if (pushAfterSubscribe) pushAfterSubscribe(repeater);
       return repeater;
     },
-    unsubscribeChainEvents(repeater) {
+    unsubscribeChainEvents(repeater: Row) {
       const index = subscriptions.findIndex((s) => s.repeater === repeater);
       if (index !== -1) subscriptions.splice(index, 1);
     },
@@ -6461,7 +6522,12 @@ function fakeChainFirehose(pushAfterSubscribe) {
   };
 }
 
-async function subscribeChainEvents(query, hub, clientIp) {
+async function subscribeChainEvents(
+  query: string,
+  hub?: Row,
+  clientIp?: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
   const document = parse(query);
   return subscribe({
     schema: chainEventsSchema,
@@ -6476,12 +6542,12 @@ async function subscribeChainEvents(query, hub, clientIp) {
 // through JSON is also a MORE faithful comparison than a raw deep-equal:
 // real clients only ever see this result after it's been JSON-serialized
 // for the wire, same as every other transport in this repo.
-function asPlainJson(value) {
+function asPlainJson(value: unknown) {
   return JSON.parse(JSON.stringify(value));
 }
 
 describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -6565,7 +6631,7 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
           throughput { total_extrinsics mean_extrinsics_per_block max_extrinsics_in_block }
           author_concentration { gini nakamoto_coefficient top_1pct_share entropy_normalized }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const s = body.data.blocks_summary;
@@ -6585,19 +6651,19 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
   });
 
   test("forwards to /api/v1/blocks/summary with no query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_BLOCKS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({ schema_version: 1, block_count: 0 });
         },
       },
     };
     await gql("{ blocks_summary { block_count } }", env);
-    assert.equal(capturedUrl.pathname, "/api/v1/blocks/summary");
-    assert.equal(capturedUrl.search, "");
+    assert.equal(capturedUrl!.pathname, "/api/v1/blocks/summary");
+    assert.equal(capturedUrl!.search, "");
   });
 
   test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
@@ -6612,7 +6678,7 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
           first_block last_block block_time { count } throughput { total_extrinsics }
           author_concentration { gini } latest_spec_version
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.blocks_summary, {
@@ -6631,7 +6697,7 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
 });
 
 describe("graphql — runtime (#5898, Postgres-tier spec-version timeline + retired-D1 fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -6685,7 +6751,7 @@ describe("graphql — runtime (#5898, Postgres-tier spec-version timeline + reti
           coverage_from_block coverage_from_at
           transitions { spec_version block_number observed_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.runtime, {
@@ -6710,19 +6776,19 @@ describe("graphql — runtime (#5898, Postgres-tier spec-version timeline + reti
   });
 
   test("forwards to /api/v1/runtime with no query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_BLOCKS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({ schema_version: 1, transition_count: 0 });
         },
       },
     };
     await gql("{ runtime { transition_count } }", env);
-    assert.equal(capturedUrl.pathname, "/api/v1/runtime");
-    assert.equal(capturedUrl.search, "");
+    assert.equal(capturedUrl!.pathname, "/api/v1/runtime");
+    assert.equal(capturedUrl!.search, "");
   });
 
   test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
@@ -6736,7 +6802,7 @@ describe("graphql — runtime (#5898, Postgres-tier spec-version timeline + reti
           schema_version transition_count current_spec_version
           coverage_from_block coverage_from_at transitions { spec_version }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.runtime, {
@@ -6751,7 +6817,7 @@ describe("graphql — runtime (#5898, Postgres-tier spec-version timeline + reti
 });
 
 describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledger)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
   // Minimal D1 stub: every query returns no rows, so loadGlobalIncidentsLedger's
@@ -6814,7 +6880,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
           summary
           surfaces { id endpoint_id state severity status reason netuid provider health_stale pool_eligible user_reported }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const inc = body.data.incidents;
@@ -6839,7 +6905,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
     };
     const { status, body } = await gql(
       '{ incidents(window: "30d") { schema_version window observed_at source summary surfaces { id } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.incidents, {
@@ -6868,7 +6934,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
 describe("graphql — global_incidents (#7643, get_global_incidents-aligned alias)", () => {
   // Fresh Response per fetch so incidents + global_incidents can each consume
   // their own Postgres-tier body when queried side by side.
-  function dataApi(payload) {
+  function dataApi(payload: Row) {
     return { fetch: async () => Response.json(payload) };
   }
   const emptyHealthDb = {
@@ -6910,7 +6976,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
       }`;
     const { status, body } = await gql(
       `{ global_incidents(window: "30d") ${selection} }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -6923,7 +6989,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     assert.equal(alias.surfaces[0].netuid, 5);
     const canonical = await gql(
       `{ incidents(window: "30d") ${selection} }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(canonical.status, 200);
     assert.equal(canonical.body.errors, undefined);
@@ -6969,8 +7035,8 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     const fields = body.data.__type.fields;
-    const canonical = fields.find((f) => f.name === "incidents");
-    const alias = fields.find((f) => f.name === "global_incidents");
+    const canonical = fields.find((f: Row) => f.name === "incidents");
+    const alias = fields.find((f: Row) => f.name === "global_incidents");
     assert.ok(canonical && alias, "both fields present in the schema");
     assert.deepEqual(alias.args, canonical.args);
     assert.deepEqual(alias.type, canonical.type);
@@ -6978,7 +7044,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
 });
 
 describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -7021,7 +7087,7 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
       `{ subnet_registrations(netuid: 5, window: "30d") {
           netuid window observed_at distinct_registrants registrations registrations_per_registrant
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.subnet_registrations;
@@ -7041,7 +7107,7 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
       `{ subnet_registrations(netuid: 9, window: "30d") {
           schema_version netuid window observed_at distinct_registrants registrations registrations_per_registrant
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_registrations, {
@@ -7066,7 +7132,7 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
 });
 
 describe("graphql — subnet_performance (#5714, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -7178,7 +7244,7 @@ describe("graphql — subnet_performance (#5714, Postgres-tier + zeroed-card fal
           trust { count mean max }
           validator_trust { count min max }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -7199,18 +7265,18 @@ describe("graphql — subnet_performance (#5714, Postgres-tier + zeroed-card fal
   });
 
   test("forwards the performance path to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql("{ subnet_performance(netuid: 3) { neuron_count } }", env);
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/performance"));
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/performance"));
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -7223,7 +7289,7 @@ describe("graphql — subnet_performance (#5714, Postgres-tier + zeroed-card fal
           schema_version netuid neuron_count validator_count active_count
           incentive { holders } trust { count }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_performance, {
@@ -7252,7 +7318,7 @@ describe("graphql — subnet_performance (#5714, Postgres-tier + zeroed-card fal
 });
 
 describe("graphql — subnet_concentration (#5901, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -7344,7 +7410,7 @@ describe("graphql — subnet_concentration (#5901, Postgres-tier + zeroed-card f
           emission { holders total }
           validator_stake { holders gini }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -7364,18 +7430,18 @@ describe("graphql — subnet_concentration (#5901, Postgres-tier + zeroed-card f
   });
 
   test("forwards the concentration path to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql("{ subnet_concentration(netuid: 3) { neuron_count } }", env);
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/concentration"));
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/concentration"));
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -7388,7 +7454,7 @@ describe("graphql — subnet_concentration (#5901, Postgres-tier + zeroed-card f
           schema_version netuid neuron_count entity_count uids_per_entity
           stake { holders } validator_stake { holders }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_concentration, {
@@ -7417,7 +7483,7 @@ describe("graphql — subnet_concentration (#5901, Postgres-tier + zeroed-card f
 });
 
 describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + window validation)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -7477,7 +7543,7 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
           netuid window point_count
           points { snapshot_date neuron_count stake_gini stake_nakamoto_coefficient emission_top_10pct_share }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -7493,11 +7559,11 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
   });
 
   test("forwards the window to the concentration/history Postgres path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -7505,12 +7571,12 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
     };
     await gql(
       '{ subnet_concentration_history(netuid: 3, window: "90d") { point_count } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(
-      capturedUrl.pathname.endsWith("/subnets/3/concentration/history"),
+      capturedUrl!.pathname.endsWith("/subnets/3/concentration/history"),
     );
-    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
   });
 
   test("an unsupported window is a GraphQL error, not a silent series", async () => {
@@ -7551,7 +7617,7 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     });
     const { status, body } = await gql(
       "{ search(limit: 1) { documents total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -7575,7 +7641,7 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     });
     const { status, body } = await gql(
       "{ search_index(limit: 1) { documents total next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -7604,7 +7670,7 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     });
     const { status, body } = await gql(
       "{ domains { schema_version domain_count domains { domain subnet_count netuids total_stake_tao } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -7612,7 +7678,7 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     assert.equal(d.schema_version, 1);
     assert.equal(d.domain_count, 14);
     assert.equal(d.domains.length, 14);
-    const agents = d.domains.find((row) => row.domain === "agents");
+    const agents = d.domains.find((row: Row) => row.domain === "agents");
     assert.ok(agents, "expected an agents rollup");
   });
 
@@ -7656,11 +7722,11 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
   });
 
   test("compare_validators fetches each hotkey from the Postgres tier", async () => {
-    const paths = [];
+    const paths: string[] = [];
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           paths.push(new URL(req.url).pathname);
           return Response.json({
             schema_version: 1,
@@ -7673,7 +7739,7 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     };
     const { status, body } = await gql(
       `{ compare_validators(hotkeys: ["${HOTKEY_A}"], netuid: 3) { netuid validator_count validators { hotkey total_stake_tao } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -7768,7 +7834,7 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
     const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
     const { body } = await gql(
       '{ candidates(netuid: 2, kind: "api", provider: "beta", state: "verified") }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.equal(body.data.candidates.total, 1);
@@ -7881,11 +7947,11 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
   });
 
   test("top_holders resolves the postgres tier payload", async () => {
-    let url;
+    let url: URL | undefined;
     const env = {
       METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           url = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -7897,9 +7963,9 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
     const { body } = await gql("{ top_holders(limit: 5) }", env);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.top_holders.holders[0].ss58, "5A");
-    assert.equal(url.pathname, "/api/v1/accounts/top-holders");
-    assert.equal(url.searchParams.get("limit"), "5");
-    assert.equal(url.searchParams.get("sort"), "total_tao");
+    assert.equal(url!.pathname, "/api/v1/accounts/top-holders");
+    assert.equal(url!.searchParams.get("limit"), "5");
+    assert.equal(url!.searchParams.get("sort"), "total_tao");
   });
 
   test("top_holders falls back to a schema-stable empty list when the tier is cold", async () => {
@@ -7910,11 +7976,11 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
   });
 
   test("top_holders forwards an explicit allowlisted sort", async () => {
-    let url;
+    let url: URL | undefined;
     const env = {
       METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           url = new URL(r.url);
           return Response.json({ schema_version: 1, holders: [] });
         },
@@ -7922,7 +7988,7 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
     };
     const { body } = await gql('{ top_holders(sort: "free_tao") }', env);
     assert.equal(body.errors, undefined);
-    assert.equal(url.searchParams.get("sort"), "free_tao");
+    assert.equal(url!.searchParams.get("sort"), "free_tao");
   });
 
   test("top_holders rejects an unknown sort with BAD_USER_INPUT", async () => {
@@ -7938,7 +8004,7 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
       "freshness",
       "top_holders",
     ]) {
-      assert.equal(FIELD_COMPLEXITY[f], 5, `${f} should be weighted`);
+      assert.equal((FIELD_COMPLEXITY as Row)[f], 5, `${f} should be weighted`);
     }
   });
 });
@@ -8053,7 +8119,7 @@ describe("graphql — registry_summary / source_health / lineage / rpc_endpoints
       "2026-07-20T12:00:00.000Z",
     );
     const overlaid = body.data.rpc_endpoints.endpoints.find(
-      (e) => e.id === "finney-wss",
+      (e: Row) => e.id === "finney-wss",
     );
     assert.equal(overlaid.latency_ms, 42);
     assert.equal(overlaid.health_source, "probe-derived");
@@ -8080,17 +8146,21 @@ describe("graphql — registry_summary / source_health / lineage / rpc_endpoints
       "lineage",
       "rpc_endpoints",
     ]) {
-      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+      assert.equal(
+        (FIELD_COMPLEXITY as Row)[field],
+        5,
+        `${field} should be weighted`,
+      );
     }
   });
 });
 
 describe("graphql — subnet metagraph / overview / profile (#7169, composed-route parity)", () => {
-  function tierEnv(sourceKey, payload, onUrl) {
+  function tierEnv(sourceKey: string, payload: Row, onUrl?: AnyFn) {
     return {
       [sourceKey]: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           onUrl?.(new URL(r.url));
           return Response.json(payload);
         },
@@ -8099,11 +8169,11 @@ describe("graphql — subnet metagraph / overview / profile (#7169, composed-rou
   }
 
   test("subnet_metagraph resolves the postgres-tier payload", async () => {
-    let url;
+    let url: URL | undefined;
     const env = tierEnv(
       "METAGRAPH_NEURONS_SOURCE",
       { schema_version: 1, netuid: 3, neuron_count: 1, neurons: [{ uid: 0 }] },
-      (u) => {
+      (u: URL) => {
         url = u;
       },
     );
@@ -8111,25 +8181,25 @@ describe("graphql — subnet metagraph / overview / profile (#7169, composed-rou
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.subnet_metagraph.neuron_count, 1);
-    assert.equal(url.pathname, "/api/v1/subnets/3/metagraph");
-    assert.equal(url.searchParams.get("validator_permit"), null);
+    assert.equal(url!.pathname, "/api/v1/subnets/3/metagraph");
+    assert.equal(url!.searchParams.get("validator_permit"), null);
   });
 
   test("subnet_metagraph forwards validator_permit to the tier", async () => {
-    let url;
+    let url: URL | undefined;
     const env = tierEnv(
       "METAGRAPH_NEURONS_SOURCE",
       { schema_version: 1, netuid: 3, neuron_count: 0, neurons: [] },
-      (u) => {
+      (u: URL) => {
         url = u;
       },
     );
     const { body } = await gql(
       "{ subnet_metagraph(netuid: 3, validator_permit: true) }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
-    assert.equal(url.searchParams.get("validator_permit"), "true");
+    assert.equal(url!.searchParams.get("validator_permit"), "true");
   });
 
   test("subnet_metagraph falls back to a schema-stable empty metagraph, never null", async () => {
@@ -8216,7 +8286,7 @@ describe("graphql — subnet metagraph / overview / profile (#7169, composed-rou
 });
 
 describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validators)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
   const POOL = {
@@ -8271,7 +8341,7 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
     };
     const { status, body } = await gql(
       "{ subnet_volume(netuid: 64) { netuid window total_volume_tao buy_count sentiment sentiment_ratio } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -8295,11 +8365,11 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
   });
 
   test("subnet_ohlc forwards interval + days and returns tier candles", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -8325,13 +8395,13 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
     };
     const { status, body } = await gql(
       '{ subnet_ohlc(netuid: 7, interval: "1d", days: 30) { interval candles { bucket_start close event_count } } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/7/ohlc"));
-    assert.equal(capturedUrl.searchParams.get("interval"), "1d");
-    assert.equal(capturedUrl.searchParams.get("days"), "30");
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/7/ohlc"));
+    assert.equal(capturedUrl!.searchParams.get("interval"), "1d");
+    assert.equal(capturedUrl!.searchParams.get("days"), "30");
     const o = body.data.subnet_ohlc;
     assert.equal(o.interval, "1d");
     assert.equal(o.candles[0].bucket_start, 1770000000000);
@@ -8420,11 +8490,11 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
   });
 
   test("subnet_validators resolves the Postgres-tier validator set", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -8446,11 +8516,11 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
     };
     const { status, body } = await gql(
       "{ subnet_validators(netuid: 7) { netuid validator_count block_number validators { uid hotkey stake_tao validator_permit } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/7/validators"));
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/7/validators"));
     const v = body.data.subnet_validators;
     assert.equal(v.validator_count, 1);
     assert.equal(v.block_number, 91);
@@ -8545,7 +8615,7 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
 });
 
 describe("graphql — subnet_health_percentiles (#6980, live latency percentiles)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -8589,7 +8659,7 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
     };
     const { status, body } = await gql(
       '{ subnet_health_percentiles(netuid: 7, window: "30d") { netuid window observed_at source surfaces } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -8601,11 +8671,11 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
   });
 
   test("forwards the window to the health/percentiles Postgres path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -8613,10 +8683,10 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
     };
     await gql(
       '{ subnet_health_percentiles(netuid: 3, window: "30d") { netuid } }',
-      env,
+      env as unknown as Env,
     );
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/health/percentiles"));
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/health/percentiles"));
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
   });
 
   test("an unsupported window is a GraphQL error, not a silent card", async () => {
@@ -8633,7 +8703,7 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
 });
 
 describe("graphql — subnet_event_summary (#6980, chain-event activity summary)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -8683,7 +8753,7 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
     };
     const { status, body } = await gql(
       '{ subnet_event_summary(netuid: 7, window: "7d") { netuid window total_events kind_count categories event_kinds recent_events } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -8695,11 +8765,11 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
   });
 
   test("clamps the recent-event limit into 1..50 and forwards it", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -8707,26 +8777,26 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
     };
     await gql(
       '{ subnet_event_summary(netuid: 3, window: "90d", limit: 999) { netuid } }',
-      env,
+      env as unknown as Env,
     );
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/event-summary"));
-    assert.equal(capturedUrl.searchParams.get("window"), "90d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "50");
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/event-summary"));
+    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "50");
   });
 
   test("clamps a below-range limit up to 1", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql("{ subnet_event_summary(netuid: 3, limit: 0) { netuid } }", env);
-    assert.equal(capturedUrl.searchParams.get("limit"), "1");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "1");
   });
 
   test("an unsupported window is a GraphQL error, not a silent card", async () => {
@@ -8841,7 +8911,7 @@ describe("graphql — subnet_candidates (#7641, baked per-subnet candidate artif
 });
 
 describe("graphql — subnet_performance_history (#6981, neuron_daily reward-distribution trend)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -8917,7 +8987,7 @@ describe("graphql — subnet_performance_history (#6981, neuron_daily reward-dis
           netuid window point_count
           points { snapshot_date neuron_count validator_count incentive_gini dividends_top_10pct_share trust_median validator_trust_mean }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -8934,11 +9004,11 @@ describe("graphql — subnet_performance_history (#6981, neuron_daily reward-dis
   });
 
   test("forwards the window to the performance/history Postgres path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -8946,10 +9016,10 @@ describe("graphql — subnet_performance_history (#6981, neuron_daily reward-dis
     };
     await gql(
       '{ subnet_performance_history(netuid: 3, window: "90d") { point_count } }',
-      env,
+      env as unknown as Env,
     );
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/performance/history"));
-    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/performance/history"));
+    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
   });
 
   test("an unsupported window is a GraphQL error, not a silent series", async () => {
@@ -8976,7 +9046,7 @@ describe("graphql — subnet_performance_history (#6981, neuron_daily reward-dis
 });
 
 describe("graphql — subnet_yield_history (#6981, neuron_daily emission-per-stake trend)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -9040,7 +9110,7 @@ describe("graphql — subnet_yield_history (#6981, neuron_daily emission-per-sta
           netuid window point_count
           points { snapshot_date neuron_count validator_count yield_count subnet_yield median_yield p90_yield }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9057,11 +9127,11 @@ describe("graphql — subnet_yield_history (#6981, neuron_daily emission-per-sta
   });
 
   test("forwards the window to the yield/history Postgres path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -9069,10 +9139,10 @@ describe("graphql — subnet_yield_history (#6981, neuron_daily emission-per-sta
     };
     await gql(
       '{ subnet_yield_history(netuid: 3, window: "90d") { point_count } }',
-      env,
+      env as unknown as Env,
     );
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/yield/history"));
-    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/yield/history"));
+    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
   });
 
   test("an unsupported window is a GraphQL error, not a silent series", async () => {
@@ -9099,7 +9169,7 @@ describe("graphql — subnet_yield_history (#6981, neuron_daily emission-per-sta
 });
 
 describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -9160,7 +9230,7 @@ describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () 
             rank trust stake_tao emission_tao axon take
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9205,7 +9275,7 @@ describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () 
       `{ neuron(netuid: 5, uid: 12) {
           neuron { uid is_immunity_period immunity_expires_at_block immunity_expires_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9218,18 +9288,18 @@ describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () 
   });
 
   test("hits /api/v1/subnets/{netuid}/neurons/{uid} on the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql("{ neuron(netuid: 3, uid: 7) { netuid neuron { uid } } }", env);
-    assert.equal(capturedUrl.pathname, "/api/v1/subnets/3/neurons/7");
+    assert.equal(capturedUrl!.pathname, "/api/v1/subnets/3/neurons/7");
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -9241,7 +9311,7 @@ describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () 
       `{ neuron(netuid: 9, uid: 1) {
           schema_version netuid captured_at block_number neuron { uid }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9278,7 +9348,7 @@ describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () 
 });
 
 describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -9337,7 +9407,7 @@ describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallba
             stake_tao emission_tao rank trust
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9362,11 +9432,11 @@ describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallba
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -9374,10 +9444,10 @@ describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallba
     };
     await gql(
       '{ neuron_history(netuid: 3, uid: 7, window: "7d") { window } }',
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.pathname, "/api/v1/subnets/3/neurons/7/history");
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl!.pathname, "/api/v1/subnets/3/neurons/7/history");
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -9389,7 +9459,7 @@ describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallba
       `{ neuron_history(netuid: 9, uid: 1, window: "30d") {
           schema_version netuid uid window point_count points { snapshot_date }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9436,7 +9506,7 @@ describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallba
 });
 
 describe("graphql — subnet_yield (#5713, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -9509,7 +9579,7 @@ describe("graphql — subnet_yield (#5713, Postgres-tier + zeroed-card fallback)
           p25_yield p75_yield p90_yield
           neurons { uid hotkey role stake_tao emission_tao yield }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9544,7 +9614,7 @@ describe("graphql — subnet_yield (#5713, Postgres-tier + zeroed-card fallback)
           subnet_yield mean_yield median_yield p25_yield p75_yield p90_yield
           neurons { uid }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9568,7 +9638,7 @@ describe("graphql — subnet_yield (#5713, Postgres-tier + zeroed-card fallback)
 });
 
 describe("graphql — subnet_weights (#5711, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -9611,7 +9681,7 @@ describe("graphql — subnet_weights (#5711, Postgres-tier + zeroed-card fallbac
       `{ subnet_weights(netuid: 5, window: "30d") {
           netuid window observed_at distinct_setters weight_sets sets_per_setter
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const w = body.data.subnet_weights;
@@ -9631,7 +9701,7 @@ describe("graphql — subnet_weights (#5711, Postgres-tier + zeroed-card fallbac
       `{ subnet_weights(netuid: 9, window: "30d") {
           schema_version netuid window observed_at distinct_setters weight_sets sets_per_setter
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_weights, {
@@ -9656,7 +9726,7 @@ describe("graphql — subnet_weights (#5711, Postgres-tier + zeroed-card fallbac
 });
 
 describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leaderboard fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -9720,7 +9790,7 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
           netuid window observed_at distinct_setters weight_sets setter_count
           setters { hotkey uid weight_sets share first_set_at last_set_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -9735,11 +9805,11 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
@@ -9747,10 +9817,10 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
     };
     await gql(
       '{ subnet_weight_setters(netuid: 3, window: "30d") { setter_count } }',
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/weights/setters"));
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/weights/setters"));
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -9763,7 +9833,7 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
           schema_version netuid window observed_at
           distinct_setters weight_sets setter_count setters { hotkey }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_weight_setters, {
@@ -9802,7 +9872,7 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
 });
 
 describe("graphql — subnet_stake_moves (#5716, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -9845,7 +9915,7 @@ describe("graphql — subnet_stake_moves (#5716, Postgres-tier + zeroed-card fal
       `{ subnet_stake_moves(netuid: 5, window: "30d") {
           netuid window observed_at distinct_movers movements movements_per_mover
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const m = body.data.subnet_stake_moves;
@@ -9865,7 +9935,7 @@ describe("graphql — subnet_stake_moves (#5716, Postgres-tier + zeroed-card fal
       `{ subnet_stake_moves(netuid: 9, window: "30d") {
           schema_version netuid window observed_at distinct_movers movements movements_per_mover
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_stake_moves, {
@@ -9890,7 +9960,7 @@ describe("graphql — subnet_stake_moves (#5716, Postgres-tier + zeroed-card fal
 });
 
 describe("graphql — subnet_stake_transfers (#5717, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -9933,7 +10003,7 @@ describe("graphql — subnet_stake_transfers (#5717, Postgres-tier + zeroed-card
       `{ subnet_stake_transfers(netuid: 5, window: "30d") {
           netuid window observed_at distinct_senders transfers transfers_per_sender
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const t = body.data.subnet_stake_transfers;
@@ -9953,7 +10023,7 @@ describe("graphql — subnet_stake_transfers (#5717, Postgres-tier + zeroed-card
       `{ subnet_stake_transfers(netuid: 9, window: "30d") {
           schema_version netuid window observed_at distinct_senders transfers transfers_per_sender
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_stake_transfers, {
@@ -9987,10 +10057,10 @@ describe("graphql — subnet_stake_transfers (#5717, Postgres-tier + zeroed-card
 describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7172)", () => {
   // A Postgres-tier env whose DATA_API returns `payload` and, if `captured` is
   // passed, records the forwarded URL so a test can assert path/query forwarding.
-  const tierEnv = (source, payload, captured) => ({
+  const tierEnv = (source: string, payload: Row, captured?: Row) => ({
     [source]: "postgres",
     DATA_API: {
-      fetch: async (req) => {
+      fetch: async (req: Request) => {
         if (captured) captured.url = new URL(req.url);
         return Response.json(payload);
       },
@@ -10016,7 +10086,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_idle_stake returns the Postgres-tier card", async () => {
-    const captured = {};
+    const captured: Row = {};
     const env = tierEnv(
       "METAGRAPH_NEURONS_SOURCE",
       {
@@ -10033,7 +10103,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_idle_stake(netuid: 7) {
           netuid captured_at neuron_count idle_neuron_count idle_stake_tao
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.ok(captured.url.pathname.endsWith("/subnets/7/idle-stake"));
@@ -10050,7 +10120,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_idle_stake(netuid: 9) {
           schema_version netuid captured_at neuron_count idle_neuron_count idle_stake_tao
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.deepEqual(body.data.subnet_idle_stake, {
       schema_version: 1,
@@ -10084,7 +10154,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_stake_flow forwards window/direction and unwraps { data }", async () => {
-    const captured = {};
+    const captured: Row = {};
     const env = tierEnv(
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       {
@@ -10105,7 +10175,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_stake_flow(netuid: 7, window: "7d", direction: "in") {
           window net_flow_tao stake_events unstake_events total_staked_tao
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.ok(captured.url.pathname.endsWith("/subnets/7/stake-flow"));
@@ -10124,7 +10194,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
           schema_version netuid window total_staked_tao total_unstaked_tao
           net_flow_tao stake_events unstake_events
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.deepEqual(body.data.subnet_stake_flow, {
       schema_version: 1,
@@ -10169,7 +10239,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_events forwards kind/block bounds/pagination and returns tier rows", async () => {
-    const captured = {};
+    const captured: Row = {};
     const env = tierEnv(
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       {
@@ -10201,7 +10271,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_events(netuid: 7, kind: "StakeAdded", block_start: 10, block_end: 200, limit: 50) {
           event_count limit events { event_kind amount_tao uid hotkey block_number }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.ok(captured.url.pathname.endsWith("/subnets/7/events"));
@@ -10224,7 +10294,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_events(netuid: 9) {
           schema_version netuid event_count limit offset next_cursor events { event_kind }
         } }`,
-      env,
+      env as unknown as Env,
     );
     const f = body.data.subnet_events;
     assert.equal(f.schema_version, 1);
@@ -10252,7 +10322,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_history forwards window and returns tier points", async () => {
-    const captured = {};
+    const captured: Row = {};
     const env = tierEnv(
       "METAGRAPH_NEURONS_SOURCE",
       {
@@ -10276,7 +10346,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_history(netuid: 7, window: "7d") {
           window point_count points { snapshot_date neuron_count validator_count total_stake_tao total_emission_tao }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.ok(captured.url.pathname.endsWith("/subnets/7/history"));
@@ -10295,7 +10365,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_history(netuid: 9, window: "90d") {
           schema_version netuid window point_count points { snapshot_date }
         } }`,
-      env,
+      env as unknown as Env,
     );
     const h = body.data.subnet_history;
     assert.equal(h.schema_version, 1);
@@ -10332,7 +10402,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_prometheus forwards window and returns the tier card", async () => {
-    const captured = {};
+    const captured: Row = {};
     const env = tierEnv(
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       {
@@ -10350,7 +10420,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_prometheus(netuid: 7, window: "30d") {
           window observed_at distinct_exporters announcements announcements_per_exporter
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.ok(captured.url.pathname.endsWith("/subnets/7/prometheus"));
@@ -10368,7 +10438,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       `{ subnet_prometheus(netuid: 9, window: "30d") {
           schema_version netuid window observed_at distinct_exporters announcements announcements_per_exporter
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.deepEqual(body.data.subnet_prometheus, {
       schema_version: 1,
@@ -10410,13 +10480,17 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       "subnet_history",
       "subnet_prometheus",
     ]) {
-      assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
+      assert.equal(
+        (FIELD_COMPLEXITY as Row)[field],
+        5,
+        `${field} should be weighted`,
+      );
     }
   });
 });
 
 describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -10459,7 +10533,7 @@ describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card
       `{ subnet_deregistrations(netuid: 5, window: "30d") {
           netuid window observed_at distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.subnet_deregistrations;
@@ -10479,7 +10553,7 @@ describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card
       `{ subnet_deregistrations(netuid: 9, window: "30d") {
           schema_version netuid window observed_at distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_deregistrations, {
@@ -10504,7 +10578,7 @@ describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card
 });
 
 describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -10547,7 +10621,7 @@ describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallbac
       `{ subnet_serving(netuid: 5, window: "30d") {
           netuid window observed_at distinct_servers announcements announcements_per_server
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.subnet_serving;
@@ -10567,7 +10641,7 @@ describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallbac
       `{ subnet_serving(netuid: 9, window: "30d") {
           schema_version netuid window observed_at distinct_servers announcements announcements_per_server
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_serving, {
@@ -10594,7 +10668,7 @@ describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallbac
 describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fallback)", () => {
   const NETUID = 3;
 
-  function incidentsQuery(argsClause) {
+  function incidentsQuery(argsClause: string) {
     return `{ subnet_health_incidents${argsClause} {
       schema_version netuid window observed_at source surfaces
     } }`;
@@ -10613,11 +10687,11 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
   });
 
   test("resolves Postgres-tier data, forwarding netuid in the path + window param", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -10648,14 +10722,14 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
     };
     const { status, body } = await gql(
       incidentsQuery(`(netuid: ${NETUID}, window: "30d")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(
-      capturedUrl.pathname,
+      capturedUrl!.pathname,
       `/api/v1/subnets/${NETUID}/health/incidents`,
     );
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
     const d = body.data.subnet_health_incidents;
     assert.equal(d.window, "30d");
     const s = d.surfaces[0];
@@ -10673,7 +10747,7 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
     };
     const { status, body } = await gql(
       incidentsQuery(`(netuid: ${NETUID})`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_health_incidents, {
@@ -10699,7 +10773,7 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
 });
 
 describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -10742,7 +10816,7 @@ describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card f
       `{ subnet_axon_removals(netuid: 5, window: "30d") {
           netuid window observed_at distinct_removers removals removals_per_remover
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.subnet_axon_removals;
@@ -10762,7 +10836,7 @@ describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card f
       `{ subnet_axon_removals(netuid: 9, window: "30d") {
           schema_version netuid window observed_at distinct_removers removals removals_per_remover
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_axon_removals, {
@@ -10789,7 +10863,7 @@ describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card f
 describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -10846,7 +10920,7 @@ describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card 
           address window total_registrations subnet_count concentration dominant_netuid
           subnets { netuid registrations first_registered_at last_registered_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.account_registrations;
@@ -10881,7 +10955,7 @@ describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card 
           schema_version address window total_registrations subnet_count
           concentration dominant_netuid subnets { netuid }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_registrations, {
@@ -10918,7 +10992,7 @@ describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card 
 describe("graphql — account_deregistrations (#5701, Postgres-tier + zeroed-card fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -10975,7 +11049,7 @@ describe("graphql — account_deregistrations (#5701, Postgres-tier + zeroed-car
           address window total_deregistrations subnet_count concentration dominant_netuid
           subnets { netuid deregistrations first_deregistered_at last_deregistered_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.account_deregistrations;
@@ -11010,7 +11084,7 @@ describe("graphql — account_deregistrations (#5701, Postgres-tier + zeroed-car
           schema_version address window total_deregistrations subnet_count
           concentration dominant_netuid subnets { netuid }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_deregistrations, {
@@ -11047,7 +11121,7 @@ describe("graphql — account_deregistrations (#5701, Postgres-tier + zeroed-car
 describe("graphql — account_serving (#5705, Postgres-tier + zeroed-card fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -11104,7 +11178,7 @@ describe("graphql — account_serving (#5705, Postgres-tier + zeroed-card fallba
           address window total_announcements subnet_count concentration dominant_netuid
           subnets { netuid announcements first_served_at last_served_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.account_serving;
@@ -11139,7 +11213,7 @@ describe("graphql — account_serving (#5705, Postgres-tier + zeroed-card fallba
           schema_version address window total_announcements subnet_count
           concentration dominant_netuid subnets { netuid }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_serving, {
@@ -11176,7 +11250,7 @@ describe("graphql — account_serving (#5705, Postgres-tier + zeroed-card fallba
 describe("graphql — account_axon_removals (#5699, Postgres-tier + zeroed-card fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -11233,7 +11307,7 @@ describe("graphql — account_axon_removals (#5699, Postgres-tier + zeroed-card 
           address window total_removals subnet_count concentration dominant_netuid
           subnets { netuid removals first_removed_at last_removed_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.account_axon_removals;
@@ -11268,7 +11342,7 @@ describe("graphql — account_axon_removals (#5699, Postgres-tier + zeroed-card 
           schema_version address window total_removals subnet_count
           concentration dominant_netuid subnets { netuid }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_axon_removals, {
@@ -11305,7 +11379,7 @@ describe("graphql — account_axon_removals (#5699, Postgres-tier + zeroed-card 
 describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -11363,7 +11437,7 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
           address window total_movements subnet_count concentration dominant_netuid
           subnets { netuid movements first_moved_at last_moved_at price_tao_at_last_move }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.account_stake_moves;
@@ -11400,7 +11474,7 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
           schema_version address window total_movements subnet_count
           concentration dominant_netuid subnets { netuid }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_stake_moves, {
@@ -11438,7 +11512,7 @@ describe("graphql — account_children / account_parents (#6976, live chain RPC 
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const CHILD_SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-  function stubFetch(handler) {
+  function stubFetch(handler: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = handler;
     return () => {
@@ -11450,7 +11524,7 @@ describe("graphql — account_children / account_parents (#6976, live chain RPC 
     ["account_children", "children", "child"],
     ["account_parents", "parents", "parent"],
   ]) {
-    function query(argsClause) {
+    function query(argsClause: string) {
       return `{ ${field}${argsClause} {
         schema_version account queried_at
         subnets { netuid entries { ${counterpartKey} proportion proportion_fraction } }
@@ -11468,7 +11542,7 @@ describe("graphql — account_children / account_parents (#6976, live chain RPC 
         assert.equal(status, 200);
         assert.equal(body.data[field], null);
         assert.ok(
-          body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+          body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
         );
         assert.equal(called, false);
       } finally {
@@ -11489,8 +11563,8 @@ describe("graphql — account_children / account_parents (#6976, live chain RPC 
     });
 
     test(`${field}: subnets:[] when the account genuinely has none, schema-stable`, async () => {
-      const restore = stubFetch(async (_url, init) => {
-        const parsedBody = JSON.parse(init.body);
+      const restore = stubFetch(async (_url: unknown, init: RequestInit) => {
+        const parsedBody = JSON.parse(init.body as string);
         if (parsedBody.method === "state_getKeysPaged") {
           return { ok: true, json: async () => ({ result: [] }) };
         }
@@ -11557,7 +11631,7 @@ describe("graphql — account_children / account_parents (#6976, live chain RPC 
 describe("graphql — account_weight_setters (#6976, Postgres-tier { data, generatedAt } + zeroed-card fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_weight_setters${argsClause} {
       schema_version address window total_weight_sets subnet_count concentration dominant_netuid
       subnets { netuid weight_sets first_set_at last_set_at }
@@ -11615,7 +11689,7 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
     };
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", window: "30d")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.account_weight_setters;
@@ -11630,11 +11704,11 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             data: { schema_version: 1, address: SS58, subnets: [] },
@@ -11645,10 +11719,10 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
     };
     await gql(query(`(ss58: "${SS58}", window: "30d")`), env);
     assert.equal(
-      capturedUrl.pathname,
+      capturedUrl!.pathname,
       `/api/v1/accounts/${SS58}/weight-setters`,
     );
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
@@ -11704,10 +11778,12 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
     };
     const { status, body } = await gql(
       query('(ss58: "not-a-valid-address")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -11731,7 +11807,7 @@ describe("graphql — account_entities (#6976, R2 entity labels + Postgres-tier 
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const ENTITIES_ARTIFACT_PATH = "/metagraph/entities.json";
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_entities${argsClause} {
       schema_version ss58 ownership_tie_count
       labels { name category notes source_urls }
@@ -11842,10 +11918,12 @@ describe("graphql — account_entities (#6976, R2 entity labels + Postgres-tier 
     };
     const { status, body } = await gql(
       query('(ss58: "not-a-valid-address")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -11859,7 +11937,7 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
   const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -11926,7 +12004,7 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
           counterparties { address sent_tao received_tao net_tao transfer_count last_block }
           relationship { counterparty }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.account_counterparties;
@@ -12017,7 +12095,7 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
             transfers { block_number event_index netuid from to amount_tao direction observed_at }
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const r = body.data.account_counterparties;
@@ -12075,7 +12153,7 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
           counterparties { address sent_tao received_tao net_tao transfer_count last_block }
           relationship { counterparty }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_counterparties, {
@@ -12112,7 +12190,7 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
           counterparties { address }
           relationship { counterparty }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_counterparties, {
@@ -12147,7 +12225,7 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
             transfers { direction }
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_counterparties.relationship, {
@@ -12188,7 +12266,7 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
             transfers { block_number event_index netuid from to amount_tao direction observed_at }
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_counterparties.relationship.transfers, [
@@ -12244,9 +12322,9 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
   const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function dataApi(response, capture) {
+  function dataApi(response: Row, capture?: Row) {
     return {
-      fetch: async (req) => {
+      fetch: async (req: Request) => {
         if (capture) capture.url = new URL(req.url);
         return response;
       },
@@ -12303,7 +12381,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
           schema_version ss58 transfer_count limit offset next_cursor
           transfers { block_number event_index from to amount_tao direction observed_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -12329,7 +12407,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
   });
 
   test("hits /api/v1/accounts/{ss58}/transfers and forwards every filter", async () => {
-    const capture = {};
+    const capture: Row = {};
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: dataApi(
@@ -12347,7 +12425,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
     };
     const { status } = await gql(
       `{ account_transfers(ss58: "${SS58}", limit: 5, offset: 2, cursor: "c:9:1", direction: "received", block_start: 10, block_end: 20) { transfer_count } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/transfers`);
@@ -12360,14 +12438,14 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds before forwarding", async () => {
-    const capture = {};
+    const capture: Row = {};
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: dataApi(Response.json({}), capture),
     };
     await gql(
       `{ account_transfers(ss58: "${SS58}", limit: 100000, offset: -5) { transfer_count } }`,
-      env,
+      env as unknown as Env,
     );
     const forwardedLimit = Number(capture.url.searchParams.get("limit"));
     const forwardedOffset = Number(capture.url.searchParams.get("offset"));
@@ -12389,7 +12467,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
       `{ account_transfers(ss58: "${SS58}") {
           schema_version ss58 transfer_count limit offset next_cursor transfers { from }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_transfers, {
@@ -12420,7 +12498,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
       `{ account_transfers(ss58: "${SS58}") {
           transfers { block_number event_index from to amount_tao direction observed_at }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_transfers.transfers, [
@@ -12449,7 +12527,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
     };
     const { body } = await gql(
       '{ account_transfers(ss58: "not-an-address") { transfer_count } }',
-      env,
+      env as unknown as Env,
     );
     assert.ok(body.errors, "expected a GraphQL error");
     assert.ok(/ss58/i.test(body.errors[0].message));
@@ -12469,16 +12547,16 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
   const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function dataApi(response, capture) {
+  function dataApi(response: Row, capture?: Row) {
     return {
-      fetch: async (req) => {
+      fetch: async (req: Request) => {
         if (capture) capture.url = new URL(req.url);
         return response;
       },
     };
   }
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_events${argsClause} {
       schema_version ss58 event_count limit offset next_cursor
       events { block_number event_index event_kind hotkey coldkey netuid uid amount_tao alpha_amount observed_at extrinsic_index }
@@ -12558,7 +12636,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
   });
 
   test("hits /api/v1/accounts/{ss58}/events and forwards every filter", async () => {
-    const capture = {};
+    const capture: Row = {};
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: dataApi(
@@ -12578,7 +12656,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
       query(
         `(ss58: "${SS58}", kind: "StakeAdded", netuid: 7, block_start: 10, block_end: 20, limit: 5, offset: 2, cursor: "c:9:1")`,
       ),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/events`);
@@ -12592,7 +12670,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds and omits absent filters", async () => {
-    const capture = {};
+    const capture: Row = {};
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: dataApi(Response.json({}), capture),
@@ -12689,16 +12767,16 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
 describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHistory fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-  function dataApi(response, capture) {
+  function dataApi(response: Row, capture?: Row) {
     return {
-      fetch: async (req) => {
+      fetch: async (req: Request) => {
         if (capture) capture.url = new URL(req.url);
         return response;
       },
     };
   }
 
-  function query(argsClause) {
+  function query(argsClause: string) {
     return `{ account_history${argsClause} {
       schema_version ss58 day_count limit offset next_cursor
       days { day netuid event_count event_kinds first_block last_block }
@@ -12723,11 +12801,11 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
     };
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", from: "not-a-date")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err, "expected a BAD_USER_INPUT error");
     // The same message REST's parseDateRange and MCP's optionalDayArg emit.
@@ -12741,7 +12819,9 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
       query(`(ss58: "${SS58}", from: "2026-07-01", to: "07/16/2026")`),
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
   });
 
@@ -12750,18 +12830,20 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
       query(`(ss58: "${SS58}", from: "2026-7-1")`),
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("well-formed from/to bounds are accepted and forwarded to the tier", async () => {
-    const capture = {};
+    const capture: Row = {};
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: dataApi(Response.json({ days: [] }), capture),
     };
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", from: "2026-07-01", to: "2026-07-16")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -12785,10 +12867,12 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
     };
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", to: "not-a-date")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(prepared, false, "must not reach D1");
   });
 
@@ -12855,7 +12939,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
   });
 
   test("hits /api/v1/accounts/{ss58}/history and forwards every filter", async () => {
-    const capture = {};
+    const capture: Row = {};
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: dataApi(
@@ -12875,7 +12959,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
       query(
         `(ss58: "${SS58}", netuid: 7, from: "2026-06-01", to: "2026-06-30", limit: 5, offset: 2, cursor: "c:20260615:3")`,
       ),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/history`);
@@ -12888,7 +12972,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds and omits absent filters", async () => {
-    const capture = {};
+    const capture: Row = {};
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: dataApi(Response.json({}), capture),
@@ -12997,7 +13081,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
 describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 
-  function historyQuery(argsClause) {
+  function historyQuery(argsClause: string) {
     return `{ account_identity_history${argsClause} {
       schema_version account entry_count limit offset next_cursor
       entries { observed_at name url github image discord description additional identity_hash }
@@ -13025,11 +13109,11 @@ describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live f
   });
 
   test("resolves Postgres-tier data as-is, forwarding limit/offset/cursor as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -13057,16 +13141,16 @@ describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live f
     };
     const { status, body } = await gql(
       historyQuery(`(ss58: "${SS58}", limit: 5, offset: 10, cursor: "xyz")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(
-      capturedUrl.pathname,
+      capturedUrl!.pathname,
       `/api/v1/accounts/${SS58}/identity-history`,
     );
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl.searchParams.get("offset"), "10");
-    assert.equal(capturedUrl.searchParams.get("cursor"), "xyz");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
+    assert.equal(capturedUrl!.searchParams.get("cursor"), "xyz");
     assert.equal(body.data.account_identity_history.entry_count, 1);
     assert.equal(body.data.account_identity_history.entries[0].name, "Example");
     assert.equal(
@@ -13162,7 +13246,7 @@ describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live f
 });
 
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -13207,7 +13291,7 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
           window day_count
           days { snapshot_date subnet_count total_stake_tao alpha_price_tao_weighted alpha_price_tao_median validator_count miner_count mean_emission_share }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.economics_trends.window, "90d");
@@ -13223,11 +13307,11 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -13239,8 +13323,8 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
       },
     };
     await gql('{ economics_trends(window: "7d") { day_count } }', env);
-    assert.equal(capturedUrl.pathname, "/api/v1/economics/trends");
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl!.pathname, "/api/v1/economics/trends");
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
   });
 
   test("a malformed Postgres-tier body falls back to the D1 rollup (schema-stable empty on cold D1)", async () => {
@@ -13250,7 +13334,7 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
     };
     const { status, body } = await gql(
       "{ economics_trends { day_count days { snapshot_date } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.economics_trends.day_count, 0);
@@ -13274,7 +13358,7 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
       `{ economics_trends(window: "7d") {
           window day_count days { snapshot_date total_stake_tao validator_count }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.economics_trends.window, "7d");
@@ -13292,7 +13376,7 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
     };
     const { status, body } = await gql(
       "{ economics_trends { day_count days { snapshot_date } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.economics_trends.day_count, 0);
@@ -13305,7 +13389,9 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
     );
     assert.equal(status, 200);
     assert.equal(body.data, null);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.match(body.errors[0].message, /99d/);
   });
 
@@ -13315,7 +13401,7 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
 });
 
 describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback leaderboard)", () => {
-  function moversQuery(argsClause) {
+  function moversQuery(argsClause: string) {
     return `{ subnet_movers${argsClause} {
       schema_version window start_date end_date sort subnet_count
       network {
@@ -13357,11 +13443,11 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
   });
 
   test("resolves Postgres-tier movers for a valid non-default window/sort combination", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -13411,13 +13497,13 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
     };
     const { status, body } = await gql(
       moversQuery('(window: "7d", sort: "emission")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/subnets/movers");
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
-    assert.equal(capturedUrl.searchParams.get("sort"), "emission");
-    assert.equal(capturedUrl.searchParams.get("limit"), "20");
+    assert.equal(capturedUrl!.pathname, "/api/v1/subnets/movers");
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl!.searchParams.get("sort"), "emission");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "20");
     assert.equal(body.data.subnet_movers.window, "7d");
     assert.equal(body.data.subnet_movers.sort, "emission");
     assert.equal(body.data.subnet_movers.subnet_count, 1);
@@ -13431,18 +13517,18 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
   });
 
   test("a limit argument is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({ schema_version: 1, movers: [] });
         },
       },
     };
     await gql(moversQuery("(limit: 5)"), env);
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
   });
 
   test("a malformed Postgres-tier body degrades to schema-stable defaults (no throw)", async () => {
@@ -13466,7 +13552,7 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
     assert.equal(status, 200);
     assert.equal(body.data, null);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err);
     assert.match(err.message, /1y/);
@@ -13477,7 +13563,7 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
     assert.equal(status, 200);
     assert.equal(body.data, null);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err);
     assert.match(err.message, /bogus/);
@@ -13488,7 +13574,7 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
     assert.equal(status, 200);
     assert.equal(body.data, null);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err);
     assert.match(err.message, /1 to 100/);
@@ -13499,7 +13585,7 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
     assert.equal(status, 200);
     assert.equal(body.data, null);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err);
   });
@@ -13510,7 +13596,7 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
 });
 
 describe("graphql — chain_turnover (#5686, Postgres-tier + cold-store fallback)", () => {
-  function turnoverQuery(argsClause) {
+  function turnoverQuery(argsClause: string) {
     return `{ chain_turnover${argsClause} {
       schema_version window start_date end_date comparable subnet_count
       network { validators_start validators_end validators_entered validators_exited validator_retention stability_score }
@@ -13543,11 +13629,11 @@ describe("graphql — chain_turnover (#5686, Postgres-tier + cold-store fallback
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -13591,12 +13677,12 @@ describe("graphql — chain_turnover (#5686, Postgres-tier + cold-store fallback
     };
     const { status, body } = await gql(
       turnoverQuery('(window: "7d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/turnover");
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/turnover");
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_turnover.window, "7d");
     assert.equal(body.data.chain_turnover.comparable, true);
     assert.equal(body.data.chain_turnover.subnet_count, 1);
@@ -13631,7 +13717,7 @@ describe("graphql — chain_turnover (#5686, Postgres-tier + cold-store fallback
 });
 
 describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", () => {
-  function weightsQuery(argsClause) {
+  function weightsQuery(argsClause: string) {
     return `{ chain_weights${argsClause} {
       schema_version window observed_at subnet_count
       network { distinct_setters weight_sets sets_per_setter }
@@ -13643,9 +13729,9 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
   // The network aggregate (COUNT/COUNT DISTINCT/MAX(observed_at)) has no GROUP
   // BY; the per-subnet leaderboard is GROUP BY netuid -- same two-query shape
   // loadChainWeights always issues (mirrors the mcp-server.test.mjs fixture).
-  function chainWeightsD1({ network, subnets = [] } = {}) {
+  function chainWeightsD1({ network, subnets = [] }: Row = {}) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
           bind() {
             return {
@@ -13677,11 +13763,11 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -13717,12 +13803,12 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
     };
     const { status, body } = await gql(
       weightsQuery('(window: "30d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/weights");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/weights");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_weights.window, "30d");
     assert.equal(body.data.chain_weights.subnet_count, 1);
     assert.equal(body.data.chain_weights.network.weight_sets, 40);
@@ -13787,7 +13873,7 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
     assert.equal(status, 200);
     assert.equal(body.data, null);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err);
     assert.match(err.message, /99d/);
@@ -13799,7 +13885,7 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
 });
 
 describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fallback)", () => {
-  function callsQuery(argsClause) {
+  function callsQuery(argsClause: string) {
     return `{ chain_calls${argsClause} {
       schema_version window group_by observed_at total_extrinsics call_count
       calls { call_module call_function count share }
@@ -13845,7 +13931,7 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
     };
     const { status, body } = await gql(
       callsQuery(`(window: "30d", group_by: "module_function")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const d = body.data.chain_calls;
@@ -13905,11 +13991,11 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
   });
 
   test("window/group_by/limit/call_module args are forwarded to the /chain/calls path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -13926,14 +14012,14 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
       callsQuery(
         `(window: "30d", group_by: "module", limit: 5, call_module: "SubtensorModule")`,
       ),
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/calls");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("group_by"), "module");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/calls");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("group_by"), "module");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(
-      capturedUrl.searchParams.get("call_module"),
+      capturedUrl!.searchParams.get("call_module"),
       "SubtensorModule",
     );
   });
@@ -13961,7 +14047,7 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
 });
 
 describe("graphql — chain_activity (#5879, Postgres-tier activity series + cold-store fallback)", () => {
-  function activityQuery(argsClause) {
+  function activityQuery(argsClause: string) {
     return `{ chain_activity${argsClause} {
       schema_version window observed_at day_count
       days { day block_count extrinsic_count event_count successful_extrinsics success_rate unique_signers }
@@ -14057,11 +14143,11 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
   });
 
   test("the window arg is forwarded to the /chain/activity path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -14073,8 +14159,8 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
       },
     };
     await gql(activityQuery(`(window: "30d")`), env);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/activity");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/activity");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
   });
 
   test("rejects an unsupported window with BAD_USER_INPUT", async () => {
@@ -14088,7 +14174,7 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
 });
 
 describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store fallback)", () => {
-  function feesQuery(argsClause) {
+  function feesQuery(argsClause: string) {
     return `{ chain_fees${argsClause} {
       schema_version window observed_at day_count
       daily { day extrinsic_count total_fee_tao avg_fee_tao median_fee_tao total_tip_tao avg_tip_tao median_tip_tao }
@@ -14206,11 +14292,11 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
   });
 
   test("window/limit/call_module args are forwarded to the /chain/fees path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -14224,12 +14310,12 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     };
     await gql(
       feesQuery(`(window: "30d", limit: 5, call_module: "Balances")`),
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/fees");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl.searchParams.get("call_module"), "Balances");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/fees");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("call_module"), "Balances");
   });
 
   test("rejects an unsupported window with BAD_USER_INPUT", async () => {
@@ -14250,7 +14336,7 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
 });
 
 describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", () => {
-  function servingQuery(argsClause) {
+  function servingQuery(argsClause: string) {
     return `{ chain_serving${argsClause} {
       schema_version window observed_at subnet_count
       network { distinct_servers announcements announcements_per_server }
@@ -14263,9 +14349,9 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
   // GROUP BY; the per-subnet leaderboard is GROUP BY netuid -- same two-query
   // shape loadChainServing always issues. The subnet query only fires when the
   // network row carries a non-null newest_observed.
-  function chainServingD1({ network, subnets = [] } = {}) {
+  function chainServingD1({ network, subnets = [] }: Row = {}) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
           bind() {
             return {
@@ -14301,11 +14387,11 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -14341,12 +14427,12 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
     };
     const { status, body } = await gql(
       servingQuery('(window: "30d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/serving");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/serving");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_serving.window, "30d");
     assert.equal(body.data.chain_serving.subnet_count, 1);
     assert.equal(body.data.chain_serving.network.distinct_servers, 4);
@@ -14401,7 +14487,7 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
     assert.equal(status, 200);
     assert.equal(body.data, null);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err);
     assert.match(err.message, /99d/);
@@ -14413,7 +14499,7 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
 });
 
 describe("graphql — chain_weight_setters (#5689, Postgres-tier, D1 fully eliminated)", () => {
-  function weightSettersQuery(argsClause) {
+  function weightSettersQuery(argsClause: string) {
     return `{ chain_weight_setters${argsClause} {
       schema_version window observed_at distinct_setters weight_sets setter_count
       setters { hotkey netuid uid weight_sets share first_set_at last_set_at }
@@ -14435,11 +14521,11 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier, D1 fully elimi
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -14465,12 +14551,12 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier, D1 fully elimi
     };
     const { status, body } = await gql(
       weightSettersQuery('(window: "30d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/weights/setters");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/weights/setters");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_weight_setters.window, "30d");
     assert.equal(body.data.chain_weight_setters.setter_count, 1);
     assert.equal(body.data.chain_weight_setters.setters[0].hotkey, "5Setter");
@@ -14496,7 +14582,7 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier, D1 fully elimi
     assert.equal(status, 200);
     assert.equal(body.data, null);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err);
     assert.match(err.message, /99d/);
@@ -14528,7 +14614,7 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
 
   // loadChainAlphaVolume issues a single (netuid, event_kind) GROUP BY over
   // account_events; the mock returns those aggregate rows for the one query.
-  function chainAlphaVolumeD1(rows = []) {
+  function chainAlphaVolumeD1(rows: Row[] = []) {
     return {
       prepare() {
         return {
@@ -14571,11 +14657,11 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
   });
 
   test("resolves Postgres-tier data for an explicit limit, forwarding it as a query param", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -14630,8 +14716,8 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
     };
     const { status, body } = await gql(alphaVolumeQuery("(limit: 5)"), env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/alpha-volume");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/alpha-volume");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     const card = body.data.chain_alpha_volume;
     assert.equal(card.window, "24h");
     assert.equal(card.subnet_count, 1);
@@ -14644,11 +14730,11 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
   });
 
   test("clamps an over-max limit before forwarding it to the Postgres tier", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({});
         },
@@ -14656,7 +14742,7 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
     };
     const { status } = await gql(alphaVolumeQuery("(limit: 9999)"), env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -14740,7 +14826,7 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
 
   // No GROUP BY window label -- loadBulkHealthTrends issues a single query
   // over the full 30d cutoff and buckets rows into 7d/30d itself.
-  function bulkTrendsD1(rows = []) {
+  function bulkTrendsD1(rows: Row[] = []) {
     return {
       prepare() {
         return {
@@ -14768,11 +14854,11 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data, forwarding the request unchanged", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -14798,7 +14884,7 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
     };
     const { status, body } = await gql(trendsQuery(), env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/health/trends");
+    assert.equal(capturedUrl!.pathname, "/api/v1/health/trends");
     assert.equal(
       body.data.health_trends.observed_at,
       "2026-07-10T00:00:00.000Z",
@@ -14854,7 +14940,7 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   test("observed_at is stamped from the health:meta KV freshness on the D1-live path", async () => {
     const env = {
       METAGRAPH_CONTROL: {
-        async get(key) {
+        async get(key: string) {
           return key === KV_HEALTH_META
             ? { last_run_at: "2026-06-23T00:00:00.000Z" }
             : null;
@@ -14891,7 +14977,7 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
 describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallback)", () => {
   const NETUID = 3;
 
-  function trendsQuery(netuid) {
+  function trendsQuery(netuid: number) {
     return `{ subnet_health_trends(netuid: ${netuid}) { schema_version netuid observed_at source windows } }`;
   }
 
@@ -14909,11 +14995,11 @@ describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallb
   });
 
   test("resolves Postgres-tier data, forwarding the netuid in the path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -14941,7 +15027,7 @@ describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallb
     const { status, body } = await gql(trendsQuery(NETUID), env);
     assert.equal(status, 200);
     assert.equal(
-      capturedUrl.pathname,
+      capturedUrl!.pathname,
       `/api/v1/subnets/${NETUID}/health/trends`,
     );
     const d = body.data.subnet_health_trends;
@@ -15001,7 +15087,7 @@ describe("graphql — subnet_health (#7640, live-cron overlay parity with REST +
     );
     const { status, body } = await gql(
       `{ subnet_health(netuid: ${NETUID}) }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const card = body.data.subnet_health;
@@ -15018,7 +15104,7 @@ describe("graphql — subnet_health (#7640, live-cron overlay parity with REST +
   test("subnet_health resolves the schema-stable unknown card when the live store is cold", async () => {
     const { status, body } = await gql(
       `{ subnet_health(netuid: ${NETUID}) }`,
-      emptyEnv,
+      emptyEnv as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_health, {
@@ -15058,7 +15144,7 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
 
   // loadSubnetUptime issues a single GROUP BY over surface_uptime_daily; the
   // mock only needs to answer all() with the aggregated day rows.
-  function uptimeD1(rows = []) {
+  function uptimeD1(rows: Row[] = []) {
     return {
       prepare() {
         return {
@@ -15090,11 +15176,11 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data and forwards window + min_samples", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -15132,12 +15218,12 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
     };
     const { status, body } = await gql(
       uptimeQuery(`netuid: ${NETUID}, window: "1y", min_samples: 5`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, `/api/v1/subnets/${NETUID}/uptime`);
-    assert.equal(capturedUrl.searchParams.get("window"), "1y");
-    assert.equal(capturedUrl.searchParams.get("min_samples"), "5");
+    assert.equal(capturedUrl!.pathname, `/api/v1/subnets/${NETUID}/uptime`);
+    assert.equal(capturedUrl!.searchParams.get("window"), "1y");
+    assert.equal(capturedUrl!.searchParams.get("min_samples"), "5");
     const d = body.data.subnet_uptime;
     assert.equal(d.window, "1y");
     assert.equal(d.reliability.score, 99);
@@ -15212,7 +15298,7 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
     );
     assert.equal(status, 200);
     assert.ok(
-      body.errors?.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+      body.errors?.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
       `expected BAD_USER_INPUT, got: ${JSON.stringify(body.errors)}`,
     );
   });
@@ -15223,7 +15309,7 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
     );
     assert.equal(status, 200);
     assert.ok(
-      body.errors?.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+      body.errors?.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
       `expected BAD_USER_INPUT, got: ${JSON.stringify(body.errors)}`,
     );
   });
@@ -15231,7 +15317,7 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
   test("observed_at is stamped from the health:meta KV freshness on the D1-live path", async () => {
     const env = {
       METAGRAPH_CONTROL: {
-        async get(key) {
+        async get(key: string) {
           return key === KV_HEALTH_META
             ? { last_run_at: "2026-06-23T00:00:00.000Z" }
             : null;
@@ -15277,9 +15363,9 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
     endpoints = [],
     networks = [],
     buckets = [],
-  } = {}) {
+  }: Row = {}) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
           bind() {
             return {
@@ -15332,11 +15418,11 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
   });
 
   test("resolves Postgres-tier data for a valid non-default window, forwarding it as a query param", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_RPC_USAGE_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -15388,8 +15474,8 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
     };
     const { status, body } = await gql(usageQuery('(window: "30d")'), env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/rpc/usage");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.pathname, "/api/v1/rpc/usage");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
     const usage = body.data.rpc_usage;
     assert.equal(usage.window, "30d");
     assert.equal(usage.bucket_granularity, "6h");
@@ -15486,7 +15572,7 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
   test("observed_at is stamped from the health:meta KV freshness on the D1-live path", async () => {
     const env = {
       METAGRAPH_CONTROL: {
-        async get(key) {
+        async get(key: string) {
           return key === KV_HEALTH_META
             ? { last_run_at: "2026-06-23T00:00:00.000Z" }
             : null;
@@ -15518,7 +15604,7 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
     assert.equal(status, 200);
     assert.equal(body.data, null);
     const err = body.errors.find(
-      (e) => e.extensions?.code === "BAD_USER_INPUT",
+      (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
     );
     assert.ok(err);
     assert.match(err.message, /99d/);
@@ -15531,7 +15617,7 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
 
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
-    const hub = fakeChainFirehose((repeater) => {
+    const hub = fakeChainFirehose((repeater: Row) => {
       // subscribeChainEvents is only invoked once the async generator is
       // first pulled (async generator function BODIES don't run until
       // next() is called) -- pushing here, synchronously inside that same
@@ -15552,10 +15638,10 @@ describe("Subscription.chainEvents", () => {
   });
 
   test("passes the tables argument through to subscribeChainEvents as a Set", async () => {
-    let receivedTopics;
+    let receivedTopics: Set<string> | undefined;
     const hub = fakeChainFirehose();
     const originalSubscribe = hub.subscribeChainEvents.bind(hub);
-    hub.subscribeChainEvents = (topics) => {
+    hub.subscribeChainEvents = (topics: Set<string>) => {
       receivedTopics = topics;
       return originalSubscribe(topics);
     };
@@ -15568,16 +15654,16 @@ describe("Subscription.chainEvents", () => {
     // function only creates the generator object, it doesn't execute any of
     // the body until the first next().
     const pending = result[Symbol.asyncIterator]().next();
-    assert.deepEqual([...receivedTopics].sort(), ["blocks", "extrinsics"]);
+    assert.deepEqual([...receivedTopics!].sort(), ["blocks", "extrinsics"]);
     await hub.unsubscribeChainEvents(hub.subscriptions[0]?.repeater);
     pending.catch(() => {}); // left permanently pending; not under test here
   });
 
   test("an omitted tables argument means no filter (null, matches everything)", async () => {
-    let receivedTopics = "unset";
+    let receivedTopics: unknown = "unset";
     const hub = fakeChainFirehose();
     const originalSubscribe = hub.subscribeChainEvents.bind(hub);
-    hub.subscribeChainEvents = (topics) => {
+    hub.subscribeChainEvents = (topics: Set<string>) => {
       receivedTopics = topics;
       return originalSubscribe(topics);
     };
@@ -15590,10 +15676,10 @@ describe("Subscription.chainEvents", () => {
   });
 
   test("an EXPLICIT empty tables argument means an empty Set (matches nothing) -- consistent with the SSE/WS firehose's own all-unrecognized-topics semantics, not silently 'everything'", async () => {
-    let receivedTopics = "unset";
+    let receivedTopics: unknown = "unset";
     const hub = fakeChainFirehose();
     const originalSubscribe = hub.subscribeChainEvents.bind(hub);
-    hub.subscribeChainEvents = (topics) => {
+    hub.subscribeChainEvents = (topics: Set<string>) => {
       receivedTopics = topics;
       return originalSubscribe(topics);
     };
@@ -15603,7 +15689,7 @@ describe("Subscription.chainEvents", () => {
     );
     result[Symbol.asyncIterator]().next(); // trigger the generator body
     assert.ok(receivedTopics instanceof Set);
-    assert.equal(receivedTopics.size, 0);
+    assert.equal((receivedTopics as Set<string>).size, 0);
   });
 
   test("returns a clear GraphQLError when reached without the graphql-ws WS transport (no context.chainFirehose)", async () => {
@@ -15634,7 +15720,7 @@ describe("Subscription.chainEvents", () => {
     let receivedClientIp = "unset";
     const hub = fakeChainFirehose();
     const originalSubscribe = hub.subscribeChainEvents.bind(hub);
-    hub.subscribeChainEvents = (topics, clientIp) => {
+    hub.subscribeChainEvents = (topics: string[], clientIp: string) => {
       receivedClientIp = clientIp;
       return originalSubscribe(topics);
     };
@@ -15651,7 +15737,7 @@ describe("Subscription.chainEvents", () => {
     let receivedClientIp = "unset";
     const hub = fakeChainFirehose();
     const originalSubscribe = hub.subscribeChainEvents.bind(hub);
-    hub.subscribeChainEvents = (topics, clientIp) => {
+    hub.subscribeChainEvents = (topics: string[], clientIp: string) => {
       receivedClientIp = clientIp;
       return originalSubscribe(topics);
     };
@@ -15690,7 +15776,7 @@ describe("Subscription.chainEvents", () => {
     // pending next() actually resolves first, matching how a real client
     // completes a subscription only after having received at least one
     // event, not mid-flight on an empty stream.
-    const hub = fakeChainFirehose((repeater) => {
+    const hub = fakeChainFirehose((repeater: Row) => {
       repeater.push({ table: "blocks" });
     });
     const result = await subscribeChainEvents(
@@ -15716,7 +15802,7 @@ describe("Subscription.chainEvents", () => {
 describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallback)", () => {
   const HOTKEY = "5FTestValidatorHotkeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
-  function nominatorsQuery(argsClause) {
+  function nominatorsQuery(argsClause: string) {
     return `{ validator_nominators${argsClause} {
       schema_version hotkey window sort limit offset nominator_count
       nominators { coldkey staked_tao unstaked_tao net_staked_tao gross_staked_tao event_count last_observed_at }
@@ -15726,9 +15812,9 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
   // loadValidatorNominators issues TWO queries: a COUNT(DISTINCT coldkey) total
   // (paging-independent) and the per-coldkey GROUP BY rows -- same two-query shape
   // the chainWeightsD1 fixture above models, so branch on the SQL.
-  function nominatorsD1(rows = [], nominatorCount = rows.length) {
+  function nominatorsD1(rows: Row[] = [], nominatorCount = rows.length) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
           bind: () => ({
             all: async () =>
@@ -15754,11 +15840,11 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
   });
 
   test("resolves Postgres-tier data for a valid non-default window/sort, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             data: {
@@ -15790,15 +15876,15 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
       nominatorsQuery(
         `(hotkey: "${HOTKEY}", window: "7d", sort: "gross_staked")`,
       ),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(
-      capturedUrl.pathname,
+      capturedUrl!.pathname,
       `/api/v1/validators/${HOTKEY}/nominators`,
     );
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
-    assert.equal(capturedUrl.searchParams.get("sort"), "gross_staked");
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl!.searchParams.get("sort"), "gross_staked");
     assert.equal(body.data.validator_nominators.window, "7d");
     assert.equal(body.data.validator_nominators.sort, "gross_staked");
     assert.equal(body.data.validator_nominators.nominator_count, 1);
@@ -15829,7 +15915,7 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     };
     const { status, body } = await gql(
       nominatorsQuery(`(hotkey: "${HOTKEY}")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.validator_nominators.nominator_count, 0);
@@ -15848,7 +15934,7 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     };
     const { status, body } = await gql(
       nominatorsQuery(`(hotkey: "${HOTKEY}")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.validator_nominators, {
@@ -15886,11 +15972,11 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
 
   test("coldkey narrows to one nominator, forwarded to the Postgres tier as a query param (#7884)", async () => {
     const COLDKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Request) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             data: {
@@ -15924,7 +16010,7 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl.searchParams.get("coldkey"), COLDKEY);
+    assert.equal(capturedUrl!.searchParams.get("coldkey"), COLDKEY);
     assert.equal(body.data.validator_nominators.nominator_count, 1);
     assert.equal(body.data.validator_nominators.nominators[0].coldkey, COLDKEY);
   });
@@ -15969,11 +16055,11 @@ describe("graphql — chain_performance (#5688, Postgres-tier + zeroed-card fall
   });
 
   test("resolves Postgres-tier data, requesting the mirrored REST path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -16016,7 +16102,7 @@ describe("graphql — chain_performance (#5688, Postgres-tier + zeroed-card fall
     };
     const { status, body } = await gql(PERFORMANCE_QUERY, env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/performance");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/performance");
     assert.equal(body.data.chain_performance.subnet_count, 2);
     assert.equal(body.data.chain_performance.neuron_count, 3);
     assert.equal(body.data.chain_performance.incentive.nakamoto_coefficient, 2);
@@ -16069,11 +16155,11 @@ describe("graphql — chain_concentration (#5872, Postgres-tier + zeroed-card fa
   });
 
   test("resolves Postgres-tier data, requesting the mirrored REST path", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -16106,7 +16192,7 @@ describe("graphql — chain_concentration (#5872, Postgres-tier + zeroed-card fa
     };
     const { status, body } = await gql(CONCENTRATION_QUERY, env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/concentration");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/concentration");
     assert.equal(body.data.chain_concentration.subnet_count, 2);
     assert.equal(body.data.chain_concentration.neuron_count, 3);
     assert.equal(body.data.chain_concentration.entity_count, 2);
@@ -16137,7 +16223,7 @@ describe("graphql — chain_concentration (#5872, Postgres-tier + zeroed-card fa
 });
 
 describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -16203,7 +16289,7 @@ describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => 
           network_yield validator_yield miner_yield
           distribution { count mean p90 }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     const c = body.data.chain_yield;
@@ -16221,19 +16307,19 @@ describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => 
   });
 
   test("forwards to /api/v1/chain/yield with no query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({ schema_version: 1, subnet_count: 0 });
         },
       },
     };
     await gql("{ chain_yield { subnet_count } }", env);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/yield");
-    assert.equal(capturedUrl.search, "");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/yield");
+    assert.equal(capturedUrl!.search, "");
   });
 
   test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
@@ -16248,7 +16334,7 @@ describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => 
           captured_at total_stake_tao total_emission_tao
           network_yield validator_yield miner_yield distribution { count }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.chain_yield, {
@@ -16279,7 +16365,7 @@ describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => 
     };
     const { status, body } = await gql(
       `{ chain_yield { distribution { count mean median min max p10 p25 p75 p90 } } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.chain_yield.distribution, {
@@ -16303,7 +16389,7 @@ describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => 
 describe("graphql — sudo_key (#5896, live chain RPC via sudo-key.ts)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/sudo-key.test.mjs.
-  function withFetchStub(stub, fn) {
+  function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
     return Promise.resolve(fn()).finally(() => {
@@ -16371,7 +16457,7 @@ describe("graphql — sudo_key (#5896, live chain RPC via sudo-key.ts)", () => {
 describe("graphql — network_parameters (#6343, live chain RPC via network-parameters.ts)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/network-parameters.test.mjs.
-  function withFetchStub(stub, fn) {
+  function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
     return Promise.resolve(fn()).finally(() => {
@@ -16387,9 +16473,9 @@ describe("graphql — network_parameters (#6343, live chain RPC via network-para
     "0x658faa385070e074c85bf6b568cf0555503e4fe5f139cae8b9d045e82e1c83a2";
 
   function goldenFetchStub() {
-    return async (_url, init) => {
-      const key = JSON.parse(init.body).params[0];
-      const byKey = {
+    return async (_url: unknown, init: RequestInit) => {
+      const key = JSON.parse(init.body as string).params[0] as string;
+      const byKey: Row = {
         [TAO_WEIGHT_KEY]: "0x7a14ae47e17a142e",
         [STAKE_THRESHOLD_KEY]: "0x0010a5d4e8000000", // 1e12 rao = 1000 TAO
         [COOLDOWN_KEY]: "0x201c000000000000", // 7200 blocks
@@ -16447,7 +16533,7 @@ describe("graphql — network_parameters (#6343, live chain RPC via network-para
 });
 
 describe("graphql — network_randomness (#6990, live chain RPC via randomness.ts)", () => {
-  function kvEnv(payload) {
+  function kvEnv(payload: Row) {
     return { METAGRAPH_CONTROL: { get: async () => payload } };
   }
 
@@ -16461,7 +16547,7 @@ describe("graphql — network_randomness (#6990, live chain RPC via randomness.t
     });
     const { status, body } = await gql(
       "{ network_randomness { schema_version last_stored_round oldest_stored_round stored_round_span queried_at } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16483,7 +16569,7 @@ describe("graphql — network_randomness (#6990, live chain RPC via randomness.t
     });
     const { status, body } = await gql(
       "{ network_randomness { last_stored_round stored_round_span queried_at } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16502,7 +16588,7 @@ describe("graphql — network_randomness (#6990, live chain RPC via randomness.t
 });
 
 describe("graphql — randomness_status (#7649, get_randomness_status-aligned alias)", () => {
-  function kvEnv(payload) {
+  function kvEnv(payload: Row) {
     return { METAGRAPH_CONTROL: { get: async () => payload } };
   }
 
@@ -16517,7 +16603,7 @@ describe("graphql — randomness_status (#7649, get_randomness_status-aligned al
     const { status, body } = await gql(
       `{ randomness_status { schema_version last_stored_round oldest_stored_round stored_round_span queried_at }
          network_randomness { schema_version last_stored_round oldest_stored_round stored_round_span queried_at } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16541,7 +16627,7 @@ describe("graphql — randomness_status (#7649, get_randomness_status-aligned al
     });
     const { status, body } = await gql(
       "{ randomness_status { last_stored_round oldest_stored_round stored_round_span queried_at } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16570,8 +16656,8 @@ describe("graphql — randomness_status (#7649, get_randomness_status-aligned al
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     const fields = body.data.__type.fields;
-    const canonical = fields.find((f) => f.name === "network_randomness");
-    const alias = fields.find((f) => f.name === "randomness_status");
+    const canonical = fields.find((f: Row) => f.name === "network_randomness");
+    const alias = fields.find((f: Row) => f.name === "randomness_status");
     assert.ok(canonical && alias, "both fields present in the schema");
     assert.deepEqual(alias.args, canonical.args);
     assert.deepEqual(alias.type, canonical.type);
@@ -16579,7 +16665,7 @@ describe("graphql — randomness_status (#7649, get_randomness_status-aligned al
 });
 
 describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs)", () => {
-  function kvEnv(payload) {
+  function kvEnv(payload: Row) {
     return { METAGRAPH_CONTROL: { get: async () => payload } };
   }
   const H160 = "0x1234567890abcdef1234567890abcdef12345678";
@@ -16593,7 +16679,7 @@ describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs
     });
     const { status, body } = await gql(
       `{ evm_address(h160: "${H160}") { schema_version h160 ss58 queried_at } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16613,7 +16699,7 @@ describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs
     });
     const { status, body } = await gql(
       `{ evm_address(h160: "${H160}") { h160 ss58 } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16638,7 +16724,7 @@ describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs
 });
 
 describe("graphql — evm_address_mapping (#7648, get_evm_address_mapping name parity)", () => {
-  function kvEnv(payload) {
+  function kvEnv(payload: Row) {
     return { METAGRAPH_CONTROL: { get: async () => payload } };
   }
   const H160 = "0x1234567890abcdef1234567890abcdef12345678";
@@ -16652,7 +16738,7 @@ describe("graphql — evm_address_mapping (#7648, get_evm_address_mapping name p
     });
     const { status, body } = await gql(
       `{ evm_address_mapping(h160: "${H160}") { schema_version h160 ss58 queried_at } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16672,7 +16758,7 @@ describe("graphql — evm_address_mapping (#7648, get_evm_address_mapping name p
     });
     const { status, body } = await gql(
       `{ evm_address_mapping(h160: "${H160}") { h160 ss58 } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16716,7 +16802,7 @@ describe("graphql — evm_address_mapping (#7648, get_evm_address_mapping name p
 describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled.ts)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/subnet-recycled.test.mjs.
-  function withFetchStub(stub, fn) {
+  function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
     return Promise.resolve(fn()).finally(() => {
@@ -16779,7 +16865,7 @@ describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled
         assert.equal(status, 200);
         assert.equal(body.data.subnet_recycled, null);
         assert.ok(
-          body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+          body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
         );
         assert.equal(called, false);
       },
@@ -16791,7 +16877,9 @@ describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled
       "{ subnet_recycled(netuid: -1) { recycled_tao } }",
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("subnet_recycled is weighted heavier than a Postgres-tier relationship field, since it hits live chain RPC", () => {
@@ -16805,7 +16893,7 @@ describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled
 describe("graphql — subnet_burn (#6321, live chain RPC via subnet-burn.ts)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/subnet-burn.test.mjs.
-  function withFetchStub(stub, fn) {
+  function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
     return Promise.resolve(fn()).finally(() => {
@@ -16868,7 +16956,7 @@ describe("graphql — subnet_burn (#6321, live chain RPC via subnet-burn.ts)", (
         assert.equal(status, 200);
         assert.equal(body.data.subnet_burn, null);
         assert.ok(
-          body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+          body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
         );
         assert.equal(called, false);
       },
@@ -16880,7 +16968,9 @@ describe("graphql — subnet_burn (#6321, live chain RPC via subnet-burn.ts)", (
       "{ subnet_burn(netuid: -1) { burn_tao } }",
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("subnet_burn is weighted heavier than a Postgres-tier relationship field, since it hits live chain RPC", () => {
@@ -16894,7 +16984,7 @@ describe("graphql — account_balance (#5700, live chain RPC via account-balance
 
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/account-balance.test.mjs.
-  function withFetchStub(stub, fn) {
+  function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
     return Promise.resolve(fn()).finally(() => {
@@ -16963,7 +17053,7 @@ describe("graphql — account_balance (#5700, live chain RPC via account-balance
         assert.equal(status, 200);
         assert.equal(body.data.account_balance, null);
         assert.ok(
-          body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+          body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
         );
         assert.equal(called, false);
       },
@@ -16981,7 +17071,7 @@ describe("graphql — account_balance (#5700, live chain RPC via account-balance
 describe("graphql — account_root_claim (#7229)", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-  function withFetchStub(stub, fn) {
+  function withFetchStub(stub: AnyFn, fn: AnyFn) {
     const orig = globalThis.fetch;
     globalThis.fetch = stub;
     return Promise.resolve(fn()).finally(() => {
@@ -17033,7 +17123,7 @@ describe("graphql — registry_leaderboards (#5661, shared composer + REST-match
 
   // Same shape handleLeaderboards' surface_status aggregate yields; the stub
   // ignores the SQL, so a single board is asserted at a time.
-  function healthDb(results) {
+  function healthDb(results: Row[]) {
     return {
       prepare: () => ({ bind: () => ({ all: async () => ({ results }) }) }),
     };
@@ -17073,7 +17163,7 @@ describe("graphql — registry_leaderboards (#5661, shared composer + REST-match
     };
     const { status, body } = await gql(
       `{ registry_leaderboards(board: "healthiest") { board boards } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -17144,7 +17234,9 @@ describe("graphql — saved_query (#7642, curated saved-query templates)", () =>
       `{ saved_query(id: "no-such-template") }`,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.match(body.errors[0].message, /no-such-template/);
     assert.match(body.errors[0].message, /subnet-leaderboard/);
     assert.equal(body.data?.saved_query ?? null, null);
@@ -17155,7 +17247,9 @@ describe("graphql — saved_query (#7642, curated saved-query templates)", () =>
       `{ saved_query(id: "subnet-leaderboard", params: { not_a_real_param: 1 }) }`,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.match(body.errors[0].message, /not_a_real_param/);
   });
 
@@ -17178,7 +17272,7 @@ describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => 
     min_childkey_take_ratio: 0.1,
   };
 
-  function hpEnv(body) {
+  function hpEnv(body: Row) {
     return {
       METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
       DATA_API: { fetch: async () => Response.json(body) },
@@ -17239,17 +17333,17 @@ describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => 
   });
 
   test("subnet_hyperparameters requests the subnet's own hyperparameters route", async () => {
-    let seen = null;
+    let seen: URL | null = null;
     await gql(`{ subnet_hyperparameters(netuid: 12) { netuid } }`, {
       METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           seen = new URL(req.url);
           return Response.json({});
         },
       },
     });
-    assert.equal(seen.pathname, "/api/v1/subnets/12/hyperparameters");
+    assert.equal(seen!.pathname, "/api/v1/subnets/12/hyperparameters");
   });
 
   test("subnet_hyperparameters_history resolves the Postgres-tier page", async () => {
@@ -17328,11 +17422,11 @@ describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => 
   });
 
   test("subnet_hyperparameters_history forwards limit/offset, clamped to the REST feed bounds", async () => {
-    let seen = null;
+    let seen: URL | null = null;
     const env = {
       METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           seen = new URL(req.url);
           return Response.json({ entries: [] });
         },
@@ -17340,23 +17434,23 @@ describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => 
     };
     await gql(
       `{ subnet_hyperparameters_history(netuid: 2, limit: 5, offset: 10) { netuid } }`,
-      env,
+      env as unknown as Env,
     );
-    assert.equal(seen.pathname, "/api/v1/subnets/2/hyperparameters/history");
-    assert.equal(seen.searchParams.get("limit"), "5");
-    assert.equal(seen.searchParams.get("offset"), "10");
+    assert.equal(seen!.pathname, "/api/v1/subnets/2/hyperparameters/history");
+    assert.equal(seen!.searchParams.get("limit"), "5");
+    assert.equal(seen!.searchParams.get("offset"), "10");
 
     // Over-wide pages are clamped to MAX_LIMIT rather than forwarded verbatim.
     await gql(
       `{ subnet_hyperparameters_history(netuid: 2, limit: 99999) { netuid } }`,
-      env,
+      env as unknown as Env,
     );
-    assert.equal(seen.searchParams.get("limit"), "1000");
+    assert.equal(seen!.searchParams.get("limit"), "1000");
 
     // An absent limit/offset falls back to the feed defaults.
     await gql(`{ subnet_hyperparameters_history(netuid: 2) { netuid } }`, env);
-    assert.equal(seen.searchParams.get("limit"), "100");
-    assert.equal(seen.searchParams.get("offset"), "0");
+    assert.equal(seen!.searchParams.get("limit"), "100");
+    assert.equal(seen!.searchParams.get("offset"), "0");
   });
 
   test("both fields are priced at the relationship-field complexity weight", () => {
@@ -17377,7 +17471,7 @@ describe("Query.account_identity", () => {
     "schema_version account has_identity name url github image discord description additional captured_at";
 
   // Same D1 stub shape the account_identity_history tests use.
-  function identityD1(rows) {
+  function identityD1(rows: Row[]) {
     return {
       prepare: () => ({
         bind: () => ({ all: async () => ({ results: rows }) }),
@@ -17410,7 +17504,7 @@ describe("Query.account_identity", () => {
     };
     const { status, body } = await gql(
       `{ account_identity(ss58: "${AI_SS58}") { ${AI_FIELDS} } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -17445,11 +17539,11 @@ describe("Query.account_identity", () => {
 
   test("the Postgres tier takes precedence over D1", async () => {
     let d1Called = false;
-    let seen = null;
+    let seen: URL | null = null;
     const env = {
       METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           seen = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -17475,13 +17569,13 @@ describe("Query.account_identity", () => {
     };
     const { status, body } = await gql(
       `{ account_identity(ss58: "${AI_SS58}") { ${AI_FIELDS} } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.account_identity.name, "FromPostgres");
     assert.equal(body.data.account_identity.has_identity, true);
-    assert.equal(seen.pathname, `/api/v1/accounts/${AI_SS58}/identity`);
+    assert.equal(seen!.pathname, `/api/v1/accounts/${AI_SS58}/identity`);
     // The `??` short-circuits: D1 is only read when the tier returns nothing.
     assert.equal(d1Called, false);
   });
@@ -17524,10 +17618,12 @@ describe("Query.account_identity", () => {
     };
     const { status, body } = await gql(
       '{ account_identity(ss58: "not-a-valid-address") { account } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -17541,7 +17637,7 @@ describe("Query.account_identity", () => {
 });
 
 describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)", () => {
-  function prometheusQuery(argsClause) {
+  function prometheusQuery(argsClause: string) {
     return `{ chain_prometheus${argsClause} {
       schema_version window observed_at subnet_count
       network { distinct_exporters announcements announcements_per_exporter }
@@ -17553,9 +17649,9 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
   // Mirrors chainServingD1: loadChainPrometheus issues the network aggregate
   // (COUNT DISTINCT hotkey / MAX(observed_at), no GROUP BY) and only then the
   // GROUP BY netuid leaderboard, and only when newest_observed is non-null.
-  function chainPrometheusD1({ network, subnets = [] } = {}) {
+  function chainPrometheusD1({ network, subnets = [] }: Row = {}) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
           bind() {
             return {
@@ -17616,11 +17712,11 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -17656,13 +17752,13 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
     };
     const { status, body } = await gql(
       prometheusQuery('(window: "30d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/prometheus");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/prometheus");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_prometheus.window, "30d");
     assert.equal(body.data.chain_prometheus.subnet_count, 1);
     assert.equal(body.data.chain_prometheus.network.distinct_exporters, 5);
@@ -17694,18 +17790,18 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql(prometheusQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented window is accepted", async () => {
@@ -17732,7 +17828,9 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
     };
     const { status, body } = await gql(prometheusQuery('(window: "1y")'), env);
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -17746,7 +17844,7 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
 });
 
 describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallback)", () => {
-  function removalsQuery(argsClause) {
+  function removalsQuery(argsClause: string) {
     return `{ chain_axon_removals${argsClause} {
       schema_version window observed_at subnet_count
       network { distinct_removers removals removals_per_remover }
@@ -17758,9 +17856,9 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
   // loadChainAxonRemovals issues the network aggregate (COUNT DISTINCT hotkey /
   // MAX(observed_at), no GROUP BY) and only then the GROUP BY netuid
   // leaderboard, and only when newest_observed is non-null.
-  function chainAxonRemovalsD1({ network, subnets = [] } = {}) {
+  function chainAxonRemovalsD1({ network, subnets = [] }: Row = {}) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
           bind() {
             return {
@@ -17821,11 +17919,11 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -17861,13 +17959,13 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
     };
     const { status, body } = await gql(
       removalsQuery('(window: "30d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/axon-removals");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/axon-removals");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_axon_removals.window, "30d");
     assert.equal(body.data.chain_axon_removals.network.distinct_removers, 5);
   });
@@ -17898,18 +17996,18 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql(removalsQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented window is accepted", async () => {
@@ -17936,7 +18034,9 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
     };
     const { status, body } = await gql(removalsQuery('(window: "1y")'), env);
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -17950,7 +18050,7 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
 });
 
 describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallback)", () => {
-  function regQuery(argsClause) {
+  function regQuery(argsClause: string) {
     return `{ chain_registrations${argsClause} {
       schema_version window observed_at subnet_count
       network { distinct_registrants registrations registrations_per_registrant }
@@ -17962,9 +18062,9 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
   // loadChainRegistrations issues the network aggregate (COUNT DISTINCT hotkey
   // / MAX(observed_at), no GROUP BY) and only then the GROUP BY netuid
   // leaderboard, and only when newest_observed is non-null.
-  function chainRegD1({ network, subnets = [] } = {}) {
+  function chainRegD1({ network, subnets = [] }: Row = {}) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
           bind() {
             return {
@@ -18028,11 +18128,11 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -18068,13 +18168,13 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
     };
     const { status, body } = await gql(
       regQuery('(window: "30d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/registrations");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/registrations");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_registrations.window, "30d");
     assert.equal(body.data.chain_registrations.network.distinct_registrants, 5);
   });
@@ -18105,18 +18205,18 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql(regQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented window is accepted", async () => {
@@ -18141,7 +18241,9 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
     };
     const { status, body } = await gql(regQuery('(window: "1y")'), env);
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -18155,7 +18257,7 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
 });
 
 describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fallback)", () => {
-  function deregQuery(argsClause) {
+  function deregQuery(argsClause: string) {
     return `{ chain_deregistrations${argsClause} {
       schema_version window observed_at subnet_count
       network { distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey }
@@ -18167,9 +18269,9 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
   // loadChainDeregistrations issues the network aggregate (COUNT DISTINCT hotkey
   // / MAX(observed_at), no GROUP BY) and only then the GROUP BY netuid
   // leaderboard, and only when newest_observed is non-null.
-  function chainDeregD1({ network, subnets = [] } = {}) {
+  function chainDeregD1({ network, subnets = [] }: Row = {}) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
           bind() {
             return {
@@ -18233,11 +18335,11 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -18273,13 +18375,13 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
     };
     const { status, body } = await gql(
       deregQuery('(window: "30d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/deregistrations");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/deregistrations");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_deregistrations.window, "30d");
     assert.equal(
       body.data.chain_deregistrations.network.distinct_deregistered_hotkeys,
@@ -18313,18 +18415,18 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql(deregQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented window is accepted", async () => {
@@ -18349,7 +18451,9 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
     };
     const { status, body } = await gql(deregQuery('(window: "1y")'), env);
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -18365,7 +18469,7 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
 describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", () => {
   const SIGNER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function signersQuery(argsClause) {
+  function signersQuery(argsClause: string) {
     return `{ chain_signers${argsClause} {
       schema_version window sort observed_at signer_count
       signers { signer tx_count total_fee_tao total_tip_tao last_tx_block }
@@ -18374,7 +18478,7 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
 
   // loadChainSigners issues one ranked extrinsics-tier read; the rows carry the
   // per-signer aggregate.
-  function signersD1(rows = []) {
+  function signersD1(rows: Row[] = []) {
     return {
       prepare: () => ({
         bind: () => ({ all: async () => ({ results: rows }) }),
@@ -18423,11 +18527,11 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data, forwarding window/limit/sort/call_module", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             schema_version: 1,
@@ -18452,35 +18556,35 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
       signersQuery(
         '(window: "30d", limit: 5, sort: "total_fee_tao", call_module: "Balances")',
       ),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/signers");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl.searchParams.get("sort"), "total_fee_tao");
-    assert.equal(capturedUrl.searchParams.get("call_module"), "Balances");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/signers");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.searchParams.get("sort"), "total_fee_tao");
+    assert.equal(capturedUrl!.searchParams.get("call_module"), "Balances");
     assert.equal(body.data.chain_signers.sort, "total_fee_tao");
     assert.equal(body.data.chain_signers.signers[0].total_fee_tao, 9.5);
   });
 
   test("omits the optional sort/call_module params when the caller supplies neither", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({ signers: [] });
         },
       },
     };
     await gql(signersQuery(""), env);
-    assert.equal(capturedUrl.searchParams.get("sort"), null);
-    assert.equal(capturedUrl.searchParams.get("call_module"), null);
-    assert.equal(capturedUrl.searchParams.get("window"), "7d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "50");
+    assert.equal(capturedUrl!.searchParams.get("sort"), null);
+    assert.equal(capturedUrl!.searchParams.get("call_module"), null);
+    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "50");
   });
 
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
@@ -18525,18 +18629,18 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({});
         },
       },
     };
     await gql(signersQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented sort is accepted", async () => {
@@ -18561,10 +18665,12 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     };
     const { status, body } = await gql(
       signersQuery('(sort: "not_a_real_sort")'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -18582,7 +18688,9 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     };
     const { status, body } = await gql(signersQuery('(window: "1y")'), env);
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -18600,10 +18708,12 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     };
     const { status, body } = await gql(
       signersQuery(`(call_module: "${"x".repeat(101)}")`),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(called, false);
   });
 
@@ -18635,11 +18745,11 @@ describe("graphql — chain_idle_stake (#6975, Postgres-tier + cold-store fallba
   });
 
   test("resolves Postgres-tier data", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -18660,7 +18770,7 @@ describe("graphql — chain_idle_stake (#6975, Postgres-tier + cold-store fallba
     };
     const { status, body } = await gql(query, env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/idle-stake");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/idle-stake");
     assert.equal(body.data.chain_idle_stake.subnet_count, 1);
     assert.equal(body.data.chain_idle_stake.total_idle_stake_tao, 12.5);
     assert.equal(body.data.chain_idle_stake.subnets[0].netuid, 7);
@@ -18728,11 +18838,11 @@ describe("graphql — chain_stake_flow (#6975, Postgres-tier + cold-store fallba
   });
 
   test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -18778,12 +18888,12 @@ describe("graphql — chain_stake_flow (#6975, Postgres-tier + cold-store fallba
     };
     const { status, body } = await gql(
       flowQuery('(window: "30d", limit: 5)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/stake-flow");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/stake-flow");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_stake_flow.window, "30d");
     assert.equal(body.data.chain_stake_flow.subnet_count, 1);
     assert.equal(body.data.chain_stake_flow.network.net_flow_tao, 60);
@@ -18803,7 +18913,9 @@ describe("graphql — chain_stake_flow (#6975, Postgres-tier + cold-store fallba
     };
     const { status, body } = await gql(flowQuery('(window: "1y")'), env);
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -18858,11 +18970,11 @@ describe("graphql — chain_stake_moves (#6975, Postgres-tier + cold-store fallb
   });
 
   test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -18898,12 +19010,12 @@ describe("graphql — chain_stake_moves (#6975, Postgres-tier + cold-store fallb
     };
     const { status, body } = await gql(
       movesQuery('(window: "30d", limit: 8)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/stake-moves");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "8");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/stake-moves");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "8");
     assert.equal(body.data.chain_stake_moves.network.movements, 12);
     assert.equal(body.data.chain_stake_moves.subnets[0].netuid, 5);
   });
@@ -18911,7 +19023,9 @@ describe("graphql — chain_stake_moves (#6975, Postgres-tier + cold-store fallb
   test("unsupported window is BAD_USER_INPUT", async () => {
     const { status, body } = await gql(movesQuery('(window: "90d")'));
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
   });
 
@@ -18967,11 +19081,11 @@ describe("graphql — chain_stake_transfers (#6975, Postgres-tier + cold-store f
   });
 
   test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -19007,12 +19121,12 @@ describe("graphql — chain_stake_transfers (#6975, Postgres-tier + cold-store f
     };
     const { status, body } = await gql(
       transfersQuery('(window: "30d", limit: 3)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/stake-transfers");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "3");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/stake-transfers");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "3");
     assert.equal(body.data.chain_stake_transfers.network.transfers, 6);
     assert.equal(body.data.chain_stake_transfers.subnets[0].netuid, 9);
   });
@@ -19020,7 +19134,9 @@ describe("graphql — chain_stake_transfers (#6975, Postgres-tier + cold-store f
   test("unsupported window is BAD_USER_INPUT", async () => {
     const { status, body } = await gql(transfersQuery('(window: "1y")'));
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
   });
 
@@ -19071,11 +19187,11 @@ describe("graphql — chain_transfer_pairs (#6975, Postgres-tier + cold-store fa
   });
 
   test("resolves Postgres-tier data forwarding window/sort/limit", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -19103,13 +19219,13 @@ describe("graphql — chain_transfer_pairs (#6975, Postgres-tier + cold-store fa
     };
     const { status, body } = await gql(
       pairsQuery('(window: "30d", sort: "count", limit: 10)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/transfer-pairs");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("sort"), "count");
-    assert.equal(capturedUrl.searchParams.get("limit"), "10");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/transfer-pairs");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("sort"), "count");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "10");
     assert.equal(body.data.chain_transfer_pairs.sort, "count");
     assert.equal(body.data.chain_transfer_pairs.pairs[0].from, "5Sender");
   });
@@ -19117,7 +19233,9 @@ describe("graphql — chain_transfer_pairs (#6975, Postgres-tier + cold-store fa
   test("unsupported window is BAD_USER_INPUT", async () => {
     const { status, body } = await gql(pairsQuery('(window: "90d")'));
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
   });
 
@@ -19134,7 +19252,9 @@ describe("graphql — chain_transfer_pairs (#6975, Postgres-tier + cold-store fa
     };
     const { status, body } = await gql(pairsQuery('(sort: "fee")'), env);
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
     assert.equal(called, false);
   });
@@ -19187,11 +19307,11 @@ describe("graphql — chain_transfers (#6975, Postgres-tier + cold-store fallbac
   });
 
   test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (r) => {
+        fetch: async (r: Row) => {
           capturedUrl = new URL(r.url);
           return Response.json({
             schema_version: 1,
@@ -19214,12 +19334,12 @@ describe("graphql — chain_transfers (#6975, Postgres-tier + cold-store fallbac
     };
     const { status, body } = await gql(
       xfersQuery('(window: "30d", limit: 15)'),
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl.pathname, "/api/v1/chain/transfers");
-    assert.equal(capturedUrl.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl.searchParams.get("limit"), "15");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain/transfers");
+    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "15");
     assert.equal(body.data.chain_transfers.total_volume_tao, 500);
     assert.equal(body.data.chain_transfers.top_senders[0].address, "5Alice");
     assert.equal(body.data.chain_transfers.top_receivers[0].address, "5Bob");
@@ -19228,7 +19348,9 @@ describe("graphql — chain_transfers (#6975, Postgres-tier + cold-store fallbac
   test("unsupported window is BAD_USER_INPUT", async () => {
     const { status, body } = await gql(xfersQuery('(window: "1y")'));
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data, null);
   });
 
@@ -19284,7 +19406,7 @@ describe("graphql — adapter (#6984, reuses loadAdapter / MCP get_adapter)", ()
     });
     const { status, body } = await gql(
       '{ adapter(slug: "missing") { slug } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -19303,14 +19425,18 @@ describe("graphql — adapter (#6984, reuses loadAdapter / MCP get_adapter)", ()
       '{ adapter(slug: "Gittensor") { slug } }',
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data?.adapter ?? null, null);
   });
 
   test("an empty slug is BAD_USER_INPUT", async () => {
     const { status, body } = await gql('{ adapter(slug: "  ") { slug } }');
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.equal(body.data?.adapter ?? null, null);
   });
 
@@ -19373,7 +19499,7 @@ describe("graphql — gaps", () => {
     const env = fixtureEnv({ "/metagraph/gaps.json": GAPS_BLOB });
     const filtered = await gql(
       "{ gaps(netuid: 7) { gaps total generated_at } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
     assert.equal(filtered.body.errors, undefined);
@@ -19386,7 +19512,7 @@ describe("graphql — gaps", () => {
 
     const paged = await gql(
       "{ gaps(limit: 1) { gaps total returned next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(paged.body.data.gaps.gaps.length, 1);
     assert.equal(paged.body.data.gaps.total, 2);
@@ -19398,7 +19524,7 @@ describe("graphql — gaps", () => {
     const env = fixtureEnv({ "/metagraph/gaps.json": GAPS_BLOB });
     const { status, body } = await gql(
       '{ gaps(sort: "gap_count", order: "desc", coverage_level: "manifested") { gaps total } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.gaps.total, 1);
@@ -19452,7 +19578,7 @@ describe("graphql — evidence", () => {
     });
     const searched = await gql(
       '{ evidence(q: "OpenAPI") { claims total generated_at summary } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(searched.status, 200);
     assert.equal(searched.body.errors, undefined);
@@ -19462,7 +19588,7 @@ describe("graphql — evidence", () => {
 
     const paged = await gql(
       "{ evidence(limit: 1) { claims total returned next_cursor } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(paged.body.data.evidence.claims.length, 1);
     assert.equal(paged.body.data.evidence.total, 2);
@@ -19475,7 +19601,7 @@ describe("graphql — evidence", () => {
     });
     const { status, body } = await gql(
       '{ evidence(sort: "subject", order: "desc") { claims schema_version } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     // Lexicographic desc: "sn-7" > "sn-31".
@@ -19504,7 +19630,7 @@ describe("graphql — evidence", () => {
 
 // #7171: GraphQL parity for GET /api/v1/chain-events (Query feed).
 describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -19551,7 +19677,7 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
             block_number event_index pallet method args phase extrinsic_index observed_at
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -19568,10 +19694,10 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
   test("a block+extrinsic lookup resolves that extrinsic's emitted events", async () => {
     // The get_extrinsic_chain_events use case (#7647): the raw pallet.method
     // events one specific extrinsic emitted, scoped by ?block=&extrinsic=.
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             count: 2,
@@ -19608,19 +19734,19 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
           count
           events { block_number event_index pallet method extrinsic_index }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl.searchParams.get("block"), "9");
-    assert.equal(capturedUrl.searchParams.get("extrinsic"), "1");
+    assert.equal(capturedUrl!.searchParams.get("block"), "9");
+    assert.equal(capturedUrl!.searchParams.get("extrinsic"), "1");
     assert.equal(body.data.chain_events.count, 2);
     const events = body.data.chain_events.events;
     assert.equal(events.length, 2);
-    assert.ok(events.every((e) => e.block_number === 9));
-    assert.ok(events.every((e) => e.extrinsic_index === 1));
+    assert.ok(events.every((e: Row) => e.block_number === 9));
+    assert.ok(events.every((e: Row) => e.extrinsic_index === 1));
     assert.deepEqual(
-      events.map((e) => `${e.pallet}.${e.method}`),
+      events.map((e: Row) => `${e.pallet}.${e.method}`),
       ["SubtensorModule.StakeAdded", "System.ExtrinsicSuccess"],
     );
   });
@@ -19638,7 +19764,7 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
     };
     const { status, body } = await gql(
       "{ chain_events(block: 9, extrinsic: 3) { count next_cursor next_before events { pallet } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -19651,10 +19777,10 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
   });
 
   test("forwards filter args as query params, including legacy before", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             count: 0,
@@ -19667,22 +19793,22 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
     };
     await gql(
       '{ chain_events(pallet: "SubtensorModule", method: "WeightsSet", block: 9, extrinsic: 1, before: 8, limit: 25) { count } }',
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.pathname, "/api/v1/chain-events");
-    assert.equal(capturedUrl.searchParams.get("pallet"), "SubtensorModule");
-    assert.equal(capturedUrl.searchParams.get("method"), "WeightsSet");
-    assert.equal(capturedUrl.searchParams.get("block"), "9");
-    assert.equal(capturedUrl.searchParams.get("extrinsic"), "1");
-    assert.equal(capturedUrl.searchParams.get("before"), "8");
-    assert.equal(capturedUrl.searchParams.get("limit"), "25");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain-events");
+    assert.equal(capturedUrl!.searchParams.get("pallet"), "SubtensorModule");
+    assert.equal(capturedUrl!.searchParams.get("method"), "WeightsSet");
+    assert.equal(capturedUrl!.searchParams.get("block"), "9");
+    assert.equal(capturedUrl!.searchParams.get("extrinsic"), "1");
+    assert.equal(capturedUrl!.searchParams.get("before"), "8");
+    assert.equal(capturedUrl!.searchParams.get("limit"), "25");
   });
 
   test("prefers cursor over before when both are set", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             count: 0,
@@ -19694,8 +19820,8 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
       },
     };
     await gql('{ chain_events(cursor: "1.2.3", before: 99) { count } }', env);
-    assert.equal(capturedUrl.searchParams.get("cursor"), "1.2.3");
-    assert.equal(capturedUrl.searchParams.get("before"), null);
+    assert.equal(capturedUrl!.searchParams.get("cursor"), "1.2.3");
+    assert.equal(capturedUrl!.searchParams.get("before"), null);
   });
 
   test("a DATA_API 400 is BAD_USER_INPUT, not an empty feed", async () => {
@@ -19708,10 +19834,12 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
     };
     const { status, body } = await gql(
       '{ chain_events(method: "WeightsSet") { count } }',
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
     assert.match(body.errors[0].message, /method requires pallet/);
     assert.equal(body.data?.chain_events ?? null, null);
   });
@@ -19722,7 +19850,7 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
     };
     const { status, body } = await gql(
       "{ chain_events { count next_before next_cursor events { pallet } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -19749,7 +19877,7 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
             block_number event_index pallet method args phase extrinsic_index observed_at
           }
         } }`,
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.chain_events.events[0], {
@@ -19777,7 +19905,7 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
     };
     const { status, body } = await gql(
       "{ chain_events { count events { pallet } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -19796,7 +19924,7 @@ describe("graphql — chain_events (#7171, DATA_API all-events feed)", () => {
 // sibling of chain_events), reusing the loadChainActivity + optionalBlocksWindow
 // that MCP get_chain_activity already calls, both relocated to data-api-mcp.ts.
 describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)", () => {
-  function dataApi(response) {
+  function dataApi(response: Row) {
     return { fetch: async () => response };
   }
 
@@ -19816,10 +19944,10 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
   });
 
   test("resolves the pallet.method aggregate from DATA_API", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             window_blocks: 1000,
@@ -19834,14 +19962,14 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
     };
     const { status, body } = await gql(
       "{ chain_events_stats { window_blocks groups activity { pallet method count } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     // Same DATA_API path REST's /chain-events/stats proxy uses; omitted blocks
     // defaults to 1000.
-    assert.equal(capturedUrl.pathname, "/api/v1/chain-events/stats");
-    assert.equal(capturedUrl.searchParams.get("blocks"), "1000");
+    assert.equal(capturedUrl!.pathname, "/api/v1/chain-events/stats");
+    assert.equal(capturedUrl!.searchParams.get("blocks"), "1000");
     assert.equal(body.data.chain_events_stats.window_blocks, 1000);
     assert.equal(body.data.chain_events_stats.groups, 2);
     assert.equal(body.data.chain_events_stats.activity.length, 2);
@@ -19853,10 +19981,10 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
   });
 
   test("forwards an explicit blocks window as a query param", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({ window_blocks: 250, groups: 0, activity: [] });
         },
@@ -19864,17 +19992,17 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
     };
     const { body } = await gql(
       "{ chain_events_stats(blocks: 250) { window_blocks } }",
-      env,
+      env as unknown as Env,
     );
-    assert.equal(capturedUrl.searchParams.get("blocks"), "250");
+    assert.equal(capturedUrl!.searchParams.get("blocks"), "250");
     assert.equal(body.data.chain_events_stats.window_blocks, 250);
   });
 
   test("clamps an over-cap blocks window to 5000", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             window_blocks: 5000,
@@ -19885,14 +20013,14 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
       },
     };
     await gql("{ chain_events_stats(blocks: 99999) { window_blocks } }", env);
-    assert.equal(capturedUrl.searchParams.get("blocks"), "5000");
+    assert.equal(capturedUrl!.searchParams.get("blocks"), "5000");
   });
 
   test("treats an explicit null blocks as the default window", async () => {
-    let capturedUrl;
+    let capturedUrl: URL | undefined;
     const env = {
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedUrl = new URL(req.url);
           return Response.json({
             window_blocks: 1000,
@@ -19903,7 +20031,7 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
       },
     };
     await gql("{ chain_events_stats(blocks: null) { window_blocks } }", env);
-    assert.equal(capturedUrl.searchParams.get("blocks"), "1000");
+    assert.equal(capturedUrl!.searchParams.get("blocks"), "1000");
   });
 
   test("a non-positive / non-integer blocks is BAD_USER_INPUT, not an aggregate", async () => {
@@ -19914,7 +20042,7 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
       );
       assert.equal(status, 200);
       assert.ok(
-        body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+        body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
         `blocks=${blocks} should be BAD_USER_INPUT`,
       );
       assert.match(body.errors[0].message, /blocks/);
@@ -19926,7 +20054,7 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
     const env = { DATA_API: dataApi(Response.json({})) };
     const { status, body } = await gql(
       "{ chain_events_stats(blocks: 500) { window_blocks groups activity { pallet } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -19956,7 +20084,7 @@ describe("graphql — chain_events_stats (#7432, DATA_API all-events aggregate)"
     };
     const { status, body } = await gql(
       "{ chain_events_stats { window_blocks groups activity { pallet } } }",
-      env,
+      env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);

--- a/tests/green-compute-call-subnet-surface-verify.test.ts
+++ b/tests/green-compute-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-110-green-compute-healthz";
 
@@ -112,7 +112,7 @@ describe("SN110 SN110 call_subnet_surface verification (#7121)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/groundlayer-call-subnet-surface-verify.test.ts
+++ b/tests/groundlayer-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-20-taomarketcap-subnet-api";
 const NETUID = 20;
@@ -126,7 +126,7 @@ describe("SN20 GroundLayer call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/health-history-mcp.test.ts
+++ b/tests/health-history-mcp.test.ts
@@ -12,7 +12,7 @@ import {
   healthHistoryQueryUrl,
   loadHealthHistory,
 } from "../src/health-history-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const HISTORY_DATE = await latestArtifactDate("health/history");
@@ -299,7 +299,11 @@ describe("health-history-mcp — MCP metadata", () => {
       .mockRejectedValue(err);
     try {
       await assert.rejects(
-        () => tool.handler({ date: HISTORY_BLOB.date }, { env: {} }),
+        () =>
+          tool.handler(
+            { date: HISTORY_BLOB.date },
+            { env: {} as unknown as Env },
+          ),
         (thrown: Row) => {
           assert.equal(thrown.toolError, true);
           assert.equal(thrown.code, "invalid_params");
@@ -319,7 +323,7 @@ describe("health-history-mcp — MCP metadata", () => {
         tool.handler(
           { date: HISTORY_BLOB.date },
           {
-            env: {},
+            env: {} as unknown as Env,
             readArtifact: async () => {
               throw new Error("kaboom");
             },

--- a/tests/hone-call-subnet-surface-verify.test.ts
+++ b/tests/hone-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-5-hone-subnet-api";
 
@@ -110,7 +110,7 @@ describe("SN5 Hone call_subnet_surface verification (#7021)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/investing-call-subnet-surface-verify.test.ts
+++ b/tests/investing-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-88-investing-days-api";
 const SURFACE_URL = "https://api.investing88.ai/days";
@@ -117,7 +117,7 @@ describe("SN88 Investing call_subnet_surface verification (#7100)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/iota-call-subnet-surface-verify.test.ts
+++ b/tests/iota-call-subnet-surface-verify.test.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-9-iota-run-info";
 
@@ -107,7 +107,7 @@ describe("SN9 SN9 call_subnet_surface verification (#7025)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/itsai-call-subnet-surface-verify.test.ts
+++ b/tests/itsai-call-subnet-surface-verify.test.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-32-itsai-subnet-api";
 
@@ -108,7 +108,7 @@ describe("SN32 ItsAI call_subnet_surface verification (#7047)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/leadpoet-call-subnet-surface-verify.test.ts
+++ b/tests/leadpoet-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-71-leadpoet-health-api";
 
@@ -112,7 +112,7 @@ describe("SN71 SN71 call_subnet_surface verification (#7084)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/leoma-call-subnet-surface-verify.test.ts
+++ b/tests/leoma-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-99-leoma-health";
 
@@ -110,7 +110,7 @@ describe("SN99 SN99 call_subnet_surface verification (#7111)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/luminar-network-call-subnet-surface-verify.test.ts
+++ b/tests/luminar-network-call-subnet-surface-verify.test.ts
@@ -25,7 +25,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 87;
 

--- a/tests/mainframe-call-subnet-surface-verify.test.ts
+++ b/tests/mainframe-call-subnet-surface-verify.test.ts
@@ -27,7 +27,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-25-mainframe-pdb-file-api";
 

--- a/tests/mantis-call-subnet-surface-verify.test.ts
+++ b/tests/mantis-call-subnet-surface-verify.test.ts
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 123;
 const registry = JSON.parse(

--- a/tests/mcp-prompt-definitions.test.ts
+++ b/tests/mcp-prompt-definitions.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { listPromptDefinitions } from "../src/mcp-server.mjs";
+import { listPromptDefinitions } from "../src/mcp-server.ts";
 
 describe("listPromptDefinitions", () => {
   test("returns a non-empty list of well-shaped prompt definitions", () => {

--- a/tests/mcp-server-branch-coverage.test.ts
+++ b/tests/mcp-server-branch-coverage.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
@@ -50,7 +50,7 @@ async function rpc(
     headers: headers || { "content-type": "application/json" },
     body: method === "POST" ? JSON.stringify(payload) : undefined,
   });
-  const response = await handleMcpRequest(request, env, deps);
+  const response = await handleMcpRequest(request, env as unknown as Env, deps);
   const text = await response.text();
   return {
     status: response.status,
@@ -1074,7 +1074,11 @@ describe("handleMcpRequest — rate limiter success + content-length guard", () 
       },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
     });
-    const response = await handleMcpRequest(request, {}, makeDeps());
+    const response = await handleMcpRequest(
+      request,
+      {} as unknown as Env,
+      makeDeps(),
+    );
     assert.equal(response.status, 413);
     const body = (await response.json()) as Row;
     assert.equal(body.error.code, -32600);

--- a/tests/mcp-server-sentry-args-safety.test.ts
+++ b/tests/mcp-server-sentry-args-safety.test.ts
@@ -22,7 +22,7 @@ vi.mock("@sentry/cloudflare", () => ({
   captureException,
 }));
 
-const { handleMcpRequest } = await import("../src/mcp-server.mjs");
+const { handleMcpRequest } = await import("../src/mcp-server.ts");
 
 afterEach(() => {
   startSpanCalls.length = 0;
@@ -77,7 +77,7 @@ async function callTool(name: string, args: Row, fetchImpl?: typeof fetch) {
           params: { name, arguments: args },
         }),
       }),
-      {},
+      {} as unknown as Env,
       deps,
     );
     return ((await response.json()) as Row).result;

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test, vi } from "vitest";
-import Ajv2020 from "ajv/dist/2020.js";
+import { Ajv2020 } from "ajv/dist/2020.js";
 import {
   MCP_TOOLS,
   MCP_PROTOCOL_VERSIONS,
@@ -9,7 +9,7 @@ import {
   MAX_MCP_BODY_BYTES,
   listToolDefinitions,
   handleMcpRequest,
-} from "../src/mcp-server.mjs";
+} from "../src/mcp-server.ts";
 import * as profilesMcp from "../src/profiles-mcp.ts";
 import * as healthHistoryMcp from "../src/health-history-mcp.ts";
 import { KV_HEALTH_RPC_POOL } from "../src/health-prober.ts";
@@ -33,6 +33,7 @@ import { buildChainTransfers } from "../src/chain-transfers.ts";
 import { buildChainCalls } from "../src/chain-analytics.ts";
 import { DOMAIN_TAGS } from "../src/domain-tags.ts";
 import { EVM_PRECOMPILE_BY_ADDRESS } from "../src/evm-precompiles.ts";
+import type { AnyFn, Row } from "./row-type.ts";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
 
@@ -66,9 +67,9 @@ const HEALTH_HISTORY_BLOB = {
 };
 
 // Build injectable deps with controlled artifact + KV responses.
-function makeDeps(artifacts = {}, kv = {}) {
+function makeDeps(artifacts: Row = {}, kv: Row = {}) {
   return {
-    readArtifact(_env, path) {
+    readArtifact(_env: unknown, path: string) {
       if (Object.prototype.hasOwnProperty.call(artifacts, path)) {
         return Promise.resolve({
           ok: true,
@@ -84,7 +85,7 @@ function makeDeps(artifacts = {}, kv = {}) {
         message: `Artifact not found: ${path}`,
       });
     },
-    readHealthKv(_env, key) {
+    readHealthKv(_env: unknown, key: string) {
       return Promise.resolve(
         Object.prototype.hasOwnProperty.call(kv, key) ? kv[key] : null,
       );
@@ -93,20 +94,20 @@ function makeDeps(artifacts = {}, kv = {}) {
 }
 
 async function rpc(
-  payload,
-  { deps = makeDeps(), env = {}, method = "POST", headers = {} } = {},
+  payload: unknown,
+  { deps = makeDeps(), env = {}, method = "POST", headers = {} }: Row = {},
 ) {
   const request = new Request(MCP_URL, {
     method,
     headers: { "content-type": "application/json", ...headers },
     body: method === "POST" ? JSON.stringify(payload) : undefined,
   });
-  const response = await handleMcpRequest(request, env, deps);
+  const response = await handleMcpRequest(request, env as unknown as Env, deps);
   const text = await response.text();
   return {
     status: response.status,
     headers: response.headers,
-    body: text ? JSON.parse(text) : null,
+    body: (text ? JSON.parse(text) : null) as Row,
   };
 }
 
@@ -115,13 +116,13 @@ async function rpc(
 // bound is far looser, but this is what every real client will send).
 const A_SESSION_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
 
-function fakeMcpSessionHubBinding(overrides = {}) {
-  const calls = [];
+function fakeMcpSessionHubBinding(overrides: Row = {}) {
+  const calls: Row[] = [];
   return {
     calls,
-    idFromName: (name) => name,
+    idFromName: (name: string) => name,
     get: () => ({
-      fetch: async (url, init) => {
+      fetch: async (url: string, init: RequestInit) => {
         calls.push({ url, init });
         const path = new URL(url).pathname;
         if (overrides[path]) return overrides[path](init);
@@ -131,7 +132,7 @@ function fakeMcpSessionHubBinding(overrides = {}) {
   };
 }
 
-function callTool(name, args, opts) {
+function callTool(name: string, args?: unknown, opts?: Row) {
   return rpc(
     {
       jsonrpc: "2.0",
@@ -349,7 +350,7 @@ describe("MCP resources (#742)", () => {
     });
     const tpls = res.body.result.resourceTemplates;
     assert.equal(tpls.length, 4);
-    assert.deepEqual(tpls.map((t) => t.uriTemplate).sort(), [
+    assert.deepEqual(tpls.map((t: Row) => t.uriTemplate).sort(), [
       "metagraph://provider/{slug}",
       "metagraph://schema/{surface_id}",
       "metagraph://subnet/{netuid}",
@@ -384,7 +385,7 @@ describe("MCP resources (#742)", () => {
       { jsonrpc: "2.0", id: 1, method: "resources/list" },
       { deps },
     );
-    const uris = res.body.result.resources.map((r) => r.uri);
+    const uris = res.body.result.resources.map((r: Row) => r.uri);
     assert.ok(uris.includes("metagraph://registry/summary"));
     assert.ok(uris.includes("metagraph://subnet/7"));
     assert.ok(uris.includes("metagraph://subnet/7/status"));
@@ -398,7 +399,7 @@ describe("MCP resources (#742)", () => {
 
   test("resources/list degrades gracefully when indexes are missing", async () => {
     const res = await rpc({ jsonrpc: "2.0", id: 1, method: "resources/list" });
-    const uris = res.body.result.resources.map((r) => r.uri);
+    const uris = res.body.result.resources.map((r: Row) => r.uri);
     assert.ok(uris.includes("metagraph://registry/summary"));
     assert.ok(uris.includes("metagraph://registry/catalog"));
   });
@@ -477,7 +478,7 @@ describe("MCP resources/subscribe + resources/unsubscribe (#4983 MCP half)", () 
 
   test("resources/read on the live chain-stream resource returns ChainFirehoseHub's latest payload", async () => {
     const firehose = {
-      idFromName: (name) => name,
+      idFromName: (name: string) => name,
       get: () => ({
         fetch: async () =>
           new Response(
@@ -505,7 +506,7 @@ describe("MCP resources/subscribe + resources/unsubscribe (#4983 MCP half)", () 
 
   test("resources/read on the live chain-stream resource reports 'no event observed yet' when the hub is cold", async () => {
     const firehose = {
-      idFromName: (name) => name,
+      idFromName: (name: string) => name,
       get: () => ({
         fetch: async () =>
           new Response(JSON.stringify({ payload: null }), { status: 200 }),
@@ -758,7 +759,7 @@ describe("MCP prompts (#742)", () => {
       assert.ok(p.name && p.title && p.description);
       assert.ok(Array.isArray(p.arguments));
     }
-    assert.ok(prompts.some((p) => p.name === "integrate_with_subnet"));
+    assert.ok(prompts.some((p: Row) => p.name === "integrate_with_subnet"));
   });
 
   test("prompts/get returns a user message referencing the tools", async () => {
@@ -853,11 +854,11 @@ describe("MCP resources/prompts — branch coverage", () => {
       { jsonrpc: "2.0", id: 1, method: "resources/list" },
       { deps },
     );
-    const uris = res.body.result.resources.map((r) => r.uri);
+    const uris = res.body.result.resources.map((r: Row) => r.uri);
     assert.ok(uris.includes("metagraph://subnet/0"));
-    assert.ok(!uris.some((u) => u.includes("no-netuid")));
+    assert.ok(!uris.some((u: string) => u.includes("no-netuid")));
     assert.ok(uris.includes("metagraph://provider/by-id"));
-    assert.ok(!uris.some((u) => u.includes("no-slug")));
+    assert.ok(!uris.some((u: string) => u.includes("no-slug")));
     assert.ok(uris.includes("metagraph://schema/s1"));
     assert.ok(uris.includes("metagraph://schema/s2"));
   });
@@ -971,9 +972,13 @@ describe("MCP transport handling", () => {
       headers: { "content-type": "application/json" },
       body: "{not json",
     });
-    const response = await handleMcpRequest(request, {}, makeDeps());
+    const response = await handleMcpRequest(
+      request,
+      {} as unknown as Env,
+      makeDeps(),
+    );
     assert.equal(response.status, 400);
-    const body = await response.json();
+    const body = (await response.json()) as Row;
     assert.equal(body.error.code, -32700);
   });
 
@@ -1029,11 +1034,11 @@ describe("MCP transport handling", () => {
   });
 
   test("an oversized batch is rejected before processing messages", async () => {
-    const calls = [];
+    const calls: Row[] = [];
     const deps = {
       ...makeDeps(),
-      readArtifact(_env, path) {
-        calls.push(path);
+      readArtifact(_env: unknown, path: string) {
+        calls.push(path as unknown as Row);
         return Promise.resolve({ ok: true, data: {} });
       },
     };
@@ -1057,9 +1062,13 @@ describe("MCP transport handling", () => {
       headers: { "content-type": "application/json" },
       body: `"${"x".repeat(MAX_MCP_BODY_BYTES)}"`,
     });
-    const response = await handleMcpRequest(request, {}, makeDeps());
+    const response = await handleMcpRequest(
+      request,
+      {} as unknown as Env,
+      makeDeps(),
+    );
     assert.equal(response.status, 413);
-    const body = await response.json();
+    const body = (await response.json()) as Row;
     assert.equal(body.error.code, -32600);
   });
 
@@ -1072,9 +1081,13 @@ describe("MCP transport handling", () => {
       },
       body: "{}",
     });
-    const response = await handleMcpRequest(request, {}, makeDeps());
+    const response = await handleMcpRequest(
+      request,
+      {} as unknown as Env,
+      makeDeps(),
+    );
     assert.equal(response.status, 413);
-    const responseBody = await response.json();
+    const responseBody = (await response.json()) as Row;
     assert.equal(responseBody.error.code, -32600);
   });
 
@@ -1084,9 +1097,13 @@ describe("MCP transport handling", () => {
       headers: { "content-type": "application/json" },
     });
     assert.equal(request.body, null);
-    const response = await handleMcpRequest(request, {}, makeDeps());
+    const response = await handleMcpRequest(
+      request,
+      {} as unknown as Env,
+      makeDeps(),
+    );
     assert.equal(response.status, 400);
-    const body = await response.json();
+    const body = (await response.json()) as Row;
     assert.equal(body.error.code, -32700);
   });
 
@@ -1102,9 +1119,13 @@ describe("MCP transport handling", () => {
       },
       body: `"${"x".repeat(MAX_MCP_BODY_BYTES)}"`,
     });
-    const response = await handleMcpRequest(request, {}, makeDeps());
+    const response = await handleMcpRequest(
+      request,
+      {} as unknown as Env,
+      makeDeps(),
+    );
     assert.equal(response.status, 413);
-    const body = await response.json();
+    const body = (await response.json()) as Row;
     assert.equal(body.error.code, -32600);
   });
 
@@ -1136,9 +1157,13 @@ describe("MCP transport handling", () => {
       headers: { "content-type": "application/json" },
       body: stream,
       duplex: "half",
-    });
+    } as unknown as RequestInit);
 
-    const response = await handleMcpRequest(request, {}, makeDeps());
+    const response = await handleMcpRequest(
+      request,
+      {} as unknown as Env,
+      makeDeps(),
+    );
 
     assert.equal(response.status, 413);
     assert.equal(cancelled, true);
@@ -1166,7 +1191,7 @@ describe("MCP transport handling", () => {
               return { success: false };
             },
           },
-        },
+        } as unknown as Env,
         makeDeps(),
       );
       assert.equal(response.status, 429);
@@ -1188,12 +1213,12 @@ describe("MCP transport handling", () => {
       request,
       {
         MCP_RATE_LIMITER: {
-          async limit({ key }) {
+          async limit({ key }: { key: string }) {
             rateLimitKey = key;
             return { success: false };
           },
         },
-      },
+      } as unknown as Env,
       makeDeps(),
     );
     assert.equal(response.status, 429);
@@ -1204,7 +1229,7 @@ describe("MCP transport handling", () => {
       EXPOSED_RESPONSE_HEADERS_VALUE,
     );
     assert.equal(rateLimitKey, "203.0.113.7");
-    const body = await response.json();
+    const body = (await response.json()) as Row;
     assert.match(body.error.message, /Too many MCP requests/);
   });
 
@@ -1213,7 +1238,7 @@ describe("MCP transport handling", () => {
       method: "POST",
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
     });
-    const response = await handleMcpRequest(request, {});
+    const response = await handleMcpRequest(request, {} as unknown as Env);
     assert.equal(response.status, 200);
   });
 
@@ -1253,7 +1278,7 @@ describe("MCP transport handling", () => {
       assert.equal(res.status, 200);
       const sessionId = res.headers.get("mcp-session-id");
       assert.match(
-        sessionId,
+        sessionId as string,
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
       );
     });
@@ -1319,7 +1344,7 @@ describe("MCP transport handling", () => {
       const res = await rpc(null, {
         method: "GET",
         headers: { "mcp-session-id": A_SESSION_ID },
-        env: {},
+        env: {} as unknown as Env,
       });
       assert.equal(res.status, 405);
       assert.equal(res.headers.get("allow"), "POST, OPTIONS");
@@ -1333,7 +1358,7 @@ describe("MCP transport handling", () => {
       });
       const response = await handleMcpRequest(request, {
         MCP_SESSION_HUB: hub,
-      });
+      } as unknown as Env);
       assert.equal(response.status, 200);
       assert.equal(response.headers.get("content-type"), "text/event-stream");
       // #5545: SSE responses must carry nosniff like every other builder.
@@ -1356,9 +1381,9 @@ describe("MCP transport handling", () => {
       });
       const response = await handleMcpRequest(request, {
         MCP_SESSION_HUB: hub,
-      });
+      } as unknown as Env);
       assert.equal(response.status, 409);
-      const body = await response.json();
+      const body = (await response.json()) as Row;
       assert.match(body.error.message, /already open/);
     });
 
@@ -1372,9 +1397,9 @@ describe("MCP transport handling", () => {
       });
       const response = await handleMcpRequest(request, {
         MCP_SESSION_HUB: hub,
-      });
+      } as unknown as Env);
       assert.equal(response.status, 404);
-      const body = await response.json();
+      const body = (await response.json()) as Row;
       assert.match(body.error.message, /No such MCP session/);
     });
   });
@@ -1402,7 +1427,7 @@ describe("MCP transport handling", () => {
       });
       const response = await handleMcpRequest(request, {
         MCP_SESSION_HUB: hub,
-      });
+      } as unknown as Env);
       assert.equal(response.status, 204);
       assert.equal(hub.calls.length, 1);
       assert.match(hub.calls[0].url, /\/terminate$/);
@@ -1422,9 +1447,9 @@ describe("MCP transport handling", () => {
       });
       const response = await handleMcpRequest(request, {
         MCP_SESSION_HUB: hub,
-      });
+      } as unknown as Env);
       assert.equal(response.status, 404);
-      const body = await response.json();
+      const body = (await response.json()) as Row;
       assert.match(body.error.message, /No such MCP session/);
     });
   });
@@ -1678,7 +1703,7 @@ describe("MCP tools (injected deps)", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.results[0].netuid, 7);
     assert.ok(out.results[0].url.includes("/api/v1/subnets/7/overview"));
-    assert.ok(out.results.every((r) => r.netuid !== null));
+    assert.ok(out.results.every((r: Row) => r.netuid !== null));
     // Pagination envelope mirrors list_subnets: total/cursor/limit/next_cursor.
     assert.equal(out.total, 1);
     assert.equal(out.count, 1);
@@ -2036,13 +2061,13 @@ describe("MCP tools (injected deps)", () => {
     // 'a' and 'b' are pool_eligible ('c' is not); 'b' appears in two pools but
     // must be deduped -> exactly 2 eligible. 'b' gets live latency 70.
     assert.equal(out.eligible_count, 2);
-    assert.equal(out.endpoints.filter((e) => e.id === "b").length, 1);
+    assert.equal(out.endpoints.filter((e: Row) => e.id === "b").length, 1);
     assert.equal(out.endpoints[0].id, "b");
     assert.equal(out.endpoints[0].latency_ms, 70);
     assert.equal(out.endpoints[0].url, "wss://b.example");
     assert.equal(out.endpoints[0].network, "finney");
     // The bogus pool-key network ("0"/"1") must never leak.
-    assert.ok(out.endpoints.every((e) => e.network === "finney"));
+    assert.ok(out.endpoints.every((e: Row) => e.network === "finney"));
   });
 
   test("get_best_rpc_endpoint works without a live KV snapshot", async () => {
@@ -3015,11 +3040,11 @@ describe("MCP tools (injected deps)", () => {
       "validator-headroom",
     ]);
     assert.deepEqual(
-      out.boards["open-slots"].map((e) => e.netuid),
+      out.boards["open-slots"].map((e: Row) => e.netuid),
       [10, 11],
     );
     assert.deepEqual(
-      out.boards["highest-emission"].map((e) => e.netuid),
+      out.boards["highest-emission"].map((e: Row) => e.netuid),
       [11, 10],
     );
   });
@@ -3066,7 +3091,7 @@ describe("MCP tools (injected deps)", () => {
         }),
       },
     );
-    let out = res.body.result.structuredContent;
+    const out = res.body.result.structuredContent;
     assert.equal(out.with_economics_count, 0);
     assert.equal(out.observed_at, "2026-06-19T00:00:00Z");
     for (const key of [
@@ -3096,11 +3121,11 @@ describe("MCP tools (injected deps)", () => {
 describe("MCP get_chain_activity (DATA_API binding)", () => {
   // A stub DATA_API binding: records the requested URL and returns the supplied
   // stats payload (or a non-OK response when `status` is given).
-  function makeDataApi({ payload, status = 200 } = {}) {
-    const calls = [];
+  function makeDataApi({ payload, status = 200 }: Row = {}) {
+    const calls: URL[] = [];
     return {
       calls,
-      fetch(request) {
+      fetch(request: Request) {
         calls.push(new URL(request.url));
         return Promise.resolve(
           new Response(status === 200 ? JSON.stringify(payload) : "err", {
@@ -3159,7 +3184,7 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
     const dataApi = makeDataApi({
       payload: { window_blocks: 1000, groups: 0, activity: [] },
     });
-    const limiterKeys = [];
+    const limiterKeys: string[] = [];
     const res = await callTool(
       "get_chain_activity",
       {},
@@ -3167,7 +3192,7 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
         env: {
           DATA_API: dataApi,
           DATA_RATE_LIMITER: {
-            async limit({ key }) {
+            async limit({ key }: { key: string }) {
               limiterKeys.push(key);
               return { success: false };
             },
@@ -3185,7 +3210,7 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
     const dataApi = makeDataApi({
       payload: { window_blocks: 1000, groups: 0, activity: [] },
     });
-    const limiterKeys = [];
+    const limiterKeys: string[] = [];
     const res = await rpc(
       [
         {
@@ -3205,7 +3230,7 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
         env: {
           DATA_API: dataApi,
           DATA_RATE_LIMITER: {
-            async limit({ key }) {
+            async limit({ key }: { key: string }) {
               limiterKeys.push(key);
               return { success: true };
             },
@@ -3306,8 +3331,8 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
 
   test("list_chain_events surfaces a data-Worker 400 as an invalid_params error", async () => {
     const dataApi = {
-      calls: [],
-      fetch(request) {
+      calls: [] as URL[],
+      fetch(request: Request) {
         this.calls.push(new URL(request.url));
         return Promise.resolve(
           new Response(
@@ -3436,7 +3461,7 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
 
   test("list_chain_events errors cleanly when the data Worker fetch throws", async () => {
     const dataApi = {
-      calls: [],
+      calls: [] as URL[],
       fetch() {
         return Promise.reject(new Error("socket hang up"));
       },
@@ -3452,8 +3477,8 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
 
   test("list_chain_events falls back to a default message on a non-JSON 400 body", async () => {
     const dataApi = {
-      calls: [],
-      fetch(request) {
+      calls: [] as URL[],
+      fetch(request: Request) {
         this.calls.push(new URL(request.url));
         return Promise.resolve(new Response("not json", { status: 400 }));
       },
@@ -3475,11 +3500,11 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
 // tier as get_chain_activity above (#6637), so its tests mock DATA_API the
 // same way.
 describe("MCP get_subnet_ownership_history (DATA_API binding)", () => {
-  function makeDataApi({ payload, status = 200 } = {}) {
-    const calls = [];
+  function makeDataApi({ payload, status = 200 }: Row = {}) {
+    const calls: URL[] = [];
     return {
       calls,
-      fetch(request) {
+      fetch(request: Request) {
         calls.push(new URL(request.url));
         return Promise.resolve(
           new Response(status === 200 ? JSON.stringify(payload) : "err", {
@@ -3589,7 +3614,7 @@ describe("MCP get_subnet_ownership_history (DATA_API binding)", () => {
         ownership_changes: [],
       },
     });
-    const limiterKeys = [];
+    const limiterKeys: string[] = [];
     const res = await callTool(
       "get_subnet_ownership_history",
       { netuid: 7 },
@@ -3597,7 +3622,7 @@ describe("MCP get_subnet_ownership_history (DATA_API binding)", () => {
         env: {
           DATA_API: dataApi,
           DATA_RATE_LIMITER: {
-            async limit({ key }) {
+            async limit({ key }: { key: string }) {
               limiterKeys.push(key);
               return { success: true };
             },
@@ -3614,11 +3639,11 @@ describe("MCP get_subnet_ownership_history (DATA_API binding)", () => {
 // all-events tier as get_subnet_ownership_history above, so its tests mock
 // DATA_API the same way.
 describe("MCP get_subnet_lease_history (DATA_API binding)", () => {
-  function makeDataApi({ payload, status = 200, throws = false } = {}) {
-    const calls = [];
+  function makeDataApi({ payload, status = 200, throws = false }: Row = {}) {
+    const calls: URL[] = [];
     return {
       calls,
-      fetch(request) {
+      fetch(request: Request) {
         calls.push(new URL(request.url));
         if (throws) return Promise.reject(new Error("network down"));
         return Promise.resolve(
@@ -3738,7 +3763,7 @@ describe("MCP get_subnet_lease_history (DATA_API binding)", () => {
     const dataApi = makeDataApi({
       payload: { schema_version: 1, netuid: 7, count: 0, lease_events: [] },
     });
-    const limiterKeys = [];
+    const limiterKeys: string[] = [];
     const res = await callTool(
       "get_subnet_lease_history",
       { netuid: 7 },
@@ -3746,7 +3771,7 @@ describe("MCP get_subnet_lease_history (DATA_API binding)", () => {
         env: {
           DATA_API: dataApi,
           DATA_RATE_LIMITER: {
-            async limit({ key }) {
+            async limit({ key }: { key: string }) {
               limiterKeys.push(key);
               return { success: true };
             },
@@ -3763,11 +3788,11 @@ describe("MCP get_subnet_lease_history (DATA_API binding)", () => {
 // tier as get_subnet_ownership_history above, so its tests mock DATA_API
 // the same way.
 describe("MCP get_subnet_conviction (DATA_API binding)", () => {
-  function makeDataApi({ payload, status = 200 } = {}) {
-    const calls = [];
+  function makeDataApi({ payload, status = 200 }: Row = {}) {
+    const calls: URL[] = [];
     return {
       calls,
-      fetch(request) {
+      fetch(request: Request) {
         calls.push(new URL(request.url));
         return Promise.resolve(
           new Response(status === 200 ? JSON.stringify(payload) : "err", {
@@ -3925,7 +3950,7 @@ describe("MCP get_subnet_snapshot", () => {
   // multi-path mock pattern above -- one binding standing in for the five
   // distinct /api/v1/subnets/:netuid/* routes the compound handler fans out to.
   function subnetSnapshotPostgresEnv() {
-    const calls = [];
+    const calls: Row[] = [];
     return {
       calls,
       env: {
@@ -3933,7 +3958,7 @@ describe("MCP get_subnet_snapshot", () => {
         METAGRAPH_NEURONS_SOURCE: "postgres",
         METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             const url = new URL(request.url);
             calls.push(url);
             if (url.pathname === "/api/v1/subnets/7/hyperparameters") {
@@ -4032,7 +4057,7 @@ describe("MCP get_subnet_snapshot", () => {
         env: {
           ...env,
           DATA_API: {
-            fetch: async (request) => {
+            fetch: async (request: Request) => {
               const url = new URL(request.url);
               calls.push(url);
               if (url.pathname === "/api/v1/subnets/7/events") {
@@ -4122,14 +4147,14 @@ describe("MCP get_chain_signers", () => {
   });
 
   test("applies the data-tier limiter before the signers aggregation", async () => {
-    const limiterKeys = [];
+    const limiterKeys: string[] = [];
     const res = await callTool(
       "get_chain_signers",
       {},
       {
         env: {
           DATA_RATE_LIMITER: {
-            async limit({ key }) {
+            async limit({ key }: { key: string }) {
               limiterKeys.push(key);
               return { success: false };
             },
@@ -4143,14 +4168,14 @@ describe("MCP get_chain_signers", () => {
   });
 
   test("proceeds to the empty signers leaderboard when the data-tier limiter allows the request", async () => {
-    const limiterKeys = [];
+    const limiterKeys: string[] = [];
     const res = await callTool(
       "get_chain_signers",
       {},
       {
         env: {
           DATA_RATE_LIMITER: {
-            async limit({ key }) {
+            async limit({ key }: { key: string }) {
               limiterKeys.push(key);
               return { success: true };
             },
@@ -4211,7 +4236,7 @@ describe("MCP get_chain_signers", () => {
         },
       },
     };
-    const message = (id) => ({
+    const message = (id: unknown) => ({
       jsonrpc: "2.0",
       id,
       method: "tools/call",
@@ -4223,7 +4248,7 @@ describe("MCP get_chain_signers", () => {
     const res = await rpc([message(1), message(2), message(3)], { env });
     assert.equal(res.status, 200);
     assert.equal(res.body.length, 3);
-    for (const entry of res.body) {
+    for (const entry of res.body as unknown as Row[]) {
       assert.equal(entry.result.isError, true);
       assert.match(entry.result.content[0].text, /Too many data API requests/);
     }
@@ -4295,7 +4320,7 @@ describe("MCP get_chain_fees", () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (request) => {
+        fetch: async (request: Request) => {
           requestedUrl = new URL(request.url);
           return Response.json({
             schema_version: 1,
@@ -4313,9 +4338,9 @@ describe("MCP get_chain_fees", () => {
       { window: "30d", call_module: "Balances", limit: 10 },
       { env },
     );
-    assert.equal(requestedUrl.searchParams.get("call_module"), "Balances");
-    assert.equal(requestedUrl.searchParams.get("window"), "30d");
-    assert.equal(requestedUrl.searchParams.get("limit"), "10");
+    assert.equal(requestedUrl!.searchParams.get("call_module"), "Balances");
+    assert.equal(requestedUrl!.searchParams.get("window"), "30d");
+    assert.equal(requestedUrl!.searchParams.get("limit"), "10");
   });
 
   test("rejects an invalid window", async () => {
@@ -4360,7 +4385,7 @@ describe("MCP get_chain_registrations", () => {
     return {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (request) => {
+        fetch: async (request: Request) => {
           const url = new URL(request.url);
           const window = url.searchParams.get("window") || "7d";
           const limitParam = url.searchParams.get("limit");
@@ -4501,12 +4526,12 @@ describe("MCP decode_evm_call (#6725/#6729)", () => {
   const SUBNET_ADDRESS = "0x0000000000000000000000000000000000000803";
 
   test("decodes a real precompile call end-to-end", async () => {
-    const fn = EVM_PRECOMPILE_BY_ADDRESS.get(SUBNET_ADDRESS).functions.find(
+    const fn = EVM_PRECOMPILE_BY_ADDRESS.get(SUBNET_ADDRESS)!.functions.find(
       (f) => f.name === "getWeightsVersionKey",
     );
     const res = await callTool(
       "decode_evm_call",
-      { to: SUBNET_ADDRESS, input: `${fn.selector}${"7".padStart(64, "0")}` },
+      { to: SUBNET_ADDRESS, input: `${fn!.selector}${"7".padStart(64, "0")}` },
       {},
     );
     assert.equal(res.body.result.isError, false);
@@ -4514,7 +4539,7 @@ describe("MCP decode_evm_call (#6725/#6729)", () => {
       precompile: "Subnet",
       address: SUBNET_ADDRESS,
       function: "getWeightsVersionKey",
-      signature: fn.signature,
+      signature: fn!.signature,
       args: { netuid: 7 },
     });
   });
@@ -4582,10 +4607,10 @@ describe("MCP get_evm_address_mapping (#6725/#6728)", () => {
 
   test("returns the SS58-encoded mapping from finney RPC", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
+    globalThis.fetch = (async () => ({
       ok: true,
       json: async () => ({ result: GOLDEN_ETH_CALL_RESULT }),
-    });
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_evm_address_mapping", { h160: H160 }, {});
       const out = res.body.result.structuredContent;
@@ -4599,7 +4624,9 @@ describe("MCP get_evm_address_mapping (#6725/#6728)", () => {
 
   test("ss58 is null on RPC failure", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({ ok: false });
+    globalThis.fetch = (async () => ({
+      ok: false,
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_evm_address_mapping", { h160: H160 }, {});
       assert.equal(res.body.result.structuredContent.ss58, null);
@@ -4631,13 +4658,13 @@ describe("MCP get_chain_transfers", () => {
       senders = [{ address: "5Sa", volume_tao: 80, transfer_count: 5 }],
       receivers = [{ address: "5Rx", volume_tao: 60, transfer_count: 4 }],
     } = {},
-    capture = [],
+    capture: Row[] = [],
   ) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -4667,12 +4694,12 @@ describe("MCP get_chain_transfers", () => {
   // running the same pure builder over the caller's own window query param,
   // so the mocked response is byte-identical to what production would
   // actually serve.
-  function chainTransfersPostgresEnv({ totals, senders, receivers }) {
+  function chainTransfersPostgresEnv({ totals, senders, receivers }: Row) {
     return {
       env: {
         METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             const url = new URL(request.url);
             const window = url.searchParams.get("window") || "7d";
             return Response.json(
@@ -4743,12 +4770,12 @@ describe("MCP get_chain_transfers", () => {
 describe("MCP stake-flow and movers economics tools", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-  function stakeFlowD1(rows = [], capture = []) {
+  function stakeFlowD1(rows: Row[] = [], capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -4774,12 +4801,12 @@ describe("MCP stake-flow and movers economics tools", () => {
     };
   }
 
-  function moversD1({ bounds, aggregateRows } = {}, capture = []) {
+  function moversD1({ bounds, aggregateRows }: Row = {}, capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -4876,12 +4903,12 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.deepEqual(out.subnets, []);
   });
 
-  function accountStakeMovesD1(rows = [], capture = []) {
+  function accountStakeMovesD1(rows: Row[] = [], capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -4956,12 +4983,12 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  function accountAxonRemovalsD1(rows = [], capture = []) {
+  function accountAxonRemovalsD1(rows: Row[] = [], capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5036,12 +5063,12 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  function accountPrometheusD1(rows = [], capture = []) {
+  function accountPrometheusD1(rows: Row[] = [], capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5118,12 +5145,12 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  function accountRegistrationsD1(rows = [], capture = []) {
+  function accountRegistrationsD1(rows: Row[] = [], capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5199,12 +5226,12 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  function accountServingD1(rows = [], capture = []) {
+  function accountServingD1(rows: Row[] = [], capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5281,12 +5308,12 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
-  function accountWeightSettersD1(rows = [], capture = []) {
+  function accountWeightSettersD1(rows: Row[] = [], capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5310,12 +5337,12 @@ describe("MCP stake-flow and movers economics tools", () => {
     };
   }
 
-  function accountDeregistrationsD1(rows = [], capture = []) {
+  function accountDeregistrationsD1(rows: Row[] = [], capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5476,9 +5503,9 @@ describe("MCP stake-flow and movers economics tools", () => {
 
   test("stake-flow and movers payloads validate against outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name) =>
+    const validatorFor = (name: string) =>
       ajv.compile(
-        listToolDefinitions().find((t) => t.name === name).outputSchema,
+        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
       );
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
@@ -5655,12 +5682,12 @@ describe("MCP get_subnet_event_summary", () => {
 });
 
 describe("MCP get_subnet_stake_moves", () => {
-  function stakeMovesD1(row = null, capture = []) {
+  function stakeMovesD1(row: Row | null = null, capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5725,12 +5752,12 @@ describe("MCP get_subnet_stake_moves", () => {
 });
 
 describe("MCP get_subnet_stake_transfers", () => {
-  function stakeTransfersD1(row = null, capture = []) {
+  function stakeTransfersD1(row: Row | null = null, capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5796,12 +5823,12 @@ describe("MCP get_subnet_stake_transfers", () => {
 });
 
 describe("MCP get_subnet_registrations", () => {
-  function registrationsSubnetD1(row = null, capture = []) {
+  function registrationsSubnetD1(row: Row | null = null, capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5847,12 +5874,12 @@ describe("MCP get_subnet_registrations", () => {
 });
 
 describe("MCP get_subnet_weights", () => {
-  function weightsD1(row = null, capture = []) {
+  function weightsD1(row: Row | null = null, capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -5983,12 +6010,12 @@ describe("MCP get_subnet_axon_removals", () => {
 });
 
 describe("MCP get_subnet_serving", () => {
-  function servingD1(row = null, capture = []) {
+  function servingD1(row: Row | null = null, capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -6053,12 +6080,12 @@ describe("MCP get_subnet_serving", () => {
 });
 
 describe("MCP get_subnet_prometheus", () => {
-  function prometheusD1(row = null, capture = []) {
+  function prometheusD1(row: Row | null = null, capture: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 async all() {
@@ -6200,12 +6227,12 @@ describe("MCP get_subnet_performance_history", () => {
 });
 
 describe("MCP get_subnet_yield_history", () => {
-  function yieldHistoryD1(rows = []) {
+  function yieldHistoryD1(rows: Row[] = []) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(_sql) {
+        prepare(_sql: unknown) {
           return {
-            bind(..._params) {
+            bind(..._params: unknown[]) {
               return {
                 async all() {
                   return { results: rows };
@@ -6331,9 +6358,9 @@ describe("MCP get_rpc_usage", () => {
   function rpcUsageDb() {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(..._params) {
+            bind(..._params: unknown[]) {
               return {
                 async all() {
                   if (/COUNT\(\*\) AS total/.test(sql)) {
@@ -6470,7 +6497,7 @@ describe("MCP get_rpc_usage", () => {
   test("cold and populated payloads validate against the declared outputSchema", async () => {
     const ajv = new Ajv2020({ strict: false });
     const validate = ajv.compile(
-      listToolDefinitions().find((t) => t.name === "get_rpc_usage")
+      listToolDefinitions().find((t: Row) => t.name === "get_rpc_usage")!
         .outputSchema,
     );
     for (const [label, env] of [
@@ -6512,7 +6539,7 @@ describe("MCP call_rpc", () => {
     return {
       METAGRAPH_ENABLE_RPC_PROXY: "true",
       ASSETS: {
-        async fetch(request) {
+        async fetch(request: Request) {
           const target = new URL(request.url);
           if (target.pathname === "/metagraph/rpc/pools.json") {
             return Response.json(RPC_POOL);
@@ -6591,7 +6618,7 @@ describe("MCP call_rpc", () => {
         },
       },
       RPC_RATE_LIMITER: {
-        async limit({ key }) {
+        async limit({ key }: { key: string }) {
           limiterKey = key;
           return { success: false };
         },
@@ -6697,8 +6724,8 @@ describe("MCP call_rpc", () => {
   test("advertises a call_rpc-shaped outputSchema and the result validates against it", async () => {
     const ajv = new Ajv2020({ strict: false });
     const def = listToolDefinitions().find((t) => t.name === "call_rpc");
-    assert.ok(def.outputSchema);
-    const validate = ajv.compile(def.outputSchema);
+    assert.ok(def!.outputSchema);
+    const validate = ajv.compile(def!.outputSchema);
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async () =>
       new Response(
@@ -6795,7 +6822,9 @@ describe("MCP query_graphql (#5591 — GraphQL bridge tool)", () => {
     // uses a different key and must still pass so the request reaches the tool.
     const env = {
       RPC_RATE_LIMITER: {
-        limit: async ({ key }) => ({ success: !key.startsWith("gql:") }),
+        limit: async ({ key }: { key: string }) => ({
+          success: !key.startsWith("gql:"),
+        }),
       },
     };
     const res = await callTool(
@@ -6942,7 +6971,7 @@ describe("MCP keyword discovery relevance", () => {
     const res = await callTool("search_subnets", { query: "ai" }, { deps });
     const out = res.body.result.structuredContent;
     assert.deepEqual(
-      out.results.map((r) => r.netuid),
+      out.results.map((r: Row) => r.netuid),
       [1],
     );
   });
@@ -6960,7 +6989,7 @@ describe("MCP keyword discovery relevance", () => {
     );
     const out = res.body.result.structuredContent;
     assert.deepEqual(
-      out.results.map((r) => r.netuid),
+      out.results.map((r: Row) => r.netuid),
       [1],
     );
   });
@@ -7113,9 +7142,9 @@ describe("MCP end-to-end through the Worker dispatch", () => {
         params: { name: "list_subnet_apis", arguments: { netuid: 7 } },
       }),
     });
-    const response = await handleRequest(request, env, {});
+    const response = await handleRequest(request, env as unknown as Env, {});
     assert.equal(response.status, 200);
-    const body = await response.json();
+    const body = (await response.json()) as Row;
     assert.ok(body.result.structuredContent.service_count >= 1);
   });
 });
@@ -7123,11 +7152,11 @@ describe("MCP end-to-end through the Worker dispatch", () => {
 describe("MCP AI tools (semantic_search + ask)", () => {
   // Minimal AI bindings: embed → 1024-d vector, vector query → subnet matches,
   // completion → cited answer. Kill-switch on so aiEnabled() is satisfied.
-  function aiEnv() {
+  function aiEnv(): Row {
     return {
       METAGRAPH_ENABLE_AI: "true",
       AI: {
-        run(model, input) {
+        run(model: string, input: Row) {
           if (Array.isArray(input?.text) || typeof input?.text === "string") {
             const n = Array.isArray(input.text) ? input.text.length : 1;
             return Promise.resolve({
@@ -7190,7 +7219,7 @@ describe("MCP AI tools (semantic_search + ask)", () => {
   test("semantic_search forwards the type scope to Vectorize", async () => {
     const env = aiEnv();
     let lastOptions;
-    env.VECTORIZE.query = (_vector, options) => {
+    env.VECTORIZE.query = (_vector: unknown, options: Row) => {
       lastOptions = options;
       return Promise.resolve({ matches: [] });
     };
@@ -7200,7 +7229,7 @@ describe("MCP AI tools (semantic_search + ask)", () => {
       { env },
     );
     assert.equal(res.body.result.isError, false);
-    assert.deepEqual(lastOptions.filter, {
+    assert.deepEqual(lastOptions!.filter, {
       type: { $in: ["subnet", "provider"] },
     });
   });
@@ -7218,7 +7247,7 @@ describe("MCP AI tools (semantic_search + ask)", () => {
   test("ask forwards the type scope to Vectorize", async () => {
     const env = aiEnv();
     let lastOptions;
-    env.VECTORIZE.query = (_vector, options) => {
+    env.VECTORIZE.query = (_vector: unknown, options: Row) => {
       lastOptions = options;
       return Promise.resolve({ matches: [] });
     };
@@ -7228,7 +7257,7 @@ describe("MCP AI tools (semantic_search + ask)", () => {
       { env },
     );
     assert.equal(res.body.result.isError, false);
-    assert.deepEqual(lastOptions.filter, { type: "provider" });
+    assert.deepEqual(lastOptions!.filter, { type: "provider" });
   });
 
   test("ask returns a grounded answer with citations when AI is enabled", async () => {
@@ -7253,7 +7282,7 @@ describe("MCP AI tools (semantic_search + ask)", () => {
       return Promise.resolve({ data: [new Array(1024).fill(0.02)] });
     };
     env.AI_RATE_LIMITER = {
-      async limit({ key }) {
+      async limit({ key }: { key: string }) {
         limiterKey = key;
         return { success: false };
       },
@@ -7281,7 +7310,7 @@ describe("MCP AI tools (semantic_search + ask)", () => {
       return Promise.resolve({ response: "should not run" });
     };
     env.AI_RATE_LIMITER = {
-      async limit({ key }) {
+      async limit({ key }: { key: string }) {
         limiterCalls += 1;
         assert.equal(key, "ask:anonymous");
         return { success: false };
@@ -7305,7 +7334,7 @@ describe("MCP AI tools (semantic_search + ask)", () => {
     assert.equal(res.body.length, MAX_MCP_BATCH_LENGTH);
     assert.equal(limiterCalls, MAX_MCP_BATCH_LENGTH);
     assert.equal(aiRuns, 0);
-    for (const response of res.body) {
+    for (const response of res.body as unknown as Row[]) {
       assert.equal(response.result.isError, true);
       assert.match(response.result.content[0].text, /rate_limited/);
     }
@@ -7380,7 +7409,7 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
     assert.equal(out.results[0].base_url, "https://api.data.io");
     assert.equal(out.results[0].integration_readiness, 70);
     // subnet 8 is not in the catalog (not callable) so it is excluded.
-    assert.ok(out.results.every((r) => r.netuid !== 8));
+    assert.ok(out.results.every((r: Row) => r.netuid !== 8));
   });
 
   test("find_subnet_for_task surfaces a callable subnet ranked beyond the non-callable pool", async () => {
@@ -7510,12 +7539,12 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
     assert.match(out.services[0].snippets.curl, /X-API-Key: YOUR_API_KEY/);
     assert.match(out.services[0].snippets.python, /import requests/);
     assert.match(out.services[0].snippets.typescript, /await fetch/);
-    assert.ok(out.next_steps.some((s) => /get_subnet_health/.test(s)));
+    assert.ok(out.next_steps.some((s: string) => /get_subnet_health/.test(s)));
   });
 
   test("how_do_i_call surfaces fixture fetch instructions when available", async () => {
     const fixtureDetail = structuredClone(callDetail);
-    const service =
+    const service: Row =
       fixtureDetail["/metagraph/agent-catalog/7.json"].services[0];
     service.fixture = {
       captured_at: "2026-06-18T00:00:00.000Z",
@@ -7542,12 +7571,12 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
       out.services[0].fixture.fetch_with,
       "get_fixture with surface_id sn-7-api",
     );
-    assert.ok(out.next_steps.some((s) => /get_fixture/.test(s)));
+    assert.ok(out.next_steps.some((s: string) => /get_fixture/.test(s)));
   });
 
   test("how_do_i_call regenerates snippets without cleartext credentials", async () => {
     const cleartextDetail = structuredClone(callDetail);
-    const service =
+    const service: Row =
       cleartextDetail["/metagraph/agent-catalog/7.json"].services[0];
     service.base_url = "http://api.data.io";
     service.snippets = {
@@ -7609,11 +7638,11 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
 
 describe("MCP goal-shaped tools — branch coverage", () => {
   // Minimal AI env whose vector query returns the given subnet netuids in order.
-  function aiEnvWithMatches(netuids) {
+  function aiEnvWithMatches(netuids: number[]) {
     return {
       METAGRAPH_ENABLE_AI: "true",
       AI: {
-        run(_model, input) {
+        run(_model: unknown, input: Row) {
           if (input?.text) {
             return Promise.resolve({ data: [new Array(1024).fill(0.02)] });
           }
@@ -7623,7 +7652,7 @@ describe("MCP goal-shaped tools — branch coverage", () => {
       VECTORIZE: {
         query() {
           return Promise.resolve({
-            matches: netuids.map((n, i) => ({
+            matches: netuids.map((n: number, i: number) => ({
               id: `subnet:${n}`,
               score: 0.9 - i * 0.01,
               metadata: {
@@ -7832,7 +7861,7 @@ describe("MCP goal-shaped tools — branch coverage", () => {
     assert.equal(out.services[0].auth.required, false);
     assert.equal(out.services[0].schema.available, false);
     assert.equal(out.services[0].health.status, "unknown");
-    assert.ok(out.next_steps.every((s) => !/get_api_schema/.test(s)));
+    assert.ok(out.next_steps.every((s: string) => !/get_api_schema/.test(s)));
   });
 
   test("how_do_i_call tolerates a detail with no services array", async () => {
@@ -8002,7 +8031,7 @@ describe("MCP goal-shaped tools — branch coverage", () => {
         { deps },
       );
       const match = res.body.result.structuredContent.results.find(
-        (r) => r.netuid === 7,
+        (r: Row) => r.netuid === 7,
       );
       assert.ok(match, "subnet 7 should rank for the task");
       // health reflects the LIVE probe ("failed"), not the build-time stub.
@@ -8134,8 +8163,8 @@ describe("list_subnets", () => {
   });
 
   // Fixture readiness: {0:15, 7:90, 8:0}; surface_count: {0:17, 7:4, 8:0}.
-  const rangeNetuids = (out) =>
-    out.subnets.map((s) => s.netuid).sort((a, b) => a - b);
+  const rangeNetuids = (out: Row) =>
+    out.subnets.map((s: Row) => s.netuid).sort((a: number, b: number) => a - b);
 
   // Fixture: 0=root/active, 7=application/active/inference,
   // 8=application/deprecated with derived_categories ["data"].
@@ -8294,7 +8323,7 @@ describe("list_subnets", () => {
       )
     ).body.result.structuredContent;
     assert.deepEqual(
-      out.subnets.map((s) => s.netuid),
+      out.subnets.map((s: Row) => s.netuid),
       [7, 0, 8],
     );
     assert.equal(out.sort, "integration_readiness");
@@ -8310,7 +8339,7 @@ describe("list_subnets", () => {
       )
     ).body.result.structuredContent;
     assert.deepEqual(
-      out.subnets.map((s) => s.netuid),
+      out.subnets.map((s: Row) => s.netuid),
       [8, 0, 7],
     );
     assert.equal(out.order, "asc");
@@ -8321,7 +8350,7 @@ describe("list_subnets", () => {
       .body.result.structuredContent;
     // Allways (7), Parked (8), root (0)
     assert.deepEqual(
-      out.subnets.map((s) => s.netuid),
+      out.subnets.map((s: Row) => s.netuid),
       [7, 8, 0],
     );
   });
@@ -8330,7 +8359,7 @@ describe("list_subnets", () => {
     const out = (await callTool("list_subnets", {}, { deps })).body.result
       .structuredContent;
     assert.deepEqual(
-      out.subnets.map((s) => s.netuid),
+      out.subnets.map((s: Row) => s.netuid),
       [0, 7, 8],
     );
     assert.equal(out.sort, null);
@@ -8372,7 +8401,7 @@ describe("list_subnets", () => {
     // 80 first; the two 50s tie → netuid asc (3,5); the nulls sort last → netuid
     // asc (1,9), even under desc.
     assert.deepEqual(
-      out.subnets.map((s) => s.netuid),
+      out.subnets.map((s: Row) => s.netuid),
       [2, 3, 5, 1, 9],
     );
   });
@@ -8398,7 +8427,7 @@ describe("list_subnets", () => {
         )
       ).body.result.structuredContent;
       assert.deepEqual(
-        out.subnets.map((s) => s.netuid),
+        out.subnets.map((s: Row) => s.netuid),
         [1, 2],
       );
     }
@@ -8429,8 +8458,10 @@ describe("list_subnets", () => {
         ],
       },
     });
-    const rangeNetuids = (out) =>
-      out.subnets.map((s) => s.netuid).sort((a, b) => a - b);
+    const rangeNetuids = (out: Row) =>
+      out.subnets
+        .map((s: Row) => s.netuid)
+        .sort((a: number, b: number) => a - b);
 
     const byCoverage = (
       await callTool(
@@ -8500,9 +8531,9 @@ describe("search tools pagination", () => {
 
   // Walk every page by following next_cursor; returns the concatenated results
   // and the (cursor, next_cursor) sequence seen.
-  async function walkAll(tool, baseArgs, limit) {
-    const all = [];
-    const cursors = [];
+  async function walkAll(tool: string, baseArgs: Row, limit: unknown) {
+    const all: Row[] = [];
+    const cursors: Row[] = [];
     let cursor = 0;
     let total = null;
     // Guard well above the real page count so a cursor bug fails fast instead
@@ -8675,7 +8706,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 7 },
       {
         deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8705,7 +8736,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 999 },
       {
         deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8726,7 +8757,7 @@ describe("MCP economics + metagraph data tools", () => {
           },
           {},
         ),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8760,7 +8791,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 1000, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8780,7 +8811,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 500, direction: "unstake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8795,7 +8826,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 10 },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.structuredContent.direction, "stake");
@@ -8807,7 +8838,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 0, amount: 42, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8823,7 +8854,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: -5, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.isError, true);
@@ -8836,7 +8867,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 10, direction: "swap" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.isError, true);
@@ -8849,7 +8880,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 999, amount: 10, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.isError, true);
@@ -8862,7 +8893,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 1000, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8882,7 +8913,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 10 },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.structuredContent.direction, "stake");
@@ -8894,7 +8925,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 500, direction: "unstake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8910,7 +8941,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 0, amount: 42, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8926,7 +8957,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 10, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8961,7 +8992,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 999, amount: 10, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.isError, true);
@@ -8974,7 +9005,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 10, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -8989,7 +9020,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 10000, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -9005,7 +9036,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 64, amount: 20000, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -9021,7 +9052,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 0, amount: 42, direction: "stake" },
       {
         deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -9086,7 +9117,7 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.cursor, 1);
     assert.equal(out.next_cursor, null);
     assert.deepEqual(
-      out.subnets.map((row) => row.netuid),
+      out.subnets.map((row: Row) => row.netuid),
       [8, 9],
     );
   });
@@ -9097,7 +9128,7 @@ describe("MCP economics + metagraph data tools", () => {
       { sort: "not_a_field" },
       {
         deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.isError, true);
@@ -9109,8 +9140,11 @@ describe("MCP economics + metagraph data tools", () => {
     for (const [args, pattern] of [
       [{ netuid: -1 }, /netuid must be a non-negative integer/],
       [{ cursor: -1 }, /cursor must be a non-negative integer/],
-    ]) {
-      const res = await callTool("get_economics", args, { deps, env: {} });
+    ] as [Row, RegExp][]) {
+      const res = await callTool("get_economics", args, {
+        deps,
+        env: {} as unknown as Env,
+      });
       assert.equal(res.body.result.isError, true, JSON.stringify(args));
       assert.match(res.body.result.content[0].text, pattern);
     }
@@ -9153,7 +9187,7 @@ describe("MCP economics + metagraph data tools", () => {
       { fields: "netuid,not_a_field" },
       {
         deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.isError, true);
@@ -9189,7 +9223,7 @@ describe("MCP economics + metagraph data tools", () => {
       {},
       {
         deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -9206,10 +9240,10 @@ describe("MCP economics + metagraph data tools", () => {
     const tool = MCP_TOOLS.find((t) => t.name === "get_economics");
     await assert.rejects(
       () =>
-        tool.handler(
+        tool!.handler(
           {},
           {
-            env: {},
+            env: {} as unknown as Env,
             readHealthKv: async () => null,
             readArtifact: async () => {
               throw new Error("kaboom");
@@ -9223,7 +9257,7 @@ describe("MCP economics + metagraph data tools", () => {
   test("get_economics payload validates against its declared outputSchema", async () => {
     const ajv = new Ajv2020({ strict: false });
     const validate = ajv.compile(
-      listToolDefinitions().find((t) => t.name === "get_economics")
+      listToolDefinitions().find((t: Row) => t.name === "get_economics")!
         .outputSchema,
     );
     const res = await callTool(
@@ -9231,7 +9265,7 @@ describe("MCP economics + metagraph data tools", () => {
       { sort: "netuid", order: "asc" },
       {
         deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.ok(validate(res.body.result.structuredContent));
@@ -9276,7 +9310,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 7, sort: "completeness_score", order: "desc" },
       {
         deps: makeDeps({ "/metagraph/profiles.json": PROFILES_BLOB }),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -9291,7 +9325,7 @@ describe("MCP economics + metagraph data tools", () => {
       { sort: "not_a_field" },
       {
         deps: makeDeps({ "/metagraph/profiles.json": PROFILES_BLOB }),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.equal(res.body.result.isError, true);
@@ -9312,10 +9346,10 @@ describe("MCP economics + metagraph data tools", () => {
     const tool = MCP_TOOLS.find((t) => t.name === "list_profiles");
     await assert.rejects(
       () =>
-        tool.handler(
+        tool!.handler(
           {},
           {
-            env: {},
+            env: {} as unknown as Env,
             readArtifact: async () => {
               throw new Error("kaboom");
             },
@@ -9335,7 +9369,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 7 },
       {
         deps: makeDeps({ "/metagraph/profiles/7.json": detail }),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     const out = res.body.result.structuredContent;
@@ -9357,10 +9391,10 @@ describe("MCP economics + metagraph data tools", () => {
     const tool = MCP_TOOLS.find((t) => t.name === "get_subnet_profile");
     await assert.rejects(
       () =>
-        tool.handler(
+        tool!.handler(
           { netuid: 7 },
           {
-            env: {},
+            env: {} as unknown as Env,
             readArtifact: async () => {
               throw new Error("kaboom");
             },
@@ -9378,8 +9412,8 @@ describe("MCP economics + metagraph data tools", () => {
       .mockRejectedValue(err);
     try {
       await assert.rejects(
-        () => tool.handler({ netuid: 7 }, { env: {} }),
-        (thrown) => {
+        () => tool!.handler({ netuid: 7 }, { env: {} as unknown as Env }),
+        (thrown: Row) => {
           assert.equal(thrown.toolError, true);
           assert.equal(thrown.code, "not_found");
           assert.match(thrown.message, /Profile gone/);
@@ -9399,8 +9433,8 @@ describe("MCP economics + metagraph data tools", () => {
       .mockRejectedValue(err);
     try {
       await assert.rejects(
-        () => tool.handler({}, { env: {} }),
-        (thrown) => {
+        () => tool!.handler({}, { env: {} as unknown as Env }),
+        (thrown: Row) => {
           assert.equal(thrown.toolError, true);
           assert.equal(thrown.code, "invalid_params");
           assert.match(thrown.message, /bad filter/);
@@ -9415,7 +9449,7 @@ describe("MCP economics + metagraph data tools", () => {
   test("list_profiles payload validates against its declared outputSchema", async () => {
     const ajv = new Ajv2020({ strict: false });
     const validate = ajv.compile(
-      listToolDefinitions().find((t) => t.name === "list_profiles")
+      listToolDefinitions().find((t: Row) => t.name === "list_profiles")!
         .outputSchema,
     );
     const res = await callTool(
@@ -9423,7 +9457,7 @@ describe("MCP economics + metagraph data tools", () => {
       { sort: "netuid", order: "asc" },
       {
         deps: makeDeps({ "/metagraph/profiles.json": PROFILES_BLOB }),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.ok(validate(res.body.result.structuredContent));
@@ -9432,7 +9466,7 @@ describe("MCP economics + metagraph data tools", () => {
   test("get_subnet_profile payload validates against its declared outputSchema", async () => {
     const ajv = new Ajv2020({ strict: false });
     const validate = ajv.compile(
-      listToolDefinitions().find((t) => t.name === "get_subnet_profile")
+      listToolDefinitions().find((t: Row) => t.name === "get_subnet_profile")!
         .outputSchema,
     );
     const detail = {
@@ -9446,7 +9480,7 @@ describe("MCP economics + metagraph data tools", () => {
       { netuid: 7 },
       {
         deps: makeDeps({ "/metagraph/profiles/7.json": detail }),
-        env: {},
+        env: {} as unknown as Env,
       },
     );
     assert.ok(validate(res.body.result.structuredContent));
@@ -9530,11 +9564,11 @@ describe("MCP economics + metagraph data tools", () => {
     chainServingSubnetRows = [],
     transferPairTotals = [],
     transferPairRows = [],
-  } = {}) {
+  }: Row = {}) {
     return {
-      prepare(sql) {
+      prepare(sql: string) {
         return {
-          bind(...params) {
+          bind(...params: unknown[]) {
             return {
               all() {
                 if (sql.includes("FROM account_events")) {
@@ -9645,10 +9679,10 @@ describe("MCP economics + metagraph data tools", () => {
                 if (sql.includes("FROM neurons")) {
                   let r = neurons;
                   if (sql.includes("validator_permit = 1")) {
-                    r = r.filter((x) => x.validator_permit === 1);
+                    r = r.filter((x: Row) => x.validator_permit === 1);
                   }
                   if (sql.includes("AND uid = ?")) {
-                    r = r.filter((x) => x.uid === params[1]);
+                    r = r.filter((x: Row) => x.uid === params[1]);
                   }
                   return Promise.resolve({ results: r });
                 }
@@ -9683,7 +9717,7 @@ describe("MCP economics + metagraph data tools", () => {
                   if (sql.includes("WHERE netuid IN")) {
                     const netuids = params.map(Number);
                     return Promise.resolve({
-                      results: surfaceStatus.filter((row) =>
+                      results: surfaceStatus.filter((row: Row) =>
                         netuids.includes(row.netuid),
                       ),
                     });
@@ -10127,11 +10161,11 @@ describe("MCP economics + metagraph data tools", () => {
     });
 
     test("flag=postgres forwards limit as a REST-equivalent query param", async () => {
-      let seenUrl;
+      let seenUrl: URL | undefined;
       const env = {
         METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             seenUrl = new URL(request.url);
             return Response.json({
               schema_version: 1,
@@ -10143,16 +10177,16 @@ describe("MCP economics + metagraph data tools", () => {
         },
       };
       await callTool("get_chain_identity_history", { limit: 25 }, { env });
-      assert.equal(seenUrl.pathname, "/api/v1/chain/identity-history");
-      assert.equal(seenUrl.searchParams.get("limit"), "25");
+      assert.equal(seenUrl!.pathname, "/api/v1/chain/identity-history");
+      assert.equal(seenUrl!.searchParams.get("limit"), "25");
     });
 
     test("flag=postgres omits the limit param when not supplied", async () => {
-      let seenUrl;
+      let seenUrl: URL | undefined;
       const env = {
         METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             seenUrl = new URL(request.url);
             return Response.json({
               schema_version: 1,
@@ -10164,8 +10198,8 @@ describe("MCP economics + metagraph data tools", () => {
         },
       };
       await callTool("get_chain_identity_history", {}, { env });
-      assert.equal(seenUrl.pathname, "/api/v1/chain/identity-history");
-      assert.equal(seenUrl.searchParams.has("limit"), false);
+      assert.equal(seenUrl!.pathname, "/api/v1/chain/identity-history");
+      assert.equal(seenUrl!.searchParams.has("limit"), false);
     });
   });
 
@@ -10203,14 +10237,18 @@ describe("MCP economics + metagraph data tools", () => {
 
   // A validator-permit neuron_daily row for one boundary snapshot; keeps the
   // turnover fixtures compact so the churn arithmetic under test stays legible.
-  function turnoverRow(snapshot_date, netuid, hotkey) {
+  function turnoverRow(
+    snapshot_date: unknown,
+    netuid: number,
+    hotkey: unknown,
+  ) {
     return { snapshot_date, netuid, hotkey, validator_permit: 1 };
   }
 
   // A metagraphD1 env wired for the chain-turnover boundary reads: the MIN/MAX
   // bounds row plus the two-snapshot validator rows the loader reads.
   function chainTurnoverEnv(
-    rows,
+    rows: Row[],
     { start = "2026-06-01", end = "2026-06-30" } = {},
   ) {
     return {
@@ -10276,7 +10314,12 @@ describe("MCP economics + metagraph data tools", () => {
 
   // A grouped account_events aggregate row (one per netuid+event_kind), the
   // shape loadChainStakeFlow's SUM/COUNT/MAX query returns.
-  function stakeFlowRow(netuid, event_kind, total_tao, event_count) {
+  function stakeFlowRow(
+    netuid: number,
+    event_kind: unknown,
+    total_tao: unknown,
+    event_count: unknown,
+  ) {
     return {
       netuid,
       event_kind,
@@ -10294,8 +10337,12 @@ describe("MCP economics + metagraph data tools", () => {
   // params, reusing the shared chainAccountEventsPostgresEnv helper (its
   // buildFn ignores the unused networkDistinct arg for this tool, which
   // computes its network rollup straight off the row list).
-  function chainStakeFlowEnv(rows) {
-    return chainAccountEventsPostgresEnv(buildChainStakeFlow, null, rows);
+  function chainStakeFlowEnv(rows: Row[]) {
+    return chainAccountEventsPostgresEnv(
+      buildChainStakeFlow,
+      null as unknown as Row,
+      rows,
+    );
   }
 
   test("get_chain_stake_flow returns schema-stable zeros on cold D1", async () => {
@@ -10379,11 +10426,11 @@ describe("MCP economics + metagraph data tools", () => {
   // One GROUP BY netuid, event_kind row from account_events, the shape
   // loadChainAlphaVolume's SUM/COUNT/MAX query returns.
   function alphaVolumeRow(
-    netuid,
-    event_kind,
-    alpha_volume,
-    tao_volume,
-    event_count,
+    netuid: number,
+    event_kind: unknown,
+    alpha_volume: unknown,
+    tao_volume: unknown,
+    event_count: unknown,
   ) {
     return {
       netuid,
@@ -10401,8 +10448,12 @@ describe("MCP economics + metagraph data tools", () => {
   // [], ...) on any miss/outage, never a live D1 read. Reuses the shared
   // chainAccountEventsPostgresEnv helper (this builder ignores the unused
   // window/networkDistinct options — fixed 24h window, own row-derived rollup).
-  function chainAlphaVolumeEnv(rows) {
-    return chainAccountEventsPostgresEnv(buildChainAlphaVolume, null, rows);
+  function chainAlphaVolumeEnv(rows: Row[]) {
+    return chainAccountEventsPostgresEnv(
+      buildChainAlphaVolume,
+      null as unknown as Row,
+      rows,
+    );
   }
 
   test("get_chain_alpha_volume returns schema-stable zeros on cold D1", async () => {
@@ -10491,7 +10542,7 @@ describe("MCP economics + metagraph data tools", () => {
   // The network-wide aggregate row loadChainWeights reads first (its COUNT/
   // COUNT(DISTINCT)/MAX(observed_at) probe); a non-null newest_observed unlocks
   // the per-subnet read.
-  function weightsNetwork(weight_sets, distinct_setters) {
+  function weightsNetwork(weight_sets: unknown, distinct_setters: unknown) {
     return {
       weight_sets,
       distinct_setters,
@@ -10500,7 +10551,11 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   // A per-subnet GROUP BY netuid row (COUNT weight_sets + distinct setters).
-  function weightsRow(netuid, weight_sets, distinct_setters) {
+  function weightsRow(
+    netuid: number,
+    weight_sets: unknown,
+    distinct_setters: unknown,
+  ) {
     return { netuid, weight_sets, distinct_setters };
   }
 
@@ -10510,7 +10565,7 @@ describe("MCP economics + metagraph data tools", () => {
   // on any miss/outage, never a live D1 read. Reuses the shared
   // chainAccountEventsPostgresEnv helper -- same shape as
   // get_chain_stake_moves' Postgres-tier test above.
-  function chainWeightsEnv(network, subnets) {
+  function chainWeightsEnv(network: Row, subnets: Row[]) {
     return chainAccountEventsPostgresEnv(buildChainWeights, network, subnets);
   }
 
@@ -10600,12 +10655,16 @@ describe("MCP economics + metagraph data tools", () => {
   // (workers/data-api.mjs) would, over the caller's own window/limit query
   // params, so the mocked response is byte-identical to what production
   // would actually serve.
-  function chainAccountEventsPostgresEnv(buildFn, networkDistinct, subnetRows) {
+  function chainAccountEventsPostgresEnv(
+    buildFn: AnyFn,
+    networkDistinct: Row,
+    subnetRows: Row[],
+  ) {
     return {
       env: {
         METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             const url = new URL(request.url);
             const window = url.searchParams.get("window") || "7d";
             const limitParam = url.searchParams.get("limit");
@@ -10622,12 +10681,12 @@ describe("MCP economics + metagraph data tools", () => {
   function chainWeightSettersD1({
     leaderboardRows = [],
     totalsRow = null,
-  } = {}) {
+  }: Row = {}) {
     return {
       env: {
         METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             const url = new URL(request.url);
             const window = url.searchParams.get("window") || "7d";
             const limitParam = url.searchParams.get("limit");
@@ -10742,7 +10801,7 @@ describe("MCP economics + metagraph data tools", () => {
   // The network-wide aggregate row loadChainStakeMoves reads first (its
   // COUNT(DISTINCT coldkey)/MAX(observed_at) probe); a non-null newest_observed
   // unlocks the per-subnet read.
-  function stakeMovesNetwork(distinct_movers) {
+  function stakeMovesNetwork(distinct_movers: unknown) {
     return {
       distinct_movers,
       newest_observed: 1_750_000_000_000,
@@ -10750,11 +10809,15 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   // A per-subnet GROUP BY netuid row (COUNT movements + distinct movers).
-  function stakeMovesRow(netuid, movements, distinct_movers) {
+  function stakeMovesRow(
+    netuid: number,
+    movements: unknown,
+    distinct_movers: unknown,
+  ) {
     return { netuid, movements, distinct_movers };
   }
 
-  function chainStakeMovesEnv(network, subnets) {
+  function chainStakeMovesEnv(network: Row, subnets: Row[]) {
     return chainAccountEventsPostgresEnv(
       buildChainStakeMoves,
       network,
@@ -10843,7 +10906,7 @@ describe("MCP economics + metagraph data tools", () => {
   // The network-wide aggregate row loadChainStakeTransfers reads first (its
   // COUNT(DISTINCT coldkey)/MAX(observed_at) probe); a non-null newest_observed
   // unlocks the per-subnet read.
-  function stakeTransfersNetwork(distinct_senders) {
+  function stakeTransfersNetwork(distinct_senders: unknown) {
     return {
       distinct_senders,
       newest_observed: 1_750_000_000_000,
@@ -10851,11 +10914,15 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   // A per-subnet GROUP BY netuid row (COUNT transfers + distinct senders).
-  function stakeTransfersRow(netuid, transfers, distinct_senders) {
+  function stakeTransfersRow(
+    netuid: number,
+    transfers: unknown,
+    distinct_senders: unknown,
+  ) {
     return { netuid, transfers, distinct_senders };
   }
 
-  function chainStakeTransfersEnv(network, subnets) {
+  function chainStakeTransfersEnv(network: Row, subnets: Row[]) {
     return chainAccountEventsPostgresEnv(
       buildChainStakeTransfers,
       network,
@@ -10948,7 +11015,7 @@ describe("MCP economics + metagraph data tools", () => {
   // The network-wide aggregate row loadChainAxonRemovals reads first (its
   // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
   // unlocks the per-subnet read.
-  function axonRemovalsNetwork(distinct_removers) {
+  function axonRemovalsNetwork(distinct_removers: unknown) {
     return {
       distinct_removers,
       newest_observed: 1_750_000_000_000,
@@ -10956,11 +11023,15 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   // A per-subnet GROUP BY netuid row (COUNT removals + distinct removers).
-  function axonRemovalsRow(netuid, removals, distinct_removers) {
+  function axonRemovalsRow(
+    netuid: number,
+    removals: unknown,
+    distinct_removers: unknown,
+  ) {
     return { netuid, removals, distinct_removers };
   }
 
-  function chainAxonRemovalsEnv(network, subnets) {
+  function chainAxonRemovalsEnv(network: Row, subnets: Row[]) {
     return chainAccountEventsPostgresEnv(
       buildChainAxonRemovals,
       network,
@@ -11053,7 +11124,7 @@ describe("MCP economics + metagraph data tools", () => {
   // The network-wide aggregate row loadChainDeregistrations reads first (its
   // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
   // unlocks the per-subnet read.
-  function chainDeregistrationsNetwork(distinct_deregistered_hotkeys) {
+  function chainDeregistrationsNetwork(distinct_deregistered_hotkeys: unknown) {
     return {
       distinct_deregistered_hotkeys,
       newest_observed: 1_750_000_000_000,
@@ -11062,14 +11133,14 @@ describe("MCP economics + metagraph data tools", () => {
 
   // A per-subnet GROUP BY netuid row (COUNT deregistrations + distinct hotkeys).
   function chainDeregistrationsRow(
-    netuid,
-    deregistrations,
-    distinct_deregistered_hotkeys,
+    netuid: number,
+    deregistrations: unknown,
+    distinct_deregistered_hotkeys: unknown,
   ) {
     return { netuid, deregistrations, distinct_deregistered_hotkeys };
   }
 
-  function chainDeregistrationsEnv(network, subnets) {
+  function chainDeregistrationsEnv(network: Row, subnets: Row[]) {
     return chainAccountEventsPostgresEnv(
       buildChainDeregistrations,
       network,
@@ -11162,7 +11233,7 @@ describe("MCP economics + metagraph data tools", () => {
   // The network-wide aggregate row loadChainServing reads first (its
   // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
   // unlocks the per-subnet read.
-  function chainServingNetwork(distinct_servers) {
+  function chainServingNetwork(distinct_servers: unknown) {
     return {
       distinct_servers,
       newest_observed: 1_750_000_000_000,
@@ -11170,11 +11241,15 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   // A per-subnet GROUP BY netuid row (COUNT announcements + distinct servers).
-  function chainServingRow(netuid, announcements, distinct_servers) {
+  function chainServingRow(
+    netuid: number,
+    announcements: unknown,
+    distinct_servers: unknown,
+  ) {
     return { netuid, announcements, distinct_servers };
   }
 
-  function chainServingEnv(network, subnets) {
+  function chainServingEnv(network: Row, subnets: Row[]) {
     return chainAccountEventsPostgresEnv(buildChainServing, network, subnets);
   }
 
@@ -11259,7 +11334,7 @@ describe("MCP economics + metagraph data tools", () => {
   // The network-wide aggregate row loadChainPrometheus reads first (its
   // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
   // unlocks the per-subnet read.
-  function chainPrometheusNetwork(distinct_exporters) {
+  function chainPrometheusNetwork(distinct_exporters: unknown) {
     return {
       distinct_exporters,
       newest_observed: 1_750_000_000_000,
@@ -11267,11 +11342,15 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   // A per-subnet GROUP BY netuid row (COUNT announcements + distinct exporters).
-  function chainPrometheusRow(netuid, announcements, distinct_exporters) {
+  function chainPrometheusRow(
+    netuid: number,
+    announcements: unknown,
+    distinct_exporters: unknown,
+  ) {
     return { netuid, announcements, distinct_exporters };
   }
 
-  function chainPrometheusEnv(network, subnets) {
+  function chainPrometheusEnv(network: Row, subnets: Row[]) {
     return chainAccountEventsPostgresEnv(
       buildChainPrometheus,
       network,
@@ -11360,10 +11439,10 @@ describe("MCP economics + metagraph data tools", () => {
   // The full-window totals row loadChainTransferPairs reads first (its pair_totals
   // CTE rollup carrying top_pair_volume_tao).
   function transferPairTotals(
-    total_volume_tao,
-    transfer_count,
-    unique_pairs,
-    top,
+    total_volume_tao: unknown,
+    transfer_count: unknown,
+    unique_pairs: unknown,
+    top: unknown,
   ) {
     return {
       total_volume_tao,
@@ -11375,10 +11454,10 @@ describe("MCP economics + metagraph data tools", () => {
 
   // A per-corridor row (hotkey AS from_address, coldkey AS to_address).
   function transferPairRow(
-    from_address,
-    to_address,
-    volume_tao,
-    transfer_count,
+    from_address: unknown,
+    to_address: unknown,
+    volume_tao: unknown,
+    transfer_count: unknown,
   ) {
     return {
       from_address,
@@ -11397,12 +11476,12 @@ describe("MCP economics + metagraph data tools", () => {
   // This mocks the Postgres tier by running the same pure builder over the
   // caller's own window/sort query params, so the mocked response is
   // byte-identical to what production would actually serve.
-  function chainTransferPairsEnv(totals, pairs) {
+  function chainTransferPairsEnv(totals: Row, pairs: Row[]) {
     return {
       env: {
         METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             const url = new URL(request.url);
             const window = url.searchParams.get("window") || "7d";
             const sort = url.searchParams.get("sort") || "volume";
@@ -11790,7 +11869,7 @@ describe("MCP economics + metagraph data tools", () => {
     const path = `/metagraph/health/history/${HEALTH_HISTORY_BLOB.date}.json`;
     const deps = {
       ...makeDeps(),
-      readArtifact(_env, artifactPath) {
+      readArtifact(_env: unknown, artifactPath: string) {
         if (artifactPath === path) {
           return Promise.resolve({ ok: true, data: null, source: "test" });
         }
@@ -11828,10 +11907,10 @@ describe("MCP economics + metagraph data tools", () => {
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     await assert.rejects(
       () =>
-        tool.handler(
+        tool!.handler(
           { date: HEALTH_HISTORY_BLOB.date },
           {
-            env: {},
+            env: {} as unknown as Env,
             readArtifact: async () => {
               throw new Error("kaboom");
             },
@@ -11852,8 +11931,12 @@ describe("MCP economics + metagraph data tools", () => {
       .mockRejectedValue(err);
     try {
       await assert.rejects(
-        () => tool.handler({ date: HEALTH_HISTORY_BLOB.date }, { env: {} }),
-        (thrown) => {
+        () =>
+          tool!.handler(
+            { date: HEALTH_HISTORY_BLOB.date },
+            { env: {} as unknown as Env },
+          ),
+        (thrown: Row) => {
           assert.equal(thrown.toolError, true);
           assert.equal(thrown.code, "invalid_params");
           assert.match(thrown.message, /bad filter/);
@@ -11912,12 +11995,12 @@ describe("MCP economics + metagraph data tools", () => {
   // builder over the caller's own window/group_by query params, so the
   // mocked response is byte-identical to what production would actually
   // serve.
-  function chainCallsPostgresEnv({ total, rows }) {
+  function chainCallsPostgresEnv({ total, rows }: Row) {
     return {
       env: {
         METAGRAPH_EXTRINSICS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             const url = new URL(request.url);
             const window = url.searchParams.get("window") || "7d";
             const groupBy = url.searchParams.get("group_by") || "module";
@@ -11995,7 +12078,7 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.total_extrinsics, 80);
     assert.equal(out.calls[0].share, 0.625);
     assert.equal(
-      requestedUrl.searchParams.get("call_module"),
+      requestedUrl!.searchParams.get("call_module"),
       "SubtensorModule",
     );
   });
@@ -12066,7 +12149,7 @@ describe("MCP economics + metagraph data tools", () => {
       const out = res.body.result.structuredContent;
       assert.equal(out.domain_count, DOMAIN_TAGS.length);
       assert.equal(out.domains.length, DOMAIN_TAGS.length);
-      const inference = out.domains.find((d) => d.domain === "inference");
+      const inference = out.domains.find((d: Row) => d.domain === "inference");
       assert.equal(inference.subnet_count, 2);
     });
 
@@ -12130,7 +12213,7 @@ describe("MCP economics + metagraph data tools", () => {
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -12161,7 +12244,7 @@ describe("MCP economics + metagraph data tools", () => {
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -12513,9 +12596,9 @@ describe("MCP economics + metagraph data tools", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.netuid, 7);
     assert.equal(out.returned, 1);
-    const tagSets = out.items.map((item) => item.tags);
-    assert.ok(tagSets.some((tags) => tags.includes("registry")));
-    assert.ok(!tagSets.some((tags) => tags.includes("incident")));
+    const tagSets = out.items.map((item: Row) => item.tags);
+    assert.ok(tagSets.some((tags: string[]) => tags.includes("registry")));
+    assert.ok(!tagSets.some((tags: string[]) => tags.includes("incident")));
   });
 
   test("get_feed filters by tag, since/until, and caps with limit", async () => {
@@ -12680,12 +12763,15 @@ describe("MCP account tools (get_account + events + subnets)", () => {
   // rows. Order matters: GROUP BY (kinds) before COUNT (agg), as in the REST
   // account-routes test. `capture` records each bound (sql, params) so a test can
   // assert the clamped LIMIT/OFFSET actually reached the query.
-  function accountD1({ agg, kinds, registrations, events } = {}, capture = []) {
+  function accountD1(
+    { agg, kinds, registrations, events }: Row = {},
+    capture: Row[] = [],
+  ): Row {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 all() {
@@ -12716,7 +12802,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
 
   test("get_account_balance returns balance_tao from finney RPC", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
+    globalThis.fetch = (async () => ({
       ok: true,
       json: async () => ({
         jsonrpc: "2.0",
@@ -12729,7 +12815,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
           "00943577000000000000000000000000" +
           "0065cd1d000000000000000000000000",
       }),
-    });
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_account_balance", { ss58: SS58 }, {});
       const out = res.body.result.structuredContent;
@@ -12780,7 +12866,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
         },
       },
       RPC_RATE_LIMITER: {
-        async limit({ key }) {
+        async limit({ key }: { key: string }) {
           limiterKey = key;
           return { success: false };
         },
@@ -12841,7 +12927,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
             },
           },
           RPC_RATE_LIMITER: {
-            async limit({ key }) {
+            async limit({ key }: { key: string }) {
               limiterKey = key;
               return { success: false };
             },
@@ -12871,7 +12957,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
               },
             },
             RPC_RATE_LIMITER: {
-              async limit({ key }) {
+              async limit({ key }: { key: string }) {
                 limiterKey = key;
                 return { success: true };
               },
@@ -12890,13 +12976,13 @@ describe("MCP account tools (get_account + events + subnets)", () => {
 
   test("get_account_children returns subnets:[] when the account has no children", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async (_url, init) => {
-      const body = JSON.parse(init.body);
+    globalThis.fetch = (async (_url: unknown, init: RequestInit) => {
+      const body = JSON.parse(init.body as string);
       if (body.method === "state_getKeysPaged") {
         return { ok: true, json: async () => ({ result: [] }) };
       }
       return { ok: true, json: async () => ({ result: null }) };
-    };
+    }) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_account_children", { ss58: SS58 }, {});
       const out = res.body.result.structuredContent;
@@ -12920,7 +13006,9 @@ describe("MCP account tools (get_account + events + subnets)", () => {
 
   test("get_account_children returns subnets:null on RPC failure", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({ ok: false });
+    globalThis.fetch = (async () => ({
+      ok: false,
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_account_children", { ss58: SS58 }, {});
       assert.equal(res.body.result.structuredContent.subnets, null);
@@ -12944,7 +13032,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
         },
       },
       RPC_RATE_LIMITER: {
-        async limit({ key }) {
+        async limit({ key }: { key: string }) {
           limiterKey = key;
           return { success: false };
         },
@@ -12967,13 +13055,13 @@ describe("MCP account tools (get_account + events + subnets)", () => {
 
   test("get_account_parents returns subnets:[] when the account has no parents", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async (_url, init) => {
-      const body = JSON.parse(init.body);
+    globalThis.fetch = (async (_url: unknown, init: RequestInit) => {
+      const body = JSON.parse(init.body as string);
       if (body.method === "state_getKeysPaged") {
         return { ok: true, json: async () => ({ result: [] }) };
       }
       return { ok: true, json: async () => ({ result: null }) };
-    };
+    }) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_account_parents", { ss58: SS58 }, {});
       const out = res.body.result.structuredContent;
@@ -12996,7 +13084,9 @@ describe("MCP account tools (get_account + events + subnets)", () => {
 
   test("get_account_parents returns subnets:null on RPC failure", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({ ok: false });
+    globalThis.fetch = (async () => ({
+      ok: false,
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_account_parents", { ss58: SS58 }, {});
       assert.equal(res.body.result.structuredContent.subnets, null);
@@ -13018,7 +13108,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
         },
       },
       RPC_RATE_LIMITER: {
-        async limit({ key }) {
+        async limit({ key }: { key: string }) {
           limiterKey = key;
           return { success: false };
         },
@@ -13039,13 +13129,13 @@ describe("MCP account tools (get_account + events + subnets)", () => {
 
   test("get_account_children proceeds to the live RPC when the rate limiter allows the request", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async (_url, init) => {
-      const body = JSON.parse(init.body);
+    globalThis.fetch = (async (_url: unknown, init: RequestInit) => {
+      const body = JSON.parse(init.body as string);
       if (body.method === "state_getKeysPaged") {
         return { ok: true, json: async () => ({ result: [] }) };
       }
       return { ok: true, json: async () => ({ result: null }) };
-    };
+    }) as unknown as typeof globalThis.fetch;
     const env = {
       RPC_RATE_LIMITER: {
         async limit() {
@@ -13067,13 +13157,13 @@ describe("MCP account tools (get_account + events + subnets)", () => {
 
   test("get_account_parents proceeds to the live RPC when the rate limiter allows the request", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async (_url, init) => {
-      const body = JSON.parse(init.body);
+    globalThis.fetch = (async (_url: unknown, init: RequestInit) => {
+      const body = JSON.parse(init.body as string);
       if (body.method === "state_getKeysPaged") {
         return { ok: true, json: async () => ({ result: [] }) };
       }
       return { ok: true, json: async () => ({ result: null }) };
-    };
+    }) as unknown as typeof globalThis.fetch;
     const env = {
       RPC_RATE_LIMITER: {
         async limit() {
@@ -13280,9 +13370,9 @@ describe("MCP account tools (get_account + events + subnets)", () => {
     // validate-mcp only exercises the cold (empty-array) path, so assert the
     // POPULATED shapes here — the only check that the item schemas match the rows.
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name) =>
+    const validatorFor = (name: string) =>
       ajv.compile(
-        listToolDefinitions().find((t) => t.name === name).outputSchema,
+        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
       );
     const reg = {
       netuid: 7,
@@ -13322,7 +13412,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
       ["get_account_events", accountD1({ events: [event] })],
       ["get_account_subnets", accountD1({ registrations: [reg] })],
     ];
-    for (const [name, env] of cases) {
+    for (const [name, env] of cases as [string, Row][]) {
       const res = await callTool(name, { ss58: SS58 }, { env });
       const validate = validatorFor(name);
       assert.ok(
@@ -13395,12 +13485,12 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
   // and native-TAO transfers (get_account_transfers).
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-  function tailD1(fixtures = {}, capture = []) {
+  function tailD1(fixtures: Row = {}, capture: Row[] = []): Row {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 all() {
@@ -13614,9 +13704,9 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
 
   test("account tail payloads validate against their declared outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name) =>
+    const validatorFor = (name: string) =>
       ajv.compile(
-        listToolDefinitions().find((t) => t.name === name).outputSchema,
+        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
       );
     const dayRow = {
       day: "2025-06-24",
@@ -13655,7 +13745,7 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
       ["get_account_extrinsics", tailD1({ extrinsics: [extrinsicRow] })],
       ["get_account_transfers", tailD1({ transfers: [transferRow] })],
     ];
-    for (const [name, env] of cases) {
+    for (const [name, env] of cases as [string, Row][]) {
       const res = await callTool(name, { ss58: SS58 }, { env });
       const validate = validatorFor(name);
       assert.ok(
@@ -13669,12 +13759,12 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
 describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsics, get_block_events, list_extrinsics, get_extrinsic)", () => {
   // Tests for the chain block-explorer MCP surface.
 
-  function chainD1(fixtures = {}, capture = []) {
+  function chainD1(fixtures: Row = {}, capture: Row[] = []): Row {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 all() {
@@ -13834,7 +13924,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
   });
 
   test("list_blocks short-circuits impossible count floors without querying D1", async () => {
-    const capture = [];
+    const capture: Row[] = [];
     const env = chainD1({ blocks: [BLOCK_ROW] }, capture);
     const res = await callTool(
       "list_blocks",
@@ -13942,7 +14032,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
   });
 
   test("list_extrinsics short-circuits impossible time ranges without querying D1", async () => {
-    const capture = [];
+    const capture: Row[] = [];
     const env = chainD1({ extrinsics: [EXTRINSIC_ROW] }, capture);
     const res = await callTool(
       "list_extrinsics",
@@ -13989,12 +14079,12 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
   // "flag=postgres" tests for handleExtrinsics/handleExtrinsic in
   // tests/request-handlers-entities.test.mjs, which this block mirrors.
   describe("D1 -> Postgres serving cutover (#4694)", () => {
-    function dataApi(response) {
-      return { fetch: async (request) => response ?? { request } };
+    function dataApi(response: Row) {
+      return { fetch: async (request: Request) => response ?? { request } };
     }
 
     test("list_extrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
-      const capture = [];
+      const capture: Row[] = [];
       const env = chainD1({ extrinsics: [] }, capture);
       env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
       env.DATA_API = dataApi(
@@ -14017,7 +14107,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
     // schema-stable empty feed (buildExtrinsicFeed([], {...})), not a live D1
     // query -- a D1 mock, if bound, is never queried either way.
     test("list_extrinsics: flag=postgres falls back to the schema-stable empty feed on Postgres failure", async () => {
-      const env = {};
+      const env: Row = {};
       env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
       env.DATA_API = {
         fetch: async () => {
@@ -14029,7 +14119,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
     });
 
     test("list_extrinsics: flag absent returns the schema-stable empty feed even when DATA_API is bound (unflipped)", async () => {
-      const env = {};
+      const env: Row = {};
       env.DATA_API = dataApi(
         Response.json({
           schema_version: 1,
@@ -14043,11 +14133,11 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
 
     test("list_extrinsics: flag=postgres forwards filters as REST-equivalent query params", async () => {
       const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
-      let seenUrl;
+      let seenUrl: URL | undefined;
       const env = chainD1({ extrinsics: [] });
       env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
       env.DATA_API = {
-        fetch: async (request) => {
+        fetch: async (request: Request) => {
           seenUrl = new URL(request.url);
           return Response.json({
             schema_version: 1,
@@ -14071,20 +14161,20 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
         },
         { env },
       );
-      assert.equal(seenUrl.pathname, "/api/v1/extrinsics");
-      assert.equal(seenUrl.searchParams.get("block"), "4200000");
-      assert.equal(seenUrl.searchParams.get("offset"), "20");
-      assert.equal(seenUrl.searchParams.get("signer"), SS58);
-      assert.equal(seenUrl.searchParams.get("call_module"), "SubtensorModule");
-      assert.equal(seenUrl.searchParams.get("call_function"), "set_weights");
-      assert.equal(seenUrl.searchParams.get("call_hash"), callHash);
-      assert.equal(seenUrl.searchParams.get("success"), "true");
-      assert.equal(seenUrl.searchParams.get("limit"), "10");
+      assert.equal(seenUrl!.pathname, "/api/v1/extrinsics");
+      assert.equal(seenUrl!.searchParams.get("block"), "4200000");
+      assert.equal(seenUrl!.searchParams.get("offset"), "20");
+      assert.equal(seenUrl!.searchParams.get("signer"), SS58);
+      assert.equal(seenUrl!.searchParams.get("call_module"), "SubtensorModule");
+      assert.equal(seenUrl!.searchParams.get("call_function"), "set_weights");
+      assert.equal(seenUrl!.searchParams.get("call_hash"), callHash);
+      assert.equal(seenUrl!.searchParams.get("success"), "true");
+      assert.equal(seenUrl!.searchParams.get("limit"), "10");
     });
 
     test("get_extrinsic: flag=postgres uses Postgres data, D1 never queried", async () => {
       const hash = "0x" + "c".repeat(64);
-      const capture = [];
+      const capture: Row[] = [];
       const env = chainD1({ extrinsic: EXTRINSIC_ROW }, capture);
       env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
       env.DATA_API = dataApi(
@@ -14109,7 +14199,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
     // not a live D1 query.
     test("get_extrinsic: flag=postgres falls back to the schema-stable empty detail on Postgres failure", async () => {
       const hash = "0x" + "c".repeat(64);
-      const env = {};
+      const env: Row = {};
       env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
       env.DATA_API = {
         fetch: async () => new Response("err", { status: 500 }),
@@ -14121,11 +14211,11 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
     });
 
     test("get_extrinsic: flag=postgres forwards the ref in the request path", async () => {
-      let seenUrl;
+      let seenUrl: URL | undefined;
       const env = chainD1({ extrinsic: EXTRINSIC_ROW });
       env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
       env.DATA_API = {
-        fetch: async (request) => {
+        fetch: async (request: Request) => {
           seenUrl = new URL(request.url);
           return Response.json({
             schema_version: 1,
@@ -14136,15 +14226,15 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
         },
       };
       await callTool("get_extrinsic", { ref: "4200000-3" }, { env });
-      assert.equal(seenUrl.pathname, "/api/v1/extrinsics/4200000-3");
+      assert.equal(seenUrl!.pathname, "/api/v1/extrinsics/4200000-3");
     });
   });
 
   test("block-explorer payloads validate against their declared outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name) =>
+    const validatorFor = (name: string) =>
       ajv.compile(
-        listToolDefinitions().find((t) => t.name === name).outputSchema,
+        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
       );
     const hash = "0x" + "c".repeat(64);
     const cases = [
@@ -14174,7 +14264,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
         { ref: hash },
       ],
     ];
-    for (const [name, env, args] of cases) {
+    for (const [name, env, args] of cases as [string, Row, Row][]) {
       const res = await callTool(name, args, { env });
       const validate = validatorFor(name);
       assert.ok(
@@ -14220,11 +14310,11 @@ describe("MCP all-events tier tools (get_block_chain_events, get_extrinsic_chain
     ],
   };
 
-  function makeDataApi({ payload, status = 200 } = {}) {
-    const calls = [];
+  function makeDataApi({ payload, status = 200 }: Row = {}) {
+    const calls: URL[] = [];
     return {
       calls,
-      fetch(request) {
+      fetch(request: Request) {
         calls.push(new URL(request.url));
         return Promise.resolve(
           new Response(status === 200 ? JSON.stringify(payload) : "err", {
@@ -14314,10 +14404,10 @@ describe("MCP all-events tier tools (get_block_chain_events, get_extrinsic_chain
   });
 
   test("get_extrinsic_chain_events follows next_cursor on a follow-up page", async () => {
-    const calls = [];
+    const calls: Row[] = [];
     const dataApi = {
       calls,
-      fetch(request) {
+      fetch(request: Request) {
         calls.push(new URL(request.url));
         const cursor = new URL(request.url).searchParams.get("cursor");
         const payload = cursor
@@ -14368,7 +14458,7 @@ describe("MCP all-events tier tools (get_block_chain_events, get_extrinsic_chain
     for (const [name, args] of [
       ["get_block_chain_events", { block_number: 1 }],
       ["get_extrinsic_chain_events", { ref: "1-0" }],
-    ]) {
+    ] as [string, Row][]) {
       const res = await callTool(name, args, { env: {} });
       assert.equal(res.body.result.isError, true, name);
       assert.match(res.body.result.content[0].text, /unavailable/i);
@@ -14377,9 +14467,9 @@ describe("MCP all-events tier tools (get_block_chain_events, get_extrinsic_chain
 
   test("all-events tool payloads validate against their declared outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name) =>
+    const validatorFor = (name: string) =>
       ajv.compile(
-        listToolDefinitions().find((t) => t.name === name).outputSchema,
+        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
       );
     const dataApi = makeDataApi({
       payload: DATA_API_BLOCK_CHAIN_EVENTS_PAYLOAD,
@@ -14489,14 +14579,20 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
   // parity loaders' WHERE/GROUP-BY clauses get realistic rows. `capture` records
   // each bound (sql, params) so a test can assert what reached the query.
   function parityD1(
-    { dailyAgg, dailyRows, concentrationRows, events, identityHistory } = {},
-    capture = [],
+    {
+      dailyAgg,
+      dailyRows,
+      concentrationRows,
+      events,
+      identityHistory,
+    }: Row = {},
+    capture: Row[] = [],
   ) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 all() {
@@ -14624,7 +14720,7 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
     };
 
     test("flag=postgres uses Postgres data, D1 never queried", async () => {
-      const capture = [];
+      const capture: Row[] = [];
       const env = {
         ...parityD1({ identityHistory: [] }, capture),
         METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
@@ -14677,7 +14773,7 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
     });
 
     test("flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-      const capture = [];
+      const capture: Row[] = [];
       const env = {
         ...parityD1({ identityHistory: [MIAO_ROW] }, capture),
         DATA_API: {
@@ -14702,12 +14798,12 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
     });
 
     test("flag=postgres forwards netuid + limit/offset/cursor as a REST-equivalent request", async () => {
-      let seenUrl;
+      let seenUrl: URL | undefined;
       const env = {
         ...parityD1({ identityHistory: [] }),
         METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             seenUrl = new URL(request.url);
             return Response.json({
               schema_version: 1,
@@ -14723,19 +14819,19 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
         { netuid: 86, limit: 10, offset: 5, cursor: "abc" },
         { env },
       );
-      assert.equal(seenUrl.pathname, "/api/v1/subnets/86/identity-history");
-      assert.equal(seenUrl.searchParams.get("limit"), "10");
-      assert.equal(seenUrl.searchParams.get("offset"), "5");
-      assert.equal(seenUrl.searchParams.get("cursor"), "abc");
+      assert.equal(seenUrl!.pathname, "/api/v1/subnets/86/identity-history");
+      assert.equal(seenUrl!.searchParams.get("limit"), "10");
+      assert.equal(seenUrl!.searchParams.get("offset"), "5");
+      assert.equal(seenUrl!.searchParams.get("cursor"), "abc");
     });
 
     test("flag=postgres omits pagination params when not supplied", async () => {
-      let seenUrl;
+      let seenUrl: URL | undefined;
       const env = {
         ...parityD1({ identityHistory: [] }),
         METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (request) => {
+          fetch: async (request: Request) => {
             seenUrl = new URL(request.url);
             return Response.json({
               schema_version: 1,
@@ -14747,10 +14843,10 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
         },
       };
       await callTool("get_subnet_identity_history", { netuid: 86 }, { env });
-      assert.equal(seenUrl.pathname, "/api/v1/subnets/86/identity-history");
-      assert.equal(seenUrl.searchParams.has("limit"), false);
-      assert.equal(seenUrl.searchParams.has("offset"), false);
-      assert.equal(seenUrl.searchParams.has("cursor"), false);
+      assert.equal(seenUrl!.pathname, "/api/v1/subnets/86/identity-history");
+      assert.equal(seenUrl!.searchParams.has("limit"), false);
+      assert.equal(seenUrl!.searchParams.has("offset"), false);
+      assert.equal(seenUrl!.searchParams.has("cursor"), false);
     });
   });
 
@@ -15557,7 +15653,9 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     ).body.result.structuredContent;
     assert.equal(byMedium.total, 1);
     assert.equal(byMedium.candidates[0].id, "sn-12-openapi");
-    assert.ok(byMedium.candidates.every((row) => row.confidence === "medium"));
+    assert.ok(
+      byMedium.candidates.every((row: Row) => row.confidence === "medium"),
+    );
 
     const bad = await callTool(
       "list_candidates",
@@ -15836,18 +15934,18 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     const min = (
       await callTool("list_endpoints", { min_latency_ms: 400 }, { deps })
     ).body.result.structuredContent;
-    assert.deepEqual(min.endpoints.map((e) => e.netuid).sort(), [2, 3]);
+    assert.deepEqual(min.endpoints.map((e: Row) => e.netuid).sort(), [2, 3]);
 
     const max = (
       await callTool("list_endpoints", { max_latency_ms: 400 }, { deps })
     ).body.result.structuredContent;
-    assert.deepEqual(max.endpoints.map((e) => e.netuid).sort(), [1, 2]);
+    assert.deepEqual(max.endpoints.map((e: Row) => e.netuid).sort(), [1, 2]);
 
     const missing = (
       await callTool("list_endpoints", { min_latency_ms: 0 }, { deps })
     ).body.result.structuredContent;
     assert.deepEqual(
-      missing.endpoints.map((e) => e.netuid).sort(),
+      missing.endpoints.map((e: Row) => e.netuid).sort(),
       [1, 2, 3],
       "the row with no latency_ms at all must be excluded once a bound is set",
     );
@@ -15858,13 +15956,13 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     const min = (await callTool("list_endpoints", { min_score: 0.5 }, { deps }))
       .body.result.structuredContent;
     assert.deepEqual(
-      min.endpoints.map((e) => e.netuid),
+      min.endpoints.map((e: Row) => e.netuid),
       [1],
     );
 
     const max = (await callTool("list_endpoints", { max_score: 0.4 }, { deps }))
       .body.result.structuredContent;
-    assert.deepEqual(max.endpoints.map((e) => e.netuid).sort(), [2, 3]);
+    assert.deepEqual(max.endpoints.map((e: Row) => e.netuid).sort(), [2, 3]);
   });
 
   test("list_endpoints composes range bounds with existing filters (AND)", async () => {
@@ -16256,7 +16354,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     );
     const out = res.body.result.structuredContent;
     assert.deepEqual(
-      out.pools.map((p) => p.id),
+      out.pools.map((p: Row) => p.id),
       ["b", "c"],
     );
     assert.equal(out.total, 3);
@@ -16291,7 +16389,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     );
     const out = res.body.result.structuredContent;
     assert.deepEqual(
-      out.pools.map((p) => p.id),
+      out.pools.map((p: Row) => p.id),
       ["high"],
     );
   });
@@ -16602,7 +16700,9 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     );
     const res = await callTool("get_freshness", {}, { deps });
     const out = res.body.result.structuredContent;
-    const surfaceHealth = out.sources.find((s) => s.id === "surface-health");
+    const surfaceHealth = out.sources.find(
+      (s: Row) => s.id === "surface-health",
+    );
     assert.equal(surfaceHealth.status, "current");
     assert.equal(surfaceHealth.timestamp, FRESH_RUN);
     assert.equal(out.summary.health_probe_as_of, FRESH_RUN);
@@ -16627,9 +16727,9 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
 // only (no create/delete), matching the exact auth posture of the REST
 // routes they mirror so no new exposure is introduced (#5589/#5590).
 describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)", () => {
-  function makeControlKv(records = {}) {
+  function makeControlKv(records: Row = {}) {
     return {
-      async get(key, opts) {
+      async get(key: string, opts: Row) {
         const value = records[key];
         if (value === undefined) return null;
         return opts?.type === "json" ? value : JSON.stringify(value);
@@ -16720,7 +16820,7 @@ describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)",
     let capturedToken;
     const env = {
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const url = new URL(req.url);
           capturedPath = url.pathname;
           capturedToken = req.headers.get("x-alert-trigger-owner-token");
@@ -16838,7 +16938,7 @@ describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)",
     const id = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
     const env = {
       METAGRAPH_CONTROL: {
-        async get(key, opts) {
+        async get(key: string, opts: Row) {
           if (key !== `webhooks:sub:${id}`) return null;
           const record = {
             id,
@@ -16867,7 +16967,7 @@ describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)",
     const id = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
     const env = {
       METAGRAPH_CONTROL: {
-        async get(key, opts) {
+        async get(key: string, opts: Row) {
           if (key !== `webhooks:sub:${id}`) return null;
           const record = {
             id,
@@ -16904,7 +17004,7 @@ describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)",
     };
     const env = {
       METAGRAPH_CONTROL: {
-        async get(key, opts) {
+        async get(key: string, opts: Row) {
           const value =
             key === subKey
               ? {
@@ -16921,7 +17021,7 @@ describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)",
           if (value === null) return null;
           return opts?.type === "json" ? value : JSON.stringify(value);
         },
-        async list({ prefix }) {
+        async list({ prefix }: { prefix: string }) {
           assert.equal(prefix, `webhooks:delivery:${id}:`);
           return { keys: [{ name: deliveryKey }] };
         },
@@ -16985,7 +17085,7 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
     assert.equal(out.netuid, null);
     assert.equal(out.validator_count, 2);
     assert.deepEqual(
-      out.validators.map((v) => v.hotkey),
+      out.validators.map((v: Row) => v.hotkey),
       [HOTKEY, HOTKEY2],
     );
     // Cold base: the decision fields resolve to their null aggregates.
@@ -17002,15 +17102,15 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.validator_count, 2);
     assert.deepEqual(
-      out.validators.map((v) => v.hotkey),
+      out.validators.map((v: Row) => v.hotkey),
       [HOTKEY, HOTKEY2],
     );
   });
 
   test("compare_validators output carries no transaction/signing fields", async () => {
     const res = await callTool("compare_validators", { hotkeys: [HOTKEY] });
-    const keys = [];
-    const walk = (value) => {
+    const keys: string[] = [];
+    const walk = (value: unknown) => {
       if (Array.isArray(value)) {
         for (const item of value) walk(item);
       } else if (value && typeof value === "object") {
@@ -17031,9 +17131,9 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const hotkey = decodeURIComponent(
-            new URL(req.url).pathname.split("/").pop(),
+            new URL(req.url).pathname.split("/").pop() as string,
           );
           return Response.json({
             schema_version: 1,
@@ -17380,10 +17480,10 @@ describe("MCP subnet hyperparams/volume/recycled tools (#5225 parity)", () => {
 
   test("get_subnet_recycled returns recycled_tao:0 for genuinely unset storage", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
+    globalThis.fetch = (async () => ({
       ok: true,
       json: async () => ({ jsonrpc: "2.0", id: 1, result: null }),
-    });
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_subnet_recycled", { netuid: 7 }, {});
       const out = res.body.result.structuredContent;
@@ -17429,7 +17529,7 @@ describe("MCP subnet hyperparams/volume/recycled tools (#5225 parity)", () => {
         },
       },
       RPC_RATE_LIMITER: {
-        async limit({ key }) {
+        async limit({ key }: { key: string }) {
           limiterKey = key;
           return { success: false };
         },
@@ -17448,10 +17548,10 @@ describe("MCP subnet hyperparams/volume/recycled tools (#5225 parity)", () => {
 
   test("get_subnet_burn returns burn_tao:0 for genuinely unset storage", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
+    globalThis.fetch = (async () => ({
       ok: true,
       json: async () => ({ jsonrpc: "2.0", id: 1, result: null }),
-    });
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_subnet_burn", { netuid: 7 }, {});
       const out = res.body.result.structuredContent;
@@ -17497,7 +17597,7 @@ describe("MCP subnet hyperparams/volume/recycled tools (#5225 parity)", () => {
         },
       },
       RPC_RATE_LIMITER: {
-        async limit({ key }) {
+        async limit({ key }: { key: string }) {
           limiterKey = key;
           return { success: false };
         },
@@ -17516,10 +17616,10 @@ describe("MCP subnet hyperparams/volume/recycled tools (#5225 parity)", () => {
 
   test("get_subnet_burn proceeds to the live RPC when the rate limiter allows the request", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
+    globalThis.fetch = (async () => ({
       ok: true,
       json: async () => ({ result: "0x20a1070000000000" }), // 500000 rao
-    });
+    })) as unknown as typeof globalThis.fetch;
     const env = {
       RPC_RATE_LIMITER: {
         async limit() {
@@ -17541,10 +17641,10 @@ describe("MCP subnet hyperparams/volume/recycled tools (#5225 parity)", () => {
 describe("MCP get_subnet_lease", () => {
   test("returns leased:false for a confirmed no-lease result", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
+    globalThis.fetch = (async () => ({
       ok: true,
       json: async () => ({ jsonrpc: "2.0", id: 1, result: null }),
-    });
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_subnet_lease", { netuid: 7 }, {});
       const out = res.body.result.structuredContent;
@@ -17591,7 +17691,7 @@ describe("MCP get_subnet_lease", () => {
         },
       },
       RPC_RATE_LIMITER: {
-        async limit({ key }) {
+        async limit({ key }: { key: string }) {
           limiterKey = key;
           return { success: false };
         },
@@ -17612,7 +17712,7 @@ describe("MCP get_subnet_lease", () => {
     const beneficiary = new Uint8Array(32).fill(0x11);
     const coldkey = new Uint8Array(32).fill(0x22);
     const hotkey = new Uint8Array(32).fill(0x33);
-    function hex(bytes) {
+    function hex(bytes: Uint8Array) {
       return (
         "0x" + [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("")
       );
@@ -17649,8 +17749,8 @@ describe("MCP get_subnet_lease", () => {
       3,
     );
     const orig = globalThis.fetch;
-    globalThis.fetch = async (_url, init) => {
-      const key = JSON.parse(init.body).params[0];
+    globalThis.fetch = (async (_url: unknown, init: RequestInit) => {
+      const key = JSON.parse(init.body as string).params[0] as string;
       if (key.endsWith("0900")) {
         return { ok: true, json: async () => ({ result: "0x03000000" }) };
       }
@@ -17661,7 +17761,7 @@ describe("MCP get_subnet_lease", () => {
         return { ok: true, json: async () => ({ result: null }) };
       }
       throw new Error(`unexpected storage key ${key}`);
-    };
+    }) as unknown as typeof globalThis.fetch;
     const env = {
       RPC_RATE_LIMITER: {
         async limit() {
@@ -17685,12 +17785,15 @@ describe("MCP get_subnet_lease", () => {
 describe("MCP account identity/position-history tools (#5225 parity)", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-  function accountIdentityD1({ identity, identityHistory } = {}, capture = []) {
+  function accountIdentityD1(
+    { identity, identityHistory }: Row = {},
+    capture: Row[] = [],
+  ) {
     return {
       METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+        prepare(sql: string) {
           return {
-            bind(...params) {
+            bind(...params: unknown[]) {
               capture.push({ sql, params });
               return {
                 all() {
@@ -17731,7 +17834,7 @@ describe("MCP account identity/position-history tools (#5225 parity)", () => {
 
   describe("get_account_identity D1 -> Postgres serving cutover", () => {
     test("flag=postgres uses Postgres data, D1 never queried", async () => {
-      const capture = [];
+      const capture: Row[] = [];
       const env = {
         ...accountIdentityD1({ identity: [] }, capture),
         METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
@@ -17803,7 +17906,7 @@ describe("MCP account identity/position-history tools (#5225 parity)", () => {
 
   describe("get_account_identity_history D1 -> Postgres serving cutover", () => {
     test("flag=postgres uses Postgres data, D1 never queried", async () => {
-      const capture = [];
+      const capture: Row[] = [];
       const env = {
         ...accountIdentityD1({ identityHistory: [] }, capture),
         METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
@@ -17991,7 +18094,7 @@ describe("MCP get_account_snapshot", () => {
 
   test("composes all five live views under their named keys", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
+    globalThis.fetch = (async () => ({
       ok: true,
       json: async () => ({
         jsonrpc: "2.0",
@@ -18004,7 +18107,7 @@ describe("MCP get_account_snapshot", () => {
           "00943577000000000000000000000000" +
           "0065cd1d000000000000000000000000",
       }),
-    });
+    })) as unknown as typeof globalThis.fetch;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
@@ -18017,7 +18120,7 @@ describe("MCP get_account_snapshot", () => {
         },
       },
       DATA_API: {
-        fetch: async (request) => {
+        fetch: async (request: Request) => {
           const url = new URL(request.url);
           if (url.pathname === `/api/v1/accounts/${SS58}/portfolio`) {
             return Response.json({
@@ -18083,7 +18186,7 @@ describe("MCP get_account_snapshot", () => {
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (request) => {
+        fetch: async (request: Request) => {
           const url = new URL(request.url);
           if (url.pathname === `/api/v1/accounts/${SS58}/events`) {
             assert.equal(url.searchParams.get("limit"), "25");
@@ -18122,7 +18225,7 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedPath = new URL(req.url).pathname;
           return Response.json({
             schema_version: 1,
@@ -18161,7 +18264,7 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           capturedPath = new URL(req.url).pathname;
           return Response.json({
             schema_version: 1,
@@ -18177,10 +18280,10 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
 
   test("get_sudo_key returns hotkey:null for genuinely unset storage", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
+    globalThis.fetch = (async () => ({
       ok: true,
       json: async () => ({ jsonrpc: "2.0", id: 1, result: null }),
-    });
+    })) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_sudo_key", {}, {});
       const out = res.body.result.structuredContent;
@@ -18217,9 +18320,9 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     const COOLDOWN_KEY =
       "0x658faa385070e074c85bf6b568cf0555503e4fe5f139cae8b9d045e82e1c83a2";
     const orig = globalThis.fetch;
-    globalThis.fetch = async (_url, init) => {
-      const key = JSON.parse(init.body).params[0];
-      const byKey = {
+    globalThis.fetch = (async (_url: unknown, init: RequestInit) => {
+      const key = JSON.parse(init.body as string).params[0] as string;
+      const byKey: Row = {
         [TAO_WEIGHT_KEY]: "0x7a14ae47e17a142e",
         [STAKE_THRESHOLD_KEY]: "0x0010a5d4e8000000",
         [COOLDOWN_KEY]: "0x201c000000000000",
@@ -18228,7 +18331,7 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
         ok: true,
         json: async () => ({ jsonrpc: "2.0", id: 1, result: byKey[key] }),
       };
-    };
+    }) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_network_parameters", {}, {});
       const out = res.body.result.structuredContent;
@@ -18268,9 +18371,9 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     const OLDEST_STORED_ROUND_KEY =
       "0xa285cdb66e8b8524ea70b1693c7b1e05bc30947083dc3a2cb9eb93b9db7c6fbd";
     const orig = globalThis.fetch;
-    globalThis.fetch = async (_url, init) => {
-      const key = JSON.parse(init.body).params[0];
-      const byKey = {
+    globalThis.fetch = (async (_url: unknown, init: RequestInit) => {
+      const key = JSON.parse(init.body as string).params[0] as string;
+      const byKey: Row = {
         [LAST_STORED_ROUND_KEY]: "0x404b4c0000000000", // round 5,000,000
         [OLDEST_STORED_ROUND_KEY]: "0xe82f4c0000000000", // round 4,993,000
       };
@@ -18278,7 +18381,7 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
         ok: true,
         json: async () => ({ jsonrpc: "2.0", id: 1, result: byKey[key] }),
       };
-    };
+    }) as unknown as typeof globalThis.fetch;
     try {
       const res = await callTool("get_randomness_status", {}, {});
       const out = res.body.result.structuredContent;
@@ -18325,7 +18428,7 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     const env = {
       METAGRAPH_BLOCKS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           assert.equal(new URL(req.url).pathname, "/api/v1/runtime");
           return Response.json({
             schema_version: 1,
@@ -18416,7 +18519,7 @@ describe("MCP get_top_holders — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({ schema_version: 1, marker: "from-postgres" });
@@ -18757,7 +18860,7 @@ describe("MCP chain-*/subnet-* analytics tools — Postgres tier wiring", () => 
       const env = {
         METAGRAPH_NEURONS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (req) => {
+          fetch: async (req: Request) => {
             const reqUrl = new URL(req.url);
             captured = reqUrl.pathname + reqUrl.search;
             return Response.json({
@@ -18836,7 +18939,7 @@ describe("MCP get_rpc_usage — Postgres tier wiring", () => {
       const env = {
         METAGRAPH_RPC_USAGE_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (req) => {
+          fetch: async (req: Request) => {
             const reqUrl = new URL(req.url);
             captured = reqUrl.pathname + reqUrl.search;
             return Response.json({
@@ -18921,7 +19024,7 @@ describe("MCP subnet-snapshots-tier analytics tools — Postgres tier wiring", (
       const env = {
         METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (req) => {
+          fetch: async (req: Request) => {
             const reqUrl = new URL(req.url);
             captured = reqUrl.pathname + reqUrl.search;
             return Response.json({
@@ -19043,7 +19146,7 @@ describe("MCP extrinsics-tier chain analytics tools — Postgres tier wiring", (
       const env = {
         METAGRAPH_EXTRINSICS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (req) => {
+          fetch: async (req: Request) => {
             const reqUrl = new URL(req.url);
             captured = reqUrl.pathname + reqUrl.search;
             return Response.json({
@@ -19148,7 +19251,7 @@ describe("MCP blocks-tier chain-explorer tools — Postgres tier wiring", () => 
       const env = {
         METAGRAPH_BLOCKS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (req) => {
+          fetch: async (req: Request) => {
             const reqUrl = new URL(req.url);
             captured = reqUrl.pathname + reqUrl.search;
             return Response.json({
@@ -19211,7 +19314,7 @@ describe("MCP get_subnet_hyperparams* tools — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({ schema_version: 1, marker: "from-postgres" });
@@ -19266,7 +19369,7 @@ describe("MCP get_subnet_hyperparams* tools — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({ schema_version: 1, marker: "from-postgres" });
@@ -19291,7 +19394,7 @@ describe("MCP get_subnet_hyperparams* tools — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({ schema_version: 1, marker: "from-postgres" });
@@ -19314,7 +19417,7 @@ describe("MCP get_subnet_hyperparams* tools — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({ schema_version: 1, marker: "from-postgres" });
@@ -19626,7 +19729,7 @@ describe("MCP account_events-tier subnet/validator activity tools — Postgres t
       const env = {
         METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (req) => {
+          fetch: async (req: Request) => {
             const reqUrl = new URL(req.url);
             captured = reqUrl.pathname + reqUrl.search;
             return Response.json({
@@ -19695,7 +19798,7 @@ describe("MCP get_subnet_stake_flow / get_subnet_volume — Postgres tier wiring
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -19747,7 +19850,7 @@ describe("MCP get_subnet_stake_flow / get_subnet_volume — Postgres tier wiring
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -19825,7 +19928,7 @@ describe("MCP get_subnet_ohlc — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -19890,7 +19993,7 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -19954,7 +20057,7 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20015,7 +20118,7 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20076,7 +20179,7 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20137,7 +20240,7 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20186,7 +20289,7 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20247,7 +20350,7 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20308,7 +20411,7 @@ describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_reg
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20381,7 +20484,7 @@ describe("MCP get_block_events — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20401,7 +20504,7 @@ describe("MCP get_block_events — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20466,7 +20569,7 @@ describe("MCP get_account_extrinsics — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({ schema_version: 1, marker: "from-postgres" });
@@ -20491,7 +20594,7 @@ describe("MCP get_account_extrinsics — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({ schema_version: 1, marker: "from-postgres" });
@@ -20557,7 +20660,7 @@ describe("MCP list_block_extrinsics — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20584,7 +20687,7 @@ describe("MCP list_block_extrinsics — Postgres tier wiring", () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
-        fetch: async (req) => {
+        fetch: async (req: Request) => {
           const reqUrl = new URL(req.url);
           captured = reqUrl.pathname + reqUrl.search;
           return Response.json({
@@ -20710,7 +20813,7 @@ describe("MCP health-tier analytics tools — Postgres tier wiring", () => {
       const env = {
         METAGRAPH_HEALTH_SOURCE: "postgres",
         DATA_API: {
-          fetch: async (req) => {
+          fetch: async (req: Request) => {
             const reqUrl = new URL(req.url);
             captured = reqUrl.pathname + reqUrl.search;
             return Response.json({

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
@@ -64,7 +64,11 @@ async function callMcp(
     },
     body: JSON.stringify(body),
   });
-  const response = await handleMcpRequest(request, env, makeDeps(extraDeps));
+  const response = await handleMcpRequest(
+    request,
+    env as unknown as Env,
+    makeDeps(extraDeps),
+  );
   return (await response.json()) as Row;
 }
 

--- a/tests/minotaur-call-subnet-surface-verify.test.ts
+++ b/tests/minotaur-call-subnet-surface-verify.test.ts
@@ -31,7 +31,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 112;
 

--- a/tests/nepher-robotics-call-subnet-surface-verify.test.ts
+++ b/tests/nepher-robotics-call-subnet-surface-verify.test.ts
@@ -26,7 +26,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 49;
 

--- a/tests/nova-call-subnet-surface-verify.test.ts
+++ b/tests/nova-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-68-nova-score-share-molecules";
 

--- a/tests/numinous-call-subnet-surface-verify.test.ts
+++ b/tests/numinous-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-6-numinous-api-health";
 
@@ -112,7 +112,7 @@ describe("SN6 Numinous call_subnet_surface verification (#7022)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/oneoneone-call-subnet-surface-verify.test.ts
+++ b/tests/oneoneone-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-111-taomarketcap-subnet-api";
 const NETUID = 111;
@@ -126,7 +126,7 @@ describe("SN111 oneoneone call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/oro-call-subnet-surface-verify.test.ts
+++ b/tests/oro-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-15-oro-health";
 
@@ -110,7 +110,7 @@ describe("SN15 SN15 call_subnet_surface verification (#7031)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/oxmarkets-call-subnet-surface-verify.test.ts
+++ b/tests/oxmarkets-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-35-oxmarkets-health";
 
@@ -112,7 +112,7 @@ describe("SN35 OxMarkets call_subnet_surface verification (#7050)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/perturb-call-subnet-surface-verify.test.ts
+++ b/tests/perturb-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-26-perturb-subnet-api";
 
@@ -110,7 +110,7 @@ describe("SN26 Perturb call_subnet_surface verification (#7042)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/profile-completeness-mcp.test.ts
+++ b/tests/profile-completeness-mcp.test.ts
@@ -15,7 +15,7 @@ import type { Row } from "./row-type.ts";
 
 type LoadCtx = Parameters<typeof loadProfileCompletenessList>[0];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/profiles-mcp.test.ts
+++ b/tests/profiles-mcp.test.ts
@@ -13,7 +13,7 @@ import {
   profilesMcpError,
   profilesQueryUrl,
 } from "../src/profiles-mcp.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 type ProfilesCtx = Parameters<typeof loadProfilesList>[0];

--- a/tests/provider-endpoints-mcp.test.ts
+++ b/tests/provider-endpoints-mcp.test.ts
@@ -17,7 +17,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadProviderEndpointsList>[0];
 type LoadDeps = Parameters<typeof loadProviderEndpointsList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/providers-mcp.test.ts
+++ b/tests/providers-mcp.test.ts
@@ -16,7 +16,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadProvidersList>[0];
 type LoadDeps = Parameters<typeof loadProvidersList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/quasar-call-subnet-surface-verify.test.ts
+++ b/tests/quasar-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-24-taomarketcap-subnet-api";
 const NETUID = 24;
@@ -124,7 +124,7 @@ describe("SN24 Quasar call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/redteam-call-subnet-surface-verify.test.ts
+++ b/tests/redteam-call-subnet-surface-verify.test.ts
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const registry = JSON.parse(
   readFileSync(

--- a/tests/registry-coverage.test.ts
+++ b/tests/registry-coverage.test.ts
@@ -9,7 +9,7 @@ import {
   loadRegistryCoverage,
   registryCoverageToolError,
 } from "../src/registry-coverage.ts";
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
 type LoadCtx = Parameters<typeof loadRegistryCoverage>[0];

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -20,7 +20,7 @@ import {
   handleTrajectory,
   handleUptime,
 } from "../workers/request-handlers/analytics-routes.ts";
-import { MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_TOOLS } from "../src/mcp-server.ts";
 import {
   unsupportedWindowMessage,
   HISTORY_WINDOWS,
@@ -1111,7 +1111,7 @@ describe("handleCompareValidators", () => {
     assert.ok(compareValidatorsTool, "compare_validators tool must exist");
     const mcpData = await compareValidatorsTool.handler(
       { hotkeys: [HOTKEY_A, HOTKEY_B], netuid: 7 },
-      { env: createLocalArtifactEnv() },
+      { env: createLocalArtifactEnv() as unknown as Env },
     );
 
     assert.deepEqual(mcpData, restBody.data);

--- a/tests/review-enrichment-targets-mcp.test.ts
+++ b/tests/review-enrichment-targets-mcp.test.ts
@@ -16,7 +16,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadReviewEnrichmentTargetsList>[0];
 type LoadDeps = Parameters<typeof loadReviewEnrichmentTargetsList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/review-gaps-mcp.test.ts
+++ b/tests/review-gaps-mcp.test.ts
@@ -15,7 +15,7 @@ import type { Row } from "./row-type.ts";
 
 type LoadCtx = Parameters<typeof loadReviewGapsList>[0];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/rpc-pools-mcp.test.ts
+++ b/tests/rpc-pools-mcp.test.ts
@@ -15,7 +15,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadRpcPoolsList>[0];
 type LoadDeps = Parameters<typeof loadRpcPoolsList>[2];
 
-import { MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/score-call-subnet-surface-verify.test.ts
+++ b/tests/score-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-44-score-subnet-api";
 
@@ -110,7 +110,7 @@ describe("SN44 Score call_subnet_surface verification (#7058)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/search-index-mcp.test.ts
+++ b/tests/search-index-mcp.test.ts
@@ -16,7 +16,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadSearchIndexList>[0];
 type LoadDeps = Parameters<typeof loadSearchIndexList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/search-mcp.test.ts
+++ b/tests/search-mcp.test.ts
@@ -16,7 +16,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadSearchList>[0];
 type LoadDeps = Parameters<typeof loadSearchList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 

--- a/tests/sn100-call-subnet-surface-verify.test.ts
+++ b/tests/sn100-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-100-platform-network-subnet-api";
 
@@ -129,7 +129,7 @@ describe("SN100 Plaτform call_subnet_surface verification (#7112)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn106-call-subnet-surface-verify.test.ts
+++ b/tests/sn106-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 106;
 

--- a/tests/sn107-call-subnet-surface-verify.test.ts
+++ b/tests/sn107-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 107;
 

--- a/tests/sn108-call-subnet-surface-verify.test.ts
+++ b/tests/sn108-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-108-talkhead-health";
 

--- a/tests/sn109-call-subnet-surface-verify.test.ts
+++ b/tests/sn109-call-subnet-surface-verify.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-109-taomarketcap-subnet-api";
 const NETUID = 109;
@@ -116,7 +116,7 @@ describe("SN109 Academia call_subnet_surface verification (#7120)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn112-call-subnet-surface-verify.test.ts
+++ b/tests/sn112-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 112;
 

--- a/tests/sn113-call-subnet-surface-verify.test.ts
+++ b/tests/sn113-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 113;
 

--- a/tests/sn114-call-subnet-surface-verify.test.ts
+++ b/tests/sn114-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-114-soma-health";
 const NETUID = 114;
@@ -107,7 +107,7 @@ describe("SN114 SOMA call_subnet_surface verification (#7125)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn115-call-subnet-surface-verify.test.ts
+++ b/tests/sn115-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-115-taomarketcap-subnet-api";
 
@@ -141,7 +141,7 @@ describe("SN115 HashiChain call_subnet_surface verification (#7126)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn118-call-subnet-surface-verify.test.ts
+++ b/tests/sn118-call-subnet-surface-verify.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-118-taomarketcap-subnet-api";
 const NETUID = 118;
@@ -114,7 +114,7 @@ describe("SN118 Ditto call_subnet_surface verification (#7128)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn120-call-subnet-surface-verify.test.ts
+++ b/tests/sn120-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 120;
 

--- a/tests/sn121-call-subnet-surface-verify.test.ts
+++ b/tests/sn121-call-subnet-surface-verify.test.ts
@@ -25,7 +25,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 121;
 

--- a/tests/sn125-call-subnet-surface-verify.test.ts
+++ b/tests/sn125-call-subnet-surface-verify.test.ts
@@ -25,7 +25,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-125-eightball-subnet-api";
 const NETUID = 125;
@@ -128,7 +128,7 @@ describe("SN125 8 Ball call_subnet_surface verification (#7133)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn126-call-subnet-surface-verify.test.ts
+++ b/tests/sn126-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-126-poker44-health";
 
@@ -126,7 +126,7 @@ describe("SN126 Poker44 call_subnet_surface verification (#7134)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn127-call-subnet-surface-verify.test.ts
+++ b/tests/sn127-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-127-astrid-subnet-api";
 
@@ -137,7 +137,7 @@ describe("SN127 Astrid call_subnet_surface verification (#7135)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn128-call-subnet-surface-verify.test.ts
+++ b/tests/sn128-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-128-taomarketcap-subnet-api";
 
@@ -150,7 +150,7 @@ describe("SN128 ByteLeap call_subnet_surface verification (#7136)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn13-call-subnet-surface-verify.test.ts
+++ b/tests/sn13-call-subnet-surface-verify.test.ts
@@ -29,7 +29,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 13;
 

--- a/tests/sn23-call-subnet-surface-verify.test.ts
+++ b/tests/sn23-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-23-trishool-api-root";
 

--- a/tests/sn27-call-subnet-surface-verify.test.ts
+++ b/tests/sn27-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-27-taomarketcap-subnet-api";
 
@@ -141,7 +141,7 @@ describe("SN27 NI Compute call_subnet_surface verification (#7043)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn28-call-subnet-surface-verify.test.ts
+++ b/tests/sn28-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-28-gm-subnet-api";
 
@@ -129,7 +129,7 @@ describe("SN28 gm call_subnet_surface verification (#7044)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn33-call-subnet-surface-verify.test.ts
+++ b/tests/sn33-call-subnet-surface-verify.test.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-33-readyai-subnet-api";
 
@@ -114,7 +114,7 @@ describe("SN33 ReadyAI call_subnet_surface verification (#7048)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn34-call-subnet-surface-verify.test.ts
+++ b/tests/sn34-call-subnet-surface-verify.test.ts
@@ -31,7 +31,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 34;
 const SURFACE_ID = "sn-34-bitmind-subnet-api";

--- a/tests/sn40-call-subnet-surface-verify.test.ts
+++ b/tests/sn40-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-40-taomarketcap-subnet-api";
 const NETUID = 40;
@@ -135,7 +135,7 @@ describe("SN40 Ralph call_subnet_surface verification (#7054)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn42-call-subnet-surface-verify.test.ts
+++ b/tests/sn42-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 
 const SURFACE_ID = "sn-42-gopher-ai-subnet-api";

--- a/tests/sn43-call-subnet-surface-verify.test.ts
+++ b/tests/sn43-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-43-graphite-health";
 
@@ -125,7 +125,7 @@ describe("SN43 Graphite call_subnet_surface verification (#7057)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn46-call-subnet-surface-verify.test.ts
+++ b/tests/sn46-call-subnet-surface-verify.test.ts
@@ -35,7 +35,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 46;
 

--- a/tests/sn47-call-subnet-surface-verify.test.ts
+++ b/tests/sn47-call-subnet-surface-verify.test.ts
@@ -21,7 +21,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-47-evolai-subnet-api";
 const NETUID = 47;
@@ -117,7 +117,7 @@ describe("SN47 EvolAI call_subnet_surface verification (#7061)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn50-call-subnet-surface-verify.test.ts
+++ b/tests/sn50-call-subnet-surface-verify.test.ts
@@ -33,7 +33,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 50;
 

--- a/tests/sn51-call-subnet-surface-verify.test.ts
+++ b/tests/sn51-call-subnet-surface-verify.test.ts
@@ -49,7 +49,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 51;
 

--- a/tests/sn53-call-subnet-surface-verify.test.ts
+++ b/tests/sn53-call-subnet-surface-verify.test.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-53-taomarketcap-subnet-api";
 const NETUID = 53;
@@ -115,7 +115,7 @@ describe("SN53 EfficientFrontier call_subnet_surface verification (#7066)", () =
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn55-call-subnet-surface-verify.test.ts
+++ b/tests/sn55-call-subnet-surface-verify.test.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-55-niome-tasks-api";
 const NETUID = 55;
@@ -117,7 +117,7 @@ describe("SN55 NIOME call_subnet_surface verification (#7068)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn56-call-subnet-surface-verify.test.ts
+++ b/tests/sn56-call-subnet-surface-verify.test.ts
@@ -53,7 +53,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 56;
 const OPENAPI_SCHEMA = "https://api.gradients.io/openapi.json";

--- a/tests/sn57-call-subnet-surface-verify.test.ts
+++ b/tests/sn57-call-subnet-surface-verify.test.ts
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-57-sparket-subnet-api";
 const NETUID = 57;
@@ -125,7 +125,7 @@ describe("SN57 Sparket call_subnet_surface verification (#7070)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn58-call-subnet-surface-verify.test.ts
+++ b/tests/sn58-call-subnet-surface-verify.test.ts
@@ -40,7 +40,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 58;
 

--- a/tests/sn59-call-subnet-surface-verify.test.ts
+++ b/tests/sn59-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-59-babelbit-health";
 
@@ -130,7 +130,7 @@ describe("SN59 Babelbit call_subnet_surface verification (#7072)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn60-call-subnet-surface-verify.test.ts
+++ b/tests/sn60-call-subnet-surface-verify.test.ts
@@ -54,7 +54,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 60;
 

--- a/tests/sn62-call-subnet-surface-verify.test.ts
+++ b/tests/sn62-call-subnet-surface-verify.test.ts
@@ -48,7 +48,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 62;
 

--- a/tests/sn63-call-subnet-surface-verify.test.ts
+++ b/tests/sn63-call-subnet-surface-verify.test.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-63-enigma-health";
 
@@ -114,7 +114,7 @@ describe("SN63 Enigma call_subnet_surface verification (#7076)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn65-call-subnet-surface-verify.test.ts
+++ b/tests/sn65-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 65;
 

--- a/tests/sn66-call-subnet-surface-verify.test.ts
+++ b/tests/sn66-call-subnet-surface-verify.test.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-66-ninja-health";
 const NETUID = 66;

--- a/tests/sn67-call-subnet-surface-verify.test.ts
+++ b/tests/sn67-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-67-harnyx-healthz-api";
 const NETUID = 67;
@@ -120,7 +120,7 @@ describe("SN67 Harnyx call_subnet_surface verification (#7080)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn69-call-subnet-surface-verify.test.ts
+++ b/tests/sn69-call-subnet-surface-verify.test.ts
@@ -21,7 +21,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-69-taomarketcap-subnet-api";
 
@@ -129,7 +129,7 @@ describe("SN69 ain call_subnet_surface verification (#7082)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn7-allways-surfaces-call-subnet-surface-verify.test.ts
+++ b/tests/sn7-allways-surfaces-call-subnet-surface-verify.test.ts
@@ -30,7 +30,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const registry = JSON.parse(
   readFileSync(

--- a/tests/sn70-call-subnet-surface-verify.test.ts
+++ b/tests/sn70-call-subnet-surface-verify.test.ts
@@ -34,7 +34,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 70;
 

--- a/tests/sn72-call-subnet-surface-verify.test.ts
+++ b/tests/sn72-call-subnet-surface-verify.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-72-taomarketcap-subnet-api";
 const NETUID = 72;
@@ -119,7 +119,7 @@ describe("SN72 StreetVision call_subnet_surface verification (#7085)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn73-call-subnet-surface-verify.test.ts
+++ b/tests/sn73-call-subnet-surface-verify.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-73-taomarketcap-subnet-api";
 const NETUID = 73;
@@ -116,7 +116,7 @@ describe("SN73 MetaHash call_subnet_surface verification (#7086)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn74-call-subnet-surface-verify.test.ts
+++ b/tests/sn74-call-subnet-surface-verify.test.ts
@@ -38,7 +38,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 74;
 

--- a/tests/sn75-call-subnet-surface-verify.test.ts
+++ b/tests/sn75-call-subnet-surface-verify.test.ts
@@ -41,7 +41,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 75;
 

--- a/tests/sn76-call-subnet-surface-verify.test.ts
+++ b/tests/sn76-call-subnet-surface-verify.test.ts
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 76;
 

--- a/tests/sn77-call-subnet-surface-verify.test.ts
+++ b/tests/sn77-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 77;
 

--- a/tests/sn78-call-subnet-surface-verify.test.ts
+++ b/tests/sn78-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 78;
 

--- a/tests/sn79-call-subnet-surface-verify.test.ts
+++ b/tests/sn79-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-79-taos-im-subnet-api";
 
@@ -114,7 +114,7 @@ describe("SN79 MVTRX call_subnet_surface verification (#7092)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn80-call-subnet-surface-verify.test.ts
+++ b/tests/sn80-call-subnet-surface-verify.test.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-80-taomarketcap-subnet-api";
 const NETUID = 80;
@@ -114,7 +114,7 @@ describe("SN80 dogelayer call_subnet_surface verification (#7093)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn84-call-subnet-surface-verify.test.ts
+++ b/tests/sn84-call-subnet-surface-verify.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-84-taomarketcap-subnet-api";
 const NETUID = 84;
@@ -114,7 +114,7 @@ describe("SN84 ansuz call_subnet_surface verification (#7097)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn85-call-subnet-surface-verify.test.ts
+++ b/tests/sn85-call-subnet-surface-verify.test.ts
@@ -25,7 +25,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 85;
 

--- a/tests/sn89-call-subnet-surface-verify.test.ts
+++ b/tests/sn89-call-subnet-surface-verify.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 89;
 

--- a/tests/sn90-call-subnet-surface-verify.test.ts
+++ b/tests/sn90-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-90-degenbrain-subnet-api";
 
@@ -131,7 +131,7 @@ describe("SN90 DegenBrain call_subnet_surface verification (#7102)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn92-call-subnet-surface-verify.test.ts
+++ b/tests/sn92-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-92-taomarketcap-subnet-api";
 
@@ -142,7 +142,7 @@ describe("SN92 Tensorclaw call_subnet_surface verification (#7104)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/sn95-call-subnet-surface-verify.test.ts
+++ b/tests/sn95-call-subnet-surface-verify.test.ts
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 95;
 

--- a/tests/source-snapshots-mcp.test.ts
+++ b/tests/source-snapshots-mcp.test.ts
@@ -16,7 +16,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadSourceSnapshotsList>[0];
 type LoadDeps = Parameters<typeof loadSourceSnapshotsList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/subnet-candidates-mcp.test.ts
+++ b/tests/subnet-candidates-mcp.test.ts
@@ -16,7 +16,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadSubnetCandidatesList>[0];
 type LoadDeps = Parameters<typeof loadSubnetCandidatesList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const NETUID = 7;
 const ARTIFACT = subnetCandidatesArtifactPath(NETUID);

--- a/tests/subnet-endpoints-mcp.test.ts
+++ b/tests/subnet-endpoints-mcp.test.ts
@@ -16,7 +16,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadSubnetEndpointsList>[0];
 type LoadDeps = Parameters<typeof loadSubnetEndpointsList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const NETUID = 7;
 const ARTIFACT = subnetEndpointsArtifactPath(NETUID);

--- a/tests/subnet-evidence-mcp.test.ts
+++ b/tests/subnet-evidence-mcp.test.ts
@@ -20,7 +20,7 @@ import {
   MCP_INSTRUCTIONS,
   MCP_SERVER_VERSION,
   MCP_TOOLS,
-} from "../src/mcp-server.mjs";
+} from "../src/mcp-server.ts";
 
 const NETUID = 7;
 const ARTIFACT = subnetEvidenceArtifactPath(NETUID);

--- a/tests/surface-verify.test.ts
+++ b/tests/surface-verify.test.ts
@@ -8,7 +8,7 @@ import {
   SURFACE_ID_PATTERN,
 } from "../src/surface-verify.ts";
 import { handleRequest } from "../workers/api.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row, AnyFn } from "./row-type.ts";
 
@@ -508,7 +508,7 @@ describe("verify_integration MCP tool (#358)", () => {
             params: { name: "verify_integration", arguments: args },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       return ((await response.json()) as Row).result;
@@ -566,7 +566,7 @@ describe("verify_integration MCP tool (#358)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;
@@ -612,7 +612,7 @@ describe("verify_integration MCP tool (#358)", () => {
             params: { name: "verify_integration", arguments: args },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       return ((await response.json()) as Row).result;

--- a/tests/surfaces-mcp.test.ts
+++ b/tests/surfaces-mcp.test.ts
@@ -16,7 +16,7 @@ import type { Row } from "./row-type.ts";
 type LoadCtx = Parameters<typeof loadSurfacesList>[0];
 type LoadDeps = Parameters<typeof loadSurfacesList>[2];
 
-import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
 
 const SAMPLE_BLOB = {
   generated_at: "2026-07-01T00:00:00.000Z",

--- a/tests/swap-call-subnet-surface-verify.test.ts
+++ b/tests/swap-call-subnet-surface-verify.test.ts
@@ -26,7 +26,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const registry = JSON.parse(
   readFileSync(

--- a/tests/swarm-call-subnet-surface-verify.test.ts
+++ b/tests/swarm-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-124-swarm-health";
 
@@ -110,7 +110,7 @@ describe("SN124 SN124 call_subnet_surface verification (#7132)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/targon-call-subnet-surface-verify.test.ts
+++ b/tests/targon-call-subnet-surface-verify.test.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-4-targon-subnet-api";
 
@@ -104,7 +104,7 @@ describe("SN4 SN4 call_subnet_surface verification (#7020)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/templar-call-subnet-surface-verify.test.ts
+++ b/tests/templar-call-subnet-surface-verify.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-3-templar-grafana-openapi";
 const OPENAPI_URL = "https://grafana.tplr.ai/public/openapi3.json";
@@ -115,7 +115,7 @@ describe("SN3 Templar call_subnet_surface verification (#7019)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/tensorusd-call-subnet-surface-verify.test.ts
+++ b/tests/tensorusd-call-subnet-surface-verify.test.ts
@@ -31,7 +31,7 @@ import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const NETUID = 113;
 

--- a/tests/trajectoryrl-call-subnet-surface-verify.test.ts
+++ b/tests/trajectoryrl-call-subnet-surface-verify.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-11-trajectoryrl-subnet-api";
 
@@ -119,7 +119,7 @@ describe("SN11 TrajectoryRL call_subnet_surface verification (#7027)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/vanta-call-subnet-surface-verify.test.ts
+++ b/tests/vanta-call-subnet-surface-verify.test.ts
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-8-vanta-model-parameters";
 const SURFACE_URL =
@@ -119,7 +119,7 @@ describe("SN8 Vanta call_subnet_surface verification (#7024)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/verathos-call-subnet-surface-verify.test.ts
+++ b/tests/verathos-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-96-verathos-health";
 
@@ -112,7 +112,7 @@ describe("SN96 SN96 call_subnet_surface verification (#7108)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/yanez-miid-call-subnet-surface-verify.test.ts
+++ b/tests/yanez-miid-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-54-yanez-miners-stats-health";
 
@@ -115,7 +115,7 @@ describe("SN54 SN54 call_subnet_surface verification (#7067)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/tests/zeus-call-subnet-surface-verify.test.ts
+++ b/tests/zeus-call-subnet-surface-verify.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { callSubnetSurface } from "../src/call-subnet-surface.ts";
 import type { Row } from "./row-type.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 
 const SURFACE_ID = "sn-18-zeus-health";
 
@@ -110,7 +110,7 @@ describe("SN18 SN18 call_subnet_surface verification (#7034)", () => {
             },
           }),
         }),
-        {},
+        {} as unknown as Env,
         deps,
       );
       const result = ((await response.json()) as Row).result;

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -294,12 +294,12 @@ import {
 import { McpSessionHub } from "./mcp-session-hub.ts";
 import { AlerterHub } from "./alerter-hub.ts";
 import { SubnetStatusHub } from "./subnet-status-hub.ts";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest } from "../src/mcp-server.ts";
 import { handleFeedRequest, resolveFeedFormat } from "../src/feeds.ts";
 import { handleBadgeRequest } from "../src/badge.ts";
 import { handleOgImage } from "../src/og-image.ts";
 import { handleIconProxy } from "../src/icon-proxy.ts";
-import { handleGraphQLRequest } from "../src/graphql.mjs";
+import { handleGraphQLRequest } from "../src/graphql.ts";
 import {
   handleAuthorizeRequest,
   handleGithubOAuthCallback,

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -53,7 +53,7 @@ import {
   maxComplexityRule,
   maxDepthRule,
   schema as chainEventsGraphqlSchema,
-} from "../src/graphql.mjs";
+} from "../src/graphql.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "./mcp-session-hub.ts";
 
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";

--- a/workers/request-handlers/discovery.ts
+++ b/workers/request-handlers/discovery.ts
@@ -13,7 +13,7 @@ import {
   MCP_CAPABILITIES,
   MCP_REGISTRY_META,
   MCP_RESOURCE_TEMPLATES,
-} from "../../src/mcp-server.mjs";
+} from "../../src/mcp-server.ts";
 import { feedLinkHeader } from "../../src/feeds.ts";
 import {
   buildAgentToolsIndex,


### PR DESCRIPTION
## Summary
Part of the TS migration epic (#7510). Completes Phase 3 (#7516, `src/`): converts the last two hand-written `.mjs` runtime files in the repo's src/ tree — the GraphQL layer and the MCP server — plus their test suites:
- `src/graphql.mjs` (10409 lines) + `tests/graphql.test.mjs` (19999 lines)
- `src/mcp-server.mjs` (16877 lines) + `tests/mcp-server.test.mjs` (20663 lines)

and updates the `.mjs` import specifier in all ~170 referencing files (the mcp-server importer count is dominated by the per-subnet `*-call-subnet-surface-verify` test family).

Together with #7856 (data-api, Phase 2 completion), this makes the **entire backend/tooling stack TypeScript** — zero hand-written `.mjs`/`.js` runtime files remain. Phase 7 (#7521: tsconfig lockdown, permanent no-mjs CI gate, doc updates) unblocks once both merge.

## Typing approach
Mirrors the earlier conversions: local `Row`/`AnyFn` aliases, a per-file context interface (`GqlContext` for the graphql `execute()` contextValue; `McpCtx` for `buildMcpContext`'s tool-handler context), resolver/tool-handler signatures annotated mechanically, and `as unknown as` bridges only where two already-shipped modules disagree about a shape (e.g. the MCP loaders' ctx interfaces requiring a `readArtifact` field that the GraphQL call sites supply through the loaders' own deps override instead — never dereferenced through ctx).

## Behavior-verified cleanups (not blind casts)
- Dropped three silently-ignored excess options at call sites rather than widening the callee signatures — checked against each implementation: `loadEconomicsTrends`/`loadGlobalIncidents` never read `windowDays`, `buildSubnetOhlc` never reads `days`, `loadSubnetUptime` never reads `minSamples`. The `.mjs` originals passed them as inert extra properties.
- One real mistype fixed: `DataApiMcpContext.clientIp` claimed `string` but the graphql-ws path populates `string | null` — widened to match reality (only ever interpolated into a rate-limit key).

## Test plan
- [x] `npx tsc --noEmit` clean (repo-wide)
- [x] `npx eslint` + `prettier --check` clean on all 175 touched files
- [x] `npx vitest run` on the converted suites: 2126/2126 passing (graphql + mcp-server + sentry/docs-drift)
- [ ] CI green (full suite runs there per review policy)