### PR TITLE
fix(pipeline): run validate:no-hand-written-mjs in the local pipeline

### DIFF
--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -99,6 +99,7 @@ function checkCommands(): Step[] {
     step("worker:test"),
     step("worker:deploy:dry-run"),
     step("scan:public-safety"),
+    step("validate:no-hand-written-mjs"),
     step("validate:private-boundary"),
     step("test"),
   ];
@@ -161,6 +162,7 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     step("worker:test"),
     step("worker:deploy:dry-run"),
     step("scan:public-safety"),
+    step("validate:no-hand-written-mjs"),
     step("validate:private-boundary"),
     step("test"),
   ];


### PR DESCRIPTION
## Summary

`tests/pipeline-validator-parity.test.ts` (#1767) is **currently failing on `main`**, which red-lights the `test` job on every open PR:

```
AssertionError: validate.yml runs validators the local `npm run check` does not:
validate:no-hand-written-mjs. Add them to scripts/pipeline.ts checkCommands (and refreshCommands).
```

#7956 added the `no-hand-written-mjs` gate to `.github/workflows/validate.yml` but not to `scripts/pipeline.ts`, breaking the "the local pipeline is a superset of CI's validators" invariant that test exists to enforce.

## Fix

Adds `step("validate:no-hand-written-mjs")` to **both** `checkCommands()` and `refreshCommands()` — exactly what the assertion asks for — positioned to match validate.yml's own ordering (immediately before `validate:private-boundary`, mirroring lines 647/680 there).

## Verification

```
npx vitest run tests/pipeline-validator-parity.test.ts
Test Files  1 passed (1)
     Tests  2 passed (2)
```

Confirmed failing on a clean checkout of `main` before this change, and passing with it.

## Scope

One file, three lines added: `scripts/pipeline.ts`. No behaviour change beyond running a validator locally that CI already runs.