### PR TITLE
feat(graphql): add type/netuid/q/sort/order filters to the search field

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -65,6 +65,11 @@ import { loadProfileCompletenessList } from "./profile-completeness-mcp.ts";
 // #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
 // MCP get_adapter already calls (#3255) -- not a reimplementation.
 import { loadAdapter } from "./adapters-mcp.ts";
+// #7876: type/netuid/q/sort/order parity on the search field, reusing the same
+// loadSearchList loader MCP list_search / REST GET /api/v1/search already call
+// (over the same /metagraph/search.json artifact listPage reads) -- not a
+// reimplementation.
+import { loadSearchList } from "./search-mcp.ts";
 // #7170: GraphQL parity for the changelog/contracts/health-history REST routes,
 // reusing the same loaders MCP get_changelog/get_contracts/get_health_history
 // already call -- not a reimplementation.
@@ -560,7 +565,7 @@ export const SDL = `
     "The largest TAO holders ranked by the chosen sort (total_tao by default), limit 1-100 (default 20). An unknown sort is a BAD_USER_INPUT error. Resolves to a schema-stable empty list when the holders tier is cold, never null. Opaque JSON, matching the get_top_holders MCP/REST shape. Mirrors GET /api/v1/accounts/top-holders."
     top_holders(sort: String, limit: Int): JSON
     "The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search."
-    search(limit: Int, cursor: String): SearchDocumentList!
+    search(limit: Int, cursor: String, type: String, netuid: Int, q: String, sort: String, order: String): SearchDocumentList!
     "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index."
     search_index(limit: Int, cursor: String): SearchDocumentList!
     "The per-domain rollup overview: every tag in the fixed 14-tag capability taxonomy with its member subnet count, total stake, total emission share, and within-domain emission concentration. Computed live from the subnets index + economics tier. Mirrors GET /api/v1/domains."
@@ -6665,15 +6670,43 @@ const rootValue = {
     return rootValue.incidents({ window }, context);
   },
 
-  search({ limit, cursor }: Row, context: GqlContext) {
-    // Same baked search artifact + list-window the REST route serves, paged
-    // through the shared listPage helper the other artifact lists use.
-    return listPage(context, ARTIFACT.search, "documents", {
-      limit,
-      cursor,
-      resultKey: "documents",
-      keyFn: (d: Row) => d.id,
-    });
+  search(
+    { limit, cursor, type, netuid, q, sort, order }: Row,
+    context: GqlContext,
+  ) {
+    // #7876: with no type/netuid/q/sort/order this stays byte-identical -- the
+    // same baked search artifact paged through the shared listPage helper the
+    // other artifact lists use. Supplying any of those filters routes through
+    // loadSearchList instead: the same /metagraph/search.json read plus the
+    // shared query engine REST's GET /api/v1/search and MCP list_search apply,
+    // so a filtered GraphQL search matches them rather than a GraphQL-only
+    // reimplementation. loadSearchList validates its own args (an unsupported
+    // type/sort is a GraphQL error, not a silently substituted default) and
+    // returns the same {documents,total,next_cursor,...} shape listPage does.
+    if (
+      type == null &&
+      netuid == null &&
+      q == null &&
+      sort == null &&
+      order == null
+    ) {
+      return listPage(context, ARTIFACT.search, "documents", {
+        limit,
+        cursor,
+        resultKey: "documents",
+        keyFn: (d: Row) => d.id,
+      });
+    }
+    // loadSearchList validates its own args and returns the same
+    // {documents,total,next_cursor,...} shape listPage does. Note its cursor is
+    // the shared query engine's integer keyset offset, so pairing a filter with
+    // the listPage path's opaque string cursor is a BAD_USER_INPUT (surfaced by
+    // the loader), matching REST/MCP.
+    return loadSearchList(
+      mcpCtx(context),
+      { limit, cursor, type, netuid, q, sort, order },
+      { readArtifact },
+    );
   },
 
   search_index({ limit, cursor }: Row, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -20632,3 +20632,113 @@ describe("graphql — subnet_hyperparameters_history cursor (#7882)", () => {
     assert.equal(new URL(seen.url!).searchParams.has("cursor"), false);
   });
 });
+
+// #7876: the search field gained the type/netuid/q/sort/order filters
+// GET /api/v1/search and MCP list_search already accept, delegating to
+// loadSearchList when any is supplied while keeping the unfiltered listPage
+// path byte-identical. SearchDocumentList.documents is opaque JSON, so tests
+// select it whole and assert on the parsed rows.
+describe("graphql — search filters (#7876)", () => {
+  const searchEnv = () =>
+    fixtureEnv({
+      "/metagraph/search.json": {
+        documents: [
+          {
+            id: "subnet:7",
+            type: "subnet",
+            netuid: 7,
+            title: "Allways",
+            tokens: "alpha",
+          },
+          {
+            id: "surface:7",
+            type: "surface",
+            netuid: 7,
+            title: "Allways API",
+            tokens: "beta",
+          },
+          {
+            id: "subnet:9",
+            type: "subnet",
+            netuid: 9,
+            title: "Other",
+            tokens: "gamma",
+          },
+          {
+            id: "provider:x",
+            type: "provider",
+            title: "Acme",
+            tokens: "delta",
+          },
+        ],
+      },
+    });
+
+  const ids = (docs: Row[]) => docs.map((d) => d.id);
+
+  test("filters by type", async () => {
+    const { status, body } = await gql(
+      `{ search(type: "provider") { documents total } }`,
+      searchEnv() as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.search.total, 1);
+    assert.deepEqual(ids(body.data.search.documents), ["provider:x"]);
+  });
+
+  test("filters by type + netuid together", async () => {
+    const { body } = await gql(
+      `{ search(type: "subnet", netuid: 7) { documents total } }`,
+      searchEnv() as unknown as Env,
+    );
+    assert.equal(body.data.search.total, 1);
+    assert.deepEqual(ids(body.data.search.documents), ["subnet:7"]);
+  });
+
+  test("runs a keyword q search over the index", async () => {
+    const { body } = await gql(
+      `{ search(q: "Allways") { documents total } }`,
+      searchEnv() as unknown as Env,
+    );
+    assert.ok(body.data.search.total >= 1);
+    assert.ok(ids(body.data.search.documents).includes("subnet:7"));
+  });
+
+  test("accepts sort/order", async () => {
+    const { body } = await gql(
+      `{ search(type: "subnet", sort: "netuid", order: "desc") { documents } }`,
+      searchEnv() as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.search.documents[0].netuid, 9);
+  });
+
+  test("with no filter argument stays on the unfiltered listPage path", async () => {
+    const { body } = await gql(
+      `{ search(limit: 1) { documents total next_cursor } }`,
+      searchEnv() as unknown as Env,
+    );
+    // Byte-identical to today: full index, tokens retained, opaque next_cursor.
+    assert.equal(body.data.search.total, 4);
+    assert.equal(body.data.search.documents.length, 1);
+    assert.equal(body.data.search.documents[0].tokens, "alpha");
+    assert.ok(body.data.search.next_cursor);
+  });
+
+  test("an invalid type is a GraphQL error, not a silently substituted default", async () => {
+    const { body } = await gql(
+      `{ search(type: "not-a-type") { total } }`,
+      searchEnv() as unknown as Env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("a negative netuid is a GraphQL error", async () => {
+    const { body } = await gql(
+      `{ search(netuid: -1) { total } }`,
+      searchEnv() as unknown as Env,
+    );
+    assert.ok(body.errors?.length);
+  });
+});


### PR DESCRIPTION
## Summary

The GraphQL `search` field only paginated (`limit`/`cursor`), while `GET /api/v1/search` and MCP `list_search` both filter by `type`/`netuid`/`q` and sort by `sort`/`order`. This adds those arguments.

When any filter is supplied the resolver **delegates to `loadSearchList`** — the loader those two surfaces already call, over the **same `/metagraph/search.json` artifact** `listPage` reads — rather than re-deriving a GraphQL-only filter. (Same pattern as the merged `list_search` filter work, #7932/#7935.)

Closes #7876

## Backward compatibility

A call with **no** `type`/`netuid`/`q`/`sort`/`order` is byte-identical to today — it still pages the baked index through `listPage` (full `documents` incl. token blobs, opaque string cursor). Only a call that actually supplies a filter takes the loader path.

## One subtlety worth flagging

The unfiltered `listPage` path uses an **opaque string** cursor; `loadSearchList`'s cursor is the shared query engine's **integer keyset offset**. So pairing a filter with a legacy string cursor is a `BAD_USER_INPUT` — surfaced by the loader, exactly as REST/MCP do — rather than silently mis-paging. The field keeps `cursor: String` in the SDL for the unfiltered path's compatibility.

## Tests

7 new cases in `tests/graphql.test.ts`: filter by `type`; `type`+`netuid` together; a `q` keyword search; `sort`/`order`; the no-filter call still on the `listPage` path (tokens retained, opaque `next_cursor`); and invalid `type` / negative `netuid` each surfacing as a GraphQL error. `graphql.test.ts` + `pipeline-validator-parity.test.ts` pass together (**950**). Lint clean.

## Scope

Backend only — `src/graphql.ts` (+43/-10) and `tests/graphql.test.ts` (+110). No `apps/ui`, no generated artifacts.