### PR TITLE
feat(api): add full REST filter parity to GraphQL rpc_endpoints

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -45,6 +45,10 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.ts";
 // same loadProviderEndpointsList that MCP list_provider_endpoints already calls
 // (#3289) -- not a reimplementation.
 import { loadProviderEndpointsList } from "./provider-endpoints-mcp.ts";
+// #7886: GraphQL parity for GET /api/v1/rpc/endpoints filters — reuse
+// loadRpcEndpointsList (live overlay + applyQueryFilters on the endpoints
+// collection), matching endpoint_pools / rpc_pools / provider_endpoints.
+import { loadRpcEndpointsList } from "./rpc-endpoints-mcp.ts";
 // #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
 // and page logic REST and MCP already use) -- not a reimplementation.
@@ -173,7 +177,6 @@ import {
   LEADERBOARD_BOARDS,
   loadSubnetTrajectory,
   mergeFreshness,
-  mergeRpcEndpoints,
   overlayOverviewHealth,
   loadSubnetReliability,
   overlayCatalogDetail,
@@ -340,7 +343,7 @@ import {
   buildCounterparties,
   buildCounterpartyRelationship,
 } from "./counterparties.ts";
-import { KV_HEALTH_META, KV_HEALTH_RPC_POOL } from "./kv-keys.ts";
+import { KV_HEALTH_META } from "./kv-keys.ts";
 import {
   ANALYTICS_WINDOWS,
   DEFAULT_ANALYTICS_WINDOW,
@@ -642,8 +645,8 @@ export const SDL = `
     source_health: JSON
     "The maintainer-approved cross-network subnet lineage: which testnet subnets have graduated to mainnet (mainnet <-> testnet pairs with match evidence), plus any flagged broken links. Null when the lineage has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_lineage MCP/REST shape. Mirrors GET /api/v1/lineage."
     lineage: JSON
-    "The full catalog of monitored Bittensor base-layer RPC endpoints and their status (each endpoint's URL, network, and probe-derived health/latency), with the same live 15-minute cron RPC-pool overlay REST and MCP apply before serving. Null when the catalog has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the list_rpc_endpoints MCP/REST shape. Mirrors GET /api/v1/rpc/endpoints."
-    rpc_endpoints: JSON
+    "The full catalog of monitored Bittensor base-layer RPC endpoints and their status (each endpoint's URL, network, and probe-derived health/latency), with the same live 15-minute cron RPC-pool overlay REST and MCP apply before serving. Filter by kind/layer/netuid/pool_eligible/provider/publication_state/status, threshold with min_/max_latency_ms and min_/max_score, project with fields, sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default; a cold/absent catalog is likewise a GraphQL error (matching endpoint_pools / rpc_pools). Opaque JSON passed through verbatim, matching the list_rpc_endpoints MCP/REST shape. Mirrors GET /api/v1/rpc/endpoints."
+    rpc_endpoints(kind: String, layer: String, netuid: Int, pool_eligible: Boolean, provider: String, publication_state: String, status: String, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, fields: [String!], limit: Int, cursor: String, sort: String, order: String): JSON
     "The latest generated registry changelog: artifact added/modified/removed rows, subnet added/removed/renamed events, and coverage deltas since the previous publish. Resolves to a GraphQL error (not null) when the changelog artifact has not been baked in this environment, matching the REST route's 404 and the get_changelog MCP tool. Mirrors GET /api/v1/changelog."
     changelog: Changelog
     "The registry's public artifact contract metadata: every baked artifact path, storage tier, schema reference, and consumer notes. Resolves to a GraphQL error (not null) when the contracts artifact has not been baked in this environment, matching the REST route's 404 and the get_contracts MCP tool. Mirrors GET /api/v1/contracts."
@@ -6301,18 +6304,16 @@ const rootValue = {
     return loadArtifact(context, "/metagraph/lineage.json");
   },
 
-  async rpc_endpoints(_args, context) {
-    // Same baked catalog the REST route + list_rpc_endpoints MCP tool read,
-    // with the same live overlay: the 15-minute cron RPC-pool KV snapshot
-    // replaces the stale build-time health/latency (mergeRpcEndpoints). With no
-    // live snapshot the static catalog passes through; a cold artifact degrades
-    // to null instead of erroring, matching the other artifact-backed resolvers.
-    const staticData = await loadArtifact(
-      context,
-      "/metagraph/rpc-endpoints.json",
-    );
-    const pool = await readHealthKv(context.env, KV_HEALTH_RPC_POOL);
-    return pool ? mergeRpcEndpoints(staticData, pool) : staticData;
+  async rpc_endpoints(args, context) {
+    // #7886: reuse loadRpcEndpointsList — same live 15-minute cron overlay +
+    // endpoints-collection list-query transforms REST applies. The loader
+    // validates its own args and throws on an invalid filter/sort or a cold
+    // artifact; that throw becomes a GraphQL error, matching endpoint_pools /
+    // rpc_pools' "an unsupported filter/sort is a GraphQL error, not a
+    // silently substituted default" convention.
+    return loadRpcEndpointsList({ ...context, readHealthKv }, args, {
+      readArtifact,
+    });
   },
 
   // #7170: reuse get_changelog's/get_contracts's own loaders unchanged (the same

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -1,0 +1,295 @@
+// RPC endpoint catalog loader for GraphQL/REST parity on GET /api/v1/rpc/endpoints.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/rpc-endpoints.json artifact, after the live 15-minute cron overlay
+// (mergeRpcEndpoints) — same order REST's liveHealthOverlay -> applyQueryFilters
+// pipeline uses. Structurally mirrors provider-endpoints-mcp.ts (endpoints
+// collection filters) and rpc-pools-mcp.ts (live overlay before filter).
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
+import { mergeRpcEndpoints } from "./health-serving.ts";
+
+export const RPC_ENDPOINTS_ARTIFACT = "/metagraph/rpc-endpoints.json";
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+
+export interface RpcEndpointsMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function rpcEndpointsMcpError(
+  code: string,
+  message: string,
+): RpcEndpointsMcpError {
+  const error = new Error(message) as RpcEndpointsMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalRangeBound(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): number | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+function resolveFieldsProjection(
+  args: Record<string, unknown> | null | undefined,
+): string | null {
+  const value = args?.fields;
+  if (value === undefined || value === null || value === "") return null;
+  if (Array.isArray(value)) {
+    const parts = value
+      .filter((part): part is string => typeof part === "string")
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (parts.length === 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "Argument `fields` must be a non-empty list of field names when provided.",
+      );
+    }
+    return parts.join(",");
+  }
+  return optionalString(args, "fields");
+}
+
+function resolveCursor(
+  args: Record<string, unknown> | null | undefined,
+): number | null {
+  const value = args?.cursor;
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value === "string") {
+    if (!/^\d+$/.test(value.trim())) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    return Number(value.trim());
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      "cursor must be a non-negative integer.",
+    );
+  }
+  return value;
+}
+
+export function rpcEndpointsQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/rpc-endpoints");
+  if (args?.netuid !== undefined) {
+    const netuid = args.netuid;
+    if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  if (args?.pool_eligible !== undefined && args?.pool_eligible !== null) {
+    if (typeof args.pool_eligible !== "boolean") {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "pool_eligible must be a boolean when provided.",
+      );
+    }
+    url.searchParams.set("pool_eligible", String(args.pool_eligible));
+  }
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = resolveFieldsProjection(args);
+  if (fields) url.searchParams.set("fields", fields);
+  const minLatency = optionalRangeBound(args, "min_latency_ms");
+  if (minLatency !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatency));
+  }
+  const maxLatency = optionalRangeBound(args, "max_latency_ms");
+  if (maxLatency !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatency));
+  }
+  const minScore = optionalRangeBound(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalRangeBound(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 1000)));
+  }
+  const cursor = resolveCursor(args);
+  if (cursor !== null) url.searchParams.set("cursor", String(cursor));
+  return url;
+}
+
+export interface RpcEndpointsListResult {
+  generated_at: unknown;
+  notes: unknown;
+  schema_version: unknown;
+  summary: unknown;
+  source: unknown;
+  operational_observed_at: unknown;
+  endpoints: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+type RpcEndpointsCtx = {
+  env: Env;
+  readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  readHealthKv?: (
+    env: Env,
+    key: string,
+  ) => Promise<Record<string, unknown> | null>;
+};
+
+export async function loadRpcEndpointsList(
+  ctx: RpcEndpointsCtx,
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<RpcEndpointsListResult> {
+  const queryUrl = rpcEndpointsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, RPC_ENDPOINTS_ARTIFACT);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw rpcEndpointsMcpError(
+        "not_found",
+        "RPC endpoints catalog snapshot unavailable.",
+      );
+    }
+    throw rpcEndpointsMcpError(
+      code,
+      `Could not load ${RPC_ENDPOINTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw rpcEndpointsMcpError(
+      "not_found",
+      "RPC endpoints catalog snapshot unavailable.",
+    );
+  }
+
+  // Live overlay matching GraphQL/REST: with no live snapshot the static
+  // catalog passes through; with a snapshot, mergeRpcEndpoints replaces
+  // stale build-time health/latency before filters run.
+  let overlaid = blob as Record<string, unknown>;
+  const livePool = ctx.readHealthKv
+    ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+    : null;
+  if (livePool) {
+    const merged = mergeRpcEndpoints(overlaid, livePool);
+    if (merged) overlaid = merged as Record<string, unknown>;
+  }
+
+  const transformed = applyQueryFilters(overlaid, queryUrl, "endpoints", []);
+  if (transformed.error) {
+    throw rpcEndpointsMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = (transformed.meta ?? {}) as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.endpoints) ? (data.endpoints as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    schema_version: data.schema_version ?? null,
+    summary: data.summary ?? null,
+    source: data.source ?? null,
+    operational_observed_at: data.operational_observed_at ?? null,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7945,9 +7945,11 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
 
 // #7168: GraphQL parity for the registry-summary / source-health / lineage /
 // rpc-endpoints REST routes, each reusing the same baked artifact its MCP tool
+// GraphQL parity for the four "catalog snapshot" fields that MCP
 // (registry_summary / get_source_health / get_lineage / list_rpc_endpoints)
-// reads -- a cold artifact degrades to null (schema-stable), never a GraphQL
-// error, matching agent_resources and the other artifact-backed resolvers.
+// reads -- registry_summary / source_health / lineage degrade to null on a
+// cold artifact; rpc_endpoints (#7886) now errors like endpoint_pools when
+// the catalog is missing (filter loader path).
 describe("graphql — registry_summary / source_health / lineage / rpc_endpoints (#7168)", () => {
   test("registry_summary resolves the baked summary artifact", async () => {
     const env = fixtureEnv({
@@ -8001,15 +8003,46 @@ describe("graphql — registry_summary / source_health / lineage / rpc_endpoints
         id: "finney-wss",
         url: "wss://entrypoint-finney.opentensor.ai",
         network: "finney",
+        kind: "subtensor-wss",
+        layer: "bittensor-base",
+        provider: "opentensor",
+        publication_state: "monitored",
         status: "degraded",
+        latency_ms: 200,
+        score: 40,
+        pool_eligible: true,
+        netuid: 0,
         archive_support: false,
       },
       {
         id: "subvortex",
         url: "wss://subvortex.example",
         network: "finney",
+        kind: "subtensor-wss",
+        layer: "bittensor-base",
+        provider: "subvortex",
+        publication_state: "monitored",
         status: "degraded",
+        latency_ms: 80,
+        score: 70,
+        pool_eligible: false,
+        netuid: 0,
         archive_support: true,
+      },
+      {
+        id: "finney-rpc",
+        url: "https://entrypoint-finney.opentensor.ai",
+        network: "finney",
+        kind: "subtensor-rpc",
+        layer: "bittensor-base",
+        provider: "opentensor",
+        publication_state: "pool-eligible",
+        status: "ok",
+        latency_ms: 50,
+        score: 90,
+        pool_eligible: true,
+        netuid: 0,
+        archive_support: false,
       },
     ],
   };
@@ -8021,10 +8054,10 @@ describe("graphql — registry_summary / source_health / lineage / rpc_endpoints
     const { status, body } = await gql("{ rpc_endpoints }", env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.rpc_endpoints.endpoints.length, 2);
+    assert.equal(body.data.rpc_endpoints.endpoints.length, 3);
     assert.equal(body.data.rpc_endpoints.endpoints[0].id, "finney-wss");
     // No live snapshot -> the static catalog passes through unchanged.
-    assert.equal(body.data.rpc_endpoints.source, undefined);
+    assert.equal(body.data.rpc_endpoints.source, null);
   });
 
   test("rpc_endpoints applies the live 15-minute RPC-pool overlay", async () => {
@@ -8059,18 +8092,46 @@ describe("graphql — registry_summary / source_health / lineage / rpc_endpoints
     assert.equal(overlaid.health_source, "probe-derived");
   });
 
-  test("each field degrades to null on a cold artifact, never a GraphQL error", async () => {
-    for (const field of [
-      "registry_summary",
-      "source_health",
-      "lineage",
-      "rpc_endpoints",
-    ]) {
+  test("rpc_endpoints combines filters and sort/order (#7886)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/rpc-endpoints.json": RPC_ENDPOINTS_BLOB,
+    });
+    const { status, body } = await gql(
+      `{ rpc_endpoints(
+          kind: "subtensor-wss",
+          provider: "opentensor",
+          pool_eligible: true,
+          sort: "latency_ms",
+          order: "asc"
+        ) }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.rpc_endpoints.total, 1);
+    assert.equal(body.data.rpc_endpoints.endpoints.length, 1);
+    assert.equal(body.data.rpc_endpoints.endpoints[0].id, "finney-wss");
+    assert.equal(body.data.rpc_endpoints.sort, "latency_ms");
+    assert.equal(body.data.rpc_endpoints.order, "asc");
+  });
+
+  test("rpc_endpoints an unsupported sort is a GraphQL error (#7886)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/rpc-endpoints.json": RPC_ENDPOINTS_BLOB,
+    });
+    const { body } = await gql('{ rpc_endpoints(sort: "bogus") }', env);
+    assert.ok(body.errors, "expected a GraphQL error");
+  });
+
+  test("registry_summary / source_health / lineage degrade to null on a cold artifact; rpc_endpoints errors like endpoint_pools", async () => {
+    for (const field of ["registry_summary", "source_health", "lineage"]) {
       const { status, body } = await gql(`{ ${field} }`);
       assert.equal(status, 200, `${field} should not error`);
       assert.equal(body.errors, undefined, `${field} should not error`);
       assert.equal(body.data[field], null, `${field} should degrade to null`);
     }
+    const { body: rpcBody } = await gql("{ rpc_endpoints }");
+    assert.ok(rpcBody.errors, "rpc_endpoints cold catalog is a GraphQL error");
   });
 
   test("FIELD_COMPLEXITY weights all four new fields like their sibling relationship fields", () => {

--- a/tests/rpc-endpoints-mcp.test.ts
+++ b/tests/rpc-endpoints-mcp.test.ts
@@ -1,0 +1,356 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  RPC_ENDPOINTS_ARTIFACT,
+  loadRpcEndpointsList,
+  rpcEndpointsMcpError,
+  rpcEndpointsQueryUrl,
+} from "../src/rpc-endpoints-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type Ctx = Parameters<typeof loadRpcEndpointsList>[0];
+type Deps = Parameters<typeof loadRpcEndpointsList>[2];
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  notes: "test",
+  summary: { endpoint_count: 3 },
+  endpoints: [
+    {
+      id: "finney-wss",
+      kind: "subtensor-wss",
+      layer: "bittensor-base",
+      provider: "opentensor",
+      publication_state: "monitored",
+      status: "degraded",
+      latency_ms: 200,
+      score: 40,
+      pool_eligible: true,
+      netuid: 0,
+    },
+    {
+      id: "subvortex",
+      kind: "subtensor-wss",
+      layer: "bittensor-base",
+      provider: "subvortex",
+      publication_state: "monitored",
+      status: "ok",
+      latency_ms: 80,
+      score: 70,
+      pool_eligible: false,
+      netuid: 0,
+    },
+    {
+      id: "finney-rpc",
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      provider: "opentensor",
+      publication_state: "pool-eligible",
+      status: "ok",
+      latency_ms: 50,
+      score: 90,
+      pool_eligible: true,
+      netuid: 0,
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === RPC_ENDPOINTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("rpc-endpoints-mcp (#7886)", () => {
+  test("rpcEndpointsMcpError is shaped for toolError handling", () => {
+    const err = rpcEndpointsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("rpcEndpointsQueryUrl forwards the full REST filter set", () => {
+    const url = rpcEndpointsQueryUrl({
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      netuid: 0,
+      pool_eligible: true,
+      provider: "opentensor",
+      publication_state: "monitored",
+      status: "ok",
+      min_latency_ms: 10,
+      max_latency_ms: 100,
+      min_score: 50,
+      max_score: 100,
+      fields: ["id", "latency_ms"],
+      sort: "latency_ms",
+      order: "asc",
+      limit: 10,
+      cursor: "0",
+    });
+    assert.equal(url.searchParams.get("kind"), "subtensor-rpc");
+    assert.equal(url.searchParams.get("layer"), "bittensor-base");
+    assert.equal(url.searchParams.get("netuid"), "0");
+    assert.equal(url.searchParams.get("pool_eligible"), "true");
+    assert.equal(url.searchParams.get("provider"), "opentensor");
+    assert.equal(url.searchParams.get("publication_state"), "monitored");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("min_latency_ms"), "10");
+    assert.equal(url.searchParams.get("max_latency_ms"), "100");
+    assert.equal(url.searchParams.get("min_score"), "50");
+    assert.equal(url.searchParams.get("max_score"), "100");
+    assert.equal(url.searchParams.get("fields"), "id,latency_ms");
+    assert.equal(url.searchParams.get("sort"), "latency_ms");
+    assert.equal(url.searchParams.get("order"), "asc");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "0");
+  });
+
+  test("rpcEndpointsQueryUrl accepts a string fields projection and numeric cursor", () => {
+    const url = rpcEndpointsQueryUrl({
+      fields: " id,score ",
+      cursor: 5,
+      limit: 2000,
+    });
+    assert.equal(url.searchParams.get("fields"), "id,score");
+    assert.equal(url.searchParams.get("cursor"), "5");
+    assert.equal(url.searchParams.get("limit"), "1000");
+  });
+
+  test("rpcEndpointsQueryUrl clamps a non-positive limit to the default", () => {
+    const url = rpcEndpointsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+    const nanUrl = rpcEndpointsQueryUrl({ limit: Number.NaN });
+    assert.equal(nanUrl.searchParams.get("limit"), "50");
+    const strUrl = rpcEndpointsQueryUrl({ limit: "lots" });
+    assert.equal(strUrl.searchParams.get("limit"), "50");
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid inputs", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ sort: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ pool_eligible: "yes" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ fields: [] }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ fields: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: "abc" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ provider: 12 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ min_latency_ms: "slow" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList combines filters and sorts", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as Ctx,
+      {
+        kind: "subtensor-wss",
+        provider: "opentensor",
+        pool_eligible: true,
+        sort: "latency_ms",
+        order: "asc",
+      },
+    );
+    assert.equal(out.total, 1);
+    assert.equal(out.endpoints[0].id, "finney-wss");
+    assert.equal(out.sort, "latency_ms");
+    assert.equal(out.order, "asc");
+  });
+
+  test("loadRpcEndpointsList applies the live overlay before filtering", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({
+          last_run_at: "2026-07-20T12:00:00.000Z",
+          endpoints: [
+            {
+              id: "finney-wss",
+              status: "ok",
+              classification: "live",
+              latency_ms: 42,
+            },
+          ],
+        }),
+      } as unknown as Ctx,
+      { max_latency_ms: 50 },
+    );
+    assert.equal(out.source, "live-cron-prober");
+    const overlaid = out.endpoints.find((e) => e.id === "finney-wss");
+    assert.ok(overlaid);
+    assert.equal(overlaid.latency_ms, 42);
+    assert.ok(out.endpoints.every((e) => (e.latency_ms as number) <= 50));
+  });
+
+  test("loadRpcEndpointsList keeps static catalog when live merge cannot apply", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({ endpoints: "nope" }),
+      } as unknown as Ctx,
+      {},
+    );
+    assert.equal(out.source, null);
+    assert.equal(out.endpoints.length, 3);
+  });
+
+  test("loadRpcEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as Ctx,
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ id: "injected", netuid: 0 }] },
+        }),
+      } as unknown as Deps,
+    );
+    assert.equal(out.endpoints[0].id, "injected");
+  });
+
+  test("loadRpcEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as Ctx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as Ctx,
+          {},
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /rpc-endpoints\.json/.test(err.message),
+    );
+  });
+
+  test("loadRpcEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as Ctx,
+          {},
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadRpcEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as Ctx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList({ env: {}, readArtifact } as unknown as Ctx, {
+          fields: "not_a_column",
+        }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: {
+        endpoints: [{ id: "a" }, { id: "b" }],
+      },
+      meta: undefined,
+    });
+    try {
+      const out = await loadRpcEndpointsList(
+        { env: {}, readArtifact } as unknown as Ctx,
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadRpcEndpointsList treats a non-array endpoints key as empty", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: null },
+        }),
+      } as unknown as Ctx,
+      {},
+    );
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/rpc-endpoints-mcp.ts` loader: live RPC-pool overlay then `applyQueryFilters` on the `endpoints` collection (same path REST uses).
- Wire GraphQL `rpc_endpoints` with the full REST filter/sort/page argument set; invalid filters and a cold catalog surface as GraphQL errors (matching `endpoint_pools` / `rpc_pools`).
- Cover combined filters + sort/order in GraphQL tests, plus loader unit tests.

Closes #7886

## Test plan
- [x] `npx vitest run tests/rpc-endpoints-mcp.test.ts`
- [x] `npx vitest run tests/graphql.test.mjs -t rpc_endpoints`
- [x] Private-boundary validation passed
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)