### PR TITLE
feat(api): add block/time-range filters to sudo GraphQL field (#7874)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -875,8 +875,8 @@ export const SDL = `
     evm_address(h160: String!): EvmAddressMapping
     "The get_evm_address_mapping-aligned name for evm_address, so the MCP tool name and this Query field line up. Structurally identical to evm_address -- same live RPC read, same validation, same schema-stable null on an unresolved mapping -- not a second lookup. Mirrors GET /api/v1/evm/address/{h160}."
     evm_address_mapping(h160: String!): EvmAddressMapping
-    "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
-    sudo(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
+    "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Optionally narrow by block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same block/time filters GET /api/v1/sudo and the get_sudo MCP tool accept. Mirrors GET /api/v1/sudo."
+    sudo(limit: Int, offset: Int, cursor: String, block: Int, block_start: Int, block_end: Int, from: String, to: String, call_function: String, success: Boolean): ExtrinsicList!
   }
 
   type SubnetList {
@@ -7419,7 +7419,18 @@ const rootValue = {
   },
 
   async sudo(
-    { limit, offset, cursor, block, call_function: callFunction, success }: Row,
+    {
+      limit,
+      offset,
+      cursor,
+      block,
+      block_start: blockStart,
+      block_end: blockEnd,
+      from,
+      to,
+      call_function: callFunction,
+      success,
+    }: Row,
     context: GqlContext,
   ) {
     // The Sudo governance feed is the /extrinsics feed with call_module fixed
@@ -7437,6 +7448,14 @@ const rootValue = {
     params.set("offset", String(safeOffset));
     if (cursor) params.set("cursor", cursor);
     if (block != null) params.set("block", String(block));
+    // #7874: block_start/block_end (inclusive height range) and from/to
+    // (observed_at epoch-ms range) forwarded straight through to the same
+    // /api/v1/sudo route get_sudo uses. from/to are String args (epoch-ms
+    // overflows GraphQL Int's 32 bits), matching account_history's from/to.
+    if (blockStart != null) params.set("block_start", String(blockStart));
+    if (blockEnd != null) params.set("block_end", String(blockEnd));
+    if (from != null) params.set("from", from);
+    if (to != null) params.set("to", to);
     if (callFunction) params.set("call_function", callFunction);
     if (success != null) params.set("success", String(success));
     const data =

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -3283,6 +3283,94 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     assert.equal(capturedUrl!.searchParams.get("signer"), null);
   });
 
+  test("sudo: a block_start/block_end height range is forwarded to the Postgres tier (#7874)", async () => {
+    let capturedUrl: URL | undefined;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 50,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ sudo(block_start: 100, block_end: 500) { total } }`,
+      env as unknown as Env,
+    );
+    assert.equal(capturedUrl!.pathname, "/api/v1/sudo");
+    assert.equal(capturedUrl!.searchParams.get("block_start"), "100");
+    assert.equal(capturedUrl!.searchParams.get("block_end"), "500");
+    assert.equal(capturedUrl!.searchParams.has("from"), false);
+    assert.equal(capturedUrl!.searchParams.has("to"), false);
+  });
+
+  test("sudo: a from/to observed_at range is forwarded to the Postgres tier (#7874)", async () => {
+    let capturedUrl: URL | undefined;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 50,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ sudo(from: "1750000000000", to: "1760000000000") { total } }`,
+      env as unknown as Env,
+    );
+    assert.equal(capturedUrl!.searchParams.get("from"), "1750000000000");
+    assert.equal(capturedUrl!.searchParams.get("to"), "1760000000000");
+    assert.equal(capturedUrl!.searchParams.has("block_start"), false);
+    assert.equal(capturedUrl!.searchParams.has("block_end"), false);
+  });
+
+  test("introspection: sudo exposes block_start/block_end (Int) and from/to (String) args (#7874)", async () => {
+    const { status, body } = await gql(
+      `{ __type(name: "Query") { fields {
+          name
+          args { name type { kind name ofType { kind name } } }
+        } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const sudo = body.data.__type.fields.find((f: Row) => f.name === "sudo");
+    const argType = (name: string) => {
+      const a = sudo.args.find((x: Row) => x.name === name);
+      assert.ok(a, `expected a ${name} arg on sudo`);
+      return a.type;
+    };
+    for (const name of ["block_start", "block_end"]) {
+      assert.deepEqual(argType(name), {
+        kind: "SCALAR",
+        name: "Int",
+        ofType: null,
+      });
+    }
+    for (const name of ["from", "to"]) {
+      assert.deepEqual(argType(name), {
+        kind: "SCALAR",
+        name: "String",
+        ofType: null,
+      });
+    }
+  });
+
   test("sudo: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
     let capturedUrl: URL | undefined;
     const env = {


### PR DESCRIPTION
## Summary

GraphQL's `sudo(limit, offset, cursor, block, call_function, success)` field couldn't narrow by block or time range, while `GET /api/v1/sudo` and the MCP `get_sudo` tool both accept `block_start`/`block_end` and `from`/`to`. This adds those four filters so a client can slice the Sudo-pallet feed identically to REST and MCP.

- `block_start`/`block_end` — inclusive block-height range (`Int`).
- `from`/`to` — observed_at epoch-ms range. `String` args, not `Int`: epoch-ms (~1.7e12) overflows GraphQL's 32-bit `Int`, matching the existing `account_history(from: String, to: String)` field.

The resolver forwards each supplied arg verbatim to the same `/api/v1/sudo` route `get_sudo` uses — no duplicated filtering logic. The route still fixes `call_module=Sudo`, so `signer`/`call_module` stay intentionally absent.

## Changes

- `src/graphql.ts`: `block_start`/`block_end`/`from`/`to` on the `sudo` SDL field (+ docstring) and their forwarding in the resolver.
- `tests/graphql.test.ts`: a block-range forwarding test, a time-range forwarding test (each asserts the unrelated filters are omitted), and an introspection signature guard for the new args + scalar types.

## Validation

`lint`, `format:check`, `typecheck`, `npx vitest run tests/graphql.test.ts` (964 passed), `build`, `validate`, `scan:public-safety`, `git diff --check` — all green.

Closes #7874