### PR TITLE
feat(api): add REST-parity filters to blocks GraphQL field (#7870)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -672,8 +672,8 @@ export const SDL = `
     extrinsic(ref: String!): ExtrinsicDetail
     "Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes."
     governance_config_changes(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
-    "Recent-block feed (newest first). Mirrors GET /api/v1/blocks."
-    blocks(limit: Int, offset: Int, cursor: String): BlockList!
+    "Recent-block feed (newest first). Optionally filter by author (SS58), spec_version, block_start/block_end (inclusive block-height range), from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history), min_extrinsics, and min_events — the same filter set MCP list_blocks and GET /api/v1/blocks accept. Mirrors GET /api/v1/blocks."
+    blocks(limit: Int, offset: Int, cursor: String, author: String, spec_version: Int, block_start: Int, block_end: Int, from: String, to: String, min_extrinsics: Int, min_events: Int): BlockList!
     "One block by numeric height or 0x block hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}."
     block(ref: String!): BlockDetail
     "The extrinsics in one block by ref (numeric block_number or 0x hash), in natural read order (extrinsic_index ASC), paginated with limit (1-100, default 50)/offset. Returns block_number:null + extrinsics:[] for an unknown ref or cold store, never a GraphQL error. Mirrors GET /api/v1/blocks/{ref}/extrinsics."
@@ -7174,13 +7174,42 @@ const rootValue = {
     };
   },
 
-  async blocks({ limit, offset, cursor }, context) {
+  async blocks(
+    {
+      limit,
+      offset,
+      cursor,
+      author,
+      spec_version: specVersion,
+      block_start: blockStart,
+      block_end: blockEnd,
+      from,
+      to,
+      min_extrinsics: minExtrinsics,
+      min_events: minEvents,
+    },
+    context,
+  ) {
     const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
     const safeOffset = clampOffset(offset);
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
     if (cursor) params.set("cursor", cursor);
+    // #7870: forward the same optional filters MCP list_blocks / GET /api/v1/blocks
+    // accept, straight through to the Postgres tier (no duplicated filtering logic).
+    // block_start/block_end are block heights and min_* are counts, all within Int
+    // range; from/to are observed_at epoch-ms and overflow GraphQL Int's 32 bits, so
+    // they are String args passed verbatim (mirroring account_history's from/to).
+    if (author) params.set("author", author);
+    if (specVersion != null) params.set("spec_version", String(specVersion));
+    if (blockStart != null) params.set("block_start", String(blockStart));
+    if (blockEnd != null) params.set("block_end", String(blockEnd));
+    if (from != null) params.set("from", from);
+    if (to != null) params.set("to", to);
+    if (minExtrinsics != null)
+      params.set("min_extrinsics", String(minExtrinsics));
+    if (minEvents != null) params.set("min_events", String(minEvents));
     // #4909: blocks' D1 write path is retired and the table is dropped in
     // production, so the Postgres tier being cold is the expected steady state —
     // fall back to the same pure builder REST uses, never a GraphQL error.

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3599,6 +3599,114 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
   });
 
+  test("blocks: the REST-parity filters are all forwarded as query params to the Postgres tier (#7870)", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            block_count: 0,
+            limit: 50,
+            offset: 0,
+            next_cursor: null,
+            blocks: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ blocks(
+          author: "5Author"
+          spec_version: 200
+          block_start: 100
+          block_end: 500
+          from: "1750000000000"
+          to: "1760000000000"
+          min_extrinsics: 2
+          min_events: 3
+        ) { total } }`,
+      env,
+    );
+    assert.equal(capturedUrl.pathname, "/api/v1/blocks");
+    assert.equal(capturedUrl.searchParams.get("author"), "5Author");
+    assert.equal(capturedUrl.searchParams.get("spec_version"), "200");
+    assert.equal(capturedUrl.searchParams.get("block_start"), "100");
+    assert.equal(capturedUrl.searchParams.get("block_end"), "500");
+    assert.equal(capturedUrl.searchParams.get("from"), "1750000000000");
+    assert.equal(capturedUrl.searchParams.get("to"), "1760000000000");
+    assert.equal(capturedUrl.searchParams.get("min_extrinsics"), "2");
+    assert.equal(capturedUrl.searchParams.get("min_events"), "3");
+  });
+
+  test("blocks: a single filter is forwarded and the unset filters are omitted (#7870)", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            block_count: 0,
+            limit: 50,
+            offset: 0,
+            next_cursor: null,
+            blocks: [],
+          });
+        },
+      },
+    };
+    await gql(`{ blocks(author: "5Solo") { total } }`, env);
+    assert.equal(capturedUrl.searchParams.get("author"), "5Solo");
+    assert.equal(capturedUrl.searchParams.has("spec_version"), false);
+    assert.equal(capturedUrl.searchParams.has("block_start"), false);
+    assert.equal(capturedUrl.searchParams.has("block_end"), false);
+    assert.equal(capturedUrl.searchParams.has("from"), false);
+    assert.equal(capturedUrl.searchParams.has("to"), false);
+    assert.equal(capturedUrl.searchParams.has("min_extrinsics"), false);
+    assert.equal(capturedUrl.searchParams.has("min_events"), false);
+  });
+
+  test("introspection: blocks exposes the new REST-parity filter args with the right scalar types (#7870)", async () => {
+    const { status, body } = await gql(
+      `{ __type(name: "Query") { fields {
+          name
+          args { name type { kind name ofType { kind name } } }
+        } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const blocks = body.data.__type.fields.find((f) => f.name === "blocks");
+    const argType = (name) => {
+      const a = blocks.args.find((x) => x.name === name);
+      assert.ok(a, `expected a ${name} arg on blocks`);
+      return a.type;
+    };
+    for (const name of ["author", "from", "to"]) {
+      assert.deepEqual(argType(name), {
+        kind: "SCALAR",
+        name: "String",
+        ofType: null,
+      });
+    }
+    for (const name of [
+      "spec_version",
+      "block_start",
+      "block_end",
+      "min_extrinsics",
+      "min_events",
+    ]) {
+      assert.deepEqual(argType(name), {
+        kind: "SCALAR",
+        name: "Int",
+        ofType: null,
+      });
+    }
+  });
+
   test("blocks: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
     const env = {
       METAGRAPH_BLOCKS_SOURCE: "postgres",


### PR DESCRIPTION
## Summary

`blocks(limit, offset, cursor)` only exposed pagination, while `GET /api/v1/blocks` and the MCP `list_blocks` tool both accept the full block-filter set. This adds the missing filters to the GraphQL field so a GraphQL client can filter blocks identically to REST and MCP:

`author` (SS58), `spec_version`, `block_start`/`block_end` (inclusive block-height range), `from`/`to` (observed_at epoch-ms range), `min_extrinsics`, `min_events`.

The resolver forwards each supplied arg straight through to the same Postgres-tier route `list_blocks` uses — no duplicated filtering logic (per the issue). `from`/`to` are `String` args, not `Int`: they are observed_at epoch-ms (~1.7e12) which overflows GraphQL's 32-bit `Int`, matching the existing `account_history(from: String, to: String)` field; `block_start`/`block_end`/`spec_version`/`min_*` stay `Int` (heights and counts within range).

## Changes

- `src/graphql.mjs`: added the 8 filter args to the `blocks` SDL field (+ docstring) and forwarded them from the resolver.
- `tests/graphql.test.mjs`: all-filters-forwarded test, a single-filter test (asserts unset filters are omitted), and an introspection signature guard for the new args + their scalar types.

## Validation

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npx vitest run tests/graphql.test.mjs` (927 passed), `npm run build`, `npm run validate`, `npm run scan:public-safety`, `git diff --check` — all green. Diff is confined to the two files above.

Closes #7870