### PR TITLE
test(ui): add coverage for use-subnet-probe-health's own combine/gate logic

### DIFF
--- a/apps/ui/src/hooks/use-subnet-probe-health.test.ts
+++ b/apps/ui/src/hooks/use-subnet-probe-health.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { combineSubnetProbeHealth } from "./use-subnet-probe-health";
+import type { EndpointIncident } from "@/lib/metagraphed/types";
+
+describe("combineSubnetProbeHealth", () => {
+  it("resolves from all three sources when they agree", () => {
+    expect(
+      combineSubnetProbeHealth(74, true, {
+        mapData: { data: { 74: { health: "ok" } } },
+        detailData: { data: { ok: 3, warn: 0, down: 0, unknown: 0 } },
+        incidentsData: { data: [] },
+      }),
+    ).toBe("ok");
+  });
+
+  it("stays unknown until hydration completes, even with concrete cached data", () => {
+    expect(
+      combineSubnetProbeHealth(74, false, {
+        mapData: { data: { 74: { health: "down" } } },
+        detailData: { data: { ok: 0, warn: 0, down: 5, unknown: 0 } },
+        incidentsData: {
+          data: [{ id: "a", netuid: 74, state: "down", ended_at: null }],
+        },
+      }),
+    ).toBe("unknown");
+  });
+
+  it("falls back to the summary rollup when the map has no entry for this netuid", () => {
+    expect(
+      combineSubnetProbeHealth(74, true, {
+        mapData: { data: {} },
+        detailData: { data: { ok: 0, warn: 2, down: 0, unknown: 0 } },
+        incidentsData: { data: [] },
+      }),
+    ).toBe("warn");
+  });
+
+  it("falls back to active incident health for this netuid when map+summary are unknown", () => {
+    const incidents: EndpointIncident[] = [
+      { id: "a", netuid: 1, state: "down", ended_at: null },
+      { id: "b", netuid: 74, state: "warn", ended_at: null },
+    ];
+    expect(
+      combineSubnetProbeHealth(74, true, {
+        mapData: { data: { 74: { health: "unknown" } } },
+        detailData: { data: { ok: 0, warn: 0, down: 0, unknown: 0 } },
+        incidentsData: { data: incidents },
+      }),
+    ).toBe("warn");
+  });
+
+  it("prefers a concrete map health over a disagreeing summary/incident state", () => {
+    const incidents: EndpointIncident[] = [{ id: "a", netuid: 74, state: "down", ended_at: null }];
+    expect(
+      combineSubnetProbeHealth(74, true, {
+        mapData: { data: { 74: { health: "ok" } } },
+        detailData: { data: { ok: 0, warn: 0, down: 9, unknown: 0 } },
+        incidentsData: { data: incidents },
+      }),
+    ).toBe("ok");
+  });
+
+  it("stays unknown when every source is missing or empty", () => {
+    expect(combineSubnetProbeHealth(74, true, {})).toBe("unknown");
+    expect(
+      combineSubnetProbeHealth(74, true, {
+        mapData: { data: {} },
+        detailData: { data: {} },
+        incidentsData: { data: [] },
+      }),
+    ).toBe("unknown");
+  });
+});

--- a/apps/ui/src/hooks/use-subnet-probe-health.ts
+++ b/apps/ui/src/hooks/use-subnet-probe-health.ts
@@ -3,33 +3,39 @@ import {
   endpointIncidentsQuery,
   subnetHealthMapQuery,
   subnetHealthQuery,
+  type SubnetHealthEntry,
 } from "@/lib/metagraphed/queries";
 import {
   resolveSubnetProbeHealth,
   worstActiveIncidentHealth,
 } from "@/lib/metagraphed/subnet-probe-health";
 import { useHydrated } from "@/hooks/use-hydrated";
-import type { EndpointIncident, HealthState } from "@/lib/metagraphed/types";
+import type { EndpointIncident, HealthState, HealthSummary } from "@/lib/metagraphed/types";
+
+export interface SubnetProbeHealthSources {
+  mapData?: { data?: Record<number, SubnetHealthEntry> };
+  detailData?: { data?: HealthSummary };
+  incidentsData?: { data?: EndpointIncident[] };
+}
 
 /**
- * Canonical probe-derived health for one subnet (#5332). Shared by the subnet
- * masthead HealthPill. Backed by `/api/v1/health` (map) → per-subnet `/health`
- * count rollup → active endpoint-incidents for this netuid when the rollup is
- * still unknown. Never by profile/chain lifecycle `status`.
+ * Pure combine/gate step behind {@link useSubnetProbeHealth}, split out so it's
+ * directly unit-testable (this suite has no RTL/jsdom, so hooks are tested via
+ * their exported pure functions rather than `renderHook`).
+ *
+ * These are plain (non-suspense) queries, so their cache can already be
+ * resolved by hydration time even though SSR committed "unknown" — stay
+ * "unknown" until hydration completes so both passes agree.
  */
-export function useSubnetProbeHealth(netuid: number): HealthState {
-  const mapQ = useQuery(subnetHealthMapQuery());
-  const detailQ = useQuery(subnetHealthQuery(netuid));
-  const incidentsQ = useQuery({ ...endpointIncidentsQuery(), retry: 0 });
-  // These are plain (non-suspense) queries, so their cache can already be
-  // resolved by hydration time even though SSR committed "unknown" — stay
-  // "unknown" until hydration completes so both passes agree.
-  const hydrated = useHydrated();
-  const mapHealth = hydrated ? mapQ.data?.data?.[netuid]?.health : undefined;
-  const summary = hydrated ? detailQ.data?.data : undefined;
-  const incidentHealth = hydrated
-    ? worstActiveIncidentHealth(incidentsQ.data?.data as EndpointIncident[] | undefined, netuid)
-    : undefined;
+export function combineSubnetProbeHealth(
+  netuid: number,
+  hydrated: boolean,
+  sources: SubnetProbeHealthSources,
+): HealthState {
+  if (!hydrated) return resolveSubnetProbeHealth({});
+  const mapHealth = sources.mapData?.data?.[netuid]?.health;
+  const summary = sources.detailData?.data;
+  const incidentHealth = worstActiveIncidentHealth(sources.incidentsData?.data, netuid);
   return resolveSubnetProbeHealth({
     mapHealth,
     summary: summary
@@ -41,5 +47,23 @@ export function useSubnetProbeHealth(netuid: number): HealthState {
         }
       : undefined,
     incidentHealth,
+  });
+}
+
+/**
+ * Canonical probe-derived health for one subnet (#5332). Shared by the subnet
+ * masthead HealthPill. Backed by `/api/v1/health` (map) → per-subnet `/health`
+ * count rollup → active endpoint-incidents for this netuid when the rollup is
+ * still unknown. Never by profile/chain lifecycle `status`.
+ */
+export function useSubnetProbeHealth(netuid: number): HealthState {
+  const mapQ = useQuery(subnetHealthMapQuery());
+  const detailQ = useQuery(subnetHealthQuery(netuid));
+  const incidentsQ = useQuery({ ...endpointIncidentsQuery(), retry: 0 });
+  const hydrated = useHydrated();
+  return combineSubnetProbeHealth(netuid, hydrated, {
+    mapData: mapQ.data,
+    detailData: detailQ.data,
+    incidentsData: incidentsQ.data,
   });
 }


### PR DESCRIPTION
Closes #7905

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/bitfathers94/metagraphed/screenshots-7905/after__mobile_dark.png)<br><sub>after</sub> |
