### PR TITLE
feat(mcp): plumb before cursor into list_chain_events

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -8783,9 +8783,10 @@ export const MCP_TOOLS = [
       "all-events tier: each event's block, event index, pallet, method, decoded " +
       "args, phase, and emitting extrinsic index. Optionally filter by pallet, " +
       "method (needs pallet unless block is set), block, or one extrinsic's events " +
-      "(extrinsic needs block); page with limit (1-200, default 50) and the opaque " +
-      "cursor. The event-level companion to list_extrinsics and get_chain_activity " +
-      "(the pallet.method distribution). Mirrors GET /api/v1/chain-events.",
+      "(extrinsic needs block); page with limit (1-200, default 50), the opaque " +
+      "keyset cursor, or the legacy before=block_number cursor. The event-level " +
+      "companion to list_extrinsics and get_chain_activity (the pallet.method " +
+      "distribution). Mirrors GET /api/v1/chain-events.",
     inputSchema: {
       type: "object",
       properties: {
@@ -8817,7 +8818,15 @@ export const MCP_TOOLS = [
           type: "string",
           description:
             "Opaque keyset cursor from a previous response's next_cursor, for stable " +
-            "deep pagination over (block_number, event_index).",
+            "deep pagination over (block_number, event_index). Preferred over before " +
+            "when both are set.",
+        },
+        before: {
+          type: "integer",
+          description:
+            "Legacy block_number-only cursor: return events strictly before this " +
+            "block. Prefer cursor for deep pagination; ignored when cursor is set.",
+          minimum: 0,
         },
         limit: {
           type: "integer",
@@ -8836,6 +8845,7 @@ export const MCP_TOOLS = [
         block: args?.block,
         extrinsic: args?.extrinsic,
         cursor: optionalString(args, "cursor"),
+        before: args?.before,
         limit: args?.limit,
       });
     },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3377,6 +3377,51 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
     assert.equal(q.get("limit"), "25");
   });
 
+  test("list_chain_events forwards the legacy before cursor (#7895)", async () => {
+    const dataApi = makeDataApi({
+      payload: {
+        count: 1,
+        next_before: 4199990,
+        next_cursor: "4199990.0",
+        events: [
+          {
+            block_number: 4199995,
+            event_index: 0,
+            pallet: "System",
+            method: "ExtrinsicSuccess",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_chain_events",
+      { before: 4200000, limit: 10 },
+      { env: { DATA_API: dataApi } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.count, 1);
+    assert.equal(out.next_before, 4199990);
+    assert.equal(out.events[0].block_number, 4199995);
+    const q = dataApi.calls[0].searchParams;
+    assert.equal(q.get("before"), "4200000");
+    assert.equal(q.get("limit"), "10");
+    assert.equal(q.get("cursor"), null);
+  });
+
+  test("list_chain_events prefers cursor over before when both are set (#7895)", async () => {
+    const dataApi = makeDataApi({ payload: { count: 0, events: [] } });
+    await callTool(
+      "list_chain_events",
+      { cursor: "1.2.3", before: 99, limit: 5 },
+      { env: { DATA_API: dataApi } },
+    );
+    const q = dataApi.calls[0].searchParams;
+    assert.equal(q.get("cursor"), "1.2.3");
+    assert.equal(q.get("before"), null);
+    assert.equal(q.get("limit"), "5");
+  });
+
   test("list_chain_events surfaces a non-400 data-Worker error as tier_unavailable", async () => {
     const dataApi = makeDataApi({ status: 503 });
     const res = await callTool(


### PR DESCRIPTION
## Summary
- Add `before` to MCP `list_chain_events` `inputSchema` and pass it through to `loadChainEventsFeed` (loader already supported it).
- Cover legacy `before` pagination and cursor-over-`before` preference in MCP tests.

Closes #7895

## Test plan
- [x] `npx vitest run tests/mcp-server.test.mjs -t list_chain_events`
- [x] Private-boundary validation passed
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)