### PR TITLE
feat(api): validator_nominators coldkey filter mirroring REST/MCP (#7884)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -689,7 +689,7 @@ export const SDL = `
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
     validator(hotkey: String!): Validator
     "One validator's nominator leaderboard over a 7d/30d/90d window (default 30d): every coldkey that staked to or unstaked from this hotkey in the window, with its staked/unstaked/net/gross TAO, event count, and last-activity time, ranked by sort (net_staked | gross_staked | last_activity, default net_staked). An unsupported window/sort is a GraphQL error, not a silently substituted default; a hotkey with no nominators resolves to a schema-stable empty list, never null and never a GraphQL error. Mirrors GET /api/v1/validators/{hotkey}/nominators."
-    validator_nominators(hotkey: String!, window: String, sort: String): NominatorList!
+    validator_nominators(hotkey: String!, window: String, sort: String, coldkey: String): NominatorList!
     "One validator's cross-subnet staked-over-time history: one point per day (window: 7d/30d/90d/1y/all, default 30d), summed across every subnet it validates in, plus a rewards-per-1000-TAO rate. A hotkey with no matching neuron_daily rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/validators/{hotkey}/history."
     validator_history(hotkey: String!, window: String): ValidatorHistory!
     "Site-wide accounts leaderboard -- every currently-registered hotkey, aggregated cross-subnet from the current neurons snapshot. Mirrors GET /api/v1/accounts."
@@ -7366,7 +7366,7 @@ const rootValue = {
     };
   },
 
-  async validator_nominators({ hotkey, window, sort }, context) {
+  async validator_nominators({ hotkey, window, sort, coldkey }, context) {
     // Same window/sort allow-lists handleValidatorNominators validates against --
     // an unsupported value is a GraphQL BAD_USER_INPUT error, not a silently
     // substituted default. `sort` is optional: omitted resolves to
@@ -7384,9 +7384,20 @@ const rootValue = {
         { extensions: { code: "BAD_USER_INPUT" } },
       );
     }
+    // #7884: narrow to one nominator, mirroring the REST route's `coldkey` query
+    // param + MCP get_validator_nominators. A supplied non-SS58 value is a
+    // BAD_USER_INPUT error (same guard MCP applies), not a silent no-op. The
+    // filter is applied at the Postgres tier's SQL WHERE, so it only needs to
+    // ride the request params; the empty-rows builder fallback is unaffected.
+    if (coldkey != null && !SS58_ADDRESS_PATTERN.test(coldkey)) {
+      throw new GraphQLError("coldkey must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
     const params = new URLSearchParams();
     params.set("window", requestedWindow);
     if (sort != null) params.set("sort", sort);
+    if (coldkey != null) params.set("coldkey", coldkey);
     // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildValidatorNominators
     // fallback contract REST uses. The Postgres tier's response is a REST-style
     // { data, generatedAt } envelope, so only its `.data` is taken; `generatedAt` is

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -15883,6 +15883,61 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     assert.match(body.errors[0].message, /net_staked/);
     assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
   });
+
+  test("coldkey narrows to one nominator, forwarded to the Postgres tier as a query param (#7884)", async () => {
+    const COLDKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            data: {
+              schema_version: 1,
+              hotkey: HOTKEY,
+              window: "30d",
+              sort: "net_staked",
+              limit: 20,
+              offset: 0,
+              nominator_count: 1,
+              nominators: [
+                {
+                  coldkey: COLDKEY,
+                  staked_tao: 12.5,
+                  unstaked_tao: 2.5,
+                  net_staked_tao: 10,
+                  gross_staked_tao: 15,
+                  event_count: 3,
+                  last_observed_at: "2026-07-10T00:00:00.000Z",
+                },
+              ],
+            },
+            generatedAt: "2026-07-10T00:00:00.000Z",
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", coldkey: "${COLDKEY}")`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.searchParams.get("coldkey"), COLDKEY);
+    assert.equal(body.data.validator_nominators.nominator_count, 1);
+    assert.equal(body.data.validator_nominators.nominators[0].coldkey, COLDKEY);
+  });
+
+  test("a malformed coldkey is a GraphQL error, not a silently ignored filter (#7884)", async () => {
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", coldkey: "not-an-ss58")`),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.match(body.errors[0].message, /coldkey must be a valid SS58/);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
 });
 
 describe("graphql — chain_performance (#5688, Postgres-tier + zeroed-card fallback)", () => {


### PR DESCRIPTION
Closes #7884

## Summary

Adds a `coldkey: String` argument to the `validator_nominators` GraphQL field, closing a parity gap: `GET /api/v1/validators/{hotkey}/nominators` and MCP `get_validator_nominators` both accept `coldkey` to return one nominator's record, but GraphQL had no way to narrow.

## What changed (2 files)

- **`src/graphql.mjs`** — new `coldkey: String` arg on `validator_nominators`. The resolver validates a supplied value against `SS58_ADDRESS_PATTERN` (a malformed value is a `BAD_USER_INPUT` error — the same guard MCP applies — not a silently ignored filter) and forwards it as the `coldkey` query param. The Postgres tier already applies `coldkey` as a SQL `WHERE`, so no loader is re-implemented; the empty-rows builder fallback is unaffected. `limit`/`offset` stay intentionally absent per the existing code comment near this field.
- **`tests/graphql.test.mjs`** — covers the coldkey being forwarded to the tier + narrowing to one nominator, and the malformed-coldkey `BAD_USER_INPUT` rejection.

Mirrors the field's existing `hotkey`/`window`/`sort` argument style exactly. GraphQL is served dynamically from the SDL — no generated contract/OpenAPI artifacts change.

## Validation

- [x] `tests/graphql.test.mjs` green (921 tests); new resolver + guard exercised by both added tests (100% patch).
- [x] `eslint` + `prettier` clean on changed files.
