### PR TITLE
feat(mcp): add type/netuid filters to list_search (#7896)

### DIFF
--- a/src/search-mcp.ts
+++ b/src/search-mcp.ts
@@ -86,6 +86,21 @@ export function searchQueryUrl(
     }
     url.searchParams.set("cursor", String(cursor));
   }
+  const type = optionalEnum(args, "type", ["subnet", "surface", "provider"]);
+  if (type) url.searchParams.set("type", type);
+  if (args?.netuid !== undefined) {
+    if (
+      typeof args.netuid !== "number" ||
+      !Number.isInteger(args.netuid) ||
+      (args.netuid as number) < 0
+    ) {
+      throw searchMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
   return url;
 }
 
@@ -167,19 +182,29 @@ export const LIST_SEARCH_MCP_TOOL = {
   description:
     "Keyword-search the full registry search index: subnet, surface, and " +
     "provider documents with their per-document token blobs, mirroring " +
-    "GET /api/v1/search. Filter with q, sort with sort + order, project with " +
-    "fields, and page with limit (1-100) / cursor. Unlike search_subnets — which reads " +
-    "the same artifact but only ever returns subnet hits — this spans all " +
-    "three document types, so it works to find surfaces and providers even " +
-    "when the AI layer semantic_search depends on is not configured. Unlike " +
-    "list_search_index, which serves the slim variant without token blobs, this " +
-    "keeps the full documents. Use semantic_search for meaning-based discovery.",
+    "GET /api/v1/search. Filter with q, type, netuid; sort with sort + order; " +
+    "project with fields; and page with limit (1-100) / cursor. Unlike " +
+    "search_subnets — which reads the same artifact but only ever returns subnet " +
+    "hits — this spans all three document types, so it works to find surfaces and " +
+    "providers even when the AI layer semantic_search depends on is not configured. " +
+    "Unlike list_search_index, which serves the slim variant without token blobs, " +
+    "this keeps the full documents. Use semantic_search for meaning-based discovery.",
   inputSchema: {
     type: "object",
     properties: {
       q: {
         type: "string",
         description: "Keyword search across title, subtitle, slug, and tokens.",
+      },
+      type: {
+        type: "string",
+        enum: ["subnet", "surface", "provider"],
+        description: "Filter by document type (subnet, surface, or provider).",
+      },
+      netuid: {
+        type: "integer",
+        description: "Filter by subnet netuid.",
+        minimum: 0,
       },
       sort: {
         type: "string",

--- a/tests/search-mcp.test.ts
+++ b/tests/search-mcp.test.ts
@@ -119,6 +119,27 @@ describe("search-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "id,title");
   });
 
+  test("searchQueryUrl sets type and netuid params", () => {
+    const url = searchQueryUrl({ type: "surface", netuid: 7 });
+    assert.equal(url.searchParams.get("type"), "surface");
+    assert.equal(url.searchParams.get("netuid"), "7");
+  });
+
+  test("searchQueryUrl rejects invalid type and negative netuid", () => {
+    assert.throws(
+      () => searchQueryUrl({ type: "miner" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
   test("searchQueryUrl clamps a non-numeric limit to the default", () => {
     const url = searchQueryUrl({ limit: "lots" });
     assert.equal(url.searchParams.get("limit"), "50");
@@ -151,6 +172,29 @@ describe("search-mcp", () => {
     );
     assert.equal(out.returned, 1);
     assert.equal(out.documents[0].type, "provider");
+  });
+
+  test("loadSearchList filters by type and netuid", async () => {
+    const byType = await loadSearchList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { type: "subnet" },
+    );
+    assert.equal(byType.returned, 1);
+    assert.equal(byType.documents[0].type, "subnet");
+
+    const byNetuid = await loadSearchList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { netuid: 7 },
+    );
+    assert.equal(byNetuid.returned, 2);
+
+    const byBoth = await loadSearchList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { type: "surface", netuid: 7 },
+    );
+    assert.equal(byBoth.returned, 1);
+    assert.equal(byBoth.documents[0].type, "surface");
+    assert.equal(byBoth.documents[0].netuid, 7);
   });
 
   test("loadSearchList surfaces surface hits search_subnets would drop", async () => {
@@ -392,6 +436,9 @@ describe("search-mcp", () => {
       { sort: "title", order: "desc", limit: 1 },
       { sort: "netuid", order: "asc", limit: 2, cursor: 1 },
       { fields: "id,title", limit: 2 },
+      { type: "subnet" },
+      { type: "surface", netuid: 7 },
+      { netuid: 7 },
       {},
     ];
 


### PR DESCRIPTION
## Summary

- Add `type` (enum: subnet/surface/provider) and `netuid` (integer ≥0) to `list_search`'s `inputSchema.properties` in `src/search-mcp.ts`
- Wire both params through `searchQueryUrl()` so they reach `applyQueryFilters` via the `documents` collection config already in `API_QUERY_COLLECTIONS`
- Extend `tests/search-mcp.test.ts` with dedicated type+netuid validation tests and filter tests, plus parity coverage against the REST route

## Validation

- `npm run lint` — clean
- `npm run format:check` — clean
- `npx vitest run tests/search-mcp.test.ts` — 31/31 passed

Closes #7896