### PR TITLE
feat(mcp): list_enrichment_targets agent_status filter mirroring REST (#7898)

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2264,8 +2264,11 @@ function coverageDepthTarget(row, rank = null) {
   };
 }
 
-function coverageDepthMatches(row, { tier, severity, gapCode }) {
+function coverageDepthMatches(row, { tier, severity, gapCode, agentStatus }) {
   if (tier && row.tier !== tier) return false;
+  // #7898: agent readiness is an independent axis from tier -- the same
+  // agent_status filter REST's GET /api/v1/coverage-depth accepts.
+  if (agentStatus && row.agent_status !== agentStatus) return false;
   if (gapCode && !(row.top_gap_codes || []).includes(gapCode)) return false;
   if (
     severity &&
@@ -10466,6 +10469,12 @@ export const MCP_TOOLS = [
             "Optional stable gap code filter, e.g. missing-fixture or missing-schema.",
           pattern: "^[a-z0-9-]+$",
         },
+        agent_status: {
+          type: "string",
+          enum: QUERY_ENUMS.agentReadinessStatus,
+          description:
+            "Optional agent-readiness filter: callable, base-layer, candidate, needs-evidence, or blocked.",
+        },
         netuid: {
           type: "integer",
           description:
@@ -10482,6 +10491,11 @@ export const MCP_TOOLS = [
         args,
         "severity",
         COVERAGE_DEPTH_SEVERITIES,
+      );
+      const agentStatus = optionalEnum(
+        args,
+        "agent_status",
+        QUERY_ENUMS.agentReadinessStatus,
       );
       const gapCode = optionalGapCode(args);
       const netuid =
@@ -10515,10 +10529,16 @@ export const MCP_TOOLS = [
           }))
           .filter((entry) => Number.isInteger(entry.row?.netuid));
       }
-      const filters = { tier, severity, gap_code: gapCode, netuid };
+      const filters = {
+        tier,
+        severity,
+        gap_code: gapCode,
+        agent_status: agentStatus,
+        netuid,
+      };
       const targets = candidates
         .filter(({ row }) =>
-          coverageDepthMatches(row, { tier, severity, gapCode }),
+          coverageDepthMatches(row, { tier, severity, gapCode, agentStatus }),
         )
         .slice(0, limit)
         .map(({ row, rank }) => coverageDepthTarget(row, rank));

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2898,6 +2898,44 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(rowOut.targets[0].rank, null);
   });
 
+  test("list_enrichment_targets filters by agent_status (#7898)", async () => {
+    const callable = await callTool(
+      "list_enrichment_targets",
+      { agent_status: "callable" },
+      { deps },
+    );
+    const callableOut = callable.body.result.structuredContent;
+    assert.equal(callableOut.returned, 1);
+    assert.equal(callableOut.targets[0].netuid, 7);
+    assert.equal(callableOut.filters.agent_status, "callable");
+
+    const blocked = await callTool(
+      "list_enrichment_targets",
+      { agent_status: "blocked" },
+      { deps },
+    );
+    const blockedOut = blocked.body.result.structuredContent;
+    assert.equal(blockedOut.returned, 1);
+    assert.equal(blockedOut.targets[0].netuid, 31);
+
+    // Independent of tier: a status that no row carries returns nothing.
+    const none = await callTool(
+      "list_enrichment_targets",
+      { agent_status: "candidate" },
+      { deps },
+    );
+    assert.equal(none.body.result.structuredContent.returned, 0);
+  });
+
+  test("list_enrichment_targets rejects an agent_status outside the enum (#7898)", async () => {
+    const res = await callTool(
+      "list_enrichment_targets",
+      { agent_status: "bogus" },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, true);
+  });
+
   test("list_enrichment_targets reports missing coverage-depth artifact", async () => {
     const missingDeps = makeDeps({});
     const res = await callTool(


### PR DESCRIPTION
Closes #7898

## Summary

Adds an `agent_status` optional-enum argument to the `list_enrichment_targets` MCP tool, closing a parity gap: `GET /api/v1/coverage-depth` accepts an `agent_status` filter (`callable` / `base-layer` / `candidate` / `needs-evidence` / `blocked`) but the tool had no equivalent — and its `additionalProperties: false` schema rejected the arg outright.

## What changed (2 files)

- **`src/mcp-server.mjs`** — `agent_status` declared in `inputSchema.properties` and read via the tool's existing `optionalEnum(args, "tier", COVERAGE_DEPTH_TIERS)` pattern. The allowed values come straight from **`QUERY_ENUMS.agentReadinessStatus`** (already imported and used inline for other enums in this file), so the tool cannot drift from the contract that defines the REST filter. `coverageDepthMatches` gains the matching predicate — agent readiness is an axis independent of `tier`, so the two AND together — and the applied value is echoed in the response's `filters` block alongside the existing ones.
- **`tests/mcp-server.test.mjs`** — covers filtering by two distinct enum values (`callable` → netuid 7, `blocked` → netuid 31), a value no row carries returning nothing, the echoed `filters.agent_status`, and an out-of-enum value erroring.

`filters` is declared `{ type: "object" }` in the tool's outputSchema, so the added key needs no schema change.

## Validation

- [x] `tests/mcp-server.test.mjs` green (1197 tests) — every added line exercised (100% patch).
- [x] `eslint` + `prettier` clean on changed files.
