### PR TITLE
feat(mcp): add type/netuid filters to list_search_index (#7897)

### DIFF
--- a/src/search-index-mcp.ts
+++ b/src/search-index-mcp.ts
@@ -93,6 +93,21 @@ export function searchIndexQueryUrl(
     }
     url.searchParams.set("cursor", String(cursor));
   }
+  const type = optionalEnum(args, "type", ["subnet", "surface", "provider"]);
+  if (type) url.searchParams.set("type", type);
+  if (args?.netuid !== undefined) {
+    if (
+      typeof args.netuid !== "number" ||
+      !Number.isInteger(args.netuid) ||
+      (args.netuid as number) < 0
+    ) {
+      throw searchIndexMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
   return url;
 }
 
@@ -183,16 +198,26 @@ export const LIST_SEARCH_INDEX_MCP_TOOL = {
   description:
     "Fetch slim search-index documents from the registry: subnet/provider " +
     "entries with title, slug, kind, and netuid without the heavy per-document " +
-    "token blobs in search.json. Filter with q, sort with sort + order, project " +
-    "with fields, and page with limit (1-100) / cursor. Use semantic_search for " +
-    "meaning-based discovery or search_subnets for keyword subnet lookup. Mirrors " +
-    "GET /api/v1/search-index.",
+    "token blobs in search.json. Filter with q, type, netuid; sort with sort + " +
+    "order; project with fields; and page with limit (1-100) / cursor. Use " +
+    "semantic_search for meaning-based discovery or search_subnets for keyword " +
+    "subnet lookup. Mirrors GET /api/v1/search-index.",
   inputSchema: {
     type: "object",
     properties: {
       q: {
         type: "string",
         description: "Keyword search across title, subtitle, slug, and tokens.",
+      },
+      type: {
+        type: "string",
+        enum: ["subnet", "surface", "provider"],
+        description: "Filter by document type (subnet, surface, or provider).",
+      },
+      netuid: {
+        type: "integer",
+        description: "Filter by subnet netuid.",
+        minimum: 0,
       },
       sort: {
         type: "string",

--- a/tests/search-index-mcp.test.ts
+++ b/tests/search-index-mcp.test.ts
@@ -24,13 +24,23 @@ const SAMPLE_BLOB = {
   documents: [
     {
       id: "subnet-7",
+      type: "subnet",
       kind: "subnet",
       netuid: 7,
       slug: "sn-7",
       title: "Subnet Seven",
     },
     {
+      id: "surface-7-openapi",
+      type: "surface",
+      kind: "subnet-api",
+      netuid: 7,
+      slug: "sn-7-openapi",
+      title: "Seven OpenAPI",
+    },
+    {
       id: "provider-datura",
+      type: "provider",
       kind: "provider",
       slug: "datura",
       title: "Datura",
@@ -107,6 +117,27 @@ describe("search-index-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "id,title");
   });
 
+  test("searchIndexQueryUrl sets type and netuid params", () => {
+    const url = searchIndexQueryUrl({ type: "subnet", netuid: 7 });
+    assert.equal(url.searchParams.get("type"), "subnet");
+    assert.equal(url.searchParams.get("netuid"), "7");
+  });
+
+  test("searchIndexQueryUrl rejects invalid type and negative netuid", () => {
+    assert.throws(
+      () => searchIndexQueryUrl({ type: "miner" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchIndexQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => searchIndexQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
   test("searchIndexQueryUrl rejects a non-numeric limit", () => {
     assert.throws(
       () => searchIndexQueryUrl({ limit: "lots" }),
@@ -145,13 +176,36 @@ describe("search-index-mcp", () => {
     assert.equal(out.documents[0].netuid, 7);
   });
 
+  test("loadSearchIndexList filters by type and netuid", async () => {
+    const byType = await loadSearchIndexList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { type: "provider" },
+    );
+    assert.equal(byType.returned, 1);
+    assert.equal(byType.documents[0].type, "provider");
+
+    const byNetuid = await loadSearchIndexList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { netuid: 7 },
+    );
+    assert.equal(byNetuid.returned, 2);
+
+    const byBoth = await loadSearchIndexList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { type: "surface", netuid: 7 },
+    );
+    assert.equal(byBoth.returned, 1);
+    assert.equal(byBoth.documents[0].type, "surface");
+    assert.equal(byBoth.documents[0].netuid, 7);
+  });
+
   test("loadSearchIndexList sorts and pages the collection", async () => {
     const out = await loadSearchIndexList(
       { env: {}, readArtifact } as unknown as LoadCtx,
       { sort: "title", order: "desc", limit: 1 },
     );
     assert.equal(out.returned, 1);
-    assert.equal(out.total, 2);
+    assert.equal(out.total, 3);
     assert.equal(out.documents[0].slug, "sn-7");
     assert.equal(out.next_cursor, 1);
   });


### PR DESCRIPTION
## Summary

- Add `type` (enum: subnet/surface/provider) and `netuid` (integer ≥0) to `list_search_index`'s `inputSchema.properties` in `src/search-index-mcp.ts`
- Wire both params through `searchIndexQueryUrl()` so they reach `applyQueryFilters` via the `documents` collection config already in `API_QUERY_COLLECTIONS`
- Extend `tests/search-index-mcp.test.ts` with dedicated type+netuid validation and filter tests; updated SAMPLE_BLOB to include a surface document for filter coverage

## Validation

- `npm run lint` — clean
- `npx prettier --write` — no changes
- `npx vitest run tests/search-index-mcp.test.ts` — 27/27 passed

Closes #7897