### PR TITLE
feat(api): add REST filter parity to GraphQL subnet_evidence

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -18,6 +18,7 @@ import { loadSourceSnapshotsList } from "./source-snapshots-mcp.ts";
 // transforms REST and MCP already use) -- not a reimplementation.
 import { loadGapsList } from "./gaps-mcp.ts";
 import { loadEvidenceList } from "./evidence-mcp.ts";
+import { loadSubnetEvidenceList } from "./subnet-evidence-mcp.ts";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
@@ -576,8 +577,8 @@ export const SDL = `
     subnet_event_summary(netuid: Int!, window: String, limit: Int): SubnetEventSummary!
     "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps."
     subnet_gaps(netuid: Int!): JSON
-    "One subnet's curation evidence record — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry. Null when no evidence record has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_evidence MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/evidence."
-    subnet_evidence(netuid: Int!): JSON
+    "One subnet's curation evidence ledger — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry, with REST list-query parity: filter with q (keyword), sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/evidence."
+    subnet_evidence(netuid: Int!, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): JSON
     "One subnet's unpromoted candidate-surface queue — the baked per-subnet /metagraph/candidates/{netuid}.json artifact the REST route and get_subnet_candidates MCP tool read. Null when no candidate artifact has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim. Distinct from candidates(...) (the filterable network-wide candidate catalog). Mirrors GET /api/v1/subnets/{netuid}/candidates."
     subnet_candidates(netuid: Int!): JSON
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
@@ -7030,15 +7031,13 @@ const rootValue = {
     return loadArtifact(context, `/metagraph/review/gaps/${netuid}.json`);
   },
 
-  async subnet_evidence({ netuid }: Row, context: GqlContext) {
-    if (!Number.isInteger(netuid) || netuid < 0) {
-      throw new GraphQLError("netuid must be a non-negative integer.", {
-        extensions: { code: "BAD_USER_INPUT" },
-      });
-    }
-    // Same baked evidence artifact the REST route + get_subnet_evidence MCP
-    // tool read; null when no record has been baked for this netuid.
-    return loadArtifact(context, `/metagraph/evidence/${netuid}.json`);
+  // #7879: reuse loadSubnetEvidenceList (the same loader MCP list_subnet_evidence
+  // + REST GET /api/v1/subnets/{netuid}/evidence call) unchanged. netuid
+  // validation, q/sort/order/fields/limit/cursor validation, and filtering are
+  // all handled by the loader -- an invalid arg throws and becomes a GraphQL
+  // error, matching every other filtered field's convention.
+  subnet_evidence(args: Row, context: GqlContext) {
+    return loadSubnetEvidenceList(mcpCtx(context), args, { readArtifact });
   },
 
   async subnet_candidates({ netuid }: Row, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8847,7 +8847,7 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
     const env = fixtureEnv({
       "/metagraph/evidence/5.json": {
         netuid: 5,
-        sources: ["https://example.com"],
+        claims: [{ subject: "sn-5", claim: "Has API" }],
       },
     });
     const { status, body } = await gql("{ subnet_evidence(netuid: 5) }", env);
@@ -8856,14 +8856,53 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
     assert.equal(body.data.subnet_evidence.netuid, 5);
   });
 
-  test("subnet_evidence degrades to null when no record is baked", async () => {
-    const { status, body } = await gql("{ subnet_evidence(netuid: 999) }");
-    assert.equal(status, 200);
-    assert.equal(body.errors, undefined);
-    assert.equal(body.data.subnet_evidence, null);
+  test("subnet_evidence surfaces a missing artifact as a GraphQL error (#7879)", async () => {
+    const { body } = await gql("{ subnet_evidence(netuid: 999) }");
+    assert.ok(body.errors?.length);
   });
 
-  test("a negative netuid is a GraphQL error on both artifact fields", async () => {
+  test("subnet_evidence filters claims by q keyword (#7879)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/evidence/7.json": {
+        netuid: 7,
+        claims: [
+          { subject: "sn-7", claim: "Has OpenAPI" },
+          { subject: "sn-7", claim: "Has dashboard" },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      '{ subnet_evidence(netuid: 7, q: "OpenAPI") }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_evidence.returned, 1);
+    assert.equal(body.data.subnet_evidence.claims[0].claim, "Has OpenAPI");
+  });
+
+  test("subnet_evidence paginates claims with limit/cursor (#7879)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/evidence/7.json": {
+        netuid: 7,
+        claims: [
+          { subject: "sn-7", claim: "A" },
+          { subject: "sn-7", claim: "B" },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      "{ subnet_evidence(netuid: 7, limit: 1) }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_evidence.total, 2);
+    assert.equal(body.data.subnet_evidence.returned, 1);
+    assert.equal(body.data.subnet_evidence.next_cursor, 1);
+  });
+
+  test("a negative netuid is a GraphQL error on subnet_gaps and subnet_evidence", async () => {
     for (const field of ["subnet_gaps", "subnet_evidence"]) {
       const { body } = await gql(`{ ${field}(netuid: -1) }`);
       assert.ok(body.errors, `expected a GraphQL error for ${field}`);


### PR DESCRIPTION
## Summary

- Wires `subnet_evidence(netuid, q, sort, order, fields, limit, cursor)` to `loadSubnetEvidenceList` (the same loader `list_subnet_evidence` MCP tool and `GET /api/v1/subnets/{netuid}/evidence` REST route use) — no filtering logic re-implemented
- Adds `q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int` args matching REST parity
- An invalid filter/sort/limit/cursor is a GraphQL error (not a silent default), consistent with `evidence` / `endpoint_incidents` / `source_snapshots`
- Updates existing tests: the fixture now carries a `claims[]` array (matching the loader's expected artifact shape) and the previous null-degradation test now asserts a GraphQL error for a missing artifact
- Adds 2 new tests: keyword (`q`) filter and limit/cursor pagination

## Test plan

- [x] `npx vitest run tests/graphql.test.ts -t "subnet_gaps / subnet_evidence"` — 8 tests pass
- [x] `npx eslint src/graphql.ts` — clean

Closes #7879