### PR TITLE
feat(api): add providers GraphQL list filters without breaking cursor contract (#7888)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -49,6 +49,10 @@ import { loadProviderEndpointsList } from "./provider-endpoints-mcp.ts";
 // loadRpcEndpointsList (live overlay + applyQueryFilters on the endpoints
 // collection), matching endpoint_pools / rpc_pools / provider_endpoints.
 import { loadRpcEndpointsList } from "./rpc-endpoints-mcp.ts";
+// #7888: GraphQL parity for GET /api/v1/providers list filters (id/kind/
+// authority/sort/order/fields + limit/cursor), reusing loadProvidersList that
+// MCP list_providers already calls -- not a reimplementation.
+import { loadProvidersList } from "./providers-mcp.ts";
 // #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
 // and page logic REST and MCP already use) -- not a reimplementation.
@@ -633,8 +637,8 @@ export const SDL = `
     subnet_overview(netuid: Int!): JSON
     "One subnet's contributor-review profile: candidate surfaces, contract version, endpoints, and completeness/curation metadata. Null when no profile has been baked for that netuid (rather than a GraphQL error); a negative netuid is a BAD_USER_INPUT error. Opaque JSON passed through verbatim, matching the get_subnet_profile MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/profile."
     subnet_profile(netuid: Int!): JSON
-    "Paginated provider/source registry."
-    providers(limit: Int, cursor: String): ProviderList!
+    "Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers)."
+    providers(id: String, kind: String, authority: String, sort: String, order: String, fields: String, limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
     provider(id: String!): Provider
     "One adapter-backed public metrics snapshot by slug (e.g. 'gittensor', 'allways', 'sn-64'): the captured adapter snapshot, extension metadata, and netuid linkage. An invalid slug is a BAD_USER_INPUT error; a missing slug resolves to null (schema-stable, never a GraphQL error). Mirrors GET /api/v1/adapters/{slug}."
@@ -6272,13 +6276,51 @@ const rootValue = {
     };
   },
 
-  providers({ limit, cursor }: Row, context: GqlContext) {
-    return listPage(context, ARTIFACT.providers, "providers", {
+  // #7888: add REST/MCP list-query filters (id/kind/authority/sort/order/fields)
+  // by reusing loadProvidersList for validate+filter+sort, while preserving the
+  // pre-existing GraphQL providers contract the gate flagged as a breaker on
+  // #7920: opaque string id-keyset cursor/next_cursor (not REST's Int offset)
+  // and schema-stable empty list on a cold/absent artifact (not a GraphQL
+  // error). limit/cursor are applied here via paginate, not the loader.
+  async providers(args: Row, context: GqlContext) {
+    const { limit, cursor, ...filters } = args;
+    // Default empty list; only overwrite on a successful load. Cold/absent
+    // (or any non-invalid_params loader failure) keeps this historical contract.
+    let rows: Row[] = [];
+    try {
+      // Omit GraphQL limit/cursor so the loader returns the full filtered set.
+      // When a fields projection is supplied, keep/force `id` so the opaque
+      // string keyset cursor still resolves.
+      const loadArgs: Row = { ...filters };
+      if (typeof loadArgs.fields === "string" && loadArgs.fields.trim()) {
+        const trimmed = loadArgs.fields.trim();
+        loadArgs.fields = /(^|,)\s*id\s*(,|$)/i.test(trimmed)
+          ? trimmed
+          : `id,${trimmed}`;
+      }
+      const data = await loadProvidersList(mcpCtx(context), loadArgs, {
+        readArtifact,
+      });
+      rows = data.providers as Row[];
+    } catch (rawErr) {
+      const err = rawErr as Row;
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+    }
+    const { page, total, nextCursor } = paginate(
+      rows,
       limit,
       cursor,
-      keyFn: (p: Row) => p.id,
-      map: providerNode,
-    });
+      (p: Row) => p.id,
+    );
+    return {
+      items: page.map(providerNode),
+      total,
+      next_cursor: nextCursor,
+    };
   },
 
   async provider({ id }: Row, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -445,7 +445,7 @@ describe("handleGraphQLRequest — resolvers (cold store)", () => {
     assert.equal(body.data.subnet, null);
   });
 
-  test("providers returns empty list when artifact not found", async () => {
+  test("providers returns empty list when artifact not found (pre-#7888 contract)", async () => {
     const { status, body } = await gql(
       "{ providers { items { id name } total } }",
     );
@@ -2715,12 +2715,12 @@ describe("graphql — resolver branch coverage", () => {
     assert.deepEqual(body.data.provider.subnets, []);
   });
 
-  test("providers paginate with an id cursor", async () => {
+  test("providers paginate with an opaque string id cursor (pre-#7888 contract)", async () => {
     const env = fixtureEnv({
       "/metagraph/providers.json": {
         providers: [
-          { id: "a", name: "A" },
-          { id: "b", name: "B" },
+          { id: "a", name: "A", kind: "data-provider", authority: "official" },
+          { id: "b", name: "B", kind: "data-provider", authority: "community" },
         ],
       },
     });
@@ -2729,8 +2729,182 @@ describe("graphql — resolver branch coverage", () => {
       env as unknown as Env,
     );
     assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
     assert.equal(body.data.providers.total, 2);
+    assert.equal(body.data.providers.items.length, 1);
     assert.equal(body.data.providers.next_cursor, "a");
+  });
+
+  test("providers filters by id and by kind (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        schema_version: 1,
+        providers: [
+          {
+            id: "datura",
+            name: "Datura",
+            kind: "data-provider",
+            authority: "official",
+          },
+          {
+            id: "chutes",
+            name: "Chutes",
+            kind: "infrastructure-provider",
+            authority: "official",
+          },
+          {
+            id: "community-x",
+            name: "Community X",
+            kind: "data-provider",
+            authority: "community",
+          },
+        ],
+      },
+    });
+
+    const byId = await gql(
+      '{ providers(id: "chutes") { items { id kind } total } }',
+      env as unknown as Env,
+    );
+    assert.equal(byId.status, 200);
+    assert.equal(byId.body.errors, undefined);
+    assert.equal(byId.body.data.providers.total, 1);
+    assert.equal(byId.body.data.providers.items[0].id, "chutes");
+    assert.equal(
+      byId.body.data.providers.items[0].kind,
+      "infrastructure-provider",
+    );
+
+    const byKind = await gql(
+      '{ providers(kind: "data-provider") { items { id } total } }',
+      env as unknown as Env,
+    );
+    assert.equal(byKind.status, 200);
+    assert.equal(byKind.body.errors, undefined);
+    assert.equal(byKind.body.data.providers.total, 2);
+    assert.deepEqual(
+      byKind.body.data.providers.items.map((p: Row) => p.id).sort(),
+      ["community-x", "datura"],
+    );
+  });
+
+  test("providers surfaces an invalid kind as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          { id: "datura", kind: "data-provider", authority: "official" },
+        ],
+      },
+    });
+    const { body } = await gql(
+      '{ providers(kind: "bogus") { total } }',
+      env as unknown as Env,
+    );
+    assert.ok(body.errors?.length > 0);
+    assert.match(body.errors[0].message, /kind/i);
+  });
+
+  test("providers forwards authority/sort/order/fields through the shared loader (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          {
+            id: "datura",
+            name: "Datura",
+            kind: "data-provider",
+            authority: "official",
+            surface_count: 3,
+          },
+          {
+            id: "community-x",
+            name: "Community X",
+            kind: "data-provider",
+            authority: "community",
+            surface_count: 1,
+          },
+        ],
+      },
+    });
+    // fields without id → resolver prefixes id for keyset stability.
+    const withoutId = await gql(
+      `{ providers(
+          authority: "official",
+          sort: "id",
+          order: "asc",
+          fields: "kind,authority",
+          limit: 10
+        ) { items { id kind authority } total next_cursor } }`,
+      env as unknown as Env,
+    );
+    assert.equal(withoutId.status, 200);
+    assert.equal(withoutId.body.errors, undefined);
+    assert.equal(withoutId.body.data.providers.total, 1);
+    assert.equal(withoutId.body.data.providers.items[0].id, "datura");
+    assert.equal(withoutId.body.data.providers.items[0].authority, "official");
+    assert.equal(withoutId.body.data.providers.next_cursor, null);
+
+    // fields already listing id → keep the projection as-is (other branch).
+    const withId = await gql(
+      `{ providers(fields: "id,kind", limit: 1) { items { id kind } total next_cursor } }`,
+      env as unknown as Env,
+    );
+    assert.equal(withId.status, 200);
+    assert.equal(withId.body.errors, undefined);
+    assert.equal(withId.body.data.providers.items.length, 1);
+    assert.equal(withId.body.data.providers.next_cursor, "datura");
+  });
+
+  test("providers maps invalid_params to BAD_USER_INPUT (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          { id: "datura", kind: "data-provider", authority: "official" },
+        ],
+      },
+    });
+    const badAuthority = await gql(
+      '{ providers(authority: "not-real") { total } }',
+      env as unknown as Env,
+    );
+    assert.ok(
+      badAuthority.body.errors?.find(
+        (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
+      ),
+    );
+    const badFields = await gql(
+      '{ providers(fields: "   ") { total } }',
+      env as unknown as Env,
+    );
+    assert.ok(
+      badFields.body.errors?.find(
+        (e: Row) => e.extensions?.code === "BAD_USER_INPUT",
+      ),
+    );
+  });
+
+  test("providers follows a string next_cursor to the next page (#7888)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/providers.json": {
+        providers: [
+          { id: "a", name: "A", kind: "data-provider", authority: "official" },
+          { id: "b", name: "B", kind: "registry", authority: "community" },
+        ],
+      },
+    });
+    const first = await gql(
+      "{ providers(limit: 1) { items { id } next_cursor } }",
+      env as unknown as Env,
+    );
+    assert.equal(first.body.data.providers.items[0].id, "a");
+    assert.equal(first.body.data.providers.next_cursor, "a");
+    const second = await gql(
+      `{ providers(limit: 1, cursor: "a") { items { id } next_cursor } }`,
+      env as unknown as Env,
+    );
+    assert.equal(second.body.errors, undefined);
+    assert.equal(second.body.data.providers.items[0].id, "b");
+    assert.equal(second.body.data.providers.next_cursor, null);
   });
 
   test("surfaces paginate, falling back to key for the cursor when id is absent", async () => {


### PR DESCRIPTION
## Summary
- Add REST/MCP list-query filters to `Query.providers` (`id`, `kind`, `authority`, `sort`, `order`, `fields`) by reusing `loadProvidersList`.
- Preserve opaque **string** id-keyset `cursor` / `next_cursor` and cold/absent → empty list (non-breaking vs #7920).
- Invalid filter enums → `BAD_USER_INPUT`.
- Fresh rebase on current `main` (providers-only diff). Fixes #7995 failures: implicit-`any` in tests + Codecov noise from an accidental sibling-field revert in that rebase.

Closes #7888.
Supersedes #7914 / #7920 / #7927 / #7934 / #7939 / #7995.

## What Changed
- `src/graphql.ts` — filter args + resolver only (no other GraphQL fields touched).
- `tests/graphql.test.ts` — id/kind/authority/sort/order/fields, cursor follow, cold empty, `BAD_USER_INPUT`; callbacks typed as `Row`.

## Validation
- `npx eslint src/graphql.ts` — clean
- `npx prettier --write` on touched files
- `npx tsc --noEmit` — no errors in touched files
- `npx vitest run tests/graphql.test.ts -t providers` — 9 passing
- Local V8 on providers resolver: all statements/branches covered