### PR TITLE
feat(graphql): filter/sort/page the nested Subnet.surfaces field

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -57,6 +57,11 @@ import { loadProfileCompletenessList } from "./profile-completeness-mcp.ts";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.ts";
+// #7885: nested Subnet.surfaces filter parity, reusing the same loader MCP
+// list_surfaces / REST GET /api/v1/surfaces already call -- not a
+// reimplementation. Reads the same /metagraph/surfaces.json the unfiltered
+// nested path reads, so filtered and unfiltered reads can't diverge.
+import { loadSurfacesList } from "./surfaces-mcp.ts";
 // #7170: GraphQL parity for the changelog/contracts/health-history REST routes,
 // reusing the same loaders MCP get_changelog/get_contracts/get_health_history
 // already call -- not a reimplementation.
@@ -893,8 +898,8 @@ export const SDL = `
     health: SubnetHealth
     "Per-subnet economic + validator metrics."
     economics: SubnetEconomics
-    "Curated public interface surfaces of this subnet."
-    surfaces: [Surface!]!
+    "Curated public interface surfaces of this subnet. Called with no arguments this is the full unpaged list (unchanged). Supplying any filter/sort/page argument routes the field through the same loader MCP list_surfaces and REST GET /api/v1/surfaces use -- filter by kind/provider/id, sort with sort/order, project with fields, and page with limit (1-100)/cursor (a non-negative integer offset). An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default (#7885)."
+    surfaces(kind: String, provider: String, id: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): [Surface!]!
     "Endpoint/resource registry rows for this subnet."
     endpoints: [Endpoint!]!
   }
@@ -4818,9 +4823,45 @@ function subnetNode(identity: Row, prefetch: Row = {}) {
       loadSubnetHealth(context, netuid),
     economics: (_args: unknown, context: GqlContext) =>
       loadSubnetEconomics(context, netuid),
-    surfaces: bundledOr(prefetch.surfaces, loadSubnetSurfaces),
+    // #7885: with no arguments this stays exactly what it was -- the rows
+    // bundled onto the subnet detail artifact, else the surfaces artifact
+    // filtered by netuid. Supplying ANY filter/sort/page argument routes it
+    // through list_surfaces' own loader instead (the same
+    // /metagraph/surfaces.json read plus the shared query engine REST applies),
+    // so a filtered nested read matches REST rather than a GraphQL-only
+    // reimplementation. Unfiltered callers keep the bundling optimisation.
+    surfaces: async (args: Row, context: GqlContext) => {
+      if (!hasSubnetSurfaceFilters(args)) {
+        return bundledOr(prefetch.surfaces, loadSubnetSurfaces)(args, context);
+      }
+      const result = await loadSurfacesList(
+        mcpCtx(context),
+        { ...args, netuid },
+        { readArtifact },
+      );
+      return result.surfaces;
+    },
     endpoints: bundledOr(prefetch.endpoints, loadSubnetEndpoints),
   };
+}
+
+// #7885: the nested Subnet.surfaces filter/sort/page vocabulary -- the same
+// arguments MCP list_surfaces and REST accept (netuid excluded: the nested
+// field takes it from its parent subnet).
+const SUBNET_SURFACE_FILTER_ARGS = [
+  "kind",
+  "provider",
+  "id",
+  "sort",
+  "order",
+  "fields",
+  "limit",
+  "cursor",
+];
+
+function hasSubnetSurfaceFilters(args: Row | undefined | null): boolean {
+  if (!args) return false;
+  return SUBNET_SURFACE_FILTER_ARGS.some((key) => args[key] !== undefined);
 }
 
 // formatExtrinsic's call_args is a decoded JS value (object/array/null), but

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -20213,3 +20213,104 @@ describe("graphql — coverage + coverage_depth", () => {
     );
   });
 });
+
+// #7885: the nested Subnet.surfaces field gained the same filter/sort/page
+// vocabulary MCP list_surfaces and REST GET /api/v1/surfaces accept, delegating
+// to that loader rather than re-deriving a GraphQL-only filter. Unfiltered
+// reads keep their existing bundled behaviour.
+describe("graphql — nested Subnet.surfaces filters (#7885)", () => {
+  const NETUID = 7;
+
+  const surfacesArtifact = {
+    surfaces: [
+      {
+        id: "sn7-api",
+        netuid: NETUID,
+        kind: "subnet-api",
+        provider: "allways",
+        status: "ok",
+      },
+      {
+        id: "sn7-openapi",
+        netuid: NETUID,
+        kind: "openapi",
+        provider: "allways",
+        status: "ok",
+      },
+      {
+        id: "sn7-docs",
+        netuid: NETUID,
+        kind: "docs",
+        provider: "other-co",
+        status: "ok",
+      },
+      // A different subnet's row must never leak into the nested field.
+      { id: "sn9-api", netuid: 9, kind: "subnet-api", provider: "allways" },
+    ],
+  };
+
+  const subnetEnv = () =>
+    fixtureEnv({
+      "/metagraph/surfaces.json": surfacesArtifact,
+      [`/metagraph/subnets/${NETUID}.json`]: {
+        subnet: { netuid: NETUID, name: "Allways", slug: "allways" },
+        surfaces: [
+          { id: "bundled-only", netuid: NETUID, kind: "rpc", status: "ok" },
+        ],
+      },
+    });
+
+  test("filters the nested list by kind", async () => {
+    const { status, body } = await gql(
+      `{ subnet(netuid: ${NETUID}) { surfaces(kind: "openapi") { id kind } } }`,
+      subnetEnv() as unknown as Env,
+    );
+    assert.equal(status, 200);
+    const rows = body.data.subnet.surfaces;
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, "sn7-openapi");
+  });
+
+  test("filters the nested list by provider, scoped to the parent subnet", async () => {
+    const { body } = await gql(
+      `{ subnet(netuid: ${NETUID}) { surfaces(provider: "allways") { id netuid } } }`,
+      subnetEnv() as unknown as Env,
+    );
+    const rows = body.data.subnet.surfaces;
+    assert.deepEqual(rows.map((r: Row) => r.id).sort(), [
+      "sn7-api",
+      "sn7-openapi",
+    ]);
+    // netuid 9's allways row is excluded — the parent subnet still scopes it.
+    assert.ok(rows.every((r: Row) => r.netuid === NETUID));
+  });
+
+  test("sorts and pages the nested list like REST", async () => {
+    const { body } = await gql(
+      `{ subnet(netuid: ${NETUID}) { surfaces(sort: "id", order: "desc", limit: 1) { id } } }`,
+      subnetEnv() as unknown as Env,
+    );
+    const rows = body.data.subnet.surfaces;
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, "sn7-openapi");
+  });
+
+  test("surfaces an invalid nested filter as a GraphQL error, not a silent default", async () => {
+    const { body } = await gql(
+      `{ subnet(netuid: ${NETUID}) { surfaces(kind: "bogus-kind") { id } } }`,
+      subnetEnv() as unknown as Env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("with no arguments keeps its existing bundled behaviour", async () => {
+    const { body } = await gql(
+      `{ subnet(netuid: ${NETUID}) { surfaces { id } } }`,
+      subnetEnv() as unknown as Env,
+    );
+    // Still the row bundled onto the subnet detail artifact — unfiltered
+    // callers never go through the list loader.
+    assert.equal(body.data.subnet.surfaces.length, 1);
+    assert.equal(body.data.subnet.surfaces[0].id, "bundled-only");
+  });
+});


### PR DESCRIPTION
## Summary

The nested `Subnet.surfaces: [Surface!]!` field took **no arguments**, so a GraphQL client could only read a subnet's full unfiltered surface list — while MCP `list_surfaces` and REST `GET /api/v1/surfaces` both filter by `kind`/`provider`/`id`, sort with `sort`/`order`, project with `fields`, and page with `limit`/`cursor`.

This adds that same vocabulary to the nested field and **delegates to `loadSurfacesList`** — the loader those two surfaces already call — rather than re-deriving a GraphQL-only filter.

Closes #7885

## Why delegating is safe here

`loadSurfacesList` reads `/metagraph/surfaces.json` — **the same artifact** the unfiltered nested path already reads (`ARTIFACT.surfaces`), so a filtered and an unfiltered nested read can't diverge on data source. It also validates its own arguments, so an unsupported filter/sort is a GraphQL error rather than a silently substituted default, matching every sibling list field's convention.

## Backward compatibility

**Calling the field with no arguments is completely unchanged** — it still serves the rows bundled onto the subnet detail artifact, preserving that single-read optimisation for every existing query. Only a call that actually supplies a filter/sort/page argument takes the loader path. The parent subnet's `netuid` is always applied, so another subnet's rows can never leak in.

## Two deliberate deviations from the issue text

1. **`cursor: Int`, not `String`** — the loader (and REST) accept a non-negative integer offset; a String cursor would be rejected as `invalid_params` on every call.
2. The issue describes the **root** `surfaces(netuid, ...)` field as already supporting these filters; it does not (it takes only `netuid`/`limit`/`cursor`). So "reuse the root field's logic" isn't possible as written — delegating to the shared loader is the equivalent, drift-free way to get REST parity. The root field is left untouched, keeping this PR scoped to the issue's stated deliverable.

## Tests

5 new cases in `tests/graphql.test.ts`: filter by `kind`; filter by `provider` (asserting another subnet's row is still excluded); `sort`/`order`/`limit`; an invalid filter surfacing as a GraphQL error; and the no-argument call still returning the bundled row. Full file passes: **929 tests**. Lint + `scan:public-safety` clean.

## Scope

Two files, backend only: `src/graphql.ts` (+44/-3) and `tests/graphql.test.ts`. No `apps/ui` changes, no generated artifacts.