### PR TITLE
test(ui): cover value-unit localStorage preference persistence

### DIFF
--- a/apps/ui/src/lib/metagraphed/value-unit.test.ts
+++ b/apps/ui/src/lib/metagraphed/value-unit.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readStoredValueUnit } from "./value-unit";
+
+const STORAGE_KEY = "mg:value-unit";
+
+describe("readStoredValueUnit", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns both during SSR when window is absent (first-load default)", () => {
+    expect(readStoredValueUnit()).toBe("both");
+  });
+
+  it("returns both when localStorage is empty", () => {
+    vi.stubGlobal("window", {
+      localStorage: { getItem: vi.fn(() => null) },
+    });
+    expect(readStoredValueUnit()).toBe("both");
+  });
+
+  it("restores a valid stored preference", () => {
+    for (const unit of ["tao", "usd", "both"] as const) {
+      vi.stubGlobal("window", {
+        localStorage: { getItem: vi.fn((k: string) => (k === STORAGE_KEY ? unit : null)) },
+      });
+      expect(readStoredValueUnit()).toBe(unit);
+    }
+  });
+
+  it("falls back to both for invalid/corrupt stored values", () => {
+    for (const raw of ["spacious", "TAO", "{bad", ""]) {
+      vi.stubGlobal("window", {
+        localStorage: { getItem: vi.fn(() => raw) },
+      });
+      expect(readStoredValueUnit()).toBe("both");
+    }
+  });
+
+  it("degrades to both when localStorage.getItem throws", () => {
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: vi.fn(() => {
+          throw new Error("localStorage is not available");
+        }),
+      },
+    });
+    expect(() => readStoredValueUnit()).not.toThrow();
+    expect(readStoredValueUnit()).toBe("both");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/value-unit.tsx
+++ b/apps/ui/src/lib/metagraphed/value-unit.tsx
@@ -13,6 +13,23 @@ interface Ctx {
 const ValueUnitContext = createContext<Ctx>({ unit: DEFAULT, setUnit: () => {} });
 
 /**
+ * Read the persisted τ/USD/Both preference. SSR-safe and corrupt-data-safe:
+ * missing window, blocked storage, or values outside the 3-way allowlist all
+ * fall back to DEFAULT without throwing.
+ */
+export function readStoredValueUnit(): ValueUnit {
+  if (typeof window === "undefined") return DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "tao" || raw === "usd" || raw === "both") return raw;
+    return DEFAULT;
+  } catch {
+    /* storage blocked — keep default */
+    return DEFAULT;
+  }
+}
+
+/**
  * Provides the τ/USD/Both display preference for money values on the current
  * page. SSR-safe: initial render uses the DEFAULT and rehydrates the persisted
  * choice from localStorage in an effect (so server/client HTML match).
@@ -21,12 +38,7 @@ export function ValueUnitProvider({ children }: { children: ReactNode }) {
   const [unit, setUnitState] = useState<ValueUnit>(DEFAULT);
 
   useEffect(() => {
-    try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
-      if (raw === "tao" || raw === "usd" || raw === "both") setUnitState(raw);
-    } catch {
-      /* storage blocked — keep default */
-    }
+    setUnitState(readStoredValueUnit());
   }, []);
 
   const setUnit = (u: ValueUnit) => {


### PR DESCRIPTION
## Summary
- Extract `readStoredValueUnit()` (same SSR/corrupt-safe pattern as `density.readChoice`) and use it from `ValueUnitProvider`'s rehydrate effect.
- Add tests for first-load default, valid stored preferences (`tao`/`usd`/`both`), invalid/corrupt values, and blocked `localStorage`.

Fixes #7911

## Test plan
- [x] `cd apps/ui && npx vitest run src/lib/metagraphed/value-unit.test.ts`


Made with [Cursor](https://cursor.com)