### PR TITLE
feat(mcp): add netuid/limit/cursor/sort/order to get_global_incidents

### DIFF
--- a/src/global-incidents-mcp.ts
+++ b/src/global-incidents-mcp.ts
@@ -1,0 +1,175 @@
+// Global incident list-query helpers for MCP parity on GET /api/v1/incidents.
+// Mirrors endpoint-incidents-mcp.ts: validate the same filter/sort/page args the
+// REST route accepts on top of `window`, then run them through applyQueryFilters
+// over the window-scoped ledger (Postgres tier or cold empty fallback).
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
+
+export const GLOBAL_INCIDENTS_SORT_FIELDS =
+  API_QUERY_COLLECTIONS.incidents.sort_fields;
+
+export interface GlobalIncidentsMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function globalIncidentsMcpError(
+  code: string,
+  message: string,
+): GlobalIncidentsMcpError {
+  const error = new Error(message) as GlobalIncidentsMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw globalIncidentsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+/** Build the list-query URL for the incidents collection (no `window` — that is route scope). */
+export function globalIncidentsQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/incidents");
+  if (args?.netuid !== undefined) {
+    const netuid = args.netuid;
+    if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+      throw globalIncidentsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(netuid));
+  }
+  const sort = optionalEnum(args, "sort", GLOBAL_INCIDENTS_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  if (args?.limit !== undefined) {
+    const limit = args.limit;
+    if (
+      typeof limit !== "number" ||
+      !Number.isInteger(limit) ||
+      limit < 1 ||
+      limit > 1000
+    ) {
+      throw globalIncidentsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 1000.",
+      );
+    }
+    url.searchParams.set("limit", String(limit));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw globalIncidentsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+/** Flat query params to forward on the Postgres-tier /api/v1/incidents request. */
+export function globalIncidentsListParams(
+  args: Record<string, unknown> | null | undefined,
+): Record<string, string> {
+  const params: Record<string, string> = {};
+  for (const [key, value] of globalIncidentsQueryUrl(args).searchParams) {
+    params[key] = value;
+  }
+  return params;
+}
+
+export interface GlobalIncidentsListResult extends Row {
+  surfaces: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+/**
+ * Apply the incidents list-query transform to a formatGlobalIncidents ledger
+ * and flatten pagination onto the payload the way list_endpoint_incidents does.
+ */
+export function applyGlobalIncidentsListQuery(
+  ledger: Record<string, unknown> | null | undefined,
+  args: Record<string, unknown> | null | undefined,
+): GlobalIncidentsListResult {
+  const blob =
+    ledger && typeof ledger === "object"
+      ? ledger
+      : ({ surfaces: [] } as Record<string, unknown>);
+  const queryUrl = globalIncidentsQueryUrl(args);
+  const transformed = applyQueryFilters(blob, queryUrl, "incidents", []);
+  if (transformed.error) {
+    throw globalIncidentsMcpError("invalid_params", transformed.error.message);
+  }
+  const data = (transformed.data ?? blob) as Record<string, unknown>;
+  const meta = (transformed.meta ?? {}) as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.surfaces) ? (data.surfaces as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    ...data,
+    surfaces: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+/** Shared inputSchema.properties for netuid/limit/cursor/sort/order (plus callers add window). */
+export const GLOBAL_INCIDENTS_LIST_INPUT_PROPERTIES = {
+  netuid: {
+    type: "integer",
+    description: "Filter to one subnet netuid.",
+    minimum: 0,
+  },
+  sort: {
+    type: "string",
+    enum: GLOBAL_INCIDENTS_SORT_FIELDS,
+    description: "Field to sort surfaces by before paging.",
+  },
+  order: {
+    type: "string",
+    enum: ["asc", "desc"],
+    description: "Sort direction for sort (default asc).",
+  },
+  limit: {
+    type: "integer",
+    description: "Max surface rows to return (1-1000). Enables pagination.",
+    minimum: 1,
+    maximum: 1000,
+  },
+  cursor: {
+    type: "integer",
+    description: "Pagination cursor from a prior response's next_cursor.",
+    minimum: 0,
+  },
+} as const;

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -193,6 +193,11 @@ import {
   loadEndpointIncidentsList,
 } from "./endpoint-incidents-mcp.ts";
 import {
+  applyGlobalIncidentsListQuery,
+  GLOBAL_INCIDENTS_LIST_INPUT_PROPERTIES,
+  globalIncidentsListParams,
+} from "./global-incidents-mcp.ts";
+import {
   LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS,
   LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
   LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,
@@ -912,7 +917,8 @@ export const MCP_INSTRUCTIONS =
   LIST_PROFILES_INSTRUCTIONS +
   "get_subnet_profile one subnet's public-safe profile detail, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
-  "probe failures, get_chain_signers the windowed most-active-account " +
+  "probe failures (filter by netuid; sort/page with sort/order/limit/cursor), " +
+  "get_chain_signers the windowed most-active-account " +
   "leaderboard (extrinsic counts + fees), get_rpc_usage the RPC reverse-proxy " +
   "usage analytics (request volume, latency, failover, cache hits, per-endpoint " +
   "distribution) over a 7d/30d window, get_subnet_metagraph the " +
@@ -5219,7 +5225,9 @@ export const MCP_TOOLS = [
     description:
       "Fetch the cross-subnet incident ledger: surfaces that had consecutive " +
       "probe failures grouped into downtime incidents over the requested window " +
-      "(7d or 30d). Mirrors GET /api/v1/incidents.",
+      "(7d or 30d). Filter by netuid; sort with sort + order; page with limit " +
+      "(1-1000) / cursor — the same list-query pattern as list_endpoint_incidents. " +
+      "Mirrors GET /api/v1/incidents.",
     inputSchema: {
       type: "object",
       properties: {
@@ -5228,6 +5236,7 @@ export const MCP_TOOLS = [
           enum: ["7d", "30d"],
           description: "Incident lookback window (default 7d).",
         },
+        ...GLOBAL_INCIDENTS_LIST_INPUT_PROPERTIES,
       },
       additionalProperties: false,
     },
@@ -5237,18 +5246,26 @@ export const MCP_TOOLS = [
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
       const { label, days } = parseAnalyticsWindow(args?.window ?? "7d");
-      return (
+      // Validate list args up front (same vocabulary as REST), then pass them
+      // through on the Postgres-tier request the way handleGlobalIncidents
+      // forwards the caller's URL — DATA_API returns the window ledger; the
+      // in-memory incidents list-query below is what actually filters/pages.
+      const listParams = globalIncidentsListParams(args);
+      const ledger =
         (await tryPostgresTier(
           ctx.env,
-          mcpNeuronsTierRequest("/api/v1/incidents", { window: label }),
+          mcpNeuronsTierRequest("/api/v1/incidents", {
+            window: label,
+            ...listParams,
+          }),
           "METAGRAPH_HEALTH_SOURCE",
         )) ??
         (await loadGlobalIncidents({
           windowLabel: label,
           windowDays: days,
           observedAt: await mcpObservedAt(ctx),
-        }))
-      );
+        }));
+      return applyGlobalIncidentsListQuery(ledger, args);
     },
   },
   {
@@ -13424,6 +13441,13 @@ const TOOL_OUTPUT_SCHEMAS = {
       observed_at: NULLABLE_STRING,
       summary: { type: "object" },
       surfaces: { type: "array", items: { type: "object" } },
+      total: { type: "integer" },
+      returned: { type: "integer" },
+      limit: { type: "integer" },
+      cursor: { type: "integer" },
+      next_cursor: NULLABLE_INT,
+      sort: NULLABLE_STRING,
+      order: NULLABLE_STRING,
     },
   },
   get_subnet_metagraph: {

--- a/tests/global-incidents-mcp.test.ts
+++ b/tests/global-incidents-mcp.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  applyGlobalIncidentsListQuery,
+  GLOBAL_INCIDENTS_LIST_INPUT_PROPERTIES,
+  GLOBAL_INCIDENTS_SORT_FIELDS,
+  globalIncidentsListParams,
+  globalIncidentsMcpError,
+  globalIncidentsQueryUrl,
+} from "../src/global-incidents-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+const SURFACE_ROWS = [
+  { netuid: 7, surface_id: "a", incident_count: 1, downtime_ms: 300 },
+  { netuid: 7, surface_id: "b", incident_count: 3, downtime_ms: 100 },
+  { netuid: 12, surface_id: "c", incident_count: 2, downtime_ms: 900 },
+];
+
+const LEDGER = {
+  schema_version: 1,
+  window: "7d",
+  observed_at: "2026-07-01T00:00:00.000Z",
+  source: "live-cron-prober",
+  summary: { incident_count: 3, affected_surface_count: 3 },
+  surfaces: SURFACE_ROWS,
+};
+
+describe("global-incidents-mcp", () => {
+  test("globalIncidentsMcpError is shaped for MCP toolError handling", () => {
+    const err = globalIncidentsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("GLOBAL_INCIDENTS_SORT_FIELDS matches the incidents collection", () => {
+    assert.deepEqual(GLOBAL_INCIDENTS_SORT_FIELDS, [
+      "downtime_ms",
+      "incident_count",
+      "netuid",
+      "surface_id",
+    ]);
+    assert.deepEqual(
+      GLOBAL_INCIDENTS_LIST_INPUT_PROPERTIES.sort.enum,
+      GLOBAL_INCIDENTS_SORT_FIELDS,
+    );
+  });
+
+  test("globalIncidentsQueryUrl validates filters and cursor", () => {
+    const url = globalIncidentsQueryUrl({
+      netuid: 7,
+      sort: "downtime_ms",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("sort"), "downtime_ms");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("globalIncidentsListParams is a flat string map of the query URL", () => {
+    assert.deepEqual(
+      globalIncidentsListParams({
+        netuid: 12,
+        limit: 1,
+        sort: "incident_count",
+        order: "asc",
+      }),
+      {
+        netuid: "12",
+        limit: "1",
+        sort: "incident_count",
+        order: "asc",
+      },
+    );
+  });
+
+  test("globalIncidentsQueryUrl rejects invalid sort", () => {
+    assert.throws(
+      () => globalIncidentsQueryUrl({ sort: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("globalIncidentsQueryUrl rejects out-of-range limit", () => {
+    assert.throws(
+      () => globalIncidentsQueryUrl({ limit: 0 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => globalIncidentsQueryUrl({ limit: 1001 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("globalIncidentsQueryUrl rejects negative cursor and netuid", () => {
+    assert.throws(
+      () => globalIncidentsQueryUrl({ cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => globalIncidentsQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("globalIncidentsQueryUrl rejects non-integer netuid/limit/cursor", () => {
+    assert.throws(
+      () => globalIncidentsQueryUrl({ netuid: "7" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => globalIncidentsQueryUrl({ limit: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => globalIncidentsQueryUrl({ cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => globalIncidentsQueryUrl({ order: "sideways" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("globalIncidentsQueryUrl ignores empty optional enum strings", () => {
+    const url = globalIncidentsQueryUrl({ sort: "", order: "" });
+    assert.equal(url.searchParams.get("sort"), null);
+    assert.equal(url.searchParams.get("order"), null);
+  });
+
+  test("applyGlobalIncidentsListQuery filters by netuid", () => {
+    const out = applyGlobalIncidentsListQuery(LEDGER, { netuid: 12 });
+    assert.deepEqual(
+      out.surfaces.map((s) => s.netuid),
+      [12],
+    );
+    assert.equal(out.total, 1);
+    assert.equal(out.returned, 1);
+    assert.equal(out.window, "7d");
+  });
+
+  test("applyGlobalIncidentsListQuery paginates the surfaces ledger", () => {
+    const page0 = applyGlobalIncidentsListQuery(LEDGER, {
+      limit: 1,
+      sort: "downtime_ms",
+      order: "desc",
+    });
+    assert.equal(page0.surfaces.length, 1);
+    assert.equal(page0.surfaces[0].surface_id, "c");
+    assert.equal(page0.total, 3);
+    assert.equal(page0.limit, 1);
+    assert.equal(page0.cursor, 0);
+    assert.equal(page0.next_cursor, 1);
+    assert.equal(page0.sort, "downtime_ms");
+    assert.equal(page0.order, "desc");
+
+    const page1 = applyGlobalIncidentsListQuery(LEDGER, {
+      limit: 1,
+      cursor: 1,
+      sort: "downtime_ms",
+      order: "desc",
+    });
+    assert.equal(page1.surfaces[0].surface_id, "a");
+    assert.equal(page1.cursor, 1);
+    assert.equal(page1.next_cursor, 2);
+  });
+
+  test("applyGlobalIncidentsListQuery tolerates a missing surfaces array", () => {
+    const out = applyGlobalIncidentsListQuery(
+      { schema_version: 1, marker: "from-postgres" },
+      { limit: 1 },
+    );
+    assert.equal(out.marker, "from-postgres");
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("applyGlobalIncidentsListQuery tolerates a null ledger", () => {
+    const out = applyGlobalIncidentsListQuery(null, {});
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("applyGlobalIncidentsListQuery surfaces applyQueryFilters errors", () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      error: { parameter: "sort", message: "sort is not supported." },
+    });
+    try {
+      assert.throws(
+        () => applyGlobalIncidentsListQuery(LEDGER, {}),
+        (err: Row) =>
+          err.code === "invalid_params" &&
+          /sort is not supported/.test(String(err.message)),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("applyGlobalIncidentsListQuery falls back when data/meta are absent", () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({});
+    try {
+      const out = applyGlobalIncidentsListQuery(LEDGER, { limit: 1 });
+      assert.equal(out.total, 3);
+      assert.equal(out.returned, 3);
+      assert.equal(out.limit, 3);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -12240,6 +12240,92 @@ describe("MCP economics + metagraph data tools", () => {
     assert.deepEqual(out.surfaces, []);
   });
 
+  test("get_global_incidents filters by netuid and paginates over the Postgres ledger (#7890)", async () => {
+    const surfaces = [
+      { netuid: 7, surface_id: "a", incident_count: 1, downtime_ms: 300 },
+      { netuid: 7, surface_id: "b", incident_count: 3, downtime_ms: 100 },
+      { netuid: 12, surface_id: "c", incident_count: 2, downtime_ms: 900 },
+    ];
+    let captured;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          const reqUrl = new URL(req.url);
+          captured = reqUrl.pathname + reqUrl.search;
+          return Response.json({
+            schema_version: 1,
+            window: "7d",
+            observed_at: "2026-07-01T00:00:00.000Z",
+            source: "live-cron-prober",
+            summary: {
+              incident_count: surfaces.length,
+              affected_surface_count: surfaces.length,
+            },
+            surfaces,
+          });
+        },
+      },
+    };
+
+    const filtered = await callTool(
+      "get_global_incidents",
+      { window: "7d", netuid: 12 },
+      { env },
+    );
+    assert.equal(filtered.body.result.isError, false);
+    const filteredOut = filtered.body.result.structuredContent;
+    assert.deepEqual(
+      filteredOut.surfaces.map((s) => s.netuid),
+      [12],
+    );
+    assert.equal(filteredOut.total, 1);
+    assert.ok(
+      String(captured).includes("netuid=12"),
+      `expected netuid passed through to DATA_API, got ${captured}`,
+    );
+
+    const page = await callTool(
+      "get_global_incidents",
+      {
+        window: "7d",
+        limit: 1,
+        cursor: 0,
+        sort: "downtime_ms",
+        order: "desc",
+      },
+      { env },
+    );
+    assert.equal(page.body.result.isError, false);
+    const pageOut = page.body.result.structuredContent;
+    assert.equal(pageOut.surfaces.length, 1);
+    assert.equal(pageOut.surfaces[0].surface_id, "c");
+    assert.equal(pageOut.total, 3);
+    assert.equal(pageOut.limit, 1);
+    assert.equal(pageOut.cursor, 0);
+    assert.equal(pageOut.next_cursor, 1);
+    assert.equal(pageOut.sort, "downtime_ms");
+    assert.equal(pageOut.order, "desc");
+    assert.ok(
+      String(captured).includes("limit=1"),
+      `expected limit passed through to DATA_API, got ${captured}`,
+    );
+  });
+
+  test("get_global_incidents rejects invalid list-query params", async () => {
+    const badSort = await callTool("get_global_incidents", {
+      window: "7d",
+      sort: "not-a-field",
+    });
+    assert.equal(badSort.body.result.isError, true);
+
+    const badLimit = await callTool("get_global_incidents", {
+      window: "7d",
+      limit: 0,
+    });
+    assert.equal(badLimit.body.result.isError, true);
+  });
+
   test("live analytics tools reject invalid window/board params", async () => {
     const uptime = await callTool("get_subnet_uptime", {
       netuid: 7,


### PR DESCRIPTION
## Summary

- Expose `netuid`, `limit`, `cursor`, `sort`, and `order` on MCP `get_global_incidents`, matching `GET /api/v1/incidents` and the `list_endpoint_incidents` filter/sort/page pattern.
- Handler forwards those params on the Postgres-tier incidents request, then runs the shared `incidents` list-query transform over the window ledger (same post-load filtering REST uses).
- Pagination fields (`total` / `returned` / `limit` / `cursor` / `next_cursor` / `sort` / `order`) are flattened onto the tool payload like the endpoint-incidents family.

Closes #7890

## What Changed

- `src/global-incidents-mcp.ts` — query URL builder, list-param pass-through, and `applyGlobalIncidentsListQuery`.
- `src/mcp-server.mjs` — extend `get_global_incidents` inputSchema + handler; document pagination on the output schema.
- `tests/global-incidents-mcp.test.ts` + `tests/mcp-server.test.mjs` — netuid filter, paginated fetch, invalid-param rejection.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7890`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (MCP-only; no schema regen required.)

## Validation

- [x] `npx vitest run tests/global-incidents-mcp.test.ts` (15 passed, 100% patch coverage on the new module)
- [x] `npx vitest run tests/mcp-server.test.mjs -t get_global_incidents` (7 passed)
- [x] `npx vitest run tests/mcp-server-branch-coverage.test.ts -t get_global_incidents`
- [x] `npx prettier --check src/global-incidents-mcp.ts tests/global-incidents-mcp.test.ts`
- [x] `git diff --check`