### PR TITLE
feat(mcp): add list_subnet_surfaces — the filtered sibling of get_subnet_surfaces

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -140,6 +140,12 @@ import {
   loadSubnetEndpointsList,
 } from "./subnet-endpoints-mcp.ts";
 import {
+  LIST_SUBNET_SURFACES_INSTRUCTIONS,
+  LIST_SUBNET_SURFACES_MCP_TOOL,
+  LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
+  loadSubnetSurfacesList,
+} from "./subnet-surfaces-mcp.ts";
+import {
   LIST_SUBNET_EVIDENCE_INSTRUCTIONS,
   LIST_SUBNET_EVIDENCE_MCP_TOOL,
   LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA,
@@ -1064,6 +1070,7 @@ export const MCP_INSTRUCTIONS =
   LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS +
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS +
+  LIST_SUBNET_SURFACES_INSTRUCTIONS +
   "get_subnet_candidates its pending candidate surfaces, " +
   LIST_SUBNET_CANDIDATES_INSTRUCTIONS +
   "get_subnet_evidence " +
@@ -9908,6 +9915,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SUBNET_SURFACES_MCP_TOOL,
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSubnetSurfacesList(asMcpLoaderCtx(ctx), args);
+    },
+  },
+  {
     name: "get_subnet_candidates",
     title: "Get one subnet's candidate surfaces",
     description:
@@ -15511,6 +15524,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   list_subnet_endpoints: LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
+  list_subnet_surfaces: LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
   list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
   list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,

--- a/src/subnet-surfaces-mcp.ts
+++ b/src/subnet-surfaces-mcp.ts
@@ -1,0 +1,275 @@
+// Per-subnet curated-surface list loader for MCP parity on
+// GET /api/v1/subnets/{netuid}/surfaces. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/surfaces/{netuid}.json artifact.
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+
+const SURFACE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["curated-surfaces"].sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const SUBNET_SURFACES_QUERY_FILTER_NAMES = ["kind", "provider", "id"];
+
+export function subnetSurfacesArtifactPath(netuid: unknown): string {
+  return `/metagraph/surfaces/${netuid}.json`;
+}
+
+export interface SubnetSurfacesMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function subnetSurfacesMcpError(
+  code: string,
+  message: string,
+): SubnetSurfacesMcpError {
+  const error = new Error(message) as SubnetSurfacesMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireNetuid(
+  args: Record<string, unknown> | null | undefined,
+): number {
+  const netuid = args?.netuid;
+  if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+    throw subnetSurfacesMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetSurfacesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetSurfacesMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function subnetSurfacesQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/subnets/surfaces");
+  requireNetuid(args);
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const id = optionalString(args, "id");
+  if (id) url.searchParams.set("id", id);
+  const sort = optionalEnum(args, "sort", SURFACE_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw subnetSurfacesMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+export interface SubnetSurfacesListResult {
+  generated_at: unknown;
+  netuid: unknown;
+  surfaces: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadSubnetSurfacesList(
+  ctx: {
+    env: Env;
+    readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  },
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<SubnetSurfacesListResult> {
+  const netuid = requireNetuid(args);
+  const queryUrl = subnetSurfacesQueryUrl(args);
+  const artifactPath = subnetSurfacesArtifactPath(netuid);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw subnetSurfacesMcpError(
+        "not_found",
+        `No surface snapshot exists for netuid ${netuid}.`,
+      );
+    }
+    throw subnetSurfacesMcpError(
+      code,
+      `Could not load ${artifactPath} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw subnetSurfacesMcpError(
+      "not_found",
+      `No surface snapshot exists for netuid ${netuid}.`,
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob as Record<string, unknown>,
+    queryUrl,
+    "curated-surfaces",
+    SUBNET_SURFACES_QUERY_FILTER_NAMES,
+  );
+  if (transformed.error) {
+    throw subnetSurfacesMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = transformed.meta as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.surfaces) ? (data.surfaces as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    netuid: data.netuid ?? netuid,
+    surfaces: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SUBNET_SURFACES_INSTRUCTIONS =
+  "list_subnet_surfaces one subnet's curated public surfaces with REST " +
+  "list-query filters (kind, provider, id, sort/order, and pagination; mirrors " +
+  "GET /api/v1/subnets/{netuid}/surfaces), ";
+
+export const LIST_SUBNET_SURFACES_MCP_TOOL = {
+  name: "list_subnet_surfaces",
+  title: "List one subnet's curated surfaces",
+  description:
+    "Fetch curated public interface surfaces for one subnet by netuid: each " +
+    "promoted surface with its kind, provider, title, url, and review state. " +
+    "Filter by kind, provider, or id; sort with sort + order; and page with " +
+    "limit (1-100) / cursor. The filtered sibling of get_subnet_surfaces (raw " +
+    "artifact dump). Mirrors GET /api/v1/subnets/{netuid}/surfaces.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      id: {
+        type: "string",
+        description: "Filter to a single surface id.",
+      },
+      sort: {
+        type: "string",
+        enum: SURFACE_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["netuid"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SUBNET_SURFACES_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["surfaces"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    netuid: NULLABLE_INT,
+    surfaces: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/subnet-surfaces-mcp.test.ts
+++ b/tests/subnet-surfaces-mcp.test.ts
@@ -1,0 +1,357 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  LIST_SUBNET_SURFACES_INSTRUCTIONS,
+  LIST_SUBNET_SURFACES_MCP_TOOL,
+  LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
+  loadSubnetSurfacesList,
+  subnetSurfacesArtifactPath,
+  subnetSurfacesMcpError,
+  subnetSurfacesQueryUrl,
+} from "../src/subnet-surfaces-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type LoadCtx = Parameters<typeof loadSubnetSurfacesList>[0];
+type LoadDeps = Parameters<typeof loadSubnetSurfacesList>[2];
+
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
+
+const NETUID = 7;
+const ARTIFACT = subnetSurfacesArtifactPath(NETUID);
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  netuid: NETUID,
+  surfaces: [
+    {
+      id: "allways-api",
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      name: "Allways API",
+    },
+    {
+      id: "allways-openapi",
+      netuid: NETUID,
+      kind: "openapi",
+      provider: "allways",
+      name: "Allways OpenAPI",
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("subnet-surfaces-mcp", () => {
+  test("subnetSurfacesMcpError is shaped for MCP toolError handling", () => {
+    const err = subnetSurfacesMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("subnetSurfacesQueryUrl validates filters and cursor", () => {
+    const url = subnetSurfacesQueryUrl({
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      id: "allways-api",
+      sort: "kind",
+      order: "asc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("provider"), "allways");
+    assert.equal(url.searchParams.get("id"), "allways-api");
+    assert.equal(url.searchParams.get("sort"), "kind");
+    assert.equal(url.searchParams.get("order"), "asc");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("subnetSurfacesQueryUrl rejects missing netuid", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({}),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, provider: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, sort: "not_a_column" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, provider: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, order: "sideways" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects an empty id", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, id: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = subnetSurfacesQueryUrl({ netuid: NETUID, limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetSurfacesQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = subnetSurfacesQueryUrl({ netuid: NETUID, limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetSurfacesQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => subnetSurfacesQueryUrl({ netuid: NETUID, cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetSurfacesQueryUrl clamps limit above the MCP maximum", () => {
+    const url = subnetSurfacesQueryUrl({ netuid: NETUID, limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadSubnetSurfacesList returns filtered rows with pagination meta", async () => {
+    const out = await loadSubnetSurfacesList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { netuid: NETUID, kind: "subnet-api" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].kind, "subnet-api");
+    assert.equal(out.netuid, NETUID);
+  });
+
+  test("loadSubnetSurfacesList sorts and pages the collection", async () => {
+    const out = await loadSubnetSurfacesList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { netuid: NETUID, sort: "id", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSubnetSurfacesList uses an injected readArtifact dep", async () => {
+    const out = await loadSubnetSurfacesList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as LoadCtx,
+      { netuid: 0 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            surfaces: [{ netuid: 0, kind: "docs" }],
+          },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.surfaces[0].netuid, 0);
+  });
+
+  test("loadSubnetSurfacesList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetSurfacesList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /surfaces\/7\.json/.test(err.message),
+    );
+  });
+
+  test("loadSubnetSurfacesList rejects an invalid list-query transform", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      error: { message: "bad filter" },
+    } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
+    try {
+      await assert.rejects(
+        () =>
+          loadSubnetSurfacesList(
+            { env: {}, readArtifact } as unknown as LoadCtx,
+            { netuid: NETUID },
+          ),
+        (err: Row) => err.code === "invalid_params",
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetSurfacesList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSubnetSurfacesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: [{ netuid: 0, kind: "docs" }] },
+        }),
+      } as unknown as LoadCtx,
+      { netuid: 0 },
+    );
+    assert.equal(out.generated_at, null);
+  });
+
+  test("loadSubnetSurfacesList treats a non-array surfaces key as empty", async () => {
+    const out = await loadSubnetSurfacesList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: null },
+        }),
+      } as unknown as LoadCtx,
+      { netuid: NETUID },
+    );
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSubnetSurfacesList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: [{ netuid: 9 }, { netuid: 9 }] },
+      meta: {},
+    } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
+    try {
+      const out = await loadSubnetSurfacesList(
+        { env: {}, readArtifact } as unknown as LoadCtx,
+        { netuid: NETUID },
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetSurfacesList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetSurfacesList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadSubnetSurfacesList rejects missing netuid", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetSurfacesList(
+          { env: {}, readArtifact } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SUBNET_SURFACES_MCP_TOOL.name, "list_subnet_surfaces");
+    assert.match(LIST_SUBNET_SURFACES_INSTRUCTIONS, /list_subnet_surfaces/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(
+        LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
+      ),
+    );
+  });
+
+  test("MCP server exports wire list_subnet_surfaces", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_subnet_surfaces/);
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_subnet_surfaces");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one subnet's curated surfaces");
+  });
+});


### PR DESCRIPTION
## Context

`GET /api/v1/subnets/{netuid}/surfaces` supports `kind, provider, id, sort, order, limit, cursor`, but the only MCP tool for it (`get_subnet_surfaces`) dumps the raw baked artifact with **zero filters** — the same gap the `list_subnet_endpoints` / `list_provider_endpoints` siblings already closed for their routes.

## Change

- **New `src/subnet-surfaces-mcp.ts`** (cloning `src/subnet-endpoints-mcp.ts`'s structure) exporting `list_subnet_surfaces(netuid, kind, provider, id, sort, order, limit, cursor)` with full REST filter parity — applies the same list-query transforms over the baked `/metagraph/surfaces/{netuid}.json` artifact via the shared **`curated-surfaces`** query collection. No filtering re-implemented.
- **Registered** in the mcp-server tool registry, its instructions string, and its output-schema map.
- `get_subnet_surfaces` left untouched.

## Deliverables

- [x] New `src/subnet-surfaces-mcp.ts` exporting `list_subnet_surfaces` with full REST filter parity
- [x] Tool registered in the mcp-server tool object
- [x] Test coverage: `kind` filter and `provider` filter

## Tests

A full module test suite (27 tests): query-url validation of every filter/sort/cursor path and their rejections, limit clamping at both bounds, the loader's filtered/sorted/paged result, injected-dep, `not_found` / other-failure / malformed / empty / pagination-fallback paths, and the MCP registry wiring. `validate:mcp` passes (203 tools), typecheck clean, eslint + prettier clean, public-safety scan passes, and **zero uncovered statements/branches** on the new module.

Closes #7902