### PR TITLE
feat(api): subnet_turnover changes toggle mirroring REST ?changes=true (#7883)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -797,7 +797,7 @@ export const SDL = `
     "Live current registration/burn cost for one subnet -- the dynamic price between the static min_burn_tao/max_burn_tao bounds, read directly from chain via RPC (not the Postgres tier). burn_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/burn."
     subnet_burn(netuid: Int!): SubnetBurn
     "One subnet's validator/neuron-set turnover (entered/exited/retention/0-100 stability) between the boundary snapshots of a 7d/30d/90d/1y/all window (default 30d), from neuron_daily. comparable is false and the churn metrics zeroed on a single-snapshot or cold store, never null. Mirrors GET /api/v1/subnets/{netuid}/turnover."
-    subnet_turnover(netuid: Int!, window: String): SubnetTurnover!
+    subnet_turnover(netuid: Int!, window: String, changes: Boolean): SubnetTurnover!
     "Every automatic ownership transfer one subnet has undergone (#6637, part of the conviction/ownership-contest tracker epic #4302), decoded from the chain_events SubnetOwnerChanged stream -- Bittensor subnet ownership is a permissionless, conviction-weighted contest that transfers automatically once a challenger's conviction overtakes the incumbent owner's, no vote required. A subnet that has never changed hands returns an empty list. Reaches the Postgres-only all-events tier directly (no D1 predecessor); an out-of-range netuid or an unavailable tier is a GraphQL error, never a silent empty list. Mirrors GET /api/v1/subnets/{netuid}/ownership-history."
     subnet_ownership_history(netuid: Int!): SubnetOwnershipHistory!
     "Live per-subnet conviction leaderboard (#6638, part of the conviction/ownership-contest tracker epic #4302) -- who currently holds the most rolled conviction, i.e. how close the subnet is to an automatic ownership flip. Companion to subnet_ownership_history (that's the event log of past flips; this is the current standings). A subnet with no active challengers/owner lock returns an empty leaderboard. Reaches the Postgres-only all-events tier directly; an out-of-range netuid or an unavailable tier is a GraphQL error, never a silent empty leaderboard. Mirrors GET /api/v1/subnets/{netuid}/conviction."
@@ -3124,6 +3124,8 @@ export const SDL = `
     uids_deregistered: Int!
     neuron_retention: Float
     stability_score: Int
+    "Per-neuron churn detail (entered/exited validator lists plus UID reassignments), populated only when the field's changes toggle is set, mirroring REST's ?changes=true. Null otherwise, and on a cold store."
+    changes: JSON
   }
 
   "Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history."
@@ -9918,7 +9920,7 @@ const rootValue = {
     return loadSubnetBurn(context.env, netuid);
   },
 
-  async subnet_turnover({ netuid, window }, context) {
+  async subnet_turnover({ netuid, window, changes }, context) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError("netuid must be a u16 subnet id (0-65535).", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -9934,11 +9936,15 @@ const rootValue = {
     }
     const params = new URLSearchParams();
     params.set("window", label);
+    // #7883: opt into REST's ?changes=true per-neuron detail. Only forward the
+    // param when true so the default scorecard request stays byte-identical; the
+    // tier answers with an extra `changes` key the JSON field passes through.
+    if (changes === true) params.set("changes", "true");
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildTurnover([]) empty-card
     // fallback contract the REST handler uses (neuron_daily boundary snapshots); a
     // subnet with no boundary rows in the window is a schema-stable empty card,
-    // never a GraphQL error. Mirrors the default scorecard (REST's ?changes=true
-    // detail is omitted).
+    // never a GraphQL error. The cold fallback carries no `changes` detail, so the
+    // field resolves to null even when the toggle is set.
     const data =
       (await tryPostgresTier(
         context.env,
@@ -9966,6 +9972,7 @@ const rootValue = {
       uids_deregistered: data.uids_deregistered ?? 0,
       neuron_retention: data.neuron_retention ?? null,
       stability_score: data.stability_score ?? null,
+      changes: data.changes ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4303,6 +4303,62 @@ describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallbac
     assert.equal(body.data, null);
     assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
   });
+
+  test("changes: true forwards ?changes=true and passes the detail through as JSON (#7883)", async () => {
+    let capturedUrl;
+    const changesDetail = {
+      validators_entered_count: 2,
+      validators_exited_count: 1,
+      uid_reassignment_count: 0,
+      validators_entered: ["5Hentered1", "5Hentered2"],
+      validators_exited: ["5Hexited1"],
+      uid_reassignments: [],
+    };
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            netuid: 5,
+            window: "30d",
+            comparable: true,
+            changes: changesDetail,
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ subnet_turnover(netuid: 5, changes: true) { netuid comparable changes } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.searchParams.get("changes"), "true");
+    assert.deepEqual(body.data.subnet_turnover.changes, changesDetail);
+  });
+
+  test("without the changes toggle the param is omitted and changes resolves to null (#7883)", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ schema_version: 1, netuid: 5, window: "30d" });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ subnet_turnover(netuid: 5) { changes } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.searchParams.has("changes"), false);
+    assert.equal(body.data.subnet_turnover.changes, null);
+  });
 });
 
 // #6978: GraphQL parity for the conviction/ownership-contest (#4302) and


### PR DESCRIPTION
Closes #7883

## Summary

Adds a `changes: Boolean` argument to the `subnet_turnover` GraphQL field, closing a parity gap: `GET /api/v1/subnets/{netuid}/turnover` accepts a `changes` toggle to return the underlying per-neuron churn detail, but GraphQL only ever returned the summary scorecard.

## What changed (2 files)

- **`src/graphql.mjs`** — new `changes: Boolean` arg on `subnet_turnover`, and a `changes: JSON` field on the `SubnetTurnover` type carrying the detail (entered/exited validator lists + UID reassignments) exactly as REST shapes it via `turnoverChangeDetail`. The resolver forwards `?changes=true` **only when the toggle is set** (so the default scorecard request stays byte-identical) and passes the tier's `changes` key straight through. It resolves to `null` on the default request and on a cold store (the empty-card fallback carries no detail). No loader is re-implemented.
- **`tests/graphql.test.mjs`** — covers the toggle forwarding `?changes=true` + passing the detail through as JSON, and the default omitting the param with `changes` null.

GraphQL is served dynamically from the SDL — no generated contract/OpenAPI artifacts change.

## Validation

- [x] `tests/graphql.test.mjs` green (921 tests); both new paths exercised by the added tests (100% patch).
- [x] `eslint` + `prettier` clean on changed files.
