### PR TITLE
feat(api): add provider_endpoints GraphQL field with full REST filter parity

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -608,6 +608,8 @@ export const SDL = `
     surfaces(netuid: Int, limit: Int, cursor: String): SurfaceList!
     "Endpoint/resource registry, optionally scoped to one subnet."
     endpoints(netuid: Int, limit: Int, cursor: String): EndpointList!
+    "One provider's endpoint rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints."
+    provider_endpoints(slug: String!, kind: String, layer: String, publication_state: String, status: String, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, sort: String, order: String, limit: Int, cursor: String): JSON
     "Generalized endpoint pool scores -- each pool's kind, eligible/total endpoint count, and probe-derived routing score. Filter by id/kind, threshold with min_/max_eligible_count and min_/max_endpoint_count, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/endpoint-pools."
     endpoint_pools(id: String, kind: String, min_eligible_count: Float, max_eligible_count: Float, min_endpoint_count: Float, max_endpoint_count: Float, sort: String, order: String, fields: String, limit: Int, cursor: Int): PoolList!
     "The load-balanced Bittensor RPC pool scores -- the RPC-specific predecessor of endpoint_pools (#6570): same pools[] row shape and filter/sort/page surface, with a live 15-minute cron eligibility overlay applied before filtering/sorting. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/rpc/pools."
@@ -4201,6 +4203,7 @@ export const FIELD_COMPLEXITY = {
   economics: RELATIONSHIP_FIELD_COMPLEXITY,
   surfaces: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
+  provider_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoint_pools: RELATIONSHIP_FIELD_COMPLEXITY,
   rpc_pools: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -6197,6 +6200,17 @@ const rootValue = {
       netuid,
       keyFn: (e) => e.id ?? e.surface_id,
     });
+  },
+
+  // #7868: reuse list_provider_endpoints' own loader unchanged (provider-
+  // endpoints-mcp.ts) -- the same read + filter/sort/page the REST route and
+  // MCP tool run over the baked per-provider artifact. It validates its own
+  // args and throws on an invalid one (or a cold/absent provider artifact) --
+  // that throw becomes a GraphQL error, matching endpoint_pools/gaps' "an
+  // unsupported filter/sort is a GraphQL error, not a silently substituted
+  // default" convention.
+  provider_endpoints(args, context) {
+    return loadProviderEndpointsList(context, args, { readArtifact });
   },
 
   // #6985: reuse list_endpoint_pools's/list_rpc_pools's/list_endpoint_incidents's

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7719,6 +7719,55 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
   });
 });
 
+describe("graphql — provider_endpoints (#7868, per-provider filtered endpoint list)", () => {
+  const ENV = () =>
+    fixtureEnv({
+      "/metagraph/providers/acme/endpoints.json": {
+        endpoints: [
+          { id: "acme-e1", kind: "subtensor-rpc", status: "ok", netuid: 1 },
+          { id: "acme-e2", kind: "subnet-api", status: "degraded", netuid: 2 },
+        ],
+      },
+    });
+
+  test("returns the provider's full endpoint list unfiltered", async () => {
+    const { status, body } = await gql(
+      '{ provider_endpoints(slug: "acme") }',
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.provider_endpoints.endpoints.length, 2);
+    assert.equal(body.data.provider_endpoints.endpoints[0].id, "acme-e1");
+  });
+
+  test("applies a kind filter via the shared loader", async () => {
+    const { status, body } = await gql(
+      '{ provider_endpoints(slug: "acme", kind: "subtensor-rpc") }',
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.provider_endpoints.endpoints.length, 1);
+    assert.equal(
+      body.data.provider_endpoints.endpoints[0].kind,
+      "subtensor-rpc",
+    );
+  });
+
+  test("an unsupported sort is a GraphQL error, not a silent default", async () => {
+    const { body } = await gql(
+      '{ provider_endpoints(slug: "acme", sort: "bogus") }',
+      ENV(),
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+  });
+
+  test("provider_endpoints is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.provider_endpoints, 5);
+  });
+});
+
 describe("graphql — agent_resources (#6987, baked AI-resources index)", () => {
   test("resolves the baked AI-resources index", async () => {
     const env = fixtureEnv({


### PR DESCRIPTION
## Context

`GET /api/v1/providers/{slug}/endpoints` (MCP tool `list_provider_endpoints`) had no GraphQL equivalent — `type Query` has no `provider_endpoints` field, so a client couldn't list one provider's endpoints with filtering.

## Change

Adds `provider_endpoints(slug: String!, kind, layer, publication_state, status, min_latency_ms, max_latency_ms, min_score, max_score, sort, order, limit, cursor): JSON` to `type Query`, **reusing `list_provider_endpoints`' own loader** (`provider-endpoints-mcp.ts`) unchanged — the same read + filter/sort/page the REST route and MCP tool run over the baked `/metagraph/providers/{slug}/endpoints.json` artifact. No filtering logic re-implemented.

Full REST filter parity: every listed query param is a resolver argument. The loader validates its own args and throws on an invalid filter/sort or a cold/absent provider artifact — that throw surfaces as a GraphQL error, matching the `endpoint_pools` / `gaps` convention ("an unsupported filter/sort is a GraphQL error, not a silently substituted default"). Payload passes through as the existing opaque `JSON` scalar.

## Deliverables

- [x] `provider_endpoints(slug, ...)` field added to `type Query` with full REST filter parity
- [x] Resolver wraps the existing loader
- [x] Test coverage: unfiltered case + a kind-filter combination (plus an unsupported-sort error)

## Tests

4 new tests (unfiltered list, kind filter narrowing via the shared loader, unsupported-sort GraphQL error, complexity weighting). Full `tests/graphql.test.mjs` suite green (923), eslint + prettier clean, public-safety scan passes, and **zero uncovered statements or branches** on the new resolver.

Closes #7868