### PR TITLE
feat(api): GraphQL parity for search field args (type/netuid/q/sort/order)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2578,7 +2578,7 @@ export type Query = {
   saved_query?: Maybe<Scalars['JSON']['output']>;
   /** The registry's captured API-schema index: which subnet surfaces publish a machine-readable OpenAPI/Swagger schema, each schema's hash, and its drift status (new/unchanged/changed). Null when the schema index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the list_schemas MCP/REST shape. Mirrors GET /api/v1/schemas. */
   schemas?: Maybe<Scalars['JSON']['output']>;
-  /** The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search. */
+  /** The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Filter by type/netuid, keyword-search with q, sort with sort/order, and page with limit (1-100)/cursor -- the same list-query transforms REST and MCP apply. An invalid type/sort/order/limit/cursor is a GraphQL error, not a silently substituted default. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search. */
   search: SearchDocumentList;
   /** The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index. */
   search_index: SearchDocumentList;
@@ -3442,8 +3442,13 @@ export type QuerySaved_QueryArgs = {
 
 
 export type QuerySearchArgs = {
-  cursor?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  q?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -87,8 +87,16 @@ export const SDL = /* GraphQL */ `
     freshness: JSON
     "The largest TAO holders ranked by the chosen sort (total_tao by default), limit 1-100 (default 20). An unknown sort is a BAD_USER_INPUT error. Resolves to a schema-stable empty list when the holders tier is cold, never null. Opaque JSON, matching the get_top_holders MCP/REST shape. Mirrors GET /api/v1/accounts/top-holders."
     top_holders(sort: String, limit: Int): JSON
-    "The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search."
-    search(limit: Int, cursor: String): SearchDocumentList!
+    "The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Filter by type/netuid, keyword-search with q, sort with sort/order, and page with limit (1-100)/cursor -- the same list-query transforms REST and MCP apply. An invalid type/sort/order/limit/cursor is a GraphQL error, not a silently substituted default. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search."
+    search(
+      type: String
+      netuid: Int
+      q: String
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): SearchDocumentList!
     "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index."
     search_index(limit: Int, cursor: String): SearchDocumentList!
     "The per-domain rollup overview: every tag in the fixed 14-tag capability taxonomy with its member subnet count, total stake, total emission share, and within-domain emission concentration. Computed live from the subnets index + economics tier. Mirrors GET /api/v1/domains."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -18,6 +18,11 @@ import { loadSourceSnapshotsList } from "./source-snapshots-mcp.ts";
 // transforms REST and MCP already use) -- not a reimplementation.
 import { loadGapsList } from "./gaps-mcp.ts";
 import { loadEvidenceList } from "./evidence-mcp.ts";
+// #7876: GraphQL parity for the search field's type/netuid/q/sort/order
+// filters, reusing list_search's own loadSearchList loader unchanged (same
+// baked /metagraph/search.json read + list-query transforms REST and MCP
+// already apply) -- not a reimplementation.
+import { loadSearchList } from "./search-mcp.ts";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
@@ -3129,15 +3134,14 @@ const rootValue = {
     return rootValue.incidents({ window }, context);
   },
 
-  search({ limit, cursor }: Row, context: GqlContext) {
-    // Same baked search artifact + list-window the REST route serves, paged
-    // through the shared listPage helper the other artifact lists use.
-    return listPage(context, ARTIFACT.search, "documents", {
-      limit,
-      cursor,
-      resultKey: "documents",
-      keyFn: (d: Row) => d.id,
-    });
+  // #7876: GraphQL parity for the search field's REST/MCP filters. Reuse
+  // list_search's own loadSearchList loader unchanged -- the same baked
+  // /metagraph/search.json read plus the q/type/netuid/sort/order/limit/cursor
+  // list-query transforms REST and MCP already apply -- so the GraphQL search
+  // field cannot drift from them. An unsupported filter/sort or a cold artifact
+  // is a GraphQL error, matching source_snapshots/evidence/profiles.
+  search(args: Row, context: GqlContext) {
+    return loadSearchList(mcpCtx(context), args, { readArtifact });
   },
 
   search_index({ limit, cursor }: Row, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8185,11 +8185,84 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     assert.ok(body.data.search_index.next_cursor);
   });
 
-  test("search degrades to an empty page on a cold artifact", async () => {
-    const { status, body } = await gql("{ search { documents total } }");
+  test("search errors on a cold artifact, matching REST/MCP (#7876)", async () => {
+    // Now backed by loadSearchList -- the same loader REST GET /api/v1/search and
+    // MCP list_search use -- so a cold/absent artifact is a GraphQL error exactly
+    // as REST returns not_found, not the empty-page degradation the old listPage
+    // path uniquely produced. Matches the source_snapshots/evidence convention.
+    const { body } = await gql("{ search { documents total } }");
+    assert.ok(
+      body.errors,
+      "expected a GraphQL error when the search artifact is cold",
+    );
+    assert.equal(body.data?.search ?? null, null);
+  });
+
+  test("search filters by a keyword q (#7876)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/search.json": {
+        documents: [
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "Alpha",
+            tokens: "alpha vision",
+          },
+          {
+            id: "surface:2",
+            type: "surface",
+            netuid: 2,
+            title: "Beta",
+            tokens: "beta audio",
+          },
+          {
+            id: "provider:3",
+            type: "provider",
+            netuid: 3,
+            title: "Gamma",
+            tokens: "gamma data",
+          },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      '{ search(q: "beta") { documents total } }',
+      env as unknown as Env,
+    );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.deepEqual(body.data.search, { documents: [], total: 0 });
+    const s = body.data.search;
+    assert.equal(s.total, 1);
+    assert.equal(s.documents.length, 1);
+    assert.equal(s.documents[0].id, "surface:2");
+  });
+
+  test("search filters by a type + netuid combination (#7876)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/search.json": {
+        documents: [
+          { id: "subnet:1", type: "subnet", netuid: 1, title: "Alpha" },
+          {
+            id: "surface:1",
+            type: "surface",
+            netuid: 1,
+            title: "Alpha surface",
+          },
+          { id: "subnet:2", type: "subnet", netuid: 2, title: "Beta" },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      '{ search(type: "subnet", netuid: 1) { documents total } }',
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const s = body.data.search;
+    assert.equal(s.total, 1);
+    assert.equal(s.documents.length, 1);
+    assert.equal(s.documents[0].id, "subnet:1");
   });
 
   test("domains rolls up every tag in the fixed taxonomy", async () => {


### PR DESCRIPTION
## Summary

Brings the GraphQL `search` field to full parity with `GET /api/v1/search` and the
`list_search` MCP tool by exposing the `type`, `netuid`, `q`, `sort`, and `order`
filters they already support. Previously the GraphQL field only paginated
(`limit`/`cursor`); a client could not run a keyword/type/netuid-scoped search the way
REST and MCP callers can.

Same pattern as the sibling loader-reuse parity fields (`source_snapshots`, `evidence`,
`profiles`): the resolver now delegates to `list_search`'s own `loadSearchList` loader
(`src/search-mcp.ts`) unchanged, rather than reimplementing any filter/sort/paginate
logic — so the GraphQL field cannot drift from REST/MCP.

Closes #7876

## What this adds

`Query.search` argument set, before → after:

- before: `search(limit: Int, cursor: String)`
- after: `search(type: String, netuid: Int, q: String, sort: String, order: String, limit: Int, cursor: Int)`

The five new arguments (`type`, `netuid`, `q`, `sort`, `order`) are passed straight
through to `loadSearchList`, which applies the exact `applyQueryFilters` list-query
transforms over the baked `/metagraph/search.json` artifact that REST and MCP already
use. `cursor` moves from `String` to `Int` to match the loader's integer keyset cursor
(the same shape every sibling list field uses); `search_index` is untouched.

## Implementation

- `src/graphql.ts` — the `search` resolver now returns
  `loadSearchList(mcpCtx(context), args, { readArtifact })`, mirroring the
  `source_snapshots`/`evidence` resolvers verbatim; imports `loadSearchList` from
  `./search-mcp.ts`.
- `src/graphql-sdl.ts` — the `search` field's SDL signature + doc string gain the five
  filters (doc string mirrors the sibling fields' "an invalid filter/sort is a GraphQL
  error, not a silently substituted default" wording).
- `generated/graphql/types.ts` — regenerated via `npm run build:graphql-types`;
  `validate:graphql-types-drift` is current.

### Behaviour note (cold artifact)

Because `search` now shares `loadSearchList`, a cold/absent `search.json` artifact is a
GraphQL error (the loader's `not_found`), exactly as REST returns a 404 and MCP raises
`not_found` — identical to the `source_snapshots`/`evidence` convention. This replaces
the old `listPage` path's unique empty-page degradation, aligning the field with "run a
search identically to REST and MCP." The existing cold-artifact test was updated to
assert this parity behaviour.

## Test coverage

Added to `tests/graphql.test.ts` (per the deliverable checklist):

- `search filters by a keyword q (#7876)` — `search(q: "beta")` returns only the matching
  document.
- `search filters by a type + netuid combination (#7876)` — `search(type: "subnet", netuid: 1)`
  returns only the subnet document on netuid 1.
- Updated the cold-artifact test to assert the REST/MCP-parity error.

## Verification (local)

- `vitest run tests/graphql.test.ts tests/graphql-sentry-and-error-code.test.ts` — 969 passing.
- `codecov/patch`: the one added runtime line (`return loadSearchList(...)`) is hit by 4
  tests; the SDL/import/generated changes add no uncovered runtime lines.
- `validate:graphql-types-drift` — generated types current.
- `tsc --noEmit`, `eslint`, `prettier --check`, `validate:contract-drift`,
  `scan-public-safety` — all clean.
- Rebases clean on `origin/main`.
