### PR TITLE
feat(mcp): add full REST filter set to list_rpc_endpoints

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -134,6 +134,12 @@ import {
   loadProfileCompletenessList,
 } from "./profile-completeness-mcp.ts";
 import {
+  LIST_RPC_ENDPOINTS_INSTRUCTIONS,
+  LIST_RPC_ENDPOINTS_MCP_TOOL,
+  LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
+  loadRpcEndpointsList,
+} from "./rpc-endpoints-mcp.ts";
+import {
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS,
   LIST_SUBNET_ENDPOINTS_MCP_TOOL,
   LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
@@ -437,7 +443,6 @@ import {
   loadSubnetReliability,
   loadSubnetTrajectory,
   mergeFreshness,
-  mergeRpcEndpoints,
   overlayArtifactEndpoints,
   overlayCatalogDetail,
   overlayCatalogIndex,
@@ -1042,8 +1047,7 @@ export const MCP_INSTRUCTIONS =
   "list_endpoints the " +
   "network-wide monitored endpoint-resource catalog, " +
   LIST_EVIDENCE_INSTRUCTIONS +
-  "list_rpc_endpoints the monitored " +
-  "Bittensor RPC endpoint catalog, " +
+  LIST_RPC_ENDPOINTS_INSTRUCTIONS +
   LIST_SOURCE_SNAPSHOTS_INSTRUCTIONS +
   "list_rpc_pools the load-balanced RPC pool " +
   "scores, " +
@@ -9765,30 +9769,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_rpc_endpoints",
-    title: "List Bittensor RPC endpoints",
-    description:
-      "Fetch the catalog of monitored Bittensor base-layer RPC endpoints and " +
-      "their status (each endpoint's URL, network, and probe-derived " +
-      "health/latency). This is the full-catalog view; use get_best_rpc_endpoint " +
-      "instead to pick one live-healthy endpoint. Mirrors GET /api/v1/rpc/endpoints.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args: unknown, ctx: McpCtx) {
-      const staticData = await loadArtifactData(
-        ctx,
-        "/metagraph/rpc-endpoints.json",
-      );
-      // Live overlay (mirrors workers/api.mjs's rpc-endpoints raw-artifact
-      // route): the build-time snapshot bakes stale health/latency, replace
-      // it from the 15-minute cron RPC-pool KV snapshot.
-      const pool = ctx.readHealthKv
-        ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
-        : null;
-      return pool ? mergeRpcEndpoints(staticData, pool) : staticData;
+    ...LIST_RPC_ENDPOINTS_MCP_TOOL,
+    async handler(args: Row, ctx: McpCtx) {
+      return loadRpcEndpointsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -15428,16 +15411,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
   list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
-  list_rpc_endpoints: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      endpoints: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_rpc_endpoints: LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
   list_evidence: LIST_EVIDENCE_OUTPUT_SCHEMA,
   list_fixtures: {
     type: "object",

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -1,0 +1,369 @@
+// RPC endpoint list loader for MCP parity on GET /api/v1/rpc/endpoints.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/rpc-endpoints.json artifact, after the live 15-minute cron
+// overlay (mergeRpcEndpoints) — same order REST's liveHealthOverlay ->
+// applyQueryFilters pipeline uses, so status/latency filters read the live
+// snapshot. Structurally mirrors rpc-pools-mcp.ts.
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
+import { mergeRpcEndpoints } from "./health-serving.ts";
+
+export const RPC_ENDPOINTS_ARTIFACT = "/metagraph/rpc-endpoints.json";
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const BOOLEAN_STRINGS = ["true", "false"];
+
+export interface RpcEndpointsMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function rpcEndpointsMcpError(
+  code: string,
+  message: string,
+): RpcEndpointsMcpError {
+  const error = new Error(message) as RpcEndpointsMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalRangeBound(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): number | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw rpcEndpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function rpcEndpointsQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/rpc-endpoints");
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  if (args?.netuid !== undefined) {
+    if (
+      typeof args.netuid !== "number" ||
+      !Number.isInteger(args.netuid) ||
+      (args.netuid as number) < 0
+    ) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const poolEligible = optionalEnum(args, "pool_eligible", BOOLEAN_STRINGS);
+  if (poolEligible) url.searchParams.set("pool_eligible", poolEligible);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const minLatencyMs = optionalRangeBound(args, "min_latency_ms");
+  if (minLatencyMs !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatencyMs));
+  }
+  const maxLatencyMs = optionalRangeBound(args, "max_latency_ms");
+  if (maxLatencyMs !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatencyMs));
+  }
+  const minScore = optionalRangeBound(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalRangeBound(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw rpcEndpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+interface RpcEndpointsMcpCtx {
+  env: Env;
+  readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  readHealthKv?: (
+    env: Env,
+    key: string,
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+export interface RpcEndpointsListResult {
+  generated_at: unknown;
+  notes: unknown;
+  endpoints: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadRpcEndpointsList(
+  ctx: RpcEndpointsMcpCtx,
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<RpcEndpointsListResult> {
+  const queryUrl = rpcEndpointsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, RPC_ENDPOINTS_ARTIFACT);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw rpcEndpointsMcpError(
+        "not_found",
+        "RPC endpoint snapshot unavailable.",
+      );
+    }
+    throw rpcEndpointsMcpError(
+      code,
+      `Could not load ${RPC_ENDPOINTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw rpcEndpointsMcpError(
+      "not_found",
+      "RPC endpoint snapshot unavailable.",
+    );
+  }
+
+  // Live 15-minute cron overlay, matching REST's liveHealthOverlay for the
+  // "rpc-endpoints" route — applied before filtering so status/latency filters
+  // read current probe-derived values, not stale baked ones.
+  let overlaid = blob as Record<string, unknown>;
+  const livePool = ctx.readHealthKv
+    ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+    : null;
+  const merged = livePool ? mergeRpcEndpoints(overlaid, livePool) : null;
+  if (merged) overlaid = merged as Record<string, unknown>;
+
+  const transformed = applyQueryFilters(overlaid, queryUrl, "endpoints", []);
+  if (transformed.error) {
+    throw rpcEndpointsMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = transformed.meta as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.endpoints) ? (data.endpoints as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_RPC_ENDPOINTS_INSTRUCTIONS =
+  "list_rpc_endpoints the monitored Bittensor RPC endpoints with REST list-query " +
+  "filters (kind, layer, netuid, pool_eligible, provider, publication_state, " +
+  "status, latency/score bounds, and pagination; mirrors GET /api/v1/rpc/endpoints), ";
+
+export const LIST_RPC_ENDPOINTS_MCP_TOOL = {
+  name: "list_rpc_endpoints",
+  title: "List Bittensor RPC endpoints",
+  description:
+    "Fetch the catalog of monitored Bittensor base-layer RPC endpoints and their " +
+    "status. Filter by kind, layer, netuid, pool_eligible, provider, " +
+    "publication_state, or status; bound latency_ms and score with min_/max_ " +
+    "params; sort with sort + order; project with fields; and page with limit " +
+    "(1-100) / cursor. Use get_best_rpc_endpoint to pick one live-healthy " +
+    "endpoint instead of browsing. Mirrors GET /api/v1/rpc/endpoints.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind.",
+      },
+      layer: {
+        type: "string",
+        enum: ENDPOINT_LAYERS,
+        description: "Filter by endpoint layer.",
+      },
+      netuid: {
+        type: "integer",
+        description: "Filter by subnet netuid.",
+        minimum: 0,
+      },
+      pool_eligible: {
+        type: "string",
+        enum: BOOLEAN_STRINGS,
+        description: "Filter by whether the endpoint is pool-eligible.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      publication_state: {
+        type: "string",
+        enum: PUBLICATION_STATES,
+        description: "Filter by publication state.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      min_latency_ms: {
+        type: "number",
+        description: "Inclusive minimum probe latency in milliseconds.",
+      },
+      max_latency_ms: {
+        type: "number",
+        description: "Inclusive maximum probe latency in milliseconds.",
+      },
+      min_score: {
+        type: "number",
+        description: "Inclusive minimum probe score.",
+      },
+      max_score: {
+        type: "number",
+        description: "Inclusive maximum probe score.",
+      },
+      sort: {
+        type: "string",
+        enum: ENDPOINT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of endpoint row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["endpoints"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    endpoints: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/rpc-endpoints-mcp.test.ts
+++ b/tests/rpc-endpoints-mcp.test.ts
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  RPC_ENDPOINTS_ARTIFACT,
+  LIST_RPC_ENDPOINTS_INSTRUCTIONS,
+  LIST_RPC_ENDPOINTS_MCP_TOOL,
+  LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
+  loadRpcEndpointsList,
+  rpcEndpointsMcpError,
+  rpcEndpointsQueryUrl,
+} from "../src/rpc-endpoints-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type LoadCtx = Parameters<typeof loadRpcEndpointsList>[0];
+type LoadDeps = Parameters<typeof loadRpcEndpointsList>[2];
+
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["rpc endpoint catalog"],
+  endpoints: [
+    {
+      id: "dwellir-finney-rpc",
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      provider: "dwellir",
+      status: "ok",
+      latency_ms: 80,
+      score: 95,
+      pool_eligible: true,
+      publication_state: "verified",
+    },
+    {
+      id: "allnodes-finney-rpc",
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      provider: "allnodes",
+      status: "degraded",
+      latency_ms: 600,
+      score: 40,
+      pool_eligible: false,
+      publication_state: "verified",
+    },
+    {
+      id: "dwellir-finney-wss",
+      kind: "subtensor-wss",
+      layer: "bittensor-base",
+      provider: "dwellir",
+      status: "ok",
+      latency_ms: 90,
+      score: 93,
+      pool_eligible: true,
+      publication_state: "verified",
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === RPC_ENDPOINTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("rpc-endpoints-mcp", () => {
+  test("rpcEndpointsMcpError is shaped for MCP toolError handling", () => {
+    const err = rpcEndpointsMcpError("invalid_params", "bad status");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("rpcEndpointsQueryUrl sets all filter and range params", () => {
+    const url = rpcEndpointsQueryUrl({
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      netuid: 0,
+      pool_eligible: "true",
+      provider: "dwellir",
+      publication_state: "verified",
+      status: "ok",
+      min_latency_ms: 50,
+      max_latency_ms: 200,
+      min_score: 80,
+      max_score: 100,
+      sort: "latency_ms",
+      order: "asc",
+      fields: "id,status",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subtensor-rpc");
+    assert.equal(url.searchParams.get("layer"), "bittensor-base");
+    assert.equal(url.searchParams.get("netuid"), "0");
+    assert.equal(url.searchParams.get("pool_eligible"), "true");
+    assert.equal(url.searchParams.get("provider"), "dwellir");
+    assert.equal(url.searchParams.get("publication_state"), "verified");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("min_latency_ms"), "50");
+    assert.equal(url.searchParams.get("max_latency_ms"), "200");
+    assert.equal(url.searchParams.get("min_score"), "80");
+    assert.equal(url.searchParams.get("max_score"), "100");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects invalid status", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ status: "healthy" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects negative netuid and fractional cursor", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcEndpointsQueryUrl rejects non-finite range bound", () => {
+    assert.throws(
+      () => rpcEndpointsQueryUrl({ min_latency_ms: Infinity }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList returns all endpoints when unfiltered", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      {},
+    );
+    assert.equal(out.returned, 3);
+    assert.deepEqual(out.notes, ["rpc endpoint catalog"]);
+  });
+
+  test("loadRpcEndpointsList filters by kind, provider, and status", async () => {
+    const byKind = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { kind: "subtensor-wss" },
+    );
+    assert.equal(byKind.returned, 1);
+    assert.equal(byKind.endpoints[0].id, "dwellir-finney-wss");
+
+    const byProvider = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { provider: "dwellir", status: "ok" },
+    );
+    assert.equal(byProvider.returned, 2);
+
+    const byStatus = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { status: "degraded" },
+    );
+    assert.equal(byStatus.returned, 1);
+    assert.equal(byStatus.endpoints[0].provider, "allnodes");
+  });
+
+  test("loadRpcEndpointsList filters by score range", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { min_score: 90 },
+    );
+    assert.equal(out.returned, 2);
+    assert.ok(out.endpoints.every((e) => (e as Row).score >= 90));
+  });
+
+  test("loadRpcEndpointsList sorts and pages the collection", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { sort: "latency_ms", order: "asc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.endpoints[0].id, "dwellir-finney-rpc");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadRpcEndpointsList skips overlay when readHealthKv absent", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      {},
+    );
+    assert.equal(out.returned, 3);
+  });
+
+  test("loadRpcEndpointsList applies live overlay before filtering", async () => {
+    const livePool = {
+      last_run_at: "2026-07-01T01:00:00.000Z",
+      endpoints: [
+        {
+          id: "allnodes-finney-rpc",
+          status: "ok",
+          latency_ms: 100,
+          classification: "fast",
+        },
+      ],
+    };
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => livePool,
+      } as unknown as LoadCtx,
+      { status: "ok" },
+    );
+    assert.equal(out.returned, 3);
+  });
+
+  test("loadRpcEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as LoadCtx,
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ id: "solo" }] },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.endpoints[0].id, "solo");
+  });
+
+  test("loadRpcEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /rpc-endpoints\.json/.test(err.message),
+    );
+  });
+
+  test("loadRpcEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList({ env: {}, readArtifact } as unknown as LoadCtx, {
+          fields: "not_a_column",
+        }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcEndpointsList projects row fields when requested", async () => {
+    const out = await loadRpcEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { fields: "id,status", limit: 1 },
+    );
+    assert.deepEqual(out.endpoints[0], {
+      id: "dwellir-finney-rpc",
+      status: "ok",
+    });
+  });
+
+  test("loadRpcEndpointsList treats a non-array endpoints key as empty", async () => {
+    const out = await loadRpcEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: null },
+        }),
+      } as unknown as LoadCtx,
+      {},
+    );
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadRpcEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { endpoints: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadRpcEndpointsList(
+        { env: {}, readArtifact } as unknown as LoadCtx,
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadRpcEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_RPC_ENDPOINTS_MCP_TOOL.name, "list_rpc_endpoints");
+    assert.match(LIST_RPC_ENDPOINTS_INSTRUCTIONS, /list_rpc_endpoints/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_rpc_endpoints with filters", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_rpc_endpoints/);
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_rpc_endpoints");
+    assert.ok(tool);
+    assert.equal(tool.title, "List Bittensor RPC endpoints");
+    assert.ok(tool.inputSchema.properties.kind);
+    assert.ok(tool.inputSchema.properties.status);
+    assert.ok(tool.inputSchema.properties.min_latency_ms);
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts the `list_rpc_endpoints` inline handler from `src/mcp-server.ts` into a dedicated `src/rpc-endpoints-mcp.ts` module, matching the pattern used by other mcp modules
- Adds `network`, `status`, `pool_eligible`, `sort`, `order`, `fields`, `limit`, and `cursor` parameters to `list_rpc_endpoints`, giving it full REST list-query parity with `GET /api/v1/rpc/endpoints`
- Live health overlay via `mergeRpcEndpoints` from `KV_HEALTH_RPC_POOL` is preserved inside the new module (same logic, just moved)
- Removes `mergeRpcEndpoints` from the `mcp-server.ts` health-serving import since it's now used only inside `rpc-endpoints-mcp.ts`
- 23 unit tests cover filter/sort/fields/pagination/overlay/error paths and MCP server wiring

## Test plan

- [x] `npx vitest run tests/rpc-endpoints-mcp.test.ts` — 23 tests pass
- [x] `npx eslint src/rpc-endpoints-mcp.ts tests/rpc-endpoints-mcp.test.ts` — clean
- [x] `npx prettier --check src/rpc-endpoints-mcp.ts tests/rpc-endpoints-mcp.test.ts` — clean

Closes #7893