### PR TITLE
chore(ci): per-PR runner reductions — merge test+checks, job-level gating, draft skips, one-runner previews

### DIFF
--- a/.github/actions/deploy-ui-preview/action.yml
+++ b/.github/actions/deploy-ui-preview/action.yml
@@ -1,0 +1,180 @@
+name: Deploy UI preview
+description: >-
+  The trusted deploy half of the per-PR preview pipeline, shared by its two call sites so they can
+  never drift (mirrors JSONbored/loopover's identical composite): ui-preview.yml deploys same-repo
+  PRs inline in the build job, and ui-preview-deploy.yml deploys fork PRs from the workflow_run
+  trust boundary. It validates a built .output bundle, writes the preview Wrangler config HERE
+  (never taken from the PR -- a fork cannot control bindings, routes, or vars; the untrusted
+  build's own generated wrangler.json is never read), uploads a 0%-traffic preview version (a
+  workers.dev URL; wrangler only uploads the bundle, it never executes it), and records the GitHub
+  Deployment + success status that loopover's review bot reads for the "after" screenshot. Callers
+  must have Node available (actions/setup-node) before invoking, and keep their own
+  failure()-gated step that records a `failure` deployment_status (that step is caller-specific:
+  it must also catch failures of the caller's OWN earlier steps, which this action cannot see).
+inputs:
+  pr-number:
+    description: The pull request number this preview belongs to (the review bot re-reviews it on success).
+    required: true
+  head-sha:
+    description: The PR head SHA the deployment record points at. Pass only GitHub-set values, never fork-supplied data.
+    required: true
+  dist-dir:
+    description: Path to the built Nitro output (server/ + public/), relative to the workspace.
+    required: true
+  cloudflare-api-token:
+    description: Cloudflare API token with "Workers Scripts:Edit" on the account.
+    required: true
+  cloudflare-account-id:
+    description: The Cloudflare account id that owns metagraphed-ui.
+    required: true
+  github-token:
+    description: Token with deployments:write, used to record the Deployment for the review bot.
+    required: true
+outputs:
+  preview_url:
+    description: The workers.dev preview URL the upload produced.
+    value: ${{ steps.upload.outputs.preview_url }}
+runs:
+  using: composite
+  steps:
+    # Pinned to this repo's own root wrangler devDependency version, installed globally: the fork
+    # call site never checks out the repo tree the bundle came from, so node_modules/wrangler isn't
+    # available there.
+    - name: Install trusted Wrangler
+      shell: bash
+      run: npm install --global wrangler@4.110.0
+
+    # The bundle may have been produced by an UNTRUSTED build (fork code; harmless for the trusted
+    # same-repo call site, where the same checks still catch build anomalies). Validate it before
+    # handing it to wrangler: reject symlinks (a path-traversal / exfil vector when the bundle is
+    # processed), require the expected SSR build structure, and allowlist file extensions so a
+    # malicious build can't smuggle scripts/binaries/unexpected paths into the deploy.
+    - name: Validate dist bundle
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "${{ inputs.dist-dir }}"
+        # 1) No symlinks anywhere in the bundle.
+        symlinks="$(find . -type l)"
+        if [ -n "$symlinks" ]; then
+          echo "::error::Bundle contains symlinks — refusing to deploy:"
+          printf '%s\n' "$symlinks"
+          exit 1
+        fi
+        # 2) Required SSR build structure (server worker entry + public assets dir — apps/ui's own
+        #    Nitro cloudflare-module output names it "public", not "client").
+        test -f server/index.mjs || { echo "::error::bundle missing server/index.mjs"; exit 1; }
+        test -d public || { echo "::error::bundle missing public/ assets dir"; exit 1; }
+        # 3) Allowlist file extensions — fail on anything that isn't a normal web/build output (blocks
+        #    smuggled scripts/binaries). A few extensionless CF asset files are explicitly permitted.
+        unexpected="$(find . -regextype posix-extended -type f \
+          -not -iregex '.*\.(mjs|js|cjs|map|json|css|html?|txt|svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|ttf|otf|eot|wasm|xml|webmanifest|md|csv|zip|wgsl|glb|gltf)$' \
+          -not -name '_headers' -not -name '_redirects' -not -name '_routes.json' -not -name '.assetsignore')"
+        if [ -n "$unexpected" ]; then
+          echo "::error::Bundle contains unexpected file types — refusing to deploy:"
+          printf '%s\n' "$unexpected"
+          exit 1
+        fi
+        echo "Bundle validated: no symlinks, expected SSR structure, allowlisted file types only."
+
+    # The Wrangler config is written HERE (trusted) — never taken from the PR — so a fork cannot
+    # control bindings, routes, or vars. It points at the validated bundle. It deliberately OMITS the
+    # production custom-domain route (metagraph.sh): `wrangler versions upload` creates a 0%-traffic
+    # preview version (a workers.dev URL) and applies no routes, so the route is unused here — and
+    # omitting it guarantees that even a future switch to `wrangler deploy` could never point
+    # fork-built code at the production domain. Do not add a `routes` block to this preview config.
+    # Deliberately NOT the wrangler.json the untrusted build step generated — a malicious PR could
+    # otherwise smuggle bindings/vars through apps/ui/wrangler.jsonc.
+    - name: Write trusted preview Wrangler config
+      shell: bash
+      run: |
+        cat > "${{ inputs.dist-dir }}/server/wrangler.preview.json" <<'JSON'
+        {
+          "compatibility_date": "2026-07-17",
+          "name": "metagraphed-ui",
+          "workers_dev": true,
+          "preview_urls": true,
+          "compatibility_flags": ["nodejs_compat"],
+          "placement": {
+            "mode": "smart"
+          },
+          "observability": {
+            "enabled": true,
+            "logs": {
+              "enabled": true,
+              "head_sampling_rate": 1
+            },
+            "traces": {
+              "enabled": true,
+              "head_sampling_rate": 1
+            }
+          },
+          "vars": {
+            "VITE_METAGRAPH_API_BASE": "https://api.metagraph.sh"
+          },
+          "main": "index.mjs",
+          "assets": {
+            "binding": "ASSETS",
+            "directory": "../public"
+          },
+          "no_bundle": true,
+          "rules": [
+            {
+              "type": "ESModule",
+              "globs": ["**/*.mjs", "**/*.js"]
+            }
+          ]
+        }
+        JSON
+
+    - name: Upload preview version
+      id: upload
+      shell: bash
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-token }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare-account-id }}
+      run: |
+        set -o pipefail
+        out=$(wrangler versions upload --config "${{ inputs.dist-dir }}/server/wrangler.preview.json" 2>&1 | tee /dev/stderr)
+        # Take a workers.dev URL that belongs to the metagraphed-ui worker, so any other URL in the
+        # logs (or a changed output format) can't be recorded as the preview by mistake. Tolerant of
+        # the version-alias prefix (`<alias>-metagraphed-ui.<sub>.workers.dev`).
+        url=$(printf '%s\n' "$out" | grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' | grep -i 'metagraphed-ui' | head -n1)
+        if [ -z "$url" ]; then
+          echo "::error::Could not parse an expected metagraphed-ui preview URL from wrangler output"
+          exit 1
+        fi
+        echo "preview_url=$url" >> "$GITHUB_OUTPUT"
+        echo "Preview: $url"
+
+    - name: Record deployment for loopover
+      if: ${{ steps.upload.outputs.preview_url != '' }}
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const url = ${{ toJSON(steps.upload.outputs.preview_url) }};
+          const sha = ${{ toJSON(inputs.head-sha) }};
+          const prNumber = Number(${{ toJSON(inputs.pr-number) }});
+          const deployment = await github.rest.repos.createDeployment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: sha,
+            environment: `preview/pr-${prNumber}`,
+            auto_merge: false,
+            required_contexts: [],
+            transient_environment: true,
+            description: "metagraphed UI preview",
+            // loopover's review bot reads `pr` here to re-review this exact PR once the preview is live.
+            payload: JSON.stringify({ pr: prNumber, head_sha: sha }),
+          });
+          await github.rest.repos.createDeploymentStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            deployment_id: deployment.data.id,
+            state: "success",
+            environment: `preview/pr-${prNumber}`,
+            environment_url: url,
+            description: "Preview ready",
+          });
+          core.notice(`Preview deployment recorded for PR #${prNumber}: ${url}`);

--- a/.github/workflows/ui-preview-deploy.yml
+++ b/.github/workflows/ui-preview-deploy.yml
@@ -1,12 +1,14 @@
 name: UI Preview Deploy
 
-# Deploy half of the fork-safe per-PR preview pipeline (see "UI Preview Build"'s own header for the
-# full rationale — mirrors JSONbored/loopover's identical ui-preview-deploy.yml). Triggered when "UI
-# Preview Build" completes. Because it runs on `workflow_run`, GitHub always executes the workflow
-# definition from the DEFAULT BRANCH (never the fork's), so it is trusted and may use secrets. It
-# downloads the built artifact (it never checks out or runs PR/fork source — it only uploads the
-# already-built bundle), deploys a transient preview version, and records the GitHub Deployment +
-# status that loopover's review bot reads to render the "after" screenshot.
+# FORK-ONLY deploy half of the per-PR preview pipeline (since 2026-07-24 — same-repo PRs deploy
+# inline in ui-preview.yml's build-deploy job, and this job skips runner-free for their builds;
+# mirrors JSONbored/loopover's identical change). Triggered when "UI Preview Build" completes.
+# Because it runs on `workflow_run`, GitHub always executes the workflow definition from the DEFAULT
+# BRANCH (never the fork's), so it is trusted and may use secrets. It downloads the built artifact
+# (the only checkout below is of the default branch, solely to invoke the shared local composite
+# action — it never checks out or runs PR/fork source), deploys a transient preview version via
+# .github/actions/deploy-ui-preview, and records the GitHub Deployment + status that loopover's
+# review bot reads to render the "after" screenshot.
 #
 # Security boundary: the BUILD ran fork code with NO secrets; this DEPLOY has secrets but runs NO fork
 # code (wrangler only uploads the bundle — fork code executes solely inside the isolated workers.dev
@@ -25,7 +27,7 @@ permissions:
   contents: read
   actions: read # download the build artifact from the triggering run
   deployments: write # record the preview Deployment loopover's review bot reads
-  pull-requests: read # resolve the (often fork) PR for this build by matching head SHA
+  pull-requests: read # resolve the fork PR for this build by matching head SHA
 
 concurrency:
   group: ui-preview-deploy-${{ github.event.workflow_run.head_sha }}
@@ -34,16 +36,18 @@ concurrency:
 jobs:
   deploy:
     name: Deploy UI preview version
-    # Bind the ONE job that holds Cloudflare credentials to a GitHub deployment environment, so the org
-    # can attach approval gating and/or environment-scoped secrets to it. Unprotected by default (so
-    # previews stay automatic); add required reviewers in Settings → Environments → preview to require a
-    # manual approval before any (fork) preview deploys.
+    # Bind the ONE fork-facing job that holds Cloudflare credentials to a GitHub deployment
+    # environment, so the org can attach approval gating and/or environment-scoped secrets to it.
+    # Unprotected by default (so previews stay automatic); add required reviewers in Settings →
+    # Environments → preview to require a manual approval before any fork preview deploys.
     environment:
       name: preview
-      url: ${{ steps.upload.outputs.preview_url }}
-    # Only successful build runs that originated from a pull_request (incl forks). A path-skipped or
-    # failed build still fires workflow_run with a non-success conclusion — ignore those.
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+      url: ${{ steps.deploy.outputs.preview_url }}
+    # Only successful build runs that originated from a FORK pull_request: same-repo PRs deploy
+    # inline in ui-preview.yml (their build workflow still completes and fires this trigger — the
+    # repo comparison below is what lets those runs skip without consuming a runner). A path-skipped
+    # or failed build still fires workflow_run with a non-success conclusion — ignore those too.
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name != github.event.workflow_run.repository.full_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -60,145 +64,35 @@ jobs:
             echo "::notice::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set — skipping preview deploy (before-only screenshots)."
           fi
 
+      # TRUSTED checkout of the default branch (github.sha for a workflow_run event is the default
+      # branch head) — required only so the local `uses: ./.github/actions/deploy-ui-preview`
+      # reference below can find its action.yml. Never the fork's code.
+      - name: Checkout default branch
+        if: steps.cfg.outputs.ready == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Setup Node
         if: steps.cfg.outputs.ready == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.23.1
 
-      # Pinned to this repo's own root wrangler devDependency version, installed globally since this
-      # job never checks out the repo (only the artifact) so node_modules/wrangler isn't available.
-      - name: Install trusted Wrangler
+      # Resolve the fork PR this build belongs to BEFORE deploying, so the composite can record the
+      # deployment against it. Both easy signals are EMPTY for fork PRs (the only PRs that reach this
+      # job now): workflow_run.pull_requests is empty for cross-repo runs, and the commit→PR
+      # association API doesn't index a fork-head commit from the base repo. So we ALSO match the
+      # open PR whose head points at this exact build SHA — head.sha is GitHub-set (the base repo
+      # tracks the fork head as refs/pull/N/head), so it's safe to trust even for forks.
+      - name: Resolve PR for this build
+        id: pr
         if: steps.cfg.outputs.ready == 'true'
-        run: npm install --global wrangler@4.110.0
-
-      # Cross-run download: the artifact lives on the triggering build run, not this one.
-      - name: Download built UI artifact
-        if: steps.cfg.outputs.ready == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ui-preview-dist
-          path: preview-dist
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      # The artifact was produced by the UNTRUSTED build (fork code). Validate it before handing it to
-      # wrangler: reject symlinks (a path-traversal / exfil vector when the bundle is processed), require
-      # the expected SSR build structure, and allowlist file extensions so a malicious build can't smuggle
-      # scripts/binaries/unexpected paths into the deploy.
-      - name: Validate downloaded artifact
-        if: steps.cfg.outputs.ready == 'true'
-        run: |
-          set -euo pipefail
-          cd preview-dist
-          # 1) No symlinks anywhere in the bundle.
-          symlinks="$(find . -type l)"
-          if [ -n "$symlinks" ]; then
-            echo "::error::Artifact contains symlinks — refusing to deploy:"
-            printf '%s\n' "$symlinks"
-            exit 1
-          fi
-          # 2) Required SSR build structure (server worker entry + public assets dir — apps/ui's own
-          #    Nitro cloudflare-module output names it "public", not "client").
-          test -f server/index.mjs || { echo "::error::artifact missing server/index.mjs"; exit 1; }
-          test -d public || { echo "::error::artifact missing public/ assets dir"; exit 1; }
-          # 3) Allowlist file extensions — fail on anything that isn't a normal web/build output (blocks
-          #    smuggled scripts/binaries). A few extensionless CF asset files are explicitly permitted.
-          unexpected="$(find . -regextype posix-extended -type f \
-            -not -iregex '.*\.(mjs|js|cjs|map|json|css|html?|txt|svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|ttf|otf|eot|wasm|xml|webmanifest|md|csv|zip|wgsl|glb|gltf)$' \
-            -not -name '_headers' -not -name '_redirects' -not -name '_routes.json' -not -name '.assetsignore')"
-          if [ -n "$unexpected" ]; then
-            echo "::error::Artifact contains unexpected file types — refusing to deploy:"
-            printf '%s\n' "$unexpected"
-            exit 1
-          fi
-          echo "Artifact validated: no symlinks, expected SSR structure, allowlisted file types only."
-
-      # The Wrangler config is written HERE (trusted) — never taken from the PR — so a fork cannot
-      # control bindings, routes, or vars. It points at the downloaded built bundle. It deliberately
-      # OMITS the production custom-domain route (metagraph.sh): `wrangler versions upload` creates a
-      # 0%-traffic preview version (a workers.dev URL) and applies no routes, so the route is unused
-      # here — and omitting it guarantees that even a future switch to `wrangler deploy` could never
-      # point fork-built code at the production domain. Do not add a `routes` block to this preview
-      # config. Deliberately NOT the wrangler.json the untrusted build step generated (excluded from
-      # the uploaded artifact) — a malicious PR could otherwise smuggle bindings/vars through
-      # apps/ui/wrangler.jsonc.
-      - name: Write trusted preview Wrangler config
-        if: steps.cfg.outputs.ready == 'true'
-        run: |
-          cat > preview-dist/server/wrangler.preview.json <<'JSON'
-          {
-            "compatibility_date": "2026-07-17",
-            "name": "metagraphed-ui",
-            "workers_dev": true,
-            "preview_urls": true,
-            "compatibility_flags": ["nodejs_compat"],
-            "placement": {
-              "mode": "smart"
-            },
-            "observability": {
-              "enabled": true,
-              "logs": {
-                "enabled": true,
-                "head_sampling_rate": 1
-              },
-              "traces": {
-                "enabled": true,
-                "head_sampling_rate": 1
-              }
-            },
-            "vars": {
-              "VITE_METAGRAPH_API_BASE": "https://api.metagraph.sh"
-            },
-            "main": "index.mjs",
-            "assets": {
-              "binding": "ASSETS",
-              "directory": "../public"
-            },
-            "no_bundle": true,
-            "rules": [
-              {
-                "type": "ESModule",
-                "globs": ["**/*.mjs", "**/*.js"]
-              }
-            ]
-          }
-          JSON
-
-      - name: Upload preview version
-        id: upload
-        if: steps.cfg.outputs.ready == 'true'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          set -o pipefail
-          out=$(wrangler versions upload --config preview-dist/server/wrangler.preview.json 2>&1 | tee /dev/stderr)
-          # Take a workers.dev URL that belongs to the metagraphed-ui worker, so any other URL in the
-          # logs (or a changed output format) can't be recorded as the preview by mistake. Tolerant of
-          # the version-alias prefix (`<alias>-metagraphed-ui.<sub>.workers.dev`).
-          url=$(printf '%s\n' "$out" | grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' | grep -i 'metagraphed-ui' | head -n1)
-          if [ -z "$url" ]; then
-            echo "::error::Could not parse an expected metagraphed-ui preview URL from wrangler output"
-            exit 1
-          fi
-          echo "preview_url=$url" >> "$GITHUB_OUTPUT"
-          echo "Preview: $url"
-
-      - name: Record deployment for loopover
-        if: steps.cfg.outputs.ready == 'true' && steps.upload.outputs.preview_url != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const url = ${{ toJSON(steps.upload.outputs.preview_url) }};
-            // Trust only the GitHub-set head_sha — never fork-supplied data.
-            const sha = context.payload.workflow_run.head_sha;
+            const sha = context.payload.workflow_run.head_sha; // GitHub-set; never fork-supplied
             const slug = `${context.repo.owner}/${context.repo.repo}`;
-            // Resolve the PR for this build. Both signals below are EMPTY for fork PRs (the common case
-            // here): workflow_run.pull_requests is empty for cross-repo runs, and the commit→PR
-            // association API doesn't index a fork-head commit from the base repo. So we ALSO match the
-            // open PR whose head points at this exact build SHA — head.sha is GitHub-set (the base repo
-            // tracks the fork head as refs/pull/N/head), so it's safe to trust even for forks.
             let prNumber = context.payload.workflow_run.pull_requests?.[0]?.number;
             if (!prNumber) {
               const assoc = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -219,67 +113,49 @@ jobs:
               prNumber = openPrs.find((p) => p.head.sha === sha)?.number;
             }
             if (!prNumber) {
-              core.setFailed(`Could not resolve an open PR for ${sha} — skipping deployment record.`);
+              core.setFailed(`Could not resolve an open PR for ${sha} — skipping deploy.`);
               return;
             }
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: sha,
-              environment: `preview/pr-${prNumber}`,
-              auto_merge: false,
-              required_contexts: [],
-              transient_environment: true,
-              description: "metagraphed UI preview",
-              // loopover's review bot reads `pr` here to re-review this exact PR once the preview is live.
-              payload: JSON.stringify({ pr: prNumber, head_sha: sha }),
-            });
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: deployment.data.id,
-              state: "success",
-              environment: `preview/pr-${prNumber}`,
-              environment_url: url,
-              description: "Preview ready",
-            });
-            core.notice(`Preview deployment recorded for PR #${prNumber}: ${url}`);
+            core.setOutput("number", String(prNumber));
+
+      # Cross-run download: the artifact lives on the triggering build run, not this one.
+      - name: Download built UI artifact
+        if: steps.cfg.outputs.ready == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ui-preview-dist
+          path: preview-dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      # Validation, trusted config, wrangler upload, and the success Deployment record all live in the
+      # shared composite (kept byte-identical with ui-preview.yml's same-repo call site by construction).
+      - name: Deploy preview
+        id: deploy
+        if: steps.cfg.outputs.ready == 'true'
+        uses: ./.github/actions/deploy-ui-preview
+        with:
+          pr-number: ${{ steps.pr.outputs.number }}
+          head-sha: ${{ github.event.workflow_run.head_sha }}
+          dist-dir: preview-dist
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Record FAILED deployment for loopover
         # Runs when an earlier step in this job failed (artifact validation rejected the bundle, the
         # wrangler upload errored, etc.) — i.e. a deploy was attempted but never produced a preview.
-        # Record a `failure` deployment_status so loopover's review bot flips the "after" cell from an
-        # eternal spinner to a terminal "preview deploy failed" card, instead of waiting forever for a
-        # success event that will never come. Gated on CF creds so a credential-less skip records nothing.
-        if: failure() && steps.cfg.outputs.ready == 'true'
+        # Record a `failure` deployment_status so the review bot flips the "after" cell from an
+        # eternal spinner to a terminal "preview deploy failed" card, instead of waiting forever for
+        # a success event that will never come. Gated on CF creds so a credential-less skip records
+        # nothing; reuses the resolution step's PR (if THAT failed, there is nothing to record
+        # against — the resolution step already setFailed with the reason).
+        if: ${{ failure() && steps.cfg.outputs.ready == 'true' && steps.pr.outputs.number != '' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const sha = context.payload.workflow_run.head_sha; // GitHub-set; never fork-supplied
-            const slug = `${context.repo.owner}/${context.repo.repo}`;
-            // Same fork-safe PR resolution as the success step above.
-            let prNumber = context.payload.workflow_run.pull_requests?.[0]?.number;
-            if (!prNumber) {
-              const assoc = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: sha,
-              });
-              prNumber = assoc.data.find((p) => p.state === "open" && p.base.repo.full_name === slug)?.number;
-            }
-            if (!prNumber) {
-              const openPrs = await github.paginate(github.rest.pulls.list, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: "open",
-                per_page: 100,
-              });
-              prNumber = openPrs.find((p) => p.head.sha === sha)?.number;
-            }
-            if (!prNumber) {
-              core.warning(`Preview deploy failed but could not resolve a PR for ${sha} — no failure status recorded.`);
-              return;
-            }
+            const prNumber = Number(${{ toJSON(steps.pr.outputs.number) }});
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -1,29 +1,34 @@
 name: UI Preview Build
 
-# Build half of the fork-safe per-PR preview pipeline. Runs for EVERY PR — including forks — and
-# deliberately WITHOUT secrets (fork PRs get a read-only token): it only produces the built `.output`
-# artifact. The trusted `ui-preview-deploy.yml` (triggered on workflow_run) then deploys that artifact
-# WITH secrets and records the GitHub Deployment that loopover's review bot reads for the "after"
-# screenshot in a PR's visual-preview table.
+# Per-PR preview pipeline, split by trust (reshaped 2026-07-24, mirroring JSONbored/loopover's
+# identical change — one fewer runner slot per same-repo UI push, which is nearly every UI push at
+# this repo's volume):
 #
-# Why this exists: apps/ui deploys to production via Cloudflare Workers Builds (a dashboard-configured
-# git integration on push to main — see apps/ui/vite.config.ts's own header comment), which never
-# surfaces a GitHub-visible signal (no check-run, no deployment, no PR comment) for a branch/PR build,
-# even though it does build one. loopover's preview-discovery chain (Deployments API → commit-check
-# scan → bot PR-comment scan) has nothing to find there, so "after" screenshots never render. This
-# workflow pair mirrors JSONbored/loopover's own identical `ui-preview.yml` / `ui-preview-deploy.yml`
-# pattern (same author, same TanStack Start + Nitro cloudflare-module stack, same problem, already
-# proven in production) rather than depending on Cloudflare's own preview mechanism at all.
+#   SAME-REPO PRs (`build-deploy`): a branch in this repo implies a collaborator, and same-repo
+#   pull_request runs get secrets — so ONE job builds and deploys inline via the shared
+#   .github/actions/deploy-ui-preview composite. No artifact hop, no second runner, and the
+#   workflow_run deploy job skips runner-free.
 #
-# Why split into two workflows: a preview requires building the PR's UI, and building runs the PR's
-# (possibly fork-authored) code. Doing that here with no secret access — and deploying the resulting
-# bundle in a separate trusted step that never executes fork code — is the standard way to give fork
-# PRs previews without exposing Cloudflare credentials to untrusted code.
+#   FORK PRs (`build`): unchanged two-stage boundary. The build runs fork code with NO secrets (fork
+#   PRs get a read-only token) and only produces the built `.output` artifact; the trusted
+#   `ui-preview-deploy.yml` (workflow_run) then deploys that artifact WITH secrets and records the
+#   GitHub Deployment that loopover's review bot reads for the "after" screenshot. Building runs the
+#   PR's (possibly fork-authored) code — doing that with no secret access, and deploying the bundle
+#   in a separate trusted step that never executes fork code, is the standard way to give fork PRs
+#   previews without exposing Cloudflare credentials to untrusted code. Do NOT collapse the fork
+#   path into build-deploy: that boundary is the entire security model.
+#
+# Why this pipeline exists at all: apps/ui deploys to production via Cloudflare Workers Builds (a
+# dashboard-configured git integration on push to main — see apps/ui/vite.config.ts's own header
+# comment), which never surfaces a GitHub-visible signal (no check-run, no deployment, no PR
+# comment) for a branch/PR build, so loopover's preview-discovery chain (Deployments API →
+# commit-check scan → bot PR-comment scan) has nothing to find there and "after" screenshots never
+# render without it.
 
 on:
   pull_request:
     # Explicit list because the default (opened/synchronize/reopened) omits ready_for_review — once the
-    # build job below skips draft PRs, marking a PR ready must itself trigger a real preview build, not
+    # build jobs below skip draft PRs, marking a PR ready must itself trigger a real preview build, not
     # wait for the next push. Mirrors validate.yml's own pull_request.types list.
     types: [opened, synchronize, reopened, ready_for_review]
     # Matches validate.yml's own `run_ui_validation` path filter reasoning: apps/ui consumes
@@ -42,13 +47,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  # ------------------------- SAME-REPO: build + deploy in one runner -------------------------
+  build-deploy:
     name: Build UI preview artifact
-    # Skip draft PRs (anti-abuse): a full npm ci + UI build on every push to a PR nobody has marked
-    # ready for review yet. Mirrors validate.yml's own draft-skip convention for the `ui` job.
-    if: ${{ github.event.pull_request.draft != true }}
+    # Same-repo only (fork PRs take the `build` job below). Skip draft PRs (anti-abuse): a full
+    # npm ci + UI build on every push to a PR nobody has marked ready for review yet.
+    if: ${{ github.event.pull_request.draft != true && github.event.pull_request.head.repo.fork != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      deployments: write # record the preview Deployment loopover's review bot reads
+    # Same environment binding as ui-preview-deploy.yml's job: the org can attach approval gating
+    # and/or environment-scoped secrets to every path that holds Cloudflare credentials.
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.preview_url }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -71,10 +85,102 @@ jobs:
         run: npm ci
 
       # Builds apps/ui only. Nitro's cloudflare-module preset writes the SSR worker entry + static
-      # assets to apps/ui/.output/{server,public} (NOT dist/ — verified against a real local build,
-      # this repo's own build output directory differs from loopover-ui's). VITE_METAGRAPH_API_BASE is
-      # a public URL (apps/ui/.env.example's own documented default), not a secret — points the preview
-      # at the real production API, same as loopover's own preview build does for its own backend.
+      # assets to apps/ui/.output/{server,public}. VITE_METAGRAPH_API_BASE is a public URL
+      # (apps/ui/.env.example's own documented default), not a secret. The generated
+      # .output/server/wrangler.json is IGNORED by the deploy — the composite writes its own trusted
+      # preview config from scratch (see .github/actions/deploy-ui-preview).
+      - name: Build UI
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+          VITE_METAGRAPH_API_BASE: https://api.metagraph.sh
+        run: npm run build --workspace=apps/ui
+
+      # Deploys stay best-effort when the Cloudflare secrets aren't configured (before-only
+      # screenshots) — mirrors ui-preview-deploy.yml's guard.
+      - name: Check Cloudflare secrets
+        id: cfg
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set — skipping preview deploy (before-only screenshots)."
+          fi
+
+      - name: Deploy preview
+        id: deploy
+        if: ${{ steps.cfg.outputs.ready == 'true' }}
+        uses: ./.github/actions/deploy-ui-preview
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          # GitHub-set; the same value the checkout above pinned.
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          dist-dir: apps/ui/.output
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Record FAILED deployment for loopover
+        # A deploy was attempted but never produced a preview (build-side failures skip this via the
+        # cfg gate ordering: cfg only runs after a successful build). Record a `failure`
+        # deployment_status so the review bot flips the "after" cell from an eternal spinner to a
+        # terminal "preview deploy failed" card. Gated on CF creds so a credential-less skip records
+        # nothing.
+        if: ${{ failure() && steps.cfg.outputs.ready == 'true' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha; // GitHub-set; never fork-supplied
+            const prNumber = context.payload.pull_request.number;
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              environment: `preview/pr-${prNumber}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              description: "metagraphed UI preview (failed)",
+              payload: JSON.stringify({ pr: prNumber, head_sha: sha }),
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: "failure",
+              environment: `preview/pr-${prNumber}`,
+              description: "Preview deploy failed",
+            });
+            core.notice(`Recorded FAILED preview deployment for PR #${prNumber}.`);
+
+  # ------------------------- FORK: unprivileged build half only -------------------------
+  build:
+    name: Build UI preview artifact (fork)
+    # Fork PRs only — no secrets here, ever (see the file header). Draft guard as above.
+    if: ${{ github.event.pull_request.draft != true && github.event.pull_request.head.repo.fork == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      # Same build as build-deploy above — see its comment for the output-path/env rationale.
       - name: Build UI
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
@@ -85,7 +191,8 @@ jobs:
       # (server/ + public/) — no secrets, no source needed downstream. Deliberately does NOT upload
       # apps/ui/.output/server/wrangler.json: that file is generated from the untrusted checkout (a
       # malicious PR could edit apps/ui/wrangler.jsonc to smuggle bindings/vars/routes into it), so the
-      # trusted deploy step writes its own wrangler config from scratch instead of trusting this one.
+      # trusted deploy composite writes its own wrangler config from scratch instead of trusting this
+      # one.
       - name: Upload built UI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,10 @@ name: Validate
 
 on:
   pull_request:
+    # Explicit list because the default (opened/synchronize/reopened) omits ready_for_review -- the
+    # heavy jobs below skip draft PRs, so marking a PR ready must itself trigger a real run, not wait
+    # for the next push. Mirrors ui-preview.yml's own types list.
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -28,13 +32,15 @@ concurrency:
 # schemas, code, or CI config — skip build/contract/registry/deploy work, while
 # still reporting a real `success` conclusion (not `skipped`) on every step.
 #
-# The work splits across two parallel jobs that both build: `test` builds then
-# runs the suite + coverage; `checks` builds then runs lint + the ~20 contract /
-# schema / safety validations. They are independent — no validation needs the
-# test results — so two runners make the wall-clock max(test, checks), not the
-# sum. Both build because the suite's reader tests serve R2-only artifacts
-# (registry-summary.json etc.) that have NO committed fallback and only exist
-# after `npm run build`, so a fresh runner must stage them.
+# The suite and the ~20 contract/schema/safety validations run in ONE `test` job (merged
+# 2026-07-24; they were two parallel jobs that each ran their own npm ci + full build). The old
+# split bought wall-clock (max instead of sum) at the cost of a second 30-minute-class runner on
+# EVERY PR -- and at this account's PR volume the shared 20-concurrent-job pool, not wall-clock,
+# is the binding constraint (observed: a 40+-deep starved queue across repos). One job pays one
+# npm ci + one build for both halves. Step order is load-bearing: the contract drift validators
+# MUST precede the build (they compare committed files the build overwrites), the derived-artifact
+# freshness check MUST follow the build and precede the suite (the suite's artifact writers mutate
+# staging trees), and the suite runs last so coverage capture is unaffected.
 jobs:
   # Computes the docs-fast-lane eligibility for the `checks` job below. This is
   # a plain shell `git diff` inline in the trusted workflow — no third-party
@@ -110,6 +116,7 @@ jobs:
       run_workflows_validation: ${{ steps.filter.outputs.run_workflows_validation }}
       run_migrations_validation: ${{ steps.filter.outputs.run_migrations_validation }}
       run_ui_validation: ${{ steps.filter.outputs.run_ui_validation }}
+      run_python_validation: ${{ steps.filter.outputs.run_python_validation }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -131,6 +138,7 @@ jobs:
               echo "run_workflows_validation=true"
               echo "run_migrations_validation=true"
               echo "run_ui_validation=true"
+              echo "run_python_validation=true"
             } >> "$GITHUB_OUTPUT"
             echo "Not a pull_request event (${{ github.event_name }}) -- full validation runs."
             exit 0
@@ -150,6 +158,7 @@ jobs:
               echo "run_workflows_validation=true"
               echo "run_migrations_validation=true"
               echo "run_ui_validation=true"
+              echo "run_python_validation=true"
             } >> "$GITHUB_OUTPUT"
             echo "No changed files detected -- full validation runs."
             exit 0
@@ -175,6 +184,13 @@ jobs:
             echo "run_ui_validation=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_ui_validation=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Same-shape flag for the python job: the Python SDK's hermetic suite reads only python/**,
+          # so a PR with zero changes there cannot affect its result.
+          if grep -qE '^python/' changed-files.txt; then
+            echo "run_python_validation=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_python_validation=false" >> "$GITHUB_OUTPUT"
           fi
 
           # HARD GUARDRAIL: any registry/ path forces full validation,
@@ -202,8 +218,21 @@ jobs:
 
   test:
     name: test
+    needs: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 30 # build + full suite with coverage, the main per-PR gate
+    timeout-minutes: 45 # one npm ci + one build now serves BOTH the suite and the ~20 validators (see the merge note above jobs:)
+    # Skip draft PRs (anti-abuse, mirrors ui-preview.yml): a draft consumed the full heavy fan-out on
+    # every push before anyone marked it ready. Job-level skip is safe here: this repo has ZERO
+    # required status contexts on main (verified via branches/main/protection), and the review
+    # pipeline's fetchLiveCiAggregate buckets skipped identically to success.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft != true }}
+    env:
+      # The docs fast lane + narrow validator skips, unchanged from the old `checks` job -- see the
+      # `changes` job comment above for what each flag proves. Still per-STEP guards (not job-level):
+      # the suite half of this job must run even on a docs-only diff.
+      DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+      RUN_WORKFLOWS_VALIDATION: ${{ needs.changes.outputs.run_workflows_validation }}
+      RUN_MIGRATIONS_VALIDATION: ${{ needs.changes.outputs.run_migrations_validation }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -214,182 +243,6 @@ jobs:
           # (a PR can't start failing just because main moved) and matches what
           # Codecov's patch status is measuring. See the coverage upload steps
           # below for why this specifically also fixes commit attribution.
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22.23.1
-          cache: npm
-          # Without this, setup-node's cache key hashes EVERY package-lock.json
-          # in the tree (root + deploy/wss-lb), so a change to the latter's
-          # lockfile would invalidate this job's cache even though `npm ci`
-          # here only ever reads the root lockfile. packages/client is an npm
-          # workspace (#3066) with no lockfile of its own anymore — its version
-          # bumps land in the root lockfile, which this path already covers.
-          cache-dependency-path: package-lock.json
-
-      - name: Install
-        run: npm ci
-
-      # Stage artifacts before the suite: the reader tests serve R2-only
-      # artifacts that have NO committed fallback (dist/metagraph-r2/metagraph/*,
-      # e.g. registry-summary.json), which only exist after a build.
-      - name: Build artifacts
-        env:
-          METAGRAPH_PRESERVE_PROBE_HEALTH: "1"
-        run: npm run build
-
-      - name: Prepare test reports dir
-        run: mkdir -p reports/junit
-
-      # The suite runs in two non-overlapping passes (see vitest.config.ts's
-      # fileParallelism note). `test:ci` runs the parallelizable bulk — every
-      # file EXCEPT five that race each other (or the shared R2 staging tree)
-      # under parallel execution — concurrently WITH coverage;
-      # `test:ci:artifacts` (the last step below) then runs those five
-      # serially, after coverage is already captured + uploaded. Two
-      # (artifacts.test.mjs, discovery-artifacts.test.mjs) are
-      # filesystem-mutating artifact writers; two more (public-safety.test.mjs,
-      # validate-error-messages.test.mjs) each transiently write/mutate a real
-      # file validate-schemas.ts's own full-registry scan reads, which raced
-      # a concurrent registry scan in another test file (see
-      # public-safety.test.mjs's header comment for the original incident
-      # writeup); refresh-build-summary.test.mjs rewrites the real
-      # build-summary.json at the R2 staging root in place, racing the same
-      # staging tree the artifact writers above touch. All five drive their
-      # work via execFileSync child processes and add zero in-process
-      # coverage, so coverage comes only from `test:ci` and CI still makes a
-      # single Codecov upload.
-      #
-      # NOTE: the `test` job intentionally does NOT participate in the docs
-      # fast lane above. Coverage is a repo-wide delta gate (codecov.yml), not
-      # diff-scoped, so shortcutting it on a docs-only PR would let a docs PR
-      # merge without an accurate coverage report. It's also not the wall-clock
-      # long pole when it does run alongside a fast `checks` job.
-      - name: Test (parallel, with coverage gate)
-        env:
-          VITEST_JUNIT_PATH: reports/junit/vitest.xml
-        run: npm run test:ci
-
-      - name: Verify coverage report exists
-        run: test -s coverage/lcov.info
-
-      # Upload coverage to Codecov — the primary PR coverage gate (delta-based
-      # project + patch, see codecov.yml). vitest's thresholds are now just a
-      # local backstop. Same-repo PRs and main pushes use the repository token;
-      # fork PRs use Codecov's public-repo tokenless upload path instead.
-      # Missing coverage or upload errors fail the test job.
-      #
-      # Explicit override_branch/commit/pr on BOTH paths below: GITHUB_SHA is the
-      # ephemeral refs/pull/:N/merge commit on pull_request events, and the
-      # checkout step above pins to the real head sha instead (so tests run the
-      # contributor's actual commit) -- so auto-detection would otherwise attach
-      # the report to a merge sha that never appears in the PR's own checks list.
-      #
-      # version: pinned, not the action's own 'latest' default (metagraphed#7554's
-      # own CI hit "Could not verify signature" on the CLI's self-download+GPG-verify
-      # step -- root-caused by reading codecov-action's dist/codecov.sh: it builds
-      # the download URL as cli.codecov.io/${CC_VERSION}/..., and with 'latest' that
-      # resolves through Codecov's CDN alias, where the binary/SHA256SUM/.sig can
-      # momentarily disagree across edge nodes -- confirmed transient: a re-run
-      # ~1 min later succeeded with no other change. A pinned version tag is an
-      # immutable, long-since-fully-propagated path, so this class of race can't
-      # recur here. Bump deliberately (not blindly to whatever's newest) if pinning
-      # ever needs to move.
-      - name: Upload coverage to Codecov
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          disable_search: true
-          version: v11.3.1
-          override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-          override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
-          fail_ci_if_error: true
-
-      # override_branch is prefixed with the fork owner (owner:branch): Codecov only treats a branch
-      # string with a colon-separated prefix as "unprotected"/tokenless-eligible; a bare branch name
-      # looks like it could be a real (possibly protected) branch on the base repo and gets rejected with
-      # "Token required because branch is protected" even with zero token configuration anywhere.
-      # codecov-cli's own auto-detection never adds this prefix either (verified in its source), so it
-      # must be supplied explicitly. override_commit/override_pr are unaffected -- that check only
-      # inspects the branch string.
-      - name: Upload coverage to Codecov (fork PR tokenless)
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: ./coverage/lcov.info
-          disable_search: true
-          version: v11.3.1
-          override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
-          override_commit: ${{ github.event.pull_request.head.sha }}
-          override_pr: ${{ github.event.pull_request.number }}
-          fail_ci_if_error: true
-
-      - name: Upload Vitest results to Codecov
-        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./reports/junit/vitest.xml
-          report_type: test_results
-          disable_search: true
-          version: v11.3.1
-          override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
-          override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
-          fail_ci_if_error: false
-
-      - name: Upload Vitest results to Codecov (fork PR tokenless)
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: ./reports/junit/vitest.xml
-          report_type: test_results
-          disable_search: true
-          version: v11.3.1
-          override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
-          override_commit: ${{ github.event.pull_request.head.sha }}
-          override_pr: ${{ github.event.pull_request.number }}
-          fail_ci_if_error: false
-
-      # The two filesystem-mutating artifact writers, run serially LAST so they
-      # never overlap the parallel readers above and coverage is already
-      # uploaded. They mutate the same on-disk artifact tree, so they cannot run
-      # concurrently with each other either — the serial default applies. This is
-      # a pure correctness gate (no coverage); a failure here still fails the job.
-      - name: Test (artifact writers, serial)
-        run: npm run test:ci:artifacts
-
-  checks:
-    name: checks
-    needs: changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 30 # build plus the ~20 contract/schema/registry/safety validators
-    env:
-      # A single guard expression, computed once, that every expensive step
-      # below gates on. Deliberately a per-STEP `if:`, not a job-level `if:`
-      # on `checks` itself: a job-level skip reports conclusion=skipped, and
-      # while Gittensory's own CI aggregate (fetchLiveCiAggregate) buckets
-      # skipped identically to success, GitHub's native required-status-check
-      # semantics for a *future* required context are not governed by that
-      # code path. Per-step guards keep this job always reporting a real
-      # success/failure conclusion, which is unconditionally safe under both
-      # systems, at the cost of a few extra seconds on the one self-hosted
-      # runner for `Setup Node` + `Install` + the guard evaluation itself.
-      DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
-      RUN_WORKFLOWS_VALIDATION: ${{ needs.changes.outputs.run_workflows_validation }}
-      RUN_MIGRATIONS_VALIDATION: ${{ needs.changes.outputs.run_migrations_validation }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          # Same pin as the `test` job's checkout -- keep both jobs testing the
-          # identical commit.
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       # Compute the deletion-filtered list of files this PR submits, inline in the
@@ -420,8 +273,12 @@ jobs:
         with:
           node-version: 22.23.1
           cache: npm
-          # See the `test` job's Setup Node step for why this is needed --
-          # same over-scoped-cache-key issue applies here.
+          # Without this, setup-node's cache key hashes EVERY package-lock.json
+          # in the tree (root + deploy/wss-lb), so a change to the latter's
+          # lockfile would invalidate this job's cache even though `npm ci`
+          # here only ever reads the root lockfile. packages/client is an npm
+          # workspace (#3066) with no lockfile of its own anymore — its version
+          # bumps land in the root lockfile, which this path already covers.
           cache-dependency-path: package-lock.json
 
       - name: Install
@@ -482,8 +339,12 @@ jobs:
           npm run validate:generated-client
           npm run validate:committed-seed
 
+      # Stage artifacts for BOTH halves: the suite's reader tests serve R2-only artifacts with NO
+      # committed fallback (dist/metagraph-r2/metagraph/*), and every post-build validator below reads
+      # the fresh tree. Unconditional (no DOCS_ONLY skip): the suite runs on the docs fast lane too --
+      # coverage is a repo-wide delta gate, exactly as the pre-merge `test` job always built. MUST run
+      # AFTER the contract drift validators above (they compare the committed files this overwrites).
       - name: Build artifacts
-        if: env.DOCS_ONLY != 'true'
         env:
           METAGRAPH_PRESERVE_PROBE_HEALTH: "1"
         run: npm run build
@@ -679,14 +540,144 @@ jobs:
       - name: Validate private boundary
         run: npm run validate:private-boundary
 
+      - name: Prepare test reports dir
+        run: mkdir -p reports/junit
+
+      # The suite runs in two non-overlapping passes (see vitest.config.ts's
+      # fileParallelism note). `test:ci` runs the parallelizable bulk — every
+      # file EXCEPT five that race each other (or the shared R2 staging tree)
+      # under parallel execution — concurrently WITH coverage;
+      # `test:ci:artifacts` (the last step below) then runs those five
+      # serially, after coverage is already captured + uploaded. Two
+      # (artifacts.test.mjs, discovery-artifacts.test.mjs) are
+      # filesystem-mutating artifact writers; two more (public-safety.test.mjs,
+      # validate-error-messages.test.mjs) each transiently write/mutate a real
+      # file validate-schemas.ts's own full-registry scan reads, which raced
+      # a concurrent registry scan in another test file (see
+      # public-safety.test.mjs's header comment for the original incident
+      # writeup); refresh-build-summary.test.mjs rewrites the real
+      # build-summary.json at the R2 staging root in place, racing the same
+      # staging tree the artifact writers above touch. All five drive their
+      # work via execFileSync child processes and add zero in-process
+      # coverage, so coverage comes only from `test:ci` and CI still makes a
+      # single Codecov upload.
+      #
+      # NOTE: the `test` job intentionally does NOT participate in the docs
+      # fast lane above. Coverage is a repo-wide delta gate (codecov.yml), not
+      # diff-scoped, so shortcutting it on a docs-only PR would let a docs PR
+      # merge without an accurate coverage report. It's also not the wall-clock
+      # long pole when it does run alongside a fast `checks` job.
+      - name: Test (parallel, with coverage gate)
+        env:
+          VITEST_JUNIT_PATH: reports/junit/vitest.xml
+        run: npm run test:ci
+
+      - name: Verify coverage report exists
+        run: test -s coverage/lcov.info
+
+      # Upload coverage to Codecov — the primary PR coverage gate (delta-based
+      # project + patch, see codecov.yml). vitest's thresholds are now just a
+      # local backstop. Same-repo PRs and main pushes use the repository token;
+      # fork PRs use Codecov's public-repo tokenless upload path instead.
+      # Missing coverage or upload errors fail the test job.
+      #
+      # Explicit override_branch/commit/pr on BOTH paths below: GITHUB_SHA is the
+      # ephemeral refs/pull/:N/merge commit on pull_request events, and the
+      # checkout step above pins to the real head sha instead (so tests run the
+      # contributor's actual commit) -- so auto-detection would otherwise attach
+      # the report to a merge sha that never appears in the PR's own checks list.
+      #
+      # version: pinned, not the action's own 'latest' default (metagraphed#7554's
+      # own CI hit "Could not verify signature" on the CLI's self-download+GPG-verify
+      # step -- root-caused by reading codecov-action's dist/codecov.sh: it builds
+      # the download URL as cli.codecov.io/${CC_VERSION}/..., and with 'latest' that
+      # resolves through Codecov's CDN alias, where the binary/SHA256SUM/.sig can
+      # momentarily disagree across edge nodes -- confirmed transient: a re-run
+      # ~1 min later succeeded with no other change. A pinned version tag is an
+      # immutable, long-since-fully-propagated path, so this class of race can't
+      # recur here. Bump deliberately (not blindly to whatever's newest) if pinning
+      # ever needs to move.
+      - name: Upload coverage to Codecov
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          disable_search: true
+          version: v11.3.1
+          override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          fail_ci_if_error: true
+
+      # override_branch is prefixed with the fork owner (owner:branch): Codecov only treats a branch
+      # string with a colon-separated prefix as "unprotected"/tokenless-eligible; a bare branch name
+      # looks like it could be a real (possibly protected) branch on the base repo and gets rejected with
+      # "Token required because branch is protected" even with zero token configuration anywhere.
+      # codecov-cli's own auto-detection never adds this prefix either (verified in its source), so it
+      # must be supplied explicitly. override_commit/override_pr are unaffected -- that check only
+      # inspects the branch string.
+      - name: Upload coverage to Codecov (fork PR tokenless)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage/lcov.info
+          disable_search: true
+          version: v11.3.1
+          override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
+          override_commit: ${{ github.event.pull_request.head.sha }}
+          override_pr: ${{ github.event.pull_request.number }}
+          fail_ci_if_error: true
+
+      - name: Upload Vitest results to Codecov
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./reports/junit/vitest.xml
+          report_type: test_results
+          disable_search: true
+          version: v11.3.1
+          override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          fail_ci_if_error: false
+
+      - name: Upload Vitest results to Codecov (fork PR tokenless)
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./reports/junit/vitest.xml
+          report_type: test_results
+          disable_search: true
+          version: v11.3.1
+          override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
+          override_commit: ${{ github.event.pull_request.head.sha }}
+          override_pr: ${{ github.event.pull_request.number }}
+          fail_ci_if_error: false
+
+      # The two filesystem-mutating artifact writers, run serially LAST so they
+      # never overlap the parallel readers above and coverage is already
+      # uploaded. They mutate the same on-disk artifact tree, so they cannot run
+      # concurrently with each other either — the serial default applies. This is
+      # a pure correctness gate (no coverage); a failure here still fails the job.
+      - name: Test (artifact writers, serial)
+        run: npm run test:ci:artifacts
+
   # The Python SDK (python/) ships its own hermetic unittest suite (37 cases) but
   # was never run in CI — a regression in retry/backoff, Retry-After capping,
   # pagination, JSON-RPC unwrap, or the SSRF-safe redirect handler could land on a
   # PR (and reach PyPI) despite covering tests existing. This job runs it on every
-  # PR. It is independent of the Node jobs, so it adds no wall-clock to the
-  # test/checks long poles.
+  # PR that touches python/**. It is independent of the Node job, so it adds no wall-clock to the
+  # `test` long pole.
   python:
     name: python
+    needs: changes
+    # Path-gated at the JOB level (safe: zero required status contexts on main, and the review
+    # pipeline buckets skipped as success -- see the `test` job comment): the hermetic suite reads
+    # only python/**, so a PR with zero changes there cannot change its result. Draft PRs skip
+    # entirely, same as every heavy job here. Push/dispatch runs are unaffected.
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft != true && needs.changes.outputs.run_python_validation == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15 # hermetic unittest suite (37 cases), no network
     steps:
@@ -703,19 +694,19 @@ jobs:
         working-directory: python
         run: uv run --extra test python -m unittest discover -s tests
 
-  # apps/ui (TanStack Start/Vite frontend, #3062) — entirely independent of the
-  # backend jobs above: a backend-only PR never installs or builds this tree,
-  # and vice versa. Gated on run_ui_validation (see the `changes` job comment)
-  # via the SAME per-step guard pattern `checks` uses for its docs fast lane —
-  # never a job-level `if:`, so this job always reports a real success/failure
-  # conclusion rather than `skipped`.
+  # apps/ui (TanStack Start/Vite frontend, #3062) — entirely independent of the backend job above:
+  # a backend-only PR never installs or builds this tree, and vice versa. Gated on run_ui_validation
+  # (see the `changes` job comment) at the JOB level since 2026-07-24 — the old per-step guard
+  # pattern still consumed a full runner on every backend PR just to boot, check out, and evaluate
+  # ~18 false guards. Job-level skip is safe for the same reason as `test`'s draft skip: this repo
+  # has ZERO required status contexts on main, and the review pipeline's fetchLiveCiAggregate
+  # buckets skipped identically to success. Draft PRs skip entirely, mirroring the other heavy jobs.
   ui:
     name: ui
     needs: changes
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft != true && needs.changes.outputs.run_ui_validation == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30 # workspace install, drift-check builds, typecheck/test, and the Playwright e2e pass
-    env:
-      RUN_UI_VALIDATION: ${{ needs.changes.outputs.run_ui_validation }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -723,7 +714,6 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node
-        if: env.RUN_UI_VALIDATION == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.23.1
@@ -734,7 +724,6 @@ jobs:
       # from the one root lockfile -- there is no way to `npm ci` a single
       # workspace in isolation.
       - name: Install
-        if: env.RUN_UI_VALIDATION == 'true'
         run: npm ci
 
       # apps/ui consumes packages/client as a live workspace link (#3066), not
@@ -758,7 +747,6 @@ jobs:
       # `npm run build --workspace=packages/client` + commit of the runtime
       # bundle fails loudly here rather than shipping stale runtime code.
       - name: Build packages/client (drift check)
-        if: env.RUN_UI_VALIDATION == 'true'
         run: |
           npm run build --workspace=packages/client
           if ! git diff --exit-code -- packages/client/dist; then
@@ -772,7 +760,6 @@ jobs:
       # Builds deploy never depends on rebuilding a sibling workspace
       # package first (#4860).
       - name: Build packages/ui-kit (drift check)
-        if: env.RUN_UI_VALIDATION == 'true'
         run: |
           npm run build --workspace=packages/ui-kit
           if ! git diff --exit-code -- packages/ui-kit/dist; then
@@ -788,7 +775,6 @@ jobs:
       # stale/missing docs pages silently otherwise (caught live 2026-07-18:
       # two newly-merged routes had zero corresponding doc pages).
       - name: Build API reference docs (drift check)
-        if: env.RUN_UI_VALIDATION == 'true'
         working-directory: apps/ui
         run: |
           node scripts/generate-openapi-docs.ts
@@ -804,7 +790,6 @@ jobs:
       # same renderer README.md's own catalog section uses) -- an enriched
       # subnet that never regenerates this page silently drifts otherwise.
       - name: Build subnet catalog docs (drift check)
-        if: env.RUN_UI_VALIDATION == 'true'
         working-directory: apps/ui
         run: |
           node scripts/generate-catalog-docs.ts
@@ -814,11 +799,9 @@ jobs:
           fi
 
       - name: Typecheck packages/ui-kit
-        if: env.RUN_UI_VALIDATION == 'true'
         run: npm run typecheck --workspace=packages/ui-kit
 
       - name: Test packages/ui-kit
-        if: env.RUN_UI_VALIDATION == 'true'
         run: npm test --workspace=packages/ui-kit
 
       # Enforces the #4867 epic's core invariant: packages/ui-kit stays a
@@ -826,26 +809,21 @@ jobs:
       # eslint.config.ts) fails on @tanstack/react-router,
       # @tanstack/react-query, or any import resolving into apps/ui/**.
       - name: Lint packages/ui-kit (app-logic import guardrail)
-        if: env.RUN_UI_VALIDATION == 'true'
         run: npm run lint --workspace=packages/ui-kit
 
       - name: Lint (ESLint + Prettier)
-        if: env.RUN_UI_VALIDATION == 'true'
         run: npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui
 
       - name: Typecheck
-        if: env.RUN_UI_VALIDATION == 'true'
         run: npm run typecheck --workspace=apps/ui
 
       - name: Test
-        if: env.RUN_UI_VALIDATION == 'true'
         run: npm test --workspace=apps/ui
 
       # Uses the @playwright/test devDependency already installed by `npm ci`
       # above (not a fresh npx fetch) -- installs just its matching browser
       # binary, no separate version to keep in sync.
       - name: Install Playwright Chromium
-        if: env.RUN_UI_VALIDATION == 'true'
         working-directory: apps/ui
         run: npx playwright install --with-deps chromium
 
@@ -854,7 +832,6 @@ jobs:
       # in the known baseline, so this doesn't block on the existing tracked
       # overflow backlog (#3930, #3931, #3985, etc.).
       - name: Responsive overflow check (e2e)
-        if: env.RUN_UI_VALIDATION == 'true'
         run: npm run test:e2e --workspace=apps/ui
 
       # LOVABLE_SANDBOX force-enables Nitro's cloudflare-module preset outside
@@ -862,7 +839,6 @@ jobs:
       # client build with no Worker entry) -- matches the exact env Cloudflare
       # Workers Builds sets in production (see apps/ui/DEPLOY.md).
       - name: Build
-        if: env.RUN_UI_VALIDATION == 'true'
         env:
           LOVABLE_SANDBOX: "1"
           NITRO_PRESET: cloudflare-module
@@ -896,7 +872,6 @@ jobs:
       # standalone repo's own now-removed ci.yml had this as `.output/...`,
       # which never actually matched this project's real build output).
       - name: Bundle size budget (initial client JS, gzipped)
-        if: env.RUN_UI_VALIDATION == 'true'
         working-directory: apps/ui
         env:
           BUDGET_KB: 320
@@ -962,7 +937,6 @@ jobs:
       # CI ran) -- surfaces high/critical runtime-dependency advisories at PR
       # time without failing the job. Tighten to blocking once it stays clean.
       - name: Dependency CVE scan (SCA, report-only)
-        if: env.RUN_UI_VALIDATION == 'true'
         run: |
           npm audit --audit-level=high --omit=dev --workspace=apps/ui \
             || echo "::warning::npm audit found high/critical advisories in apps/ui's runtime dependencies — review above (report-only; not failing CI yet)"


### PR DESCRIPTION
## Summary

This repo's Validate fan-out (5 jobs per PR, two of them 30-minute-class each running their own `npm ci` + full build) plus ~100 preview builds/week made it the largest consumer of the account's shared 20-concurrent-job pool (observed today: a 40+-deep starved queue that froze the sibling repo's release automation for hours). Same-day mirror of JSONbored/loopover#8523.

**1. `test` + `checks` merge into one job.** One npm ci + one build serves the suite and the ~20 validators. The old split bought wall-clock (max instead of sum) at the cost of a second heavy runner on every PR — at current volume the pool, not wall-clock, is the binding constraint. Step order is load-bearing and documented in place: contract-drift validators **before** the build (they compare committed files the build overwrites), derived-artifact freshness **after** the build and **before** the suite (whose artifact writers mutate staging trees), suite + Codecov last. The docs fast lane and the narrow workflows/migrations skips survive unchanged as per-step guards (the suite half must run even on docs-only diffs — coverage is repo-wide).

**2. `python` is path-gated at the job level** on a new `changes.run_python_validation` flag (`^python/` — its hermetic suite reads nothing else). Job-level skips are safe here and this is now documented where the old hedge was: main has **zero** required status contexts (verified via `branches/main/protection`) and `fetchLiveCiAggregate` buckets skipped identically to success.

**3. `ui`'s per-step guard pattern becomes a job-level `if`** for the same reason — a backend PR no longer boots a full runner just to check out and evaluate ~18 false guards.

**4. Draft PRs skip every heavy job** (and the `types` list gains `ready_for_review`, so marking ready triggers a real run — mirrors ui-preview.yml's existing list).

**5. Same-repo UI PRs deploy their preview in ONE runner** via the new shared `.github/actions/deploy-ui-preview` composite; `ui-preview-deploy.yml` becomes fork-only, skipping runner-free for same-repo builds via the `head_repository` comparison. The fork trust boundary (secretless build → trusted workflow_run deploy, artifact validation, trusted-config-only wrangler) is preserved byte-for-byte inside the composite.

Net: a typical backend PR drops 5 → 2 jobs (changes + merged test), UI PRs 7 → 4, python-only PRs keep a fast lane.

## Validation

`npm run validate:workflows` (22 files) green; `tests/pipeline-validator-parity.test.ts` green (the merged job invokes the identical `npm run validate:*` set); `actionlint` clean on all touched files; Prettier clean. The merged job's first live run on this PR is the end-to-end proof of the step ordering.