### PR TITLE
feat(mcp): add list_subnet_health — filtered sibling of get_subnet_health (#7901)

### DIFF
--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -382,6 +382,14 @@ assert.ok(
 const overview = await callOk("get_subnet", { netuid: 7 });
 assert.equal(overview.netuid ?? overview.subnet?.netuid ?? 7, 7);
 await callOk("get_subnet_health", { netuid: 7 });
+const subnetHealthPage = await callOk("list_subnet_health", {
+  netuid: 7,
+  limit: 3,
+});
+assert.ok(
+  Array.isArray(subnetHealthPage.surfaces),
+  "list_subnet_health must return surfaces[]",
+);
 
 const apis = await callOk("list_subnet_apis", { netuid: 7 });
 assert.ok(

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -152,6 +152,12 @@ import {
   loadSubnetCandidatesList,
 } from "./subnet-candidates-mcp.ts";
 import {
+  LIST_SUBNET_HEALTH_INSTRUCTIONS,
+  LIST_SUBNET_HEALTH_MCP_TOOL,
+  LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
+  loadSubnetHealthList,
+} from "./subnet-health-mcp.ts";
+import {
   LIST_EVIDENCE_INSTRUCTIONS,
   LIST_EVIDENCE_MCP_TOOL,
   LIST_EVIDENCE_OUTPUT_SCHEMA,
@@ -908,7 +914,9 @@ export const MCP_INSTRUCTIONS =
   GET_NETWORK_HEALTH_INSTRUCTIONS +
   GET_HEALTH_HISTORY_INSTRUCTIONS +
   "get_health_trends the all-subnet 7d/30d " +
-  "uptime + latency matrix, get_subnet_health_trends one subnet's per-surface " +
+  "uptime + latency matrix, get_subnet_health one subnet's live health card, " +
+  LIST_SUBNET_HEALTH_INSTRUCTIONS +
+  "get_subnet_health_trends one subnet's per-surface " +
   "health trends, get_subnet_health_percentiles its " +
   "per-surface p50/p95/p99 request-latency distribution, " +
   "get_subnet_health_incidents its per-surface SLA + reconstructed downtime " +
@@ -2945,6 +2953,12 @@ export const MCP_TOOLS = [
         reliability,
         surfaces: [],
       };
+    },
+  },
+  {
+    ...LIST_SUBNET_HEALTH_MCP_TOOL,
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSubnetHealthList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -11998,6 +12012,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       }),
     },
   },
+  list_subnet_health: LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
   get_subnet_health_trends: {
     type: "object",
     additionalProperties: true,

--- a/src/subnet-health-mcp.ts
+++ b/src/subnet-health-mcp.ts
@@ -1,0 +1,366 @@
+// Per-subnet health surfaces list loader for MCP parity on
+// GET /api/v1/subnets/{netuid}/health. Applies the same list-query
+// transforms as the REST route over the live per-subnet health card
+// (or a test-injected snapshot at the retired
+// /metagraph/health/subnets/{netuid}.json path).
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import { overlaySubnetHealth, resolveLiveHealth } from "./health-serving.ts";
+
+const HEALTH_SURFACE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["health-surfaces"].sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const HEALTH_CLASSIFICATIONS = QUERY_ENUMS.healthClassification;
+const SUBNET_HEALTH_QUERY_FILTER_NAMES = [
+  "kind",
+  "provider",
+  "status",
+  "classification",
+];
+
+export function subnetHealthArtifactPath(netuid: unknown): string {
+  return `/metagraph/health/subnets/${netuid}.json`;
+}
+
+export interface SubnetHealthMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function subnetHealthMcpError(
+  code: string,
+  message: string,
+): SubnetHealthMcpError {
+  const error = new Error(message) as SubnetHealthMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireNetuid(
+  args: Record<string, unknown> | null | undefined,
+): number {
+  const netuid = args?.netuid;
+  if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+function unknownSubnetHealthCard(netuid: number): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    netuid,
+    summary: {
+      status: "unknown",
+      surface_count: 0,
+      ok_count: 0,
+      degraded_count: 0,
+      failed_count: 0,
+      unknown_count: 0,
+      last_checked: null,
+      last_ok: null,
+      avg_latency_ms: null,
+    },
+    operational_observed_at: null,
+    health_source: "unavailable",
+    surfaces: [],
+  };
+}
+
+export function subnetHealthQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/subnets/health");
+  requireNetuid(args);
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const classification = optionalEnum(
+    args,
+    "classification",
+    HEALTH_CLASSIFICATIONS,
+  );
+  if (classification) url.searchParams.set("classification", classification);
+  const sort = optionalEnum(args, "sort", HEALTH_SURFACE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw subnetHealthMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+export interface SubnetHealthListResult {
+  generated_at: unknown;
+  schema_version: unknown;
+  netuid: unknown;
+  summary: unknown;
+  operational_observed_at: unknown;
+  health_source: unknown;
+  surfaces: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadSubnetHealthList(
+  ctx: {
+    env: Env;
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+    readHealthKv?: (
+      env: Env,
+      key: string,
+    ) => Promise<Record<string, unknown> | null>;
+  },
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+    resolveLiveHealth: resolveLive,
+    overlaySubnetHealth: overlay,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+    resolveLiveHealth?: typeof resolveLiveHealth;
+    overlaySubnetHealth?: typeof overlaySubnetHealth;
+  } = {},
+): Promise<SubnetHealthListResult> {
+  const netuid = requireNetuid(args);
+  const queryUrl = subnetHealthQueryUrl(args);
+  const artifactPath = subnetHealthArtifactPath(netuid);
+
+  let blob: Record<string, unknown>;
+
+  // Endpoints-shaped injection path: unit tests pass a surfaces-bearing
+  // snapshot via readArtifact (retired artifact path). Production leaves
+  // this unset and uses the live overlay below (REST parity).
+  if (readArtifact) {
+    const result = await readArtifact(ctx.env, artifactPath);
+    if (!result?.ok) {
+      const code =
+        (result as { code?: string } | undefined)?.code ||
+        "artifact_unavailable";
+      if (code === "artifact_not_found") {
+        throw subnetHealthMcpError(
+          "not_found",
+          `No health snapshot exists for netuid ${netuid}.`,
+        );
+      }
+      throw subnetHealthMcpError(
+        code,
+        `Could not load ${artifactPath} (${code}).`,
+      );
+    }
+    const data = result.data;
+    if (!data || typeof data !== "object") {
+      throw subnetHealthMcpError(
+        "not_found",
+        `No health snapshot exists for netuid ${netuid}.`,
+      );
+    }
+    blob = data as Record<string, unknown>;
+  } else {
+    const resolve = resolveLive ?? resolveLiveHealth;
+    const overlayFn = overlay ?? overlaySubnetHealth;
+    const live = await resolve({
+      readHealthKv: ctx.readHealthKv,
+      env: ctx.env,
+    });
+    blob =
+      (overlayFn(null, live, netuid) as Record<string, unknown> | null) ??
+      unknownSubnetHealthCard(netuid);
+  }
+
+  const transformed = applyQueryFilters(
+    blob,
+    queryUrl,
+    "health-surfaces",
+    SUBNET_HEALTH_QUERY_FILTER_NAMES,
+  );
+  if (transformed.error) {
+    throw subnetHealthMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = transformed.meta as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.surfaces) ? (data.surfaces as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    schema_version: data.schema_version ?? null,
+    netuid: data.netuid ?? netuid,
+    summary: data.summary ?? null,
+    operational_observed_at: data.operational_observed_at ?? null,
+    health_source: data.health_source ?? null,
+    surfaces: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SUBNET_HEALTH_INSTRUCTIONS =
+  "list_subnet_health one subnet's live health surfaces with REST list-query " +
+  "filters (kind, provider, status, classification, sort, and pagination; " +
+  "mirrors GET /api/v1/subnets/{netuid}/health), ";
+
+export const LIST_SUBNET_HEALTH_MCP_TOOL = {
+  name: "list_subnet_health",
+  title: "List one subnet's health surfaces",
+  description:
+    "Fetch live operational health surfaces for one subnet by netuid: each " +
+    "surface with kind, provider, probe-derived status, classification, " +
+    "latency, and last-ok timestamps. Filter by kind, provider, status, or " +
+    "classification; sort with sort + order; project with fields; and page " +
+    "with limit (1-100) / cursor. Distinct from get_subnet_health (unfiltered " +
+    "live card) and get_network_health (global rollup). Mirrors " +
+    "GET /api/v1/subnets/{netuid}/health.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      classification: {
+        type: "string",
+        enum: HEALTH_CLASSIFICATIONS,
+        description: "Filter by probe classification.",
+      },
+      sort: {
+        type: "string",
+        enum: HEALTH_SURFACE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of health surface row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["netuid"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SUBNET_HEALTH_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["surfaces"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    schema_version: { type: ["string", "integer", "null"] },
+    netuid: NULLABLE_INT,
+    summary: { type: ["object", "null"] },
+    operational_observed_at: NULLABLE_STRING,
+    health_source: NULLABLE_STRING,
+    surfaces: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -2578,6 +2578,108 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_subnet_health filters live surfaces by status and classification", async () => {
+    const deps = makeDeps(
+      {},
+      {
+        "health:current": {
+          last_run_at: FRESH_RUN,
+          surfaces: [
+            {
+              surface_id: "7:subnet-api:x",
+              netuid: 7,
+              kind: "subnet-api",
+              provider: "allways",
+              status: "ok",
+              classification: "live",
+              latency_ms: 100,
+              last_checked: "2026-07-01T00:00:00.000Z",
+              last_ok: "2026-07-01T00:00:00.000Z",
+            },
+            {
+              surface_id: "7:openapi:y",
+              netuid: 7,
+              kind: "openapi",
+              provider: "allways",
+              status: "failed",
+              classification: "timeout",
+              latency_ms: null,
+              last_checked: "2026-07-01T00:00:00.000Z",
+              last_ok: null,
+            },
+          ],
+        },
+      },
+    );
+    const byStatus = await callTool(
+      "list_subnet_health",
+      { netuid: 7, status: "ok" },
+      { deps },
+    );
+    assert.equal(byStatus.body.result.structuredContent.returned, 1);
+    assert.equal(
+      byStatus.body.result.structuredContent.surfaces[0].status,
+      "ok",
+    );
+
+    const byClassification = await callTool(
+      "list_subnet_health",
+      { netuid: 7, classification: "timeout" },
+      { deps },
+    );
+    assert.equal(byClassification.body.result.structuredContent.returned, 1);
+    assert.equal(
+      byClassification.body.result.structuredContent.surfaces[0]
+        .classification,
+      "timeout",
+    );
+  });
+
+  test("list_subnet_health returns empty surfaces when the live store is cold", async () => {
+    const res = await callTool(
+      "list_subnet_health",
+      { netuid: 7 },
+      { deps: makeDeps() },
+    );
+    const out = res.body.result.structuredContent;
+    assert.notEqual(res.body.result.isError, true);
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.health_source, "unavailable");
+  });
+
+  test("list_subnet_health payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_subnet_health",
+    )?.outputSchema;
+    const deps = makeDeps(
+      {},
+      {
+        "health:current": {
+          last_run_at: FRESH_RUN,
+          surfaces: [
+            {
+              surface_id: "7:subnet-api:x",
+              netuid: 7,
+              kind: "subnet-api",
+              status: "ok",
+              classification: "live",
+              latency_ms: 80,
+              last_checked: "2026-07-01T00:00:00.000Z",
+              last_ok: "2026-07-01T00:00:00.000Z",
+            },
+          ],
+        },
+      },
+    );
+    const res = await callTool(
+      "list_subnet_health",
+      { netuid: 7, limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_endpoint_pools returns filtered pool rows", async () => {
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {

--- a/tests/subnet-health-mcp.test.ts
+++ b/tests/subnet-health-mcp.test.ts
@@ -1,0 +1,466 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  LIST_SUBNET_HEALTH_INSTRUCTIONS,
+  LIST_SUBNET_HEALTH_MCP_TOOL,
+  LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
+  loadSubnetHealthList,
+  subnetHealthArtifactPath,
+  subnetHealthMcpError,
+  subnetHealthQueryUrl,
+} from "../src/subnet-health-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type LoadCtx = Parameters<typeof loadSubnetHealthList>[0];
+type LoadDeps = Parameters<typeof loadSubnetHealthList>[2];
+
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
+
+const NETUID = 7;
+const ARTIFACT = subnetHealthArtifactPath(NETUID);
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  netuid: NETUID,
+  summary: { status: "degraded", surface_count: 2 },
+  operational_observed_at: "2026-07-01T00:15:00.000Z",
+  health_source: "live-cron-prober",
+  surfaces: [
+    {
+      surface_id: "7:subnet-api:x",
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      status: "ok",
+      classification: "live",
+      latency_ms: 120,
+    },
+    {
+      surface_id: "7:openapi:y",
+      netuid: NETUID,
+      kind: "openapi",
+      provider: "allways",
+      status: "failed",
+      classification: "timeout",
+      latency_ms: null,
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("subnet-health-mcp", () => {
+  test("subnetHealthMcpError is shaped for MCP toolError handling", () => {
+    const err = subnetHealthMcpError("invalid_params", "bad status");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("subnetHealthQueryUrl validates filters and cursor", () => {
+    const url = subnetHealthQueryUrl({
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      status: "ok",
+      classification: "live",
+      sort: "latency_ms",
+      order: "asc",
+      fields: "surface_id,status",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("provider"), "allways");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("classification"), "live");
+    assert.equal(url.searchParams.get("sort"), "latency_ms");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("subnetHealthQueryUrl rejects missing netuid", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({}),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects invalid status", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, status: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects invalid classification", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, classification: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, provider: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, sort: "not_a_column" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, provider: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, order: "sideways" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, fields: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, fields: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = subnetHealthQueryUrl({ netuid: NETUID, limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetHealthQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = subnetHealthQueryUrl({ netuid: NETUID, limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetHealthQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl clamps limit above the MCP maximum", () => {
+    const url = subnetHealthQueryUrl({ netuid: NETUID, limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadSubnetHealthList filters by status", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID, status: "ok" },
+      { readArtifact } as unknown as LoadDeps,
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].status, "ok");
+    assert.equal(out.netuid, NETUID);
+  });
+
+  test("loadSubnetHealthList filters by classification", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID, classification: "timeout" },
+      { readArtifact } as unknown as LoadDeps,
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].classification, "timeout");
+  });
+
+  test("loadSubnetHealthList sorts and pages the collection", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID, sort: "status", order: "asc", limit: 1 },
+      { readArtifact } as unknown as LoadDeps,
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSubnetHealthList uses an injected readArtifact dep", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: 0 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            surfaces: [{ netuid: 0, kind: "docs", status: "ok" }],
+          },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.surfaces[0].netuid, 0);
+  });
+
+  test("loadSubnetHealthList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          { env: {} } as unknown as LoadCtx,
+          { netuid: NETUID },
+          {
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as LoadDeps,
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetHealthList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          { env: {} } as unknown as LoadCtx,
+          { netuid: NETUID },
+          {
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as LoadDeps,
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /health\/subnets\/7\.json/.test(err.message),
+    );
+  });
+
+  test("loadSubnetHealthList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          { env: {} } as unknown as LoadCtx,
+          { netuid: NETUID, fields: "not_a_column" },
+          { readArtifact } as unknown as LoadDeps,
+        ),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetHealthList projects row fields when requested", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID, fields: "surface_id,status", limit: 1 },
+      { readArtifact } as unknown as LoadDeps,
+    );
+    assert.deepEqual(out.surfaces[0], {
+      surface_id: "7:subnet-api:x",
+      status: "ok",
+    });
+  });
+
+  test("loadSubnetHealthList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: 0 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: [{ netuid: 0, kind: "docs" }] },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.summary, null);
+  });
+
+  test("loadSubnetHealthList treats a non-array surfaces key as empty", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: null },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSubnetHealthList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: [{ netuid: 9 }, { netuid: 9 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSubnetHealthList(
+        { env: {} } as unknown as LoadCtx,
+        { netuid: NETUID },
+        { readArtifact } as unknown as LoadDeps,
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetHealthList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          { env: {} } as unknown as LoadCtx,
+          { netuid: NETUID },
+          {
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as LoadDeps,
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetHealthList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          { env: {} } as unknown as LoadCtx,
+          { netuid: NETUID },
+          {
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as LoadDeps,
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadSubnetHealthList rejects missing netuid", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList({ env: {} } as unknown as LoadCtx, {}, {
+          readArtifact,
+        } as unknown as LoadDeps),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetHealthList uses live overlay when readArtifact is unset", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID },
+      {
+        resolveLiveHealth: async () => ({
+          last_run_at: "2026-07-01T00:15:00.000Z",
+          surfaces: [
+            {
+              surface_id: "7:subnet-api:x",
+              netuid: NETUID,
+              kind: "subnet-api",
+              provider: "allways",
+              status: "ok",
+              classification: "live",
+              latency_ms: 50,
+              last_checked: "2026-07-01T00:15:00.000Z",
+              last_ok: "2026-07-01T00:15:00.000Z",
+            },
+          ],
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].status, "ok");
+    assert.equal(out.operational_observed_at, "2026-07-01T00:15:00.000Z");
+  });
+
+  test("loadSubnetHealthList honors an injected overlaySubnetHealth dep", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID },
+      {
+        resolveLiveHealth: async () => ({ surfaces: [] }),
+        overlaySubnetHealth: () => ({
+          netuid: NETUID,
+          health_source: "injected",
+          surfaces: [
+            {
+              surface_id: "7:docs:z",
+              netuid: NETUID,
+              kind: "docs",
+              status: "degraded",
+              classification: "rate-limited",
+            },
+          ],
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.health_source, "injected");
+    assert.equal(out.surfaces[0].classification, "rate-limited");
+  });
+
+  test("loadSubnetHealthList returns unknown card when live store is cold", async () => {
+    const out = await loadSubnetHealthList(
+      {
+        env: {},
+        readHealthKv: async () => null,
+      } as unknown as LoadCtx,
+      { netuid: NETUID },
+    );
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.health_source, "unavailable");
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SUBNET_HEALTH_MCP_TOOL.name, "list_subnet_health");
+    assert.match(LIST_SUBNET_HEALTH_INSTRUCTIONS, /list_subnet_health/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_SUBNET_HEALTH_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_subnet_health", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_subnet_health/);
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_subnet_health");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one subnet's health surfaces");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `list_subnet_health` as the filtered MCP sibling of `get_subnet_health`, cloning `src/subnet-endpoints-mcp.ts`'s module shape.
- Full REST filter parity for `GET /api/v1/subnets/{netuid}/health`: `kind`, `provider`, `status`, `classification`, `sort`, `order`, `fields`, `limit`, `cursor` over the live per-subnet health card.
- Leave `get_subnet_health` untouched (unfiltered live card).

Closes #7901.

## What Changed

- `src/subnet-health-mcp.ts` — new loader + MCP tool/output schema (live overlay; injectable snapshot path for unit tests).
- `src/mcp-server.ts` — register tool + instructions + outputSchema map.
- `tests/subnet-health-mcp.test.ts` — status/classification filters plus full branch coverage.
- `tests/mcp-server.test.ts` — wire-level status/classification/cold-store/outputSchema checks.
- `scripts/validate-mcp.ts` — smoke call for the new tool.

## Registry Safety

- Links open issue `#7901`.
- No secrets / private URLs.
- No schema/OpenAPI regen (MCP tool only; server card is worker-computed).

## Test plan

- [x] `npx vitest run tests/subnet-health-mcp.test.ts`
- [x] `npx vitest run tests/mcp-server.test.ts -t list_subnet_health`
- [ ] Confirm `get_subnet_health` behavior unchanged
- [ ] Confirm filters match REST `GET /api/v1/subnets/{netuid}/health`


Made with [Cursor](https://cursor.com)