### PR TITLE
feat(api): add subnet_endpoints root field + parameterize nested Subnet.endpoints (#7869)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -45,6 +45,7 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.ts";
 // same loadProviderEndpointsList that MCP list_provider_endpoints already calls
 // (#3289) -- not a reimplementation.
 import { loadProviderEndpointsList } from "./provider-endpoints-mcp.ts";
+import { loadSubnetEndpointsList } from "./subnet-endpoints-mcp.ts";
 // #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
 // and page logic REST and MCP already use) -- not a reimplementation.
@@ -638,6 +639,8 @@ export const SDL = `
     surfaces(netuid: Int, limit: Int, cursor: String): SurfaceList!
     "Endpoint/resource registry, optionally scoped to one subnet."
     endpoints(netuid: Int, limit: Int, cursor: String): EndpointList!
+    "One subnet's endpoint/resource registry with the full REST filter/sort/page set, read from that subnet's own endpoint snapshot. Filter by kind/layer/publication_state/status, threshold with min_/max_latency_ms and min_/max_score, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/enum or a bad cursor is a GraphQL error, not a silently substituted default. cursor is an Int offset (matching the list_subnet_endpoints MCP tool and the loader's numeric-cursor check; the issue's literal String would fail that check). Returns the opaque JSON list envelope (endpoints[] + pagination), the per-subnet companion of the root endpoints field. Mirrors GET /api/v1/subnets/{netuid}/endpoints."
+    subnet_endpoints(netuid: Int!, kind: String, layer: String, publication_state: String, status: String, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, sort: String, order: String, limit: Int, cursor: Int): JSON
     "Generalized endpoint pool scores -- each pool's kind, eligible/total endpoint count, and probe-derived routing score. Filter by id/kind, threshold with min_/max_eligible_count and min_/max_endpoint_count, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/endpoint-pools."
     endpoint_pools(id: String, kind: String, min_eligible_count: Float, max_eligible_count: Float, min_endpoint_count: Float, max_endpoint_count: Float, sort: String, order: String, fields: String, limit: Int, cursor: Int): PoolList!
     "The load-balanced Bittensor RPC pool scores -- the RPC-specific predecessor of endpoint_pools (#6570): same pools[] row shape and filter/sort/page surface, with a live 15-minute cron eligibility overlay applied before filtering/sorting. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/rpc/pools."
@@ -895,8 +898,8 @@ export const SDL = `
     economics: SubnetEconomics
     "Curated public interface surfaces of this subnet."
     surfaces: [Surface!]!
-    "Endpoint/resource registry rows for this subnet."
-    endpoints: [Endpoint!]!
+    "Endpoint/resource registry rows for this subnet. With no arguments it returns the subnet's full endpoint list unchanged; supplying any of the same filter/sort/page arguments as the root subnet_endpoints field routes through the same loader and returns the filtered rows."
+    endpoints(kind: String, layer: String, publication_state: String, status: String, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, sort: String, order: String, limit: Int, cursor: Int): [Endpoint!]!
   }
 
   type ProviderList {
@@ -4238,6 +4241,7 @@ export const FIELD_COMPLEXITY = {
   surfaces: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoint_pools: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   rpc_pools: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4819,7 +4823,8 @@ function subnetNode(identity: Row, prefetch: Row = {}) {
     economics: (_args: unknown, context: GqlContext) =>
       loadSubnetEconomics(context, netuid),
     surfaces: bundledOr(prefetch.surfaces, loadSubnetSurfaces),
-    endpoints: bundledOr(prefetch.endpoints, loadSubnetEndpoints),
+    endpoints: (args: Row, context: GqlContext) =>
+      loadSubnetEndpointsNested(context, netuid, args, prefetch.endpoints),
   };
 }
 
@@ -4948,6 +4953,40 @@ function loadSubnetSurfaces(context: GqlContext, netuid: number) {
 
 function loadSubnetEndpoints(context: GqlContext, netuid: number) {
   return loadRows(context, ARTIFACT.endpoints, "endpoints", netuid);
+}
+
+// #7869: the nested Subnet.endpoints resolver. With no filter/page arguments it
+// preserves the existing behavior exactly -- a bundled prefetch list (a null
+// bundle resolves to an empty list) or the loadSubnetEndpoints/loadRows path --
+// so unfiltered queries and their tests are unchanged. When ANY argument is
+// supplied it routes through loadSubnetEndpointsList (the same subnet-endpoints-mcp
+// loader the root subnet_endpoints field and list_subnet_endpoints MCP tool use),
+// returning only its endpoints rows to satisfy the [Endpoint!]! shape. A
+// cold/absent per-subnet snapshot or an invalid filter degrades to an empty list
+// rather than erroring the parent Subnet query -- the same schema-stable
+// convention Provider.endpoints (loadProviderEndpoints) follows.
+async function loadSubnetEndpointsNested(
+  context: GqlContext,
+  netuid: number,
+  args: Row,
+  prefetched: Row[] | undefined,
+) {
+  const hasQuery = args != null && Object.keys(args).length > 0;
+  if (!hasQuery) {
+    return prefetched !== undefined
+      ? (prefetched ?? [])
+      : loadSubnetEndpoints(context, netuid);
+  }
+  try {
+    const result = await loadSubnetEndpointsList(
+      mcpCtx(context),
+      { ...args, netuid },
+      { readArtifact },
+    );
+    return result.endpoints;
+  } catch {
+    return [];
+  }
 }
 
 async function loadProviderSubnets(context: GqlContext, netuids: number[]) {
@@ -6337,6 +6376,16 @@ const rootValue = {
   // default" convention.
   endpoint_pools(args: Row, context: GqlContext) {
     return loadEndpointPoolsList(mcpCtx(context), args, { readArtifact });
+  },
+
+  // #7869: the per-subnet endpoint list, reusing subnet-endpoints-mcp.ts's
+  // loadSubnetEndpointsList (the same loader list_subnet_endpoints /
+  // GET /api/v1/subnets/{netuid}/endpoints call) unchanged -- it validates
+  // netuid + every filter/sort/enum/cursor and throws on an invalid one, which
+  // the executor surfaces as a normal GraphQL error. Returns the full JSON
+  // envelope (endpoints[] + pagination), matching the MCP/REST shape.
+  subnet_endpoints(args: Row, context: GqlContext) {
+    return loadSubnetEndpointsList(mcpCtx(context), args, { readArtifact });
   },
 
   rpc_pools(args: Row, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8821,6 +8821,114 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
   });
 });
 
+describe("graphql — subnet_endpoints (#7869, per-subnet endpoint list + nested filters)", () => {
+  const SUBNET_ENDPOINTS_BLOB = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    netuid: 7,
+    endpoints: [
+      {
+        id: "allways-api",
+        netuid: 7,
+        kind: "subnet-api",
+        layer: "bittensor-base",
+        provider: "allways",
+        status: "ok",
+        latency_ms: 120,
+        score: 92,
+        pool_eligible: true,
+      },
+      {
+        id: "allways-openapi",
+        netuid: 7,
+        kind: "openapi",
+        layer: "bittensor-base",
+        provider: "allways",
+        status: "degraded",
+        latency_ms: 450,
+        score: 70,
+        pool_eligible: false,
+      },
+    ],
+  };
+
+  test("root subnet_endpoints applies a filter and returns the JSON list envelope (#7869)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints/7.json": SUBNET_ENDPOINTS_BLOB,
+    });
+    const { status, body } = await gql(
+      `{ subnet_endpoints(netuid: 7, kind: "subnet-api") }`,
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints.netuid, 7);
+    assert.equal(body.data.subnet_endpoints.returned, 1);
+    assert.equal(body.data.subnet_endpoints.endpoints.length, 1);
+    assert.equal(body.data.subnet_endpoints.endpoints[0].kind, "subnet-api");
+  });
+
+  test("root subnet_endpoints sorts + pages, exposing pagination meta (#7869)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints/7.json": SUBNET_ENDPOINTS_BLOB,
+    });
+    const { status, body } = await gql(
+      `{ subnet_endpoints(netuid: 7, sort: "score", order: "desc", limit: 1) }`,
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints.total, 2);
+    assert.equal(body.data.subnet_endpoints.returned, 1);
+    assert.equal(body.data.subnet_endpoints.next_cursor, 1);
+  });
+
+  test("root subnet_endpoints surfaces a bad cursor as a GraphQL error, not a substituted default (#7869)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints/7.json": SUBNET_ENDPOINTS_BLOB,
+    });
+    const { status, body } = await gql(
+      `{ subnet_endpoints(netuid: 7, cursor: -1) }`,
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors, "expected a GraphQL error for a negative cursor");
+    assert.match(body.errors[0].message, /cursor/i);
+  });
+
+  test("nested Subnet.endpoints applies a filter via the same loader (#7869)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets/7.json": { subnet: { netuid: 7, name: "Allways" } },
+      "/metagraph/endpoints/7.json": SUBNET_ENDPOINTS_BLOB,
+    });
+    const { status, body } = await gql(
+      `{ subnet(netuid: 7) { endpoints(kind: "subnet-api") { id kind } } }`,
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet.endpoints.length, 1);
+    assert.equal(body.data.subnet.endpoints[0].id, "allways-api");
+    assert.equal(body.data.subnet.endpoints[0].kind, "subnet-api");
+  });
+
+  test("nested Subnet.endpoints with a filter degrades to an empty list when the per-subnet snapshot is cold (#7869)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets/7.json": { subnet: { netuid: 7, name: "Allways" } },
+    });
+    const { status, body } = await gql(
+      `{ subnet(netuid: 7) { endpoints(status: "ok") { id } } }`,
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet.endpoints, []);
+  });
+
+  test("subnet_endpoints is weighted as a fan-out field (#7869)", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_endpoints, 5);
+  });
+});
+
 describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifacts)", () => {
   test("subnet_gaps resolves the baked gap report", async () => {
     const env = fixtureEnv({


### PR DESCRIPTION
## Summary

GraphQL had neither a root `subnet_endpoints(netuid, ...)` query field nor any filter args on the nested `Subnet.endpoints` field, so a client could only fetch a subnet's unfiltered full endpoint list. This adds both, wiring each to `src/subnet-endpoints-mcp.ts`'s existing `loadSubnetEndpointsList` loader (the same one `list_subnet_endpoints` and `GET /api/v1/subnets/{netuid}/endpoints` use) — no re-implemented filtering.

- **New root field** `subnet_endpoints(netuid: Int!, kind, layer, publication_state, status, min_latency_ms, max_latency_ms, min_score, max_score, sort, order, limit, cursor): JSON` — mirrors `endpoint_pools`: passes args straight to the loader, which validates every filter/sort/enum/cursor and throws (→ a GraphQL error) on an invalid one.
- **Nested `Subnet.endpoints`** now accepts the same argument set. With **no arguments** it keeps the existing behavior byte-for-byte (bundled prefetch list — a null bundle → `[]` — or the `loadSubnetEndpoints` path), so unfiltered queries and their tests are unchanged. When any argument is supplied it routes through `loadSubnetEndpointsList` and returns the filtered rows, degrading a cold/invalid read to `[]` rather than erroring the parent query (the same convention `Provider.endpoints` follows).
- `FIELD_COMPLEXITY` weights the new root field as a fan-out field.

### One deliberate deviation from the issue's literal SDL

The issue spec wrote `cursor: String`, but the loader (`subnetEndpointsQueryUrl`) and the `list_subnet_endpoints` MCP tool both require an **integer** cursor (`typeof cursor === "number"`), and the sibling `endpoint_pools`/`rpc_pools` root fields already use `cursor: Int`. A `String` cursor would fail the loader's numeric-cursor check, so this ships **`cursor: Int`** to match the loader/MCP/precedent. Everything else matches the issue's arg list exactly.

## Changes

- `src/graphql.ts`: import the loader; new `subnet_endpoints` SDL field + docstring; `FIELD_COMPLEXITY` entry; root resolver; the 12 filter args on the nested `Subnet.endpoints` SDL field; an arg-aware nested resolver (`loadSubnetEndpointsNested`).
- `tests/graphql.test.ts`: root filter, root sort+page (pagination meta), root bad-cursor→error, nested filter via the loader, nested cold-snapshot→`[]`, and the fan-out complexity weight.

## Validation

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npx vitest run tests/graphql.test.ts` (930 passed), `npm run build`, `npm run validate`, `npm run scan:public-safety`, `git diff --check` — all green. Diff confined to the two files above.

Closes #7869