### PR TITLE
test(ui): add coverage for partners.ts lookups

### DIFF
--- a/apps/ui/src/lib/metagraphed/partners.test.ts
+++ b/apps/ui/src/lib/metagraphed/partners.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { PARTNER_NETUIDS, PARTNER_VALIDATORS, isPartnerHotkey, partnerForNetuid } from "./partners";
+
+// #7909: regression coverage for the partner-lookup helpers' found and
+// not-found paths. Every expectation derives from PARTNER_VALIDATORS rather
+// than hard-coding a netuid/hotkey literal, so the suite keeps testing the
+// lookup logic (not a frozen copy of the config) as rows are added and the
+// placeholder hotkeys are swapped for production ones.
+
+const [firstPartner] = PARTNER_VALIDATORS;
+// A netuid no row claims — derived so it stays "unknown" even if rows are added.
+const UNKNOWN_NETUID = Math.max(...PARTNER_VALIDATORS.map((p) => p.netuid)) + 1;
+
+describe("partnerForNetuid", () => {
+  it("returns the matching row for every configured partner netuid", () => {
+    for (const partner of PARTNER_VALIDATORS) {
+      expect(partnerForNetuid(partner.netuid)).toBe(partner);
+    }
+  });
+
+  it("returns null for a netuid no partner validates on", () => {
+    expect(partnerForNetuid(UNKNOWN_NETUID)).toBeNull();
+  });
+
+  it("returns null for null/undefined rather than throwing", () => {
+    expect(partnerForNetuid(null)).toBeNull();
+    expect(partnerForNetuid(undefined)).toBeNull();
+  });
+});
+
+describe("isPartnerHotkey", () => {
+  it("recognizes every configured partner hotkey", () => {
+    for (const partner of PARTNER_VALIDATORS) {
+      expect(isPartnerHotkey(partner.hotkey)).toBe(true);
+    }
+  });
+
+  it("rejects a hotkey no partner uses", () => {
+    expect(isPartnerHotkey(`${firstPartner.hotkey}-not-a-partner`)).toBe(false);
+  });
+
+  it("rejects empty/null/undefined input rather than throwing", () => {
+    expect(isPartnerHotkey("")).toBe(false);
+    expect(isPartnerHotkey(null)).toBe(false);
+    expect(isPartnerHotkey(undefined)).toBe(false);
+  });
+});
+
+describe("PARTNER_NETUIDS", () => {
+  it("indexes exactly the netuids in PARTNER_VALIDATORS", () => {
+    expect([...PARTNER_NETUIDS].sort((a, b) => a - b)).toEqual(
+      PARTNER_VALIDATORS.map((p) => p.netuid).sort((a, b) => a - b),
+    );
+  });
+
+  it("agrees with partnerForNetuid on membership", () => {
+    for (const netuid of PARTNER_NETUIDS) {
+      expect(partnerForNetuid(netuid)).not.toBeNull();
+    }
+    expect(PARTNER_NETUIDS.has(UNKNOWN_NETUID)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing regression coverage for `apps/ui/src/lib/metagraphed/partners.ts` (#7909) — both pure lookup helpers, on both their found and not-found paths.

- **`partnerForNetuid()`** — returns the matching row for every configured partner netuid; returns `null` for a netuid no partner validates on; returns `null` for `null`/`undefined` rather than throwing.
- **`isPartnerHotkey()`** — `true` for every configured partner hotkey; `false` for a non-partner hotkey; `false` for empty/`null`/`undefined`.
- **`PARTNER_NETUIDS`** — pinned to stay in sync with `PARTNER_VALIDATORS` and to agree with `partnerForNetuid()` on membership.

## Note on the fixtures

Every expectation **derives from `PARTNER_VALIDATORS`** instead of hard-coding a netuid or hotkey literal (the unknown netuid is computed as `max(netuids) + 1`). That keeps the suite testing the lookup *logic* rather than a frozen copy of the config — it stays green as partner rows are added and when the currently-placeholder hotkeys are swapped for production ones, and it keeps no key-like literal in the test file.

## Scope

Test-only: one new file, `apps/ui/src/lib/metagraphed/partners.test.ts`. No `.tsx`, no visual output, no source changes. 8 tests, all passing locally (`npm test --workspace=apps/ui`); lint + `scan:public-safety` clean.

Closes #7909