### PR TITLE
feat(api): global_incidents/incidents list filters (#7875)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2009,12 +2009,26 @@ export type GlobalHealth = {
 /** Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope. */
 export type GlobalIncidents = {
   __typename?: 'GlobalIncidents';
+  /** Offset this page started at (#7875). */
+  cursor: Scalars['Int']['output'];
+  /** Page size actually applied (#7875). */
+  limit: Scalars['Int']['output'];
+  /** Offset to pass as cursor for the next page, or null on the last page (#7875). */
+  next_cursor?: Maybe<Scalars['Int']['output']>;
   observed_at?: Maybe<Scalars['String']['output']>;
+  /** Sort direction applied (#7875). */
+  order?: Maybe<Scalars['String']['output']>;
+  /** Surfaces returned on this page (#7875). */
+  returned: Scalars['Int']['output'];
   schema_version: Scalars['Int']['output'];
+  /** Sort field applied, or null when unsorted (#7875). */
+  sort?: Maybe<Scalars['String']['output']>;
   source?: Maybe<Scalars['String']['output']>;
   /** Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape. */
   summary?: Maybe<Scalars['JSON']['output']>;
   surfaces: Array<EndpointIncident>;
+  /** Surfaces matching the filters before paging (#7875). Equals the surfaces length when no limit/cursor is supplied. */
+  total: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
 };
 
@@ -3181,6 +3195,11 @@ export type QueryGapsArgs = {
 
 
 export type QueryGlobal_IncidentsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3215,6 +3234,11 @@ export type QueryHealth_HistoryArgs = {
 
 
 export type QueryIncidentsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -7364,11 +7388,18 @@ export type GlobalHealthResolvers<ContextType = GqlContext, ParentType extends R
 }>;
 
 export type GlobalIncidentsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GlobalIncidents'] = ResolversParentTypes['GlobalIncidents']> = ResolversObject<{
+  cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   surfaces?: Resolver<Array<ResolversTypes['EndpointIncident']>, ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -503,9 +503,23 @@ export const SDL = /* GraphQL */ `
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
     "Global endpoint-incident ledger over a 7d/30d window; degrades to a schema-stable empty ledger (never a GraphQL error) on a cold/retired health tier. Mirrors GET /api/v1/incidents."
-    incidents(window: String): GlobalIncidents!
+    incidents(
+      window: String
+      netuid: Int
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): GlobalIncidents!
     "The get_global_incidents-aligned name for the same global downtime-incident ledger (#7643): identical 7d/30d window validation, tier fallback, and cold-tier degradation as incidents — a thin alias so MCP tool names and GraphQL fields line up. Distinct from endpoint_incidents (the active endpoint failure/degradation feed, GET /api/v1/endpoint-incidents): this is the historical incident ledger. Returns the typed GlobalIncidents envelope rather than the issue's literal JSON suggestion, matching incidents. Mirrors GET /api/v1/incidents."
-    global_incidents(window: String): GlobalIncidents!
+    global_incidents(
+      window: String
+      netuid: Int
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): GlobalIncidents!
     "Recent-extrinsic feed (newest first), optionally filtered. Mirrors GET /api/v1/extrinsics."
     extrinsics(
       limit: Int
@@ -2781,6 +2795,20 @@ export const SDL = /* GraphQL */ `
     "Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape."
     summary: JSON
     surfaces: [EndpointIncident!]!
+    "Surfaces matching the filters before paging (#7875). Equals the surfaces length when no limit/cursor is supplied."
+    total: Int!
+    "Surfaces returned on this page (#7875)."
+    returned: Int!
+    "Page size actually applied (#7875)."
+    limit: Int!
+    "Offset this page started at (#7875)."
+    cursor: Int!
+    "Offset to pass as cursor for the next page, or null on the last page (#7875)."
+    next_cursor: Int
+    "Sort field applied, or null when unsorted (#7875)."
+    sort: String
+    "Sort direction applied (#7875)."
+    order: String
   }
 
   "One endpoint incident in the global ledger. Mirrors the REST EndpointIncident shape (enum-valued fields carried as their string values)."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3092,7 +3092,10 @@ const rootValue = {
     });
   },
 
-  async incidents({ window }: Row, context: GqlContext) {
+  async incidents(
+    { window, netuid, sort, order, limit, cursor }: Row,
+    context: GqlContext,
+  ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleGlobalIncidents
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL BAD_USER_INPUT
     // error, not a silent empty result. analyticsWindow reads only the ?window param.
@@ -3119,13 +3122,56 @@ const rootValue = {
         "METAGRAPH_HEALTH_SOURCE",
       )) as Row | null) ??
       (await loadGlobalIncidentsLedger(context.env, { label })).data;
-    return {
+    const ledger = {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? label,
       observed_at: data.observed_at ?? null,
       source: data.source ?? null,
       summary: data.summary ?? null,
       surfaces: data.surfaces ?? [],
+    };
+    // #7875: apply the same list query GET /api/v1/incidents runs over the
+    // ledger's surfaces (listQueryWith("incidents", [window])) -- the netuid
+    // filter plus sort/order and limit/cursor paging. applyQueryFilters is the
+    // same helper the REST pipeline and the list_* MCP loaders use, so the
+    // allowlists cannot drift; an unsupported sort/limit/cursor is a GraphQL
+    // error rather than a silently substituted default.
+    if (netuid != null && (!Number.isInteger(netuid) || netuid < 0)) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const queryUrl = new URL("https://graphql.internal/incidents");
+    for (const [name, value] of [
+      ["netuid", netuid],
+      ["sort", sort],
+      ["order", order],
+      ["limit", limit],
+      ["cursor", cursor],
+    ] as const) {
+      if (value != null) queryUrl.searchParams.set(name, String(value));
+    }
+    const transformed = applyQueryFilters(ledger, queryUrl, "incidents", [
+      "netuid",
+    ]);
+    if (transformed.error) {
+      throw new GraphQLError(transformed.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const filtered = transformed.data as Row;
+    const page = ((transformed.meta as Row)?.pagination ?? {}) as Row;
+    const surfaces = Array.isArray(filtered.surfaces) ? filtered.surfaces : [];
+    return {
+      ...ledger,
+      surfaces,
+      total: page.total ?? surfaces.length,
+      returned: page.returned ?? surfaces.length,
+      limit: page.limit ?? surfaces.length,
+      cursor: page.cursor ?? 0,
+      next_cursor: page.next_cursor ?? null,
+      sort: page.sort ?? null,
+      order: page.order ?? null,
     };
   },
 
@@ -3134,8 +3180,8 @@ const rootValue = {
   // Identical window validation (7d/30d -> BAD_USER_INPUT), Postgres-tier ->
   // retired-D1 fallback, and schema-stable cold-tier degradation; nothing
   // re-derived. Distinct from endpoint_incidents (the active endpoint feed).
-  async global_incidents({ window }: Row, context: GqlContext) {
-    return rootValue.incidents({ window }, context);
+  async global_incidents(args: Row, context: GqlContext) {
+    return rootValue.incidents(args, context);
   },
 
   // #7876: GraphQL parity for the search field's REST/MCP filters. Reuse

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -7558,6 +7558,176 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     assert.equal(FIELD_COMPLEXITY.global_incidents, FIELD_COMPLEXITY.incidents);
   });
 
+  // #7875: netuid filter + sort/order + limit/cursor paging, applied through the
+  // same list query GET /api/v1/incidents runs over the ledger's surfaces.
+  function threeSurfaceEnv() {
+    const surface = (id: string, netuid: number, downtime: number) => ({
+      id,
+      endpoint_id: `ep-${id}`,
+      state: "resolved",
+      severity: "minor",
+      status: "failed",
+      netuid,
+      provider: "alpha",
+      downtime_ms: downtime,
+      incident_count: 1,
+      surface_id: id,
+    });
+    return {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi({
+        schema_version: 1,
+        window: "30d",
+        observed_at: "2026-07-01T00:00:00.000Z",
+        source: "postgres",
+        summary: { incident_count: 3 },
+        surfaces: [
+          surface("inc-a", 5, 300),
+          surface("inc-b", 7, 200),
+          surface("inc-c", 5, 100),
+        ],
+      }),
+      METAGRAPH_HEALTH_DB: emptyHealthDb,
+    } as unknown as Env;
+  }
+
+  test("filters by netuid (#7875)", async () => {
+    const { status, body } = await gql(
+      '{ global_incidents(window: "30d", netuid: 5) { total returned surfaces { id netuid } } }',
+      threeSurfaceEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const out = body.data.global_incidents;
+    assert.equal(out.total, 2);
+    assert.deepEqual(out.surfaces.map((s: Row) => s.id).sort(), [
+      "inc-a",
+      "inc-c",
+    ]);
+  });
+
+  test("pages with limit/cursor and reports next_cursor (#7875)", async () => {
+    const first = await gql(
+      '{ global_incidents(window: "30d", sort: "surface_id", order: "asc", limit: 2) { total returned limit cursor next_cursor sort order surfaces { id } } }',
+      threeSurfaceEnv(),
+    );
+    assert.equal(first.body.errors, undefined);
+    const p1 = first.body.data.global_incidents;
+    assert.equal(p1.total, 3);
+    assert.equal(p1.returned, 2);
+    assert.equal(p1.limit, 2);
+    assert.equal(p1.cursor, 0);
+    assert.equal(p1.next_cursor, 2);
+    assert.equal(p1.sort, "surface_id");
+    assert.equal(p1.order, "asc");
+    assert.deepEqual(
+      p1.surfaces.map((s: Row) => s.id),
+      ["inc-a", "inc-b"],
+    );
+
+    const second = await gql(
+      '{ global_incidents(window: "30d", sort: "surface_id", order: "asc", limit: 2, cursor: 2) { returned next_cursor surfaces { id } } }',
+      threeSurfaceEnv(),
+    );
+    const p2 = second.body.data.global_incidents;
+    assert.equal(p2.returned, 1);
+    assert.equal(p2.next_cursor, null);
+    assert.deepEqual(
+      p2.surfaces.map((s: Row) => s.id),
+      ["inc-c"],
+    );
+  });
+
+  test("combines a netuid filter with paging (#7875)", async () => {
+    const { body } = await gql(
+      '{ global_incidents(window: "30d", netuid: 5, sort: "surface_id", order: "asc", limit: 1) { total returned next_cursor surfaces { id netuid } } }',
+      threeSurfaceEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    const out = body.data.global_incidents;
+    assert.equal(out.total, 2);
+    assert.equal(out.returned, 1);
+    assert.equal(out.next_cursor, 1);
+    assert.equal(out.surfaces[0].id, "inc-a");
+  });
+
+  test("an unfiltered query reports schema-stable pagination meta (#7875)", async () => {
+    const { body } = await gql(
+      '{ global_incidents(window: "30d") { total returned next_cursor sort order surfaces { id } } }',
+      threeSurfaceEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    const out = body.data.global_incidents;
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 3);
+    assert.equal(out.next_cursor, null);
+    // No sort was requested, so no ordering was applied; `order` still reports
+    // the list query's default direction, exactly as the REST route does.
+    assert.equal(out.sort, null);
+    assert.equal(out.order, "asc");
+  });
+
+  test("falls back to schema-stable meta when the list query returns no pagination (#7875)", async () => {
+    // The envelope's total/returned/limit/cursor are non-null Ints, so the
+    // resolver must degrade rather than emit undefined if the shared list
+    // query ever returns a page without pagination meta.
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: [{ id: "inc-a" }, { id: "inc-b" }] },
+      meta: {},
+    } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
+    try {
+      const { body } = await gql(
+        '{ global_incidents(window: "30d") { total returned limit cursor next_cursor sort order surfaces { id } } }',
+        threeSurfaceEnv(),
+      );
+      assert.equal(body.errors, undefined);
+      const out = body.data.global_incidents;
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("degrades to an empty page when the list query returns no surfaces array (#7875)", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { surfaces: null },
+      meta: {},
+    } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
+    try {
+      const { body } = await gql(
+        '{ global_incidents(window: "30d") { total returned surfaces { id } } }',
+        threeSurfaceEnv(),
+      );
+      assert.equal(body.errors, undefined);
+      assert.deepEqual(body.data.global_incidents.surfaces, []);
+      assert.equal(body.data.global_incidents.total, 0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("a negative netuid and an unsupported sort are GraphQL errors (#7875)", async () => {
+    const badNetuid = await gql(
+      '{ global_incidents(window: "30d", netuid: -1) { total } }',
+      threeSurfaceEnv(),
+    );
+    assert.ok(badNetuid.body.errors, "expected an error for netuid");
+    assert.equal(badNetuid.body.errors[0].extensions.code, "BAD_USER_INPUT");
+
+    const badSort = await gql(
+      '{ global_incidents(window: "30d", sort: "not_a_column") { total } }',
+      threeSurfaceEnv(),
+    );
+    assert.ok(badSort.body.errors, "expected an error for sort");
+    assert.equal(badSort.body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
   test("has the identical GraphQL signature as incidents (args + return type)", async () => {
     const { status, body } = await gql(
       `{ __type(name: "Query") { fields {


### PR DESCRIPTION
## Summary

`global_incidents(window)` accepted only a time window, while `GET /api/v1/incidents` runs a full list query over the ledger's surfaces — `listQueryWith("incidents", [window])` — supporting `netuid`, `sort`, `order`, `limit`, `cursor`. This adds them.

Closes #7875.

## Approach

The ledger is composed exactly as before (`METAGRAPH_HEALTH_SOURCE` Postgres tier → `loadGlobalIncidentsLedger` fallback, schema-stable on a cold tier — nothing re-derived). The query is then applied with **`applyQueryFilters`**, the same helper the REST pipeline and the `list_*` MCP loaders use, so the allowlists cannot drift from REST.

## Why both fields changed

A pre-existing test asserts `global_incidents` keeps the **identical signature** as `incidents` — they're intentional aliases (#7643). So the args go on both, the filtering lives in the shared `incidents` implementation, and `global_incidents` stays a thin delegate. That keeps the alias invariant green and fixes the same gap on `incidents` for free.

## Behavior

- **`netuid` filter**, **sort** with `sort` + `order`, **paging** with `limit` / `cursor` — exactly as REST does.
- **Unsupported sort/limit/cursor** → `BAD_USER_INPUT` GraphQL error, matching the file's "not a silently substituted default" convention.
- **Unfiltered queries** pass the ledger through with its surfaces intact.
- `GlobalIncidents` gains the pagination meta REST reports (`total`, `returned`, `limit`, `cursor`, `next_cursor`, `sort`, `order`) — **additive**, so existing selections are unaffected.

## Codegen

Args are declared in `src/graphql-sdl.ts` (types-epic D, #7862) and `generated/graphql/types.ts` is regenerated. `validate:graphql-types-drift` reports **"Generated GraphQL types are current."**

## Note on one argument type

`cursor` is `Int`, not `String` as the issue text suggests — matching the list query's offset cursor and the sibling fields merged in #7980 / #7998 / #8030. Happy to switch if you'd prefer the literal text.

## Validation (full CI-parity gate set, run locally on this tree)

- [x] `npx vitest run tests/graphql.test.ts` — **977 passing** (whole GraphQL suite; the alias-signature test and existing incidents tests unchanged and green)
- [x] New coverage: the issue's named deliverables — **a `netuid` filter and a paginated fetch** — plus filter+sort+paging combined, `next_cursor` round-tripped to page 2 and back, schema-stable meta on an unfiltered query, rejection of a negative `netuid` / bad `sort`, and the two degradation paths
- [x] Changed resolver at **100% statement AND branch coverage** — no missing lines, no partials
- [x] `npx tsc --noEmit` — **0 errors**; `validate:graphql-types-drift` clean
- [x] `node scripts/validate-api.ts` — 177 Worker API routes + 8 Postgres-tier routes validated
- [x] `eslint` 0 errors; repo-pinned `prettier --check` clean on staged LF content
