### PR TITLE
test(ui): add coverage for use-tao-price.ts + market.functions.ts

### DIFF
--- a/apps/ui/src/hooks/use-tao-price.test.ts
+++ b/apps/ui/src/hooks/use-tao-price.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTaoPrice } from "./use-tao-price";
+
+describe("resolveTaoPrice", () => {
+  it("returns the price on a successful fetch with a positive price", () => {
+    expect(resolveTaoPrice({ price: 412.5 })).toBe(412.5);
+  });
+
+  it("returns null when price is zero or negative", () => {
+    expect(resolveTaoPrice({ price: 0 })).toBeNull();
+    expect(resolveTaoPrice({ price: -1 })).toBeNull();
+  });
+
+  it("returns null when there is no data yet (pending) or the query failed (error)", () => {
+    expect(resolveTaoPrice(undefined)).toBeNull();
+    expect(resolveTaoPrice({})).toBeNull();
+  });
+});

--- a/apps/ui/src/hooks/use-tao-price.ts
+++ b/apps/ui/src/hooks/use-tao-price.ts
@@ -1,6 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { getTaoMarket, type TaoMarketData } from "@/lib/metagraphed/market.functions";
 
+/** Guards against a missing/non-positive price; exported for unit tests. */
+export function resolveTaoPrice(data: TaoMarketData | undefined): number | null {
+  return typeof data?.price === "number" && data.price > 0 ? data.price : null;
+}
+
 /**
  * Shared TAO/USD price hook. Backed by the same coinpaprika query used on
  * /subnets so the browser cache dedupes across the app.
@@ -16,6 +21,5 @@ export function useTaoPrice() {
     gcTime: 5 * 60_000,
     retry: 1,
   });
-  const price = typeof data?.price === "number" && data.price > 0 ? data.price : null;
-  return { price, isPending, isError };
+  return { price: resolveTaoPrice(data), isPending, isError };
 }

--- a/apps/ui/src/lib/metagraphed/market.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchTaoMarket } from "./market.functions";
+
+describe("fetchTaoMarket", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the parsed USD quote on a successful fetch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          quotes: { USD: { price: 412.5, market_cap: 1, volume_24h: 2 } },
+        }),
+      }),
+    );
+
+    await expect(fetchTaoMarket()).resolves.toEqual({
+      price: 412.5,
+      market_cap: 1,
+      volume_24h: 2,
+    });
+  });
+
+  it("resolves an empty object when the payload has no USD quote", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ quotes: {} }),
+      }),
+    );
+
+    await expect(fetchTaoMarket()).resolves.toEqual({});
+  });
+
+  it("throws with the status code on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }),
+    );
+
+    await expect(fetchTaoMarket()).rejects.toThrow("TAO market data returned 503");
+  });
+
+  it("propagates a network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    await expect(fetchTaoMarket()).rejects.toThrow("network down");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/market.functions.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.ts
@@ -6,11 +6,14 @@ export interface TaoMarketData {
   volume_24h?: number;
 }
 
-export const getTaoMarket = createServerFn({ method: "GET" }).handler(
-  async (): Promise<TaoMarketData> => {
-    const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
-    if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
-    const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
-    return payload.quotes?.USD ?? {};
-  },
-);
+// Extracted from the handler so it's unit-testable without depending on
+// createServerFn's AsyncLocalStorage request context -- see
+// market.functions.test.ts.
+export async function fetchTaoMarket(): Promise<TaoMarketData> {
+  const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
+  if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
+  const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
+  return payload.quotes?.USD ?? {};
+}
+
+export const getTaoMarket = createServerFn({ method: "GET" }).handler(fetchTaoMarket);


### PR DESCRIPTION
Closes #7907

Adds unit-test coverage for the TAO/USD price path by extracting the two untested pieces into testable units:

- `resolveTaoPrice(data)` (from `use-tao-price.ts`) — guards a missing / non-positive price, returning the price or `null`. `useTaoPrice` now delegates to it; no behavior change.
- `fetchTaoMarket()` (from `market.functions.ts`) — the fetch/parse/error core of the `getTaoMarket` server fn, pulled out as a plain async function so it can be unit-tested directly.

Coverage: `resolveTaoPrice` (positive → price; zero / negative / undefined / empty → `null`); `fetchTaoMarket` (successful USD-quote parse, empty object when no USD quote, throws with the status code on a non-ok response, propagates a network error).

Test-only plus a no-op refactor — no rendered-UI change, so no screenshots.
