### PR TITLE
feat(api): add cursor to subnet_hyperparameters_history GraphQL field (#7882)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -518,8 +518,8 @@ export const SDL = `
     subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!
     "One subnet's live on-chain hyperparameters (latest snapshot only). The hyperparameters block is null when the subnet has no captured row -- a schema-stable card, never a GraphQL error, matching the Query.block ref-lookup convention. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters."
     subnet_hyperparameters(netuid: Int!): SubnetHyperparameters
-    "One subnet's append-only hyperparameter-change history, newest first, one entry per observed change. Forward-only: entries exist only from when the diff-on-change write started. A subnet with no recorded changes resolves to an empty entry list, never null. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters/history."
-    subnet_hyperparameters_history(netuid: Int!, limit: Int, offset: Int): SubnetHyperparamsHistory!
+    "One subnet's append-only hyperparameter-change history, newest first, one entry per observed change. Forward-only: entries exist only from when the diff-on-change write started. Page with limit/offset, or follow next_cursor via the optional cursor arg -- the same pagination set MCP get_subnet_hyperparams_history and GET /api/v1/subnets/{netuid}/hyperparameters/history accept. A subnet with no recorded changes resolves to an empty entry list, never null. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters/history."
+    subnet_hyperparameters_history(netuid: Int!, limit: Int, offset: Int, cursor: String): SubnetHyperparamsHistory!
     "Per-subnet neuron-deregistration activity over a 7d/30d window (distinct deregistered hotkeys, NeuronDeregistered count, and deregistrations per hotkey); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/deregistrations."
     subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
     "Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving."
@@ -5129,16 +5129,20 @@ const rootValue = {
   },
 
   async subnet_hyperparameters_history(
-    { netuid, limit, offset }: Row,
+    { netuid, limit, offset, cursor }: Row,
     context: GqlContext,
   ) {
     // Same FEED_PAGINATION bounds parsePagination applies for REST, so a GraphQL
-    // caller cannot request a wider page than the route allows.
+    // caller cannot request a wider page than the route allows. cursor is
+    // forwarded verbatim for the route to re-parse (keyset seek takes
+    // precedence over offset), matching MCP get_subnet_hyperparams_history and
+    // the sibling account_history feed resolver (#7882).
     const safeLimit = clampLimit(limit, FEED_PAGINATION);
     const safeOffset = clampOffset(offset);
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
+    if (cursor != null) params.set("cursor", cursor);
     const data =
       ((await tryPostgresTier(
         context.env,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -17439,6 +17439,9 @@ describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => 
     assert.equal(seen!.pathname, "/api/v1/subnets/2/hyperparameters/history");
     assert.equal(seen!.searchParams.get("limit"), "5");
     assert.equal(seen!.searchParams.get("offset"), "10");
+    // Unset cursor must not appear on the query string (REST treats a missing
+    // cursor as offset-mode paging).
+    assert.equal(seen!.searchParams.has("cursor"), false);
 
     // Over-wide pages are clamped to MAX_LIMIT rather than forwarded verbatim.
     await gql(
@@ -17451,6 +17454,86 @@ describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => 
     await gql(`{ subnet_hyperparameters_history(netuid: 2) { netuid } }`, env);
     assert.equal(seen!.searchParams.get("limit"), "100");
     assert.equal(seen!.searchParams.get("offset"), "0");
+    assert.equal(seen!.searchParams.has("cursor"), false);
+  });
+
+  test("subnet_hyperparameters_history forwards cursor for keyset pagination (#7882)", async () => {
+    let seen: URL | null = null;
+    const env = {
+      METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          seen = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            netuid: 2,
+            entry_count: 1,
+            limit: 5,
+            offset: 0,
+            next_cursor: "next-page-cursor",
+            entries: [
+              {
+                block_number: 5000100,
+                observed_at: "2026-07-02T00:00:00.000Z",
+                hyperparams_hash: "cafebabe",
+                hyperparameters: { tempo: 360 },
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ subnet_hyperparameters_history(netuid: 2, limit: 5, cursor: "opaque-cursor-value") { schema_version netuid entry_count limit offset next_cursor entries { block_number hyperparams_hash } } }`,
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(seen!.pathname, "/api/v1/subnets/2/hyperparameters/history");
+    assert.equal(seen!.searchParams.get("limit"), "5");
+    assert.equal(seen!.searchParams.get("offset"), "0");
+    assert.equal(seen!.searchParams.get("cursor"), "opaque-cursor-value");
+    assert.deepEqual(body.data.subnet_hyperparameters_history, {
+      schema_version: 1,
+      netuid: 2,
+      entry_count: 1,
+      limit: 5,
+      offset: 0,
+      next_cursor: "next-page-cursor",
+      entries: [
+        {
+          block_number: 5000100,
+          hyperparams_hash: "cafebabe",
+        },
+      ],
+    });
+  });
+
+  test("introspection: subnet_hyperparameters_history exposes cursor as String (#7882)", async () => {
+    const { status, body } = await gql(
+      `{ __type(name: "Query") { fields {
+          name
+          args { name type { kind name ofType { kind name } } }
+        } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const field = body.data.__type.fields.find(
+      (f: { name: string }) => f.name === "subnet_hyperparameters_history",
+    );
+    assert.ok(field, "expected subnet_hyperparameters_history on Query");
+    const cursor = field.args.find(
+      (a: { name: string }) => a.name === "cursor",
+    );
+    assert.ok(
+      cursor,
+      "expected a cursor arg on subnet_hyperparameters_history",
+    );
+    assert.deepEqual(cursor.type, {
+      kind: "SCALAR",
+      name: "String",
+      ofType: null,
+    });
   });
 
   test("both fields are priced at the relationship-field complexity weight", () => {


### PR DESCRIPTION
## Summary

`subnet_hyperparameters_history` only accepted `limit`/`offset`, while `GET /api/v1/subnets/{netuid}/hyperparameters/history` and MCP `get_subnet_hyperparams_history` already support keyset `cursor` pagination. This adds the missing `cursor: String` GraphQL arg and forwards it verbatim to the same Postgres-tier route — no duplicated paging logic.

## What Changed

- `src/graphql.ts` — SDL + resolver: optional `cursor` alongside existing `limit`/`offset`; unset cursor is omitted from the query string (offset-mode unchanged).
- `tests/graphql.test.ts` — cursor forwarded + response round-trip, unset cursor omitted, introspection signature guard.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7882`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no schema/OpenAPI regen; GraphQL SDL-only.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (GraphQL field arg parity with existing REST/MCP.)

## Validation

- [x] `npx vitest run tests/graphql.test.ts -t subnet_hyperparameters` (11 passed)
- [x] `npx eslint src/graphql.ts tests/graphql.test.ts`
- [x] `npx prettier --check src/graphql.ts tests/graphql.test.ts`
- [x] `npm run typecheck`
- [x] `npm run scan:public-safety`
- [x] `npm run validate:private-boundary`
- [x] `git diff --check`
- [ ] CI green on this PR

Diff is confined to the two files above.

Made with [Cursor](https://cursor.com)