### PR TITLE
feat(mcp): add REST-parity filters to list_rpc_endpoints (#7893)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -199,6 +199,11 @@ import {
   loadRpcPoolsList,
 } from "./rpc-pools-mcp.ts";
 import {
+  LIST_RPC_ENDPOINTS_MCP_TOOL,
+  LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
+  loadRpcEndpointsList,
+} from "./rpc-endpoints-mcp.ts";
+import {
   LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS,
   LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
   LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
@@ -443,7 +448,6 @@ import {
   loadSubnetReliability,
   loadSubnetTrajectory,
   mergeFreshness,
-  mergeRpcEndpoints,
   overlayArtifactEndpoints,
   overlayCatalogDetail,
   overlayCatalogIndex,
@@ -9779,30 +9783,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_rpc_endpoints",
-    title: "List Bittensor RPC endpoints",
-    description:
-      "Fetch the catalog of monitored Bittensor base-layer RPC endpoints and " +
-      "their status (each endpoint's URL, network, and probe-derived " +
-      "health/latency). This is the full-catalog view; use get_best_rpc_endpoint " +
-      "instead to pick one live-healthy endpoint. Mirrors GET /api/v1/rpc/endpoints.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args: unknown, ctx: McpCtx) {
-      const staticData = await loadArtifactData(
-        ctx,
-        "/metagraph/rpc-endpoints.json",
-      );
-      // Live overlay (mirrors workers/api.mjs's rpc-endpoints raw-artifact
-      // route): the build-time snapshot bakes stale health/latency, replace
-      // it from the 15-minute cron RPC-pool KV snapshot.
-      const pool = ctx.readHealthKv
-        ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
-        : null;
-      return pool ? mergeRpcEndpoints(staticData, pool) : staticData;
+    ...LIST_RPC_ENDPOINTS_MCP_TOOL,
+    async handler(args: Row, ctx: McpCtx) {
+      return loadRpcEndpointsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -15465,16 +15448,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
   list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
-  list_rpc_endpoints: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      endpoints: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_rpc_endpoints: LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
   list_evidence: LIST_EVIDENCE_OUTPUT_SCHEMA,
   list_fixtures: {
     type: "object",

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -1,0 +1,381 @@
+// RPC endpoint list loader for MCP parity on GET /api/v1/rpc/endpoints (#7893).
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/rpc-endpoints.json artifact, after the live 15-minute cron
+// overlay (mergeRpcEndpoints) — same order REST's liveHealthOverlay ->
+// applyQueryFilters pipeline uses for the "rpc-endpoints" route id, so a
+// filter like status or min_/max_latency_ms reads live health, not a stale
+// baked value. Structurally mirrors rpc-pools-mcp.ts (the closest sibling:
+// same live-overlay-before-applyQueryFilters ordering over the shared
+// "endpoints" query collection provider-endpoints-mcp.ts also uses).
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
+import { mergeRpcEndpoints } from "./health-serving.ts";
+
+export const RPC_ENDPOINTS_ARTIFACT = "/metagraph/rpc-endpoints.json";
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+
+export interface RpcEndpointsMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function rpcEndpointsMcpError(
+  code: string,
+  message: string,
+): RpcEndpointsMcpError {
+  const error = new Error(message) as RpcEndpointsMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalRangeBound(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): number | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+export function rpcEndpointsQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/rpc-endpoints");
+  if (args?.netuid !== undefined) {
+    const netuid = args.netuid;
+    if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(netuid));
+  }
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  if (args?.pool_eligible !== undefined) {
+    if (typeof args.pool_eligible !== "boolean") {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "pool_eligible must be a boolean when provided.",
+      );
+    }
+    url.searchParams.set("pool_eligible", String(args.pool_eligible));
+  }
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  const minLatency = optionalRangeBound(args, "min_latency_ms");
+  if (minLatency !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatency));
+  }
+  const maxLatency = optionalRangeBound(args, "max_latency_ms");
+  if (maxLatency !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatency));
+  }
+  const minScore = optionalRangeBound(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalRangeBound(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  if (args?.limit !== undefined) {
+    const limit = args.limit;
+    if (
+      typeof limit !== "number" ||
+      !Number.isInteger(limit) ||
+      limit < 1 ||
+      limit > 100
+    ) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(limit));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+interface RpcEndpointsMcpCtx {
+  env: Env;
+  readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  readHealthKv?: (
+    env: Env,
+    key: string,
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+export interface RpcEndpointsListResult {
+  generated_at: unknown;
+  notes: unknown;
+  source: unknown;
+  operational_observed_at: unknown;
+  endpoints: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadRpcEndpointsList(
+  ctx: RpcEndpointsMcpCtx,
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<RpcEndpointsListResult> {
+  const queryUrl = rpcEndpointsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, RPC_ENDPOINTS_ARTIFACT);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw rpcEndpointsMcpError(
+        "not_found",
+        "RPC endpoint snapshot unavailable.",
+      );
+    }
+    throw rpcEndpointsMcpError(
+      code,
+      `Could not load ${RPC_ENDPOINTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw rpcEndpointsMcpError(
+      "not_found",
+      "RPC endpoint snapshot unavailable.",
+    );
+  }
+
+  // Live 15-minute cron overlay, matching REST's liveHealthOverlay for the
+  // "rpc-endpoints" route id — applied before filtering so a filter like
+  // status or the latency_ms/score bounds reads the current snapshot, not
+  // the baked one. Falls back to the static artifact unchanged when there is
+  // no live pool snapshot yet (mergeRpcEndpoints returns null in that case).
+  let overlaid = blob as Record<string, unknown>;
+  const livePool = ctx.readHealthKv
+    ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+    : null;
+  const merged = livePool ? mergeRpcEndpoints(overlaid, livePool) : null;
+  if (merged) overlaid = merged as Record<string, unknown>;
+
+  const transformed = applyQueryFilters(overlaid, queryUrl, "endpoints", []);
+  if (transformed.error) {
+    throw rpcEndpointsMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = transformed.meta as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.endpoints) ? (data.endpoints as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    source: data.source ?? null,
+    operational_observed_at: data.operational_observed_at ?? null,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_RPC_ENDPOINTS_MCP_TOOL = {
+  name: "list_rpc_endpoints",
+  title: "List Bittensor RPC endpoints",
+  description:
+    "Fetch the catalog of monitored Bittensor base-layer RPC endpoints and " +
+    "their status (each endpoint's URL, network, and probe-derived " +
+    "health/latency). Filter by kind/layer/netuid/provider/" +
+    "publication_state/status/pool_eligible, threshold with min_/" +
+    "max_latency_ms and min_/max_score, sort with sort + order, and page " +
+    "with limit (1-100) / cursor. This is the full-catalog view; use " +
+    "get_best_rpc_endpoint instead to pick one live-healthy endpoint. " +
+    "Mirrors GET /api/v1/rpc/endpoints.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Surface kind, e.g. 'subtensor-rpc' or 'subtensor-wss'.",
+      },
+      layer: {
+        type: "string",
+        enum: ENDPOINT_LAYERS,
+        description: "Endpoint layer, e.g. 'bittensor-base'.",
+      },
+      netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      provider: {
+        type: "string",
+        description: "Provider slug, e.g. 'opentensor'.",
+      },
+      publication_state: {
+        type: "string",
+        enum: PUBLICATION_STATES,
+        description: "Filter by publication state.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      pool_eligible: {
+        type: "boolean",
+        description: "Only endpoints eligible (or not) for RPC pooling.",
+      },
+      min_latency_ms: {
+        type: "number",
+        description: "Keep endpoints with latency_ms >= this bound.",
+      },
+      max_latency_ms: {
+        type: "number",
+        description: "Keep endpoints with latency_ms <= this bound.",
+      },
+      min_score: {
+        type: "number",
+        description: "Keep endpoints with score >= this bound.",
+      },
+      max_score: {
+        type: "number",
+        description: "Keep endpoints with score <= this bound.",
+      },
+      sort: {
+        type: "string",
+        enum: ENDPOINT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of endpoint row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["endpoints"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    source: NULLABLE_STRING,
+    operational_observed_at: NULLABLE_STRING,
+    endpoints: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -16083,7 +16083,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_rpc_endpoints rejects an unexpected argument", async () => {
-    const res = await callTool("list_rpc_endpoints", { netuid: 7 });
+    const res = await callTool("list_rpc_endpoints", { bogus: "nope" });
     assert.equal(res.body.result.isError, true);
   });
 

--- a/tests/rpc-endpoints-mcp.test.ts
+++ b/tests/rpc-endpoints-mcp.test.ts
@@ -1,0 +1,414 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  RPC_ENDPOINTS_ARTIFACT,
+  LIST_RPC_ENDPOINTS_MCP_TOOL,
+  LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
+  rpcEndpointsMcpError,
+  rpcEndpointsQueryUrl,
+  loadRpcEndpointsList,
+} from "../src/rpc-endpoints-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type LoadCtx = Parameters<typeof loadRpcEndpointsList>[0];
+type LoadDeps = Parameters<typeof loadRpcEndpointsList>[2];
+
+import { MCP_TOOLS } from "../src/mcp-server.ts";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  source: "static-build",
+  operational_observed_at: null,
+  endpoints: [
+    {
+      id: "finney-1",
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      netuid: 0,
+      provider: "opentensor",
+      publication_state: "monitored",
+      status: "ok",
+      pool_eligible: true,
+      latency_ms: 120,
+      score: 0.9,
+    },
+    {
+      id: "finney-2",
+      kind: "subtensor-wss",
+      layer: "bittensor-base",
+      netuid: 0,
+      provider: "opentensor",
+      publication_state: "pool-eligible",
+      status: "degraded",
+      pool_eligible: false,
+      latency_ms: 800,
+      score: 0.4,
+    },
+    {
+      id: "archive-1",
+      kind: "archive",
+      layer: "bittensor-base",
+      netuid: 0,
+      provider: "datura",
+      publication_state: "monitored",
+      status: "ok",
+      pool_eligible: true,
+      latency_ms: 300,
+      score: 0.7,
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === RPC_ENDPOINTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("rpc-endpoints-mcp", () => {
+  test("rpcEndpointsMcpError is shaped for MCP toolError handling", () => {
+    const err = rpcEndpointsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("rpcEndpointsQueryUrl validates filters, range bounds, and cursor", () => {
+    const url = rpcEndpointsQueryUrl({
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      netuid: 0,
+      provider: "opentensor",
+      publication_state: "monitored",
+      status: "ok",
+      pool_eligible: true,
+      min_latency_ms: 10,
+      max_latency_ms: 500,
+      min_score: 0.1,
+      max_score: 0.95,
+      sort: "latency_ms",
+      order: "desc",
+      fields: "id,status",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subtensor-rpc");
+    assert.equal(url.searchParams.get("layer"), "bittensor-base");
+    assert.equal(url.searchParams.get("netuid"), "0");
+    assert.equal(url.searchParams.get("provider"), "opentensor");
+    assert.equal(url.searchParams.get("publication_state"), "monitored");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("pool_eligible"), "true");
+    assert.equal(url.searchParams.get("min_latency_ms"), "10");
+    assert.equal(url.searchParams.get("max_latency_ms"), "500");
+    assert.equal(url.searchParams.get("min_score"), "0.1");
+    assert.equal(url.searchParams.get("max_score"), "0.95");
+    assert.equal(url.searchParams.get("sort"), "latency_ms");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("fields"), "id,status");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a negative netuid", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a non-integer netuid", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects empty provider", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ provider: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a non-boolean pool_eligible", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ pool_eligible: "true" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects non-numeric range bounds", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ min_latency_ms: "lots" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a non-integer cursor", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ fields: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ limit: 0 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ limit: 500 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList combines kind + status + pool_eligible filters", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { kind: "subtensor-rpc", status: "ok", pool_eligible: true },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].id, "finney-1");
+  });
+
+  test("loadRpcEndpointsList combines provider + range filters + sort/order", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      {
+        provider: "opentensor",
+        min_latency_ms: 100,
+        sort: "latency_ms",
+        order: "desc",
+      },
+    );
+    assert.equal(out.returned, 2);
+    assert.deepEqual(
+      out.endpoints.map((e) => e.id),
+      ["finney-2", "finney-1"],
+    );
+  });
+
+  test("loadRpcEndpointsList applies the live health overlay before filtering", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({
+          last_run_at: "2026-07-02T00:00:00.000Z",
+          endpoints: [{ id: "finney-2", status: "ok", latency_ms: 50 }],
+        }),
+      } as unknown as LoadCtx,
+      { status: "ok" },
+    );
+    assert.equal(out.source, "live-cron-prober");
+    assert.equal(out.operational_observed_at, "2026-07-02T00:00:00.000Z");
+    assert.equal(out.returned, 3);
+    const overlaid = out.endpoints.find((e) => e.id === "finney-2");
+    assert.equal(overlaid?.latency_ms, 50);
+    assert.equal(overlaid?.health_source, "probe-derived");
+  });
+
+  test("loadRpcEndpointsList falls back to the static artifact when no live pool is present", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      {},
+    );
+    assert.equal(out.source, "static-build");
+    assert.equal(out.returned, 3);
+  });
+
+  test("loadRpcEndpointsList skips the overlay when the live snapshot has no endpoints array", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({ last_run_at: "2026-07-02T00:00:00.000Z" }),
+      } as unknown as LoadCtx,
+      {},
+    );
+    assert.equal(out.source, "static-build");
+  });
+
+  test("loadRpcEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as LoadCtx,
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ id: "test" }] },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.endpoints[0].id, "test");
+  });
+
+  test("loadRpcEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /rpc-endpoints\.json/.test(err.message),
+    );
+  });
+
+  test("loadRpcEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList({ env: {}, readArtifact } as unknown as LoadCtx, {
+          fields: "not_a_column",
+        }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList rejects contradictory range bounds", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList({ env: {}, readArtifact } as unknown as LoadCtx, {
+          min_latency_ms: 900,
+          max_latency_ms: 100,
+        }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadRpcEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { endpoints: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadRpcEndpointsList(
+        { env: {}, readArtifact } as unknown as LoadCtx,
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadRpcEndpointsList defaults endpoints to an empty array when the transformed data lacks one", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: {},
+      meta: {},
+    });
+    try {
+      const out = await loadRpcEndpointsList(
+        { env: {}, readArtifact } as unknown as LoadCtx,
+        {},
+      );
+      assert.deepEqual(out.endpoints, []);
+      assert.equal(out.total, 0);
+      assert.equal(out.returned, 0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_RPC_ENDPOINTS_MCP_TOOL.name, "list_rpc_endpoints");
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_rpc_endpoints", () => {
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_rpc_endpoints");
+    assert.ok(tool);
+    assert.equal(tool.title, "List Bittensor RPC endpoints");
+  });
+});


### PR DESCRIPTION
feat(mcp): add REST-parity filters to list_rpc_endpoints (#7893)

list_rpc_endpoints had an empty inputSchema and returned the whole
artifact unfiltered, even though GET /api/v1/rpc/endpoints supports the
full endpoints query collection. New src/rpc-endpoints-mcp.ts mirrors
rpc-pools-mcp.ts/provider-endpoints-mcp.ts: overlay the live RPC-pool
health snapshot, then run applyQueryFilters over the shared "endpoints"
collection for kind/layer/netuid/provider/publication_state/status/
pool_eligible, min_/max_latency_ms, min_/max_score, sort/order, fields,
and limit/cursor pagination.

Closes #7893

