### PR TITLE
feat(api): subnet_turnover changes toggle with a typed churn detail (#7883)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -829,7 +829,7 @@ export const SDL = `
     "Live current registration/burn cost for one subnet -- the dynamic price between the static min_burn_tao/max_burn_tao bounds, read directly from chain via RPC (not the Postgres tier). burn_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/burn."
     subnet_burn(netuid: Int!): SubnetBurn
     "One subnet's validator/neuron-set turnover (entered/exited/retention/0-100 stability) between the boundary snapshots of a 7d/30d/90d/1y/all window (default 30d), from neuron_daily. comparable is false and the churn metrics zeroed on a single-snapshot or cold store, never null. Mirrors GET /api/v1/subnets/{netuid}/turnover."
-    subnet_turnover(netuid: Int!, window: String): SubnetTurnover!
+    subnet_turnover(netuid: Int!, window: String, changes: Boolean): SubnetTurnover!
     "Every automatic ownership transfer one subnet has undergone (#6637, part of the conviction/ownership-contest tracker epic #4302), decoded from the chain_events SubnetOwnerChanged stream -- Bittensor subnet ownership is a permissionless, conviction-weighted contest that transfers automatically once a challenger's conviction overtakes the incumbent owner's, no vote required. A subnet that has never changed hands returns an empty list. Reaches the Postgres-only all-events tier directly (no D1 predecessor); an out-of-range netuid or an unavailable tier is a GraphQL error, never a silent empty list. Mirrors GET /api/v1/subnets/{netuid}/ownership-history."
     subnet_ownership_history(netuid: Int!): SubnetOwnershipHistory!
     "Live per-subnet conviction leaderboard (#6638, part of the conviction/ownership-contest tracker epic #4302) -- who currently holds the most rolled conviction, i.e. how close the subnet is to an automatic ownership flip. Companion to subnet_ownership_history (that's the event log of past flips; this is the current standings). A subnet with no active challengers/owner lock returns an empty leaderboard. Reaches the Postgres-only all-events tier directly; an out-of-range netuid or an unavailable tier is a GraphQL error, never a silent empty leaderboard. Mirrors GET /api/v1/subnets/{netuid}/conviction."
@@ -3156,6 +3156,32 @@ export const SDL = `
     uids_deregistered: Int!
     neuron_retention: Float
     stability_score: Int
+    "Per-neuron churn detail behind the counts above, populated only when the field's changes toggle is set (mirroring REST's ?changes=true). Null otherwise, and on a cold store."
+    changes: SubnetTurnoverChanges
+  }
+
+  "One validator that entered or left a subnet's validator set between the window's boundary snapshots."
+  type TurnoverValidatorChange {
+    hotkey: String!
+    "The UID it held at the boundary snapshot, null when the row carried no usable uid."
+    uid: Int
+  }
+
+  "One UID that changed hands between the window's boundary snapshots."
+  type TurnoverUidReassignment {
+    uid: Int!
+    from_hotkey: String!
+    to_hotkey: String!
+  }
+
+  "The per-neuron churn behind a subnet's turnover scorecard: which validators entered and exited, and which UIDs were reassigned. Mirrors the changes block of GET /api/v1/subnets/{netuid}/turnover?changes=true."
+  type SubnetTurnoverChanges {
+    validators_entered_count: Int!
+    validators_exited_count: Int!
+    uid_reassignment_count: Int!
+    validators_entered: [TurnoverValidatorChange!]!
+    validators_exited: [TurnoverValidatorChange!]!
+    uid_reassignments: [TurnoverUidReassignment!]!
   }
 
   "Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history."
@@ -4828,6 +4854,49 @@ function subnetNode(identity: Row, prefetch: Row = {}) {
 // exists in this schema yet) -- stringify it here rather than letting
 // graphql-js' default String serializer coerce the object via `String(...)`
 // (which would silently produce "[object Object]").
+// REST's turnoverChangeDetail block, normalized into the SubnetTurnoverChanges
+// type. Absent when the caller did not set the changes toggle and on the cold
+// buildTurnover([]) fallback, both of which resolve the field to null rather
+// than a fabricated empty block. Counts fall back to their own list lengths so
+// a body carrying lists but no counts still answers consistently, and entries
+// missing a hotkey/uid are dropped rather than surfaced as nulls inside the
+// non-nullable list items.
+function turnoverChangesNode(detail: Row | null | undefined) {
+  if (!detail || typeof detail !== "object") return null;
+  const validatorList = (value: unknown) =>
+    (Array.isArray(value) ? value : [])
+      .filter((entry: Row) => typeof entry?.hotkey === "string")
+      .map((entry: Row) => ({
+        hotkey: entry.hotkey,
+        uid: Number.isInteger(entry.uid) ? entry.uid : null,
+      }));
+  const entered = validatorList(detail.validators_entered);
+  const exited = validatorList(detail.validators_exited);
+  const reassignments = (
+    Array.isArray(detail.uid_reassignments) ? detail.uid_reassignments : []
+  )
+    .filter(
+      (entry: Row) =>
+        Number.isInteger(entry?.uid) &&
+        typeof entry?.from_hotkey === "string" &&
+        typeof entry?.to_hotkey === "string",
+    )
+    .map((entry: Row) => ({
+      uid: entry.uid,
+      from_hotkey: entry.from_hotkey,
+      to_hotkey: entry.to_hotkey,
+    }));
+  return {
+    validators_entered_count: detail.validators_entered_count ?? entered.length,
+    validators_exited_count: detail.validators_exited_count ?? exited.length,
+    uid_reassignment_count:
+      detail.uid_reassignment_count ?? reassignments.length,
+    validators_entered: entered,
+    validators_exited: exited,
+    uid_reassignments: reassignments,
+  };
+}
+
 function extrinsicNode(extrinsic: Row) {
   if (!extrinsic) return null;
   return {
@@ -10137,7 +10206,7 @@ const rootValue = {
     return loadSubnetBurn(context.env, netuid);
   },
 
-  async subnet_turnover({ netuid, window }: Row, context: GqlContext) {
+  async subnet_turnover({ netuid, window, changes }: Row, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError("netuid must be a u16 subnet id (0-65535).", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -10155,11 +10224,14 @@ const rootValue = {
     const { label } = windowResult;
     const params = new URLSearchParams();
     params.set("window", label);
+    // Opt into REST's ?changes=true per-neuron detail. Only forward the param
+    // when true, so the default scorecard request stays byte-identical.
+    if (changes === true) params.set("changes", "true");
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildTurnover([]) empty-card
     // fallback contract the REST handler uses (neuron_daily boundary snapshots); a
     // subnet with no boundary rows in the window is a schema-stable empty card,
-    // never a GraphQL error. Mirrors the default scorecard (REST's ?changes=true
-    // detail is omitted).
+    // never a GraphQL error. The cold fallback carries no `changes` block, so the
+    // field resolves to null even when the toggle is set.
     const data =
       ((await tryPostgresTier(
         context.env,
@@ -10187,6 +10259,7 @@ const rootValue = {
       uids_deregistered: data.uids_deregistered ?? 0,
       neuron_retention: data.neuron_retention ?? null,
       stability_score: data.stability_score ?? null,
+      changes: turnoverChangesNode(data.changes as Row | null | undefined),
     };
   },
 

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -4342,6 +4342,132 @@ describe("graphql — subnet_turnover (#5886, Postgres-tier + empty-card fallbac
       body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
     );
   });
+
+  const CHANGES_SELECTION = `changes {
+    validators_entered_count validators_exited_count uid_reassignment_count
+    validators_entered { hotkey uid }
+    validators_exited { hotkey uid }
+    uid_reassignments { uid from_hotkey to_hotkey }
+  }`;
+
+  test("changes: true forwards ?changes=true and resolves the typed churn detail (#7883)", async () => {
+    let capturedUrl: URL | undefined;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            netuid: 5,
+            window: "30d",
+            comparable: true,
+            changes: {
+              validators_entered_count: 2,
+              validators_exited_count: 1,
+              uid_reassignment_count: 1,
+              validators_entered: [
+                { hotkey: "5Hentered1", uid: 3 },
+                { hotkey: "5Hentered2", uid: null },
+              ],
+              validators_exited: [{ hotkey: "5Hexited1", uid: 9 }],
+              uid_reassignments: [
+                { uid: 12, from_hotkey: "5Hold", to_hotkey: "5Hnew" },
+              ],
+            },
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ subnet_turnover(netuid: 5, changes: true) { comparable ${CHANGES_SELECTION} } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl?.searchParams.get("changes"), "true");
+    const detail = body.data.subnet_turnover.changes;
+    assert.equal(detail.validators_entered_count, 2);
+    assert.equal(detail.uid_reassignment_count, 1);
+    assert.deepEqual(detail.validators_entered, [
+      { hotkey: "5Hentered1", uid: 3 },
+      { hotkey: "5Hentered2", uid: null },
+    ]);
+    assert.deepEqual(detail.validators_exited, [
+      { hotkey: "5Hexited1", uid: 9 },
+    ]);
+    assert.deepEqual(detail.uid_reassignments, [
+      { uid: 12, from_hotkey: "5Hold", to_hotkey: "5Hnew" },
+    ]);
+  });
+
+  test("without the changes toggle the param is omitted and changes is null (#7883)", async () => {
+    let capturedUrl: URL | undefined;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ schema_version: 1, netuid: 5, window: "30d" });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ subnet_turnover(netuid: 5) { changes { uid_reassignment_count } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl?.searchParams.has("changes"), false);
+    assert.equal(body.data.subnet_turnover.changes, null);
+  });
+
+  test("a cold store resolves changes to null even when the toggle is set (#7883)", async () => {
+    const { status, body } = await gql(
+      `{ subnet_turnover(netuid: 1, changes: true) { comparable changes { uid_reassignment_count } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_turnover.comparable, false);
+    assert.equal(body.data.subnet_turnover.changes, null);
+  });
+
+  test("changes counts fall back to list lengths and malformed entries are dropped (#7883)", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: 5,
+            changes: {
+              // No *_count keys, and entries missing hotkey/uid must not surface
+              // as nulls inside the non-nullable list items.
+              validators_entered: [{ hotkey: "5Hkept", uid: 1 }, { uid: 2 }],
+              validators_exited: [],
+              uid_reassignments: [
+                { uid: 4, from_hotkey: "5Ha", to_hotkey: "5Hb" },
+                { uid: 5, from_hotkey: "5Hc" },
+              ],
+            },
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      `{ subnet_turnover(netuid: 5, changes: true) { ${CHANGES_SELECTION} } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const detail = body.data.subnet_turnover.changes;
+    assert.equal(detail.validators_entered_count, 1);
+    assert.equal(detail.validators_exited_count, 0);
+    assert.equal(detail.uid_reassignment_count, 1);
+    assert.deepEqual(detail.validators_entered, [{ hotkey: "5Hkept", uid: 1 }]);
+    assert.deepEqual(detail.uid_reassignments, [
+      { uid: 4, from_hotkey: "5Ha", to_hotkey: "5Hb" },
+    ]);
+  });
 });
 
 // #6978: GraphQL parity for the conviction/ownership-contest (#4302) and


### PR DESCRIPTION
Closes #7883

## Summary

Adds a `changes: Boolean` argument to `subnet_turnover`, closing a parity gap: `GET /api/v1/subnets/{netuid}/turnover` accepts a `changes` toggle that returns the underlying per-neuron churn detail, but GraphQL only ever returned the summary scorecard.

**The detail is modelled as real GraphQL types, not an opaque `JSON` blob.** A previous attempt at this issue exposed it as `changes: JSON`; review flagged that an untyped passthrough sits awkwardly in a typed object, so this version defines proper types — the entered/exited validator lists and UID reassignments are introspectable and field-selectable like the rest of the schema.

```graphql
type SubnetTurnoverChanges {
  validators_entered_count: Int!
  validators_exited_count: Int!
  uid_reassignment_count: Int!
  validators_entered: [TurnoverValidatorChange!]!
  validators_exited: [TurnoverValidatorChange!]!
  uid_reassignments: [TurnoverUidReassignment!]!
}
```

`TurnoverValidatorChange` is `{ hotkey: String!, uid: Int }` and `TurnoverUidReassignment` is `{ uid: Int!, from_hotkey: String!, to_hotkey: String! }` — matching `src/turnover.ts`'s `ValidatorDetail` and reassignment shapes exactly.

## What changed (2 files)

- **`src/graphql.ts`** — the three types above, the `changes: Boolean` arg, and `turnoverChangesNode`, which normalizes REST's `turnoverChangeDetail` block: counts fall back to their own list lengths (so a body with lists but no counts still answers consistently), and entries missing a `hotkey`/`uid` are dropped rather than surfaced as nulls inside the non-nullable list items. The param is forwarded **only when the toggle is true**, so the default scorecard request stays byte-identical. Resolves to `null` on the default request and on the cold `buildTurnover([])` fallback, which carries no `changes` block.
- **`tests/graphql.test.ts`** — the typed detail round-tripping through a full field selection, the default omitting the param with `changes` null, the cold store resolving null even with the toggle set, and the count-fallback / malformed-entry-dropping behaviour.

GraphQL is served dynamically from the SDL — no generated contract/OpenAPI artifacts change.

## Validation

- [x] `tests/graphql.test.ts` green (928 tests) — every added line exercised (100% patch).
- [x] `tsc --noEmit` clean; `eslint` + `prettier` clean.

---

### Note: one CI-unblocking commit included

`main` is currently red for an unrelated reason, so no PR cut from it can go green on its own. #7956 added a `validate:no-hand-written-mjs` step to `validate.yml` but did not register it in `scripts/pipeline.ts`, so `tests/pipeline-validator-parity.test.ts` fails on pristine `main` (verified locally against `origin/main` in a clean worktree):

> AssertionError: validate.yml runs validators the local `npm run check` does not: validate:no-hand-written-mjs. Add them to scripts/pipeline.ts checkCommands (and refreshCommands).

This PR includes that two-line registration, exactly as the failure message prescribes and identically to how the other in-flight PRs (#7970, #7972, #7975) unblock themselves. Happy to drop it if a dedicated fix lands first — it is isolated to `scripts/pipeline.ts` and independent of the `subnet_turnover` change.
