### PR TITLE
test(ui): cover use-in-view.ts

### DIFF
--- a/apps/ui/src/hooks/use-in-view.test.ts
+++ b/apps/ui/src/hooks/use-in-view.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { canObserveInView, entriesIndicateInView } from "./use-in-view";
+
+// useInView needs a React + DOM runtime, but this suite is plain-node (no DOM,
+// no renderHook — see apps/ui/vitest.config.ts), so we cover the hook's real
+// decision logic through its two extracted, exported pure pieces plus a minimal
+// IntersectionObserver mock that replays the observer's one-shot lifecycle.
+
+describe("canObserveInView", () => {
+  it("cannot observe without an element (SSR / not-yet-mounted fallback)", () => {
+    expect(canObserveInView(null, true)).toBe(false);
+  });
+
+  it("cannot observe without IntersectionObserver (no-IntersectionObserver fallback)", () => {
+    expect(canObserveInView({} as Element, false)).toBe(false);
+  });
+
+  it("observes when the element is mounted and IntersectionObserver exists", () => {
+    expect(canObserveInView({} as Element, true)).toBe(true);
+  });
+});
+
+describe("entriesIndicateInView", () => {
+  it("is visible once any entry intersects (one-shot trigger)", () => {
+    expect(entriesIndicateInView([{ isIntersecting: false }, { isIntersecting: true }])).toBe(true);
+  });
+
+  it("stays not-yet-visible while nothing intersects", () => {
+    expect(entriesIndicateInView([{ isIntersecting: false }, { isIntersecting: false }])).toBe(
+      false,
+    );
+  });
+
+  it("treats an empty entry list as not intersecting", () => {
+    expect(entriesIndicateInView([])).toBe(false);
+  });
+});
+
+describe("IntersectionObserver one-shot lifecycle (minimal mock)", () => {
+  it("becomes visible on first intersect and stays visible after leaving the viewport", () => {
+    const observe = vi.fn();
+    const unobserve = vi.fn();
+    const disconnect = vi.fn();
+    let notify: IntersectionObserverCallback | undefined;
+
+    class MockIntersectionObserver {
+      constructor(cb: IntersectionObserverCallback) {
+        notify = cb;
+      }
+      observe = observe;
+      unobserve = unobserve;
+      disconnect = disconnect;
+      takeRecords = () => [];
+      root = null;
+      rootMargin = "";
+      thresholds = [];
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+    // Mirror the useInView effect body: observe, then flip-once-and-disconnect.
+    let inView = false;
+    const observer = new IntersectionObserver((entries) => {
+      if (entriesIndicateInView(entries)) {
+        inView = true;
+        observer.disconnect();
+      }
+    });
+    const el = {} as Element;
+    observer.observe(el);
+    expect(observe).toHaveBeenCalledWith(el);
+
+    // present but not intersecting yet -> no change, observer still armed
+    notify?.(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      observer as unknown as IntersectionObserver,
+    );
+    expect(inView).toBe(false);
+    expect(disconnect).not.toHaveBeenCalled();
+
+    // first real intersection -> visible + disconnect (one-shot)
+    notify?.(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      observer as unknown as IntersectionObserver,
+    );
+    expect(inView).toBe(true);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+
+    // element leaves the viewport again -> still visible, never re-armed
+    notify?.(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      observer as unknown as IntersectionObserver,
+    );
+    expect(inView).toBe(true);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/ui/src/hooks/use-in-view.ts
+++ b/apps/ui/src/hooks/use-in-view.ts
@@ -1,6 +1,33 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 
 /**
+ * True when useInView can observe the target: the element is mounted AND the
+ * runtime provides `IntersectionObserver`. When this is false the hook takes
+ * its fallback path and marks the target visible immediately (SSR /
+ * not-yet-mounted / no-`IntersectionObserver` runtime). Written as a type guard
+ * so the hook keeps `el` non-null after the check without a cast; extracted so
+ * the fallback decision is unit-testable in this DOM-less node suite (see
+ * apps/ui/vitest.config.ts).
+ */
+export function canObserveInView<T extends Element>(
+  el: T | null,
+  hasIntersectionObserver: boolean,
+): el is T {
+  return el !== null && hasIntersectionObserver;
+}
+
+/**
+ * One-shot visibility predicate: any intersecting entry means "become visible".
+ * The hook flips to `true` and disconnects on the first hit, so it stays
+ * visible forever even after the element scrolls back out of view.
+ */
+export function entriesIndicateInView(
+  entries: ReadonlyArray<{ isIntersecting: boolean }>,
+): boolean {
+  return entries.some((entry) => entry.isIntersecting);
+}
+
+/**
  * Tracks whether an element is within (or near) the viewport, via
  * IntersectionObserver. Once the element has intersected, stays `true`
  * forever (the observer disconnects) — for gating one-shot data fetches
@@ -14,13 +41,13 @@ export function useInView<T extends Element>(rootMargin = "200px"): [RefObject<T
   useEffect(() => {
     if (inView) return;
     const el = ref.current;
-    if (!el || typeof IntersectionObserver === "undefined") {
+    if (!canObserveInView(el, typeof IntersectionObserver !== "undefined")) {
       setInView(true);
       return;
     }
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((e) => e.isIntersecting)) {
+        if (entriesIndicateInView(entries)) {
           setInView(true);
           observer.disconnect();
         }


### PR DESCRIPTION
## Summary

Adds regression coverage for `apps/ui/src/hooks/use-in-view.ts`, which had zero tests. `useInView` is a one-shot "become-visible-forever" hook built on `IntersectionObserver`, used to gate per-row data fetches so only rows scrolled into view fire network requests.

Closes #7906

## What this covers

`apps/ui`'s vitest suite is plain-node (no DOM, no `renderHook` — see `apps/ui/vitest.config.ts`), so — mirroring the merged `use-api-session.test.ts` convention — the hook's real decision logic is lifted into two small exported pure helpers and tested directly, plus a minimal `IntersectionObserver` mock that replays the observer's one-shot lifecycle:

- **`canObserveInView(el, hasIntersectionObserver)`** — the fallback decision. Covers both fallback branches the issue calls out: no element (SSR / not-yet-mounted) and no `IntersectionObserver` in the runtime, plus the observe-me path. Written as a type guard so the hook keeps `el` narrowed non-null after the check with no cast.
- **`entriesIndicateInView(entries)`** — the one-shot trigger predicate: intersecting, non-intersecting, and empty-list cases.
- **`IntersectionObserver` one-shot lifecycle (minimal mock)** — observe → not-intersecting (no change, still armed) → first intersect (visible + `disconnect`) → leaves the viewport again (stays visible, never re-armed), asserting `disconnect` fires exactly once.

The refactor is behavior-preserving: the hook now calls the two extracted helpers instead of inlining the same conditions; its `observe` / `disconnect` / `setInView` runtime is unchanged.

## Scope / gates

- Non-visual `apps/ui/src/hooks` change — no routes/components/`.tsx` touched, so it is exempt from the screenshot-evidence requirement.
- `apps/ui` eslint (`eslint .`, incl. `prettier/prettier`) clean; `tsc --noEmit` no new errors; `vitest run` green; rebases clean on `main`.
