### PR TITLE
feat(api): add GraphQL fixture(surface_id) field

### DIFF
--- a/src/fixtures-mcp.ts
+++ b/src/fixtures-mcp.ts
@@ -1,0 +1,138 @@
+// Per-surface fixture loader for GraphQL/REST/MCP parity on
+// GET /api/v1/fixtures/{surface_id}. Resolves deprecated surface_id aliases
+// the same way get_fixture does, then reads the baked
+// /metagraph/fixtures/{id}.json artifact.
+
+import type { StorageReadResult } from "../workers/storage.ts";
+import { SURFACE_ALIASES_PATH } from "./surface-aliases.ts";
+import { findSurface } from "./surface-verify.ts";
+
+// Same charset gate get_fixture / the REST fixture detail route apply so a
+// surface_id cannot escape the fixtures/ R2 namespace.
+export const FIXTURE_SURFACE_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
+export function fixtureArtifactPath(surfaceId: string): string {
+  return `/metagraph/fixtures/${surfaceId}.json`;
+}
+
+export interface FixtureMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function fixtureMcpError(
+  code: string,
+  message: string,
+): FixtureMcpError {
+  const error = new Error(message) as FixtureMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+export function parseFixtureSurfaceId(
+  args: Record<string, unknown> | null | undefined,
+): string {
+  const surfaceId = args?.surface_id;
+  if (typeof surfaceId !== "string" || surfaceId.trim() === "") {
+    throw fixtureMcpError(
+      "invalid_params",
+      "Argument `surface_id` must be a non-empty string.",
+    );
+  }
+  const normalized = surfaceId.trim();
+  if (!FIXTURE_SURFACE_ID_PATTERN.test(normalized)) {
+    throw fixtureMcpError(
+      "invalid_params",
+      "surface_id contains invalid characters.",
+    );
+  }
+  return normalized;
+}
+
+type FixtureCtx = {
+  env: Env;
+  readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+};
+
+async function readOptional(
+  read: (env: Env, path: string) => Promise<StorageReadResult>,
+  env: Env,
+  path: string,
+): Promise<Record<string, unknown> | null> {
+  const result = await read(env, path);
+  if (!result?.ok || !result.data || typeof result.data !== "object") {
+    return null;
+  }
+  return result.data as Record<string, unknown>;
+}
+
+export async function resolveFixtureArtifactId(
+  ctx: FixtureCtx,
+  surfaceId: string,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<string> {
+  const read = readArtifact ?? ctx.readArtifact;
+  const catalog = await readOptional(
+    read,
+    ctx.env,
+    "/metagraph/operational-surfaces.json",
+  );
+  const surfaces = Array.isArray(catalog?.surfaces)
+    ? (catalog.surfaces as Record<string, unknown>[])
+    : [];
+  let surface = findSurface(surfaces, surfaceId);
+  if (!surface) {
+    const aliases = await readOptional(read, ctx.env, SURFACE_ALIASES_PATH);
+    surface = findSurface(surfaces, surfaceId, aliases);
+  }
+  const resolved = surface?.surface_id;
+  return typeof resolved === "string" && resolved ? resolved : surfaceId;
+}
+
+export async function loadFixture(
+  ctx: FixtureCtx,
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<unknown> {
+  const surfaceId = parseFixtureSurfaceId(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const artifactId = await resolveFixtureArtifactId(ctx, surfaceId, {
+    readArtifact: read,
+  });
+  const artifactPath = fixtureArtifactPath(artifactId);
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (
+      code === "artifact_not_found" ||
+      code === "r2_binding_missing" ||
+      code === "artifact_unavailable"
+    ) {
+      throw fixtureMcpError(
+        "not_found",
+        "No resource at the requested identifier. Use search_subnets or " +
+          "list_subnet_apis to discover valid netuids / surface ids.",
+      );
+    }
+    throw fixtureMcpError(code, `Could not load ${artifactPath} (${code}).`);
+  }
+  const data = result.data;
+  if (!data || typeof data !== "object") {
+    throw fixtureMcpError(
+      "not_found",
+      "No resource at the requested identifier. Use search_subnets or " +
+        "list_subnet_apis to discover valid netuids / surface ids.",
+    );
+  }
+  return data;
+}

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -73,6 +73,10 @@ import { loadProfileCompletenessList } from "./profile-completeness-mcp.ts";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.ts";
+// #7867: GraphQL parity for GET /api/v1/fixtures/{surface_id}, reusing
+// loadFixture (same surface_id validation + alias resolve + artifact read
+// get_fixture already performs).
+import { loadFixture } from "./fixtures-mcp.ts";
 // #7170: GraphQL parity for the changelog/contracts/health-history REST routes,
 // reusing the same loaders MCP get_changelog/get_contracts/get_health_history
 // already call -- not a reimplementation.
@@ -561,6 +565,8 @@ export const SDL = `
     saved_query(id: String!, params: JSON): JSON
     "The recorded response fixtures for registered surfaces, used to replay/verify a surface without calling it. Null when no fixture index has been baked in this environment. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
     fixtures: JSON
+    "One captured live request/response fixture by surface_id — the sanitized sample get_fixture / GET /api/v1/fixtures/{surface_id} return. Resolves deprecated surface_id aliases the same way MCP does. Null when no fixture exists for the id (rather than a GraphQL error). An invalid surface_id is BAD_USER_INPUT. Opaque JSON passed through verbatim. Mirrors GET /api/v1/fixtures/{surface_id}."
+    fixture(surface_id: String!): JSON
     "The agent-callable service catalog: without a netuid, the global index of subnets exposing callable services; with one, that subnet's full per-service catalog. Both are overlaid with live health exactly as REST composes them. Null when the catalog has not been baked. Opaque JSON, matching the get_agent_catalog MCP/REST shape. Mirrors GET /api/v1/agent-catalog."
     agent_catalog(netuid: Int): JSON
     "Artifact freshness: each published artifact's generated_at/age, merged with the live cron snapshot stamp when the health store is warm. Null when no freshness artifact has been baked. Opaque JSON, matching the get_freshness MCP/REST shape. Mirrors GET /api/v1/freshness."
@@ -4350,6 +4356,7 @@ export const FIELD_COMPLEXITY = {
   candidates: RELATIONSHIP_FIELD_COMPLEXITY,
   saved_query: RELATIONSHIP_FIELD_COMPLEXITY,
   fixtures: RELATIONSHIP_FIELD_COMPLEXITY,
+  fixture: RELATIONSHIP_FIELD_COMPLEXITY,
   agent_catalog: RELATIONSHIP_FIELD_COMPLEXITY,
   freshness: RELATIONSHIP_FIELD_COMPLEXITY,
   top_holders: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5345,6 +5352,26 @@ const rootValue = {
 
   fixtures(_args: unknown, context: GqlContext) {
     return loadArtifact(context, "/metagraph/fixtures.json");
+  },
+
+  // #7867: reuse loadFixture (the same loader get_fixture uses) unchanged --
+  // same surface_id charset gate, deprecated-id alias resolve, and artifact
+  // path as REST GET /api/v1/fixtures/{surface_id}. invalid_params becomes
+  // BAD_USER_INPUT; any other loader miss (not_found / cold R2) resolves to
+  // null, matching adapter's cold/absent convention.
+  async fixture(args: Row, context: GqlContext) {
+    try {
+      return await loadFixture(mcpCtx(context), args, { readArtifact });
+    } catch (rawErr) {
+      const err = rawErr as Row;
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      if (err?.toolError) return null;
+      throw err;
+    }
   },
 
   async agent_catalog({ netuid }: Row, context: GqlContext) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -447,6 +447,7 @@ import {
   SURFACE_ID_PATTERN,
 } from "./surface-verify.ts";
 import { SURFACE_ALIASES_PATH } from "./surface-aliases.ts";
+import { loadFixture } from "./fixtures-mcp.ts";
 import {
   callSubnetSurface,
   matchSchemaOperation,
@@ -9598,17 +9599,9 @@ export const MCP_TOOLS = [
       additionalProperties: false,
     },
     async handler(args: Row, ctx: McpCtx) {
-      const surfaceId = requireString(args, "surface_id");
-      // surface_id is part of an R2 key path; reject anything that could escape
-      // the fixtures/ namespace.
-      if (!/^[A-Za-z0-9._:-]+$/.test(surfaceId)) {
-        throw toolError(
-          "invalid_params",
-          "surface_id contains invalid characters.",
-        );
-      }
-      const artifactId = await resolveArtifactSurfaceId(ctx, surfaceId);
-      return loadArtifactData(ctx, `/metagraph/fixtures/${artifactId}.json`);
+      // #7867: shared loadFixture — same surface_id charset gate, deprecated-id
+      // alias resolve, and artifact read GraphQL fixture(surface_id) uses.
+      return loadFixture(asMcpLoaderCtx(ctx), args);
     },
   },
   {

--- a/tests/fixtures-mcp.test.ts
+++ b/tests/fixtures-mcp.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  FIXTURE_SURFACE_ID_PATTERN,
+  fixtureArtifactPath,
+  fixtureMcpError,
+  loadFixture,
+  parseFixtureSurfaceId,
+  resolveFixtureArtifactId,
+} from "../src/fixtures-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type Ctx = Parameters<typeof loadFixture>[0];
+type Deps = Parameters<typeof loadFixture>[2];
+
+const SAMPLE_FIXTURE = {
+  surface_id: "allways-api-health",
+  netuid: 7,
+  kind: "subnet-api",
+  request: { method: "GET", url: "https://api.all-ways.io/health" },
+  response: { status: 200, body: { ok: true } },
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === fixtureArtifactPath("allways-api-health")) {
+    return Promise.resolve({ ok: true, data: SAMPLE_FIXTURE });
+  }
+  if (path === fixtureArtifactPath("7:subnet-api:new")) {
+    return Promise.resolve({
+      ok: true,
+      data: { surface_id: "7:subnet-api:new", response: { status: 200 } },
+    });
+  }
+  if (path === "/metagraph/operational-surfaces.json") {
+    return Promise.resolve({
+      ok: true,
+      data: {
+        surfaces: [
+          {
+            surface_id: "7:subnet-api:new",
+            surface_key: "srf-renamed",
+            netuid: 7,
+            kind: "subnet-api",
+          },
+        ],
+      },
+    });
+  }
+  if (path === "/metagraph/surface-aliases.json") {
+    return Promise.resolve({
+      ok: true,
+      data: {
+        aliases: [
+          {
+            deprecated_id: "7:subnet-api:old",
+            surface_key: "srf-renamed",
+            current_id: "7:subnet-api:new",
+            netuid: 7,
+            kind: "subnet-api",
+          },
+        ],
+      },
+    });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("fixtures-mcp (#7867)", () => {
+  test("fixtureMcpError is shaped for toolError handling", () => {
+    const err = fixtureMcpError("invalid_params", "bad id");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("parseFixtureSurfaceId validates surface_id", () => {
+    assert.equal(
+      parseFixtureSurfaceId({ surface_id: "allways-api-health" }),
+      "allways-api-health",
+    );
+    assert.ok(FIXTURE_SURFACE_ID_PATTERN.test("7:subnet-api:new_v2"));
+    assert.throws(
+      () => parseFixtureSurfaceId({}),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => parseFixtureSurfaceId({ surface_id: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => parseFixtureSurfaceId({ surface_id: "../secrets" }),
+      (err: Row) =>
+        err.code === "invalid_params" && /invalid characters/.test(err.message),
+    );
+  });
+
+  test("loadFixture returns the baked fixture", async () => {
+    const out = (await loadFixture(
+      { env: {}, readArtifact } as unknown as Ctx,
+      { surface_id: "allways-api-health" },
+    )) as Row;
+    assert.equal(out.surface_id, "allways-api-health");
+    assert.equal((out.response as Row).status, 200);
+  });
+
+  test("loadFixture resolves a deprecated surface_id alias", async () => {
+    const out = (await loadFixture(
+      { env: {}, readArtifact } as unknown as Ctx,
+      { surface_id: "7:subnet-api:old" },
+    )) as Row;
+    assert.equal(out.surface_id, "7:subnet-api:new");
+  });
+
+  test("resolveFixtureArtifactId falls back to the input id when catalogs are cold", async () => {
+    const id = await resolveFixtureArtifactId(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false, code: "artifact_not_found" }),
+      } as unknown as Ctx,
+      "plain-id",
+    );
+    assert.equal(id, "plain-id");
+  });
+
+  test("loadFixture uses an injected readArtifact dep", async () => {
+    const out = (await loadFixture(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as Ctx,
+      { surface_id: "injected" },
+      {
+        readArtifact: async (_env, path) => {
+          if (path.includes("operational-surfaces")) {
+            return { ok: true, data: { surfaces: [] } };
+          }
+          return {
+            ok: true,
+            data: { surface_id: "injected", from: "dep" },
+          };
+        },
+      } as unknown as Deps,
+    )) as Row;
+    assert.equal(out.from, "dep");
+  });
+
+  test("loadFixture maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadFixture({ env: {}, readArtifact } as unknown as Ctx, {
+          surface_id: "missing-fixture",
+        }),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadFixture maps r2_binding_missing to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadFixture(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "r2_binding_missing",
+            }),
+          } as unknown as Ctx,
+          { surface_id: "allways-api-health" },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadFixture maps bare failure to not_found via artifact_unavailable", async () => {
+    await assert.rejects(
+      () =>
+        loadFixture(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as Ctx,
+          { surface_id: "allways-api-health" },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadFixture surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadFixture(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as Ctx,
+          { surface_id: "allways-api-health" },
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /fixtures\/allways-api-health\.json/.test(err.message),
+    );
+  });
+
+  test("loadFixture rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadFixture(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as Ctx,
+          { surface_id: "allways-api-health" },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("resolveFixtureArtifactId uses a direct catalog hit without aliases", async () => {
+    const id = await resolveFixtureArtifactId(
+      { env: {}, readArtifact } as unknown as Ctx,
+      "7:subnet-api:new",
+    );
+    assert.equal(id, "7:subnet-api:new");
+  });
+});

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8480,6 +8480,68 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
     assert.equal(body.data.fixtures, null);
   });
 
+  test("fixture resolves one baked fixture by surface_id (#7867)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/fixtures/allways-api-health.json": {
+        surface_id: "allways-api-health",
+        request: { method: "GET" },
+        response: { status: 200, body: { ok: true } },
+      },
+    });
+    const { status, body } = await gql(
+      '{ fixture(surface_id: "allways-api-health") }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.fixture.surface_id, "allways-api-health");
+    assert.equal(body.data.fixture.response.status, 200);
+  });
+
+  test("fixture degrades to null when the surface_id has no fixture (#7867)", async () => {
+    const { status, body } = await gql(
+      '{ fixture(surface_id: "missing-fixture") }',
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.fixture, null);
+  });
+
+  test("fixture an invalid surface_id is BAD_USER_INPUT (#7867)", async () => {
+    const { body } = await gql('{ fixture(surface_id: "../secrets") }');
+    assert.ok(body.errors?.length > 0);
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
+    assert.equal(body.data?.fixture ?? null, null);
+  });
+
+  test("fixture propagates a non-toolError from the artifact read (#7867)", async () => {
+    const env = {
+      METAGRAPH_R2_LATEST_PREFIX: "latest/",
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              throw new Error("corrupt fixture artifact");
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ fixture(surface_id: "allways-api-health") }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors?.length > 0);
+    assert.equal(body.data?.fixture ?? null, null);
+  });
+
+  test("fixture is priced at the relationship-field complexity weight", () => {
+    assert.equal(FIELD_COMPLEXITY.fixture, FIELD_COMPLEXITY.fixtures);
+  });
+
   test("agent_catalog resolves the global index", async () => {
     const env = fixtureEnv({
       "/metagraph/agent-catalog.json": {


### PR DESCRIPTION
## Summary
- Add `src/fixtures-mcp.ts` `loadFixture` with the same surface_id charset gate, deprecated-id alias resolve, and artifact read `get_fixture` used.
- Add GraphQL `fixture(surface_id: String!): JSON` beside `fixtures`; invalid ids are `BAD_USER_INPUT`, missing fixtures degrade to `null`.
- Point MCP `get_fixture` at the shared loader; cover found / not-found / invalid-id / propagate paths.

Closes #7867

## Test plan
- [x] `npx vitest run tests/fixtures-mcp.test.ts`
- [x] `npx vitest run tests/graphql.test.ts -t fixture`
- [x] `npx vitest run tests/mcp-server.test.ts -t get_fixture`
- [x] Local patch coverage on changed `src/**` lines: 0 misses / 0 partials; `fixtures-mcp.ts` 100% lines/branches
- [x] Private-boundary validation passed
- [ ] CI Validate + codecov/patch green on this PR