### PR TITLE
feat(api): full REST filter/sort parity on the GraphQL endpoints field (#7887)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -35,6 +35,10 @@ import {
 import { loadProfilesList } from "./profiles-mcp.ts";
 import { contractVersion } from "../workers/responses.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.ts";
+// #7887: the root `endpoints` field reuses the SAME shared list-query filter/sort
+// machinery REST /api/v1/endpoints and MCP list_endpoints apply, so its
+// kind/layer/provider/... filters can never drift from theirs.
+import { applyQueryFilters } from "../workers/list-query.ts";
 // #6985: GraphQL parity for the endpoint-pools/rpc-pools/endpoint-incidents REST
 // routes, reusing the same shaping functions list_endpoint_pools/list_rpc_pools/
 // list_endpoint_incidents already call for MCP parity -- not a reimplementation.
@@ -637,7 +641,7 @@ export const SDL = `
     "Curated public interface surfaces, optionally scoped to one subnet."
     surfaces(netuid: Int, limit: Int, cursor: String): SurfaceList!
     "Endpoint/resource registry, optionally scoped to one subnet."
-    endpoints(netuid: Int, limit: Int, cursor: String): EndpointList!
+    endpoints(netuid: Int, kind: String, layer: String, provider: String, publication_state: String, status: String, pool_eligible: Boolean, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, sort: String, order: String, fields: [String!], limit: Int, cursor: String): EndpointList!
     "One provider's endpoint rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints."
     provider_endpoints(slug: String!, kind: String, layer: String, publication_state: String, status: String, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, sort: String, order: String, limit: Int, cursor: String): JSON
     "Generalized endpoint pool scores -- each pool's kind, eligible/total endpoint count, and probe-derived routing score. Filter by id/kind, threshold with min_/max_eligible_count and min_/max_endpoint_count, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/endpoint-pools."
@@ -6321,13 +6325,65 @@ const rootValue = {
     });
   },
 
-  endpoints({ netuid, limit, cursor }: Row, context: GqlContext) {
-    return listPage(context, ARTIFACT.endpoints, "endpoints", {
-      limit,
-      cursor,
-      netuid,
-      keyFn: (e: Row) => e.id ?? e.surface_id,
-    });
+  // #7887: full REST filter/sort parity for GET /api/v1/endpoints. Rather than
+  // re-deriving a GraphQL-only filterFn, reuse applyQueryFilters (the same
+  // machinery REST + list_endpoints use) for the filter + sort pass -- passing
+  // only the filter/sort args, NOT limit/cursor, so it filters and orders the
+  // full set without paginating -- then apply this field's own established
+  // keyset pagination over the result, preserving EndpointList's String cursor.
+  // An invalid filter/sort is a GraphQL error, matching REST's 400 and every
+  // sibling field's "not a silently substituted default" convention.
+  async endpoints(args: Row, context: GqlContext) {
+    const data = (await loadArtifact(context, ARTIFACT.endpoints)) ?? {
+      endpoints: [],
+    };
+    const url = new URL("https://graphql.local/endpoints");
+    const set = (name: string, value: unknown) => {
+      if (value !== undefined && value !== null && value !== "") {
+        url.searchParams.set(name, String(value));
+      }
+    };
+    set("netuid", args.netuid);
+    set("kind", args.kind);
+    set("layer", args.layer);
+    set("provider", args.provider);
+    set("publication_state", args.publication_state);
+    set("status", args.status);
+    if (args.pool_eligible !== undefined && args.pool_eligible !== null) {
+      set("pool_eligible", args.pool_eligible ? "true" : "false");
+    }
+    set("min_latency_ms", args.min_latency_ms);
+    set("max_latency_ms", args.max_latency_ms);
+    set("min_score", args.min_score);
+    set("max_score", args.max_score);
+    set("sort", args.sort);
+    set("order", args.order);
+    if (Array.isArray(args.fields) && args.fields.length > 0) {
+      set("fields", args.fields.join(","));
+    }
+    const transformed = applyQueryFilters(
+      data as Record<string, unknown>,
+      url,
+      "endpoints",
+      [],
+    );
+    if (transformed.error) {
+      throw new GraphQLError(transformed.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const rows = Array.isArray(
+      (transformed.data as Record<string, unknown>)?.endpoints,
+    )
+      ? ((transformed.data as { endpoints: Row[] }).endpoints as Row[])
+      : [];
+    const { page, total, nextCursor } = paginate(
+      rows,
+      args.limit,
+      args.cursor,
+      (e: Row) => e.id ?? e.surface_id,
+    );
+    return { items: page, total, next_cursor: nextCursor };
   },
 
   // #7868: reuse list_provider_endpoints' own loader unchanged (provider-

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1315,6 +1315,80 @@ describe("graphql — surfaces / endpoints / health roots", () => {
     assert.equal(second.body.data.endpoints.items[0].id, "e2");
   });
 
+  test("endpoints applies the full REST filter/sort set (#7887)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints.json": {
+        endpoints: [
+          {
+            id: "e1",
+            netuid: 1,
+            kind: "subnet-api",
+            provider: "acme",
+            status: "ok",
+            latency_ms: 50,
+            score: 90,
+          },
+          {
+            id: "e2",
+            netuid: 1,
+            kind: "rpc",
+            provider: "acme",
+            status: "ok",
+            latency_ms: 200,
+            score: 40,
+          },
+          {
+            id: "e3",
+            netuid: 2,
+            kind: "subnet-api",
+            provider: "other",
+            status: "failed",
+            latency_ms: 30,
+            score: 70,
+          },
+        ],
+      },
+    });
+
+    // Three filters combined (kind + status + provider) → only e1.
+    const filtered = await gql(
+      '{ endpoints(kind: "subnet-api", status: "ok", provider: "acme") { items { id } total } }',
+      env as unknown as Env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.endpoints.total, 1);
+    assert.equal(filtered.body.data.endpoints.items[0].id, "e1");
+
+    // sort + order.
+    const sorted = await gql(
+      '{ endpoints(sort: "score", order: "desc") { items { id score } } }',
+      env as unknown as Env,
+    );
+    assert.deepEqual(
+      sorted.body.data.endpoints.items.map((e: Row) => e.id),
+      ["e1", "e3", "e2"],
+    );
+
+    // A range filter (min_score) → e1 (90) and e3 (70), not e2 (40).
+    const ranged = await gql(
+      "{ endpoints(min_score: 70) { items { id } total } }",
+      env as unknown as Env,
+    );
+    assert.equal(ranged.body.data.endpoints.total, 2);
+    assert.deepEqual(
+      ranged.body.data.endpoints.items.map((e: Row) => e.id).sort(),
+      ["e1", "e3"],
+    );
+
+    // An invalid filter value is a GraphQL error, not a silent default.
+    const invalid = await gql(
+      '{ endpoints(kind: "not-a-real-kind") { total } }',
+      env as unknown as Env,
+    );
+    assert.ok(invalid.body.errors?.length);
+    assert.equal(invalid.body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
   test("health lifts the live rollup and exposes per-subnet summaries", async () => {
     const env = fixtureEnv(
       {},


### PR DESCRIPTION
Closes #7887

## What

The root `endpoints` field accepted only `netuid, limit, cursor`, while `GET /api/v1/endpoints` (and MCP `list_endpoints`) also filter by `kind, layer, provider, publication_state, status, pool_eligible`, threshold by `min/max_latency_ms` + `min/max_score`, and `sort/order`. This adds the full argument set, mirroring the `endpoint_pools`/`rpc_pools`/`endpoint_incidents` precedent.

## How

The resolver reuses **`applyQueryFilters`** — the same shared list-query machinery REST and MCP already apply — for the filter + sort pass, so its filters can never drift from theirs (not a GraphQL-only reimplementation). Key detail: it passes **only the filter/sort args, not `limit`/`cursor`**, so `applyQueryFilters` filters and orders the *full* set without paginating; the field then applies its own established **keyset pagination** over the result. That preserves `EndpointList`'s `String` cursor — **no breaking change** to existing `endpoints(limit, cursor)` callers. An invalid filter/sort value is a GraphQL `BAD_USER_INPUT` error, matching REST's 400 and every sibling field's "not a silently substituted default" convention.

## Tests — `tests/graphql.test.ts`

- Three filters combined (`kind` + `status` + `provider`) → the single matching endpoint.
- `sort` + `order` (by `score`, desc) → correct ordering.
- A range filter (`min_score`) → threshold applied.
- An invalid filter value → GraphQL `BAD_USER_INPUT`.
- All existing `endpoints`/`surfaces`/`health` tests still pass (netuid filter, keyset pagination unchanged).

`npx vitest run tests/graphql.test.ts` — 929 passed; eslint + prettier clean; typecheck clean for these files; rebased on latest `main` (kept alongside the newly-merged `provider_endpoints` field).

- [x] `endpoints` field accepts the full REST filter set
- [x] Test coverage: 3+ filters combined plus sort/order
- [x] Links a tracked, currently-open issue (`Closes #7887`)
