### PR TITLE
feat(mcp): add list_subnet_health, filtered sibling of get_subnet_health

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -140,6 +140,12 @@ import {
   loadSubnetEndpointsList,
 } from "./subnet-endpoints-mcp.ts";
 import {
+  LIST_SUBNET_HEALTH_INSTRUCTIONS,
+  LIST_SUBNET_HEALTH_MCP_TOOL,
+  LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
+  loadSubnetHealthList,
+} from "./subnet-health-mcp.ts";
+import {
   LIST_SUBNET_EVIDENCE_INSTRUCTIONS,
   LIST_SUBNET_EVIDENCE_MCP_TOOL,
   LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA,
@@ -1064,6 +1070,7 @@ export const MCP_INSTRUCTIONS =
   LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS +
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS +
+  LIST_SUBNET_HEALTH_INSTRUCTIONS +
   "get_subnet_candidates its pending candidate surfaces, " +
   LIST_SUBNET_CANDIDATES_INSTRUCTIONS +
   "get_subnet_evidence " +
@@ -9908,6 +9915,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SUBNET_HEALTH_MCP_TOOL,
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSubnetHealthList(ctx, args);
+    },
+  },
+  {
     name: "get_subnet_candidates",
     title: "Get one subnet's candidate surfaces",
     description:
@@ -15511,6 +15524,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   list_subnet_endpoints: LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
+  list_subnet_health: LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
   list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
   list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,

--- a/src/subnet-health-mcp.ts
+++ b/src/subnet-health-mcp.ts
@@ -1,0 +1,318 @@
+// Per-subnet health list loader for MCP parity on
+// GET /api/v1/subnets/{netuid}/health (#7901). Applies the same list-query
+// transforms as the REST route over the live-only health overlay -- this
+// route is live-only by design (workers/api.ts's liveHealthOverlay never
+// reads a static artifact for "subnet-health"; it serves an explicit
+// "unknown" payload on a cold snapshot instead), so there is no artifact
+// read step here, unlike the sibling subnet-endpoints-mcp.ts.
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import { overlaySubnetHealth, resolveLiveHealth } from "./health-serving.ts";
+
+const HEALTH_SORT_FIELDS = API_QUERY_COLLECTIONS["health-surfaces"].sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const HEALTH_CLASSIFICATIONS = QUERY_ENUMS.healthClassification;
+// netuid selects the per-subnet snapshot (not a row filter here — the REST
+// route excludes it the same way, listQuery("health-surfaces", { exclude:
+// ["netuid"] }) in src/contracts.ts), so it's kept out of the filter names
+// passed to applyQueryFilters even though the shared "health-surfaces"
+// collection declares it as a general filter.
+const SUBNET_HEALTH_QUERY_FILTER_NAMES = [
+  "kind",
+  "provider",
+  "status",
+  "classification",
+];
+
+export interface SubnetHealthMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function subnetHealthMcpError(
+  code: string,
+  message: string,
+): SubnetHealthMcpError {
+  const error = new Error(message) as SubnetHealthMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireNetuid(
+  args: Record<string, unknown> | null | undefined,
+): number {
+  const netuid = args?.netuid;
+  if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+export function subnetHealthQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/subnets/health");
+  requireNetuid(args);
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const classification = optionalEnum(
+    args,
+    "classification",
+    HEALTH_CLASSIFICATIONS,
+  );
+  if (classification) {
+    url.searchParams.set("classification", classification);
+  }
+  const sort = optionalEnum(args, "sort", HEALTH_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    const limit = args.limit;
+    if (
+      typeof limit !== "number" ||
+      !Number.isInteger(limit) ||
+      limit < 1 ||
+      limit > 100
+    ) {
+      throw subnetHealthMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(limit));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw subnetHealthMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+interface SubnetHealthMcpCtx {
+  env: Env;
+  readHealthKv?: (
+    env: Env,
+    key: string,
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+export interface SubnetHealthListResult {
+  netuid: unknown;
+  summary: unknown;
+  operational_observed_at: unknown;
+  health_source: unknown;
+  surfaces: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+// unknown/cold-snapshot fallback shape, matching get_subnet_health's own
+// (src/mcp-server.ts) so the two tools agree on what "no live data" looks
+// like.
+function unknownSubnetHealth(netuid: number): Row {
+  return {
+    schema_version: 1,
+    netuid,
+    summary: { status: "unknown", surface_count: 0 },
+    operational_observed_at: null,
+    health_source: "unavailable",
+    surfaces: [],
+  };
+}
+
+export async function loadSubnetHealthList(
+  ctx: SubnetHealthMcpCtx,
+  args: Record<string, unknown> | null | undefined,
+  {
+    resolveLiveHealth: resolveLiveHealthDep,
+  }: {
+    resolveLiveHealth?: typeof resolveLiveHealth;
+  } = {},
+): Promise<SubnetHealthListResult> {
+  const netuid = requireNetuid(args);
+  const queryUrl = subnetHealthQueryUrl(args);
+  const resolve = resolveLiveHealthDep ?? resolveLiveHealth;
+  const live = await resolve({
+    readHealthKv: ctx.readHealthKv,
+    env: ctx.env,
+  });
+  const overlaid = overlaySubnetHealth(null, live, netuid);
+  const data = overlaid ?? unknownSubnetHealth(netuid);
+
+  const transformed = applyQueryFilters(
+    data,
+    queryUrl,
+    "health-surfaces",
+    SUBNET_HEALTH_QUERY_FILTER_NAMES,
+  );
+  if (transformed.error) {
+    throw subnetHealthMcpError("invalid_params", transformed.error.message);
+  }
+  const result = transformed.data as Record<string, unknown>;
+  const meta = transformed.meta as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(result.surfaces) ? (result.surfaces as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    netuid: result.netuid ?? netuid,
+    summary: result.summary ?? null,
+    operational_observed_at: result.operational_observed_at ?? null,
+    health_source: result.health_source ?? null,
+    surfaces: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SUBNET_HEALTH_INSTRUCTIONS =
+  "list_subnet_health one subnet's live per-surface health rows with REST " +
+  "list-query filters (kind, provider, status, classification, sort, order, " +
+  "pagination; mirrors GET /api/v1/subnets/{netuid}/health), ";
+
+export const LIST_SUBNET_HEALTH_MCP_TOOL = {
+  name: "list_subnet_health",
+  title: "List one subnet's live health records",
+  description:
+    "Fetch live operational health for one subnet's surfaces (probed every " +
+    "~15 minutes): per-surface status, classification, latency, and last-ok " +
+    "timestamp. Filter by kind, provider, status, or classification; sort " +
+    "with sort + order; and page with limit (1-100) / cursor. Distinct from " +
+    "get_subnet_health (unfiltered current snapshot). Mirrors " +
+    "GET /api/v1/subnets/{netuid}/health.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      classification: {
+        type: "string",
+        enum: HEALTH_CLASSIFICATIONS,
+        description: "Filter by probe-derived health classification.",
+      },
+      sort: {
+        type: "string",
+        enum: HEALTH_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of surface row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["netuid"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SUBNET_HEALTH_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["netuid", "surfaces"],
+  properties: {
+    netuid: { type: "integer" },
+    summary: { type: "object" },
+    operational_observed_at: NULLABLE_STRING,
+    health_source: NULLABLE_STRING,
+    surfaces: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/subnet-health-mcp.test.ts
+++ b/tests/subnet-health-mcp.test.ts
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  LIST_SUBNET_HEALTH_INSTRUCTIONS,
+  LIST_SUBNET_HEALTH_MCP_TOOL,
+  LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
+  loadSubnetHealthList,
+  subnetHealthMcpError,
+  subnetHealthQueryUrl,
+} from "../src/subnet-health-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type LoadCtx = Parameters<typeof loadSubnetHealthList>[0];
+type LoadDeps = Parameters<typeof loadSubnetHealthList>[2];
+
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
+
+const NETUID = 7;
+
+const SAMPLE_LIVE = {
+  last_run_at: "2026-07-01T00:00:00.000Z",
+  surfaces: [
+    {
+      surface_id: "allways-api",
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      url: "https://allways.example/api",
+      status: "ok",
+      classification: null,
+      latency_ms: 120,
+      status_code: 200,
+      last_checked: "2026-07-01T00:00:00.000Z",
+      last_ok: "2026-07-01T00:00:00.000Z",
+    },
+    {
+      surface_id: "allways-docs",
+      netuid: NETUID,
+      kind: "docs",
+      provider: "allways",
+      url: "https://allways.example/docs",
+      status: "degraded",
+      classification: "content-mismatch",
+      latency_ms: 900,
+      status_code: 200,
+      last_checked: "2026-07-01T00:00:00.000Z",
+      last_ok: null,
+    },
+  ],
+};
+
+async function resolveLive(): Promise<Row> {
+  return SAMPLE_LIVE as unknown as Row;
+}
+
+async function resolveLiveEmpty(): Promise<null> {
+  return null;
+}
+
+describe("subnet-health-mcp", () => {
+  test("subnetHealthMcpError is shaped for MCP toolError handling", () => {
+    const err = subnetHealthMcpError("invalid_params", "bad kind");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("subnetHealthQueryUrl validates filters and cursor", () => {
+    const url = subnetHealthQueryUrl({
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      status: "ok",
+      classification: "content-mismatch",
+      sort: "latency_ms",
+      order: "asc",
+      fields: "surface_id,status",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("provider"), "allways");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("classification"), "content-mismatch");
+    assert.equal(url.searchParams.get("sort"), "latency_ms");
+    assert.equal(url.searchParams.get("order"), "asc");
+    assert.equal(url.searchParams.get("fields"), "surface_id,status");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("subnetHealthQueryUrl rejects missing netuid", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({}),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects a negative netuid", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects invalid status", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, status: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects invalid classification", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, classification: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, provider: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, sort: "not_a_column" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, provider: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, order: "sideways" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects empty fields and non-string fields", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, fields: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, fields: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects a non-integer limit", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, limit: "lots" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects limit outside 1-100", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, limit: 0 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, limit: 101 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects a negative cursor", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetHealthList returns filtered rows by status", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID, status: "degraded" },
+      { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+    );
+    assert.equal(out.returned, 1);
+    assert.equal((out.surfaces[0] as Row).status, "degraded");
+    assert.equal(out.netuid, NETUID);
+  });
+
+  test("loadSubnetHealthList returns filtered rows by classification", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID, classification: "content-mismatch" },
+      { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+    );
+    assert.equal(out.returned, 1);
+    assert.equal((out.surfaces[0] as Row).surface_id, "allways-docs");
+  });
+
+  test("loadSubnetHealthList sorts and pages the collection", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID, sort: "latency_ms", order: "desc", limit: 1 },
+      { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal((out.surfaces[0] as Row).surface_id, "allways-docs");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSubnetHealthList projects row fields when requested", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID, fields: "surface_id,status", limit: 1 },
+      { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+    );
+    assert.deepEqual(out.surfaces[0], {
+      surface_id: "allways-api",
+      status: "ok",
+    });
+  });
+
+  test("loadSubnetHealthList falls back to the unknown snapshot when live data is absent", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: NETUID },
+      { resolveLiveHealth: resolveLiveEmpty } as unknown as LoadDeps,
+    );
+    assert.equal(out.netuid, NETUID);
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+    assert.equal(out.health_source, "unavailable");
+    assert.deepEqual(out.summary, { status: "unknown", surface_count: 0 });
+  });
+
+  test("loadSubnetHealthList falls back to the unknown snapshot for a netuid with no live rows", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {} } as unknown as LoadCtx,
+      { netuid: 999 },
+      { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+    );
+    assert.equal(out.netuid, 999);
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.health_source, "unavailable");
+  });
+
+  test("loadSubnetHealthList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          { env: {} } as unknown as LoadCtx,
+          { netuid: NETUID, fields: "not_a_column" },
+          { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+        ),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetHealthList rejects missing netuid", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList({ env: {} } as unknown as LoadCtx, {}, {
+          resolveLiveHealth: resolveLive,
+        } as unknown as LoadDeps),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadSubnetHealthList uses the default resolveLiveHealth dependency when none is injected", async () => {
+    const out = await loadSubnetHealthList(
+      {
+        env: {},
+        readHealthKv: async () => null,
+      } as unknown as LoadCtx,
+      { netuid: NETUID },
+    );
+    assert.equal(out.netuid, NETUID);
+    assert.deepEqual(out.surfaces, []);
+  });
+
+  test("loadSubnetHealthList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: {
+        netuid: NETUID,
+        surfaces: [{ surface_id: "x" }, { surface_id: "y" }],
+      },
+      meta: {},
+    });
+    try {
+      const out = await loadSubnetHealthList(
+        { env: {} } as unknown as LoadCtx,
+        { netuid: NETUID },
+        { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetHealthList treats a non-array surfaces key as empty", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { netuid: NETUID, surfaces: null },
+      meta: {},
+    });
+    try {
+      const out = await loadSubnetHealthList(
+        { env: {} } as unknown as LoadCtx,
+        { netuid: NETUID },
+        { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+      );
+      assert.deepEqual(out.surfaces, []);
+      assert.equal(out.total, 0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetHealthList falls back to the requested netuid when the transformed row omits it", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: [{ surface_id: "x" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadSubnetHealthList(
+        { env: {} } as unknown as LoadCtx,
+        { netuid: NETUID },
+        { resolveLiveHealth: resolveLive } as unknown as LoadDeps,
+      );
+      assert.equal(out.netuid, NETUID);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SUBNET_HEALTH_MCP_TOOL.name, "list_subnet_health");
+    assert.match(LIST_SUBNET_HEALTH_INSTRUCTIONS, /list_subnet_health/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_SUBNET_HEALTH_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_subnet_health", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_subnet_health/);
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_subnet_health");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one subnet's live health records");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `list_subnet_health`, a filtered/sortable/paginated MCP sibling of the existing unfiltered `get_subnet_health` tool, mirroring `GET /api/v1/subnets/{netuid}/health` list-query parity the way `list_subnet_endpoints` already mirrors `GET /api/v1/subnets/{netuid}/endpoints`.

Closes #7901

## What Changed

- `src/subnet-health-mcp.ts` (new): `subnetHealthQueryUrl` (validates `netuid`, `kind`, `provider`, `status`, `classification`, `sort`, `order`, `fields`, `limit` 1-100, `cursor`), `loadSubnetHealthList` (resolves live health via `resolveLiveHealth`/`overlaySubnetHealth` from `src/health-serving.ts` -- this route is live-only by design, no static artifact read, unlike `subnet-endpoints-mcp.ts`), the `LIST_SUBNET_HEALTH_MCP_TOOL` definition, `LIST_SUBNET_HEALTH_OUTPUT_SCHEMA`, and `LIST_SUBNET_HEALTH_INSTRUCTIONS`.
- `src/mcp-server.ts`: wired the new tool in (import, `MCP_TOOLS` entry, `TOOL_OUTPUT_SCHEMAS` entry, `MCP_INSTRUCTIONS` concatenation) following the exact pattern of every other `list_*` tool.
- `tests/subnet-health-mcp.test.ts` (new): error-shape test, `subnetHealthQueryUrl` validation coverage for every param (including the `status` and `classification` filters called out in the issue), `loadSubnetHealthList` filtering/sorting/pagination/projection tests, the unknown-snapshot fallback when live data is absent for the requested netuid, the default-dependency path, an injected-`applyQueryFilters`-mock test for the pagination-meta-absent fallback, MCP tool metadata/output-schema Ajv compile check, and MCP-server export-wiring check.
- No schema/contract change (MCP tool additions don't require server-card regen per the repo's own contribution guide) and no `public/metagraph/**` artifacts touched.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7901`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A -- no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A -- MCP-only addition, no REST/OpenAPI change.)

## Validation

- [x] `npx tsc --noEmit -p .` -- clean
- [x] `npx eslint .` -- clean
- [x] `npx prettier --check src/subnet-health-mcp.ts src/mcp-server.ts tests/subnet-health-mcp.test.ts` -- clean
- [x] `git diff --check` -- clean
- [x] `npx vitest run tests/subnet-health-mcp.test.ts --coverage --coverage.include="src/subnet-health-mcp.ts"` -- 29/29 passing, 100% statements/branches/functions/lines
- [x] `npx vitest run tests/mcp-server.test.ts` -- passes (one unrelated pre-existing local-env failure confirmed present on a clean checkout of `main` before this change: `resolves real artifacts from the local env`, which needs `npm run build` first per this repo's own contribution guide's note on reader tests)
- [x] `npm run scan:public-safety` -- no findings in touched files (pre-existing findings elsewhere are unrelated to this diff)
