### PR TITLE
test(ui): cover TAO market fetch and price>0 guard

### DIFF
--- a/apps/ui/src/hooks/use-tao-price.test.ts
+++ b/apps/ui/src/hooks/use-tao-price.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTaoPriceUsd } from "./use-tao-price";
+
+describe("resolveTaoPriceUsd", () => {
+  it("returns a positive price", () => {
+    expect(resolveTaoPriceUsd({ price: 412.5 })).toBe(412.5);
+  });
+
+  it("returns null when price is missing, zero, negative, or non-numeric", () => {
+    expect(resolveTaoPriceUsd(undefined)).toBeNull();
+    expect(resolveTaoPriceUsd({})).toBeNull();
+    expect(resolveTaoPriceUsd({ price: 0 })).toBeNull();
+    expect(resolveTaoPriceUsd({ price: -1 })).toBeNull();
+    expect(resolveTaoPriceUsd({ price: Number.NaN })).toBeNull();
+  });
+});

--- a/apps/ui/src/hooks/use-tao-price.ts
+++ b/apps/ui/src/hooks/use-tao-price.ts
@@ -1,5 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
-import { getTaoMarket, type TaoMarketData } from "@/lib/metagraphed/market.functions";
+import {
+  getTaoMarket,
+  type TaoMarketData,
+} from "@/lib/metagraphed/market.functions";
+
+/**
+ * Resolve a displayable TAO/USD price. Returns `null` unless `price` is a
+ * finite number strictly greater than zero — callers must render a
+ * "USD unavailable" fallback rather than invent a number.
+ */
+export function resolveTaoPriceUsd(data: TaoMarketData | undefined): number | null {
+  return typeof data?.price === "number" && data.price > 0 ? data.price : null;
+}
 
 /**
  * Shared TAO/USD price hook. Backed by the same coinpaprika query used on
@@ -16,6 +28,5 @@ export function useTaoPrice() {
     gcTime: 5 * 60_000,
     retry: 1,
   });
-  const price = typeof data?.price === "number" && data.price > 0 ? data.price : null;
-  return { price, isPending, isError };
+  return { price: resolveTaoPriceUsd(data), isPending, isError };
 }

--- a/apps/ui/src/lib/metagraphed/market.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchTaoMarketData } from "./market.functions";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchTaoMarketData", () => {
+  it("returns the USD quote when price is positive", async () => {
+    const usd = { price: 412.5, market_cap: 1e9, volume_24h: 2e7 };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ quotes: { USD: usd } }),
+      }),
+    );
+
+    await expect(fetchTaoMarketData()).resolves.toEqual(usd);
+    expect(fetch).toHaveBeenCalledWith("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
+  });
+
+  it("returns an empty object when the USD quote is missing (price guard lives in the hook)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ quotes: {} }),
+      }),
+    );
+    await expect(fetchTaoMarketData()).resolves.toEqual({});
+  });
+
+  it("returns the payload even when price is zero or negative (hook rejects those)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ quotes: { USD: { price: 0 } } }),
+      }),
+    );
+    await expect(fetchTaoMarketData()).resolves.toEqual({ price: 0 });
+  });
+
+  it("throws when the upstream response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    );
+    await expect(fetchTaoMarketData()).rejects.toThrow("TAO market data returned 503");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/market.functions.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.ts
@@ -6,11 +6,18 @@ export interface TaoMarketData {
   volume_24h?: number;
 }
 
+/**
+ * Fetch TAO/USD market quotes from CoinPaprika. Throws on non-OK HTTP.
+ * Extracted from the createServerFn handler so unit tests can cover success /
+ * empty / failure without the TanStack Start transport.
+ */
+export async function fetchTaoMarketData(): Promise<TaoMarketData> {
+  const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
+  if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
+  const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
+  return payload.quotes?.USD ?? {};
+}
+
 export const getTaoMarket = createServerFn({ method: "GET" }).handler(
-  async (): Promise<TaoMarketData> => {
-    const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
-    if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
-    const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
-    return payload.quotes?.USD ?? {};
-  },
+  async (): Promise<TaoMarketData> => fetchTaoMarketData(),
 );


### PR DESCRIPTION
## Summary
- Extract `fetchTaoMarketData` from the `createServerFn` handler and cover success / empty / zero-price payload / HTTP error with a mocked `fetch`.
- Extract `resolveTaoPriceUsd` from `useTaoPrice` and cover the `price > 0` guard (null for missing/zero/negative/NaN).
- No `.tsx` / visual changes.

Closes #7907

## Test plan
- [x] `cd apps/ui && npx vitest run src/lib/metagraphed/market.functions.test.ts src/hooks/use-tao-price.test.ts`

Made with [Cursor](https://cursor.com)