### PR TITLE
feat(api): add providers GraphQL list filters without breaking cursor contract (#7888)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -45,6 +45,10 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.ts";
 // same loadProviderEndpointsList that MCP list_provider_endpoints already calls
 // (#3289) -- not a reimplementation.
 import { loadProviderEndpointsList } from "./provider-endpoints-mcp.ts";
+// #7888: GraphQL parity for GET /api/v1/providers list filters (id/kind/
+// authority/sort/order/fields + limit/cursor), reusing loadProvidersList that
+// MCP list_providers already calls -- not a reimplementation.
+import { loadProvidersList } from "./providers-mcp.ts";
 // #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
 // and page logic REST and MCP already use) -- not a reimplementation.
@@ -596,8 +600,8 @@ export const SDL = `
     subnet_overview(netuid: Int!): JSON
     "One subnet's contributor-review profile: candidate surfaces, contract version, endpoints, and completeness/curation metadata. Null when no profile has been baked for that netuid (rather than a GraphQL error); a negative netuid is a BAD_USER_INPUT error. Opaque JSON passed through verbatim, matching the get_subnet_profile MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/profile."
     subnet_profile(netuid: Int!): JSON
-    "Paginated provider/source registry."
-    providers(limit: Int, cursor: String): ProviderList!
+    "Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers)."
+    providers(id: String, kind: String, authority: String, sort: String, order: String, fields: String, limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
     provider(id: String!): Provider
     "One adapter-backed public metrics snapshot by slug (e.g. 'gittensor', 'allways', 'sn-64'): the captured adapter snapshot, extension metadata, and netuid linkage. An invalid slug is a BAD_USER_INPUT error; a missing slug resolves to null (schema-stable, never a GraphQL error). Mirrors GET /api/v1/adapters/{slug}."
@@ -6131,13 +6135,55 @@ const rootValue = {
     };
   },
 
-  providers({ limit, cursor }, context) {
-    return listPage(context, ARTIFACT.providers, "providers", {
+  // #7888: add REST/MCP list-query filters (id/kind/authority/sort/order/fields)
+  // by reusing loadProvidersList for validate+filter+sort, while preserving the
+  // pre-existing GraphQL providers contract the gate flagged as a breaker on
+  // #7920: opaque string id-keyset cursor/next_cursor (not REST's Int offset)
+  // and schema-stable empty list on a cold/absent artifact (not a GraphQL
+  // error). limit/cursor are applied here via paginate, not the loader.
+  async providers(args, context) {
+    const { limit, cursor, ...filters } = args ?? {};
+    let rows;
+    try {
+      // Omit GraphQL limit/cursor so the loader returns the full filtered set;
+      // fields is forwarded for REST parity (id is forced in so keyset paging
+      // still works when a projection would otherwise drop it).
+      const loadArgs = { ...filters };
+      if (
+        typeof loadArgs.fields === "string" &&
+        loadArgs.fields.trim() &&
+        !/(^|,)\s*id\s*(,|$)/i.test(loadArgs.fields)
+      ) {
+        loadArgs.fields = `id,${loadArgs.fields.trim()}`;
+      }
+      const data = await loadProvidersList(context, loadArgs, {
+        readArtifact,
+      });
+      rows = data.providers;
+    } catch (err) {
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      // Cold/absent artifact (not_found / unavailable): keep the historical
+      // empty-list contract for this field.
+      if (err?.toolError) {
+        return { items: [], total: 0, next_cursor: null };
+      }
+      throw err;
+    }
+    const { page, total, nextCursor } = paginate(
+      rows,
       limit,
       cursor,
-      keyFn: (p) => p.id,
-      map: providerNode,
-    });
+      (p) => p.id,
+    );
+    return {
+      items: page.map(providerNode),
+      total,
+      next_cursor: nextCursor,
+    };
   },
 
   async provider({ id }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -441,11 +441,12 @@ describe("handleGraphQLRequest — resolvers (cold store)", () => {
     assert.equal(body.data.subnet, null);
   });
 
-  test("providers returns empty list when artifact not found", async () => {
+  test("providers returns empty list when artifact not found (pre-#7888 contract)", async () => {
     const { status, body } = await gql(
       "{ providers { items { id name } total } }",
     );
     assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
     assert.deepEqual(body.data.providers, { items: [], total: 0 });
   });
 
@@ -2697,12 +2698,12 @@ describe("graphql — resolver branch coverage", () => {
     assert.deepEqual(body.data.provider.subnets, []);
   });
 
-  test("providers paginate with an id cursor", async () => {
+  test("providers paginate with an opaque string id cursor (pre-#7888 contract)", async () => {
     const env = fixtureEnv({
       "/metagraph/providers.json": {
         providers: [
-          { id: "a", name: "A" },
-          { id: "b", name: "B" },
+          { id: "a", name: "A", kind: "data-provider", authority: "official" },
+          { id: "b", name: "B", kind: "data-provider", authority: "community" },
         ],
       },
     });
@@ -2711,8 +2712,133 @@ describe("graphql — resolver branch coverage", () => {
       env,
     );
     assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
     assert.equal(body.data.providers.total, 2);
+    assert.equal(body.data.providers.items.length, 1);
     assert.equal(body.data.providers.next_cursor, "a");
+  });
+
+  test("providers filters by id and by kind (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        schema_version: 1,
+        providers: [
+          {
+            id: "datura",
+            name: "Datura",
+            kind: "data-provider",
+            authority: "official",
+          },
+          {
+            id: "chutes",
+            name: "Chutes",
+            kind: "infrastructure-provider",
+            authority: "official",
+          },
+          {
+            id: "community-x",
+            name: "Community X",
+            kind: "data-provider",
+            authority: "community",
+          },
+        ],
+      },
+    });
+
+    const byId = await gql(
+      '{ providers(id: "chutes") { items { id kind } total } }',
+      env,
+    );
+    assert.equal(byId.status, 200);
+    assert.equal(byId.body.errors, undefined);
+    assert.equal(byId.body.data.providers.total, 1);
+    assert.equal(byId.body.data.providers.items[0].id, "chutes");
+    assert.equal(
+      byId.body.data.providers.items[0].kind,
+      "infrastructure-provider",
+    );
+
+    const byKind = await gql(
+      '{ providers(kind: "data-provider") { items { id } total } }',
+      env,
+    );
+    assert.equal(byKind.status, 200);
+    assert.equal(byKind.body.errors, undefined);
+    assert.equal(byKind.body.data.providers.total, 2);
+    assert.deepEqual(byKind.body.data.providers.items.map((p) => p.id).sort(), [
+      "community-x",
+      "datura",
+    ]);
+  });
+
+  test("providers surfaces an invalid kind as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          { id: "datura", kind: "data-provider", authority: "official" },
+        ],
+      },
+    });
+    const { body } = await gql('{ providers(kind: "bogus") { total } }', env);
+    assert.ok(body.errors?.length > 0);
+    assert.match(body.errors[0].message, /kind/i);
+  });
+
+  test("providers forwards authority/sort/order/fields through the shared loader (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          {
+            id: "datura",
+            name: "Datura",
+            kind: "data-provider",
+            authority: "official",
+            surface_count: 3,
+          },
+          {
+            id: "community-x",
+            name: "Community X",
+            kind: "data-provider",
+            authority: "community",
+            surface_count: 1,
+          },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      `{ providers(
+          authority: "official",
+          sort: "id",
+          order: "asc",
+          fields: "kind,authority",
+          limit: 10
+        ) { items { id kind authority } total next_cursor } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.providers.total, 1);
+    assert.equal(body.data.providers.items[0].id, "datura");
+    assert.equal(body.data.providers.items[0].authority, "official");
+    assert.equal(body.data.providers.next_cursor, null);
+  });
+
+  test("providers maps invalid_params to BAD_USER_INPUT (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          { id: "datura", kind: "data-provider", authority: "official" },
+        ],
+      },
+    });
+    const { body } = await gql(
+      '{ providers(authority: "not-real") { total } }',
+      env,
+    );
+    assert.ok(
+      body.errors?.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("surfaces paginate, falling back to key for the cursor when id is absent", async () => {


### PR DESCRIPTION
## Summary

- Add REST/MCP list-query filters to `Query.providers` (`id`, `kind`, `authority`, `sort`, `order`, `fields`) by reusing `loadProvidersList` for validation + filter/sort.
- **Preserve the existing GraphQL contract** that caused LoopOver to reject #7920: opaque **string** id-keyset `cursor` / `next_cursor` (not REST’s integer offset), and cold/absent artifact → schema-stable **empty list** (not a GraphQL error).
- Invalid filter enums still surface as `BAD_USER_INPUT`.

Closes #7888.
Supersedes #7914 / #7920.

## What Changed

- `src/graphql.mjs` — filter args on `providers`; shared-loader filter/sort + local string-keyset `paginate`.
- `tests/graphql.test.mjs` — id/kind filters, authority/sort/order/fields, string cursor, cold empty list, `BAD_USER_INPUT`.

## Why not full REST cursor parity?

LoopOver closed #7920 for changing `next_cursor: String→Int` and flipping cold-store from `{items:[],total:0}` to an error — breaking for existing GraphQL clients. This PR delivers the issue’s filter deliverables without that break.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7888`) — required.
- [x] No secrets / private URLs.
- [x] GraphQL SDL change only (additive filter args; cursor types unchanged).

## Validation

- [x] `npx vitest run tests/graphql.test.mjs -t providers` — 8 passing
- [x] `npx prettier --write` on touched files