### PR TITLE
feat(api): subnet_candidates GraphQL filter/sort/page parity (#7878)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -52,6 +52,10 @@ import { loadAdapterCandidatesList } from "./adapter-candidates-mcp.ts";
 import { loadEnrichmentEvidenceList } from "./enrichment-evidence-mcp.ts";
 import { loadEnrichmentQueueList } from "./enrichment-queue-mcp.ts";
 import { loadReviewEnrichmentTargetsList } from "./review-enrichment-targets-mcp.ts";
+// #7878: GraphQL parity for GET /api/v1/subnets/{netuid}/candidates, reusing
+// loadSubnetCandidatesList that MCP list_subnet_candidates already calls
+// (#7899) -- not a reimplementation.
+import { loadSubnetCandidatesList } from "./subnet-candidates-mcp.ts";
 import { loadReviewGapsList } from "./review-gaps-mcp.ts";
 import { loadProfileCompletenessList } from "./profile-completeness-mcp.ts";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
@@ -578,8 +582,8 @@ export const SDL = `
     subnet_gaps(netuid: Int!): JSON
     "One subnet's curation evidence record — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry. Null when no evidence record has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_evidence MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/evidence."
     subnet_evidence(netuid: Int!): JSON
-    "One subnet's unpromoted candidate-surface queue — the baked per-subnet /metagraph/candidates/{netuid}.json artifact the REST route and get_subnet_candidates MCP tool read. Null when no candidate artifact has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim. Distinct from candidates(...) (the filterable network-wide candidate catalog). Mirrors GET /api/v1/subnets/{netuid}/candidates."
-    subnet_candidates(netuid: Int!): JSON
+    "One subnet's unpromoted candidate-surface queue — the baked per-subnet /metagraph/candidates/{netuid}.json artifact the REST route and get_subnet_candidates MCP tool read. Filter with kind, provider, state, id, and confidence; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the candidates rows. Null when no candidate artifact has been baked for the netuid (rather than a GraphQL error). Distinct from candidates(...) (the filterable network-wide candidate catalog). Mirrors GET /api/v1/subnets/{netuid}/candidates."
+    subnet_candidates(netuid: Int!, kind: String, provider: String, state: String, id: String, confidence: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): JSON
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
@@ -7041,17 +7045,41 @@ const rootValue = {
     return loadArtifact(context, `/metagraph/evidence/${netuid}.json`);
   },
 
-  async subnet_candidates({ netuid }: Row, context: GqlContext) {
+  async subnet_candidates(args: Row, context: GqlContext) {
+    const { netuid } = args;
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    // Same baked per-subnet candidates artifact the REST route +
-    // get_subnet_candidates MCP tool read (distinct from the network-wide
-    // candidates(...) catalog); null when no artifact has been baked for this
-    // netuid, matching subnet_gaps/subnet_evidence's cold-artifact convention.
-    return loadArtifact(context, `/metagraph/candidates/${netuid}.json`);
+    // #7878: reuse loadSubnetCandidatesList -- the same loader the
+    // list_subnet_candidates MCP tool calls (#7899) -- rather than
+    // reimplementing the filter/sort/page pass here, so this field cannot
+    // drift from GET /api/v1/subnets/{netuid}/candidates. It reads the same
+    // baked per-subnet artifact (distinct from the network-wide candidates(...)
+    // catalog) and validates every filter/sort value against the REST
+    // allowlists, throwing on an unsupported one; that throw surfaces as a
+    // normal GraphQL error, matching the review_* family's convention.
+    try {
+      return await loadSubnetCandidatesList(mcpCtx(context), args, {
+        readArtifact,
+      });
+    } catch (rawErr) {
+      const err = rawErr as Row;
+      // An unsupported filter/sort value is BAD_USER_INPUT, matching every
+      // other field's "not a silently substituted default" convention.
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      // Any other loader miss (not baked / cold R2 / unavailable) stays null,
+      // preserving this field's documented cold-artifact contract --
+      // loadArtifact, which this resolver used before, swallowed those the
+      // same way.
+      if (err?.toolError) return null;
+      throw err;
+    }
   },
 
   async subnet_health_incidents({ netuid, window }: Row, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8908,6 +8908,116 @@ describe("graphql — subnet_candidates (#7641, baked per-subnet candidate artif
   test("is weighted as a fan-out field", () => {
     assert.equal(FIELD_COMPLEXITY.subnet_candidates, 5);
   });
+
+  // #7878: full REST filter/sort/page parity, reusing the same loader
+  // list_subnet_candidates calls.
+  const FILTER_ENV = () =>
+    fixtureEnv({
+      "/metagraph/candidates/5.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 5,
+        candidates: [
+          {
+            id: "alpha-api",
+            netuid: 5,
+            kind: "subnet-api",
+            provider: "alpha",
+            state: "maintainer-review",
+            confidence: "high",
+          },
+          {
+            id: "alpha-openapi",
+            netuid: 5,
+            kind: "openapi",
+            provider: "alpha",
+            state: "schema-valid",
+            confidence: "low",
+          },
+          {
+            id: "beta-api",
+            netuid: 5,
+            kind: "subnet-api",
+            provider: "beta",
+            state: "schema-valid",
+            confidence: "low",
+          },
+        ],
+      },
+    });
+
+  test("combines two filters (kind + state) (#7878)", async () => {
+    const { status, body } = await gql(
+      '{ subnet_candidates(netuid: 5, kind: "subnet-api", state: "schema-valid") }',
+      FILTER_ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const out = body.data.subnet_candidates;
+    assert.equal(out.returned, 1);
+    assert.equal(out.candidates[0].id, "beta-api");
+  });
+
+  test("filters by provider, confidence, and id (#7878)", async () => {
+    const { body } = await gql(
+      '{ subnet_candidates(netuid: 5, provider: "alpha", confidence: "low") }',
+      FILTER_ENV(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_candidates.returned, 1);
+    assert.equal(body.data.subnet_candidates.candidates[0].id, "alpha-openapi");
+
+    const byId = await gql(
+      '{ subnet_candidates(netuid: 5, id: "beta-api") }',
+      FILTER_ENV(),
+    );
+    assert.equal(byId.body.errors, undefined);
+    assert.equal(byId.body.data.subnet_candidates.returned, 1);
+    assert.equal(byId.body.data.subnet_candidates.candidates[0].id, "beta-api");
+  });
+
+  test("sorts, pages, and round-trips next_cursor (#7878)", async () => {
+    const first = await gql(
+      '{ subnet_candidates(netuid: 5, confidence: "low", sort: "id", order: "asc", limit: 1) }',
+      FILTER_ENV(),
+    );
+    assert.equal(first.body.errors, undefined);
+    const page1 = first.body.data.subnet_candidates;
+    assert.equal(page1.total, 2);
+    assert.equal(page1.returned, 1);
+    assert.equal(page1.candidates[0].id, "alpha-openapi");
+    assert.equal(page1.next_cursor, 1);
+
+    const second = await gql(
+      '{ subnet_candidates(netuid: 5, confidence: "low", sort: "id", order: "asc", limit: 1, cursor: 1) }',
+      FILTER_ENV(),
+    );
+    const page2 = second.body.data.subnet_candidates;
+    assert.equal(page2.candidates[0].id, "beta-api");
+    assert.equal(page2.next_cursor, null);
+  });
+
+  test("an unsupported filter or sort value is a GraphQL error (#7878)", async () => {
+    const badState = await gql(
+      '{ subnet_candidates(netuid: 5, state: "bogus") }',
+      FILTER_ENV(),
+    );
+    assert.ok(badState.body.errors, "expected a GraphQL error for state");
+
+    const badConfidence = await gql(
+      '{ subnet_candidates(netuid: 5, confidence: "extreme") }',
+      FILTER_ENV(),
+    );
+    assert.ok(
+      badConfidence.body.errors,
+      "expected a GraphQL error for confidence",
+    );
+
+    const badSort = await gql(
+      '{ subnet_candidates(netuid: 5, sort: "not_a_column") }',
+      FILTER_ENV(),
+    );
+    assert.ok(badSort.body.errors, "expected a GraphQL error for sort");
+  });
 });
 
 describe("graphql — subnet_performance_history (#6981, neuron_daily reward-distribution trend)", () => {


### PR DESCRIPTION
## Summary

`subnet_candidates(netuid)` exposed **none** of the REST route's query surface — it returned the whole baked artifact verbatim. `GET /api/v1/subnets/{netuid}/candidates` supports `kind, provider, state, id, confidence, sort, order, limit, cursor`. This adds all of them.

Closes #7878.

## Approach — reuse, not reimplement

The resolver delegates to **`loadSubnetCandidatesList`**, the same loader MCP `list_subnet_candidates` calls (#7899, merged as #7930), instead of open-coding a filter/sort/page pass. That's the convention this file already uses for `review_gaps`, `review_adapter_candidates`, `adapter`, and friends — and it means this field *cannot* drift from REST, because it executes the same allowlists and the same pagination.

## Behavior

- **Filters/sort/paging**: full REST parity, with the same 1–100 limit clamp and integer cursor.
- **Unsupported filter/sort value** → `BAD_USER_INPUT` GraphQL error, matching the file's "not a silently substituted default" convention.
- **Unreadable artifact** (not baked / cold R2 / storage failure) → still resolves to **null**, preserving this field's documented cold-artifact contract. `loadArtifact`, which the resolver used before, swallowed exactly those failures the same way — so the four pre-existing tests pass unchanged.
- The envelope now carries the same pagination meta REST returns (`total`, `returned`, `limit`, `cursor`, `next_cursor`, `sort`, `order`) alongside `candidates`; the SDL description was updated to document all of it.

## Two deliberate deviations from the issue text

1. **`confidence` is `String`, not `Float`.** The published `CandidateSurface` schema defines it as `enum: ["low","medium","high"]` (`schemas/api-components.schema.json`), and the `candidates` query collection validates it as that enum. A `Float` argument could never match a row, which would defeat the issue's own Expected Outcome ("filter identically to REST").
2. **`cursor` is `Int`, not `String`.** That matches the loader and the REST route's offset cursor, and the sibling loader-backed field `review_adapter_candidates(… cursor: Int)`.

Happy to switch either if you'd rather match the issue text literally.

## Validation (full CI-parity gate set, run locally on this tree)

- [x] `npx vitest run tests/graphql.test.ts` — **928 passing** (whole GraphQL suite; the 4 pre-existing `subnet_candidates` tests unchanged and green)
- [x] New coverage: two filters combined (`kind` + `state`), `provider`+`confidence`, exact-match `id`, sort + limit paging round-tripping `next_cursor` to page 2, and rejection of a bad `state` / `confidence` / `sort`
- [x] `npx tsc --noEmit` — **0 errors** in the touched files
- [x] Changed resolver at **100% statement coverage** (verified via `vitest --coverage.include=src/graphql.ts`)
- [x] `node scripts/validate-api.ts` — 177 Worker API routes + 8 Postgres-tier routes validated
- [x] `eslint` 0 errors; repo-pinned `prettier --check` clean on staged LF content
