### PR TITLE
feat(mcp): list_search type/netuid filters mirroring GET /api/v1/search (#7896)

### DIFF
--- a/src/search-mcp.ts
+++ b/src/search-mcp.ts
@@ -11,6 +11,10 @@ import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 export const SEARCH_ARTIFACT = "/metagraph/search.json";
 
 const DOCUMENT_SORT_FIELDS = API_QUERY_COLLECTIONS.documents.sort_fields;
+// #7896: document *type* (subnet/surface/provider), sourced from the same
+// collection contract the REST route validates against so the tool cannot drift.
+const DOCUMENT_TYPES = API_QUERY_COLLECTIONS.documents.filters.type
+  .enum as string[];
 
 export interface SearchMcpError extends Error {
   toolError: true;
@@ -67,6 +71,20 @@ export function searchQueryUrl(
   const url = new URL("https://mcp.internal/search");
   const q = optionalString(args, "q");
   if (q) url.searchParams.set("q", q);
+  // #7896: scope hits by document type and subnet, the same two filter axes
+  // REST's GET /api/v1/search accepts. They AND with q and with each other.
+  const type = optionalEnum(args, "type", DOCUMENT_TYPES);
+  if (type) url.searchParams.set("type", type);
+  if (args?.netuid !== undefined) {
+    const netuid = args.netuid;
+    if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+      throw searchMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(netuid));
+  }
   const sort = optionalEnum(args, "sort", DOCUMENT_SORT_FIELDS);
   if (sort) url.searchParams.set("sort", sort);
   const order = optionalEnum(args, "order", ["asc", "desc"]);
@@ -167,7 +185,7 @@ export const LIST_SEARCH_MCP_TOOL = {
   description:
     "Keyword-search the full registry search index: subnet, surface, and " +
     "provider documents with their per-document token blobs, mirroring " +
-    "GET /api/v1/search. Filter with q, sort with sort + order, project with " +
+    "GET /api/v1/search. Filter with q, type, and netuid, sort with sort + order, project with " +
     "fields, and page with limit (1-100) / cursor. Unlike search_subnets — which reads " +
     "the same artifact but only ever returns subnet hits — this spans all " +
     "three document types, so it works to find surfaces and providers even " +
@@ -180,6 +198,17 @@ export const LIST_SEARCH_MCP_TOOL = {
       q: {
         type: "string",
         description: "Keyword search across title, subtitle, slug, and tokens.",
+      },
+      type: {
+        type: "string",
+        enum: DOCUMENT_TYPES,
+        description:
+          "Document type filter: subnet, surface, or provider. Distinct from surface kind.",
+      },
+      netuid: {
+        type: "integer",
+        description: "Filter to documents belonging to one subnet netuid.",
+        minimum: 0,
       },
       sort: {
         type: "string",

--- a/tests/search-mcp.test.ts
+++ b/tests/search-mcp.test.ts
@@ -162,6 +162,41 @@ describe("search-mcp", () => {
     assert.equal(out.documents[0].type, "surface");
   });
 
+  test("searchQueryUrl forwards type and netuid, rejecting bad values (#7896)", () => {
+    const url = searchQueryUrl({ type: "surface", netuid: 7 });
+    assert.equal(url.searchParams.get("type"), "surface");
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.throws(
+      () => searchQueryUrl({ type: "not-a-type" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSearchList scopes by a type + netuid combination (#7896)", async () => {
+    const ctx = { env: {}, readArtifact } as unknown as LoadCtx;
+    // netuid 7 has both a subnet and a surface document; type picks one.
+    const combined = await loadSearchList(ctx, { type: "surface", netuid: 7 });
+    assert.equal(combined.returned, 1);
+    assert.equal(combined.documents[0].id, "surface-7-openapi");
+
+    const byNetuid = await loadSearchList(ctx, { netuid: 7 });
+    assert.equal(byNetuid.returned, 2);
+
+    const byType = await loadSearchList(ctx, { type: "provider" });
+    assert.equal(byType.returned, 1);
+    assert.equal(byType.documents[0].slug, "datura");
+  });
+
+  test("list_search declares the type and netuid filters in its inputSchema (#7896)", () => {
+    const props = LIST_SEARCH_MCP_TOOL.inputSchema.properties as Row;
+    assert.ok(((props.type as Row).enum as string[]).includes("surface"));
+    assert.equal((props.netuid as Row).type, "integer");
+  });
+
   test("loadSearchList keeps token blobs the slim index omits", async () => {
     const out = await loadSearchList(
       { env: {}, readArtifact } as unknown as LoadCtx,


### PR DESCRIPTION
Closes #7896

## Summary

Adds `type` and `netuid` arguments to the `list_search` MCP tool, closing a parity gap: `GET /api/v1/search` supports both, but the tool had neither — and its `additionalProperties: false` schema rejected them outright.

## What changed (2 files)

- **`src/search-mcp.ts`** — `type` and `netuid` declared in `inputSchema.properties` and forwarded by `searchQueryUrl`. The `type` enum is **sourced from `API_QUERY_COLLECTIONS.documents.filters.type`** — the same collection contract the REST route validates against, mirroring how the file already derives `DOCUMENT_SORT_FIELDS` — so the tool cannot drift from REST. `netuid` reuses the same non-negative-integer guard the sibling list tools apply. Both AND with `q` and with each other; the shared `applyQueryFilters` engine already declares them, so no loader or filter logic is re-implemented.
- **`tests/search-mcp.test.ts`** — covers the `type` + `netuid` combination the issue asks for (netuid 7 has both a subnet and a surface document, so `type` disambiguates), each filter alone, invalid values rejected as `invalid_params`, and the `inputSchema` declarations.

Note: document `type` (subnet/surface/provider) is deliberately distinct from surface *kind* (openapi/website/sdk), per the contract's own comment — the description says so explicitly.

## Validation

- [x] `tests/search-mcp.test.ts` green (31 tests) — every added line exercised (100% patch).
- [x] `tests/mcp-server.test.mjs` green (1195 tests) — tool-manifest assertions unaffected.
- [x] `tsc --noEmit` clean, `eslint` + `prettier` clean.
