### PR TITLE
feat(mcp): add sort/order/fields to list_endpoints

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -72,7 +72,12 @@ import {
   listSubscribableMcpResourceClasses,
   parseSubnetStatusResourceUri,
 } from "./subnet-status-subscribe.ts";
-import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.ts";
+import {
+  API_QUERY_COLLECTIONS,
+  CONTRACT_VERSION,
+  PRIMARY_DOMAIN,
+  QUERY_ENUMS,
+} from "./contracts.ts";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
   GET_ECONOMICS_MCP_TOOL,
@@ -9584,7 +9589,8 @@ export const MCP_TOOLS = [
       "probe-derived status/latency/score. Use it to discover live endpoints " +
       "network-wide. Optionally filter by kind/layer/netuid/provider/" +
       "publication_state/status/pool_eligible, bound by min_/max_latency_ms " +
-      "and min_/max_score, and page with limit/cursor — the full catalog can " +
+      "and min_/max_score, sort with sort + order, project with fields, and " +
+      "page with limit/cursor — the full catalog can " +
       "be large. Mirrors GET /api/v1/endpoints.",
     inputSchema: {
       type: "object",
@@ -9635,6 +9641,21 @@ export const MCP_TOOLS = [
           type: "number",
           description: "Only endpoints with probe-derived score <= this.",
         },
+        sort: {
+          type: "string",
+          enum: API_QUERY_COLLECTIONS.endpoints.sort_fields,
+          description: "Field to sort by before paging.",
+        },
+        order: {
+          type: "string",
+          enum: ["asc", "desc"],
+          description: "Sort direction for sort (default asc).",
+        },
+        fields: {
+          type: "string",
+          description:
+            "Comma-separated projection of endpoint row fields to return.",
+        },
         limit: {
           type: "integer",
           description: "Max endpoints to return. Omit for the full list.",
@@ -9650,37 +9671,13 @@ export const MCP_TOOLS = [
       additionalProperties: false,
     },
     async handler(args, ctx) {
-      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
-      const layer = optionalEnum(args, "layer", QUERY_ENUMS.endpointLayer);
-      const netuid = optionalNonNegativeInt(args, "netuid");
-      const provider = optionalString(args, "provider");
-      const publicationState = optionalEnum(
-        args,
-        "publication_state",
-        QUERY_ENUMS.endpointPublicationState,
-      );
-      const status = optionalEnum(args, "status", QUERY_ENUMS.healthStatus);
-      const poolEligible = optionalNullableBoolean(args, "pool_eligible");
-      // Inclusive numeric range bounds, the MCP mirror of REST's
-      // rangeFilters: ["latency_ms", "score"] on the endpoints collection
-      // (contracts.mjs) — same shape as LIST_SUBNETS_RANGE_BOUNDS.
-      const rangeBounds = [
-        { arg: "min_latency_ms", field: "latency_ms", op: "min" },
-        { arg: "max_latency_ms", field: "latency_ms", op: "max" },
-        { arg: "min_score", field: "score", op: "min" },
-        { arg: "max_score", field: "score", op: "max" },
-      ]
-        .filter(({ arg }) => Number.isFinite(args?.[arg]))
-        .map(({ field, op, arg }) => ({ field, op, limit: args[arg] }));
-      const limit = optionalPositiveInt(args, "limit");
-      const cursor = optionalNonNegativeInt(args, "cursor") ?? 0;
       let data = await loadArtifactData(ctx, "/metagraph/endpoints.json");
       // Live per-endpoint health overlay (mirrors workers/api.mjs's raw-
       // artifact serving path): the build-time endpoints.json bakes stale
       // operational health, so replace it from the 15-minute cron snapshot
-      // before filtering/pagination -- status/pool_eligible filters below
-      // (and the latency_ms/score bounds, which come from this same overlay)
-      // must see live values, not the baked ones.
+      // before filtering -- status/pool_eligible filters below (and the
+      // latency_ms/score bounds, which come from this same overlay) must
+      // see live values, not the baked ones.
       if (
         Array.isArray(data?.endpoints) &&
         data.endpoints.some((endpoint) => endpoint?.surface_id)
@@ -9691,37 +9688,76 @@ export const MCP_TOOLS = [
         );
         if (overlaid) data = overlaid;
       }
-      const all = Array.isArray(data.endpoints) ? data.endpoints : [];
-      const filtered = all.filter(
-        (e) =>
-          (kind === null || e.kind === kind) &&
-          (layer === null || e.layer === layer) &&
-          (netuid === null || e.netuid === netuid) &&
-          (provider === null || e.provider === provider) &&
-          (publicationState === null ||
-            e.publication_state === publicationState) &&
-          (status === null || e.status === status) &&
-          (poolEligible === null || e.pool_eligible === poolEligible) &&
-          rangeBounds.every(({ field, op, limit: bound }) => {
-            const value = e[field];
-            if (typeof value !== "number") return false;
-            return op === "min" ? value >= bound : value <= bound;
-          }),
+      // Schema-stable even when the artifact predates the endpoints key or
+      // carries a malformed one — applyQueryFilters needs a real array under
+      // "endpoints" to project a (possibly empty) page rather than undefined.
+      if (!Array.isArray(data?.endpoints)) {
+        data = { ...data, endpoints: [] };
+      }
+      // Full REST-parity query — filters, sort/order, fields projection, and
+      // cursor pagination in one applyQueryFilters call over the "endpoints"
+      // collection (same collection GET /api/v1/endpoints uses), mirroring
+      // list_provider_endpoints (src/provider-endpoints-mcp.ts).
+      const queryUrl = new URL("https://mcp.internal/endpoints");
+      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
+      if (kind) queryUrl.searchParams.set("kind", kind);
+      const layer = optionalEnum(args, "layer", QUERY_ENUMS.endpointLayer);
+      if (layer) queryUrl.searchParams.set("layer", layer);
+      const netuid = optionalNonNegativeInt(args, "netuid");
+      if (netuid !== null) queryUrl.searchParams.set("netuid", String(netuid));
+      const provider = optionalString(args, "provider");
+      if (provider) queryUrl.searchParams.set("provider", provider);
+      const publicationState = optionalEnum(
+        args,
+        "publication_state",
+        QUERY_ENUMS.endpointPublicationState,
       );
-      const window = cursorWindow(filtered, {
-        collection: "endpoints",
-        dataKey: "endpoints",
-        limit,
-        cursor,
-      });
+      if (publicationState) {
+        queryUrl.searchParams.set("publication_state", publicationState);
+      }
+      const status = optionalEnum(args, "status", QUERY_ENUMS.healthStatus);
+      if (status) queryUrl.searchParams.set("status", status);
+      const poolEligible = optionalNullableBoolean(args, "pool_eligible");
+      if (poolEligible !== null) {
+        queryUrl.searchParams.set("pool_eligible", String(poolEligible));
+      }
+      for (const arg of [
+        "min_latency_ms",
+        "max_latency_ms",
+        "min_score",
+        "max_score",
+      ]) {
+        if (Number.isFinite(args?.[arg])) {
+          queryUrl.searchParams.set(arg, String(args[arg]));
+        }
+      }
+      const sort = optionalEnum(
+        args,
+        "sort",
+        API_QUERY_COLLECTIONS.endpoints.sort_fields,
+      );
+      if (sort) queryUrl.searchParams.set("sort", sort);
+      const order = optionalEnum(args, "order", ["asc", "desc"]);
+      if (order) queryUrl.searchParams.set("order", order);
+      const fields = optionalString(args, "fields");
+      if (fields) queryUrl.searchParams.set("fields", fields);
+      const limit = optionalPositiveInt(args, "limit");
+      if (limit !== null) queryUrl.searchParams.set("limit", String(limit));
+      const cursor = optionalNonNegativeInt(args, "cursor") ?? 0;
+      if (cursor > 0) queryUrl.searchParams.set("cursor", String(cursor));
+      const transformed = applyQueryFilters(data, queryUrl, "endpoints", []);
+      if (transformed.error) {
+        throw toolError("invalid_params", transformed.error.message);
+      }
+      const result = transformed.data;
+      const page = transformed.meta.pagination;
       return {
-        ...data,
-        endpoints: window.page,
-        total: window.total,
-        returned: window.returned,
-        cursor: window.cursor,
-        limit: window.limit,
-        next_cursor: window.next_cursor,
+        ...result,
+        total: page.total,
+        returned: page.returned,
+        cursor: page.cursor,
+        limit: page.limit,
+        next_cursor: page.next_cursor,
       };
     },
   },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -15622,6 +15622,60 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.endpoints[0].provider, "chutes");
   });
 
+  test("list_endpoints sorts by netuid, honoring order (default asc)", async () => {
+    const deps = endpointsDeps();
+    const asc = (await callTool("list_endpoints", { sort: "netuid" }, { deps }))
+      .body.result.structuredContent;
+    assert.deepEqual(
+      asc.endpoints.map((e) => e.netuid),
+      [7, 7, 12],
+    );
+
+    const desc = (
+      await callTool(
+        "list_endpoints",
+        { sort: "netuid", order: "desc" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(
+      desc.endpoints.map((e) => e.netuid),
+      [12, 7, 7],
+    );
+  });
+
+  test("list_endpoints projects only the requested fields", async () => {
+    const deps = endpointsDeps();
+    const res = await callTool(
+      "list_endpoints",
+      { netuid: 12, fields: "netuid,provider" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.endpoints.length, 1);
+    assert.deepEqual(Object.keys(out.endpoints[0]).sort(), [
+      "netuid",
+      "provider",
+    ]);
+  });
+
+  test("list_endpoints rejects an unknown sort/order value", async () => {
+    const deps = endpointsDeps();
+    const badSort = await callTool(
+      "list_endpoints",
+      { sort: "not-a-field" },
+      { deps },
+    );
+    assert.equal(badSort.body.result.isError, true);
+
+    const badOrder = await callTool(
+      "list_endpoints",
+      { sort: "netuid", order: "sideways" },
+      { deps },
+    );
+    assert.equal(badOrder.body.result.isError, true);
+  });
+
   test("list_endpoints rejects an unknown kind/layer/publication_state/status enum value", async () => {
     const deps = endpointsDeps();
     const badKind = await callTool(


### PR DESCRIPTION
## Summary

- `GET /api/v1/endpoints` and the MCP `list_endpoints` tool both target the same `"endpoints"` query collection (`src/contracts.ts`), but `list_endpoints`'s handler hand-rolled its own `.filter()` predicate and a manual `rangeBounds` array instead of delegating to `applyQueryFilters` — the shared filter/sort/pagination engine REST and every other MCP `list_*` tool use. That's why it never exposed `sort`, `order`, or `fields`, even though the `endpoints` collection already declares 10 valid sort fields and REST already supports all three.
- `list_provider_endpoints` (`src/provider-endpoints-mcp.ts`) is the per-provider sibling over the identical collection and already does this correctly — used as the template.

## What Changed

- `src/mcp-server.mjs` — `list_endpoints`'s handler now builds a synthetic query URL from `args` (same filters as before: kind/layer/netuid/provider/publication_state/status/pool_eligible/min_/max_latency_ms/min_/max_score, plus the new sort/order/fields) and makes one `applyQueryFilters(data, queryUrl, "endpoints", [])` call instead of the hand-rolled filter block — this also removes ~15 lines of now-redundant duplicate filtering logic. The pre-existing live-health overlay step (`overlayArtifactEndpoints` + `mcpLiveHealth`) is preserved and still runs before filtering, since the status/pool_eligible filters and latency_ms/score bounds must see live values. Added an explicit guard so the response stays schema-stable (`endpoints: []`) when the artifact predates or lacks the `endpoints` key, matching the prior behavior (`applyQueryFilters` needs a real array to project a page from). `inputSchema` gains `sort` (enum, the collection's real sort fields), `order` (`asc`/`desc`), and `fields` (comma-separated projection).
- `tests/mcp-server.test.mjs` — new tests: sorting by `netuid` with default/explicit `order`, `fields` projection, and rejection of an unknown `sort`/`order` value. All prior `list_endpoints` tests (filtering, combined filters, pagination, range bounds, the no-`endpoints`-array schema-stability case) still pass unmodified.

No `mcp-server.mjs` dispatch-table change beyond the tool object itself — `list_endpoints` is (and remains) a self-contained entry in the `MCP_TOOLS` array; `dispatchTool` just looks it up by name and calls its `handler`, so nothing else in the file was touched.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7892`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no schema/contract change; `sort`/`order`/`fields` were already valid for this collection.)

## Validation

- [x] `npx tsc --noEmit -p .` (typecheck) — clean
- [x] `npx eslint src/mcp-server.mjs tests/mcp-server.test.mjs` — clean
- [x] `npx prettier --check` on the two changed files
- [x] `git diff --check`
- [x] `npx vitest run tests/mcp-server.test.mjs -t "list_endpoints"` — 16/16 passing
- [x] `npx vitest run tests/mcp-server.test.mjs` (full file) — 1192/1193 passing; the 1 pre-existing failure (`service_count` in a local-env end-to-end test) reproduces identically on a clean `main` before this change and is unrelated to `list_endpoints`.
- [x] Targeted lcov coverage check confirms every changed line/branch in the touched handler region is exercised.
- [x] `npm run scan:public-safety` — no findings in touched files (pre-existing findings elsewhere are unrelated to this diff)

Closes #7892
