### PR TITLE
fix(api): clamp reliability score to 100 when okCount exceeds samples

### DIFF
--- a/src/reliability.ts
+++ b/src/reliability.ts
@@ -76,6 +76,15 @@ export function scoreFromStats({
             (avgLatencyMs - LATENCY_FREE_MS) * LATENCY_PENALTY_PER_MS,
           ),
         );
+  // score is documented + served as a 0-100 value, so it needs a hard upper
+  // bound: nothing upstream enforces okCount <= samples (a duplicate-write
+  // race in the daily upsert, or any malformed surface_uptime_daily row, can
+  // put okCount over samples), and an unclamped uptimeRatio > 1 would report
+  // e.g. score: 150 with a nonsensical "A" grade.
+  let score = Math.min(
+    100,
+    Math.max(0, Math.round(uptimeScore - latencyPenalty)),
+  );
   // Anti-overstatement clamp, the same guard this file already applies to the
   // displayed `uptime_ratio` (displayUptimeRatio above) and the turnover
   // `stability_score`/retention composite (#2299): a sub-perfect uptime ratio in
@@ -83,7 +92,6 @@ export function scoreFromStats({
   // flawless `score: 100` (grade A) for a surface that actually had downtime,
   // contradicting its own sub-1 `uptime_ratio`. Only a genuine okCount === samples
   // ratio (exactly 1) keeps the perfect 100; gradeFor(99) is still "A".
-  let score = Math.max(0, Math.round(uptimeScore - latencyPenalty));
   if (score >= 100 && uptimeRatio < 1) score = 99;
   return {
     score,

--- a/tests/reliability.test.ts
+++ b/tests/reliability.test.ts
@@ -97,6 +97,20 @@ describe("scoreFromStats", () => {
     assert.equal(stats!.uptime_ratio, 0.9995);
   });
 
+  test("clamps score to 100 when okCount exceeds samples (malformed/racy row)", () => {
+    // Nothing upstream enforces okCount <= samples; a duplicate-write race in
+    // the daily upsert (or any malformed row) can push okCount past samples,
+    // yielding an uptimeRatio > 1. The score must still cap at 100, not run
+    // past it (e.g. 150) with a nonsensical grade.
+    const stats = scoreFromStats({
+      samples: 10,
+      okCount: 15,
+      avgLatencyMs: null,
+    });
+    assert.equal(stats!.score, 100);
+    assert.equal(stats!.grade, "A");
+  });
+
   test("assigns each grade band from the uptime score", () => {
     const grade = (okCount: number) =>
       scoreFromStats({ samples: 100, okCount, avgLatencyMs: null })!.grade;


### PR DESCRIPTION
## Summary

No tracked issue exists for this yet (found by direct code inspection, not from the public backlog) — describing the bug fully here in lieu of a linked issue.

- `scoreFromStats` (`src/reliability.ts`) computes `uptimeRatio = okCount / samples` and `uptimeScore = uptimeRatio * 100`, then:
  ```ts
  let score = Math.max(0, Math.round(uptimeScore - latencyPenalty));
  if (score >= 100 && uptimeRatio < 1) score = 99;
  ```
  This only guards the rounds-up-to-100 case (a sub-perfect ratio in `[0.995, 1)` rounding to 100 — the file's existing "anti-overstatement clamp", documented in the comment right above it). It never bounds `score` on the upper side when `uptimeRatio > 1`, i.e. when `okCount > samples`.
- Nothing upstream enforces `okCount <= samples` for a `surface_uptime_daily` row (no CHECK constraint in `deploy/postgres/schema.sql`) — a duplicate-write race in the daily upsert, or any malformed row, can push `okCount` past `samples`.
- Concrete failure: `scoreFromStats({ samples: 10, okCount: 15, avgLatencyMs: null })` returns `score: 150` with `grade: "A"` (`gradeFor` only checks lower thresholds, so nothing catches a >100 input). This score is served on the documented 0-100 `/api/v1/subnets/{netuid}/reliability` endpoint and any badge/leaderboard reading it.
- Same class of fix already applied elsewhere in this repo for "a percentage/share must never exceed its bound" (e.g. `movers.ts`'s `pctShare`, the weight-setter share composite) — this file already documents and applies the identical guard on the symmetric sub-1 side, just missing it on the upper side.

## What Changed

- `src/reliability.ts` — `scoreFromStats` now clamps the rounded `score` to a maximum of 100 (`Math.min(100, ...)`) before the existing sub-1 anti-overstatement check, with a comment explaining why (okCount can exceed samples on a malformed/racy row).
- `tests/reliability.test.ts` — new regression test: `okCount: 15, samples: 10` (a 150% "uptime") now returns `score: 100`, not 150.

No schema/contract change: `score` is already documented and typed as 0-100; this only enforces the documented bound.

## Registry Safety

- [ ] Links a tracked, currently-open issue (`Closes #<n>`) — not applicable; self-discovered via code inspection, no tracked issue exists. Full bug report above in lieu of a linked issue.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no schema/contract change; only enforces an already-documented bound.)

## Validation

- [x] `npx tsc --noEmit -p .` (typecheck) — clean
- [x] `npx eslint src/reliability.ts tests/reliability.test.ts` — clean
- [x] `npx prettier --check` on the two changed files
- [x] `git diff --check`
- [x] `npx vitest run tests/reliability.test.ts` — 19/19 passing, 100% line/branch coverage on `src/reliability.ts`
- [x] `npm run scan:public-safety` — no findings in touched files (pre-existing findings elsewhere are unrelated to this diff)
