### PR TITLE
feat(mcp): list_surfaces id filter mirroring GET /api/v1/surfaces (#7894)

### DIFF
--- a/src/surfaces-mcp.ts
+++ b/src/surfaces-mcp.ts
@@ -75,6 +75,10 @@ export function surfacesQueryUrl(
   if (kind) url.searchParams.set("kind", kind);
   const provider = optionalString(args, "provider");
   if (provider) url.searchParams.set("provider", provider);
+  // #7894: exact-match surface id, the same filter axis REST's
+  // GET /api/v1/surfaces already accepts (curated-surfaces filters.id).
+  const id = optionalString(args, "id");
+  if (id) url.searchParams.set("id", id);
   const sort = optionalEnum(args, "sort", SURFACE_SORT_FIELDS);
   if (sort) url.searchParams.set("sort", sort);
   const order = optionalEnum(args, "order", ["asc", "desc"]);
@@ -190,7 +194,7 @@ export const LIST_SURFACES_MCP_TOOL = {
   description:
     "Fetch the catalog of curated public surfaces across all subnets: each " +
     "surface's subnet (netuid), kind, provider, title, url, and review state. " +
-    "Filter by netuid, kind, or provider; sort with sort + order; project with " +
+    "Filter by netuid, kind, provider, or exact id; sort with sort + order; project with " +
     "fields; and page with limit (1-100) / cursor. Distinct from " +
     "get_subnet_surfaces (one subnet's raw artifact dump). Mirrors " +
     "GET /api/v1/surfaces.",
@@ -210,6 +214,10 @@ export const LIST_SURFACES_MCP_TOOL = {
       provider: {
         type: "string",
         description: "Provider slug, e.g. 'datura'.",
+      },
+      id: {
+        type: "string",
+        description: "Exact surface id, to narrow to a single surface.",
       },
       sort: {
         type: "string",

--- a/tests/surfaces-mcp.test.ts
+++ b/tests/surfaces-mcp.test.ts
@@ -193,6 +193,37 @@ describe("surfaces-mcp", () => {
     assert.equal((out.surfaces[0] as Row).kind, "openapi");
   });
 
+  test("surfacesQueryUrl forwards an exact id filter (#7894)", () => {
+    const url = surfacesQueryUrl({ id: "sn7-api" });
+    assert.equal(url.searchParams.get("id"), "sn7-api");
+  });
+
+  test("surfacesQueryUrl rejects a blank or non-string id (#7894)", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ id: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => surfacesQueryUrl({ id: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSurfacesList narrows to a single surface by id (#7894)", async () => {
+    const out = await loadSurfacesList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { id: "sn12-openapi" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal((out.surfaces[0] as Row).id, "sn12-openapi");
+    assert.equal((out.surfaces[0] as Row).netuid, 12);
+  });
+
+  test("list_surfaces declares the id filter in its inputSchema (#7894)", () => {
+    const props = LIST_SURFACES_MCP_TOOL.inputSchema.properties as Row;
+    assert.equal((props.id as Row).type, "string");
+  });
+
   test("loadSurfacesList uses an injected readArtifact dep", async () => {
     const out = await loadSurfacesList(
       {


### PR DESCRIPTION
Closes #7894

## Summary

Adds an `id: String` argument to the `list_surfaces` MCP tool, closing a parity gap: `GET /api/v1/surfaces` supports narrowing to one surface by exact id, but the MCP tool had no way to express it (and its `additionalProperties: false` schema rejected the arg outright).

## What changed (2 files)

- **`src/surfaces-mcp.ts`** — `surfacesQueryUrl` now forwards `id`, in the same `optionalString` style as the tool's existing `provider` arg; `id` declared in `inputSchema.properties`; tool description updated to mention it. The shared `applyQueryFilters` engine **already declares `id` for the `curated-surfaces` collection** (`contracts.ts` → `filters.id: filterTextSchema`, the same exact-match filter as pools/endpoint-pools), so no loader or filter logic is re-implemented — only the MCP surface that was omitting it.
- **`tests/surfaces-mcp.test.ts`** — covers `id` being forwarded, blank/non-string `id` rejected as `invalid_params`, end-to-end narrowing to a single surface through `loadSurfacesList`, and the `inputSchema` declaration.

## Validation

- [x] `tests/surfaces-mcp.test.ts` green (32 tests) — every added line exercised (100% patch).
- [x] `tests/mcp-server.test.mjs` green (1193 tests) — tool-schema/manifest assertions unaffected.
- [x] `eslint` + `prettier` clean on changed files.
