### PR TITLE
feat(api): GraphQL parity for candidates field (id/confidence/sort/order)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -53,6 +53,10 @@ import { loadRpcEndpointsList } from "./rpc-endpoints-mcp.ts";
 // authority/sort/order/fields + limit/cursor), reusing loadProvidersList that
 // MCP list_providers already calls -- not a reimplementation.
 import { loadProvidersList } from "./providers-mcp.ts";
+// #7871: GraphQL parity -- candidates(...) reuses loadCandidatesList (the same
+// loader list_candidates MCP calls) so its id/confidence filters and sort/order
+// come straight from GET /api/v1/candidates and can't drift.
+import { loadCandidatesList } from "./candidates-mcp.ts";
 // #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
 // and page logic REST and MCP already use) -- not a reimplementation.
@@ -555,8 +559,8 @@ export const SDL = `
     agent_resources: JSON
     "Curation states by subnet — each subnet's registry curation level and review state. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_curation MCP/REST shape. Mirrors GET /api/v1/curation."
     curation: JSON
-    "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state and page with limit/cursor, exactly like the REST route. Resolves to {items,total,next_cursor} as opaque JSON. Mirrors GET /api/v1/candidates."
-    candidates(netuid: Int, kind: String, provider: String, state: String, limit: Int, cursor: String): JSON
+    "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state, plus id (exact match) and confidence (low/medium/high); sort with sort + order; project with fields; and page with limit (1-1000) / cursor, exactly like the REST route -- an unsupported filter/sort value is a GraphQL error, not a silently substituted default. Resolves to {candidates,total,returned,limit,cursor,next_cursor,sort,order} as opaque JSON, matching the pagination meta REST returns. A cold/absent catalog artifact is a GraphQL error (matching REST/MCP not_found), not an empty page. Mirrors GET /api/v1/candidates."
+    candidates(netuid: Int, kind: String, provider: String, state: String, id: String, confidence: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): JSON
     "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}."
     saved_query(id: String!, params: JSON): JSON
     "The recorded response fixtures for registered surfaces, used to replay/verify a surface without calling it. Null when no fixture index has been baked in this environment. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
@@ -5318,29 +5322,19 @@ const rootValue = {
     }
   },
 
-  // #6991: five registry-meta routes that had an MCP tool but no GraphQL
-  // field. Each reads the same baked artifact (and applies the same overlay /
+  // #6991: registry-meta routes that had an MCP tool but no GraphQL field.
+  // Each reads the same baked artifact (and applies the same overlay /
   // builder) its MCP tool does, so REST, MCP, and GraphQL can't drift.
-  async candidates(
-    { netuid, kind, provider, state, limit, cursor }: Row,
-    context: GqlContext,
-  ) {
-    const data = await loadArtifact(context, "/metagraph/candidates.json");
-    const all = Array.isArray(data?.candidates) ? data.candidates : [];
-    const filtered = all.filter(
-      (c: Row) =>
-        (netuid == null || c.netuid === netuid) &&
-        (kind == null || c.kind === kind) &&
-        (provider == null || c.provider === provider) &&
-        (state == null || c.state === state),
-    );
-    const { page, total, nextCursor } = paginate(
-      filtered,
-      limit,
-      cursor,
-      (c: Row) => c.id ?? c.key,
-    );
-    return { items: page, total, next_cursor: nextCursor };
+  //
+  // #7871: candidates now reuses loadCandidatesList -- the same loader
+  // list_candidates MCP calls -- instead of the earlier inline filter/paginate
+  // pass, so its id/confidence filters and sort/order come straight from the
+  // REST allowlists and this field can't drift from GET /api/v1/candidates.
+  // Mirrors the sibling gaps(...) field exactly: an unsupported filter/sort
+  // value (or a cold catalog artifact) is a GraphQL error, not a silently
+  // substituted default.
+  candidates(args: Row, context: GqlContext) {
+    return loadCandidatesList(mcpCtx(context), args, { readArtifact });
   },
 
   fixtures(_args: unknown, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8396,70 +8396,118 @@ describe("graphql — agent_resources (#6987, baked AI-resources index)", () => 
 });
 
 describe("graphql — candidates / fixtures / agent_catalog / freshness / top_holders (#6991)", () => {
+  // #7871: candidates(...) now mirrors the sibling gaps(...) field -- it reuses
+  // loadCandidatesList, so id/confidence filters, sort/order, and pagination
+  // meta come straight from GET /api/v1/candidates. The field resolves to the
+  // loader's opaque-JSON envelope ({candidates,total,returned,...}), so it is
+  // selected as a scalar (no subfield selection) like subnet_candidates.
   const CANDIDATES = {
+    generated_at: "2026-07-01T00:00:00.000Z",
+    notes: ["fixture"],
     candidates: [
-      { id: "c1", netuid: 1, kind: "docs", provider: "acme", state: "new" },
-      { id: "c2", netuid: 2, kind: "api", provider: "beta", state: "verified" },
+      {
+        id: "c1",
+        netuid: 1,
+        kind: "docs",
+        provider: "acme",
+        state: "verified",
+        confidence: "high",
+        name: "Alpha",
+      },
+      {
+        id: "c2",
+        netuid: 2,
+        kind: "openapi",
+        provider: "beta",
+        state: "stale",
+        confidence: "low",
+        name: "Bravo",
+      },
     ],
   };
 
-  test("candidates resolves the ledger with total and next_cursor", async () => {
+  test("candidates resolves the ledger with total, returned and generated_at", async () => {
     const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
     const { status, body } = await gql("{ candidates }", env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.candidates.total, 2);
-    assert.equal(body.data.candidates.items.length, 2);
+    assert.equal(body.data.candidates.candidates.length, 2);
+    assert.equal(body.data.candidates.returned, 2);
+    assert.equal(body.data.candidates.generated_at, "2026-07-01T00:00:00.000Z");
   });
 
   test("candidates applies the netuid/kind/provider/state filters", async () => {
     const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
     const { body } = await gql(
-      '{ candidates(netuid: 2, kind: "api", provider: "beta", state: "verified") }',
+      '{ candidates(netuid: 2, kind: "openapi", provider: "beta", state: "stale") }',
       env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.equal(body.data.candidates.total, 1);
-    assert.equal(body.data.candidates.items[0].id, "c2");
+    assert.equal(body.data.candidates.candidates[0].id, "c2");
   });
 
-  test("candidates keys the cursor off `key` when a row has no id", async () => {
-    const env = fixtureEnv({
-      "/metagraph/candidates.json": {
-        candidates: [
-          {
-            key: "k1",
-            netuid: 1,
-            kind: "docs",
-            provider: "acme",
-            state: "new",
-          },
-          { key: "k2", netuid: 2, kind: "api", provider: "beta", state: "new" },
-        ],
-      },
-    });
-    const { body } = await gql("{ candidates(limit: 1) }", env);
+  test("candidates filters by id (exact match)", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql(
+      '{ candidates(id: "c1") }',
+      env as unknown as Env,
+    );
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.candidates.next_cursor, "k1");
+    assert.equal(body.data.candidates.total, 1);
+    assert.equal(body.data.candidates.candidates[0].id, "c1");
+  });
+
+  test("candidates filters by confidence", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql(
+      '{ candidates(confidence: "low") }',
+      env as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.total, 1);
+    assert.equal(body.data.candidates.candidates[0].id, "c2");
+  });
+
+  test("candidates sorts by a field with an explicit order", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { status, body } = await gql(
+      '{ candidates(sort: "netuid", order: "desc") }',
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.total, 2);
+    assert.equal(body.data.candidates.candidates[0].id, "c2");
   });
 
   test("candidates pages with limit and hands back a next_cursor", async () => {
     const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
-    const { body } = await gql("{ candidates(limit: 1) }", env);
+    const { body } = await gql(
+      "{ candidates(limit: 1) }",
+      env as unknown as Env,
+    );
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.candidates.items.length, 1);
+    assert.equal(body.data.candidates.candidates.length, 1);
     assert.equal(body.data.candidates.total, 2);
-    assert.equal(body.data.candidates.next_cursor, "c1");
+    assert.equal(body.data.candidates.returned, 1);
+    assert.ok(body.data.candidates.next_cursor != null);
   });
 
-  test("candidates resolves an empty ledger when the artifact is cold", async () => {
-    const { body } = await gql("{ candidates }");
-    assert.equal(body.errors, undefined);
-    assert.deepEqual(body.data.candidates, {
-      items: [],
-      total: 0,
-      next_cursor: null,
-    });
+  test("candidates surfaces an invalid sort as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql(
+      '{ candidates(sort: "bogus") }',
+      env as unknown as Env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("candidates surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ candidates }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data.candidates, null);
   });
 
   test("fixtures resolves the baked fixture index", async () => {


### PR DESCRIPTION
## Summary

Brings the GraphQL `candidates` field to full parity with `GET /api/v1/candidates`
by reusing the **same loader the REST route and `list_candidates` MCP tool already
call** (`loadCandidatesList`) instead of the earlier inline filter/paginate pass.
This mirrors the sibling `gaps(...)` field exactly (the precedent the issue points
at), the same way `subnet_candidates` (#7878) and `gaps` (#7171) were done — so the
three surfaces (REST / MCP / GraphQL) can't drift.

Closes #7871

## What this changes (`src/graphql.ts`)

- **SDL:** the `candidates` field now accepts `id`, `confidence`, `sort`, `order`
  (plus `fields` for CSV-style projection, matching REST and the `gaps` field's full
  filter/sort/page pattern). Its description is updated to document the filters and
  the pagination-meta envelope.
- **Resolver:** replaced the hand-rolled `loadArtifact` + `Array.filter` + `paginate`
  body with a one-line pass-through that mirrors `gaps(...)`:
  `return loadCandidatesList(mcpCtx(context), args, { readArtifact });`.
  Every filter/sort/limit/cursor value is now validated against the REST allowlists
  inside the loader; an unsupported value (or a cold catalog artifact) surfaces as a
  GraphQL error, not a silently substituted default — identical to `gaps`.

## Two argument types follow REST, not the issue's illustrative sketch

The issue sketched `confidence: Float` and the field previously typed `cursor: String`.
Both are corrected to what `GET /api/v1/candidates` actually accepts, so the field
genuinely "matches REST":

- **`confidence: String`** — the shared `candidates` query collection
  (`src/contracts.ts`) validates `confidence` as an enum of `low` / `medium` / `high`,
  and the direct sibling `subnet_candidates` field already exposes it as `String`.
  A `Float` would be rejected by the loader's confidence enum and could never match a
  row, so it would not mirror REST.
- **`cursor: Int`** — REST/`loadCandidatesList` paginate by integer offset (`gaps`
  uses `cursor: Int` too); the old `cursor: String` key-based cursor was specific to
  the removed inline implementation.

## Test coverage (`tests/graphql.test.ts`)

Rewrote the `candidates` tests onto the loader shape and added the coverage the issue
asks for:

- filter by `id` (exact match)
- filter by `confidence`
- `sort` + `order` combination
- existing `netuid`/`kind`/`provider`/`state` filters, pagination meta
  (`total`/`returned`/`next_cursor`), invalid-sort → GraphQL error, and cold-artifact
  → GraphQL error (matching REST/MCP `not_found`).

## Verification

- `vitest run tests/graphql.test.ts` — 964 passing.
- Patch coverage 100% on the changed `src/graphql.ts` lines (the file's only uncovered
  line is pre-existing and outside this diff).
- `eslint`, `prettier --check`, and `tsc --noEmit` all clean.
- Rebases cleanly on `main`.

No rendered UI output changes (GraphQL schema/resolver + tests only).
