### PR TITLE
feat(api): expose providers GraphQL list filters for REST parity (#7888)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -45,6 +45,10 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.ts";
 // same loadProviderEndpointsList that MCP list_provider_endpoints already calls
 // (#3289) -- not a reimplementation.
 import { loadProviderEndpointsList } from "./provider-endpoints-mcp.ts";
+// #7888: GraphQL parity for GET /api/v1/providers list filters (id/kind/
+// authority/sort/order/fields + limit/cursor), reusing loadProvidersList that
+// MCP list_providers already calls -- not a reimplementation.
+import { loadProvidersList } from "./providers-mcp.ts";
 // #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
 // and page logic REST and MCP already use) -- not a reimplementation.
@@ -596,8 +600,8 @@ export const SDL = `
     subnet_overview(netuid: Int!): JSON
     "One subnet's contributor-review profile: candidate surfaces, contract version, endpoints, and completeness/curation metadata. Null when no profile has been baked for that netuid (rather than a GraphQL error); a negative netuid is a BAD_USER_INPUT error. Opaque JSON passed through verbatim, matching the get_subnet_profile MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/profile."
     subnet_profile(netuid: Int!): JSON
-    "Paginated provider/source registry."
-    providers(limit: Int, cursor: String): ProviderList!
+    "Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/providers."
+    providers(id: String, kind: String, authority: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProviderList!
     "One provider with its subnets."
     provider(id: String!): Provider
     "One adapter-backed public metrics snapshot by slug (e.g. 'gittensor', 'allways', 'sn-64'): the captured adapter snapshot, extension metadata, and netuid linkage. An invalid slug is a BAD_USER_INPUT error; a missing slug resolves to null (schema-stable, never a GraphQL error). Mirrors GET /api/v1/adapters/{slug}."
@@ -870,7 +874,8 @@ export const SDL = `
   type ProviderList {
     items: [Provider!]!
     total: Int!
-    next_cursor: String
+    "Opaque integer offset cursor from REST/MCP list-query pagination; null when there is no next page."
+    next_cursor: Int
   }
 
   type Provider {
@@ -6128,13 +6133,22 @@ const rootValue = {
     };
   },
 
-  providers({ limit, cursor }, context) {
-    return listPage(context, ARTIFACT.providers, "providers", {
-      limit,
-      cursor,
-      keyFn: (p) => p.id,
-      map: providerNode,
-    });
+  // #7888: reuse list_providers' own loader unchanged (same artifact read,
+  // filter, sort, and page logic REST and MCP already use) rather than the
+  // previous unfiltered listPage path. The loader validates its own args and
+  // throws on an invalid one -- that throw becomes a GraphQL error, matching
+  // endpoint_pools' "unsupported filter/sort is a GraphQL error, not a
+  // silently substituted default" convention. A cold/absent artifact is
+  // likewise a GraphQL error (matching REST/MCP not_found).
+  // loadProvidersList always returns providers[] / total / next_cursor
+  // (schema-stable), so the GraphQL envelope does not re-default those fields.
+  async providers(args, context) {
+    const data = await loadProvidersList(context, args, { readArtifact });
+    return {
+      items: data.providers.map(providerNode),
+      total: data.total,
+      next_cursor: data.next_cursor,
+    };
   },
 
   async provider({ id }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -441,12 +441,14 @@ describe("handleGraphQLRequest — resolvers (cold store)", () => {
     assert.equal(body.data.subnet, null);
   });
 
-  test("providers returns empty list when artifact not found", async () => {
+  test("providers surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP (#7888)", async () => {
     const { status, body } = await gql(
       "{ providers { items { id name } total } }",
     );
     assert.equal(status, 200);
-    assert.deepEqual(body.data.providers, { items: [], total: 0 });
+    assert.ok(body.errors?.length > 0);
+    assert.match(body.errors[0].message, /unavailable|not found|Providers/i);
+    assert.equal(body.data?.providers ?? null, null);
   });
 
   test("provider returns null when artifact not found", async () => {
@@ -2697,12 +2699,12 @@ describe("graphql — resolver branch coverage", () => {
     assert.deepEqual(body.data.provider.subnets, []);
   });
 
-  test("providers paginate with an id cursor", async () => {
+  test("providers paginate with an integer cursor (REST/MCP list-query parity)", async () => {
     const env = fixtureEnv({
       "/metagraph/providers.json": {
         providers: [
-          { id: "a", name: "A" },
-          { id: "b", name: "B" },
+          { id: "a", name: "A", kind: "data-provider", authority: "official" },
+          { id: "b", name: "B", kind: "data-provider", authority: "community" },
         ],
       },
     });
@@ -2711,8 +2713,117 @@ describe("graphql — resolver branch coverage", () => {
       env,
     );
     assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
     assert.equal(body.data.providers.total, 2);
-    assert.equal(body.data.providers.next_cursor, "a");
+    assert.equal(body.data.providers.items.length, 1);
+    assert.equal(body.data.providers.next_cursor, 1);
+  });
+
+  test("providers filters by id and by kind (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        schema_version: 1,
+        providers: [
+          {
+            id: "datura",
+            name: "Datura",
+            kind: "data-provider",
+            authority: "official",
+          },
+          {
+            id: "chutes",
+            name: "Chutes",
+            kind: "infrastructure-provider",
+            authority: "official",
+          },
+          {
+            id: "community-x",
+            name: "Community X",
+            kind: "data-provider",
+            authority: "community",
+          },
+        ],
+      },
+    });
+
+    const byId = await gql(
+      '{ providers(id: "chutes") { items { id kind } total } }',
+      env,
+    );
+    assert.equal(byId.status, 200);
+    assert.equal(byId.body.errors, undefined);
+    assert.equal(byId.body.data.providers.total, 1);
+    assert.equal(byId.body.data.providers.items[0].id, "chutes");
+    assert.equal(
+      byId.body.data.providers.items[0].kind,
+      "infrastructure-provider",
+    );
+
+    const byKind = await gql(
+      '{ providers(kind: "data-provider") { items { id } total } }',
+      env,
+    );
+    assert.equal(byKind.status, 200);
+    assert.equal(byKind.body.errors, undefined);
+    assert.equal(byKind.body.data.providers.total, 2);
+    assert.deepEqual(byKind.body.data.providers.items.map((p) => p.id).sort(), [
+      "community-x",
+      "datura",
+    ]);
+  });
+
+  test("providers surfaces an invalid kind as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          { id: "datura", kind: "data-provider", authority: "official" },
+        ],
+      },
+    });
+    const { body } = await gql('{ providers(kind: "bogus") { total } }', env);
+    assert.ok(body.errors?.length > 0);
+    assert.match(body.errors[0].message, /kind/i);
+  });
+
+  test("providers forwards authority/sort/order/fields through the shared loader (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          {
+            id: "datura",
+            name: "Datura",
+            kind: "data-provider",
+            authority: "official",
+            surface_count: 3,
+          },
+          {
+            id: "community-x",
+            name: "Community X",
+            kind: "data-provider",
+            authority: "community",
+            surface_count: 1,
+          },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      `{ providers(
+          authority: "official",
+          sort: "id",
+          order: "asc",
+          fields: "id,kind,authority",
+          limit: 10,
+          cursor: 0
+        ) { items { id kind authority } total next_cursor } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.providers.total, 1);
+    assert.equal(body.data.providers.items[0].id, "datura");
+    assert.equal(body.data.providers.items[0].authority, "official");
+    assert.equal(body.data.providers.next_cursor, null);
   });
 
   test("surfaces paginate, falling back to key for the cursor when id is absent", async () => {


### PR DESCRIPTION
## Summary

- Extend `Query.providers` with the full REST list-query filter set (`id`, `kind`, `authority`, `sort`, `order`, `fields`, `limit`, `cursor`) so GraphQL matches `GET /api/v1/providers` / MCP `list_providers`.
- Resolver reuses `loadProvidersList` from `src/providers-mcp.ts` (same path as `endpoint_pools` → its MCP loader), including invalid-filter → GraphQL error and cold-artifact → error conventions.
- `ProviderList.next_cursor` is now `Int` (offset cursor), matching REST/MCP pagination.
- Map the loader envelope without defensive `||` / `??` re-defaults — `loadProvidersList` already returns schema-stable `providers`/`total`/`next_cursor`, so those branches were unreachable and dropped Codecov patch coverage to 60% on #7914.

Closes #7888.
Supersedes #7914.

## What Changed

- `src/graphql.mjs` — SDL args + resolver swap from unfiltered `listPage` to `loadProvidersList`.
- `tests/graphql.test.mjs` — `id`/`kind` filters, authority/sort/order/fields forwarding, integer cursor pagination, invalid-kind error, cold-artifact error.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7888`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (GraphQL SDL only)

## Validation

- [x] `npx vitest run tests/graphql.test.mjs -t providers` — 7 passing
- [x] `npx prettier --write` on touched files
- [x] `git diff --check`