### PR TITLE
fix(workers): retry sync-route transactions on a fresh client after Hyperdrive connection drops

### DIFF
--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -101,6 +101,14 @@ const subnetIdentityLatestHashes = vi.hoisted(() => ({ current: [] as Row[] }));
 const healthChecksSyncFailure = vi.hoisted(() => ({
   error: null as Error | null,
 }));
+// State for the sync-route connection-retry tests (METAGRAPHED-7, second recurrence):
+// countdown semantics identical to blockDetailConnectionFailure below, but scoped to
+// health-checks-sync's surface_checks INSERT so what gets exercised is the WRITE path's
+// own fresh-client retry (workers/hyperdrive-sync-retry.ts), not the read dispatcher's.
+const healthChecksSyncConnectionFailure = vi.hoisted(() => ({
+  remainingFailures: 0,
+  code: "CONNECTION_CLOSED",
+}));
 const healthUptimeRollupSyncFailure = vi.hoisted(() => ({
   error: null as Error | null,
 }));
@@ -329,6 +337,20 @@ vi.mock("postgres", () => ({
         return Promise.reject(healthChecksSyncFailure.error);
       }
       if (
+        healthChecksSyncConnectionFailure.remainingFailures > 0 &&
+        /INSERT INTO surface_checks\b/.test(text)
+      ) {
+        healthChecksSyncConnectionFailure.remainingFailures -= 1;
+        return Promise.reject(
+          Object.assign(
+            new Error(
+              `write ${healthChecksSyncConnectionFailure.code} mock.hyperdrive.local:5432`,
+            ),
+            { code: healthChecksSyncConnectionFailure.code },
+          ),
+        );
+      }
+      if (
         featuredValidatorsQueryFailure.error &&
         /FROM featured_validators\b/.test(text)
       ) {
@@ -528,6 +550,8 @@ beforeEach(() => {
   subnetIdentitySyncFailure.error = null;
   subnetIdentityLatestHashes.current = [];
   healthChecksSyncFailure.error = null;
+  healthChecksSyncConnectionFailure.remainingFailures = 0;
+  healthChecksSyncConnectionFailure.code = "CONNECTION_CLOSED";
   subnetSnapshotSyncFailure.error = null;
   healthUptimeRollupSyncFailure.error = null;
   rpcUsageSyncFailure.error = null;
@@ -6881,6 +6905,53 @@ test("health-checks-sync maps a DB failure to a clean 502 instead of throwing", 
   );
   expect(res.status).toBe(502);
   expect(((await res.json()) as Row).error).toBe("write failed");
+});
+
+test("health-checks-sync retries with a fresh client after a Hyperdrive CONNECTION_CLOSED and lands the mirror write (METAGRAPHED-7 second recurrence)", async () => {
+  // The 09:00Z origin blip class: one dropped socket used to lose the whole probe cycle's
+  // mirror write, because the sync routes deliberately sat outside the read dispatcher's
+  // retry. The atomic sql.begin() batch makes the retry safe (rollback ⇒ nothing partial).
+  healthChecksSyncConnectionFailure.remainingFailures = 1;
+  const res = await postHealthChecks(
+    { probed: [probedRow()] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body.ok).toBe(true);
+  expect(body.checks_written).toBe(1);
+  // The INSERT ran twice: attempt 1 died on the dropped socket, attempt 2 (fresh client) landed.
+  expect(
+    sqlCalls.filter((c) => /INSERT INTO surface_checks\b/.test(c.text)).length,
+  ).toBe(2);
+});
+
+test("health-checks-sync still 502s once every connection retry is exhausted (METAGRAPHED-7)", async () => {
+  // 3 total attempts (1 original + MAX_CONNECTION_RETRY_ATTEMPTS retries) -- all failing
+  // must surface as the existing clean 502, never retry indefinitely.
+  healthChecksSyncConnectionFailure.remainingFailures = 3;
+  const res = await postHealthChecks(
+    { probed: [probedRow()] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(502);
+  expect(((await res.json()) as Row).error).toBe("write failed");
+});
+
+test("health-checks-sync does not retry a non-connection error, even once (METAGRAPHED-7 scoping)", async () => {
+  // A deterministic DB error (here a unique violation) must fail immediately -- retrying it
+  // would just re-run a doomed batch. Asserting one INSERT proves the retry is scoped to
+  // RETRYABLE_CONNECTION_ERROR_CODES, not every rejection.
+  healthChecksSyncConnectionFailure.remainingFailures = 1;
+  healthChecksSyncConnectionFailure.code = "23505";
+  const res = await postHealthChecks(
+    { probed: [probedRow()] },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(502);
+  expect(
+    sqlCalls.filter((c) => /INSERT INTO surface_checks\b/.test(c.text)).length,
+  ).toBe(1);
 });
 
 // #4832 gap-closure: health-uptime-rollup-sync -- best-effort Postgres

--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -69,6 +69,11 @@ const subnetHyperparamsLatestHashes = vi.hoisted(() => ({
 const subnetLocksSyncFailure = vi.hoisted(() => ({
   error: null as Error | null,
 }));
+// Rows the subnet-locks full-snapshot prune "deletes" (RETURNING netuid) -- same shape as
+// subnetHyperparamsPruneRows above; drives the success-path pruned count (METAGRAPHED-7
+// follow-through: the route's write path gained retry coverage, which exposed that its
+// success path had never been exercised at all).
+const subnetLocksPruneRows = vi.hoisted(() => ({ current: [] as Row[] }));
 // State for the account-identity-sync write route's tests only (#4832
 // gap-closure). No prune-rows hook -- unlike subnet_hyperparams, this table
 // has no purge step (see handleAccountIdentitySync's own header comment).
@@ -429,6 +434,9 @@ vi.mock("postgres", () => ({
       if (/DELETE FROM subnet_hyperparams\b/.test(text)) {
         return Promise.resolve(subnetHyperparamsPruneRows.current);
       }
+      if (/DELETE FROM subnet_locks\b/.test(text)) {
+        return Promise.resolve(subnetLocksPruneRows.current);
+      }
       if (/FROM account_identity WHERE account IN/.test(text)) {
         if (accountIdentityJoinQueryFailure.error) {
           return Promise.reject(accountIdentityJoinQueryFailure.error);
@@ -535,6 +543,7 @@ beforeEach(() => {
   subnetHyperparamsPruneRows.current = [];
   subnetHyperparamsLatestHashes.current = [];
   subnetLocksSyncFailure.error = null;
+  subnetLocksPruneRows.current = [];
   accountIdentitySyncFailure.error = null;
   accountIdentityLatestHashes.current = [];
   validatorNominatorCountsSyncFailure.error = null;
@@ -5239,6 +5248,54 @@ test("subnet-locks-sync maps a DB failure to a clean 502 instead of throwing", a
   });
   expect(res.status).toBe(502);
   expect(((await res.json()) as Row).error).toBe("write failed");
+});
+
+function subnetLocksSyncRow(overrides: Record<string, unknown> = {}) {
+  return {
+    netuid: 1,
+    hotkey: "5FakeHotkeyAddress",
+    is_owner: true,
+    is_perpetual: false,
+    locked_mass: 1000,
+    conviction_bits: "12345",
+    last_update: 100,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+function postSubnetLocks(body: unknown) {
+  return req("/api/v1/internal/subnet-locks-sync", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-subnet-locks-sync-token": SUBNET_LOCKS_SYNC_SECRET,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+test("subnet-locks-sync upserts the batch, prunes rows the snapshot didn't report, and reports both counts", async () => {
+  subnetLocksPruneRows.current = [{ netuid: 99 }];
+  const res = await postSubnetLocks([subnetLocksSyncRow()]);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body).toMatchObject({ ok: true, subnet_locks_written: 1, pruned: 1 });
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).toMatch(/INSERT INTO subnet_locks\b/);
+  // Full-network-snapshot semantics: whatever this batch didn't report gets pruned via the
+  // scalar row-value tuple DELETE (fetch_types:false makes bound-array ANY() unreliable).
+  expect(text).toMatch(/DELETE FROM subnet_locks\b/);
+});
+
+test("subnet-locks-sync on an empty batch is a clean no-op: no insert, no prune", async () => {
+  const res = await postSubnetLocks([]);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Row;
+  expect(body).toMatchObject({ ok: true, subnet_locks_written: 0, pruned: 0 });
+  const text = sqlCalls.map((c) => c.text).join("\n");
+  expect(text).not.toMatch(/INSERT INTO subnet_locks\b/);
+  expect(text).not.toMatch(/DELETE FROM subnet_locks\b/);
 });
 
 test("GET /api/v1/subnets/:netuid/hyperparameters returns the latest row", async () => {

--- a/tests/hyperdrive-sync-retry.test.ts
+++ b/tests/hyperdrive-sync-retry.test.ts
@@ -1,0 +1,89 @@
+// Unit tests for workers/hyperdrive-sync-retry.ts (METAGRAPHED-7, second recurrence) --
+// the sync routes' shared fresh-client transaction retry. The route-level suites
+// (data-api, registry-sync-api) prove the wiring; this file pins the helper's own
+// branch behavior: fresh client per attempt, the retryable-code scoping, the attempt
+// cap, and the non-Error rejection arm no route mock produces.
+import { beforeEach, expect, test, vi } from "vitest";
+
+// Each postgres() call returns a client whose begin() consumes the next planned
+// outcome -- so "attempts" and "clients constructed" can be asserted independently.
+const plan = vi.hoisted(() => ({
+  outcomes: [] as Array<{ reject?: unknown; resolve?: unknown }>,
+  clientsConstructed: 0,
+}));
+
+vi.mock("postgres", () => ({
+  default: () => {
+    plan.clientsConstructed += 1;
+    return {
+      begin: (cb: unknown) => {
+        const next = plan.outcomes.shift();
+        if (!next) throw new Error("test plan exhausted");
+        if ("reject" in next) return Promise.reject(next.reject);
+        void cb;
+        return Promise.resolve(next.resolve);
+      },
+    };
+  },
+}));
+
+const { syncBeginWithConnectionRetry, MAX_CONNECTION_RETRY_ATTEMPTS } =
+  await import("../workers/hyperdrive-sync-retry.ts");
+
+const env = { HYPERDRIVE: { connectionString: "postgres://mock" } };
+const connErr = (code: string) =>
+  Object.assign(new Error(`write ${code} mock.hyperdrive.local:5432`), {
+    code,
+  });
+
+beforeEach(() => {
+  plan.outcomes = [];
+  plan.clientsConstructed = 0;
+});
+
+test("first attempt succeeding uses exactly one client", async () => {
+  plan.outcomes = [{ resolve: "ok" }];
+  await expect(
+    syncBeginWithConnectionRetry(env, async () => "ok"),
+  ).resolves.toBe("ok");
+  expect(plan.clientsConstructed).toBe(1);
+});
+
+test("a retryable connection error gets a FRESH client on retry", async () => {
+  plan.outcomes = [{ reject: connErr("CONNECTION_CLOSED") }, { resolve: "ok" }];
+  await expect(
+    syncBeginWithConnectionRetry(env, async () => "ok"),
+  ).resolves.toBe("ok");
+  // The retry constructed a second client -- the dead socket lives in the first
+  // client's pool, so reusing it would hand the retry the same corpse.
+  expect(plan.clientsConstructed).toBe(2);
+});
+
+test("every retryable code retries; the cap still bounds total attempts", async () => {
+  plan.outcomes = [
+    { reject: connErr("CONNECTION_DESTROYED") },
+    { reject: connErr("CONNECT_TIMEOUT") },
+    { reject: connErr("CONNECTION_CLOSED") },
+  ];
+  await expect(
+    syncBeginWithConnectionRetry(env, async () => "ok"),
+  ).rejects.toMatchObject({ code: "CONNECTION_CLOSED" });
+  // 1 original + MAX_CONNECTION_RETRY_ATTEMPTS retries, then the last error surfaces.
+  expect(plan.clientsConstructed).toBe(1 + MAX_CONNECTION_RETRY_ATTEMPTS);
+});
+
+test("a non-connection error is never retried", async () => {
+  plan.outcomes = [{ reject: connErr("23505") }];
+  await expect(
+    syncBeginWithConnectionRetry(env, async () => "ok"),
+  ).rejects.toMatchObject({ code: "23505" });
+  expect(plan.clientsConstructed).toBe(1);
+});
+
+test("a non-object rejection (no .code to read) surfaces immediately", async () => {
+  plan.outcomes = [{ reject: null }];
+  await expect(
+    syncBeginWithConnectionRetry(env, async () => "ok"),
+  ).rejects.toBeNull();
+  expect(plan.clientsConstructed).toBe(1);
+});

--- a/tests/registry-sync-api.test.ts
+++ b/tests/registry-sync-api.test.ts
@@ -12,6 +12,14 @@ const deleteResult = vi.hoisted(() => ({
   subnets: [] as Row[],
 }));
 const failure = vi.hoisted(() => ({ error: null as Error | null }));
+// Countdown connection-failure state (METAGRAPHED-7, second recurrence) -- same semantics
+// as data-api's healthChecksSyncConnectionFailure: N rejections carrying a retryable
+// postgres.js connection code, then success, so the fresh-client retry in
+// workers/hyperdrive-sync-retry.ts is what a passing test proves.
+const connectionFailure = vi.hoisted(() => ({
+  remainingFailures: 0,
+  code: "CONNECTION_CLOSED",
+}));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -20,6 +28,20 @@ vi.mock("postgres", () => ({
       sqlCalls.push({ text, values });
       if (failure.error && /INSERT INTO providers/.test(text)) {
         return Promise.reject(failure.error);
+      }
+      if (
+        connectionFailure.remainingFailures > 0 &&
+        /INSERT INTO providers/.test(text)
+      ) {
+        connectionFailure.remainingFailures -= 1;
+        return Promise.reject(
+          Object.assign(
+            new Error(
+              `write ${connectionFailure.code} mock.hyperdrive.local:5432`,
+            ),
+            { code: connectionFailure.code },
+          ),
+        );
       }
       if (/INSERT INTO surfaces/.test(text)) {
         return Promise.resolve(surfaceResult.current);
@@ -117,6 +139,8 @@ beforeEach(() => {
   deleteResult.surfaces = [];
   deleteResult.subnets = [];
   failure.error = null;
+  connectionFailure.remainingFailures = 0;
+  connectionFailure.code = "CONNECTION_CLOSED";
 });
 
 test("rejects non-POST (405)", async () => {
@@ -595,6 +619,31 @@ test("does not delete a subnet that is also upserted in the same request", async
 
 test("maps a DB failure to a clean 502 instead of throwing", async () => {
   failure.error = new Error("connection reset");
+  const res = await worker.fetch(
+    post({ providers: [provider()] }, { secret: SECRET }),
+    baseEnv(),
+  );
+  expect(res.status).toBe(502);
+  expect((await jsonBody(res)).error).toBe("write failed");
+});
+
+test("retries with a fresh client after a Hyperdrive CONNECTION_CLOSED and lands the batch (METAGRAPHED-7 second recurrence)", async () => {
+  connectionFailure.remainingFailures = 1;
+  const res = await worker.fetch(
+    post({ providers: [provider()] }, { secret: SECRET }),
+    baseEnv(),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ ok: true, providers_written: 1 });
+  // The providers INSERT ran twice: dropped socket on attempt 1, fresh client landed attempt 2.
+  expect(
+    sqlCalls.filter((c) => /INSERT INTO providers/.test(c.text as string))
+      .length,
+  ).toBe(2);
+});
+
+test("still 502s once every connection retry is exhausted (METAGRAPHED-7)", async () => {
+  connectionFailure.remainingFailures = 3;
   const res = await worker.fetch(
     post({ providers: [provider()] }, { secret: SECRET }),
     baseEnv(),

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -21,6 +21,11 @@
 // read routes' `cache-control: public, max-age=10`).
 import postgres from "postgres";
 import * as Sentry from "@sentry/cloudflare";
+import {
+  MAX_CONNECTION_RETRY_ATTEMPTS,
+  RETRYABLE_CONNECTION_ERROR_CODES,
+  syncBeginWithConnectionRetry,
+} from "./hyperdrive-sync-retry.ts";
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 import { parseJsonPreservingBigIntegers } from "../src/postgres-json-parse.ts";
 import { decodeCursor, encodeCursor } from "../src/cursor.ts";
@@ -399,23 +404,11 @@ const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
 // METAGRAPHED-7: Hyperdrive closes/recycles pooled connections out from under a live query
 // under load -- postgres.js's Cloudflare build (node_modules/postgres/cf/src/connection.js)
-// surfaces this as one of these three `error.code`s (Errors.connection in cf/src/errors.js),
-// all transport-layer, never a query-correctness problem: CONNECTION_CLOSED (socket closed
-// mid-query), CONNECTION_DESTROYED (pool tore the connection down), CONNECT_TIMEOUT (the
-// initial handshake itself timed out). Retried below (MAX_CONNECTION_RETRY_ATTEMPTS times),
-// only for the read-only route dispatcher (already scoped to a single sql.begin()
-// transaction, so nothing can have partially committed) -- never for the write/sync routes,
-// where blindly retrying a batch that may have partially applied would risk double-writes.
-const RETRYABLE_CONNECTION_ERROR_CODES = new Set([
-  "CONNECTION_CLOSED",
-  "CONNECTION_DESTROYED",
-  "CONNECT_TIMEOUT",
-]);
-// A single retry (the original METAGRAPHED-7 fix) regressed: under sustained load,
-// Hyperdrive can recycle the retry's own freshly created connection too, so the retry
-// itself hits the same error class and the request still fails. 2 retries (3 total
-// attempts) gives a second freshly created client a chance before giving up.
-const MAX_CONNECTION_RETRY_ATTEMPTS = 2;
+// surfaces this as one of three transport-layer `error.code`s, never a query-correctness
+// problem. The retryable code set, the attempt cap, and the sync-route transaction retry
+// all live in workers/hyperdrive-sync-retry.ts (shared with registry-sync-api) -- the read
+// dispatcher below keeps its own inline fresh-client loop over the same imported constants
+// because its client options differ (bigIntSafeJson types + idle_timeout).
 
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
 // `Date.now() - days*DAY_MS` exactly. An unrecognized label falls back to the
@@ -762,30 +755,26 @@ async function handleNeuronsSync(request: Request, env: Env) {
   }
   const netuids = [...netuidMaxCapturedAt.keys()];
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
     // sql.begin() reserves ONE physical connection for the whole batch, same
     // connection-affinity reasoning as the read path above (#4686) -- and
     // makes the whole snapshot atomic: a mid-batch failure must never leave
     // `neurons` upserted with stale UIDs left un-pruned, or `neuron_daily`
     // partially written for the day.
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
 
-      const dailyRows = rows.map((row: Row) => ({
-        ...row,
-        snapshot_date: neuronSyncSnapshotDate(row.captured_at),
-        updated_at: Date.now(),
-      }));
+        const dailyRows = rows.map((row: Row) => ({
+          ...row,
+          snapshot_date: neuronSyncSnapshotDate(row.captured_at),
+          updated_at: Date.now(),
+        }));
 
-      for (let i = 0; i < rows.length; i += NEURONS_SYNC_ROWS_PER_STATEMENT) {
-        const chunk = rows.slice(i, i + NEURONS_SYNC_ROWS_PER_STATEMENT);
-        await sql`
+        for (let i = 0; i < rows.length; i += NEURONS_SYNC_ROWS_PER_STATEMENT) {
+          const chunk = rows.slice(i, i + NEURONS_SYNC_ROWS_PER_STATEMENT);
+          await sql`
           INSERT INTO neurons ${sql(chunk, ...NEURON_INSERT_COLUMNS)}
           ON CONFLICT (netuid, uid) DO UPDATE SET
             hotkey = EXCLUDED.hotkey,
@@ -807,15 +796,15 @@ async function handleNeuronsSync(request: Request, env: Env) {
             captured_at = EXCLUDED.captured_at,
             take = EXCLUDED.take
           WHERE neurons.captured_at <= EXCLUDED.captured_at`;
-      }
+        }
 
-      for (
-        let i = 0;
-        i < dailyRows.length;
-        i += NEURONS_SYNC_ROWS_PER_STATEMENT
-      ) {
-        const chunk = dailyRows.slice(i, i + NEURONS_SYNC_ROWS_PER_STATEMENT);
-        await sql`
+        for (
+          let i = 0;
+          i < dailyRows.length;
+          i += NEURONS_SYNC_ROWS_PER_STATEMENT
+        ) {
+          const chunk = dailyRows.slice(i, i + NEURONS_SYNC_ROWS_PER_STATEMENT);
+          await sql`
           INSERT INTO neuron_daily ${sql(chunk, ...NEURON_INSERT_COLUMNS, "snapshot_date", "updated_at")}
           ON CONFLICT (netuid, uid, snapshot_date) DO UPDATE SET
             hotkey = EXCLUDED.hotkey,
@@ -838,44 +827,44 @@ async function handleNeuronsSync(request: Request, env: Env) {
             updated_at = EXCLUDED.updated_at,
             take = EXCLUDED.take
           WHERE neuron_daily.captured_at <= EXCLUDED.captured_at`;
-      }
+        }
 
-      // Per-account daily position rollup (#4832 gap-closure; #4839 gave this
-      // its own Postgres write path in this same transaction, replacing D1's
-      // now-retired rollupAccountPositionDaily / src/account-position-history.mjs):
-      // the SAME snapshot as neuron_daily above, re-keyed by (account, netuid,
-      // snapshot_date) with account = hotkey. `hotkey IS NOT NULL` mirrors that
-      // retired D1 rollup's own filter -- account is NOT NULL and part of the
-      // primary key, but a neuron row's hotkey can itself be null.
-      const positionRows = dailyRows
-        .filter((row: Row) => row.hotkey != null)
-        .map((row: Row) => ({
-          account: row.hotkey,
-          netuid: row.netuid,
-          snapshot_date: row.snapshot_date,
-          uid: row.uid,
-          coldkey: row.coldkey,
-          active: row.active,
-          validator_permit: row.validator_permit,
-          rank: row.rank,
-          trust: row.trust,
-          incentive: row.incentive,
-          dividends: row.dividends,
-          stake_tao: row.stake_tao,
-          emission_tao: row.emission_tao,
-          captured_at: row.captured_at,
-          updated_at: row.updated_at,
-        }));
-      for (
-        let i = 0;
-        i < positionRows.length;
-        i += NEURONS_SYNC_ROWS_PER_STATEMENT
-      ) {
-        const chunk = positionRows.slice(
-          i,
-          i + NEURONS_SYNC_ROWS_PER_STATEMENT,
-        );
-        await sql`
+        // Per-account daily position rollup (#4832 gap-closure; #4839 gave this
+        // its own Postgres write path in this same transaction, replacing D1's
+        // now-retired rollupAccountPositionDaily / src/account-position-history.mjs):
+        // the SAME snapshot as neuron_daily above, re-keyed by (account, netuid,
+        // snapshot_date) with account = hotkey. `hotkey IS NOT NULL` mirrors that
+        // retired D1 rollup's own filter -- account is NOT NULL and part of the
+        // primary key, but a neuron row's hotkey can itself be null.
+        const positionRows = dailyRows
+          .filter((row: Row) => row.hotkey != null)
+          .map((row: Row) => ({
+            account: row.hotkey,
+            netuid: row.netuid,
+            snapshot_date: row.snapshot_date,
+            uid: row.uid,
+            coldkey: row.coldkey,
+            active: row.active,
+            validator_permit: row.validator_permit,
+            rank: row.rank,
+            trust: row.trust,
+            incentive: row.incentive,
+            dividends: row.dividends,
+            stake_tao: row.stake_tao,
+            emission_tao: row.emission_tao,
+            captured_at: row.captured_at,
+            updated_at: row.updated_at,
+          }));
+        for (
+          let i = 0;
+          i < positionRows.length;
+          i += NEURONS_SYNC_ROWS_PER_STATEMENT
+        ) {
+          const chunk = positionRows.slice(
+            i,
+            i + NEURONS_SYNC_ROWS_PER_STATEMENT,
+          );
+          await sql`
           INSERT INTO account_position_daily ${sql(chunk, "account", "netuid", "snapshot_date", "uid", "coldkey", "active", "validator_permit", "rank", "trust", "incentive", "dividends", "stake_tao", "emission_tao", "captured_at", "updated_at")}
           ON CONFLICT (account, netuid, snapshot_date) DO UPDATE SET
             uid = EXCLUDED.uid,
@@ -891,54 +880,55 @@ async function handleNeuronsSync(request: Request, env: Env) {
             captured_at = EXCLUDED.captured_at,
             updated_at = EXCLUDED.updated_at
           WHERE account_position_daily.captured_at <= EXCLUDED.captured_at`;
-      }
+        }
 
-      // Prune UIDs that no longer appear in the snapshot for a netuid this
-      // batch actually covers (deregistered/replaced UIDs) -- scoped to ONLY
-      // the netuids present in this payload, so a partial-coverage batch can
-      // never wipe an unrelated subnet's rows. Mirrors D1's loadStagedNeurons
-      // prune, minus its "legacy" whole-table branch: every batch here
-      // declares its own coverage implicitly via which netuids its rows
-      // belong to. `netuids` is never empty here -- the earlier
-      // `!incoming.length` check guarantees at least one row, and every row
-      // has a netuid.
-      //
-      // The VALUES join builds a per-netuid threshold table -- each netuid is
-      // only pruned against ITS OWN max captured_at, never another netuid's,
-      // closing the cross-netuid data-loss gap a single shared threshold
-      // would open. Built via sql.unsafe with explicit-cast positional
-      // placeholders (plain scalar binds, one per cell) rather than a bound
-      // JS array -- confirmed live 2026-07-10 that Hyperdrive's recommended
-      // `fetch_types: false` (this Worker's own setting, above) breaks
-      // postgres.js's automatic ARRAY-literal serialization (`ANY($1)`/
-      // `unnest($1::int[])` sent a malformed literal with no braces), while
-      // scalar binds -- the only kind every other query in this Worker
-      // uses -- are unaffected.
-      const valuesSql = netuids
-        .map((_, i) => `($${i * 2 + 1}::int, $${i * 2 + 2}::bigint)`)
-        .join(", ");
-      const pruneParams = netuids.flatMap((netuid) => [
-        netuid,
-        netuidMaxCapturedAt.get(netuid),
-      ]);
-      const pruned = await sql.unsafe(
-        `DELETE FROM neurons n
+        // Prune UIDs that no longer appear in the snapshot for a netuid this
+        // batch actually covers (deregistered/replaced UIDs) -- scoped to ONLY
+        // the netuids present in this payload, so a partial-coverage batch can
+        // never wipe an unrelated subnet's rows. Mirrors D1's loadStagedNeurons
+        // prune, minus its "legacy" whole-table branch: every batch here
+        // declares its own coverage implicitly via which netuids its rows
+        // belong to. `netuids` is never empty here -- the earlier
+        // `!incoming.length` check guarantees at least one row, and every row
+        // has a netuid.
+        //
+        // The VALUES join builds a per-netuid threshold table -- each netuid is
+        // only pruned against ITS OWN max captured_at, never another netuid's,
+        // closing the cross-netuid data-loss gap a single shared threshold
+        // would open. Built via sql.unsafe with explicit-cast positional
+        // placeholders (plain scalar binds, one per cell) rather than a bound
+        // JS array -- confirmed live 2026-07-10 that Hyperdrive's recommended
+        // `fetch_types: false` (this Worker's own setting, above) breaks
+        // postgres.js's automatic ARRAY-literal serialization (`ANY($1)`/
+        // `unnest($1::int[])` sent a malformed literal with no braces), while
+        // scalar binds -- the only kind every other query in this Worker
+        // uses -- are unaffected.
+        const valuesSql = netuids
+          .map((_, i) => `($${i * 2 + 1}::int, $${i * 2 + 2}::bigint)`)
+          .join(", ");
+        const pruneParams = netuids.flatMap((netuid) => [
+          netuid,
+          netuidMaxCapturedAt.get(netuid),
+        ]);
+        const pruned = await sql.unsafe(
+          `DELETE FROM neurons n
          USING (VALUES ${valuesSql}) AS batch(netuid, captured_at)
          WHERE n.netuid = batch.netuid
            AND n.captured_at < batch.captured_at
          RETURNING n.netuid`,
-        pruneParams,
-      );
+          pruneParams,
+        );
 
-      return writeJson({
-        ok: true,
-        neurons_written: rows.length,
-        neuron_daily_written: dailyRows.length,
-        account_position_daily_written: positionRows.length,
-        netuids_covered: netuids.length,
-        deregistered_pruned: pruned.length,
-      });
-    });
+        return writeJson({
+          ok: true,
+          neurons_written: rows.length,
+          neuron_daily_written: dailyRows.length,
+          account_position_daily_written: positionRows.length,
+          netuids_covered: netuids.length,
+          deregistered_pruned: pruned.length,
+        });
+      },
+    );
   } catch (err) {
     console.error("data-api neurons-sync write failed:", err);
     await captureDataApiError(err, "neurons-sync", env);
@@ -1061,23 +1051,19 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
       updated_at: row.updated_at,
     }));
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
 
-      for (
-        let i = 0;
-        i < dailyRows.length;
-        i += NEURONS_SYNC_ROWS_PER_STATEMENT
-      ) {
-        const chunk = dailyRows.slice(i, i + NEURONS_SYNC_ROWS_PER_STATEMENT);
-        await sql`
+        for (
+          let i = 0;
+          i < dailyRows.length;
+          i += NEURONS_SYNC_ROWS_PER_STATEMENT
+        ) {
+          const chunk = dailyRows.slice(i, i + NEURONS_SYNC_ROWS_PER_STATEMENT);
+          await sql`
           INSERT INTO neuron_daily ${sql(chunk, ...NEURON_INSERT_COLUMNS, "snapshot_date", "updated_at")}
           ON CONFLICT (netuid, uid, snapshot_date) DO UPDATE SET
             hotkey = EXCLUDED.hotkey,
@@ -1100,18 +1086,18 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
             updated_at = EXCLUDED.updated_at,
             take = EXCLUDED.take
           WHERE neuron_daily.captured_at <= EXCLUDED.captured_at`;
-      }
+        }
 
-      for (
-        let i = 0;
-        i < positionRows.length;
-        i += NEURONS_SYNC_ROWS_PER_STATEMENT
-      ) {
-        const chunk = positionRows.slice(
-          i,
-          i + NEURONS_SYNC_ROWS_PER_STATEMENT,
-        );
-        await sql`
+        for (
+          let i = 0;
+          i < positionRows.length;
+          i += NEURONS_SYNC_ROWS_PER_STATEMENT
+        ) {
+          const chunk = positionRows.slice(
+            i,
+            i + NEURONS_SYNC_ROWS_PER_STATEMENT,
+          );
+          await sql`
           INSERT INTO account_position_daily ${sql(chunk, "account", "netuid", "snapshot_date", "uid", "coldkey", "active", "validator_permit", "rank", "trust", "incentive", "dividends", "stake_tao", "emission_tao", "captured_at", "updated_at")}
           ON CONFLICT (account, netuid, snapshot_date) DO UPDATE SET
             uid = EXCLUDED.uid,
@@ -1127,14 +1113,15 @@ async function handleNeuronDailyBackfill(request: Request, env: Env) {
             captured_at = EXCLUDED.captured_at,
             updated_at = EXCLUDED.updated_at
           WHERE account_position_daily.captured_at <= EXCLUDED.captured_at`;
-      }
+        }
 
-      return writeJson({
-        ok: true,
-        neuron_daily_written: dailyRows.length,
-        account_position_daily_written: positionRows.length,
-      });
-    });
+        return writeJson({
+          ok: true,
+          neuron_daily_written: dailyRows.length,
+          account_position_daily_written: positionRows.length,
+        });
+      },
+    );
   } catch (err) {
     console.error("data-api neuron-daily-backfill write failed:", err);
     await captureDataApiError(err, "neuron-daily-backfill", env);
@@ -1199,18 +1186,15 @@ async function handleRollupAccountEventsDaily(request: Request, env: Env) {
 
   const runAt = Date.now();
   const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
 
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
-      const rolled = [];
-      for (const { date, start, end } of days) {
-        await sql`
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
+        const rolled = [];
+        for (const { date, start, end } of days) {
+          await sql`
           INSERT INTO account_events_daily (hotkey, netuid, day, event_count, event_kinds, first_block, last_block, updated_at)
           SELECT
             hotkey,
@@ -1231,12 +1215,12 @@ async function handleRollupAccountEventsDaily(request: Request, env: Env) {
             first_block = EXCLUDED.first_block,
             last_block = EXCLUDED.last_block,
             updated_at = EXCLUDED.updated_at`;
-        // wallet_flow_daily (#6886/#6887): the account-keyed counterpart to
-        // account_events_daily above, scoped to just the two stake-flow
-        // kinds and grouped by account instead of (hotkey, netuid). Both
-        // StakeAdded and StakeRemoved carry a positive amount_tao (see
-        // src/chain-stake-flow.ts's own header), so net = added - removed.
-        await sql`
+          // wallet_flow_daily (#6886/#6887): the account-keyed counterpart to
+          // account_events_daily above, scoped to just the two stake-flow
+          // kinds and grouped by account instead of (hotkey, netuid). Both
+          // StakeAdded and StakeRemoved carry a positive amount_tao (see
+          // src/chain-stake-flow.ts's own header), so net = added - removed.
+          await sql`
           INSERT INTO wallet_flow_daily (coldkey, day, net_flow_tao, gross_in_tao, gross_out_tao, updated_at)
           SELECT
             coldkey,
@@ -1254,10 +1238,11 @@ async function handleRollupAccountEventsDaily(request: Request, env: Env) {
             gross_in_tao = EXCLUDED.gross_in_tao,
             gross_out_tao = EXCLUDED.gross_out_tao,
             updated_at = EXCLUDED.updated_at`;
-        rolled.push(date);
-      }
-      return writeJson({ ok: true, rolled });
-    });
+          rolled.push(date);
+        }
+        return writeJson({ ok: true, rolled });
+      },
+    );
   } catch (err) {
     console.error("data-api account-events-daily rollup failed:", err);
     await captureDataApiError(err, "account-events-daily-rollup", env);
@@ -1412,17 +1397,13 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
   const rows = incoming.map(coerceSubnetHyperparamsSyncRow);
   const netuids = incoming.map((row: Row) => row.netuid);
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
 
-      await sql`
+        await sql`
         INSERT INTO subnet_hyperparams ${sql(rows, ...SUBNET_HYPERPARAMS_INSERT_COLUMNS)}
         ON CONFLICT (netuid) DO UPDATE SET
           kappa_ratio = EXCLUDED.kappa_ratio,
@@ -1462,48 +1443,48 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
           captured_at = EXCLUDED.captured_at
         WHERE subnet_hyperparams.captured_at <= EXCLUDED.captured_at`;
 
-      // Prune subnets no longer in the snapshot (deregistered/removed) --
-      // scalar positional binds via sql.unsafe, not a bound array, avoiding
-      // the same fetch_types:false ANY()/array-bind landmine documented on
-      // handleNeuronsSync's own prune above. `netuids` is never empty here
-      // -- the earlier `!incoming.length` check guarantees at least one row.
-      const placeholders = netuids
-        .map((_: unknown, i: number) => `$${i + 1}::int`)
-        .join(", ");
-      const pruned = await sql.unsafe(
-        `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${placeholders}) RETURNING netuid`,
-        netuids,
-      );
+        // Prune subnets no longer in the snapshot (deregistered/removed) --
+        // scalar positional binds via sql.unsafe, not a bound array, avoiding
+        // the same fetch_types:false ANY()/array-bind landmine documented on
+        // handleNeuronsSync's own prune above. `netuids` is never empty here
+        // -- the earlier `!incoming.length` check guarantees at least one row.
+        const placeholders = netuids
+          .map((_: unknown, i: number) => `$${i + 1}::int`)
+          .join(", ");
+        const pruned = await sql.unsafe(
+          `DELETE FROM subnet_hyperparams WHERE netuid NOT IN (${placeholders}) RETURNING netuid`,
+          netuids,
+        );
 
-      // Diff-and-append into subnet_hyperparams_history (mirrors D1's
-      // recordSubnetHyperparamsChanges) -- hashed on the RAW incoming rows
-      // (pre-coercion): formatSubnetHyperparams' toD1Flag(value) already
-      // tolerates either a 0/1 number or a real boolean, so the hash stays
-      // domain-identical to the D1 path regardless of which shape reaches it.
-      const latest = await sql`
+        // Diff-and-append into subnet_hyperparams_history (mirrors D1's
+        // recordSubnetHyperparamsChanges) -- hashed on the RAW incoming rows
+        // (pre-coercion): formatSubnetHyperparams' toD1Flag(value) already
+        // tolerates either a 0/1 number or a real boolean, so the hash stays
+        // domain-identical to the D1 path regardless of which shape reaches it.
+        const latest = await sql`
         SELECT DISTINCT ON (netuid) netuid, hyperparams_hash
         FROM subnet_hyperparams_history
         ORDER BY netuid, id DESC`;
-      const latestByNetuid = new Map(
-        latest.map((row) => [Number(row.netuid), row.hyperparams_hash]),
-      );
-      const now = Date.now();
-      const changedRows: Row[] = [];
-      for (const row of incoming) {
-        const hyperparameters = formatSubnetHyperparams(row);
-        const hash = await hyperparamsHash(hyperparameters);
-        if (latestByNetuid.get(row.netuid) === hash) continue;
-        changedRows.push({
-          netuid: row.netuid,
-          block_number: row.block_number ?? null,
-          observed_at: now,
-          ...hyperparameters,
-          hyperparams_hash: hash,
-        });
-        latestByNetuid.set(row.netuid, hash);
-      }
-      if (changedRows.length) {
-        await sql`
+        const latestByNetuid = new Map(
+          latest.map((row) => [Number(row.netuid), row.hyperparams_hash]),
+        );
+        const now = Date.now();
+        const changedRows: Row[] = [];
+        for (const row of incoming) {
+          const hyperparameters = formatSubnetHyperparams(row);
+          const hash = await hyperparamsHash(hyperparameters);
+          if (latestByNetuid.get(row.netuid) === hash) continue;
+          changedRows.push({
+            netuid: row.netuid,
+            block_number: row.block_number ?? null,
+            observed_at: now,
+            ...hyperparameters,
+            hyperparams_hash: hash,
+          });
+          latestByNetuid.set(row.netuid, hash);
+        }
+        if (changedRows.length) {
+          await sql`
           INSERT INTO subnet_hyperparams_history ${sql(
             changedRows,
             "netuid",
@@ -1512,15 +1493,16 @@ async function handleSubnetHyperparamsSync(request: Request, env: Env) {
             ...SUBNET_HYPERPARAMS_HISTORY_FIELDS,
             "hyperparams_hash",
           )}`;
-      }
+        }
 
-      return writeJson({
-        ok: true,
-        subnet_hyperparams_written: rows.length,
-        deregistered_pruned: pruned.length,
-        history_appended: changedRows.length,
-      });
-    });
+        return writeJson({
+          ok: true,
+          subnet_hyperparams_written: rows.length,
+          deregistered_pruned: pruned.length,
+          history_appended: changedRows.length,
+        });
+      },
+    );
   } catch (err) {
     console.error("data-api subnet-hyperparams-sync write failed:", err);
     await captureDataApiError(err, "subnet-hyperparams-sync", env);
@@ -1645,18 +1627,14 @@ async function handleSubnetLocksSync(request: Request, env: Env) {
     );
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
 
-      if (incoming.length) {
-        await sql`
+        if (incoming.length) {
+          await sql`
           INSERT INTO subnet_locks ${sql(incoming, ...SUBNET_LOCKS_INSERT_COLUMNS)}
           ON CONFLICT (netuid, hotkey, is_owner, is_perpetual) DO UPDATE SET
             locked_mass = EXCLUDED.locked_mass,
@@ -1664,37 +1642,38 @@ async function handleSubnetLocksSync(request: Request, env: Env) {
             last_update = EXCLUDED.last_update,
             captured_at = EXCLUDED.captured_at
           WHERE subnet_locks.captured_at <= EXCLUDED.captured_at`;
-      }
+        }
 
-      // Every run is a full-network snapshot (see header comment) -- prune
-      // whatever this batch didn't report. Row-value tuple comparison
-      // (native Postgres, no array bind) -- scalar positional placeholders
-      // via sql.unsafe, same landmine-avoidance as handleSubnetHyperparams-
-      // Sync's own prune (fetch_types:false makes bound ARRAY/ANY() params
-      // unreliable on this connection).
-      let prunedCount = 0;
-      if (incoming.length) {
-        const values: (number | string | boolean)[] = [];
-        const tuples = incoming.map((row: Row, i: number) => {
-          const base = i * 4;
-          values.push(row.netuid, row.hotkey, row.is_owner, row.is_perpetual);
-          return `($${base + 1}::int, $${base + 2}::text, $${base + 3}::bool, $${base + 4}::bool)`;
-        });
-        const prunedRows = await sql.unsafe(
-          `DELETE FROM subnet_locks
+        // Every run is a full-network snapshot (see header comment) -- prune
+        // whatever this batch didn't report. Row-value tuple comparison
+        // (native Postgres, no array bind) -- scalar positional placeholders
+        // via sql.unsafe, same landmine-avoidance as handleSubnetHyperparams-
+        // Sync's own prune (fetch_types:false makes bound ARRAY/ANY() params
+        // unreliable on this connection).
+        let prunedCount = 0;
+        if (incoming.length) {
+          const values: (number | string | boolean)[] = [];
+          const tuples = incoming.map((row: Row, i: number) => {
+            const base = i * 4;
+            values.push(row.netuid, row.hotkey, row.is_owner, row.is_perpetual);
+            return `($${base + 1}::int, $${base + 2}::text, $${base + 3}::bool, $${base + 4}::bool)`;
+          });
+          const prunedRows = await sql.unsafe(
+            `DELETE FROM subnet_locks
            WHERE (netuid, hotkey, is_owner, is_perpetual) NOT IN (${tuples.join(", ")})
            RETURNING netuid`,
-          values,
-        );
-        prunedCount = prunedRows.length;
-      }
+            values,
+          );
+          prunedCount = prunedRows.length;
+        }
 
-      return writeJson({
-        ok: true,
-        subnet_locks_written: incoming.length,
-        pruned: prunedCount,
-      });
-    });
+        return writeJson({
+          ok: true,
+          subnet_locks_written: incoming.length,
+          pruned: prunedCount,
+        });
+      },
+    );
   } catch (err) {
     console.error("data-api subnet-locks-sync write failed:", err);
     await captureDataApiError(err, "subnet-locks-sync", env);
@@ -1837,17 +1816,13 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
   const sanitized = incoming.map(sanitizeAccountIdentitySyncRow);
   const rows = sanitized.map(coerceAccountIdentitySyncRow);
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
 
-      await sql`
+        await sql`
         INSERT INTO account_identity ${sql(rows, ...ACCOUNT_IDENTITY_INSERT_COLUMNS)}
         ON CONFLICT (account) DO UPDATE SET
           name = EXCLUDED.name,
@@ -1860,35 +1835,35 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
           captured_at = EXCLUDED.captured_at
         WHERE account_identity.captured_at <= EXCLUDED.captured_at`;
 
-      // Diff-and-append into account_identity_history (mirrors D1's
-      // recordAccountIdentityChanges) -- hashed on the sanitized rows (NUL
-      // bytes already stripped above), matching identitySnapshotFromRow's
-      // own field selection.
-      const latest = await sql`
+        // Diff-and-append into account_identity_history (mirrors D1's
+        // recordAccountIdentityChanges) -- hashed on the sanitized rows (NUL
+        // bytes already stripped above), matching identitySnapshotFromRow's
+        // own field selection.
+        const latest = await sql`
         SELECT DISTINCT ON (account) account, identity_hash
         FROM account_identity_history
         ORDER BY account, id DESC`;
-      const latestByAccount = new Map(
-        latest.map((row) => [row.account, row.identity_hash]),
-      );
-      const now = Date.now();
-      const changedRows: Row[] = [];
-      for (const row of sanitized) {
-        const snapshot: Row = {};
-        for (const field of IDENTITY_FIELDS)
-          snapshot[field] = row[field] ?? null;
-        const hash = await identityHash(snapshot);
-        if (latestByAccount.get(row.account) === hash) continue;
-        changedRows.push({
-          account: row.account,
-          observed_at: now,
-          ...snapshot,
-          identity_hash: hash,
-        });
-        latestByAccount.set(row.account, hash);
-      }
-      if (changedRows.length) {
-        await sql`
+        const latestByAccount = new Map(
+          latest.map((row) => [row.account, row.identity_hash]),
+        );
+        const now = Date.now();
+        const changedRows: Row[] = [];
+        for (const row of sanitized) {
+          const snapshot: Row = {};
+          for (const field of IDENTITY_FIELDS)
+            snapshot[field] = row[field] ?? null;
+          const hash = await identityHash(snapshot);
+          if (latestByAccount.get(row.account) === hash) continue;
+          changedRows.push({
+            account: row.account,
+            observed_at: now,
+            ...snapshot,
+            identity_hash: hash,
+          });
+          latestByAccount.set(row.account, hash);
+        }
+        if (changedRows.length) {
+          await sql`
           INSERT INTO account_identity_history ${sql(
             changedRows,
             "account",
@@ -1896,14 +1871,15 @@ async function handleAccountIdentitySync(request: Request, env: Env) {
             ...IDENTITY_FIELDS,
             "identity_hash",
           )}`;
-      }
+        }
 
-      return writeJson({
-        ok: true,
-        account_identity_written: rows.length,
-        history_appended: changedRows.length,
-      });
-    });
+        return writeJson({
+          ok: true,
+          account_identity_written: rows.length,
+          history_appended: changedRows.length,
+        });
+      },
+    );
   } catch (err) {
     console.error("data-api account-identity-sync write failed:", err);
     await captureDataApiError(err, "account-identity-sync", env);
@@ -2049,27 +2025,24 @@ async function handleValidatorNominatorCountsSync(request: Request, env: Env) {
     );
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
-      await batchedUpsert(
-        sql,
-        incoming,
-        (sql, batch) => sql`
+    await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
+        await batchedUpsert(
+          sql,
+          incoming,
+          (sql, batch) => sql`
           INSERT INTO validator_nominator_counts ${sql(batch, ...VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS)}
           ON CONFLICT (hotkey) DO UPDATE SET
             nominator_count = EXCLUDED.nominator_count,
             captured_at = EXCLUDED.captured_at
           WHERE validator_nominator_counts.captured_at <= EXCLUDED.captured_at`,
-        VALIDATOR_NOMINATOR_COUNTS_MAX_ROWS_PER_BATCH,
-      );
-    });
+          VALIDATOR_NOMINATOR_COUNTS_MAX_ROWS_PER_BATCH,
+        );
+      },
+    );
     return writeJson({
       ok: true,
       validator_nominator_counts_written: incoming.length,
@@ -2182,27 +2155,24 @@ async function handleNominatorPositionsSync(request: Request, env: Env) {
     );
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
-      await batchedUpsert(
-        sql,
-        incoming,
-        (sql, batch) => sql`
+    await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
+        await batchedUpsert(
+          sql,
+          incoming,
+          (sql, batch) => sql`
           INSERT INTO nominator_positions ${sql(batch, ...NOMINATOR_POSITION_INSERT_COLUMNS)}
           ON CONFLICT (coldkey, hotkey, netuid) DO UPDATE SET
             share_fraction = EXCLUDED.share_fraction,
             captured_at = EXCLUDED.captured_at
           WHERE nominator_positions.captured_at <= EXCLUDED.captured_at`,
-        NOMINATOR_POSITIONS_MAX_ROWS_PER_BATCH,
-      );
-    });
+          NOMINATOR_POSITIONS_MAX_ROWS_PER_BATCH,
+        );
+      },
+    );
     return writeJson({
       ok: true,
       nominator_positions_written: incoming.length,
@@ -2315,28 +2285,25 @@ async function handleAccountBalancesSync(request: Request, env: Env) {
     );
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
-      await batchedUpsert(
-        sql,
-        incoming,
-        (sql, batch) => sql`
+    await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
+        await batchedUpsert(
+          sql,
+          incoming,
+          (sql, batch) => sql`
           INSERT INTO account_balances ${sql(batch, ...ACCOUNT_BALANCE_INSERT_COLUMNS)}
           ON CONFLICT (ss58) DO UPDATE SET
             free_tao = EXCLUDED.free_tao,
             reserved_tao = EXCLUDED.reserved_tao,
             captured_at = EXCLUDED.captured_at
           WHERE account_balances.captured_at <= EXCLUDED.captured_at`,
-        ACCOUNT_BALANCES_MAX_ROWS_PER_BATCH,
-      );
-    });
+          ACCOUNT_BALANCES_MAX_ROWS_PER_BATCH,
+        );
+      },
+    );
     return writeJson({ ok: true, account_balances_written: incoming.length });
   } catch (err) {
     console.error("data-api account-balances-sync write failed:", err);
@@ -2438,49 +2405,45 @@ async function handleSubnetIdentitySync(request: Request, env: Env) {
     return writeJson({ error: "profiles must be a non-empty array" }, 400);
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
 
-      const latest = await sql`
+        const latest = await sql`
         SELECT DISTINCT ON (netuid) netuid, identity_hash
         FROM subnet_identity_history
         ORDER BY netuid, id DESC`;
-      const latestByNetuid = new Map(
-        latest.map((row) => [Number(row.netuid), row.identity_hash]),
-      );
-      const [blockRow] = await sql`
-        SELECT MAX(block_number) AS block_number FROM blocks`;
-      const blockNumber =
-        blockRow?.block_number == null ? null : Number(blockRow.block_number);
-
-      const now = Date.now();
-      const changedRows: Row[] = [];
-      for (const profile of profiles) {
-        if (!Number.isInteger(profile?.netuid)) continue;
-        const snapshot = sanitizeSubnetIdentitySyncSnapshot(
-          identitySnapshotFromProfile(profile),
+        const latestByNetuid = new Map(
+          latest.map((row) => [Number(row.netuid), row.identity_hash]),
         );
-        if (!snapshot) continue;
-        const hash = await subnetIdentityHash(snapshot);
-        if (latestByNetuid.get(profile.netuid) === hash) continue;
-        changedRows.push({
-          netuid: profile.netuid,
-          block_number: blockNumber,
-          observed_at: now,
-          ...snapshot,
-          identity_hash: hash,
-        });
-        latestByNetuid.set(profile.netuid, hash);
-      }
-      if (changedRows.length) {
-        await sql`
+        const [blockRow] = await sql`
+        SELECT MAX(block_number) AS block_number FROM blocks`;
+        const blockNumber =
+          blockRow?.block_number == null ? null : Number(blockRow.block_number);
+
+        const now = Date.now();
+        const changedRows: Row[] = [];
+        for (const profile of profiles) {
+          if (!Number.isInteger(profile?.netuid)) continue;
+          const snapshot = sanitizeSubnetIdentitySyncSnapshot(
+            identitySnapshotFromProfile(profile),
+          );
+          if (!snapshot) continue;
+          const hash = await subnetIdentityHash(snapshot);
+          if (latestByNetuid.get(profile.netuid) === hash) continue;
+          changedRows.push({
+            netuid: profile.netuid,
+            block_number: blockNumber,
+            observed_at: now,
+            ...snapshot,
+            identity_hash: hash,
+          });
+          latestByNetuid.set(profile.netuid, hash);
+        }
+        if (changedRows.length) {
+          await sql`
           INSERT INTO subnet_identity_history ${sql(
             changedRows,
             "netuid",
@@ -2495,13 +2458,14 @@ async function handleSubnetIdentitySync(request: Request, env: Env) {
             "logo_url",
             "identity_hash",
           )}`;
-      }
+        }
 
-      return writeJson({
-        ok: true,
-        history_appended: changedRows.length,
-      });
-    });
+        return writeJson({
+          ok: true,
+          history_appended: changedRows.length,
+        });
+      },
+    );
   } catch (err) {
     console.error("data-api subnet-identity-sync write failed:", err);
     await captureDataApiError(err, "subnet-identity-sync", env);
@@ -2578,12 +2542,6 @@ async function handleHealthChecksSync(request: Request, env: Env) {
     return writeJson({ ok: true, checks_written: 0, status_written: 0 });
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   const validRows = probed.filter(
     (row: Row) =>
       row &&
@@ -2652,9 +2610,11 @@ async function handleHealthChecksSync(request: Request, env: Env) {
   );
 
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '10000ms'`;
-      await sql`
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '10000ms'`;
+        await sql`
         INSERT INTO surface_checks ${sql(
           checkRows,
           "surface_id",
@@ -2669,30 +2629,30 @@ async function handleHealthChecksSync(request: Request, env: Env) {
           "checked_at",
         )}
         ON CONFLICT (surface_id, checked_at) DO NOTHING`;
-      // METAGRAPHED-B: evict any stale row still holding one of this batch's
-      // surface_keys under a DIFFERENT surface_id -- a surface rename leaves
-      // the old id's row behind, and idx_surface_status_key_unique then
-      // rejects the new id's insert (the upsert's conflict target is
-      // surface_id, so the key collision surfaces as a hard error, not an
-      // update). Scalar positional binds via a VALUES join -- this Worker's
-      // fetch_types:false Hyperdrive setting breaks postgres.js's bound-array
-      // ANY($1) serialization (see the neurons-sync prune query's comment).
-      const keyedRows = dedupedStatusRows.filter(
-        (row) => row.surface_key !== null,
-      );
-      if (keyedRows.length) {
-        const valuesSql = keyedRows
-          .map((_, i) => `($${i * 2 + 1}::text, $${i * 2 + 2}::text)`)
-          .join(", ");
-        await sql.unsafe(
-          `DELETE FROM surface_status s
+        // METAGRAPHED-B: evict any stale row still holding one of this batch's
+        // surface_keys under a DIFFERENT surface_id -- a surface rename leaves
+        // the old id's row behind, and idx_surface_status_key_unique then
+        // rejects the new id's insert (the upsert's conflict target is
+        // surface_id, so the key collision surfaces as a hard error, not an
+        // update). Scalar positional binds via a VALUES join -- this Worker's
+        // fetch_types:false Hyperdrive setting breaks postgres.js's bound-array
+        // ANY($1) serialization (see the neurons-sync prune query's comment).
+        const keyedRows = dedupedStatusRows.filter(
+          (row) => row.surface_key !== null,
+        );
+        if (keyedRows.length) {
+          const valuesSql = keyedRows
+            .map((_, i) => `($${i * 2 + 1}::text, $${i * 2 + 2}::text)`)
+            .join(", ");
+          await sql.unsafe(
+            `DELETE FROM surface_status s
            USING (VALUES ${valuesSql}) AS incoming(surface_key, surface_id)
            WHERE s.surface_key = incoming.surface_key
              AND s.surface_id <> incoming.surface_id`,
-          keyedRows.flatMap((row) => [row.surface_key, row.surface_id]),
-        );
-      }
-      await sql`
+            keyedRows.flatMap((row) => [row.surface_key, row.surface_id]),
+          );
+        }
+        await sql`
         INSERT INTO surface_status ${sql(
           dedupedStatusRows,
           "surface_id",
@@ -2724,12 +2684,13 @@ async function handleHealthChecksSync(request: Request, env: Env) {
           last_ok = excluded.last_ok,
           consecutive_failures = excluded.consecutive_failures,
           updated_at = excluded.updated_at`;
-      return writeJson({
-        ok: true,
-        checks_written: checkRows.length,
-        status_written: dedupedStatusRows.length,
-      });
-    });
+        return writeJson({
+          ok: true,
+          checks_written: checkRows.length,
+          status_written: dedupedStatusRows.length,
+        });
+      },
+    );
   } catch (err) {
     console.error("data-api health-checks-sync write failed:", err);
     await captureDataApiError(err, "health-checks-sync", env);
@@ -2802,17 +2763,13 @@ async function handleHealthUptimeRollupSync(request: Request, env: Env) {
     return writeJson({ ok: true, days_rolled: [] });
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '20000ms'`;
-      for (const { date, start, end } of validDays) {
-        await sql`
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '20000ms'`;
+        for (const { date, start, end } of validDays) {
+          await sql`
         WITH ranked AS (
           SELECT
             surface_id,
@@ -2865,12 +2822,13 @@ async function handleHealthUptimeRollupSync(request: Request, env: Env) {
           p99_latency_ms = excluded.p99_latency_ms,
           status = excluded.status,
           updated_at = excluded.updated_at`;
-      }
-      return writeJson({
-        ok: true,
-        days_rolled: validDays.map((d: Row) => d.date),
-      });
-    });
+        }
+        return writeJson({
+          ok: true,
+          days_rolled: validDays.map((d: Row) => d.date),
+        });
+      },
+    );
   } catch (err) {
     console.error("data-api health-uptime-rollup-sync write failed:", err);
     await captureDataApiError(err, "health-uptime-rollup-sync", env);
@@ -2958,12 +2916,6 @@ async function handleSubnetSnapshotSync(request: Request, env: Env) {
     return writeJson({ ok: true, rows_written: 0 });
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   const snapshotRows = validRows.map((row) => ({
     netuid: row.netuid,
     snapshot_date: row.snapshot_date,
@@ -3011,9 +2963,11 @@ async function handleSubnetSnapshotSync(request: Request, env: Env) {
   }));
 
   try {
-    return await sql.begin(async (sql: postgres.TransactionSql) => {
-      await sql`SET statement_timeout = '10000ms'`;
-      await sql`
+    return await syncBeginWithConnectionRetry(
+      env,
+      async (sql: postgres.TransactionSql) => {
+        await sql`SET statement_timeout = '10000ms'`;
+        await sql`
         INSERT INTO subnet_snapshots ${sql(
           snapshotRows,
           "netuid",
@@ -3044,8 +2998,9 @@ async function handleSubnetSnapshotSync(request: Request, env: Env) {
           alpha_in_pool = COALESCE(subnet_snapshots.alpha_in_pool, excluded.alpha_in_pool),
           alpha_out_pool = COALESCE(subnet_snapshots.alpha_out_pool, excluded.alpha_out_pool),
           subnet_volume_tao = COALESCE(subnet_snapshots.subnet_volume_tao, excluded.subnet_volume_tao)`;
-      return writeJson({ ok: true, rows_written: snapshotRows.length });
-    });
+        return writeJson({ ok: true, rows_written: snapshotRows.length });
+      },
+    );
   } catch (err) {
     console.error("data-api subnet-snapshot-sync write failed:", err);
     await captureDataApiError(err, "subnet-snapshot-sync", env);
@@ -3109,6 +3064,10 @@ async function handleRpcUsageEventSync(request: Request, env: Env) {
     return writeJson({ error: "malformed rpc usage event" }, 400);
   }
 
+  // Deliberately NOT syncBeginWithConnectionRetry: this is a plain single-row INSERT with
+  // no conflict target, so an ambiguous commit (statement applied, socket died before the
+  // OK arrived -- exactly the CONNECTION_CLOSED class the retry targets) plus a retry
+  // would double-count the event. A rare dropped telemetry row is the cheaper failure.
   const sql = postgres(env.HYPERDRIVE.connectionString, {
     max: 5,
     prepare: false,
@@ -3175,16 +3134,15 @@ async function handleRpcUsageEventPrune(request: Request, env: Env) {
     return writeJson({ error: "cutoff must be a finite number" }, 400);
   }
 
-  const sql = postgres(env.HYPERDRIVE.connectionString, {
-    max: 5,
-    prepare: false,
-    fetch_types: false,
-  });
-
   try {
-    const result = await sql`
-      DELETE FROM rpc_proxy_events WHERE observed_at < ${body.cutoff}`;
-    return writeJson({ ok: true, rows_deleted: result.count });
+    // A cutoff DELETE is idempotent (re-running deletes nothing new), so unlike the
+    // event INSERT above it safely takes the shared connection retry; the transaction
+    // wrapper only buys the retry semantics, the single statement was already atomic.
+    return await syncBeginWithConnectionRetry(env, async (sql) => {
+      const result = await sql`
+        DELETE FROM rpc_proxy_events WHERE observed_at < ${body.cutoff}`;
+      return writeJson({ ok: true, rows_deleted: result.count });
+    });
   } catch (err) {
     console.error("data-api rpc-usage-prune write failed:", err);
     await captureDataApiError(err, "rpc-usage-prune", env);

--- a/workers/hyperdrive-sync-retry.ts
+++ b/workers/hyperdrive-sync-retry.ts
@@ -1,0 +1,68 @@
+// METAGRAPHED-7, second recurrence (2026-07-24): the read dispatcher's fresh-client
+// retry loop (workers/data-api.ts's route dispatcher) eliminated the read-path
+// CONNECTION_CLOSED class, but every internal sync route still lost its whole mirror
+// write to a single dropped socket -- the 09:00Z origin blip dropped health-checks-sync,
+// health-uptime-rollup-sync, and health-status-live in one burst while every read route
+// rode out the same blip on retries. The original "never retry the write/sync routes"
+// stance over-generalized: it is right for non-transactional multi-statement writes,
+// but every sync route funnels its batch through ONE atomic sql.begin() -- a failure
+// rolls the whole transaction back, so nothing can have partially applied and a retry
+// re-runs the identical idempotent batch; it cannot double-write. Single-statement
+// writes stay excluded unless the statement itself is idempotent (rpc-usage-prune's
+// cutoff DELETE is; rpc-usage-event's plain INSERT is not -- an ambiguous commit plus
+// a retry would double-count, so it keeps the no-retry stance at its call site).
+//
+// Shared between workers/data-api.ts and workers/registry-sync-api.ts -- the same
+// neutral-module reasoning as workers/postgres-tier.ts.
+import postgres from "postgres";
+
+// Retry only postgres.js's own connection-level failures -- a dropped socket, a torn-down
+// pool entry, or a connect that never completed. Anything else (constraint violations,
+// statement timeouts, syntax errors) is deterministic and must surface immediately.
+export const RETRYABLE_CONNECTION_ERROR_CODES = new Set([
+  "CONNECTION_CLOSED",
+  "CONNECTION_DESTROYED",
+  "CONNECT_TIMEOUT",
+]);
+// A single retry (the original METAGRAPHED-7 fix) regressed: under sustained load,
+// Hyperdrive can recycle the retry's own freshly created connection too, so the retry
+// itself hits the same error class and the request still fails. 2 retries (3 total
+// attempts) gives a second freshly created client a chance before giving up.
+export const MAX_CONNECTION_RETRY_ATTEMPTS = 2;
+
+// The sync routes' standard Hyperdrive client options (Cloudflare's documented
+// postgres.js settings for Workers: bounded concurrency, no prepared-statement cache
+// dependence, no type-fetch round-trip).
+const SYNC_HYPERDRIVE_OPTIONS = {
+  max: 5,
+  prepare: false,
+  fetch_types: false,
+};
+
+/** Run one atomic sync transaction with the read dispatcher's fresh-client retry
+ *  semantics: each attempt gets a brand-new client, because the dead socket lives in
+ *  the previous client's pool -- reusing it would hand the retry the same corpse. */
+export async function syncBeginWithConnectionRetry<T>(
+  env: { HYPERDRIVE: { connectionString: string } },
+  txFn: (sql: postgres.TransactionSql) => Promise<T>,
+): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    const sql = postgres(
+      env.HYPERDRIVE.connectionString,
+      SYNC_HYPERDRIVE_OPTIONS,
+    );
+    try {
+      return (await sql.begin(txFn)) as T;
+    } catch (err) {
+      if (
+        attempt >= MAX_CONNECTION_RETRY_ATTEMPTS ||
+        !RETRYABLE_CONNECTION_ERROR_CODES.has(
+          (err as { code?: string } | null)?.code as string,
+        )
+      )
+        throw err;
+    }
+    // No sql.end() on the failed client: Hyperdrive cleans up the connection when the
+    // request/invocation ends, the same documented convention every call site follows.
+  }
+}

--- a/workers/registry-sync-api.ts
+++ b/workers/registry-sync-api.ts
@@ -19,7 +19,8 @@
 // endpoint; the database itself stays exactly as private as it already was
 // (bound to 127.0.0.1 on its host, reachable only via the Cloudflare Tunnel
 // + Workers VPC Service + Hyperdrive path already proven for reads).
-import postgres from "postgres";
+import type postgres from "postgres";
+import { syncBeginWithConnectionRetry } from "./hyperdrive-sync-retry.ts";
 import { timingSafeEqual } from "../src/webhooks.ts";
 import { resolveClientIp } from "./config.ts";
 
@@ -186,12 +187,6 @@ export default {
       return json({ error: "no rows provided" }, 400);
     }
 
-    const sql = postgres(env.HYPERDRIVE.connectionString, {
-      max: 5,
-      prepare: false,
-      fetch_types: false,
-    });
-
     const summary = {
       providers_written: 0,
       subnets_written: 0,
@@ -209,7 +204,7 @@ export default {
       // already been written committed and the rest silently never applied,
       // a partial-sync state with no way to tell it happened; now the whole
       // batch commits together or rolls back together.
-      return await sql.begin(async (sql) => {
+      return await syncBeginWithConnectionRetry(env, async (sql) => {
         await sql`SET statement_timeout = '10000ms'`;
 
         for (const p of providers) {


### PR DESCRIPTION
# Summary

Closes #7997 (Sentry METAGRAPHED-7, second recurrence).

The read dispatcher's fresh-client retry eliminated the read-path `write CONNECTION_CLOSED` class, but every internal sync route still lost its whole mirror write to a single dropped Hyperdrive socket — the 2026-07-24 09:00Z origin blip dropped `health-checks-sync`, `health-uptime-rollup-sync`, and `health-status-live` in one burst while every read route rode out the same blip on retries.

The original "never retry the write/sync routes" stance over-generalized: it is right for non-transactional multi-statement writes, but every sync route funnels its batch through **one atomic `sql.begin()`** — a failure rolls the whole transaction back, so nothing can have partially applied and a retry re-runs the identical idempotent batch; it cannot double-write.

- New `workers/hyperdrive-sync-retry.ts`: `syncBeginWithConnectionRetry(env, txFn)` — fresh client per attempt (the dead socket lives in the previous client's pool), retrying only `RETRYABLE_CONNECTION_ERROR_CODES`, capped at `MAX_CONNECTION_RETRY_ATTEMPTS`. The retryable-code set and attempt cap move here (shared with the read dispatcher, which keeps its own inline loop because its client options differ — `bigIntSafeJson` types + `idle_timeout`).
- Converted all 13 transactional sync sites in `workers/data-api.ts` plus `registry-sync-api`'s batch write and `rpc-usage-prune`'s idempotent cutoff DELETE.
- Deliberately **not** converted: `rpc-usage-event`'s plain single-row INSERT (no conflict target — an ambiguous commit plus a retry would double-count; a rare dropped telemetry row is the cheaper failure), and the `withAlertTriggersSql`/`withAccountsSql` wrappers (callers are not single atomic transactions).

## Validation

- `npm run typecheck` / `npm run lint` / `npm run format:check` clean (the three touched files were prettier-clean on main; only new hunks reformatted).
- `npx vitest run tests/data-api.test.ts tests/registry-sync-api.test.ts tests/hyperdrive-sync-retry.test.ts` — 571 passing, including:
  - route-level regression tests reproducing the outage shape on `health-checks-sync` and `registry-sync` (fails once with `CONNECTION_CLOSED` → fresh-client retry lands the batch; exhaustion still 502s; a non-connection error is never retried),
  - direct unit tests pinning the helper's branches (fresh client per attempt, each retryable code, the attempt cap, non-object rejections).
- `npm run validate` + `npm run test:coverage` green.
