### PR TITLE
feat(api): add REST filter parity to GraphQL subnet_gaps

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -53,6 +53,9 @@ import { loadEnrichmentEvidenceList } from "./enrichment-evidence-mcp.ts";
 import { loadEnrichmentQueueList } from "./enrichment-queue-mcp.ts";
 import { loadReviewEnrichmentTargetsList } from "./review-enrichment-targets-mcp.ts";
 import { loadReviewGapsList } from "./review-gaps-mcp.ts";
+// #7880: GraphQL parity for GET /api/v1/subnets/{netuid}/gaps filters — reuse
+// loadSubnetGapsList (review-gap-priorities list-query on the per-subnet artifact).
+import { loadSubnetGapsList } from "./subnet-gaps-mcp.ts";
 import { loadProfileCompletenessList } from "./profile-completeness-mcp.ts";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
@@ -544,8 +547,8 @@ export const SDL = `
     subnet_validators(netuid: Int!): SubnetValidatorList!
     "One subnet's chain-event activity summary over a 7d/30d/90d window (default 30d): total events, the per-kind and per-category breakdowns with hotkey/coldkey participation and TAO/alpha amounts, and a bounded newest-first recent-event list (limit 1-50, default 10). A subnet with no events resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/event-summary."
     subnet_event_summary(netuid: Int!, window: String, limit: Int): SubnetEventSummary!
-    "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps."
-    subnet_gaps(netuid: Int!): JSON
+    "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Filter by curation_level/missing_kinds/review_state, sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps."
+    subnet_gaps(netuid: Int!, curation_level: String, missing_kinds: [String!], review_state: String, limit: Int, cursor: String, sort: String, order: String): JSON
     "One subnet's curation evidence record — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry. Null when no evidence record has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_evidence MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/evidence."
     subnet_evidence(netuid: Int!): JSON
     "One subnet's unpromoted candidate-surface queue — the baked per-subnet /metagraph/candidates/{netuid}.json artifact the REST route and get_subnet_candidates MCP tool read. Null when no candidate artifact has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim. Distinct from candidates(...) (the filterable network-wide candidate catalog). Mirrors GET /api/v1/subnets/{netuid}/candidates."
@@ -6868,17 +6871,22 @@ const rootValue = {
     };
   },
 
-  async subnet_gaps({ netuid }, context) {
-    if (!Number.isInteger(netuid) || netuid < 0) {
-      throw new GraphQLError("netuid must be a non-negative integer.", {
-        extensions: { code: "BAD_USER_INPUT" },
-      });
+  async subnet_gaps(args, context) {
+    // #7880: reuse loadSubnetGapsList — same review-gap-priorities list-query
+    // transforms REST applies on /api/v1/subnets/{netuid}/gaps. Invalid filters
+    // are GraphQL BAD_USER_INPUT errors; a cold/absent artifact degrades to null
+    // (matching this field's historical schema-stable convention, not a throw).
+    try {
+      return await loadSubnetGapsList(context, args, { readArtifact });
+    } catch (err) {
+      if (err?.toolError && err.code === "not_found") return null;
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      throw err;
     }
-    // Same baked review-gaps artifact the REST route + get_subnet_gaps MCP tool
-    // read. The MCP tool raises not_found for a netuid with no report; GraphQL
-    // degrades to null instead, matching how every other artifact-backed
-    // resolver here treats a cold/absent artifact.
-    return loadArtifact(context, `/metagraph/review/gaps/${netuid}.json`);
   },
 
   async subnet_evidence({ netuid }, context) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -121,6 +121,7 @@ import {
   LIST_REVIEW_GAPS_OUTPUT_SCHEMA,
   loadReviewGapsList,
 } from "./review-gaps-mcp.ts";
+import { loadSubnetGapsList } from "./subnet-gaps-mcp.ts";
 import {
   LIST_REVIEW_ENRICHMENT_TARGETS_INSTRUCTIONS,
   LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL,
@@ -10550,10 +10551,11 @@ export const MCP_TOOLS = [
     description:
       "Fetch one subnet's interface gap priorities and contributor enrichment " +
       "queue: missing surface kinds, priority scores, recommended actions, and " +
-      "copyable submission hints. This is the per-subnet contribution flywheel " +
-      "view behind GET /api/v1/subnets/{netuid}/gaps — distinct from " +
-      "list_enrichment_targets, which ranks the registry-wide coverage-depth " +
-      "scorecard.",
+      "copyable submission hints. Filter by curation_level/missing_kinds/" +
+      "review_state, sort with sort/order, and page with limit/cursor. This is " +
+      "the per-subnet contribution flywheel view behind " +
+      "GET /api/v1/subnets/{netuid}/gaps — distinct from list_enrichment_targets, " +
+      "which ranks the registry-wide coverage-depth scorecard.",
     inputSchema: {
       type: "object",
       properties: {
@@ -10562,24 +10564,56 @@ export const MCP_TOOLS = [
           description: "Subnet netuid.",
           minimum: 0,
         },
+        curation_level: {
+          type: "string",
+          description: "Filter priorities by curation level.",
+        },
+        missing_kinds: {
+          type: "string",
+          description:
+            "Filter priorities whose missing_kinds include this surface kind.",
+        },
+        review_state: {
+          type: "string",
+          description: "Filter by review_state substring match.",
+        },
+        sort: {
+          type: "string",
+          description: "Field to sort priorities by before paging.",
+        },
+        order: {
+          type: "string",
+          enum: ["asc", "desc"],
+          description: "Sort direction for sort (default asc).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max priority rows to return (1-100).",
+          minimum: 1,
+          maximum: 100,
+        },
+        cursor: {
+          type: "integer",
+          description: "Pagination cursor from a prior response's next_cursor.",
+          minimum: 0,
+        },
       },
       required: ["netuid"],
       additionalProperties: false,
     },
     async handler(args, ctx) {
-      const netuid = requireNetuid(args);
-      const gaps = await loadOptionalArtifact(
-        ctx,
-        `/metagraph/review/gaps/${netuid}.json`,
-      );
-      if (!gaps) {
-        throw toolError(
-          "not_found",
-          `No gap report exists for netuid ${netuid}. Use list_subnets or ` +
-            "search_subnets to discover valid netuids.",
-        );
+      try {
+        return await loadSubnetGapsList(ctx, args);
+      } catch (err) {
+        if (err?.toolError && err.code === "not_found") {
+          throw toolError(
+            "not_found",
+            `No gap report exists for netuid ${args?.netuid}. Use list_subnets or ` +
+              "search_subnets to discover valid netuids.",
+          );
+        }
+        throw err;
       }
-      return gaps;
     },
   },
   {

--- a/src/subnet-gaps-mcp.ts
+++ b/src/subnet-gaps-mcp.ts
@@ -1,0 +1,258 @@
+// Per-subnet gaps loader for GraphQL/REST parity on
+// GET /api/v1/subnets/{netuid}/gaps. Applies the same list-query transforms as
+// the REST route over the baked /metagraph/review/gaps/{netuid}.json artifact
+// (review-gap-priorities collection, netuid already scoped by path). Structurally
+// mirrors review-gaps-mcp.ts (network-wide sibling) and subnet-endpoints-mcp.ts.
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+
+const PRIORITY_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["review-gap-priorities"].sort_fields;
+const CURATION_LEVELS = QUERY_ENUMS.curationLevel;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+
+export function subnetGapsArtifactPath(netuid: number): string {
+  return `/metagraph/review/gaps/${netuid}.json`;
+}
+
+export interface SubnetGapsMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function subnetGapsMcpError(
+  code: string,
+  message: string,
+): SubnetGapsMcpError {
+  const error = new Error(message) as SubnetGapsMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+export function requireSubnetGapsNetuid(
+  args: Record<string, unknown> | null | undefined,
+): number {
+  const netuid = args?.netuid;
+  if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+    throw subnetGapsMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetGapsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetGapsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+function resolveMissingKinds(
+  args: Record<string, unknown> | null | undefined,
+): string | null {
+  const value = args?.missing_kinds;
+  if (value === undefined || value === null || value === "") return null;
+  if (Array.isArray(value)) {
+    const kinds = value
+      .filter((part): part is string => typeof part === "string")
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (kinds.length === 0) {
+      throw subnetGapsMcpError(
+        "invalid_params",
+        "Argument `missing_kinds` must be a non-empty list of surface kinds when provided.",
+      );
+    }
+    for (const kind of kinds) {
+      if (!(SURFACE_KINDS as readonly string[]).includes(kind)) {
+        throw subnetGapsMcpError(
+          "invalid_params",
+          `Argument \`missing_kinds\` must be one of: ${SURFACE_KINDS.join(", ")}.`,
+        );
+      }
+    }
+    // REST accepts a single missing_kinds enum; use the first requested kind.
+    return kinds[0];
+  }
+  return optionalEnum(args, "missing_kinds", SURFACE_KINDS);
+}
+
+function resolveCursor(
+  args: Record<string, unknown> | null | undefined,
+): number | null {
+  const value = args?.cursor;
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value === "string") {
+    if (!/^\d+$/.test(value.trim())) {
+      throw subnetGapsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    return Number(value.trim());
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw subnetGapsMcpError(
+      "invalid_params",
+      "cursor must be a non-negative integer.",
+    );
+  }
+  return value;
+}
+
+export function subnetGapsQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/subnets/gaps");
+  requireSubnetGapsNetuid(args);
+  const curationLevel = optionalEnum(args, "curation_level", CURATION_LEVELS);
+  if (curationLevel) url.searchParams.set("curation_level", curationLevel);
+  const missingKinds = resolveMissingKinds(args);
+  if (missingKinds) url.searchParams.set("missing_kinds", missingKinds);
+  const reviewState = optionalString(args, "review_state");
+  if (reviewState) url.searchParams.set("review_state", reviewState);
+  const sort = optionalEnum(args, "sort", PRIORITY_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  const cursor = resolveCursor(args);
+  if (cursor !== null) url.searchParams.set("cursor", String(cursor));
+  return url;
+}
+
+export interface SubnetGapsListResult {
+  schema_version: unknown;
+  contract_version: unknown;
+  generated_at: unknown;
+  notes: unknown;
+  netuid: unknown;
+  slug: unknown;
+  name: unknown;
+  enrichment_queue: Row[];
+  priorities: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadSubnetGapsList(
+  ctx: {
+    env: Env;
+    readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  },
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<SubnetGapsListResult> {
+  const netuid = requireSubnetGapsNetuid(args);
+  const queryUrl = subnetGapsQueryUrl(args);
+  const artifactPath = subnetGapsArtifactPath(netuid);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    // Treat cold/unbound storage the same as a missing per-netuid report so
+    // GraphQL can keep its schema-stable null degradation (and MCP still gets
+    // a not_found toolError).
+    if (
+      code === "artifact_not_found" ||
+      code === "r2_binding_missing" ||
+      code === "artifact_unavailable"
+    ) {
+      throw subnetGapsMcpError(
+        "not_found",
+        `No gap report exists for netuid ${netuid}.`,
+      );
+    }
+    throw subnetGapsMcpError(code, `Could not load ${artifactPath} (${code}).`);
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw subnetGapsMcpError(
+      "not_found",
+      `No gap report exists for netuid ${netuid}.`,
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob as Record<string, unknown>,
+    queryUrl,
+    "review-gap-priorities",
+    [],
+  );
+  if (transformed.error) {
+    throw subnetGapsMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = (transformed.meta ?? {}) as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.priorities) ? (data.priorities as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    schema_version: data.schema_version ?? null,
+    contract_version: data.contract_version ?? null,
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    netuid: data.netuid ?? netuid,
+    slug: data.slug ?? null,
+    name: data.name ?? null,
+    enrichment_queue: Array.isArray(data.enrichment_queue)
+      ? (data.enrichment_queue as Row[])
+      : [],
+    priorities: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -8752,18 +8752,123 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
 });
 
 describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifacts)", () => {
+  const SUBNET_GAPS_BLOB = {
+    schema_version: 1,
+    netuid: 5,
+    slug: "demo",
+    name: "Demo",
+    priorities: [
+      {
+        netuid: 5,
+        slug: "demo",
+        name: "Demo",
+        missing_kinds: ["docs"],
+        priority_score: 72,
+        curation_level: "maintainer-reviewed",
+        review_state: "maintainer-reviewed",
+        surface_count: 4,
+        candidate_count: 1,
+        verified_candidate_count: 1,
+      },
+      {
+        netuid: 5,
+        slug: "demo",
+        name: "Demo",
+        missing_kinds: ["openapi"],
+        priority_score: 40,
+        curation_level: "candidate-discovered",
+        review_state: "community-submitted",
+        surface_count: 2,
+        candidate_count: 3,
+        verified_candidate_count: 0,
+      },
+    ],
+    enrichment_queue: [
+      {
+        netuid: 5,
+        lane: "direct-submission",
+        missing_kinds: ["docs"],
+        recommended_action: "Submit official docs evidence",
+      },
+    ],
+  };
+
   test("subnet_gaps resolves the baked gap report", async () => {
     const env = fixtureEnv({
-      "/metagraph/review/gaps/5.json": {
-        netuid: 5,
-        gaps: [{ kind: "api", missing: true }],
-      },
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
     });
     const { status, body } = await gql("{ subnet_gaps(netuid: 5) }", env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.subnet_gaps.netuid, 5);
-    assert.equal(body.data.subnet_gaps.gaps[0].kind, "api");
+    assert.equal(body.data.subnet_gaps.priorities[0].missing_kinds[0], "docs");
+    assert.equal(
+      body.data.subnet_gaps.enrichment_queue[0].lane,
+      "direct-submission",
+    );
+  });
+
+  test("subnet_gaps filters by curation_level (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
+    });
+    const { status, body } = await gql(
+      '{ subnet_gaps(netuid: 5, curation_level: "candidate-discovered") }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_gaps.total, 1);
+    assert.equal(
+      body.data.subnet_gaps.priorities[0].curation_level,
+      "candidate-discovered",
+    );
+  });
+
+  test("subnet_gaps filters by missing_kinds (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
+    });
+    const { status, body } = await gql(
+      '{ subnet_gaps(netuid: 5, missing_kinds: ["openapi"]) }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_gaps.total, 1);
+    assert.deepEqual(body.data.subnet_gaps.priorities[0].missing_kinds, [
+      "openapi",
+    ]);
+  });
+
+  test("subnet_gaps an unsupported sort is a GraphQL error (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
+    });
+    const { body } = await gql(
+      '{ subnet_gaps(netuid: 5, sort: "bogus") }',
+      env,
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("subnet_gaps filters by review_state and pages with limit (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
+    });
+    const { status, body } = await gql(
+      '{ subnet_gaps(netuid: 5, review_state: "community-submitted", limit: 1, order: "asc") }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_gaps.total, 1);
+    assert.equal(body.data.subnet_gaps.returned, 1);
+    assert.equal(
+      body.data.subnet_gaps.priorities[0].review_state,
+      "community-submitted",
+    );
   });
 
   test("subnet_gaps degrades to null when no report is baked, never an error", async () => {
@@ -8771,6 +8876,25 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.subnet_gaps, null);
+  });
+
+  test("subnet_gaps propagates a non-toolError from the artifact read (#7880)", async () => {
+    const env = {
+      METAGRAPH_R2_LATEST_PREFIX: "latest/",
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              throw new Error("corrupt subnet gaps artifact");
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql("{ subnet_gaps(netuid: 5) }", env);
+    assert.equal(status, 200);
+    assert.ok(body.errors?.length > 0);
+    assert.equal(body.data?.subnet_gaps ?? null, null);
   });
 
   test("subnet_evidence resolves the baked evidence record", async () => {

--- a/tests/subnet-gaps-mcp.test.ts
+++ b/tests/subnet-gaps-mcp.test.ts
@@ -1,0 +1,353 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  loadSubnetGapsList,
+  requireSubnetGapsNetuid,
+  subnetGapsArtifactPath,
+  subnetGapsMcpError,
+  subnetGapsQueryUrl,
+} from "../src/subnet-gaps-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type Ctx = Parameters<typeof loadSubnetGapsList>[0];
+type Deps = Parameters<typeof loadSubnetGapsList>[2];
+
+const SAMPLE_BLOB = {
+  schema_version: 1,
+  contract_version: "1.0.0",
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["gaps"],
+  netuid: 5,
+  slug: "demo",
+  name: "Demo",
+  priorities: [
+    {
+      netuid: 5,
+      missing_kinds: ["docs"],
+      priority_score: 72,
+      curation_level: "maintainer-reviewed",
+      review_state: "maintainer-reviewed",
+    },
+    {
+      netuid: 5,
+      missing_kinds: ["openapi"],
+      priority_score: 40,
+      curation_level: "candidate-discovered",
+      review_state: "community-submitted",
+    },
+  ],
+  enrichment_queue: [{ netuid: 5, lane: "direct-submission" }],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === subnetGapsArtifactPath(5)) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("subnet-gaps-mcp (#7880)", () => {
+  test("subnetGapsMcpError is shaped for toolError handling", () => {
+    const err = subnetGapsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("requireSubnetGapsNetuid validates netuid", () => {
+    assert.equal(requireSubnetGapsNetuid({ netuid: 5 }), 5);
+    assert.throws(
+      () => requireSubnetGapsNetuid({}),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => requireSubnetGapsNetuid({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => requireSubnetGapsNetuid({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetGapsQueryUrl forwards filters including missing_kinds list", () => {
+    const url = subnetGapsQueryUrl({
+      netuid: 5,
+      curation_level: "candidate-discovered",
+      missing_kinds: ["openapi", "docs"],
+      review_state: "community-submitted",
+      sort: "priority_score",
+      order: "desc",
+      limit: 10,
+      cursor: "0",
+    });
+    assert.equal(
+      url.searchParams.get("curation_level"),
+      "candidate-discovered",
+    );
+    assert.equal(url.searchParams.get("missing_kinds"), "openapi");
+    assert.equal(url.searchParams.get("review_state"), "community-submitted");
+    assert.equal(url.searchParams.get("sort"), "priority_score");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "0");
+  });
+
+  test("subnetGapsQueryUrl accepts string missing_kinds and numeric cursor", () => {
+    const url = subnetGapsQueryUrl({
+      netuid: 5,
+      missing_kinds: "docs",
+      cursor: 3,
+      limit: 200,
+      fields: "netuid,slug",
+    });
+    assert.equal(url.searchParams.get("missing_kinds"), "docs");
+    assert.equal(url.searchParams.get("cursor"), "3");
+    assert.equal(url.searchParams.get("limit"), "100");
+    assert.equal(url.searchParams.get("fields"), "netuid,slug");
+  });
+
+  test("subnetGapsQueryUrl clamps non-positive limits to the default", () => {
+    assert.equal(
+      subnetGapsQueryUrl({ netuid: 5, limit: 0 }).searchParams.get("limit"),
+      "50",
+    );
+    assert.equal(
+      subnetGapsQueryUrl({ netuid: 5, limit: Number.NaN }).searchParams.get(
+        "limit",
+      ),
+      "50",
+    );
+    assert.equal(
+      subnetGapsQueryUrl({ netuid: 5, limit: "lots" }).searchParams.get(
+        "limit",
+      ),
+      "50",
+    );
+  });
+
+  test("subnetGapsQueryUrl rejects invalid inputs", () => {
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, sort: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, curation_level: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, order: "sideways" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, missing_kinds: ["seed-node"] }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, missing_kinds: [] }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, missing_kinds: [12] }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, missing_kinds: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, review_state: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, review_state: 12 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, cursor: "abc" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: 5, cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetGapsList filters by curation_level", async () => {
+    const out = await loadSubnetGapsList(
+      { env: {}, readArtifact } as unknown as Ctx,
+      { netuid: 5, curation_level: "candidate-discovered" },
+    );
+    assert.equal(out.total, 1);
+    assert.equal(out.priorities[0].curation_level, "candidate-discovered");
+    assert.equal(out.enrichment_queue[0].lane, "direct-submission");
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.contract_version, "1.0.0");
+    assert.equal(out.slug, "demo");
+    assert.equal(out.name, "Demo");
+  });
+
+  test("loadSubnetGapsList filters by missing_kinds", async () => {
+    const out = await loadSubnetGapsList(
+      { env: {}, readArtifact } as unknown as Ctx,
+      { netuid: 5, missing_kinds: ["docs"] },
+    );
+    assert.equal(out.total, 1);
+    assert.deepEqual(out.priorities[0].missing_kinds, ["docs"]);
+  });
+
+  test("loadSubnetGapsList uses an injected readArtifact dep", async () => {
+    const out = await loadSubnetGapsList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as Ctx,
+      { netuid: 5 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            priorities: [{ id: "injected", missing_kinds: ["website"] }],
+            enrichment_queue: null,
+          },
+        }),
+      } as unknown as Deps,
+    );
+    assert.equal(out.priorities[0].id, "injected");
+    assert.deepEqual(out.enrichment_queue, []);
+  });
+
+  test("loadSubnetGapsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetGapsList({ env: {}, readArtifact } as unknown as Ctx, {
+          netuid: 999,
+        }),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetGapsList maps r2_binding_missing to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "r2_binding_missing",
+            }),
+          } as unknown as Ctx,
+          { netuid: 5 },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetGapsList maps bare failure to not_found via artifact_unavailable", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as Ctx,
+          { netuid: 5 },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetGapsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as Ctx,
+          { netuid: 5 },
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" && /gaps\/5\.json/.test(err.message),
+    );
+  });
+
+  test("loadSubnetGapsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as Ctx,
+          { netuid: 5 },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetGapsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetGapsList({ env: {}, readArtifact } as unknown as Ctx, {
+          netuid: 5,
+          fields: "not_a_column",
+        }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetGapsList treats a non-array priorities key as empty", async () => {
+    const out = await loadSubnetGapsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { priorities: null, enrichment_queue: [{ lane: "x" }] },
+        }),
+      } as unknown as Ctx,
+      { netuid: 5 },
+    );
+    assert.deepEqual(out.priorities, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.enrichment_queue[0].lane, "x");
+  });
+
+  test("loadSubnetGapsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: {
+        priorities: [{ id: "a" }],
+        enrichment_queue: [],
+      },
+      meta: undefined,
+    });
+    try {
+      const out = await loadSubnetGapsList(
+        { env: {}, readArtifact } as unknown as Ctx,
+        { netuid: 5 },
+      );
+      assert.equal(out.total, 1);
+      assert.equal(out.returned, 1);
+      assert.equal(out.limit, 1);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+      assert.equal(out.netuid, 5);
+      assert.equal(out.generated_at, null);
+      assert.equal(out.notes, null);
+      assert.equal(out.slug, null);
+      assert.equal(out.name, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/subnet-gaps-mcp.ts` loader applying the same `review-gap-priorities` list-query transforms REST uses on `GET /api/v1/subnets/{netuid}/gaps`.
- Wire GraphQL `subnet_gaps` with `curation_level`, `missing_kinds`, `review_state`, `limit`, `cursor`, `sort`, and `order`; invalid filters are GraphQL errors; a cold catalog still degrades to null; non-toolErrors propagate.
- Point MCP `get_subnet_gaps` at the same loader; type `enrichment_queue` as `Row[]` for typecheck; cover loader branches and GraphQL error paths for patch coverage.

Closes #7880

## Test plan
- [x] `npx vitest run tests/subnet-gaps-mcp.test.ts`
- [x] `npx vitest run tests/graphql.test.mjs -t subnet_gaps`
- [x] `npx vitest run tests/mcp-server.test.mjs -t get_subnet_gaps`
- [x] Focused coverage: `src/subnet-gaps-mcp.ts` 100% lines/branches; GraphQL `subnet_gaps` resolver paths (success / not_found / BAD_USER_INPUT / throw) hit
- [x] `node --experimental-strip-types scripts/validate-private-boundary.ts`
- [ ] CI Validate + codecov/patch green on this PR
