### PR TITLE
test(ui): add coverage for humanizeOperationId

### DIFF
--- a/apps/ui/src/lib/openapi-source.test.ts
+++ b/apps/ui/src/lib/openapi-source.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { humanizeOperationId } from "./openapi-source";
+
+// #7908: regression coverage for humanizeOperationId()'s title-casing and its
+// two override tables. Every expectation below is the function's actual
+// observed output, so this pins current behaviour (including the quirks noted
+// at the bottom) rather than an idealized contract.
+
+describe("humanizeOperationId", () => {
+  it("title-cases a plain camelCase operationId with no overrides", () => {
+    expect(humanizeOperationId("listSubnets")).toBe("List Subnets");
+    expect(humanizeOperationId("listEndpoints")).toBe("List Endpoints");
+  });
+
+  it("applies the ID_OVERRIDES whole-id special case", () => {
+    // "openapi" has no camelCase boundary to split on, so it can only be
+    // caught as a whole-id override.
+    expect(humanizeOperationId("openapi")).toBe("OpenAPI");
+  });
+
+  it("applies WORD_OVERRIDES per split word", () => {
+    expect(humanizeOperationId("getApiStatus")).toBe("Get API Status");
+    expect(humanizeOperationId("listRpcEndpoints")).toBe("List RPC Endpoints");
+    expect(humanizeOperationId("getById")).toBe("Get By ID");
+    expect(humanizeOperationId("getTaoPrice")).toBe("Get TAO Price");
+    expect(humanizeOperationId("getSubnetOhlc")).toBe("Get Subnet OHLC");
+    expect(humanizeOperationId("getJsonBlob")).toBe("Get JSON Blob");
+    expect(humanizeOperationId("getHhi")).toBe("Get HHI");
+    expect(humanizeOperationId("getAiThing")).toBe("Get AI Thing");
+    expect(humanizeOperationId("getUrl")).toBe("Get URL");
+    expect(humanizeOperationId("getDx")).toBe("Get DX");
+  });
+
+  it("splits a letter→digit boundary into its own word", () => {
+    // The letter→digit split runs BEFORE the per-word override lookup, so a
+    // digit-bearing override key ("ss58", "d1") is already broken in two by
+    // the time the table is consulted and therefore never matches. Pinned
+    // here so a future change to either regex or table is a visible diff.
+    expect(humanizeOperationId("getSs58")).toBe("Get Ss 58");
+    expect(humanizeOperationId("getD1Stats")).toBe("Get D 1 Stats");
+  });
+
+  it("leaves an underscore-separated id as a single word", () => {
+    // Only whitespace (introduced by the two regexes) is split on — an
+    // underscore is not a word boundary here.
+    expect(humanizeOperationId("get_subnet")).toBe("Get_subnet");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(humanizeOperationId("")).toBe("");
+  });
+});

--- a/apps/ui/src/lib/openapi-source.ts
+++ b/apps/ui/src/lib/openapi-source.ts
@@ -42,7 +42,7 @@ const ID_OVERRIDES: Record<string, string> = {
   openapi: "OpenAPI",
 };
 
-function humanizeOperationId(id: string): string {
+export function humanizeOperationId(id: string): string {
   if (ID_OVERRIDES[id]) return ID_OVERRIDES[id];
   return id
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")


### PR DESCRIPTION
## Summary

Adds regression coverage for `humanizeOperationId()` in `apps/ui/src/lib/openapi-source.ts` (#7908) — the regex/split/override logic that turns an OpenAPI `operationId` into Title Case nav text.

Covered:
- **Default path** — plain camelCase with no overrides (`listSubnets` → `List Subnets`).
- **`ID_OVERRIDES`** whole-id special case — `openapi` → `OpenAPI` (no camelCase boundary exists, so it's only reachable as a whole-id override).
- **`WORD_OVERRIDES`** — ten entries exercised: API, RPC, ID, TAO, OHLC, JSON, HHI, AI, URL, DX.

## Two behaviours pinned deliberately

Every expectation is the function's **actual observed output**, so the suite pins current behaviour rather than an idealized contract. Two are worth calling out:

1. **The letter→digit split runs before the override lookup.** `getSs58` → `Get Ss 58` and `getD1Stats` → `Get D 1 Stats` — the digit-bearing `WORD_OVERRIDES` keys (`ss58`, `d1`) are already broken in two by the time the table is consulted, so they never match. Pinned so any future change to either regex or table shows up as a visible diff.
2. **An underscore is not a word boundary** — `get_subnet` → `Get_subnet` (only whitespace introduced by the two regexes is split on).

I've only characterized these, not changed them — behaviour is untouched.

## Scope

`humanizeOperationId` was module-private (only `openapi` was exported), so there was no way to reach it from a test; the one-word `export` is the sole source change and is behaviour-neutral. Plus one new test file. No `.tsx`, no visual output. 6 tests, all passing locally.

Closes #7908