### PR TITLE
feat(api): GraphQL schemas field mirroring GET /api/v1/schemas (#7866)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -636,6 +636,8 @@ export const SDL = `
     review_profile_completeness(netuid: Int, profile_level: String, confidence: String, identity_level: String, identity_promotion_kinds: String, native_name_quality: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ReviewProfileCompletenessList!
     "The registry-wide summary: overall subnet count, coverage/curation-level/profile-level counts, recent registry changes, and the most-complete top subnets. A fast orientation for the whole Bittensor application layer. Null when the summary has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the registry_summary MCP/REST shape. Mirrors GET /api/v1/registry/summary."
     registry_summary: JSON
+    "The registry's captured API-schema index: which subnet surfaces publish a machine-readable OpenAPI/Swagger schema, each schema's hash, and its drift status (new/unchanged/changed). Null when the schema index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the list_schemas MCP/REST shape. Mirrors GET /api/v1/schemas."
+    schemas: JSON
     "The per-provider source-health rollup: for each provider/source, the candidate-surface count and its live/redirected/dead classification, endpoint and RPC-endpoint counts, verification-result count, and an overall status. Null when the rollup has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_source_health MCP/REST shape. Mirrors GET /api/v1/source-health."
     source_health: JSON
     "The maintainer-approved cross-network subnet lineage: which testnet subnets have graduated to mainnet (mainnet <-> testnet pairs with match evidence), plus any flagged broken links. Null when the lineage has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_lineage MCP/REST shape. Mirrors GET /api/v1/lineage."
@@ -4279,6 +4281,7 @@ export const FIELD_COMPLEXITY = {
   domain_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   compare_validators: RELATIONSHIP_FIELD_COMPLEXITY,
   coverage: RELATIONSHIP_FIELD_COMPLEXITY,
+  schemas: RELATIONSHIP_FIELD_COMPLEXITY,
   coverage_depth: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_volume: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_ohlc: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6596,6 +6599,13 @@ const rootValue = {
     // Same baked artifact the REST /api/v1/coverage route + get_coverage MCP
     // tool read; GraphQL degrades to null when cold, like agent_resources.
     return loadArtifact(context, "/metagraph/coverage.json");
+  },
+
+  schemas(_args, context) {
+    // #7866: the same baked schema-index artifact the REST /api/v1/schemas
+    // route + list_schemas MCP tool read; opaque-JSON passthrough degrading to
+    // null when cold, like coverage/curation above.
+    return loadArtifact(context, "/metagraph/schemas/index.json");
   },
 
   async coverage_depth(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -19965,6 +19965,39 @@ describe("graphql — coverage + coverage_depth", () => {
     assert.equal(body.data.coverage.completeness.level, "broad");
   });
 
+  test("schemas resolves the baked schema-index artifact (#7866)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/schemas/index.json": {
+        generated_at: "2026-07-23T00:00:00.000Z",
+        schemas: [
+          {
+            surface_id: "sn-1-example-openapi",
+            hash: "abc123",
+            drift: "unchanged",
+          },
+        ],
+      },
+    });
+    const { status, body } = await gql("{ schemas }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(
+      body.data.schemas.schemas[0].surface_id,
+      "sn-1-example-openapi",
+    );
+    assert.equal(body.data.schemas.schemas[0].drift, "unchanged");
+  });
+
+  test("schemas degrades to null when the artifact has not been baked (#7866)", async () => {
+    const { status, body } = await gql("{ schemas }", emptyEnv);
+    assert.equal(status, 200);
+    assert.equal(body.data.schemas, null);
+  });
+
+  test("schemas is weighted as a fan-out field like its sibling artifact resolvers (#7866)", () => {
+    assert.equal(FIELD_COMPLEXITY.schemas, 5);
+  });
+
   test("coverage_depth resolves the baked coverage-depth artifact", async () => {
     const env = fixtureEnv({
       "/metagraph/coverage-depth.json": {


### PR DESCRIPTION
Closes #7866

## Summary

Adds a no-argument `schemas: JSON` field to `type Query` in `src/graphql.mjs`, exposing the registry's captured API-schema index (which subnet surfaces publish a machine-readable OpenAPI/Swagger schema, each schema's hash, and its new/unchanged/changed drift status). Closes the parity gap where a GraphQL client could not fetch the schema list at all.

## What changed (2 files)

- **`src/graphql.mjs`** — new `schemas: JSON` Query field (documented "Mirrors GET /api/v1/schemas."), a one-line resolver that reuses the **same baked `/metagraph/schemas/index.json` artifact** the REST route and `list_schemas` MCP tool already read (`loadArtifact`, opaque-JSON passthrough degrading to `null` when cold, exactly like the sibling `coverage`/`curation`/`registry_summary` fields), and the matching `RELATIONSHIP_FIELD_COMPLEXITY` weighting. No data source is re-implemented.
- **`tests/graphql.test.mjs`** — covers a successful baked-artifact read, the cold-store `null` degradation, and the fan-out complexity weight.

No REST/OpenAPI contract change — GraphQL is served dynamically from the SDL, so no generated artifacts are affected.

## Validation

- [x] `npm run lint` (0 errors on changed files) + `format:check` clean
- [x] `tests/graphql.test.mjs` green (922 tests); the new resolver line is exercised by the success test (100% patch).
