### PR TITLE
feat(api): subnet_health GraphQL filter/sort/page parity (#7881)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2610,7 +2610,7 @@ export type Query = {
   subnet_evidence?: Maybe<Scalars['JSON']['output']>;
   /** One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps. */
   subnet_gaps?: Maybe<Scalars['JSON']['output']>;
-  /** One subnet's current live operational-health card: the per-surface status/latency/last-ok rows from the latest ~15-minute cron probe (summarized into ok/degraded/failed/unknown counts) plus the cross-window reliability score. The at-a-glance base card completing the health family whose windowed views are subnet_health_trends/subnet_health_incidents/subnet_health_percentiles. A subnet with no live health data resolves to the same schema-stable unknown card (summary.status of unknown, empty surfaces), never null. Opaque JSON passed through verbatim, matching the get_subnet_health MCP/REST shape (the existing typed SubnetHealth is the flat health-list item, a different shape, so this base card is JSON like the sibling surfaces payloads). Mirrors GET /api/v1/subnets/{netuid}/health. */
+  /** One subnet's current live operational-health card: the per-surface status/latency/last-ok rows from the latest ~15-minute cron probe (summarized into ok/degraded/failed/unknown counts) plus the cross-window reliability score. The at-a-glance base card completing the health family whose windowed views are subnet_health_trends/subnet_health_incidents/subnet_health_percentiles. A subnet with no live health data resolves to the same schema-stable unknown card (summary.status of unknown, empty surfaces), never null. Filter with kind, provider, status, and classification; sort with sort + order; project with fields; and page with limit (1-100) / cursor, exactly as REST does -- an unsupported value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST reports (total, returned, limit, cursor, next_cursor, sort, order) alongside the surfaces. Opaque JSON otherwise matching the get_subnet_health MCP/REST shape (the existing typed SubnetHealth is the flat health-list item, a different shape, so this base card is JSON like the sibling surfaces payloads). Mirrors GET /api/v1/subnets/{netuid}/health. */
   subnet_health?: Maybe<Scalars['JSON']['output']>;
   /** One subnet's per-surface SLA (uptime ratio) and reconstructed downtime incidents over a 7d/30d window (default 7d), computed live from the health-probe history: each surface's sample count, uptime_ratio, incident_count, total downtime_ms, and the gap-island incident list. A subnet with no probe history resolves to a schema-stable empty surfaces list, never null. Mirrors GET /api/v1/subnets/{netuid}/health/incidents. */
   subnet_health_incidents: SubnetHealthIncidents;
@@ -3550,7 +3550,16 @@ export type QuerySubnet_GapsArgs = {
 
 
 export type QuerySubnet_HealthArgs = {
+  classification?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
+  kind?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   netuid: Scalars['Int']['input'];
+  order?: InputMaybe<Scalars['String']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -60,8 +60,19 @@ export const SDL = /* GraphQL */ `
       netuid: Int!
       window: String
     ): SubnetHealthPercentiles!
-    "One subnet's current live operational-health card: the per-surface status/latency/last-ok rows from the latest ~15-minute cron probe (summarized into ok/degraded/failed/unknown counts) plus the cross-window reliability score. The at-a-glance base card completing the health family whose windowed views are subnet_health_trends/subnet_health_incidents/subnet_health_percentiles. A subnet with no live health data resolves to the same schema-stable unknown card (summary.status of unknown, empty surfaces), never null. Opaque JSON passed through verbatim, matching the get_subnet_health MCP/REST shape (the existing typed SubnetHealth is the flat health-list item, a different shape, so this base card is JSON like the sibling surfaces payloads). Mirrors GET /api/v1/subnets/{netuid}/health."
-    subnet_health(netuid: Int!): JSON
+    "One subnet's current live operational-health card: the per-surface status/latency/last-ok rows from the latest ~15-minute cron probe (summarized into ok/degraded/failed/unknown counts) plus the cross-window reliability score. The at-a-glance base card completing the health family whose windowed views are subnet_health_trends/subnet_health_incidents/subnet_health_percentiles. A subnet with no live health data resolves to the same schema-stable unknown card (summary.status of unknown, empty surfaces), never null. Filter with kind, provider, status, and classification; sort with sort + order; project with fields; and page with limit (1-100) / cursor, exactly as REST does -- an unsupported value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST reports (total, returned, limit, cursor, next_cursor, sort, order) alongside the surfaces. Opaque JSON otherwise matching the get_subnet_health MCP/REST shape (the existing typed SubnetHealth is the flat health-list item, a different shape, so this base card is JSON like the sibling surfaces payloads). Mirrors GET /api/v1/subnets/{netuid}/health."
+    subnet_health(
+      netuid: Int!
+      kind: String
+      provider: String
+      status: String
+      classification: String
+      sort: String
+      order: String
+      fields: String
+      limit: Int
+      cursor: Int
+    ): JSON
     "One subnet's rolling 24h alpha trading volume from the StakeAdded/StakeRemoved trade stream: buy/sell volume in alpha and TAO, trade counts, net flow, a buy-vs-sell sentiment ratio, and volume-to-market-cap ratio. A subnet with no trades resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/volume."
     subnet_volume(netuid: Int!): SubnetVolume!
     "The machine-readable AI-resources index: the copyable agent prompt (/agent.md), MCP server install metadata and tool listing, the Bittensor skill, llms.txt, OpenAPI, and links to the agent-facing APIs. Use it to bootstrap an agent integration before calling the catalog/search fields. Null when the index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_agent_resources MCP/REST shape. Mirrors GET /api/v1/agent-resources."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -8,6 +8,10 @@ import {
 } from "graphql";
 import * as Sentry from "@sentry/cloudflare";
 import { readArtifact, readHealthKv } from "../workers/storage.ts";
+// #7881: the same list-query helper the REST pipeline and the list_* MCP
+// loaders use, so subnet_health's filter/sort/page allowlists cannot drift
+// from GET /api/v1/subnets/{netuid}/health.
+import { applyQueryFilters } from "../workers/list-query.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 // #6986: GraphQL parity for source-snapshots, reusing list_source_snapshots'
 // own loader unchanged (same artifact read, filter, sort, and page logic REST
@@ -6422,7 +6426,19 @@ const rootValue = {
     };
   },
 
-  async subnet_health({ netuid }: QuerySubnet_HealthArgs, context: GqlContext) {
+  async subnet_health(args: QuerySubnet_HealthArgs, context: GqlContext) {
+    const {
+      netuid,
+      kind,
+      provider,
+      status,
+      classification,
+      sort,
+      order,
+      fields,
+      limit,
+      cursor,
+    } = args;
     // Same non-negative netuid gate the other per-subnet resolvers use --
     // GraphQL Int coercion rejects non-integers at parse time; a negative
     // netuid is a BAD_USER_INPUT error, not a silent card.
@@ -6449,17 +6465,63 @@ const rootValue = {
       loadSubnetReliability(),
     ]);
     const overlaid = overlaySubnetHealth(null, live, netuid);
-    if (overlaid) {
-      return { ...overlaid, reliability };
+    const card = overlaid
+      ? { ...overlaid, reliability }
+      : {
+          schema_version: 1,
+          netuid,
+          summary: { status: "unknown", surface_count: 0 },
+          operational_observed_at: null,
+          health_source: "unavailable",
+          reliability,
+          surfaces: [],
+        };
+    // #7881: apply the same list query GET /api/v1/subnets/{netuid}/health runs
+    // over the card's surfaces (listQuery("health-surfaces", { exclude:
+    // ["netuid"] })) -- kind/provider/status/classification filters plus
+    // sort/order, fields projection, and limit/cursor paging. applyQueryFilters
+    // is the same helper the REST pipeline and the list_* MCP loaders use, so
+    // the allowlists cannot drift; an unsupported value is a GraphQL error
+    // rather than a silently substituted default. With no filter args the card
+    // passes through with its surfaces intact.
+    const queryUrl = new URL("https://graphql.internal/subnets/health");
+    for (const [name, value] of [
+      ["kind", kind],
+      ["provider", provider],
+      ["status", status],
+      ["classification", classification],
+      ["sort", sort],
+      ["order", order],
+      ["fields", fields],
+      ["limit", limit],
+      ["cursor", cursor],
+    ] as const) {
+      if (value != null) queryUrl.searchParams.set(name, String(value));
     }
+    const transformed = applyQueryFilters(card, queryUrl, "health-surfaces", [
+      "kind",
+      "provider",
+      "status",
+      "classification",
+    ]);
+    if (transformed.error) {
+      throw new GraphQLError(transformed.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const filtered = transformed.data as Row;
+    const page = ((transformed.meta as Row)?.pagination ?? {}) as Row;
+    const surfaces = Array.isArray(filtered.surfaces) ? filtered.surfaces : [];
     return {
-      schema_version: 1,
-      netuid,
-      summary: { status: "unknown", surface_count: 0 },
-      operational_observed_at: null,
-      health_source: "unavailable",
-      reliability,
-      surfaces: [],
+      ...card,
+      surfaces,
+      total: page.total ?? surfaces.length,
+      returned: page.returned ?? surfaces.length,
+      limit: page.limit ?? surfaces.length,
+      cursor: page.cursor ?? 0,
+      next_cursor: page.next_cursor ?? null,
+      sort: page.sort ?? null,
+      order: page.order ?? null,
     };
   },
 

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8,6 +8,7 @@ import {
   validate,
 } from "graphql";
 import { describe, test, vi } from "vitest";
+import * as listQuery from "../workers/list-query.ts";
 import * as subnetCandidatesMcp from "../src/subnet-candidates-mcp.ts";
 import * as subnetEvidenceMcp from "../src/subnet-evidence-mcp.ts";
 import {
@@ -15994,6 +15995,15 @@ describe("graphql — subnet_health (#7640, live-cron overlay parity with REST +
       health_source: "unavailable",
       reliability: null,
       surfaces: [],
+      // #7881: the card now carries the same pagination meta the REST route's
+      // list query reports alongside the surfaces.
+      total: 0,
+      returned: 0,
+      limit: 0,
+      cursor: 0,
+      next_cursor: null,
+      sort: null,
+      order: "asc",
     });
   });
 
@@ -16004,6 +16014,161 @@ describe("graphql — subnet_health (#7640, live-cron overlay parity with REST +
 
   test("subnet_health is weighted as a fan-out field", () => {
     assert.equal(FIELD_COMPLEXITY.subnet_health, 5);
+  });
+
+  // #7881: kind/provider/status/classification filters plus sort/order,
+  // fields projection and limit/cursor paging, matching the REST route's
+  // health-surfaces list query.
+  function threeSurfaceEnv() {
+    const surface = (
+      id: string,
+      surfaceStatus: string,
+      classification: string,
+      provider: string,
+      latency: number,
+    ) => ({
+      surface_id: id,
+      netuid: NETUID,
+      kind: "subnet-api",
+      provider,
+      url: `https://${provider}.example/api`,
+      status: surfaceStatus,
+      classification,
+      latency_ms: latency,
+      last_ok: "2026-06-13T00:00:00.000Z",
+      last_checked: "2026-06-13T00:05:00.000Z",
+    });
+    return fixtureEnv(
+      {},
+      {
+        kv: {
+          [KV_HEALTH_CURRENT]: {
+            surfaces: [
+              surface("s-a", "ok", "live", "alpha", 100),
+              surface("s-b", "failed", "live", "beta", 300),
+              surface("s-c", "ok", "timeout", "alpha", 200),
+            ],
+          },
+        },
+      },
+    ) as unknown as Env;
+  }
+
+  test("subnet_health filters by status (#7881)", async () => {
+    const { status, body } = await gql(
+      `{ subnet_health(netuid: ${NETUID}, status: "ok") }`,
+      threeSurfaceEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const card = body.data.subnet_health;
+    assert.equal(card.total, 2);
+    assert.deepEqual(card.surfaces.map((s: Row) => s.surface_id).sort(), [
+      "s-a",
+      "s-c",
+    ]);
+  });
+
+  test("subnet_health filters by classification (#7881)", async () => {
+    const { body } = await gql(
+      `{ subnet_health(netuid: ${NETUID}, classification: "timeout") }`,
+      threeSurfaceEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    const card = body.data.subnet_health;
+    assert.equal(card.total, 1);
+    assert.equal(card.surfaces[0].surface_id, "s-c");
+  });
+
+  test("subnet_health combines filters, sorts, and pages (#7881)", async () => {
+    const first = await gql(
+      `{ subnet_health(netuid: ${NETUID}, status: "ok", provider: "alpha", sort: "latency_ms", order: "asc", limit: 1) }`,
+      threeSurfaceEnv(),
+    );
+    assert.equal(first.body.errors, undefined);
+    const p1 = first.body.data.subnet_health;
+    assert.equal(p1.total, 2);
+    assert.equal(p1.returned, 1);
+    assert.equal(p1.next_cursor, 1);
+    assert.equal(p1.surfaces[0].surface_id, "s-a");
+
+    const second = await gql(
+      `{ subnet_health(netuid: ${NETUID}, status: "ok", provider: "alpha", sort: "latency_ms", order: "asc", limit: 1, cursor: 1) }`,
+      threeSurfaceEnv(),
+    );
+    const p2 = second.body.data.subnet_health;
+    assert.equal(p2.surfaces[0].surface_id, "s-c");
+    assert.equal(p2.next_cursor, null);
+  });
+
+  test("subnet_health projects surface fields when requested (#7881)", async () => {
+    const { body } = await gql(
+      `{ subnet_health(netuid: ${NETUID}, classification: "timeout", fields: "surface_id,status") }`,
+      threeSurfaceEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_health.surfaces[0], {
+      surface_id: "s-c",
+      status: "ok",
+    });
+  });
+
+  test("subnet_health rejects an unsupported filter or sort value (#7881)", async () => {
+    for (const arg of [
+      'status: "bogus"',
+      'classification: "bogus"',
+      'kind: "bogus"',
+      'sort: "not_a_column"',
+    ]) {
+      const { body } = await gql(
+        `{ subnet_health(netuid: ${NETUID}, ${arg}) }`,
+        threeSurfaceEnv(),
+      );
+      assert.ok(body.errors, `expected a GraphQL error for ${arg}`);
+      assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+    }
+  });
+
+  test("subnet_health falls back to schema-stable meta when the list query returns no pagination (#7881)", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: [{ surface_id: "s-a" }, { surface_id: "s-b" }] },
+      meta: {},
+    } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
+    try {
+      const { body } = await gql(
+        `{ subnet_health(netuid: ${NETUID}) }`,
+        threeSurfaceEnv(),
+      );
+      assert.equal(body.errors, undefined);
+      const card = body.data.subnet_health;
+      assert.equal(card.total, 2);
+      assert.equal(card.returned, 2);
+      assert.equal(card.limit, 2);
+      assert.equal(card.cursor, 0);
+      assert.equal(card.next_cursor, null);
+      assert.equal(card.sort, null);
+      assert.equal(card.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("subnet_health degrades to an empty page when the list query returns no surfaces array (#7881)", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: null },
+      meta: {},
+    } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
+    try {
+      const { body } = await gql(
+        `{ subnet_health(netuid: ${NETUID}) }`,
+        threeSurfaceEnv(),
+      );
+      assert.equal(body.errors, undefined);
+      assert.deepEqual(body.data.subnet_health.surfaces, []);
+      assert.equal(body.data.subnet_health.total, 0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

`subnet_health(netuid)` returned the whole live health card with **no query surface**, while `GET /api/v1/subnets/{netuid}/health` runs a full list query over its surfaces — `listQuery("health-surfaces", { exclude: ["netuid"] })` — supporting `kind, provider, status, classification, sort, order, fields, limit, cursor`. This adds all of them.

Closes #7881.

## Approach

The card is composed exactly as before (`resolveLiveHealth` → `overlaySubnetHealth` + `loadSubnetReliability`, same schema-stable *unknown* card on a cold store — nothing re-derived). The query is then applied with **`applyQueryFilters`**, the same helper the REST pipeline and the `list_*` MCP loaders use, so the allowlists cannot drift from REST.

## Behavior

- **Filters** `kind` / `provider` / `status` / `classification`, **sort** with `sort` + `order`, **project** with `fields`, **page** with `limit` / `cursor` — exactly as REST does.
- **Unsupported filter/sort value** → `BAD_USER_INPUT` GraphQL error, matching the file's "not a silently substituted default" convention.
- **Unfiltered queries** pass the card through with its surfaces intact.
- The envelope now additionally carries the pagination meta REST reports (`total`, `returned`, `limit`, `cursor`, `next_cursor`, `sort`, `order`). The pre-existing cold-card test asserted the envelope with an exact `deepEqual`, so it's updated for those additive fields — the only pre-existing expectation touched.

## Codegen

The args are declared in `src/graphql-sdl.ts` (types-epic D, #7862) and `generated/graphql/types.ts` is regenerated so `QuerySubnet_HealthArgs` carries them. `validate:graphql-types-drift` reports **"Generated GraphQL types are current."**

## Note on one argument type

`cursor` is `Int`, not `String` as the issue text suggests — matching the list query's offset cursor and the sibling loader-backed fields (`subnet_candidates`/`subnet_evidence`, merged in #7980/#7998). Happy to switch if you'd prefer the literal text.

## Validation (full CI-parity gate set, run locally on this tree)

- [x] `npx vitest run tests/graphql.test.ts` — **968 passing** (whole GraphQL suite)
- [x] New coverage: the issue's named deliverables — **a `status` filter and a `classification` filter** — plus filters combined with sort + `limit`/`cursor` paging round-tripping `next_cursor`, a `fields` projection, rejection of a bad `status`/`classification`/`kind`/`sort`, and the two schema-stable degradation paths
- [x] Changed resolver at **100% statement AND branch coverage** — no missing lines, no partials
- [x] `npx tsc --noEmit` — **0 errors**; `validate:graphql-types-drift` clean
- [x] `node scripts/validate-api.ts` — 177 Worker API routes + 8 Postgres-tier routes validated
- [x] `eslint` 0 errors; repo-pinned `prettier --check` clean on staged LF content

## Note

Supersedes #8021, which was closed for a base-branch conflict after types-epic D (#7862) moved the SDL into `src/graphql-sdl.ts` and switched resolvers to generated arg types mid-flight. All checks were green on that PR; this branch is rebuilt against the new structure.
