### PR TITLE
feat(mcp): add REST-parity filters to list_rpc_endpoints

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -181,6 +181,12 @@ import {
   loadRpcPoolsList,
 } from "./rpc-pools-mcp.ts";
 import {
+  LIST_RPC_ENDPOINTS_INSTRUCTIONS,
+  LIST_RPC_ENDPOINTS_MCP_TOOL,
+  LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
+  loadRpcEndpointsList,
+} from "./rpc-endpoints-mcp.ts";
+import {
   LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS,
   LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
   LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
@@ -425,7 +431,6 @@ import {
   loadSubnetReliability,
   loadSubnetTrajectory,
   mergeFreshness,
-  mergeRpcEndpoints,
   overlayArtifactEndpoints,
   overlayCatalogDetail,
   overlayCatalogIndex,
@@ -997,8 +1002,7 @@ export const MCP_INSTRUCTIONS =
   "unpromoted candidate surfaces still pending review, list_endpoints the " +
   "network-wide monitored endpoint-resource catalog, " +
   LIST_EVIDENCE_INSTRUCTIONS +
-  "list_rpc_endpoints the monitored " +
-  "Bittensor RPC endpoint catalog, " +
+  LIST_RPC_ENDPOINTS_INSTRUCTIONS +
   LIST_SOURCE_SNAPSHOTS_INSTRUCTIONS +
   "list_rpc_pools the load-balanced RPC pool " +
   "scores, " +
@@ -9732,30 +9736,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_rpc_endpoints",
-    title: "List Bittensor RPC endpoints",
-    description:
-      "Fetch the catalog of monitored Bittensor base-layer RPC endpoints and " +
-      "their status (each endpoint's URL, network, and probe-derived " +
-      "health/latency). This is the full-catalog view; use get_best_rpc_endpoint " +
-      "instead to pick one live-healthy endpoint. Mirrors GET /api/v1/rpc/endpoints.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args, ctx) {
-      const staticData = await loadArtifactData(
-        ctx,
-        "/metagraph/rpc-endpoints.json",
-      );
-      // Live overlay (mirrors workers/api.mjs's rpc-endpoints raw-artifact
-      // route): the build-time snapshot bakes stale health/latency, replace
-      // it from the 15-minute cron RPC-pool KV snapshot.
-      const pool = ctx.readHealthKv
-        ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
-        : null;
-      return pool ? mergeRpcEndpoints(staticData, pool) : staticData;
+    ...LIST_RPC_ENDPOINTS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadRpcEndpointsList(ctx, args);
     },
   },
   {
@@ -15382,16 +15365,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
   list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
-  list_rpc_endpoints: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      endpoints: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_rpc_endpoints: LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
   list_evidence: LIST_EVIDENCE_OUTPUT_SCHEMA,
   list_fixtures: {
     type: "object",

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -1,0 +1,384 @@
+// RPC endpoint list loader for MCP parity on GET /api/v1/rpc/endpoints (#7893).
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/rpc-endpoints.json artifact, after the live 15-minute cron
+// overlay (mergeRpcEndpoints) — same order REST's liveHealthOverlay ->
+// applyQueryFilters pipeline uses (workers/api.ts's "rpc-endpoints" case),
+// so a filter like status or the latency_ms/score bounds reads live values,
+// not the baked ones. Reuses the "endpoints" collection: GET /api/v1/rpc/
+// endpoints and list_endpoints both mirror the same generalized endpoint
+// catalog shape (src/contracts.ts), just scoped to base-layer RPC rows here.
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
+import { mergeRpcEndpoints } from "./health-serving.ts";
+
+export const RPC_ENDPOINTS_ARTIFACT = "/metagraph/rpc-endpoints.json";
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+
+export interface RpcEndpointsMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function rpcEndpointsMcpError(
+  code: string,
+  message: string,
+): RpcEndpointsMcpError {
+  const error = new Error(message) as RpcEndpointsMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalRangeBound(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): number | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+export function rpcEndpointsQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/rpc-endpoints");
+  if (args?.netuid !== undefined) {
+    const netuid = args.netuid;
+    if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  if (args?.pool_eligible !== undefined) {
+    if (typeof args.pool_eligible !== "boolean") {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "pool_eligible must be a boolean when provided.",
+      );
+    }
+    url.searchParams.set("pool_eligible", String(args.pool_eligible));
+  }
+  const minLatency = optionalRangeBound(args, "min_latency_ms");
+  if (minLatency !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatency));
+  }
+  const maxLatency = optionalRangeBound(args, "max_latency_ms");
+  if (maxLatency !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatency));
+  }
+  const minScore = optionalRangeBound(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalRangeBound(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    const limit = args.limit;
+    if (
+      typeof limit !== "number" ||
+      !Number.isInteger(limit) ||
+      limit < 1 ||
+      limit > 100
+    ) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(limit));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+interface RpcEndpointsMcpCtx {
+  env: Env;
+  readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  readHealthKv?: (
+    env: Env,
+    key: string,
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+export interface RpcEndpointsListResult {
+  generated_at: unknown;
+  notes: unknown;
+  endpoints: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadRpcEndpointsList(
+  ctx: RpcEndpointsMcpCtx,
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<RpcEndpointsListResult> {
+  const queryUrl = rpcEndpointsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, RPC_ENDPOINTS_ARTIFACT);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw rpcEndpointsMcpError(
+        "not_found",
+        "RPC endpoint snapshot unavailable.",
+      );
+    }
+    throw rpcEndpointsMcpError(
+      code,
+      `Could not load ${RPC_ENDPOINTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw rpcEndpointsMcpError(
+      "not_found",
+      "RPC endpoint snapshot unavailable.",
+    );
+  }
+
+  // Live 15-minute cron overlay, matching REST's liveHealthOverlay for the
+  // "rpc-endpoints" route id — applied before filtering so status/pool_
+  // eligible filters and the latency_ms/score bounds read live values, not
+  // the baked ones. mergeRpcEndpoints returns null when either side is
+  // malformed/absent; fall back to the static snapshot in that case, same
+  // as the prior inline handler.
+  let overlaid = blob as Row;
+  const pool = ctx.readHealthKv
+    ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+    : null;
+  if (pool) {
+    overlaid = mergeRpcEndpoints(overlaid, pool as Row) ?? overlaid;
+  }
+  if (!Array.isArray(overlaid.endpoints)) {
+    overlaid = { ...overlaid, endpoints: [] };
+  }
+
+  const transformed = applyQueryFilters(overlaid, queryUrl, "endpoints", []);
+  if (transformed.error) {
+    throw rpcEndpointsMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = transformed.meta as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.endpoints) ? (data.endpoints as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_RPC_ENDPOINTS_INSTRUCTIONS =
+  "list_rpc_endpoints the monitored Bittensor RPC endpoint catalog " +
+  "(filterable; mirrors GET /api/v1/rpc/endpoints), ";
+
+export const LIST_RPC_ENDPOINTS_MCP_TOOL = {
+  name: "list_rpc_endpoints",
+  title: "List Bittensor RPC endpoints",
+  description:
+    "Fetch the catalog of monitored Bittensor base-layer RPC endpoints and " +
+    "their status: each endpoint's URL, network, kind/layer, provider, " +
+    "publication state, and probe-derived status/latency/score. Filter by " +
+    "kind/layer/netuid/provider/publication_state/status/pool_eligible, " +
+    "threshold with min_/max_latency_ms and min_/max_score, sort with sort " +
+    "+ order, project with fields, and page with limit (1-100) / cursor. " +
+    "This is the full-catalog view; use get_best_rpc_endpoint instead to " +
+    "pick one live-healthy endpoint. Mirrors GET /api/v1/rpc/endpoints.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Surface kind, e.g. 'subtensor-rpc'.",
+      },
+      layer: {
+        type: "string",
+        enum: ENDPOINT_LAYERS,
+        description: "Endpoint layer, e.g. 'bittensor-base'.",
+      },
+      netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      provider: {
+        type: "string",
+        description: "Provider slug, e.g. 'opentensor'.",
+      },
+      publication_state: {
+        type: "string",
+        enum: PUBLICATION_STATES,
+        description: "Publication state, e.g. 'monitored' or 'pool-eligible'.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Probe-derived health status, e.g. 'ok' or 'degraded'.",
+      },
+      pool_eligible: {
+        type: "boolean",
+        description: "Only endpoints eligible (or not) for RPC pooling.",
+      },
+      min_latency_ms: {
+        type: "number",
+        description: "Keep endpoints with latency_ms >= this bound.",
+      },
+      max_latency_ms: {
+        type: "number",
+        description: "Keep endpoints with latency_ms <= this bound.",
+      },
+      min_score: {
+        type: "number",
+        description: "Keep endpoints with score >= this bound.",
+      },
+      max_score: {
+        type: "number",
+        description: "Keep endpoints with score <= this bound.",
+      },
+      sort: {
+        type: "string",
+        enum: ENDPOINT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of endpoint row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["endpoints"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    endpoints: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -15809,8 +15809,75 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_rpc_endpoints rejects an unexpected argument", async () => {
-    const res = await callTool("list_rpc_endpoints", { netuid: 7 });
+    const res = await callTool("list_rpc_endpoints", { bogus: 1 });
     assert.equal(res.body.result.isError, true);
+  });
+
+  test("list_rpc_endpoints filters by kind/netuid/status and sorts by netuid", async () => {
+    const deps = makeDeps({
+      "/metagraph/rpc-endpoints.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        endpoints: [
+          {
+            netuid: 0,
+            kind: "subtensor-rpc",
+            status: "ok",
+            url: "https://rpc-a.example",
+          },
+          {
+            netuid: 0,
+            kind: "subtensor-wss",
+            status: "degraded",
+            url: "wss://rpc-b.example",
+          },
+        ],
+      },
+    });
+    const byKind = (
+      await callTool("list_rpc_endpoints", { kind: "subtensor-wss" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byKind.returned, 1);
+    assert.equal(byKind.endpoints[0].url, "wss://rpc-b.example");
+
+    const byStatus = (
+      await callTool("list_rpc_endpoints", { status: "ok" }, { deps })
+    ).body.result.structuredContent;
+    assert.equal(byStatus.returned, 1);
+    assert.equal(byStatus.endpoints[0].url, "https://rpc-a.example");
+
+    const sorted = (
+      await callTool(
+        "list_rpc_endpoints",
+        { sort: "kind", order: "desc" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(
+      sorted.endpoints.map((e) => e.kind),
+      ["subtensor-wss", "subtensor-rpc"],
+    );
+  });
+
+  test("list_rpc_endpoints rejects an unknown kind/sort value", async () => {
+    const deps = makeDeps({
+      "/metagraph/rpc-endpoints.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        endpoints: [],
+      },
+    });
+    const badKind = await callTool(
+      "list_rpc_endpoints",
+      { kind: "not-a-kind" },
+      { deps },
+    );
+    assert.equal(badKind.body.result.isError, true);
+
+    const badSort = await callTool(
+      "list_rpc_endpoints",
+      { sort: "not-a-field" },
+      { deps },
+    );
+    assert.equal(badSort.body.result.isError, true);
   });
 
   test("list_source_snapshots returns filtered source rows", async () => {

--- a/tests/rpc-endpoints-mcp.test.ts
+++ b/tests/rpc-endpoints-mcp.test.ts
@@ -1,0 +1,450 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  RPC_ENDPOINTS_ARTIFACT,
+  LIST_RPC_ENDPOINTS_MCP_TOOL,
+  LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
+  rpcEndpointsMcpError,
+  rpcEndpointsQueryUrl,
+  loadRpcEndpointsList,
+} from "../src/rpc-endpoints-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type LoadCtx = Parameters<typeof loadRpcEndpointsList>[0];
+type LoadDeps = Parameters<typeof loadRpcEndpointsList>[2];
+
+import { MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  endpoints: [
+    {
+      id: "a",
+      netuid: 0,
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      provider: "opentensor",
+      publication_state: "monitored",
+      status: "ok",
+      pool_eligible: true,
+      latency_ms: 50,
+      score: 0.9,
+    },
+    {
+      id: "b",
+      netuid: 0,
+      kind: "subtensor-wss",
+      layer: "bittensor-base",
+      provider: "onfinality",
+      publication_state: "pool-eligible",
+      status: "degraded",
+      pool_eligible: false,
+      latency_ms: 400,
+      score: 0.4,
+    },
+    {
+      id: "c",
+      netuid: 0,
+      kind: "archive",
+      layer: "bittensor-base",
+      provider: "opentensor",
+      publication_state: "monitored",
+      status: "ok",
+      pool_eligible: true,
+      latency_ms: 900,
+      score: 0.1,
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === RPC_ENDPOINTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("rpc-endpoints-mcp", () => {
+  test("rpcEndpointsMcpError is shaped for MCP toolError handling", () => {
+    const err = rpcEndpointsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("rpcEndpointsQueryUrl validates filters, range bounds, and cursor", () => {
+    const url = rpcEndpointsQueryUrl({
+      netuid: 7,
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      provider: "opentensor",
+      publication_state: "monitored",
+      status: "ok",
+      pool_eligible: true,
+      min_latency_ms: 10,
+      max_latency_ms: 500,
+      min_score: 0.1,
+      max_score: 0.9,
+      sort: "netuid",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("kind"), "subtensor-rpc");
+    assert.equal(url.searchParams.get("layer"), "bittensor-base");
+    assert.equal(url.searchParams.get("provider"), "opentensor");
+    assert.equal(url.searchParams.get("publication_state"), "monitored");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("pool_eligible"), "true");
+    assert.equal(url.searchParams.get("min_latency_ms"), "10");
+    assert.equal(url.searchParams.get("max_latency_ms"), "500");
+    assert.equal(url.searchParams.get("min_score"), "0.1");
+    assert.equal(url.searchParams.get("max_score"), "0.9");
+    assert.equal(url.searchParams.get("sort"), "netuid");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid kind/layer/publication_state/status", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ layer: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ publication_state: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ status: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a non-boolean pool_eligible", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ pool_eligible: "yes" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects non-string provider", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ provider: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects non-numeric range bounds", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ min_latency_ms: "lots" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ max_score: "lots" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid sort/order", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ sort: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ sort: "netuid", order: "sideways" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects empty/non-string fields", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ fields: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ fields: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl trims and forwards a fields projection", () => {
+    const url = rpcEndpointsQueryUrl({ fields: " id,kind " });
+    assert.equal(url.searchParams.get("fields"), "id,kind");
+  });
+
+  test("rpcEndpointsQueryUrl rejects a non-numeric/sub-minimum/over-maximum limit", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ limit: "lots" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ limit: 0 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ limit: 500 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a negative/non-integer cursor", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList returns filtered rows with pagination meta", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { kind: "subtensor-wss" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].id, "b");
+  });
+
+  test("loadRpcEndpointsList applies range filters", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { min_score: 0.4 },
+    );
+    assert.equal(out.returned, 2);
+    assert.deepEqual(
+      out.endpoints.map((e) => e.id),
+      ["a", "b"],
+    );
+  });
+
+  test("loadRpcEndpointsList sorts and pages the collection", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { sort: "score", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.endpoints[0].id, "a");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadRpcEndpointsList applies the live health overlay before filtering", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({
+          last_run_at: "2026-07-02T00:00:00.000Z",
+          endpoints: [{ id: "b", status: "ok", latency_ms: 20 }],
+        }),
+      } as unknown as LoadCtx,
+      { status: "ok" },
+    );
+    // The overlay flips "b" from degraded to ok, so all 3 endpoints now match.
+    assert.equal(out.returned, 3);
+  });
+
+  test("loadRpcEndpointsList skips the overlay when no readHealthKv dep is provided", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { status: "degraded" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].id, "b");
+  });
+
+  test("loadRpcEndpointsList falls back to the static snapshot when mergeRpcEndpoints returns null", async () => {
+    // A live pool with no matching endpoints array makes mergeRpcEndpoints
+    // bail (returns null); the static snapshot must still be served.
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({ last_run_at: "2026-07-02T00:00:00.000Z" }),
+      } as unknown as LoadCtx,
+      {},
+    );
+    assert.equal(out.total, 3);
+  });
+
+  test("loadRpcEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as LoadCtx,
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ id: "test" }] },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.endpoints[0].id, "test");
+  });
+
+  test("loadRpcEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /rpc-endpoints\.json/.test(err.message),
+    );
+  });
+
+  test("loadRpcEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList({ env: {}, readArtifact } as unknown as LoadCtx, {
+          fields: "not_a_column",
+        }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList is schema-stable when the artifact has no endpoints array", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { generated_at: "2026-01-01T00:00:00Z" },
+        }),
+      } as unknown as LoadCtx,
+      {},
+    );
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.returned, 0);
+  });
+
+  test("loadRpcEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadRpcEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { endpoints: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadRpcEndpointsList(
+        { env: {}, readArtifact } as unknown as LoadCtx,
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadRpcEndpointsList tolerates a non-array endpoints key from applyQueryFilters", async () => {
+    const spy = vi
+      .spyOn(listQuery, "applyQueryFilters")
+      .mockReturnValue({ data: {}, meta: { pagination: {} } });
+    try {
+      const out = await loadRpcEndpointsList(
+        { env: {}, readArtifact } as unknown as LoadCtx,
+        {},
+      );
+      assert.deepEqual(out.endpoints, []);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_RPC_ENDPOINTS_MCP_TOOL.name, "list_rpc_endpoints");
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_rpc_endpoints", () => {
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_rpc_endpoints");
+    assert.ok(tool);
+    assert.equal(tool.title, "List Bittensor RPC endpoints");
+  });
+});


### PR DESCRIPTION
## Summary

- `list_rpc_endpoints` had `inputSchema.properties: {}` — completely unfiltered — even though its own description says it "Mirrors GET /api/v1/rpc/endpoints", and that REST route (`src/contracts.ts`) reuses the exact same `"endpoints"` query collection `list_endpoints` and `list_provider_endpoints` already fully support (kind/layer/netuid/provider/publication_state/status/pool_eligible filters, min_/max_latency_ms + min_/max_score range bounds, sort/order, fields projection, limit/cursor pagination).
- The prior handler was three lines: read the artifact, overlay live RPC-pool health (`mergeRpcEndpoints`), return it whole.

## What Changed

- New `src/rpc-endpoints-mcp.ts` — a self-contained module mirroring the established pattern for exactly this shape of tool (`src/rpc-pools-mcp.ts` is the closest sibling: same live-KV-overlay-before-`applyQueryFilters` ordering, same query-url/error helper shapes). `loadRpcEndpointsList` reads the artifact, applies the same live RPC-pool health overlay (`mergeRpcEndpoints`) the prior inline handler already did — falling back to the static snapshot if the merge can't produce a result, same as before — then makes one `applyQueryFilters(overlaid, queryUrl, "endpoints", [])` call for the full filter/sort/fields/pagination set.
- `src/mcp-server.mjs` — `list_rpc_endpoints` is now `{ ...LIST_RPC_ENDPOINTS_MCP_TOOL, handler }`, matching how `list_rpc_pools`/`list_curation`/`list_provider_endpoints` are wired; the output-schema registry and the agent-bootstrap instructions string now reference the module's exports instead of inline duplicates. The now-unused `mergeRpcEndpoints` import was removed (still used elsewhere for `KV_HEALTH_RPC_POOL`, which stays).
- `tests/rpc-endpoints-mcp.test.ts` (new, 30 tests) — mirrors `tests/rpc-pools-mcp.test.ts`'s structure: every filter/enum/range-bound/sort/order/fields/limit/cursor validation, the live-overlay path (including the merge-returns-null fallback), artifact-not-found vs other-failure error mapping, the pagination-meta-absent fallback, and the output-schema/tool-wiring sanity checks.
- `tests/mcp-server.test.mjs` — updated the two existing `list_rpc_endpoints` tests (the "rejects an unexpected argument" case now uses a genuinely-unknown key instead of `netuid`, which is now a valid filter) and added filter/sort/enum-rejection coverage at the integration level; the two live-overlay tests (`#18389`/`#18424` in the old line numbering) pass unmodified.

No other `mcp-server.mjs` dispatch changes — `list_rpc_endpoints` stays a self-contained `MCP_TOOLS` array entry; `dispatchTool` just looks it up by name.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7893`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no schema/contract change; the `endpoints` collection's filters already existed for REST and other MCP tools.)

## Validation

- [x] `npx tsc --noEmit -p .` (typecheck) — clean
- [x] `npx eslint src/rpc-endpoints-mcp.ts src/mcp-server.mjs tests/mcp-server.test.mjs tests/rpc-endpoints-mcp.test.ts` — clean
- [x] `npx prettier --check` on all four changed/new files
- [x] `git diff --check`
- [x] `npx vitest run tests/rpc-endpoints-mcp.test.ts` — 30/30 passing
- [x] `npx vitest run tests/mcp-server.test.mjs tests/rpc-endpoints-mcp.test.ts tests/rpc-pools-mcp.test.ts` — 1254/1255 passing; the 1 pre-existing failure (`service_count` in a local-env end-to-end test) reproduces identically on a clean `main` before this change and is unrelated.
- [x] Targeted lcov coverage check: zero uncovered lines/branches in `src/rpc-endpoints-mcp.ts` (new file) and in the touched `src/mcp-server.mjs` region.
- [x] `npm run scan:public-safety` — no findings in touched files (pre-existing findings elsewhere are unrelated to this diff)

Closes #7893
