### PR TITLE
feat(api): add block/time-range filters to sudo GraphQL field

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2684,7 +2684,7 @@ export type Query = {
   subnet_yield_history: SubnetYieldHistory;
   /** Paginated active-subnet index. */
   subnets: SubnetList;
-  /** Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo. */
+  /** Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Optionally narrow by block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same block/time filters GET /api/v1/sudo and the get_sudo MCP tool accept. Mirrors GET /api/v1/sudo. */
   sudo: ExtrinsicList;
   /** The network's on-chain sudo (superuser) key hotkey, read live from chain via RPC (not the Postgres tier). hotkey is null on RPC failure or a renounced sudo, schema-stable, never a GraphQL error. Mirrors GET /api/v1/sudo/key. */
   sudo_key?: Maybe<SudoKey>;
@@ -3779,11 +3779,15 @@ export type QuerySubnetsArgs = {
 
 export type QuerySudoArgs = {
   block?: InputMaybe<Scalars['Int']['input']>;
+  block_end?: InputMaybe<Scalars['Int']['input']>;
+  block_start?: InputMaybe<Scalars['Int']['input']>;
   call_function?: InputMaybe<Scalars['String']['input']>;
   cursor?: InputMaybe<Scalars['String']['input']>;
+  from?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   success?: InputMaybe<Scalars['Boolean']['input']>;
+  to?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -776,12 +776,16 @@ export const SDL = /* GraphQL */ `
     evm_address(h160: String!): EvmAddressMapping
     "The get_evm_address_mapping-aligned name for evm_address, so the MCP tool name and this Query field line up. Structurally identical to evm_address -- same live RPC read, same validation, same schema-stable null on an unresolved mapping -- not a second lookup. Mirrors GET /api/v1/evm/address/{h160}."
     evm_address_mapping(h160: String!): EvmAddressMapping
-    "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
+    "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Optionally narrow by block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same block/time filters GET /api/v1/sudo and the get_sudo MCP tool accept. Mirrors GET /api/v1/sudo."
     sudo(
       limit: Int
       offset: Int
       cursor: String
       block: Int
+      block_start: Int
+      block_end: Int
+      from: String
+      to: String
       call_function: String
       success: Boolean
     ): ExtrinsicList!

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3772,7 +3772,18 @@ const rootValue = {
   },
 
   async sudo(
-    { limit, offset, cursor, block, call_function: callFunction, success }: Row,
+    {
+      limit,
+      offset,
+      cursor,
+      block,
+      block_start: blockStart,
+      block_end: blockEnd,
+      from,
+      to,
+      call_function: callFunction,
+      success,
+    }: Row,
     context: GqlContext,
   ) {
     // The Sudo governance feed is the /extrinsics feed with call_module fixed
@@ -3790,6 +3801,14 @@ const rootValue = {
     params.set("offset", String(safeOffset));
     if (cursor) params.set("cursor", cursor);
     if (block != null) params.set("block", String(block));
+    // #7874: block_start/block_end (inclusive height range) and from/to
+    // (observed_at epoch-ms range) forwarded straight through to the same
+    // /api/v1/sudo route get_sudo uses. from/to are String args (epoch-ms
+    // overflows GraphQL Int's 32 bits), matching account_history's from/to.
+    if (blockStart != null) params.set("block_start", String(blockStart));
+    if (blockEnd != null) params.set("block_end", String(blockEnd));
+    if (from != null) params.set("from", from);
+    if (to != null) params.set("to", to);
     if (callFunction) params.set("call_function", callFunction);
     if (success != null) params.set("success", String(success));
     const data =

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -3283,6 +3283,94 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     assert.equal(capturedUrl!.searchParams.get("signer"), null);
   });
 
+  test("sudo: a block_start/block_end height range is forwarded to the Postgres tier (#7874)", async () => {
+    let capturedUrl: URL | undefined;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 50,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ sudo(block_start: 100, block_end: 500) { total } }`,
+      env as unknown as Env,
+    );
+    assert.equal(capturedUrl!.pathname, "/api/v1/sudo");
+    assert.equal(capturedUrl!.searchParams.get("block_start"), "100");
+    assert.equal(capturedUrl!.searchParams.get("block_end"), "500");
+    assert.equal(capturedUrl!.searchParams.has("from"), false);
+    assert.equal(capturedUrl!.searchParams.has("to"), false);
+  });
+
+  test("sudo: a from/to observed_at range is forwarded to the Postgres tier (#7874)", async () => {
+    let capturedUrl: URL | undefined;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 50,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ sudo(from: "1750000000000", to: "1760000000000") { total } }`,
+      env as unknown as Env,
+    );
+    assert.equal(capturedUrl!.searchParams.get("from"), "1750000000000");
+    assert.equal(capturedUrl!.searchParams.get("to"), "1760000000000");
+    assert.equal(capturedUrl!.searchParams.has("block_start"), false);
+    assert.equal(capturedUrl!.searchParams.has("block_end"), false);
+  });
+
+  test("introspection: sudo exposes block_start/block_end (Int) and from/to (String) args (#7874)", async () => {
+    const { status, body } = await gql(
+      `{ __type(name: "Query") { fields {
+          name
+          args { name type { kind name ofType { kind name } } }
+        } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const sudo = body.data.__type.fields.find((f: Row) => f.name === "sudo");
+    const argType = (name: string) => {
+      const a = sudo.args.find((x: Row) => x.name === name);
+      assert.ok(a, `expected a ${name} arg on sudo`);
+      return a.type;
+    };
+    for (const name of ["block_start", "block_end"]) {
+      assert.deepEqual(argType(name), {
+        kind: "SCALAR",
+        name: "Int",
+        ofType: null,
+      });
+    }
+    for (const name of ["from", "to"]) {
+      assert.deepEqual(argType(name), {
+        kind: "SCALAR",
+        name: "String",
+        ofType: null,
+      });
+    }
+  });
+
   test("sudo: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
     let capturedUrl: URL | undefined;
     const env = {


### PR DESCRIPTION
Closes #7874

Adds the block/time filters `GET /api/v1/sudo` and the `get_sudo` MCP tool already accept to the `sudo` GraphQL field, bringing the three surfaces to parity:

- `block_start` / `block_end` — inclusive block-height range (`Int`)
- `from` / `to` — `observed_at` epoch-ms range (`String`, because epoch-ms overflows GraphQL's 32-bit `Int`, matching the existing `account_history(from/to)` convention)

The resolver forwards each arg straight through to `/api/v1/sudo` with no duplicated filtering (the route already fixes `call_module=Sudo`). `generated/graphql/types.ts` is regenerated from the SDL per the types-epic D drift gate.

Tests: forwarding for `block_start`/`block_end` and `from`/`to` (asserting unrelated params stay unset for branch coverage), plus an introspection guard pinning the new arg scalar types (Int vs String).
