### PR TITLE
feat(mcp): add list_subnet_health — the filtered sibling of get_subnet_health

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -146,6 +146,12 @@ import {
   loadSubnetSurfacesList,
 } from "./subnet-surfaces-mcp.ts";
 import {
+  LIST_SUBNET_HEALTH_INSTRUCTIONS,
+  LIST_SUBNET_HEALTH_MCP_TOOL,
+  LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
+  loadSubnetHealthList,
+} from "./subnet-health-mcp.ts";
+import {
   LIST_SUBNET_EVIDENCE_INSTRUCTIONS,
   LIST_SUBNET_EVIDENCE_MCP_TOOL,
   LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA,
@@ -1075,6 +1081,7 @@ export const MCP_INSTRUCTIONS =
   "get_subnet_endpoints one subnet\u0027s endpoint resources, " +
   LIST_SUBNET_ENDPOINTS_INSTRUCTIONS +
   LIST_SUBNET_SURFACES_INSTRUCTIONS +
+  LIST_SUBNET_HEALTH_INSTRUCTIONS +
   "get_subnet_candidates its pending candidate surfaces, " +
   LIST_SUBNET_CANDIDATES_INSTRUCTIONS +
   "get_subnet_evidence " +
@@ -9904,6 +9911,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_SUBNET_HEALTH_MCP_TOOL,
+    async handler(args: Row, ctx: McpCtx) {
+      return loadSubnetHealthList(asMcpLoaderCtx(ctx), args);
+    },
+  },
+  {
     name: "get_subnet_candidates",
     title: "Get one subnet's candidate surfaces",
     description:
@@ -15508,6 +15521,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   },
   list_subnet_endpoints: LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
   list_subnet_surfaces: LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
+  list_subnet_health: LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
   list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
   list_profile_completeness: LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA,
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,

--- a/src/subnet-health-mcp.ts
+++ b/src/subnet-health-mcp.ts
@@ -1,0 +1,294 @@
+// Per-subnet health-surface list loader for MCP parity on
+// GET /api/v1/subnets/{netuid}/health. Applies the same list-query
+// transforms as the REST route over the baked
+// /metagraph/health/subnets/{netuid}.json artifact.
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+
+const HEALTH_SORT_FIELDS = API_QUERY_COLLECTIONS["health-surfaces"].sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+const HEALTH_CLASSIFICATIONS = QUERY_ENUMS.healthClassification;
+const SUBNET_HEALTH_QUERY_FILTER_NAMES = [
+  "kind",
+  "provider",
+  "status",
+  "classification",
+];
+
+export function subnetHealthArtifactPath(netuid: unknown): string {
+  return `/metagraph/health/subnets/${netuid}.json`;
+}
+
+export interface SubnetHealthMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function subnetHealthMcpError(
+  code: string,
+  message: string,
+): SubnetHealthMcpError {
+  const error = new Error(message) as SubnetHealthMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireNetuid(
+  args: Record<string, unknown> | null | undefined,
+): number {
+  const netuid = args?.netuid;
+  if (typeof netuid !== "number" || !Number.isInteger(netuid) || netuid < 0) {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      "netuid must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw subnetHealthMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function subnetHealthQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/subnets/health");
+  requireNetuid(args);
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const classification = optionalEnum(
+    args,
+    "classification",
+    HEALTH_CLASSIFICATIONS,
+  );
+  if (classification) url.searchParams.set("classification", classification);
+  const sort = optionalEnum(args, "sort", HEALTH_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw subnetHealthMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+export interface SubnetHealthListResult {
+  generated_at: unknown;
+  netuid: unknown;
+  surfaces: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadSubnetHealthList(
+  ctx: {
+    env: Env;
+    readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  },
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<SubnetHealthListResult> {
+  const netuid = requireNetuid(args);
+  const queryUrl = subnetHealthQueryUrl(args);
+  const artifactPath = subnetHealthArtifactPath(netuid);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, artifactPath);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw subnetHealthMcpError(
+        "not_found",
+        `No health snapshot exists for netuid ${netuid}.`,
+      );
+    }
+    throw subnetHealthMcpError(
+      code,
+      `Could not load ${artifactPath} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw subnetHealthMcpError(
+      "not_found",
+      `No health snapshot exists for netuid ${netuid}.`,
+    );
+  }
+  const transformed = applyQueryFilters(
+    blob as Record<string, unknown>,
+    queryUrl,
+    "health-surfaces",
+    SUBNET_HEALTH_QUERY_FILTER_NAMES,
+  );
+  if (transformed.error) {
+    throw subnetHealthMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = transformed.meta as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.surfaces) ? (data.surfaces as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    netuid: data.netuid ?? netuid,
+    surfaces: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_SUBNET_HEALTH_INSTRUCTIONS =
+  "list_subnet_health one subnet's per-surface health records with REST " +
+  "list-query filters (kind, provider, status, classification, sort/order, and " +
+  "pagination; mirrors GET /api/v1/subnets/{netuid}/health), ";
+
+export const LIST_SUBNET_HEALTH_MCP_TOOL = {
+  name: "list_subnet_health",
+  title: "List one subnet's per-surface health",
+  description:
+    "Fetch per-surface health records for one subnet by netuid: each monitored " +
+    "surface with its kind, provider, probe-derived status and classification, " +
+    "latency, and last-checked/last-ok times. Filter by kind, provider, status, " +
+    "or classification; sort with sort + order; and page with limit (1-100) / " +
+    "cursor. The filtered sibling of get_subnet_health (raw artifact dump). " +
+    "Mirrors GET /api/v1/subnets/{netuid}/health.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Subnet netuid.",
+        minimum: 0,
+      },
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Filter by surface kind, e.g. 'subnet-api'.",
+      },
+      provider: {
+        type: "string",
+        description: "Filter by provider slug.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Filter by probe-derived health status.",
+      },
+      classification: {
+        type: "string",
+        enum: HEALTH_CLASSIFICATIONS,
+        description: "Filter by probe-derived reachability classification.",
+      },
+      sort: {
+        type: "string",
+        enum: HEALTH_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    required: ["netuid"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_SUBNET_HEALTH_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["surfaces"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    netuid: NULLABLE_INT,
+    surfaces: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -2578,6 +2578,75 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_subnet_health returns filtered health rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/health/subnets/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        surfaces: [
+          {
+            id: "allways-api",
+            netuid: 7,
+            kind: "subnet-api",
+            status: "ok",
+            classification: "live",
+          },
+          {
+            id: "allways-openapi",
+            netuid: 7,
+            kind: "openapi",
+            status: "failed",
+            classification: "dead",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_health",
+      { netuid: 7, status: "ok" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].status, "ok");
+    assert.equal(out.netuid, 7);
+  });
+
+  test("list_subnet_health reports not_found when the artifact is absent", async () => {
+    const res = await callTool(
+      "list_subnet_health",
+      { netuid: 7 },
+      { deps: makeDeps() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /No health snapshot exists for netuid 7/,
+    );
+  });
+
+  test("list_subnet_health payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_subnet_health",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/health/subnets/7.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 7,
+        surfaces: [
+          { id: "allways-api", netuid: 7, kind: "subnet-api", status: "ok" },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_subnet_health",
+      { netuid: 7, limit: 1 },
+      { deps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("list_subnet_surfaces returns filtered surface rows", async () => {
     const deps = makeDeps({
       "/metagraph/surfaces/7.json": {

--- a/tests/subnet-health-mcp.test.ts
+++ b/tests/subnet-health-mcp.test.ts
@@ -1,0 +1,372 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  LIST_SUBNET_HEALTH_INSTRUCTIONS,
+  LIST_SUBNET_HEALTH_MCP_TOOL,
+  LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,
+  loadSubnetHealthList,
+  subnetHealthArtifactPath,
+  subnetHealthMcpError,
+  subnetHealthQueryUrl,
+} from "../src/subnet-health-mcp.ts";
+import type { Row } from "./row-type.ts";
+
+type LoadCtx = Parameters<typeof loadSubnetHealthList>[0];
+type LoadDeps = Parameters<typeof loadSubnetHealthList>[2];
+
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
+
+const NETUID = 7;
+const ARTIFACT = subnetHealthArtifactPath(NETUID);
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  netuid: NETUID,
+  surfaces: [
+    {
+      id: "allways-api",
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      status: "ok",
+      classification: "live",
+    },
+    {
+      id: "allways-openapi",
+      netuid: NETUID,
+      kind: "openapi",
+      provider: "allways",
+      status: "failed",
+      classification: "dead",
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("subnet-health-mcp", () => {
+  test("subnetHealthMcpError is shaped for MCP toolError handling", () => {
+    const err = subnetHealthMcpError("invalid_params", "bad status");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("subnetHealthQueryUrl validates filters and cursor", () => {
+    const url = subnetHealthQueryUrl({
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider: "allways",
+      status: "ok",
+      classification: "live",
+      sort: "status",
+      order: "asc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("provider"), "allways");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("classification"), "live");
+    assert.equal(url.searchParams.get("sort"), "status");
+    assert.equal(url.searchParams.get("order"), "asc");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("subnetHealthQueryUrl rejects missing netuid", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({}),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects invalid status and classification", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, status: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, classification: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects empty provider and invalid sort", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, provider: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, sort: "not_a_column" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects non-string provider and invalid order", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, provider: 42 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, order: "sideways" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = subnetHealthQueryUrl({ netuid: NETUID, limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetHealthQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = subnetHealthQueryUrl({ netuid: NETUID, limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("subnetHealthQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects a fractional cursor", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => subnetHealthQueryUrl({ netuid: NETUID, cursor: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("subnetHealthQueryUrl clamps limit above the MCP maximum", () => {
+    const url = subnetHealthQueryUrl({ netuid: NETUID, limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("loadSubnetHealthList returns filtered rows with pagination meta", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { netuid: NETUID, status: "ok" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].status, "ok");
+    assert.equal(out.netuid, NETUID);
+  });
+
+  test("loadSubnetHealthList filters by classification", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { netuid: NETUID, classification: "dead" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.surfaces[0].classification, "dead");
+  });
+
+  test("loadSubnetHealthList sorts and pages the collection", async () => {
+    const out = await loadSubnetHealthList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { netuid: NETUID, sort: "status", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadSubnetHealthList uses an injected readArtifact dep", async () => {
+    const out = await loadSubnetHealthList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as LoadCtx,
+      { netuid: 0 },
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            surfaces: [{ netuid: 0, kind: "docs" }],
+          },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.surfaces[0].netuid, 0);
+  });
+
+  test("loadSubnetHealthList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetHealthList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" &&
+        /health\/subnets\/7\.json/.test(err.message),
+    );
+  });
+
+  test("loadSubnetHealthList rejects an invalid list-query transform", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      error: { message: "bad filter" },
+    } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
+    try {
+      await assert.rejects(
+        () =>
+          loadSubnetHealthList(
+            { env: {}, readArtifact } as unknown as LoadCtx,
+            { netuid: NETUID },
+          ),
+        (err: Row) => err.code === "invalid_params",
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetHealthList omits nullable artifact metadata when absent", async () => {
+    const out = await loadSubnetHealthList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: [{ netuid: 0, kind: "docs" }] },
+        }),
+      } as unknown as LoadCtx,
+      { netuid: 0 },
+    );
+    assert.equal(out.generated_at, null);
+  });
+
+  test("loadSubnetHealthList treats a non-array surfaces key as empty", async () => {
+    const out = await loadSubnetHealthList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { surfaces: null },
+        }),
+      } as unknown as LoadCtx,
+      { netuid: NETUID },
+    );
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadSubnetHealthList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: [{ netuid: 9 }, { netuid: 9 }] },
+      meta: {},
+    } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
+    try {
+      const out = await loadSubnetHealthList(
+        { env: {}, readArtifact } as unknown as LoadCtx,
+        { netuid: NETUID },
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadSubnetHealthList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadSubnetHealthList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as LoadCtx,
+          { netuid: NETUID },
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadSubnetHealthList rejects missing netuid", async () => {
+    await assert.rejects(
+      () =>
+        loadSubnetHealthList(
+          { env: {}, readArtifact } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_SUBNET_HEALTH_MCP_TOOL.name, "list_subnet_health");
+    assert.match(LIST_SUBNET_HEALTH_INSTRUCTIONS, /list_subnet_health/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_SUBNET_HEALTH_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_subnet_health", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_subnet_health/);
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_subnet_health");
+    assert.ok(tool);
+    assert.equal(tool.title, "List one subnet's per-surface health");
+  });
+});


### PR DESCRIPTION
## Context

`GET /api/v1/subnets/{netuid}/health` supports `kind, provider, status, classification, sort, order, limit, cursor`, but the only MCP tool for it (`get_subnet_health`) dumps the raw baked artifact with **zero filters** — the same gap `list_subnet_surfaces` / `list_subnet_endpoints` already closed for their routes.

## Change

- **New `src/subnet-health-mcp.ts`** (cloning `src/subnet-endpoints-mcp.ts`) exporting `list_subnet_health(netuid, kind, provider, status, classification, sort, order, limit, cursor)` with full REST filter parity over the baked `/metagraph/health/subnets/{netuid}.json` artifact via the shared `health-surfaces` query collection. No filtering re-implemented.
- **Registered** in the mcp-server tool registry, instructions, and output-schema map. `get_subnet_health` left untouched.

## Deliverables

- [x] New `src/subnet-health-mcp.ts` exporting `list_subnet_health` with full REST filter parity
- [x] Tool registered in the mcp-server tool object
- [x] Test coverage: `status` filter and `classification` filter

## Tests

Full module suite (28 tests) covering every filter/sort/cursor path + rejections, limit clamping, and all loader paths — **plus 3 `callTool` tests** driving the registered tool end-to-end so the registration handler is covered. `validate:mcp` passes (204 tools), typecheck clean, eslint + prettier clean, public-safety scan passes, **100% patch coverage** across both changed files.

Closes #7901