### PR TITLE
test(ui): cover use-tao-price.ts and market.functions.ts

### DIFF
--- a/apps/ui/src/hooks/use-tao-price.test.ts
+++ b/apps/ui/src/hooks/use-tao-price.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTaoPrice } from "./use-tao-price";
+
+describe("resolveTaoPrice", () => {
+  it("returns the price on a successful fetch with a positive price", () => {
+    expect(resolveTaoPrice({ price: 412.5 })).toBe(412.5);
+    expect(resolveTaoPrice({ price: 0.0001 })).toBe(0.0001);
+  });
+
+  it("returns null when price is zero or negative", () => {
+    expect(resolveTaoPrice({ price: 0 })).toBeNull();
+    expect(resolveTaoPrice({ price: -1 })).toBeNull();
+  });
+
+  it("returns null when price is non-numeric or NaN", () => {
+    expect(resolveTaoPrice({ price: Number.NaN })).toBeNull();
+    expect(resolveTaoPrice({ price: undefined })).toBeNull();
+  });
+
+  it("returns null when there is no data yet (pending) or the query failed (error)", () => {
+    expect(resolveTaoPrice(undefined)).toBeNull();
+    expect(resolveTaoPrice({})).toBeNull();
+  });
+});

--- a/apps/ui/src/hooks/use-tao-price.ts
+++ b/apps/ui/src/hooks/use-tao-price.ts
@@ -2,6 +2,16 @@ import { useQuery } from "@tanstack/react-query";
 import { getTaoMarket, type TaoMarketData } from "@/lib/metagraphed/market.functions";
 
 /**
+ * Resolve a displayable TAO/USD price from a market payload. Returns `null`
+ * unless `price` is a number strictly greater than zero, so callers render a
+ * "USD unavailable" fallback rather than invent a number. Exported for unit
+ * tests (the hook itself needs a query/browser context).
+ */
+export function resolveTaoPrice(data: TaoMarketData | undefined): number | null {
+  return typeof data?.price === "number" && data.price > 0 ? data.price : null;
+}
+
+/**
  * Shared TAO/USD price hook. Backed by the same coinpaprika query used on
  * /subnets so the browser cache dedupes across the app.
  *
@@ -16,6 +26,5 @@ export function useTaoPrice() {
     gcTime: 5 * 60_000,
     retry: 1,
   });
-  const price = typeof data?.price === "number" && data.price > 0 ? data.price : null;
-  return { price, isPending, isError };
+  return { price: resolveTaoPrice(data), isPending, isError };
 }

--- a/apps/ui/src/lib/metagraphed/market.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchTaoMarket } from "./market.functions";
+
+const COINPAPRIKA_URL = "https://api.coinpaprika.com/v1/tickers/tao-bittensor";
+
+describe("fetchTaoMarket", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the parsed USD quote on a successful fetch with a positive price", async () => {
+    const usd = { price: 412.5, market_cap: 1_000_000_000, volume_24h: 20_000_000 };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ quotes: { USD: usd } }) }),
+    );
+
+    await expect(fetchTaoMarket()).resolves.toEqual(usd);
+    expect(fetch).toHaveBeenCalledWith(COINPAPRIKA_URL);
+  });
+
+  it("passes a zero/negative price through unchanged (the >0 guard lives in the hook)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: async () => ({ quotes: { USD: { price: 0 } } }) }),
+    );
+
+    await expect(fetchTaoMarket()).resolves.toEqual({ price: 0 });
+  });
+
+  it("resolves an empty object when the payload has a quotes block but no USD quote", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ quotes: {} }) }),
+    );
+
+    await expect(fetchTaoMarket()).resolves.toEqual({});
+  });
+
+  it("resolves an empty object when the payload has no quotes block at all", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+
+    await expect(fetchTaoMarket()).resolves.toEqual({});
+  });
+
+  it("throws with the status code on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }),
+    );
+
+    await expect(fetchTaoMarket()).rejects.toThrow("TAO market data returned 503");
+  });
+
+  it("propagates a network-level fetch error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    await expect(fetchTaoMarket()).rejects.toThrow("network down");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/market.functions.ts
+++ b/apps/ui/src/lib/metagraphed/market.functions.ts
@@ -6,11 +6,15 @@ export interface TaoMarketData {
   volume_24h?: number;
 }
 
-export const getTaoMarket = createServerFn({ method: "GET" }).handler(
-  async (): Promise<TaoMarketData> => {
-    const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
-    if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
-    const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
-    return payload.quotes?.USD ?? {};
-  },
-);
+// Extracted from the createServerFn handler so the fetch/parse/error path is
+// unit-testable directly, without TanStack Start's AsyncLocalStorage request
+// context (see market.functions.test.ts). getTaoMarket delegates to it, so
+// runtime behavior is unchanged.
+export async function fetchTaoMarket(): Promise<TaoMarketData> {
+  const response = await fetch("https://api.coinpaprika.com/v1/tickers/tao-bittensor");
+  if (!response.ok) throw new Error(`TAO market data returned ${response.status}`);
+  const payload = (await response.json()) as { quotes?: { USD?: TaoMarketData } };
+  return payload.quotes?.USD ?? {};
+}
+
+export const getTaoMarket = createServerFn({ method: "GET" }).handler(fetchTaoMarket);


### PR DESCRIPTION
Closes #7907

Adds regression coverage for the TAO/USD price fetch path — both the raw function (`getTaoMarket` in `market.functions.ts`) and its hook wrapper (`useTaoPrice` in `use-tao-price.ts`) — covering the success, guard, and failure behavior the issue asks for.

Both functions today live inside wrappers that can't be exercised by this repo's plain-node test suite (no jsdom): `getTaoMarket` is a `createServerFn(...).handler(...)` that throws `No Start context found in AsyncLocalStorage` when called outside the server runtime, and `useTaoPrice` needs a React Query/browser context. So the fetch/parse/error core and the price guard are lifted into small, behavior-preserving named exports and tested directly — the same shape as this repo's other hook helpers (`classifyEndpointLatency`, `combineSubnetProbeHealth`).

## What this adds

- **`fetchTaoMarket()`** — extracted from `getTaoMarket`'s handler; `getTaoMarket` now delegates via `.handler(fetchTaoMarket)`, so runtime behavior is identical.
- **`resolveTaoPrice(data)`** — extracted from `useTaoPrice`'s `price > 0` guard; the hook now returns `resolveTaoPrice(data)`, unchanged semantics.

## Coverage (`getTaoMarket` / `market.functions.ts`)

`market.functions.test.ts`, fetch stubbed with `vi.stubGlobal` (this repo's convention, e.g. `client.test.ts`):

- successful fetch with `price > 0` → returns the parsed USD quote;
- zero / negative price → passed through unchanged (the `> 0` guard lives in the hook);
- `quotes` present but no `USD`, and no `quotes` block at all → resolves `{}`;
- non-ok response → throws `TAO market data returned <status>`;
- network-level fetch rejection → propagates.

Result: `market.functions.ts` at **100% line / 100% branch / 100% function** coverage.

## Coverage (`use-tao-price.ts` hook wrapping)

`use-tao-price.test.ts` covers `resolveTaoPrice` — the hook's wrapping/guard behavior — for every branch: positive price → the number; zero, negative, `NaN`, `undefined` price, and empty payload (pending/error, when the query has no data) → `null`. **100% branch** coverage of the guard.

## Notes

- Test-only plus a behavior-preserving extraction — no `.tsx` component or rendered output changes, so no screenshot table is required (`apps/ui/src/lib/**` + `hooks/**` only).
- Verified locally: `npm run lint --workspace=apps/ui` (0 errors), `npm run format:check --workspace=apps/ui`, `npm run typecheck --workspace=apps/ui`, and the full `apps/ui` suite (all tests pass) all green; rebased clean on `main`.
