### PR TITLE
feat(api): add REST filter parity to GraphQL subnet_gaps

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -58,6 +58,9 @@ import { loadEnrichmentQueueList } from "./enrichment-queue-mcp.ts";
 import { loadReviewEnrichmentTargetsList } from "./review-enrichment-targets-mcp.ts";
 import { loadReviewGapsList } from "./review-gaps-mcp.ts";
 import { loadProfileCompletenessList } from "./profile-completeness-mcp.ts";
+// #7880: GraphQL parity for GET /api/v1/subnets/{netuid}/gaps filters — reuse
+// loadSubnetGapsList (review-gap-priorities list-query on the per-subnet artifact).
+import { loadSubnetGapsList } from "./subnet-gaps-mcp.ts";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.ts";
@@ -577,8 +580,8 @@ export const SDL = `
     subnet_validators(netuid: Int!): SubnetValidatorList!
     "One subnet's chain-event activity summary over a 7d/30d/90d window (default 30d): total events, the per-kind and per-category breakdowns with hotkey/coldkey participation and TAO/alpha amounts, and a bounded newest-first recent-event list (limit 1-50, default 10). A subnet with no events resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/event-summary."
     subnet_event_summary(netuid: Int!, window: String, limit: Int): SubnetEventSummary!
-    "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps."
-    subnet_gaps(netuid: Int!): JSON
+    "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Filter by curation_level/missing_kinds/review_state, sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the list_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps."
+    subnet_gaps(netuid: Int!, curation_level: String, missing_kinds: [String!], review_state: String, limit: Int, cursor: String, sort: String, order: String): JSON
     "One subnet's curation evidence record — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry. Null when no evidence record has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_evidence MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/evidence."
     subnet_evidence(netuid: Int!): JSON
     "One subnet's unpromoted candidate-surface queue — the baked per-subnet /metagraph/candidates/{netuid}.json artifact the REST route and get_subnet_candidates MCP tool read. Null when no candidate artifact has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim. Distinct from candidates(...) (the filterable network-wide candidate catalog). Mirrors GET /api/v1/subnets/{netuid}/candidates."
@@ -7033,17 +7036,30 @@ const rootValue = {
     };
   },
 
-  async subnet_gaps({ netuid }: Row, context: GqlContext) {
-    if (!Number.isInteger(netuid) || netuid < 0) {
-      throw new GraphQLError("netuid must be a non-negative integer.", {
-        extensions: { code: "BAD_USER_INPUT" },
-      });
+  async subnet_gaps(args: Row, context: GqlContext) {
+    // #7880: reuse loadSubnetGapsList — same review-gap-priorities list-query
+    // transforms REST applies on /api/v1/subnets/{netuid}/gaps. Invalid filters
+    // are GraphQL BAD_USER_INPUT errors; a cold/absent artifact degrades to null
+    // (matching this field's historical schema-stable convention, not a throw).
+    try {
+      return await loadSubnetGapsList(mcpCtx(context), args, { readArtifact });
+    } catch (err) {
+      const toolErr = err as {
+        toolError?: boolean;
+        code?: string;
+        message?: string;
+      };
+      if (toolErr?.toolError && toolErr.code === "not_found") return null;
+      if (toolErr?.toolError && toolErr.code === "invalid_params") {
+        throw new GraphQLError(
+          toolErr.message || "Invalid subnet_gaps arguments.",
+          {
+            extensions: { code: "BAD_USER_INPUT" },
+          },
+        );
+      }
+      throw err;
     }
-    // Same baked review-gaps artifact the REST route + get_subnet_gaps MCP tool
-    // read. The MCP tool raises not_found for a netuid with no report; GraphQL
-    // degrades to null instead, matching how every other artifact-backed
-    // resolver here treats a cold/absent artifact.
-    return loadArtifact(context, `/metagraph/review/gaps/${netuid}.json`);
   },
 
   async subnet_evidence({ netuid }: Row, context: GqlContext) {

--- a/src/subnet-gaps-mcp.ts
+++ b/src/subnet-gaps-mcp.ts
@@ -90,18 +90,76 @@ function clampLimit(value: unknown, fallback: number, max: number): number {
   return Math.min(max, Math.floor(value));
 }
 
+function resolveMissingKinds(
+  args: Record<string, unknown> | null | undefined,
+): string | null {
+  const value = args?.missing_kinds;
+  if (value === undefined || value === null || value === "") return null;
+  // GraphQL advertises [String!]; REST accepts a single enum — use the first
+  // requested kind after validating every entry.
+  if (Array.isArray(value)) {
+    const kinds = value
+      .filter((part): part is string => typeof part === "string")
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (kinds.length === 0) {
+      throw subnetGapsMcpError(
+        "invalid_params",
+        "Argument `missing_kinds` must be a non-empty list of surface kinds when provided.",
+      );
+    }
+    for (const kind of kinds) {
+      if (!(SURFACE_KINDS as readonly string[]).includes(kind)) {
+        throw subnetGapsMcpError(
+          "invalid_params",
+          `Argument \`missing_kinds\` must be one of: ${SURFACE_KINDS.join(", ")}.`,
+        );
+      }
+    }
+    return kinds[0];
+  }
+  return optionalEnum(args, "missing_kinds", SURFACE_KINDS as string[]);
+}
+
+function resolveCursor(
+  args: Record<string, unknown> | null | undefined,
+): number | null {
+  const value = args?.cursor;
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value === "string") {
+    if (!/^\d+$/.test(value.trim())) {
+      throw subnetGapsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    return Number(value.trim());
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw subnetGapsMcpError(
+      "invalid_params",
+      "cursor must be a non-negative integer.",
+    );
+  }
+  return value;
+}
+
 export function subnetGapsQueryUrl(
   args: Record<string, unknown> | null | undefined,
 ): URL {
   const url = new URL("https://mcp.internal/subnets/gaps");
   requireNetuid(args);
-  const curationLevel = optionalEnum(args, "curation_level", CURATION_LEVELS);
+  const curationLevel = optionalEnum(
+    args,
+    "curation_level",
+    CURATION_LEVELS as string[],
+  );
   if (curationLevel) url.searchParams.set("curation_level", curationLevel);
-  const missingKinds = optionalEnum(args, "missing_kinds", SURFACE_KINDS);
+  const missingKinds = resolveMissingKinds(args);
   if (missingKinds) url.searchParams.set("missing_kinds", missingKinds);
   const reviewState = optionalString(args, "review_state");
   if (reviewState) url.searchParams.set("review_state", reviewState);
-  const sort = optionalEnum(args, "sort", GAP_PRIORITY_SORT_FIELDS);
+  const sort = optionalEnum(args, "sort", GAP_PRIORITY_SORT_FIELDS as string[]);
   if (sort) url.searchParams.set("sort", sort);
   const order = optionalEnum(args, "order", ["asc", "desc"]);
   if (order) url.searchParams.set("order", order);
@@ -110,16 +168,8 @@ export function subnetGapsQueryUrl(
   if (args?.limit !== undefined) {
     url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
   }
-  if (args?.cursor !== undefined) {
-    const cursor = args.cursor;
-    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
-      throw subnetGapsMcpError(
-        "invalid_params",
-        "cursor must be a non-negative integer.",
-      );
-    }
-    url.searchParams.set("cursor", String(cursor));
-  }
+  const cursor = resolveCursor(args);
+  if (cursor !== null) url.searchParams.set("cursor", String(cursor));
   return url;
 }
 
@@ -156,7 +206,14 @@ export async function loadSubnetGapsList(
   if (!result?.ok) {
     const code =
       (result as { code?: string } | undefined)?.code || "artifact_unavailable";
-    if (code === "artifact_not_found") {
+    // Treat cold/unbound storage the same as a missing per-netuid report so
+    // GraphQL can keep its schema-stable null degradation (and MCP still gets
+    // a not_found toolError).
+    if (
+      code === "artifact_not_found" ||
+      code === "r2_binding_missing" ||
+      code === "artifact_unavailable"
+    ) {
       throw subnetGapsMcpError(
         "not_found",
         `No gap report exists for netuid ${netuid}.`,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8932,18 +8932,104 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
 });
 
 describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifacts)", () => {
+  const SUBNET_GAPS_BLOB = {
+    schema_version: 1,
+    netuid: 5,
+    slug: "demo",
+    name: "Demo",
+    priorities: [
+      {
+        netuid: 5,
+        slug: "demo",
+        name: "Demo",
+        missing_kinds: ["docs"],
+        priority_score: 72,
+        curation_level: "maintainer-reviewed",
+        review_state: "maintainer-reviewed",
+        surface_count: 4,
+        candidate_count: 1,
+        verified_candidate_count: 1,
+      },
+      {
+        netuid: 5,
+        slug: "demo",
+        name: "Demo",
+        missing_kinds: ["openapi"],
+        priority_score: 40,
+        curation_level: "candidate-discovered",
+        review_state: "community-submitted",
+        surface_count: 2,
+        candidate_count: 3,
+        verified_candidate_count: 0,
+      },
+    ],
+    enrichment_queue: [
+      {
+        netuid: 5,
+        lane: "direct-submission",
+        missing_kinds: ["docs"],
+        recommended_action: "Submit official docs evidence",
+      },
+    ],
+  };
+
   test("subnet_gaps resolves the baked gap report", async () => {
     const env = fixtureEnv({
-      "/metagraph/review/gaps/5.json": {
-        netuid: 5,
-        gaps: [{ kind: "api", missing: true }],
-      },
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
     });
     const { status, body } = await gql("{ subnet_gaps(netuid: 5) }", env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.subnet_gaps.netuid, 5);
-    assert.equal(body.data.subnet_gaps.gaps[0].kind, "api");
+    assert.equal(body.data.subnet_gaps.priorities[0].missing_kinds[0], "docs");
+    assert.equal(body.data.subnet_gaps.total, 2);
+  });
+
+  test("subnet_gaps filters by curation_level (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
+    });
+    const { status, body } = await gql(
+      '{ subnet_gaps(netuid: 5, curation_level: "candidate-discovered") }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_gaps.total, 1);
+    assert.equal(
+      body.data.subnet_gaps.priorities[0].curation_level,
+      "candidate-discovered",
+    );
+  });
+
+  test("subnet_gaps filters by missing_kinds (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
+    });
+    const { status, body } = await gql(
+      '{ subnet_gaps(netuid: 5, missing_kinds: ["openapi"]) }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_gaps.total, 1);
+    assert.deepEqual(body.data.subnet_gaps.priorities[0].missing_kinds, [
+      "openapi",
+    ]);
+  });
+
+  test("subnet_gaps an unsupported sort is a GraphQL error (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/5.json": SUBNET_GAPS_BLOB,
+    });
+    const { body } = await gql(
+      '{ subnet_gaps(netuid: 5, sort: "bogus") }',
+      env,
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
   });
 
   test("subnet_gaps degrades to null when no report is baked, never an error", async () => {
@@ -8951,6 +9037,25 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.subnet_gaps, null);
+  });
+
+  test("subnet_gaps propagates a non-toolError from the artifact read (#7880)", async () => {
+    const env = {
+      METAGRAPH_R2_LATEST_PREFIX: "latest/",
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              throw new Error("corrupt subnet gaps artifact");
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql("{ subnet_gaps(netuid: 5) }", env);
+    assert.equal(status, 200);
+    assert.ok(body.errors?.length > 0);
+    assert.equal(body.data?.subnet_gaps ?? null, null);
   });
 
   test("subnet_evidence resolves the baked evidence record", async () => {

--- a/tests/subnet-gaps-mcp.test.ts
+++ b/tests/subnet-gaps-mcp.test.ts
@@ -386,7 +386,66 @@ describe("subnet-gaps-mcp", () => {
           } as unknown as LoadCtx,
           { netuid: NETUID },
         ),
-      (err: Row) => err.code === "artifact_unavailable",
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetGapsList maps r2_binding_missing to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "r2_binding_missing",
+            }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("subnetGapsQueryUrl accepts string cursor and missing_kinds list", () => {
+    const url = subnetGapsQueryUrl({
+      netuid: NETUID,
+      missing_kinds: ["openapi", "docs"],
+      cursor: "3",
+    });
+    assert.equal(url.searchParams.get("missing_kinds"), "openapi");
+    assert.equal(url.searchParams.get("cursor"), "3");
+  });
+
+  test("subnetGapsQueryUrl rejects an empty missing_kinds list", () => {
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: NETUID, missing_kinds: [] }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetGapsQueryUrl rejects an invalid kind inside a missing_kinds list", () => {
+    assert.throws(
+      () =>
+        subnetGapsQueryUrl({
+          netuid: NETUID,
+          missing_kinds: ["openapi", "not-a-kind"],
+        }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetGapsQueryUrl rejects a list of only non-string missing_kinds", () => {
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: NETUID, missing_kinds: [12] }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetGapsQueryUrl rejects a non-digit string cursor", () => {
+    assert.throws(
+      () => subnetGapsQueryUrl({ netuid: NETUID, cursor: "abc" }),
+      (err: Row) => err.code === "invalid_params",
     );
   });
 


### PR DESCRIPTION
## Summary
- Reuse existing `loadSubnetGapsList` (from `list_subnet_gaps`) for GraphQL `subnet_gaps` with `curation_level`, `missing_kinds`, `review_state`, `limit`, `cursor`, `sort`, and `order`.
- Extend the loader for GraphQL `[String!]` / string cursor inputs and map cold storage to `not_found` so the field still degrades to null.
- Cover curation_level / missing_kinds filters, invalid-sort BAD_USER_INPUT, and non-toolError propagation; loader at 100% lines/branches.

Closes #7880

## Test plan
- [x] `npx vitest run tests/subnet-gaps-mcp.test.ts`
- [x] `npx vitest run tests/graphql.test.ts -t subnet_gaps`
- [x] Focused coverage: `src/subnet-gaps-mcp.ts` 100% lines/branches
- [x] Private-boundary validation passed
- [ ] CI Validate + codecov/patch green on this PR