### PR TITLE
feat(mcp): add id/confidence/sort/order to list_candidates

### DIFF
--- a/src/candidates-mcp.ts
+++ b/src/candidates-mcp.ts
@@ -1,0 +1,301 @@
+// Candidates list loader for MCP parity on GET /api/v1/candidates.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/candidates.json artifact (mirrors gaps-mcp.ts for GET /api/v1/gaps).
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+
+export const CANDIDATES_ARTIFACT = "/metagraph/candidates.json";
+
+const CANDIDATES_SORT_FIELDS = API_QUERY_COLLECTIONS.candidates.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const CANDIDATE_STATES = QUERY_ENUMS.candidateState;
+const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+
+export interface CandidatesMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function candidatesMcpError(
+  code: string,
+  message: string,
+): CandidatesMcpError {
+  const error = new Error(message) as CandidatesMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw candidatesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw candidatesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+export function candidatesQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/candidates");
+  if (args?.netuid !== undefined) {
+    const netuid = args.netuid;
+    if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+      throw candidatesMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const state = optionalEnum(args, "state", CANDIDATE_STATES);
+  if (state) url.searchParams.set("state", state);
+  const id = optionalString(args, "id");
+  if (id) url.searchParams.set("id", id);
+  const confidence = optionalEnum(args, "confidence", CONFIDENCE_LEVELS);
+  if (confidence) url.searchParams.set("confidence", confidence);
+  const sort = optionalEnum(args, "sort", CANDIDATES_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    const limit = args.limit;
+    if (
+      typeof limit !== "number" ||
+      !Number.isInteger(limit) ||
+      limit < 1 ||
+      limit > 1000
+    ) {
+      throw candidatesMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 1000.",
+      );
+    }
+    url.searchParams.set("limit", String(limit));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw candidatesMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+export interface CandidatesListResult {
+  generated_at: unknown;
+  notes: unknown;
+  schema_version: unknown;
+  candidates: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadCandidatesList(
+  ctx: {
+    env: Env;
+    readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  },
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<CandidatesListResult> {
+  const queryUrl = candidatesQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, CANDIDATES_ARTIFACT);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw candidatesMcpError(
+        "not_found",
+        "Candidates catalog snapshot unavailable.",
+      );
+    }
+    throw candidatesMcpError(
+      code,
+      `Could not load ${CANDIDATES_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw candidatesMcpError(
+      "not_found",
+      "Candidates catalog snapshot unavailable.",
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob as Record<string, unknown>,
+    queryUrl,
+    "candidates",
+    [],
+  );
+  if (transformed.error) {
+    throw candidatesMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = (transformed.meta ?? {}) as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.candidates) ? (data.candidates as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    schema_version: data.schema_version ?? null,
+    candidates: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_CANDIDATES_INSTRUCTIONS =
+  "list_candidates unpromoted candidate surfaces (filter by netuid/kind/" +
+  "provider/state/id/confidence, sort with sort/order; mirrors GET /api/v1/candidates), ";
+
+export const LIST_CANDIDATES_MCP_TOOL = {
+  name: "list_candidates",
+  title: "List unpromoted candidate surfaces",
+  description:
+    "Fetch unpromoted candidate surfaces across all subnets: surfaces that " +
+    "have been discovered or proposed but not yet curated/promoted, each " +
+    "with its subnet (netuid), kind, provider, review state, and confidence. " +
+    "Filter by netuid/kind/provider/state/id/confidence, sort with sort + order, " +
+    "and page with limit (1-1000) / cursor — the full catalog can be large. " +
+    "Mirrors GET /api/v1/candidates.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Provider slug, e.g. 'datura'.",
+      },
+      state: {
+        type: "string",
+        enum: CANDIDATE_STATES,
+        description: "Review state, e.g. 'schema-valid' or 'verified'.",
+      },
+      id: {
+        type: "string",
+        description:
+          "Exact candidate surface id match (case-insensitive), e.g. 'sn-7-openapi'.",
+      },
+      confidence: {
+        type: "string",
+        enum: CONFIDENCE_LEVELS,
+        description: "Confidence level: low, medium, or high.",
+      },
+      sort: {
+        type: "string",
+        enum: CANDIDATES_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of candidate row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description:
+          "Max candidates to return (1-1000). Omit for the full filtered list.",
+        minimum: 1,
+        maximum: 1000,
+      },
+      cursor: {
+        type: "integer",
+        description:
+          "Pagination cursor from a prior response's next_cursor. Default 0.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_CANDIDATES_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["candidates"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    schema_version: { type: ["string", "integer", "null"] },
+    candidates: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -92,6 +92,12 @@ import {
   loadGapsList,
 } from "./gaps-mcp.ts";
 import {
+  LIST_CANDIDATES_INSTRUCTIONS,
+  LIST_CANDIDATES_MCP_TOOL,
+  LIST_CANDIDATES_OUTPUT_SCHEMA,
+  loadCandidatesList,
+} from "./candidates-mcp.ts";
+import {
   LIST_ENRICHMENT_QUEUE_INSTRUCTIONS,
   LIST_ENRICHMENT_QUEUE_MCP_TOOL,
   LIST_ENRICHMENT_QUEUE_OUTPUT_SCHEMA,
@@ -993,8 +999,8 @@ export const MCP_INSTRUCTIONS =
   "get_agent_catalog the capability catalog, " +
   LIST_PROVIDERS_INSTRUCTIONS +
   LIST_SURFACES_INSTRUCTIONS +
-  "list_candidates the " +
-  "unpromoted candidate surfaces still pending review, list_endpoints the " +
+  LIST_CANDIDATES_INSTRUCTIONS +
+  "list_endpoints the " +
   "network-wide monitored endpoint-resource catalog, " +
   LIST_EVIDENCE_INSTRUCTIONS +
   "list_rpc_endpoints the monitored " +
@@ -9499,79 +9505,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_candidates",
-    title: "List unpromoted candidate surfaces",
-    description:
-      "Fetch unpromoted candidate surfaces across all subnets: surfaces that " +
-      "have been discovered or proposed but not yet curated/promoted, each " +
-      "with its subnet (netuid), kind, provider, and review state. Use it to " +
-      "see what enrichment is still pending, versus the promoted catalog in " +
-      "list_surfaces. Optionally filter by netuid/kind/provider/state and page " +
-      "with limit/cursor — the full catalog can be large. Mirrors " +
-      "GET /api/v1/candidates.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        kind: {
-          type: "string",
-          enum: QUERY_ENUMS.surfaceKind,
-          description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
-        },
-        provider: {
-          type: "string",
-          description: "Provider slug, e.g. 'datura'.",
-        },
-        state: {
-          type: "string",
-          enum: QUERY_ENUMS.candidateState,
-          description: "Review state, e.g. 'schema-valid' or 'verified'.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max candidates to return. Omit for the full list.",
-          minimum: 1,
-        },
-        cursor: {
-          type: "integer",
-          description:
-            "Pagination cursor from a prior response's next_cursor. Default 0.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
+    ...LIST_CANDIDATES_MCP_TOOL,
     async handler(args, ctx) {
-      const netuid = optionalNonNegativeInt(args, "netuid");
-      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
-      const provider = optionalString(args, "provider");
-      const state = optionalEnum(args, "state", QUERY_ENUMS.candidateState);
-      const limit = optionalPositiveInt(args, "limit");
-      const cursor = optionalNonNegativeInt(args, "cursor") ?? 0;
-      const data = await loadArtifactData(ctx, "/metagraph/candidates.json");
-      const all = Array.isArray(data.candidates) ? data.candidates : [];
-      const filtered = all.filter(
-        (c) =>
-          (netuid === null || c.netuid === netuid) &&
-          (kind === null || c.kind === kind) &&
-          (provider === null || c.provider === provider) &&
-          (state === null || c.state === state),
-      );
-      const window = cursorWindow(filtered, {
-        collection: "candidates",
-        dataKey: "candidates",
-        limit,
-        cursor,
-      });
-      return {
-        ...data,
-        candidates: window.page,
-        total: window.total,
-        returned: window.returned,
-        cursor: window.cursor,
-        limit: window.limit,
-        next_cursor: window.next_cursor,
-      };
+      return loadCandidatesList(ctx, args);
     },
   },
   {
@@ -15303,21 +15239,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   },
   list_providers: LIST_PROVIDERS_OUTPUT_SCHEMA,
   list_surfaces: LIST_SURFACES_OUTPUT_SCHEMA,
-  list_candidates: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      candidates: { type: "array", items: { type: "object" } },
-      total: { type: "integer" },
-      returned: { type: "integer" },
-      cursor: { type: "integer" },
-      limit: { type: "integer" },
-      next_cursor: { type: ["integer", "null"] },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_candidates: LIST_CANDIDATES_OUTPUT_SCHEMA,
   list_endpoints: {
     type: "object",
     additionalProperties: true,

--- a/tests/candidates-mcp.test.ts
+++ b/tests/candidates-mcp.test.ts
@@ -1,0 +1,408 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  CANDIDATES_ARTIFACT,
+  LIST_CANDIDATES_INSTRUCTIONS,
+  LIST_CANDIDATES_MCP_TOOL,
+  LIST_CANDIDATES_OUTPUT_SCHEMA,
+  candidatesMcpError,
+  candidatesQueryUrl,
+  loadCandidatesList,
+} from "../src/candidates-mcp.ts";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.mjs";
+import type { Row } from "./row-type.ts";
+
+type CandidatesCtx = Parameters<typeof loadCandidatesList>[0];
+type CandidatesDeps = Parameters<typeof loadCandidatesList>[2];
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  candidates: [
+    {
+      id: "sn-7-openapi",
+      netuid: 7,
+      kind: "openapi",
+      provider: "datura",
+      state: "verified",
+      confidence: "high",
+      name: "OpenAPI",
+    },
+    {
+      id: "sn-7-website",
+      netuid: 7,
+      kind: "website",
+      provider: "datura",
+      state: "schema-valid",
+      confidence: "low",
+      name: "Website",
+    },
+    {
+      id: "sn-12-openapi",
+      netuid: 12,
+      kind: "openapi",
+      provider: "chutes",
+      state: "stale",
+      confidence: "medium",
+      name: "OpenAPI",
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === CANDIDATES_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("candidates-mcp (#7889)", () => {
+  test("candidatesMcpError is shaped for MCP toolError handling", () => {
+    const err = candidatesMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("candidatesQueryUrl validates filters and cursor", () => {
+    const url = candidatesQueryUrl({
+      netuid: 7,
+      kind: "openapi",
+      provider: "datura",
+      state: "verified",
+      id: "sn-7-openapi",
+      confidence: "high",
+      sort: "confidence",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("kind"), "openapi");
+    assert.equal(url.searchParams.get("provider"), "datura");
+    assert.equal(url.searchParams.get("state"), "verified");
+    assert.equal(url.searchParams.get("id"), "sn-7-openapi");
+    assert.equal(url.searchParams.get("confidence"), "high");
+    assert.equal(url.searchParams.get("sort"), "confidence");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("candidatesQueryUrl rejects invalid confidence", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ confidence: "extreme" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects invalid state", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ state: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ fields: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ fields: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl trims and forwards a fields projection", () => {
+    const url = candidatesQueryUrl({ fields: " id,confidence " });
+    assert.equal(url.searchParams.get("fields"), "id,confidence");
+  });
+
+  test("candidatesQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ limit: "lots" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ limit: 0 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ limit: 1001 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects non-string provider", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ provider: 12 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("candidatesQueryUrl rejects invalid sort", () => {
+    assert.throws(
+      () => candidatesQueryUrl({ sort: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadCandidatesList filters by id", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact } as unknown as CandidatesCtx,
+      { id: "SN-7-WEBSITE" },
+    );
+    assert.equal(out.total, 1);
+    assert.equal(out.candidates[0].id, "sn-7-website");
+  });
+
+  test("loadCandidatesList filters by confidence", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact } as unknown as CandidatesCtx,
+      { confidence: "medium" },
+    );
+    assert.equal(out.total, 1);
+    assert.equal(out.candidates[0].id, "sn-12-openapi");
+  });
+
+  test("loadCandidatesList returns filtered rows with pagination meta", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact } as unknown as CandidatesCtx,
+      { netuid: 7 },
+    );
+    assert.equal(out.returned, 2);
+    assert.equal(out.candidates[0].netuid, 7);
+  });
+
+  test("loadCandidatesList sorts and pages the collection", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact } as unknown as CandidatesCtx,
+      { sort: "confidence", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.candidates[0].confidence, "medium");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadCandidatesList uses an injected readArtifact dep", async () => {
+    const out = await loadCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as CandidatesCtx,
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { candidates: [{ id: "injected", netuid: 0 }] },
+        }),
+      } as unknown as CandidatesDeps,
+    );
+    assert.equal(out.candidates[0].id, "injected");
+  });
+
+  test("loadCandidatesList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as CandidatesCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadCandidatesList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as CandidatesCtx,
+          {},
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" && /candidates\.json/.test(err.message),
+    );
+  });
+
+  test("loadCandidatesList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          { env: {}, readArtifact } as unknown as CandidatesCtx,
+          {
+            fields: "not_a_column",
+          },
+        ),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadCandidatesList projects row fields when requested", async () => {
+    const out = await loadCandidatesList(
+      { env: {}, readArtifact } as unknown as CandidatesCtx,
+      { fields: "id,confidence", limit: 1 },
+    );
+    assert.deepEqual(out.candidates[0], {
+      id: "sn-7-openapi",
+      confidence: "high",
+    });
+  });
+
+  test("loadCandidatesList omits nullable artifact metadata when absent", async () => {
+    const out = await loadCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { candidates: [{ id: "x", netuid: 0 }] },
+        }),
+      } as unknown as CandidatesCtx,
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadCandidatesList treats a non-array candidates key as empty", async () => {
+    const out = await loadCandidatesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { candidates: null },
+        }),
+      } as unknown as CandidatesCtx,
+      {},
+    );
+    assert.deepEqual(out.candidates, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadCandidatesList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: {
+        candidates: [
+          { id: "a", netuid: 9 },
+          { id: "b", netuid: 10 },
+        ],
+      },
+      meta: undefined,
+    });
+    try {
+      const out = await loadCandidatesList(
+        { env: {}, readArtifact } as unknown as CandidatesCtx,
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadCandidatesList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as CandidatesCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadCandidatesList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadCandidatesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as CandidatesCtx,
+          {},
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_CANDIDATES_MCP_TOOL.name, "list_candidates");
+    assert.match(LIST_CANDIDATES_INSTRUCTIONS, /list_candidates/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_CANDIDATES_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_candidates with new filters", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_candidates/);
+    assert.match(LIST_CANDIDATES_INSTRUCTIONS, /id\/confidence/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_candidates");
+    assert.ok(tool);
+    assert.equal(tool.name, LIST_CANDIDATES_MCP_TOOL.name);
+    assert.equal(tool.title, "List unpromoted candidate surfaces");
+    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties.id);
+    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties.confidence);
+    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties.sort);
+    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties.order);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -15430,6 +15430,99 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(byState.candidates[0].netuid, 12);
   });
 
+  test("list_candidates filters by id (case-insensitive exact match) (#7889)", async () => {
+    const deps = makeDeps({
+      "/metagraph/candidates.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        candidates: [
+          {
+            id: "sn-7-openapi",
+            netuid: 7,
+            kind: "openapi",
+            provider: "datura",
+            state: "verified",
+            confidence: "high",
+          },
+          {
+            id: "sn-7-website",
+            netuid: 7,
+            kind: "website",
+            provider: "datura",
+            state: "schema-valid",
+            confidence: "low",
+          },
+          {
+            id: "sn-12-openapi",
+            netuid: 12,
+            kind: "openapi",
+            provider: "datura",
+            state: "stale",
+            confidence: "medium",
+          },
+        ],
+      },
+    });
+    const lower = (
+      await callTool("list_candidates", { id: "sn-7-openapi" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(lower.total, 1);
+    assert.equal(lower.candidates[0].id, "sn-7-openapi");
+
+    const upper = (
+      await callTool("list_candidates", { id: "SN-7-OPENAPI" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(upper.total, 1);
+    assert.equal(upper.candidates[0].id, "sn-7-openapi");
+  });
+
+  test("list_candidates filters by confidence (#7889)", async () => {
+    const deps = makeDeps({
+      "/metagraph/candidates.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        candidates: [
+          {
+            id: "sn-7-openapi",
+            netuid: 7,
+            kind: "openapi",
+            confidence: "high",
+            provider: "datura",
+            state: "verified",
+          },
+          {
+            id: "sn-7-website",
+            netuid: 7,
+            kind: "website",
+            confidence: "low",
+            provider: "datura",
+            state: "schema-valid",
+          },
+          {
+            id: "sn-12-openapi",
+            netuid: 12,
+            kind: "openapi",
+            confidence: "medium",
+            provider: "datura",
+            state: "stale",
+          },
+        ],
+      },
+    });
+    const byMedium = (
+      await callTool("list_candidates", { confidence: "medium" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byMedium.total, 1);
+    assert.equal(byMedium.candidates[0].id, "sn-12-openapi");
+    assert.ok(byMedium.candidates.every((row) => row.confidence === "medium"));
+
+    const bad = await callTool(
+      "list_candidates",
+      { confidence: "extreme" },
+      { deps },
+    );
+    assert.equal(bad.body.result.isError, true);
+    assert.match(bad.body.result.content[0].text, /invalid_params/);
+  });
+
   test("list_candidates combines filters (AND) and reports total vs returned", async () => {
     const deps = candidatesDeps();
     const res = await callTool(


### PR DESCRIPTION
## Summary
- Extract `list_candidates` into `src/candidates-mcp.ts` (mirrors `gaps-mcp`) so MCP uses the same `applyQueryFilters` path as `GET /api/v1/candidates`.
- Add `id`, `confidence`, `sort`, and `order` to the tool `inputSchema` and pass them through the REST-backed loader.
- Cover filtering by `id` and `confidence` in unit + MCP integration tests.

Closes #7889

## Test plan
- [x] `npx vitest run tests/candidates-mcp.test.ts`
- [x] `npx vitest run tests/mcp-server.test.mjs -t list_candidates`
- [x] Private-boundary validation passed
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)