### PR TITLE
test(ui): cover useInView one-shot visibility and IO fallback

### DIFF
--- a/apps/ui/src/hooks/use-in-view.test.ts
+++ b/apps/ui/src/hooks/use-in-view.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { entriesIndicateInView, shouldFallbackInView } from "./use-in-view";
+
+describe("shouldFallbackInView", () => {
+  it("falls back when the element is missing (SSR / not mounted)", () => {
+    expect(shouldFallbackInView(null, true)).toBe(true);
+  });
+
+  it("falls back when IntersectionObserver is unavailable", () => {
+    const el = {} as Element;
+    expect(shouldFallbackInView(el, false)).toBe(true);
+  });
+
+  it("observes when the element exists and IntersectionObserver is available", () => {
+    const el = {} as Element;
+    expect(shouldFallbackInView(el, true)).toBe(false);
+  });
+});
+
+describe("entriesIndicateInView", () => {
+  it("becomes visible when any entry is intersecting (one-shot trigger)", () => {
+    expect(
+      entriesIndicateInView([
+        { isIntersecting: false },
+        { isIntersecting: true },
+      ]),
+    ).toBe(true);
+  });
+
+  it("stays not-yet-visible when nothing intersects", () => {
+    expect(
+      entriesIndicateInView([{ isIntersecting: false }, { isIntersecting: false }]),
+    ).toBe(false);
+  });
+
+  it("treats an empty entry list as not intersecting", () => {
+    expect(entriesIndicateInView([])).toBe(false);
+  });
+});
+
+describe("IntersectionObserver one-shot contract (minimal mock)", () => {
+  it("disconnects after the first intersecting callback (stays visible forever)", () => {
+    const disconnect = vi.fn();
+    const observe = vi.fn();
+    let callback: IntersectionObserverCallback | undefined;
+
+    class MockIO {
+      constructor(cb: IntersectionObserverCallback) {
+        callback = cb;
+      }
+      observe = observe;
+      disconnect = disconnect;
+      unobserve = vi.fn();
+      takeRecords = () => [];
+      root = null;
+      rootMargin = "";
+      thresholds = [];
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIO);
+
+    const io = new IntersectionObserver((entries) => {
+      if (entriesIndicateInView(entries)) {
+        // mirrors useInView: mark visible then disconnect
+        disconnect();
+      }
+    });
+    const el = {} as Element;
+    io.observe(el);
+    expect(observe).toHaveBeenCalledWith(el);
+
+    // not intersecting yet
+    callback?.(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      io as unknown as IntersectionObserver,
+    );
+    expect(disconnect).not.toHaveBeenCalled();
+
+    // first intersect → disconnect (one-shot); later leaves do not re-arm
+    callback?.(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      io as unknown as IntersectionObserver,
+    );
+    expect(disconnect).toHaveBeenCalledTimes(1);
+
+    callback?.(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      io as unknown as IntersectionObserver,
+    );
+    expect(disconnect).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/ui/src/hooks/use-in-view.ts
+++ b/apps/ui/src/hooks/use-in-view.ts
@@ -1,6 +1,25 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 
 /**
+ * True when the hook should treat the element as already in view without
+ * observing: missing element (SSR / not yet mounted) or no IntersectionObserver
+ * in the runtime.
+ */
+export function shouldFallbackInView(
+  el: Element | null,
+  hasIntersectionObserver: boolean,
+): boolean {
+  return !el || !hasIntersectionObserver;
+}
+
+/**
+ * One-shot visibility: any intersecting entry means "become visible forever".
+ */
+export function entriesIndicateInView(entries: ReadonlyArray<{ isIntersecting: boolean }>): boolean {
+  return entries.some((e) => e.isIntersecting);
+}
+
+/**
  * Tracks whether an element is within (or near) the viewport, via
  * IntersectionObserver. Once the element has intersected, stays `true`
  * forever (the observer disconnects) — for gating one-shot data fetches
@@ -14,20 +33,20 @@ export function useInView<T extends Element>(rootMargin = "200px"): [RefObject<T
   useEffect(() => {
     if (inView) return;
     const el = ref.current;
-    if (!el || typeof IntersectionObserver === "undefined") {
+    if (shouldFallbackInView(el, typeof IntersectionObserver !== "undefined")) {
       setInView(true);
       return;
     }
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((e) => e.isIntersecting)) {
+        if (entriesIndicateInView(entries)) {
           setInView(true);
           observer.disconnect();
         }
       },
       { rootMargin },
     );
-    observer.observe(el);
+    observer.observe(el as T);
     return () => observer.disconnect();
   }, [inView, rootMargin]);
 


### PR DESCRIPTION
## Summary
- Extract `shouldFallbackInView` (SSR / no-`IntersectionObserver`) and `entriesIndicateInView` (one-shot trigger).
- Cover both helpers plus a minimal `IntersectionObserver` mock that disconnects after the first intersecting callback (stays visible forever).
- No `.tsx` / visual changes.

Closes #7906

## Test plan
- [x] `cd apps/ui && npx vitest run src/hooks/use-in-view.test.ts`

Made with [Cursor](https://cursor.com)