### PR TITLE
feat(graphql): accept a keyset cursor on subnet_hyperparameters_history

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -519,7 +519,7 @@ export const SDL = `
     "One subnet's live on-chain hyperparameters (latest snapshot only). The hyperparameters block is null when the subnet has no captured row -- a schema-stable card, never a GraphQL error, matching the Query.block ref-lookup convention. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters."
     subnet_hyperparameters(netuid: Int!): SubnetHyperparameters
     "One subnet's append-only hyperparameter-change history, newest first, one entry per observed change. Forward-only: entries exist only from when the diff-on-change write started. A subnet with no recorded changes resolves to an empty entry list, never null. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters/history."
-    subnet_hyperparameters_history(netuid: Int!, limit: Int, offset: Int): SubnetHyperparamsHistory!
+    subnet_hyperparameters_history(netuid: Int!, limit: Int, offset: Int, cursor: String): SubnetHyperparamsHistory!
     "Per-subnet neuron-deregistration activity over a 7d/30d window (distinct deregistered hotkeys, NeuronDeregistered count, and deregistrations per hotkey); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/deregistrations."
     subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
     "Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving."
@@ -5132,7 +5132,7 @@ const rootValue = {
   },
 
   async subnet_hyperparameters_history(
-    { netuid, limit, offset }: Row,
+    { netuid, limit, offset, cursor }: Row,
     context: GqlContext,
   ) {
     // Same FEED_PAGINATION bounds parsePagination applies for REST, so a GraphQL
@@ -5142,6 +5142,13 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
+    // #7882: forward the keyset cursor the route already accepts. The feed is
+    // append-only and ordered (observed_at, id) DESC, so the route switches to
+    // the keyset comparison and ignores OFFSET whenever a cursor is present --
+    // this field just hands the opaque token back, exactly as REST does, so a
+    // client can page with the next_cursor already returned below. An
+    // empty/absent cursor stays offset-paged, unchanged.
+    if (cursor != null && cursor !== "") params.set("cursor", String(cursor));
     const data =
       ((await tryPostgresTier(
         context.env,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -20262,3 +20262,72 @@ describe("graphql — coverage + coverage_depth", () => {
     );
   });
 });
+
+// #7882: subnet_hyperparameters_history gained the keyset `cursor` the REST
+// route already accepts, alongside the existing offset paging.
+describe("graphql — subnet_hyperparameters_history cursor (#7882)", () => {
+  const PAGE = {
+    schema_version: 1,
+    netuid: 1,
+    entry_count: 1,
+    limit: 50,
+    offset: 0,
+    next_cursor: "eyJhIjoxfQ",
+    entries: [
+      {
+        block_number: 42,
+        observed_at: "2026-07-01T00:00:00.000Z",
+        hyperparams_hash: "abc",
+        hyperparameters: { tempo: 360 },
+      },
+    ],
+  };
+
+  /** Captures the URL the resolver forwards to the Postgres tier. */
+  function capturingEnv(seen: { url?: string }) {
+    return {
+      METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (input: Request | string) => {
+          seen.url = typeof input === "string" ? input : input.url;
+          return Response.json(PAGE);
+        },
+      },
+    };
+  }
+
+  test("forwards the cursor to the route and returns the page", async () => {
+    const seen: { url?: string } = {};
+    const { status, body } = await gql(
+      `{ subnet_hyperparameters_history(netuid: 1, cursor: "eyJhIjoxfQ") { netuid entry_count next_cursor entries { block_number } } }`,
+      capturingEnv(seen) as unknown as Env,
+    );
+    assert.equal(status, 200);
+    const params = new URL(seen.url!).searchParams;
+    assert.equal(params.get("cursor"), "eyJhIjoxfQ");
+    const result = body.data.subnet_hyperparameters_history;
+    assert.equal(result.netuid, 1);
+    assert.equal(result.next_cursor, "eyJhIjoxfQ");
+    assert.equal(result.entries[0].block_number, 42);
+  });
+
+  test("omits the cursor param entirely when not supplied, staying offset-paged", async () => {
+    const seen: { url?: string } = {};
+    await gql(
+      `{ subnet_hyperparameters_history(netuid: 1, offset: 10) { netuid } }`,
+      capturingEnv(seen) as unknown as Env,
+    );
+    const params = new URL(seen.url!).searchParams;
+    assert.equal(params.has("cursor"), false);
+    assert.equal(params.get("offset"), "10");
+  });
+
+  test("treats an empty cursor as absent rather than forwarding a blank token", async () => {
+    const seen: { url?: string } = {};
+    await gql(
+      `{ subnet_hyperparameters_history(netuid: 1, cursor: "") { netuid } }`,
+      capturingEnv(seen) as unknown as Env,
+    );
+    assert.equal(new URL(seen.url!).searchParams.has("cursor"), false);
+  });
+});


### PR DESCRIPTION
## Summary

`subnet_hyperparameters_history(netuid, limit, offset)` only exposed **offset** paging, while `GET /api/v1/subnets/{netuid}/hyperparameters/history` also accepts the **keyset cursor** — the very token this field already returns as `next_cursor`. A GraphQL client could read `next_cursor` but had no argument to feed it back.

This adds `cursor: String` and forwards it to that route.

Closes #7882

## Behaviour

The history feed is append-only and ordered `(observed_at, id) DESC`, so the route switches to the keyset comparison and **ignores `OFFSET` whenever a cursor is present** (`workers/data-api.ts`). This field simply hands the opaque token through, exactly as REST does — no cursor decoding or re-implementation here.

**Existing queries are untouched:** an absent *or empty* cursor is not forwarded at all, so offset paging behaves exactly as before.

## Tests

3 new cases in `tests/graphql.test.ts`, asserting on the URL actually forwarded to the Postgres tier:
- a supplied cursor reaches the route as `?cursor=…` and the page resolves;
- with no cursor the param is **absent** and `offset` still forwards;
- an empty-string cursor is treated as absent rather than forwarding a blank token.

Full file passes: **927 tests**. Lint + `scan:public-safety` clean.

## Scope

Backend only — `src/graphql.ts` (+9/-2) and `tests/graphql.test.ts`. No `apps/ui` changes, no generated artifacts, no schema breakage (a purely additive optional argument).