### PR TITLE
feat(mcp): add sort/order/fields to list_endpoints (#7892)

### DIFF
--- a/src/endpoints-mcp.ts
+++ b/src/endpoints-mcp.ts
@@ -1,0 +1,381 @@
+// Network-wide endpoint list loader for MCP parity on GET /api/v1/endpoints.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/endpoints.json artifact, with a live health overlay via
+// overlayArtifactEndpoints before filtering so status/latency filters read
+// current probe-derived values. Structurally mirrors provider-endpoints-mcp.ts
+// and subnet-endpoints-mcp.ts, adding sort/order/fields via applyQueryFilters.
+
+import { applyQueryFilters, type Row } from "../workers/list-query.ts";
+import type { StorageReadResult } from "../workers/storage.ts";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  overlayArtifactEndpoints,
+  resolveLiveHealth,
+} from "./health-serving.ts";
+
+export const ENDPOINTS_ARTIFACT = "/metagraph/endpoints.json";
+
+const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
+const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
+const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
+const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
+const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
+
+export interface EndpointsMcpError extends Error {
+  toolError: true;
+  code: string;
+}
+
+export function endpointsMcpError(
+  code: string,
+  message: string,
+): EndpointsMcpError {
+  const error = new Error(message) as EndpointsMcpError;
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw endpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+  allowed: string[],
+): string | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw endpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalRangeBound(
+  args: Record<string, unknown> | null | undefined,
+  key: string,
+): number | null {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw endpointsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function endpointsQueryUrl(
+  args: Record<string, unknown> | null | undefined,
+): URL {
+  const url = new URL("https://mcp.internal/endpoints");
+  const kind = optionalEnum(args, "kind", SURFACE_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
+  if (layer) url.searchParams.set("layer", layer);
+  if (args?.netuid !== undefined) {
+    if (
+      typeof args.netuid !== "number" ||
+      !Number.isInteger(args.netuid) ||
+      (args.netuid as number) < 0
+    ) {
+      throw endpointsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  if (args?.pool_eligible !== undefined) {
+    if (typeof args.pool_eligible !== "boolean") {
+      throw endpointsMcpError(
+        "invalid_params",
+        "pool_eligible must be a boolean when provided.",
+      );
+    }
+    url.searchParams.set("pool_eligible", String(args.pool_eligible));
+  }
+  const provider = optionalString(args, "provider");
+  if (provider) url.searchParams.set("provider", provider);
+  const publicationState = optionalEnum(
+    args,
+    "publication_state",
+    PUBLICATION_STATES,
+  );
+  if (publicationState) {
+    url.searchParams.set("publication_state", publicationState);
+  }
+  const status = optionalEnum(args, "status", HEALTH_STATUSES);
+  if (status) url.searchParams.set("status", status);
+  const minLatencyMs = optionalRangeBound(args, "min_latency_ms");
+  if (minLatencyMs !== null) {
+    url.searchParams.set("min_latency_ms", String(minLatencyMs));
+  }
+  const maxLatencyMs = optionalRangeBound(args, "max_latency_ms");
+  if (maxLatencyMs !== null) {
+    url.searchParams.set("max_latency_ms", String(maxLatencyMs));
+  }
+  const minScore = optionalRangeBound(args, "min_score");
+  if (minScore !== null) url.searchParams.set("min_score", String(minScore));
+  const maxScore = optionalRangeBound(args, "max_score");
+  if (maxScore !== null) url.searchParams.set("max_score", String(maxScore));
+  const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    const cursor = args.cursor;
+    if (typeof cursor !== "number" || !Number.isInteger(cursor) || cursor < 0) {
+      throw endpointsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(cursor));
+  }
+  return url;
+}
+
+interface EndpointsMcpCtx {
+  env: Env;
+  readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
+  readHealthKv?: (
+    env: Env,
+    key: string,
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+export interface EndpointsListResult {
+  generated_at: unknown;
+  notes: unknown;
+  endpoints: Row[];
+  total: unknown;
+  returned: unknown;
+  limit: unknown;
+  cursor: unknown;
+  next_cursor: unknown;
+  sort: unknown;
+  order: unknown;
+}
+
+export async function loadEndpointsList(
+  ctx: EndpointsMcpCtx,
+  args: Record<string, unknown> | null | undefined,
+  {
+    readArtifact,
+  }: {
+    readArtifact?: (env: Env, path: string) => Promise<StorageReadResult>;
+  } = {},
+): Promise<EndpointsListResult> {
+  const queryUrl = endpointsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, ENDPOINTS_ARTIFACT);
+  if (!result?.ok) {
+    const code =
+      (result as { code?: string } | undefined)?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw endpointsMcpError("not_found", "Endpoint catalog unavailable.");
+    }
+    throw endpointsMcpError(
+      code,
+      `Could not load ${ENDPOINTS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw endpointsMcpError("not_found", "Endpoint catalog unavailable.");
+  }
+
+  // Live health overlay — same guard as the REST route: only apply when the
+  // artifact carries surface_id references (i.e. it was built with live-
+  // endpoint health plumbing). Applied before applyQueryFilters so status/latency
+  // filters read current probe-derived values, not stale baked ones.
+  let overlaid = blob as Record<string, unknown>;
+  if (
+    Array.isArray(overlaid.endpoints) &&
+    (overlaid.endpoints as Row[]).some((e) => e?.surface_id)
+  ) {
+    const live = await resolveLiveHealth({
+      readHealthKv: ctx.readHealthKv,
+      env: ctx.env,
+    });
+    const merged = overlayArtifactEndpoints(overlaid, live);
+    if (merged) overlaid = merged as Record<string, unknown>;
+  }
+
+  const transformed = applyQueryFilters(overlaid, queryUrl, "endpoints", []);
+  if (transformed.error) {
+    throw endpointsMcpError("invalid_params", transformed.error.message);
+  }
+  const data = transformed.data as Record<string, unknown>;
+  const meta = transformed.meta as Record<string, unknown>;
+  const page = (meta.pagination as Record<string, unknown>) || {};
+  const rows = Array.isArray(data.endpoints) ? (data.endpoints as Row[]) : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    endpoints: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_ENDPOINTS_INSTRUCTIONS =
+  "list_endpoints the network-wide monitored endpoint catalog with REST list-" +
+  "query filters (kind, layer, netuid, pool_eligible, provider, " +
+  "publication_state, status, latency/score bounds, sort, order, fields, and " +
+  "pagination; mirrors GET /api/v1/endpoints), ";
+
+export const LIST_ENDPOINTS_MCP_TOOL = {
+  name: "list_endpoints",
+  title: "List monitored endpoint resources",
+  description:
+    "Fetch the network-wide catalog of generalized endpoint resources: every " +
+    "monitored public endpoint/surface across providers and subnets, each " +
+    "with its kind, layer, provider, subnet (netuid), publication state, and " +
+    "probe-derived status/latency/score. Filter by kind, layer, netuid, " +
+    "pool_eligible, provider, publication_state, or status; bound by " +
+    "min_/max_latency_ms and min_/max_score; sort with sort + order; project " +
+    "with fields; and page with limit (1-100) / cursor. Mirrors " +
+    "GET /api/v1/endpoints.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      kind: {
+        type: "string",
+        enum: SURFACE_KINDS,
+        description: "Surface kind, e.g. 'subnet-api' or 'openapi'.",
+      },
+      layer: {
+        type: "string",
+        enum: ENDPOINT_LAYERS,
+        description: "Endpoint layer, e.g. 'subnet-app' or 'bittensor-base'.",
+      },
+      netuid: {
+        type: "integer",
+        description: "Filter by subnet netuid.",
+        minimum: 0,
+      },
+      pool_eligible: {
+        type: "boolean",
+        description: "Only endpoints eligible (or not) for RPC pooling.",
+      },
+      provider: {
+        type: "string",
+        description: "Provider slug, e.g. 'datura'.",
+      },
+      publication_state: {
+        type: "string",
+        enum: PUBLICATION_STATES,
+        description: "Publication state, e.g. 'monitored' or 'pool-eligible'.",
+      },
+      status: {
+        type: "string",
+        enum: HEALTH_STATUSES,
+        description: "Probe-derived health status, e.g. 'ok' or 'degraded'.",
+      },
+      min_latency_ms: {
+        type: "number",
+        description: "Only endpoints with probe-derived latency_ms >= this.",
+      },
+      max_latency_ms: {
+        type: "number",
+        description: "Only endpoints with probe-derived latency_ms <= this.",
+      },
+      min_score: {
+        type: "number",
+        description: "Only endpoints with probe-derived score >= this.",
+      },
+      max_score: {
+        type: "number",
+        description: "Only endpoints with probe-derived score <= this.",
+      },
+      sort: {
+        type: "string",
+        enum: ENDPOINT_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of endpoint row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description:
+          "Pagination cursor from a prior response's next_cursor. Default 0.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_ENDPOINTS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["endpoints"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    endpoints: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -220,6 +220,12 @@ import {
   GLOBAL_INCIDENTS_SORT_FIELDS,
 } from "./global-incidents-mcp.ts";
 import {
+  LIST_ENDPOINTS_INSTRUCTIONS,
+  LIST_ENDPOINTS_MCP_TOOL,
+  LIST_ENDPOINTS_OUTPUT_SCHEMA,
+  loadEndpointsList,
+} from "./endpoints-mcp.ts";
+import {
   LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS,
   LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
   LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,
@@ -1061,8 +1067,7 @@ export const MCP_INSTRUCTIONS =
   LIST_PROVIDERS_INSTRUCTIONS +
   LIST_SURFACES_INSTRUCTIONS +
   LIST_CANDIDATES_INSTRUCTIONS +
-  "list_endpoints the " +
-  "network-wide monitored endpoint-resource catalog, " +
+  LIST_ENDPOINTS_INSTRUCTIONS +
   LIST_EVIDENCE_INSTRUCTIONS +
   "list_rpc_endpoints the monitored " +
   "Bittensor RPC endpoint catalog, " +
@@ -1893,19 +1898,6 @@ function requireNetuid(args: Row) {
 function optionalBoolean(args: Row, key: string) {
   const value = args?.[key];
   if (value === undefined || value === null) return false;
-  if (typeof value !== "boolean") {
-    throw toolError("invalid_params", `Argument \`${key}\` must be a boolean.`);
-  }
-  return value;
-}
-
-// Unlike optionalBoolean (which defaults an absent flag to false), a tri-state
-// filter arg must distinguish "not provided, don't filter" (null) from an
-// explicit true/false, or an absent filter would wrongly narrow to only the
-// false-valued rows.
-function optionalNullableBoolean(args: Row, key: string) {
-  const value = args?.[key];
-  if (value === undefined || value === null) return null;
   if (typeof value !== "boolean") {
     throw toolError("invalid_params", `Argument \`${key}\` must be a boolean.`);
   }
@@ -9674,154 +9666,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_endpoints",
-    title: "List monitored endpoint resources",
-    description:
-      "Fetch the network-wide catalog of generalized endpoint resources: every " +
-      "monitored public endpoint/surface across providers and subnets, each " +
-      "with its kind, layer, provider, subnet (netuid), publication state, and " +
-      "probe-derived status/latency/score. Use it to discover live endpoints " +
-      "network-wide. Optionally filter by kind/layer/netuid/provider/" +
-      "publication_state/status/pool_eligible, bound by min_/max_latency_ms " +
-      "and min_/max_score, and page with limit/cursor — the full catalog can " +
-      "be large. Mirrors GET /api/v1/endpoints.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        kind: {
-          type: "string",
-          enum: QUERY_ENUMS.surfaceKind,
-          description: "Surface kind, e.g. 'subnet-api' or 'openapi'.",
-        },
-        layer: {
-          type: "string",
-          enum: QUERY_ENUMS.endpointLayer,
-          description: "Endpoint layer, e.g. 'subnet-app' or 'bittensor-base'.",
-        },
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        provider: {
-          type: "string",
-          description: "Provider slug, e.g. 'datura'.",
-        },
-        publication_state: {
-          type: "string",
-          enum: QUERY_ENUMS.endpointPublicationState,
-          description:
-            "Publication state, e.g. 'monitored' or 'pool-eligible'.",
-        },
-        status: {
-          type: "string",
-          enum: QUERY_ENUMS.healthStatus,
-          description: "Probe-derived health status, e.g. 'ok' or 'degraded'.",
-        },
-        pool_eligible: {
-          type: "boolean",
-          description: "Only endpoints eligible (or not) for RPC pooling.",
-        },
-        min_latency_ms: {
-          type: "number",
-          description: "Only endpoints with probe-derived latency_ms >= this.",
-        },
-        max_latency_ms: {
-          type: "number",
-          description: "Only endpoints with probe-derived latency_ms <= this.",
-        },
-        min_score: {
-          type: "number",
-          description: "Only endpoints with probe-derived score >= this.",
-        },
-        max_score: {
-          type: "number",
-          description: "Only endpoints with probe-derived score <= this.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max endpoints to return. Omit for the full list.",
-          minimum: 1,
-        },
-        cursor: {
-          type: "integer",
-          description:
-            "Pagination cursor from a prior response's next_cursor. Default 0.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
+    ...LIST_ENDPOINTS_MCP_TOOL,
     async handler(args: Row, ctx: McpCtx) {
-      const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
-      const layer = optionalEnum(args, "layer", QUERY_ENUMS.endpointLayer);
-      const netuid = optionalNonNegativeInt(args, "netuid");
-      const provider = optionalString(args, "provider");
-      const publicationState = optionalEnum(
-        args,
-        "publication_state",
-        QUERY_ENUMS.endpointPublicationState,
-      );
-      const status = optionalEnum(args, "status", QUERY_ENUMS.healthStatus);
-      const poolEligible = optionalNullableBoolean(args, "pool_eligible");
-      // Inclusive numeric range bounds, the MCP mirror of REST's
-      // rangeFilters: ["latency_ms", "score"] on the endpoints collection
-      // (contracts.mjs) — same shape as LIST_SUBNETS_RANGE_BOUNDS.
-      const rangeBounds = [
-        { arg: "min_latency_ms", field: "latency_ms", op: "min" },
-        { arg: "max_latency_ms", field: "latency_ms", op: "max" },
-        { arg: "min_score", field: "score", op: "min" },
-        { arg: "max_score", field: "score", op: "max" },
-      ]
-        .filter(({ arg }) => Number.isFinite(args?.[arg]))
-        .map(({ field, op, arg }) => ({ field, op, limit: args[arg] }));
-      const limit = optionalPositiveInt(args, "limit");
-      const cursor = optionalNonNegativeInt(args, "cursor") ?? 0;
-      let data = await loadArtifactData(ctx, "/metagraph/endpoints.json");
-      // Live per-endpoint health overlay (mirrors workers/api.mjs's raw-
-      // artifact serving path): the build-time endpoints.json bakes stale
-      // operational health, so replace it from the 15-minute cron snapshot
-      // before filtering/pagination -- status/pool_eligible filters below
-      // (and the latency_ms/score bounds, which come from this same overlay)
-      // must see live values, not the baked ones.
-      if (
-        Array.isArray(data?.endpoints) &&
-        data.endpoints.some((endpoint: Row) => endpoint?.surface_id)
-      ) {
-        const overlaid = overlayArtifactEndpoints(
-          data,
-          await mcpLiveHealth(ctx),
-        );
-        if (overlaid) data = overlaid;
-      }
-      const all = Array.isArray(data.endpoints) ? data.endpoints : [];
-      const filtered = all.filter(
-        (e: Row) =>
-          (kind === null || e.kind === kind) &&
-          (layer === null || e.layer === layer) &&
-          (netuid === null || e.netuid === netuid) &&
-          (provider === null || e.provider === provider) &&
-          (publicationState === null ||
-            e.publication_state === publicationState) &&
-          (status === null || e.status === status) &&
-          (poolEligible === null || e.pool_eligible === poolEligible) &&
-          rangeBounds.every(({ field, op, limit: bound }) => {
-            const value = e[field];
-            if (typeof value !== "number") return false;
-            return op === "min" ? value >= bound : value <= bound;
-          }),
-      );
-      const window = cursorWindow(filtered, {
-        collection: "endpoints",
-        dataKey: "endpoints",
-        limit,
-        cursor,
-      });
-      return {
-        ...data,
-        endpoints: window.page,
-        total: window.total,
-        returned: window.returned,
-        cursor: window.cursor,
-        limit: window.limit,
-        next_cursor: window.next_cursor,
-      };
+      return loadEndpointsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
@@ -15445,21 +15292,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_providers: LIST_PROVIDERS_OUTPUT_SCHEMA,
   list_surfaces: LIST_SURFACES_OUTPUT_SCHEMA,
   list_candidates: LIST_CANDIDATES_OUTPUT_SCHEMA,
-  list_endpoints: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      endpoints: { type: "array", items: { type: "object" } },
-      total: { type: "integer" },
-      returned: { type: "integer" },
-      cursor: { type: "integer" },
-      limit: { type: "integer" },
-      next_cursor: { type: ["integer", "null"] },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_endpoints: LIST_ENDPOINTS_OUTPUT_SCHEMA,
   get_subnet_surfaces: {
     type: "object",
     additionalProperties: true,

--- a/tests/endpoints-mcp.test.ts
+++ b/tests/endpoints-mcp.test.ts
@@ -1,0 +1,457 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as healthServing from "../src/health-serving.ts";
+import * as listQuery from "../workers/list-query.ts";
+import {
+  ENDPOINTS_ARTIFACT,
+  LIST_ENDPOINTS_INSTRUCTIONS,
+  LIST_ENDPOINTS_MCP_TOOL,
+  LIST_ENDPOINTS_OUTPUT_SCHEMA,
+  endpointsMcpError,
+  endpointsQueryUrl,
+  loadEndpointsList,
+} from "../src/endpoints-mcp.ts";
+import type { Row } from "./row-type.ts";
+import { MCP_INSTRUCTIONS, MCP_TOOLS } from "../src/mcp-server.ts";
+
+type LoadCtx = Parameters<typeof loadEndpointsList>[0];
+type LoadDeps = Parameters<typeof loadEndpointsList>[2];
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: ["endpoint catalog"],
+  endpoints: [
+    {
+      id: "datura-subnet-api",
+      kind: "subnet-api",
+      layer: "subnet-app",
+      provider: "datura",
+      netuid: 1,
+      status: "ok",
+      latency_ms: 120,
+      score: 90,
+      pool_eligible: true,
+      publication_state: "monitored",
+    },
+    {
+      id: "chutes-openapi",
+      kind: "openapi",
+      layer: "subnet-app",
+      provider: "chutes",
+      netuid: 12,
+      status: "degraded",
+      latency_ms: 400,
+      score: 40,
+      pool_eligible: false,
+      publication_state: "monitored",
+    },
+    {
+      id: "allnodes-rpc",
+      kind: "subtensor-rpc",
+      layer: "bittensor-base",
+      provider: "allnodes",
+      netuid: 0,
+      status: "ok",
+      latency_ms: 80,
+      score: 95,
+      pool_eligible: true,
+      publication_state: "monitored",
+    },
+  ],
+};
+
+const BLOB_WITH_SURFACE_IDS = {
+  endpoints: [
+    {
+      id: "datura-subnet-api",
+      surface_id: "datura-subnet-api",
+      status: "degraded",
+      latency_ms: 500,
+    },
+    {
+      id: "chutes-openapi",
+      surface_id: "chutes-openapi",
+      status: "degraded",
+      latency_ms: 500,
+    },
+  ],
+};
+
+function readArtifact(_env: unknown, path: string) {
+  if (path === ENDPOINTS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("endpoints-mcp (#7892)", () => {
+  test("endpointsMcpError is shaped for MCP toolError handling", () => {
+    const err = endpointsMcpError("invalid_params", "bad status");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("endpointsQueryUrl sets all filter, range, sort, and pagination params", () => {
+    const url = endpointsQueryUrl({
+      kind: "subnet-api",
+      layer: "subnet-app",
+      netuid: 1,
+      pool_eligible: true,
+      provider: "datura",
+      publication_state: "monitored",
+      status: "ok",
+      min_latency_ms: 50,
+      max_latency_ms: 300,
+      min_score: 80,
+      max_score: 100,
+      sort: "latency_ms",
+      order: "asc",
+      fields: "id,status",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("kind"), "subnet-api");
+    assert.equal(url.searchParams.get("layer"), "subnet-app");
+    assert.equal(url.searchParams.get("netuid"), "1");
+    assert.equal(url.searchParams.get("pool_eligible"), "true");
+    assert.equal(url.searchParams.get("provider"), "datura");
+    assert.equal(url.searchParams.get("publication_state"), "monitored");
+    assert.equal(url.searchParams.get("status"), "ok");
+    assert.equal(url.searchParams.get("min_latency_ms"), "50");
+    assert.equal(url.searchParams.get("max_latency_ms"), "300");
+    assert.equal(url.searchParams.get("min_score"), "80");
+    assert.equal(url.searchParams.get("max_score"), "100");
+    assert.equal(url.searchParams.get("sort"), "latency_ms");
+    assert.equal(url.searchParams.get("order"), "asc");
+    assert.equal(url.searchParams.get("fields"), "id,status");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("endpointsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ kind: "bogus" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects invalid status", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ status: "healthy" }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects negative netuid and fractional cursor", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ netuid: -1 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ cursor: 1.5 }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects non-finite range bound", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ min_latency_ms: Infinity }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl rejects blank string filters", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ fields: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+    assert.throws(
+      () => endpointsQueryUrl({ provider: "   " }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("endpointsQueryUrl clamps invalid limit values to the REST default", () => {
+    assert.equal(endpointsQueryUrl({ limit: -1 }).searchParams.get("limit"), "50");
+    assert.equal(endpointsQueryUrl({ limit: 0 }).searchParams.get("limit"), "50");
+    assert.equal(
+      endpointsQueryUrl({ limit: Number.NaN }).searchParams.get("limit"),
+      "50",
+    );
+    assert.equal(
+      endpointsQueryUrl({ limit: "bad" as unknown as number }).searchParams.get(
+        "limit",
+      ),
+      "50",
+    );
+  });
+
+  test("endpointsQueryUrl rejects a non-boolean pool_eligible", () => {
+    assert.throws(
+      () => endpointsQueryUrl({ pool_eligible: "yes" as unknown as boolean }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadEndpointsList returns all endpoints when unfiltered", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      {},
+    );
+    assert.equal(out.returned, 3);
+    assert.deepEqual(out.notes, ["endpoint catalog"]);
+  });
+
+  test("loadEndpointsList filters by kind and status", async () => {
+    const byKind = await loadEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { kind: "openapi" },
+    );
+    assert.equal(byKind.returned, 1);
+    assert.equal(byKind.endpoints[0].provider, "chutes");
+
+    const byStatus = await loadEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { status: "ok" },
+    );
+    assert.equal(byStatus.returned, 2);
+  });
+
+  test("loadEndpointsList filters by score range", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { min_score: 85 },
+    );
+    assert.equal(out.returned, 2);
+    assert.ok(out.endpoints.every((e) => (e as Row).score >= 85));
+  });
+
+  test("loadEndpointsList sorts and pages the collection", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { sort: "latency_ms", order: "asc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.endpoints[0].id, "allnodes-rpc");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadEndpointsList skips overlay when no surface_id in endpoints", async () => {
+    const out = await loadEndpointsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({ surfaces: [] }),
+      } as unknown as LoadCtx,
+      { status: "ok" },
+    );
+    assert.equal(out.returned, 2);
+  });
+
+  test("loadEndpointsList applies live overlay before filtering", async () => {
+    const live = {
+      surfaces: [
+        { surface_id: "chutes-openapi", status: "ok", latency_ms: 50 },
+      ],
+    };
+    const out = await loadEndpointsList(
+      {
+        env: {},
+        readArtifact: async (_env: unknown, path: string) => {
+          if (path === ENDPOINTS_ARTIFACT)
+            return { ok: true, data: BLOB_WITH_SURFACE_IDS };
+          return { ok: false, code: "artifact_not_found" };
+        },
+        readHealthKv: async () => live,
+      } as unknown as LoadCtx,
+      { status: "ok" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.endpoints[0].id, "chutes-openapi");
+  });
+
+  test("loadEndpointsList keeps the artifact when overlay returns null", async () => {
+    const spy = vi
+      .spyOn(healthServing, "overlayArtifactEndpoints")
+      .mockReturnValue(null);
+    try {
+      const out = await loadEndpointsList(
+        {
+          env: {},
+          readArtifact: async (_env: unknown, path: string) => {
+            if (path === ENDPOINTS_ARTIFACT)
+              return { ok: true, data: BLOB_WITH_SURFACE_IDS };
+            return { ok: false, code: "artifact_not_found" };
+          },
+          readHealthKv: async () => ({ surfaces: [] }),
+        } as unknown as LoadCtx,
+        { status: "degraded" },
+      );
+      assert.equal(out.returned, 2);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadEndpointsList uses an injected readArtifact dep", async () => {
+    const out = await loadEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({ ok: false }),
+      } as unknown as LoadCtx,
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: [{ id: "solo" }] },
+        }),
+      } as unknown as LoadDeps,
+    );
+    assert.equal(out.endpoints[0].id, "solo");
+  });
+
+  test("loadEndpointsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadEndpointsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) =>
+        err.code === "artifact_timeout" && /endpoints\.json/.test(err.message),
+    );
+  });
+
+  test("loadEndpointsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList({ env: {}, readArtifact } as unknown as LoadCtx, {
+          fields: "not_a_column",
+        }),
+      (err: Row) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadEndpointsList projects row fields when requested", async () => {
+    const out = await loadEndpointsList(
+      { env: {}, readArtifact } as unknown as LoadCtx,
+      { kind: "openapi", fields: "id,status" },
+    );
+    assert.deepEqual(out.endpoints[0], {
+      id: "chutes-openapi",
+      status: "degraded",
+    });
+  });
+
+  test("loadEndpointsList treats a non-array endpoints key as empty", async () => {
+    const out = await loadEndpointsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { endpoints: null },
+        }),
+      } as unknown as LoadCtx,
+      {},
+    );
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadEndpointsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { endpoints: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadEndpointsList(
+        { env: {}, readArtifact } as unknown as LoadCtx,
+        {},
+      );
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadEndpointsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "not_found",
+    );
+  });
+
+  test("loadEndpointsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadEndpointsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          } as unknown as LoadCtx,
+          {},
+        ),
+      (err: Row) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_ENDPOINTS_MCP_TOOL.name, "list_endpoints");
+    assert.match(LIST_ENDPOINTS_INSTRUCTIONS, /list_endpoints/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_ENDPOINTS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_endpoints with sort, order, and fields", () => {
+    assert.match(MCP_INSTRUCTIONS, /list_endpoints/);
+    const tool = MCP_TOOLS.find((t: Row) => t.name === "list_endpoints");
+    assert.ok(tool);
+    assert.equal(tool.title, "List monitored endpoint resources");
+    const props = tool.inputSchema.properties as Row;
+    assert.ok(props.sort);
+    assert.ok(props.order);
+    assert.ok(props.fields);
+    assert.ok(props.kind);
+    assert.ok(props.status);
+    assert.ok(props.min_latency_ms);
+  });
+});

--- a/tests/endpoints-mcp.test.ts
+++ b/tests/endpoints-mcp.test.ts
@@ -173,8 +173,14 @@ describe("endpoints-mcp (#7892)", () => {
   });
 
   test("endpointsQueryUrl clamps invalid limit values to the REST default", () => {
-    assert.equal(endpointsQueryUrl({ limit: -1 }).searchParams.get("limit"), "50");
-    assert.equal(endpointsQueryUrl({ limit: 0 }).searchParams.get("limit"), "50");
+    assert.equal(
+      endpointsQueryUrl({ limit: -1 }).searchParams.get("limit"),
+      "50",
+    );
+    assert.equal(
+      endpointsQueryUrl({ limit: 0 }).searchParams.get("limit"),
+      "50",
+    );
     assert.equal(
       endpointsQueryUrl({ limit: Number.NaN }).searchParams.get("limit"),
       "50",

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -16143,6 +16143,67 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.endpoints[0].netuid, 2);
   });
 
+  test("list_endpoints sorts by netuid, honoring order (default asc)", async () => {
+    const deps = endpointsDeps();
+    const asc = (await callTool("list_endpoints", { sort: "netuid" }, { deps }))
+      .body.result.structuredContent;
+    assert.deepEqual(
+      asc.endpoints.map((e: Row) => e.netuid),
+      [7, 7, 12],
+    );
+
+    const desc = (
+      await callTool(
+        "list_endpoints",
+        { sort: "netuid", order: "desc" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(
+      desc.endpoints.map((e: Row) => e.netuid),
+      [12, 7, 7],
+    );
+  });
+
+  test("list_endpoints projects only the requested fields", async () => {
+    const deps = endpointsDeps();
+    const res = await callTool(
+      "list_endpoints",
+      { netuid: 12, fields: "netuid,provider" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.endpoints.length, 1);
+    assert.deepEqual(Object.keys(out.endpoints[0]).sort(), [
+      "netuid",
+      "provider",
+    ]);
+  });
+
+  test("list_endpoints rejects an unknown sort/order/fields value", async () => {
+    const deps = endpointsDeps();
+    const badSort = await callTool(
+      "list_endpoints",
+      { sort: "not-a-field" },
+      { deps },
+    );
+    assert.equal(badSort.body.result.isError, true);
+
+    const badOrder = await callTool(
+      "list_endpoints",
+      { sort: "netuid", order: "sideways" },
+      { deps },
+    );
+    assert.equal(badOrder.body.result.isError, true);
+
+    const badFields = await callTool(
+      "list_endpoints",
+      { fields: "not_a_column" },
+      { deps },
+    );
+    assert.equal(badFields.body.result.isError, true);
+  });
+
   test("list_evidence returns filtered claim rows", async () => {
     const deps = makeDeps({
       "/metagraph/evidence-ledger.json": {


### PR DESCRIPTION
## Summary

Adds `sort`, `order`, and `fields` to MCP `list_endpoints` for full REST parity with `GET /api/v1/endpoints`.

Closes #7892

## Why previous PRs were closed

| PR | Closed reason |
|---|---|
| [#7928](https://github.com/JSONbored/metagraphed/pull/7928) | **CI failure** — `codecov/patch` at 94.6% (2 uncovered lines in inline `mcp-server.mjs` handler); also targeted pre-TypeScript `.mjs` paths |
| [#7968](https://github.com/JSONbored/metagraphed/pull/7968) | **CI failure** — `test` job failed on coverage gate (inline handler in `mcp-server.ts` without dedicated module tests) |
| [#7971](https://github.com/JSONbored/metagraphed/pull/7971) | **Duplicate-work blocker** — gate auto-closed because [#7968](https://github.com/JSONbored/metagraphed/pull/7968) was already open on the same issue; also had red `test`/`checks` CI |

This reimplementation extracts the loader into `endpoints-mcp.ts` (matching `provider-endpoints-mcp.ts` / `subnet-endpoints-mcp.ts`) with 23 module tests + 3 new `callTool` tests for registration coverage.

## What changed (4 files)

### `src/endpoints-mcp.ts` (new)

- `loadEndpointsList` reads `/metagraph/endpoints.json`, applies live health overlay when `surface_id` rows exist, then delegates to `applyQueryFilters` over the shared `endpoints` collection
- New filters: `sort`, `order`, `fields` (plus all existing filters unchanged)
- Exports: `LIST_ENDPOINTS_MCP_TOOL`, `LIST_ENDPOINTS_INSTRUCTIONS`, `LIST_ENDPOINTS_OUTPUT_SCHEMA`

### `src/mcp-server.ts`

- Inline ~150-line handler replaced with `loadEndpointsList(asMcpLoaderCtx(ctx), args)`
- Output schema → `LIST_ENDPOINTS_OUTPUT_SCHEMA`
- Removed now-unused `optionalNullableBoolean` helper

### Tests

- `tests/endpoints-mcp.test.ts` — 27 tests (filters, sort/order, fields projection, overlay, errors, registry wiring)
- `tests/mcp-server.test.ts` — 3 new `callTool` tests (sort+order, fields projection, invalid sort/order/fields)

## Validation

- [x] `vitest run tests/endpoints-mcp.test.ts` — 27/27 passed
- [x] `vitest run tests/mcp-server.test.ts -t list_endpoints` — 17/17 passed
- [x] `npm run validate:mcp` — 203 tools
- [x] Local patch coverage on `src/endpoints-mcp.ts`: **100% lines, 100% branches** (120/120)
- [ ] Gittensory Gate + full CI green (incl. `codecov/patch` ≥99%)

## Test plan

- [ ] `list_endpoints` with `{ sort: "netuid", order: "desc" }` returns descending netuid order
- [ ] `{ netuid: 12, fields: "netuid,provider" }` projects only those columns
- [ ] `{ sort: "not-a-field" }` / `{ fields: "not_a_column" }` rejected
- [ ] Existing filter/pagination/range-bound tests still pass
