### PR TITLE
build(typescript): Phase 7 — tsconfig lockdown + permanent no-hand-written-mjs CI gate

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -233,8 +233,12 @@ its structure, naming, and comment density. Build for the class, not the one cas
 
 ### Phase B1 — Implement (match the house style)
 
-- The Worker entry/router is `workers/api.mjs`; serving/overlay/health logic lives in `src/*.mjs`;
-  the contract lives in `schemas/` (+ `schemas/components/`) and `src/contracts.mjs`.
+- The Worker entry/router is `workers/api.ts`; serving/overlay/health logic lives in `src/*.ts`;
+  the contract lives in `schemas/` (+ `schemas/components/`) and `src/contracts.ts`.
+- **All new code/script/test files must be `.ts`** — never `.mjs`/`.js`. The TypeScript migration
+  (metagraphed#7510) is complete, and the `validate:no-hand-written-mjs` CI gate fails any PR that
+  adds a `.mjs`/`.js` file under `src/`, `workers/`, `scripts/`, `tests/`, or `deploy/wss-lb/`
+  (metagraphed#7521).
 - **Schema-first rule:** never hand-edit the generated contract. Edit `schemas/` →
   `npm run build` → commit `openapi.json` + generated types/clients in the same PR.
 - A new `/api/v1` route or artifact trips hidden contract gates — see the new-route checklist in
@@ -256,7 +260,7 @@ suite if a test reads served artifacts.
 | `schemas/` or `schemas/components/`          | `npm run build` | `openapi.json`, generated types, `contracts.json`, api-index                                      |
 | A new/edited `/api/v1` route or artifact     | `npm run build` | the derived `public/metagraph/*` it produces                                                      |
 | A canonical `registry/providers/<slug>.json` | `npm run build` | regenerated artifacts (commit only the provider file + its artifacts)                             |
-| MCP tools in `src/mcp-server.mjs`            | —               | **nothing** — the server card is worker-computed, not a committed artifact                        |
+| MCP tools in `src/mcp-server.ts`             | —               | **nothing** — the server card is worker-computed, not a committed artifact                        |
 | _(any of the above)_                         | `npm run build` | **never** `public/metagraph/r2-manifest.json` / `public/metagraph/schemas/index.json` — see below |
 
 Stale committed artifacts fail the **derived-artifact freshness** + **contract-drift** gates.

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -158,12 +158,12 @@ diff touches that specific path, and `checks` gates each validator step on its o
 each other — a PR can be workflow-only or migration-only without being a docs PR. These are the only
 two `checks` validators with a clean enough path boundary to skip safely; every other validator
 (`validate:schemas`/`api`/`mcp`/`ai`/`openapi`/`types`/`client-sdk-sync`) transitively imports most of
-`src/`+`workers/**` via `workers/api.mjs`, so no path glob short of "almost the whole repo" would
+`src/`+`workers/**` via `workers/api.ts`, so no path glob short of "almost the whole repo" would
 safely exclude them — see the "new artifact/route checklist" in §8 for why a route/handler change can
 trip a contract gate with no lexical hint in the diff. Per-area **test** splitting (e.g. skip
-MCP-specific tests when `src/mcp-server.mjs` wasn't touched) was evaluated and rejected: the suite has
+MCP-specific tests when `src/mcp-server.ts` wasn't touched) was evaluated and rejected: the suite has
 no per-subject directory structure (all 154 files sit flat in `tests/`), a third of it imports
-`workers/api.mjs`'s shared router directly, and `vitest.config.mjs`'s `fileParallelism: false` exists
+`workers/api.ts`'s shared router directly, and `vitest.config.mjs`'s `fileParallelism: false` exists
 for a filesystem-race reason (see below) unrelated to subject area — splitting by area would need a
 real test-tree/module-boundary refactor, not a CI config change.
 
@@ -233,7 +233,7 @@ The gate's private scoring rubric/thresholds must **never** appear in this repo 
 | Validate a surface contribution _(new)_   | `npm run validate:surface -- registry/subnets/<slug>.json`                                                                                                                                                                                                  |
 | Public-safety scan                        | `npm run scan:public-safety`                                                                                                                                                                                                                                |
 | Code/schema: regenerate the contract      | `npm run build`                                                                                                                                                                                                                                             |
-| Code/schema: typecheck _(new)_            | `npm run typecheck` (`tsc --noEmit`; `src/`+`workers/`+`scripts/`+`tests/` are still mostly `.mjs` — see the TypeScript migration epic, metagraphed#7510)                                                                                                   |
+| Code/schema: typecheck _(new)_            | `npm run typecheck` (`tsc --noEmit`; `src/`+`workers/`+`scripts/`+`tests/` are **all `.ts`** — the migration epic metagraphed#7510 is complete, and `validate:no-hand-written-mjs` fails CI if a new `.mjs`/`.js` appears under a covered directory)        |
 | Code/schema: validators                   | `npm run validate` · `validate:schemas` · `validate:api` · `validate:openapi` · `validate:types` · `validate:contract-drift` · `validate:mcp` · `validate:ai` · `validate:docs` · `validate:intake` · `validate:workflows`                                  |
 | Tests / coverage                          | `npm test` · `npm run test:coverage`                                                                                                                                                                                                                        |
 | Full local pipeline (after a clean build) | `npm run pipeline:check`                                                                                                                                                                                                                                    |
@@ -319,8 +319,8 @@ fails the PR on its own). No local paths, env dumps, or private notes.
 SDK` commit, so a hand-bump here is redundant at best and a conflicting version at worst once the
   auto PR lands).
 - **MCP server version: do NOT bump in your PR, same as the client SDK above.** `MCP_SERVER_VERSION`
-  (`src/mcp-server.mjs`) and `server.json`'s `"version"` are versioned by the post-merge
-  `sync-mcp-version` workflow — same shape as `sync-client-version`, watching `src/mcp-server.mjs` since
+  (`src/mcp-server.ts`) and `server.json`'s `"version"` are versioned by the post-merge
+  `sync-mcp-version` workflow — same shape as `sync-client-version`, watching `src/mcp-server.ts` since
   its last `chore(mcp): bump server version` commit and bumping both files together when a tool was
   added/changed. `validate:mcp` only checks _internal_ consistency (`MCP_SERVER_VERSION` ==
   `serverInfo.version` == `server.json`'s version) — it stays green regardless of what number those
@@ -422,9 +422,9 @@ SDK` commit, so a hand-bump here is redundant at best and a conflicting version 
   `npm ci --workspace=apps/ui` command Cloudflare runs — a plain full `npm ci`/`install` won't surface
   this class of bug at all.
 - **MCP server card is worker-computed — no committed artifact.** Adding or changing tools in
-  `src/mcp-server.mjs` does NOT require regenerating `public/.well-known/mcp/server-card.json` (that
+  `src/mcp-server.ts` does NOT require regenerating `public/.well-known/mcp/server-card.json` (that
   file no longer exists in git). The card is served dynamically by `mcpServerCardResponse` in
-  `workers/request-handlers/discovery.mjs`.
+  `workers/request-handlers/discovery.ts`.
 - **New `/api/v1` route or artifact** trips hidden gates depending on whether it's committed
   (DUAL_PATTERNS), live-only D1 (R2_ONLY_PATTERNS + COMPUTED_ARTIFACTS), or `/.well-known`
   worker-computed. Mirror an existing route end-to-end; the build's derived-artifact freshness gate
@@ -433,14 +433,14 @@ SDK` commit, so a hand-bump here is redundant at best and a conflicting version 
   `scripts/validate-api.ts`'s own `checks` array needs a matching `[route, assertion]` entry (it
   asserts `checks.length === API_ROUTES.length`, a **live RPC call** against real finney, not a
   stub); codecov/patch (99%, branch-counted) needs GraphQL/MCP test coverage in the _centralized_
-  `tests/graphql.test.mjs`/`tests/mcp-server.test.mjs` files specifically, not just a per-feature
+  `tests/graphql.test.ts`/`tests/mcp-server.test.ts` files specifically, not just a per-feature
   test file — a per-feature file alone leaves the GraphQL resolver and MCP tool handler at 0% patch
-  coverage even with 100% coverage on the underlying `src/*.mjs` module; and the `ui` CI job's
+  coverage even with 100% coverage on the underlying `src/*.ts` module; and the `ui` CI job's
   "Build API reference docs (drift check)" step (added 2026-07-18, mirrors the
   `packages/client`/`packages/ui-kit` drift checks just above it) fails if `apps/ui/content/docs/
 api-reference/**` wasn't regenerated — run `node scripts/generate-openapi-docs.mjs` from
   `apps/ui/` and commit the result alongside the contract change. Two more, caught live 2026-07-18
-  shipping a templated computed artifact: `src/contracts.mjs` has **two separate registries** for a
+  shipping a templated computed artifact: `src/contracts.ts` has **two separate registries** for a
   route with no static file — a `route(...)` entry (API surface metadata) AND a distinct
   `artifact(id, path, description, schemaName)` entry (the schema-ref mapping); omitting the
   `artifact()` call makes `npm run build` throw `No public artifact contract maps API artifact
@@ -455,7 +455,7 @@ api-reference/**` wasn't regenerated — run `node scripts/generate-openapi-docs
   `npm run build` fully populates R2 staging (per ADR-0001) and rewrites both to reflect that local/CI
   build, but their committed copies on `main` reflect the last real deploy/publish — not a local build —
   for reasons unrelated to your change: `r2-manifest.json` is publish infrastructure read from its
-  committed path by `scripts/kv-publish-pointer.ts` / `scripts/cloudflare-verify.mjs` /
+  committed path by `scripts/kv-publish-pointer.ts` / `scripts/cloudflare-verify.ts` /
   `scripts/sync-summary.ts` during the actual publish, and its `*_artifact_size_bytes` totals are
   inherently non-deterministic build-to-build; `schemas/index.json` is a network-capture cache the build
   "reconciles in place". Both are explicitly excluded from the derived-artifact freshness gate in
@@ -475,8 +475,8 @@ api-reference/**` wasn't regenerated — run `node scripts/generate-openapi-docs
   with no lockfile of its own — its version bumps land in the root lockfile, already covered by this
   path. If you ever add a new `actions/setup-node` step to a workflow in this repo, set this
   explicitly rather than relying on the default.
-- The Worker router is `workers/api.mjs`; serving/overlay/health live in `src/*.mjs`; the contract in
-  `schemas/` + `src/contracts.mjs`.
+- The Worker router is `workers/api.ts`; serving/overlay/health live in `src/*.ts`; the contract in
+  `schemas/` + `src/contracts.ts`.
 
 ---
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -637,6 +637,15 @@ jobs:
         if: env.RUN_MIGRATIONS_VALIDATION == 'true'
         run: npm run validate:migrations
 
+      # Permanent lock on the TS migration (#7510/#7521): no hand-written
+      # .mjs/.js may reappear under src/, workers/, scripts/, tests/, or
+      # deploy/wss-lb/. Runs unconditionally (no DOCS_ONLY skip) — it reads
+      # only `git ls-files` output, costs well under a second, and a skip
+      # predicate would itself be a hole (a "docs-only" PR can still add a
+      # tracked .mjs file).
+      - name: Validate no hand-written .mjs/.js
+        run: npm run validate:no-hand-written-mjs
+
       - name: Validate Cloudflare config
         if: env.DOCS_ONLY != 'true'
         run: npm run cloudflare:verify:dry-run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ devcontainer-aware environment, use it instead of installing Node/Playwright you
    `npm run build`, commit the regenerated `openapi.json` + generated types in the same PR, or
    `validate:contract-drift` fails CI. Never hand-edit generated artifacts under `public/`. Do **not**
    bump `packages/client/package.json` in your PR — the `sync-client-version` workflow handles that
-   post-merge. Likewise, do **not** hand-bump `MCP_SERVER_VERSION` (`src/mcp-server.mjs`) or
+   post-merge. Likewise, do **not** hand-bump `MCP_SERVER_VERSION` (`src/mcp-server.ts`) or
    `server.json`'s `"version"` — `sync-mcp-version` bumps both automatically after a tool-registry
    change lands on main. MCP tool additions do **not** require a server-card regen (it's
    worker-computed). **99% patch coverage, branch-counted** — `codecov/patch` enforces
@@ -46,7 +46,10 @@ devcontainer-aware environment, use it instead of installing Node/Playwright you
    unsharded with `npm run test:coverage`.
 5. **House rules:** Conventional Commits, **no AI/Claude/agent attribution** in commits or PR text; no
    secrets / PATs / wallet paths / private URLs anywhere; health/uptime/latency is **probe-derived
-   only** (never hand-set); one focused change per PR. **UI/frontend work now lives in this repo**
+   only** (never hand-set); one focused change per PR. **All new code/script/test files are `.ts`,
+   never `.mjs`/`.js`** — the TypeScript migration (#7510) is complete and the
+   `validate:no-hand-written-mjs` CI gate auto-fails any PR adding a `.mjs`/`.js` file under `src/`,
+   `workers/`, `scripts/`, `tests/`, or `deploy/wss-lb/`. **UI/frontend work now lives in this repo**
    at `apps/ui/` (folded in from the former `metagraphed-ui` repo via monorepo consolidation,
    2026-07) — any PR touching visual output (routes, components, styles) **requires a before/after
    screenshot table and is always held for manual review**, regardless of AI-review confidence; a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ npm run build
 
 `npm run build` here regenerates the root schema/OpenAPI contract and is what `worker:test` depends on — it's a separate step from `apps/ui`'s own build. If you're touching `apps/ui/`, see [apps/ui/CONTRIBUTING.md](apps/ui/CONTRIBUTING.md) for its own `npm run build --workspace=apps/ui` cycle; a PR touching both may need both.
 
+**New files are TypeScript.** All new code, script, and test files must be `.ts` — never `.mjs`/`.js`. The repo-wide TypeScript migration ([#7510](https://github.com/JSONbored/metagraphed/issues/7510)) is complete, and the `validate:no-hand-written-mjs` CI gate fails any PR that adds a `.mjs`/`.js` file under `src/`, `workers/`, `scripts/`, `tests/`, or `deploy/wss-lb/`.
+
 ## Schema-first rule
 
 The contract is generated, so you never edit it by hand:
@@ -39,7 +41,7 @@ Skipping the rebuild trips `validate:contract-drift` in CI. Schemas are the sour
 These are bumped automatically after your PR merges — leave them alone:
 
 - `packages/client/package.json`'s `"version"`.
-- `src/mcp-server.mjs`'s `MCP_SERVER_VERSION` and the matching `"version"` in `server.json`.
+- `src/mcp-server.ts`'s `MCP_SERVER_VERSION` and the matching `"version"` in `server.json`.
 
 CI never requires you to bump these yourself — a PR that changes the contract or adds an MCP tool is valid without touching either. Bumping one of them in your own PR doesn't help and risks a version conflict with the automation's own follow-up PR; expect it to be closed with a request to resubmit without that edit.
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "validate:private-boundary": "node scripts/validate-private-boundary.ts",
     "validate:workflows": "node scripts/validate-workflows.ts",
     "validate:migrations": "node scripts/validate-migrations.ts",
+    "validate:no-hand-written-mjs": "node scripts/validate-no-hand-written-mjs.ts",
     "migrate": "node scripts/apply-migrations.ts",
     "migrate:dry-run": "node scripts/apply-migrations.ts --dry-run",
     "openapi:generate": "node scripts/generate-openapi.ts --write",

--- a/scripts/validate-no-hand-written-mjs.ts
+++ b/scripts/validate-no-hand-written-mjs.ts
@@ -1,0 +1,61 @@
+import { execFileSync } from "node:child_process";
+import { repoRoot } from "./lib.ts";
+
+// Permanent lock on the TypeScript migration (#7510/#7521): every hand-written
+// module under the covered directories must be `.ts`. The migration converted
+// all 800+ `.mjs` files (Phases 2-6); this gate fails closed so a new `.mjs`
+// or `.js` can't quietly reintroduce untyped code — the drift this repo lived
+// with for its first ~7000 issues.
+//
+// Checks GIT-TRACKED files only (`git ls-files`), not the filesystem: vendored
+// node_modules trees (e.g. deploy/wss-lb/node_modules) legitimately contain
+// `.mjs`, and only a tracked file can regress the repo.
+//
+// The allowlist below is the documented escape hatch for a genuine future
+// exception (a file some tool physically requires to be JS). Add the exact
+// repo-relative path WITH a comment explaining why — never widen the covered
+// dirs or disable the check instead. It is intentionally empty today: root
+// tooling configs (eslint.config.mjs, vitest.config.mjs) sit outside the
+// covered directories and don't need entries.
+const COVERED_DIRS = [
+  "src/",
+  "workers/",
+  "scripts/",
+  "tests/",
+  "deploy/wss-lb/",
+];
+const ALLOWLIST = new Set<string>([]);
+
+const tracked = execFileSync("git", ["ls-files", "-z", "--", ...COVERED_DIRS], {
+  cwd: repoRoot,
+  encoding: "utf8",
+  maxBuffer: 64 * 1024 * 1024,
+})
+  .split("\0")
+  .filter(Boolean);
+
+const offenders = tracked.filter(
+  (file) =>
+    (file.endsWith(".mjs") || file.endsWith(".js")) && !ALLOWLIST.has(file),
+);
+
+if (offenders.length > 0) {
+  console.error(
+    `validate:no-hand-written-mjs failed — ${offenders.length} hand-written ` +
+      `.mjs/.js file(s) under ${COVERED_DIRS.join(", ")}:`,
+  );
+  for (const file of offenders) {
+    console.error(`- ${file}`);
+  }
+  console.error(
+    "\nNew modules in these directories must be .ts (metagraphed#7521). " +
+      "If a tool physically requires JS, add the exact path to ALLOWLIST in " +
+      "scripts/validate-no-hand-written-mjs.ts with a comment explaining why.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `validate:no-hand-written-mjs passed — no hand-written .mjs/.js under ` +
+    `${COVERED_DIRS.join(", ")} (${tracked.length} tracked files checked).`,
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,6 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "allowJs": true,
-    "checkJs": false,
     "noEmit": true,
     "allowImportingTsExtensions": true
   },


### PR DESCRIPTION
Closes #7521. The final phase of the TypeScript migration epic (#7510) — locks the completed migration in place so it can't quietly regress.

## A. Root tsconfig tightened
Removed `allowJs: true` / `checkJs: false` (added in #7511 for the transition). `npx tsc --noEmit` verified clean both before and after the removal — nothing was silently relying on JS leniency. `strict: true` was already in force for every converted file.

## B. Permanent CI gate
New `scripts/validate-no-hand-written-mjs.ts`: fails if any **git-tracked** `.mjs`/`.js` exists under `src/`, `workers/`, `scripts/`, `tests/`, or `deploy/wss-lb/`. Checks `git ls-files` rather than the filesystem, so vendored `node_modules` trees can't false-positive and only files that can actually regress the repo are considered. Includes the allowlist escape-hatch mechanism the issue asked for — intentionally empty today, with in-file instructions requiring a path + reason comment for any future exception.

Wired as `validate:no-hand-written-mjs` in `package.json` and as an unconditional step in the `checks` job (no `DOCS_ONLY` skip — the check costs under a second and a skip predicate would itself be a hole, since a "docs-only" PR can still add a tracked `.mjs`).

**Deviation from the issue text, deliberate:** the issue suggested writing the gate as `.mjs` first ("converting it to `.ts` first would be circular") with a `.ts` fast-follow. There is no actual circularity — every sibling `validate:*` script already runs as `.ts` directly via Node 22 type-stripping — so the gate is `.ts` from the start. That also keeps its allowlist genuinely empty (no self-exception) and eliminates the fast-follow PR.

Acceptance-criteria negative test: performed locally rather than via a scratch branch — a planted tracked `src/__gate_test__.mjs` made the script exit 1 naming the file; removing it returned exit 0 across the 831 tracked files in scope.

## C. Contributor docs
`SKILL.md`, `reference.md`, `CONTRIBUTING.md`, and `AGENTS.md` now all state the `.ts`-only convention for new files and reference the CI gate. Also fixed every stale `.mjs` path reference to files the migration already converted (`workers/api.ts`, `src/mcp-server.ts`, `src/contracts.ts`, `workers/request-handlers/discovery.ts`, `scripts/cloudflare-verify.ts`, the converted test files) — references to genuinely-still-`.mjs` files (`vitest.config.mjs`, `apps/ui/scripts/generate-openapi-docs.mjs`, `apps/ui/tests/e2e/capture-pr-screenshots.mjs`) were verified against the filesystem and left as-is.

## D. Optional apps/ui / ui-kit stragglers — deliberately skipped
Per the issue these are optional and outside the epic's covered scope; they're also outside the gate's covered directories, and apps/ui tooling can't be reliably verified locally. Left for their own change if wanted.

## Test plan
- [x] `npx tsc --noEmit` clean before and after the tsconfig change
- [x] `npm run validate:no-hand-written-mjs` passes (and fails correctly on a planted offender)
- [x] `npm run validate:workflows` passes with the new checks-job step
- [x] eslint + prettier clean on all touched files
- [ ] CI green