### PR TITLE
feat(api): full REST filter parity to GraphQL candidates (id/confidence/sort/order)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -8,6 +8,8 @@ import {
 } from "graphql";
 import * as Sentry from "@sentry/cloudflare";
 import { readArtifact, readHealthKv } from "../workers/storage.ts";
+import { sortRows } from "../workers/list-query.ts";
+import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 // #6986: GraphQL parity for source-snapshots, reusing list_source_snapshots'
 // own loader unchanged (same artifact read, filter, sort, and page logic REST
@@ -555,8 +557,8 @@ export const SDL = `
     agent_resources: JSON
     "Curation states by subnet — each subnet's registry curation level and review state. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_curation MCP/REST shape. Mirrors GET /api/v1/curation."
     curation: JSON
-    "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state and page with limit/cursor, exactly like the REST route. Resolves to {items,total,next_cursor} as opaque JSON. Mirrors GET /api/v1/candidates."
-    candidates(netuid: Int, kind: String, provider: String, state: String, limit: Int, cursor: String): JSON
+    "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state/id/confidence, sort with sort/order, and page with limit/cursor, exactly like the REST route. An invalid confidence/sort/order is a GraphQL error, not a silently substituted default. Resolves to {items,total,next_cursor} as opaque JSON. Mirrors GET /api/v1/candidates."
+    candidates(netuid: Int, kind: String, provider: String, state: String, id: String, confidence: String, sort: String, order: String, limit: Int, cursor: String): JSON
     "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}."
     saved_query(id: String!, params: JSON): JSON
     "The recorded response fixtures for registered surfaces, used to replay/verify a surface without calling it. Null when no fixture index has been baked in this environment. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
@@ -4658,6 +4660,12 @@ export function maxComplexityRule(max: number) {
 export const DEFAULT_PAGE_LIMIT = 20;
 export const MAX_PAGE_LIMIT = 100;
 
+// #7871: candidates()'s confidence/sort validation. Same literal enum
+// candidates-mcp.ts's own CONFIDENCE_LEVELS uses (not a shared QUERY_ENUMS
+// entry -- src/contracts.ts inlines it the same way for the REST filter).
+const CANDIDATE_CONFIDENCE_LEVELS = ["low", "medium", "high"];
+const CANDIDATES_SORT_FIELDS = API_QUERY_COLLECTIONS.candidates.sort_fields;
+
 function paginate(
   items: Row[],
   limit: unknown,
@@ -5322,9 +5330,46 @@ const rootValue = {
   // field. Each reads the same baked artifact (and applies the same overlay /
   // builder) its MCP tool does, so REST, MCP, and GraphQL can't drift.
   async candidates(
-    { netuid, kind, provider, state, limit, cursor }: Row,
+    {
+      netuid,
+      kind,
+      provider,
+      state,
+      id,
+      confidence,
+      sort,
+      order,
+      limit,
+      cursor,
+    }: Row,
     context: GqlContext,
   ) {
+    // #7871: id/confidence/sort/order full REST filter parity. id/confidence
+    // join the existing loose netuid/kind/provider/state equality filter
+    // (matching this field's own established convention -- an unmatched
+    // filter value here has always meant "zero rows", not a GraphQL error).
+    // confidence is enum-backed on the REST side (src/contracts.ts), so an
+    // invalid value IS a GraphQL error here, same as sort/order below.
+    if (
+      confidence != null &&
+      !CANDIDATE_CONFIDENCE_LEVELS.includes(confidence as string)
+    ) {
+      throw new GraphQLError(
+        `confidence must be one of: ${CANDIDATE_CONFIDENCE_LEVELS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (sort != null && !CANDIDATES_SORT_FIELDS.includes(sort as string)) {
+      throw new GraphQLError(
+        `sort must be one of: ${CANDIDATES_SORT_FIELDS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (order != null && order !== "asc" && order !== "desc") {
+      throw new GraphQLError("order must be 'asc' or 'desc'.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
     const data = await loadArtifact(context, "/metagraph/candidates.json");
     const all = Array.isArray(data?.candidates) ? data.candidates : [];
     const filtered = all.filter(
@@ -5332,10 +5377,20 @@ const rootValue = {
         (netuid == null || c.netuid === netuid) &&
         (kind == null || c.kind === kind) &&
         (provider == null || c.provider === provider) &&
-        (state == null || c.state === state),
+        (state == null || c.state === state) &&
+        (id == null ||
+          String(c.id ?? "").toLowerCase() === String(id).toLowerCase()) &&
+        (confidence == null || c.confidence === confidence),
     );
+    // Same sort/order semantics (missing values sink to the end regardless of
+    // direction) every applyQueryFilters-backed field already applies --
+    // reused via the exported sortRows rather than re-derived here.
+    const sortParams = new URLSearchParams();
+    if (sort != null) sortParams.set("sort", String(sort));
+    if (order != null) sortParams.set("order", String(order));
+    const sorted = sortRows(filtered, sortParams);
     const { page, total, nextCursor } = paginate(
-      filtered,
+      sorted,
       limit,
       cursor,
       (c: Row) => c.id ?? c.key,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8398,8 +8398,22 @@ describe("graphql — agent_resources (#6987, baked AI-resources index)", () => 
 describe("graphql — candidates / fixtures / agent_catalog / freshness / top_holders (#6991)", () => {
   const CANDIDATES = {
     candidates: [
-      { id: "c1", netuid: 1, kind: "docs", provider: "acme", state: "new" },
-      { id: "c2", netuid: 2, kind: "api", provider: "beta", state: "verified" },
+      {
+        id: "c1",
+        netuid: 1,
+        kind: "docs",
+        provider: "acme",
+        state: "new",
+        confidence: "low",
+      },
+      {
+        id: "c2",
+        netuid: 2,
+        kind: "api",
+        provider: "beta",
+        state: "verified",
+        confidence: "high",
+      },
     ],
   };
 
@@ -8450,6 +8464,65 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
     assert.equal(body.data.candidates.items.length, 1);
     assert.equal(body.data.candidates.total, 2);
     assert.equal(body.data.candidates.next_cursor, "c1");
+  });
+
+  // #7871: full REST filter parity -- id/confidence/sort/order.
+  test("candidates filters by id", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(id: "c2") }', env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.total, 1);
+    assert.equal(body.data.candidates.items[0].id, "c2");
+  });
+
+  test("candidates filters by id case-insensitively", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(id: "C2") }', env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.total, 1);
+    assert.equal(body.data.candidates.items[0].id, "c2");
+  });
+
+  test("candidates filters by confidence", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(confidence: "high") }', env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.total, 1);
+    assert.equal(body.data.candidates.items[0].id, "c2");
+  });
+
+  test("candidates rejects an invalid confidence with a GraphQL error", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(confidence: "extreme") }', env);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("candidates sorts ascending and descending", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const asc = await gql(
+      '{ candidates(sort: "confidence", order: "asc") }',
+      env,
+    );
+    assert.equal(asc.body.errors, undefined);
+    assert.equal(asc.body.data.candidates.items[0].id, "c2");
+    const desc = await gql(
+      '{ candidates(sort: "confidence", order: "desc") }',
+      env,
+    );
+    assert.equal(desc.body.errors, undefined);
+    assert.equal(desc.body.data.candidates.items[0].id, "c1");
+  });
+
+  test("candidates rejects an invalid sort field with a GraphQL error", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(sort: "bogus") }', env);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("candidates rejects an invalid order with a GraphQL error", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(order: "sideways") }', env);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
   });
 
   test("candidates resolves an empty ledger when the artifact is cold", async () => {

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -401,7 +401,13 @@ function searchRows(
   });
 }
 
-function sortRows(rows: Row[], params: URLSearchParams): Row[] {
+// Exported for graphql.ts's hand-rolled candidates() resolver (#7871), which
+// filters/paginates outside applyQueryFilters (a plain object array, not an
+// artifact keyed by a query-collection config) but still needs the identical
+// sort/order/missing-value semantics REST and every applyQueryFilters-backed
+// field already share -- reusing this avoids a second, potentially-diverging
+// sort implementation.
+export function sortRows(rows: Row[], params: URLSearchParams): Row[] {
   const key = params.get("sort");
   if (!key) {
     return rows;


### PR DESCRIPTION
## Summary

- GraphQL's `candidates` field was missing `id`, `confidence`, `sort`, `order` -- all supported by `GET /api/v1/candidates`. Adds them so a GraphQL client can filter and sort candidates identically to REST.

Closes #7871

## What Changed

- `src/graphql.ts`: added `id: String, confidence: String, sort: String, order: String` arguments to `candidates`. `id`/`confidence` join the field's existing loose netuid/kind/provider/state equality filter (matching this field's own established convention -- an unmatched filter value has always meant "zero rows", not an error); `id` matches case-insensitively (mirroring `candidates-mcp.ts`'s REST/MCP loader). `confidence` is enum-backed on the REST side (`src/contracts.ts`'s `candidates` query collection: `low`/`medium`/`high`), so an invalid value is a `BAD_USER_INPUT` GraphQL error, same as an invalid `sort` (validated against the same collection's declared `sort_fields`) or `order`. Sorting reuses the exact missing-values-sink-to-the-end semantics every `applyQueryFilters`-backed field already applies, via a newly-exported `sortRows` from `workers/list-query.ts` (previously module-private) rather than a second, potentially-diverging sort implementation. `limit`/`cursor` pagination is untouched (the issue's own requirements only list `id`/`confidence`/`sort`/`order`; this field's opaque-cursor pagination isn't part of the ask).
- `workers/list-query.ts`: exported `sortRows` (no logic change) for the reuse above.
- `tests/graphql.test.ts`: added coverage for filtering by `id` (including case-insensitivity), filtering by `confidence`, sort ascending/descending, and the three invalid-input error cases (confidence/sort/order) -- covering both explicit issue deliverables (`id` and `confidence` filtering) plus the sort/order combination.
- No REST/OpenAPI/schema change -- GraphQL-only field addition, JSON scalar (no typed-schema regen needed).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7871`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A -- no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A -- GraphQL SDL only, no REST/OpenAPI contract change.)

## Validation

- [x] `npx tsc --noEmit -p .` -- clean
- [x] `npx eslint .` -- clean
- [x] `npx prettier --check src/graphql.ts tests/graphql.test.ts workers/list-query.ts` -- clean
- [x] `git diff --check` -- clean
- [x] `npx vitest run tests/graphql.test.ts tests/list-query.test.ts` -- 1068/1068 passing
- [x] Branch-level coverage verified via lcov for every changed line in `src/graphql.ts`'s `candidates` resolver -- zero uncovered lines or branches
- [x] `npm run scan:public-safety` -- no findings in touched files (pre-existing findings elsewhere are unrelated to this diff)
