### PR TITLE
test(ui): add coverage for use-in-view.ts one-shot visibility hook

### DIFF
--- a/apps/ui/src/hooks/use-in-view.test.ts
+++ b/apps/ui/src/hooks/use-in-view.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { hasIntersectingEntry, hasIntersectionObserverSupport } from "./use-in-view";
+
+describe("hasIntersectionObserverSupport", () => {
+  afterEach(() => {
+    delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver;
+  });
+
+  it("is false when the runtime has no IntersectionObserver (the SSR/fallback branch)", () => {
+    expect(hasIntersectionObserverSupport()).toBe(false);
+  });
+
+  it("is true once the runtime provides one", () => {
+    (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver = class {
+      observe() {}
+      disconnect() {}
+    };
+    expect(hasIntersectionObserverSupport()).toBe(true);
+  });
+});
+
+describe("hasIntersectingEntry", () => {
+  it("is false for no entries", () => {
+    expect(hasIntersectingEntry([])).toBe(false);
+  });
+
+  it("is false when no entry is intersecting", () => {
+    expect(hasIntersectingEntry([{ isIntersecting: false }, { isIntersecting: false }])).toBe(
+      false,
+    );
+  });
+
+  it("is true once any entry is intersecting -- the one-shot become-visible trigger", () => {
+    expect(hasIntersectingEntry([{ isIntersecting: false }, { isIntersecting: true }])).toBe(true);
+  });
+});

--- a/apps/ui/src/hooks/use-in-view.ts
+++ b/apps/ui/src/hooks/use-in-view.ts
@@ -1,5 +1,18 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 
+// True when there's no IntersectionObserver in this runtime (SSR, or a
+// browser that lacks it) -- the caller should treat the element as visible
+// immediately rather than wait on an observer that will never fire.
+export function hasIntersectionObserverSupport(): boolean {
+  return typeof IntersectionObserver !== "undefined";
+}
+
+// The one-shot trigger: true once any observed entry is actually
+// intersecting.
+export function hasIntersectingEntry(entries: readonly { isIntersecting: boolean }[]): boolean {
+  return entries.some((entry) => entry.isIntersecting);
+}
+
 /**
  * Tracks whether an element is within (or near) the viewport, via
  * IntersectionObserver. Once the element has intersected, stays `true`
@@ -14,13 +27,13 @@ export function useInView<T extends Element>(rootMargin = "200px"): [RefObject<T
   useEffect(() => {
     if (inView) return;
     const el = ref.current;
-    if (!el || typeof IntersectionObserver === "undefined") {
+    if (!el || !hasIntersectionObserverSupport()) {
       setInView(true);
       return;
     }
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((e) => e.isIntersecting)) {
+        if (hasIntersectingEntry(entries)) {
           setInView(true);
           observer.disconnect();
         }


### PR DESCRIPTION
Closes #7906

Adds unit-test coverage for the `useInView` one-shot visibility hook by extracting its two branch-decisions into pure, exported helpers:

- `hasIntersectionObserverSupport()` — the SSR / no-`IntersectionObserver` fallback branch (when the runtime lacks one, the element is treated visible immediately instead of waiting on an observer that never fires).
- `hasIntersectingEntry(entries)` — the one-shot become-visible trigger; `true` once any observed entry is intersecting.

`useInView` now calls these helpers instead of inline expressions — no behavior change. `use-in-view.test.ts` covers both: support present/absent, empty entries, none-intersecting, and any-intersecting.

Test-only plus a no-op refactor — no rendered-UI change, so no screenshots.
