### PR TITLE
feat(mcp): add curation_level filter to list_curation

### DIFF
--- a/src/curation-mcp.ts
+++ b/src/curation-mcp.ts
@@ -10,6 +10,7 @@ export const CURATION_ARTIFACT = "/metagraph/curation.json";
 
 const CURATION_SORT_FIELDS = API_QUERY_COLLECTIONS.curation.sort_fields;
 const COVERAGE_LEVELS = QUERY_ENUMS.coverageLevel;
+const CURATION_LEVELS = QUERY_ENUMS.curationLevel;
 
 export interface CurationMcpError extends Error {
   toolError: true;
@@ -74,6 +75,10 @@ export function curationQueryUrl(
   const coverageLevel = optionalEnum(args, "coverage_level", COVERAGE_LEVELS);
   if (coverageLevel) {
     url.searchParams.set("coverage_level", coverageLevel);
+  }
+  const curationLevel = optionalEnum(args, "curation_level", CURATION_LEVELS);
+  if (curationLevel) {
+    url.searchParams.set("curation_level", curationLevel);
   }
   const sort = optionalEnum(args, "sort", CURATION_SORT_FIELDS);
   if (sort) url.searchParams.set("sort", sort);
@@ -190,8 +195,8 @@ export const LIST_CURATION_MCP_TOOL = {
   description:
     "Fetch per-subnet curation states from the registry: coverage_level, " +
     "curation_level, source counts, and review posture for every active subnet. " +
-    "Filter by netuid or coverage_level, sort with sort + order, and page with " +
-    "limit (1-100) / cursor. Mirrors GET /api/v1/curation.",
+    "Filter by netuid, coverage_level, or curation_level, sort with sort + " +
+    "order, and page with limit (1-100) / cursor. Mirrors GET /api/v1/curation.",
   inputSchema: {
     type: "object",
     properties: {
@@ -205,6 +210,11 @@ export const LIST_CURATION_MCP_TOOL = {
         enum: COVERAGE_LEVELS,
         description:
           "Filter by coverage depth: native-only, manifested, or probed.",
+      },
+      curation_level: {
+        type: "string",
+        enum: CURATION_LEVELS,
+        description: "Filter by curation level.",
       },
       sort: {
         type: "string",

--- a/tests/curation-mcp.test.ts
+++ b/tests/curation-mcp.test.ts
@@ -54,6 +54,7 @@ describe("curation-mcp", () => {
     const url = curationQueryUrl({
       netuid: 7,
       coverage_level: "probed",
+      curation_level: "adapter-backed",
       sort: "netuid",
       order: "desc",
       limit: 10,
@@ -61,6 +62,7 @@ describe("curation-mcp", () => {
     });
     assert.equal(url.searchParams.get("netuid"), "7");
     assert.equal(url.searchParams.get("coverage_level"), "probed");
+    assert.equal(url.searchParams.get("curation_level"), "adapter-backed");
     assert.equal(url.searchParams.get("sort"), "netuid");
     assert.equal(url.searchParams.get("limit"), "10");
     assert.equal(url.searchParams.get("cursor"), "5");
@@ -69,6 +71,13 @@ describe("curation-mcp", () => {
   test("curationQueryUrl rejects invalid coverage_level", () => {
     assert.throws(
       () => curationQueryUrl({ coverage_level: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("curationQueryUrl rejects invalid curation_level", () => {
+    assert.throws(
+      () => curationQueryUrl({ curation_level: "bogus" }),
       (err: Row) => err.code === "invalid_params",
     );
   });
@@ -142,6 +151,16 @@ describe("curation-mcp", () => {
     assert.equal(out.returned, 1);
     assert.equal(out.curation[0].netuid, 7);
     assert.equal(out.curation[0].coverage_level, "probed");
+  });
+
+  test("loadCurationList filters by curation_level", async () => {
+    const out = await loadCurationList(
+      { env: mockEnv(), readArtifact: readArtifact as ReadArtifact },
+      { curation_level: "adapter-backed" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.curation[0].netuid, 31);
+    assert.equal(out.curation[0].curation_level, "adapter-backed");
   });
 
   test("loadCurationList sorts and pages the collection", async () => {


### PR DESCRIPTION
## Summary

- `GET /api/v1/curation` already accepts `?curation_level=` — the `curation` query collection in `src/contracts.ts` declares `curation_level: enumSchema(QUERY_ENUMS.curationLevel)` as a filter, and `curation_level` was already a valid `list_curation` `sort` value (it reads `API_QUERY_COLLECTIONS.curation.sort_fields`, which already includes it). But the MCP `list_curation` tool (`src/curation-mcp.ts`) never read `args.curation_level` into its query URL, and never exposed it in `inputSchema`, so REST/MCP parity was incomplete for this one filter.
- Two sibling MCP tools over collections that share the same `curation_level` filter (`gaps` and `profiles`) already wire it correctly — `src/gaps-mcp.ts` was the template for this fix.

## What Changed

- `src/curation-mcp.ts` — `curationQueryUrl` now reads `args.curation_level` through the existing `optionalEnum` helper (same shape as the adjacent `coverage_level` handling) and forwards it to the query URL; `LIST_CURATION_MCP_TOOL.inputSchema` gains the `curation_level` property; the tool description is updated to mention it.
- `tests/curation-mcp.test.ts` — extends the existing `curationQueryUrl` validation test with `curation_level`, adds a rejection test for an invalid value, and adds a `loadCurationList` test asserting the filter actually narrows the returned rows.

No `mcp-server.mjs` change: `list_curation` is spread from `LIST_CURATION_MCP_TOOL`/`loadCurationList` by reference, so this fix is fully contained in `src/curation-mcp.ts`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7891`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no schema/contract change; `curation_level` was already a valid REST filter and MCP sort value.)

## Validation

- [x] `npx tsc --noEmit -p .` (typecheck) — clean
- [x] `npx eslint src/curation-mcp.ts tests/curation-mcp.test.ts` — clean
- [x] `npx prettier --check` on the two changed files
- [x] `git diff --check`
- [x] `npx vitest run tests/curation-mcp.test.ts` — 28/28 passing, 100% line/branch coverage on `src/curation-mcp.ts`
- [x] `npm run scan:public-safety` — no findings in touched files (49 pre-existing findings elsewhere are unrelated to this diff)

Closes #7891
