### PR TITLE
feat(api): add subnet_endpoints root field + parameterize nested Subnet.endpoints

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -45,6 +45,7 @@ import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.ts";
 // same loadProviderEndpointsList that MCP list_provider_endpoints already calls
 // (#3289) -- not a reimplementation.
 import { loadProviderEndpointsList } from "./provider-endpoints-mcp.ts";
+import { loadSubnetEndpointsList } from "./subnet-endpoints-mcp.ts";
 // #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
 // and page logic REST and MCP already use) -- not a reimplementation.
@@ -638,6 +639,8 @@ export const SDL = `
     surfaces(netuid: Int, limit: Int, cursor: String): SurfaceList!
     "Endpoint/resource registry, optionally scoped to one subnet."
     endpoints(netuid: Int, limit: Int, cursor: String): EndpointList!
+    "One subnet's endpoint/resource registry rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Reuses list_subnet_endpoints' loader over the baked per-subnet artifact. An unsupported filter/sort or a cold/absent subnet is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_subnet_endpoints MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/endpoints."
+    subnet_endpoints(netuid: Int!, kind: String, layer: String, publication_state: String, status: String, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, sort: String, order: String, limit: Int, cursor: String): JSON
     "One provider's endpoint rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints."
     provider_endpoints(slug: String!, kind: String, layer: String, publication_state: String, status: String, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, sort: String, order: String, limit: Int, cursor: String): JSON
     "Generalized endpoint pool scores -- each pool's kind, eligible/total endpoint count, and probe-derived routing score. Filter by id/kind, threshold with min_/max_eligible_count and min_/max_endpoint_count, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/endpoint-pools."
@@ -897,8 +900,8 @@ export const SDL = `
     economics: SubnetEconomics
     "Curated public interface surfaces of this subnet."
     surfaces: [Surface!]!
-    "Endpoint/resource registry rows for this subnet."
-    endpoints: [Endpoint!]!
+    "Endpoint/resource registry rows for this subnet, accepting the same optional filter/sort/page arguments as the root subnet_endpoints field. With no arguments it returns the subnet's full endpoint list; with any filter/sort/page argument it routes through the list_subnet_endpoints loader for full REST parity."
+    endpoints(kind: String, layer: String, publication_state: String, status: String, min_latency_ms: Int, max_latency_ms: Int, min_score: Float, max_score: Float, sort: String, order: String, limit: Int, cursor: String): [Endpoint!]!
   }
 
   type ProviderList {
@@ -4239,6 +4242,7 @@ export const FIELD_COMPLEXITY = {
   economics: RELATIONSHIP_FIELD_COMPLEXITY,
   surfaces: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   provider_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoint_pools: RELATIONSHIP_FIELD_COMPLEXITY,
   rpc_pools: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4822,7 +4826,22 @@ function subnetNode(identity: Row, prefetch: Row = {}) {
     economics: (_args: unknown, context: GqlContext) =>
       loadSubnetEconomics(context, netuid),
     surfaces: bundledOr(prefetch.surfaces, loadSubnetSurfaces),
-    endpoints: bundledOr(prefetch.endpoints, loadSubnetEndpoints),
+    endpoints: async (args: Row, context: GqlContext) => {
+      // #7869: with any filter/sort/page argument, route through the same
+      // list_subnet_endpoints loader the root subnet_endpoints field uses so
+      // the nested field filters identically to REST/MCP; with no arguments,
+      // keep the existing prefetch fast-path unchanged.
+      const filtered = Object.keys(args).length > 0;
+      if (filtered) {
+        const result = await loadSubnetEndpointsList(
+          mcpCtx(context),
+          { netuid, ...args },
+          { readArtifact },
+        );
+        return result.endpoints;
+      }
+      return prefetch.endpoints ?? loadSubnetEndpoints(context, netuid);
+    },
   };
 }
 
@@ -6328,6 +6347,15 @@ const rootValue = {
       netuid,
       keyFn: (e: Row) => e.id ?? e.surface_id,
     });
+  },
+
+  subnet_endpoints(args: Row, context: GqlContext) {
+    // #7869: reuse list_subnet_endpoints' own loader (subnet-endpoints-mcp.ts)
+    // -- the same read + filter/sort/page the REST route and MCP tool run over
+    // the baked per-subnet endpoints artifact. Wired like endpoint_pools/gaps;
+    // the loader validates its own args and throws (invalid filter/sort or a
+    // cold/absent subnet) as a GraphQL error.
+    return loadSubnetEndpointsList(mcpCtx(context), args, { readArtifact });
   },
 
   // #7868: reuse list_provider_endpoints' own loader unchanged (provider-

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -7834,6 +7834,65 @@ describe("graphql — provider_endpoints (#7868, per-provider filtered endpoint 
   });
 });
 
+describe("graphql — subnet_endpoints (#7869, root + nested filtered endpoint list)", () => {
+  const ENV = () =>
+    fixtureEnv({
+      "/metagraph/subnets/7.json": {
+        subnet: { netuid: 7, name: "S7", slug: "s7" },
+      },
+      "/metagraph/endpoints/7.json": {
+        endpoints: [
+          { id: "sn7-e1", kind: "subtensor-rpc", status: "ok", netuid: 7 },
+          { id: "sn7-e2", kind: "subnet-api", status: "ok", netuid: 7 },
+        ],
+      },
+    });
+
+  test("root subnet_endpoints returns the full list unfiltered", async () => {
+    const { status, body } = await gql(
+      "{ subnet_endpoints(netuid: 7) }",
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints.endpoints.length, 2);
+  });
+
+  test("root subnet_endpoints applies a kind filter via the loader", async () => {
+    const { status, body } = await gql(
+      '{ subnet_endpoints(netuid: 7, kind: "subtensor-rpc") }',
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints.endpoints.length, 1);
+    assert.equal(body.data.subnet_endpoints.endpoints[0].kind, "subtensor-rpc");
+  });
+
+  test("root subnet_endpoints surfaces an unsupported sort as a GraphQL error", async () => {
+    const { body } = await gql(
+      '{ subnet_endpoints(netuid: 7, sort: "bogus") }',
+      ENV(),
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+  });
+
+  test("nested Subnet.endpoints accepts the same filter args", async () => {
+    const { status, body } = await gql(
+      '{ subnet(netuid: 7) { endpoints(kind: "subtensor-rpc") { id kind } } }',
+      ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet.endpoints.length, 1);
+    assert.equal(body.data.subnet.endpoints[0].kind, "subtensor-rpc");
+  });
+
+  test("subnet_endpoints is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_endpoints, 5);
+  });
+});
+
 describe("graphql — agent_resources (#6987, baked AI-resources index)", () => {
   test("resolves the baked AI-resources index", async () => {
     const env = fixtureEnv({


### PR DESCRIPTION
## Context

`GET /api/v1/subnets/{netuid}/endpoints` (MCP tools `get_subnet_endpoints` / `list_subnet_endpoints`) had no GraphQL root field, and the nested `Subnet.endpoints` field took no arguments — a client could only get the unfiltered full list.

## Change

- **Root** `subnet_endpoints(netuid, kind, layer, publication_state, status, min_latency_ms, max_latency_ms, min_score, max_score, sort, order, limit, cursor): JSON` — reuses `list_subnet_endpoints`' own loader (`subnet-endpoints-mcp.ts`) unchanged over the baked per-subnet artifact, wired like `endpoint_pools`/`gaps` via `mcpCtx(context)`. No filtering re-implemented.
- **Nested** `Subnet.endpoints` now accepts the same argument set: with any filter/sort/page argument it routes through the same loader for full parity; **with no arguments it keeps the existing prefetch fast-path unchanged**, so existing behavior is preserved.

The loader validates its own args and throws on an invalid filter/sort or a cold/absent subnet — that throw surfaces as a GraphQL error, matching the `endpoint_pools`/`gaps` convention.

## Deliverables

- [x] Root `subnet_endpoints(netuid, ...)` field with full REST filter parity
- [x] Nested `Subnet.endpoints` accepts the same filter/sort/page arguments
- [x] Test coverage: root field with a filter, nested field with a filter

## Tests

5 new tests (root unfiltered, root kind-filter, root unsupported-sort error, nested kind-filter, complexity). Full `tests/graphql.test.ts` suite green (933), typecheck clean for the changed files, eslint + prettier clean, public-safety scan passes, and **zero uncovered statements/branches** on both new/changed resolvers (the nested change preserves the no-arg prefetch path).

Closes #7869