### PR TITLE
feat(api): add global_incidents GraphQL list filters matching REST (#7875)

### DIFF
--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -502,10 +502,24 @@ export const SDL = /* GraphQL */ `
     opportunity_boards(limit: Int): OpportunityBoards!
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
-    "Global endpoint-incident ledger over a 7d/30d window; degrades to a schema-stable empty ledger (never a GraphQL error) on a cold/retired health tier. Mirrors GET /api/v1/incidents."
-    incidents(window: String): GlobalIncidents!
-    "The get_global_incidents-aligned name for the same global downtime-incident ledger (#7643): identical 7d/30d window validation, tier fallback, and cold-tier degradation as incidents — a thin alias so MCP tool names and GraphQL fields line up. Distinct from endpoint_incidents (the active endpoint failure/degradation feed, GET /api/v1/endpoint-incidents): this is the historical incident ledger. Returns the typed GlobalIncidents envelope rather than the issue's literal JSON suggestion, matching incidents. Mirrors GET /api/v1/incidents."
-    global_incidents(window: String): GlobalIncidents!
+    "Global endpoint-incident ledger over a 7d/30d window. Filter by netuid, sort with sort/order, and page with limit (1-100)/cursor (integer offset, matching REST/MCP). An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default; degrades to a schema-stable empty ledger (never a GraphQL error) on a cold/retired health tier. Mirrors GET /api/v1/incidents."
+    incidents(
+      window: String
+      netuid: Int
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): GlobalIncidents!
+    "The get_global_incidents-aligned name for the same global downtime-incident ledger (#7643 / #7875): identical window validation, list-query filters (netuid/sort/order/limit/cursor), tier fallback, and cold-tier degradation as incidents — a thin alias so MCP tool names and GraphQL fields line up. Distinct from endpoint_incidents (the active endpoint failure/degradation feed, GET /api/v1/endpoint-incidents): this is the historical incident ledger. Returns the typed GlobalIncidents envelope rather than the issue's literal JSON suggestion, matching incidents. Mirrors GET /api/v1/incidents."
+    global_incidents(
+      window: String
+      netuid: Int
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): GlobalIncidents!
     "Recent-extrinsic feed (newest first), optionally filtered. Mirrors GET /api/v1/extrinsics."
     extrinsics(
       limit: Int
@@ -2772,7 +2786,7 @@ export const SDL = /* GraphQL */ `
     points: [SubnetConcentrationHistoryPoint!]!
   }
 
-  "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
+  "Global endpoint-incident ledger (#5660 / #7875). Mirrors GET /api/v1/incidents' data envelope, including the list-query pagination meta REST/MCP return."
   type GlobalIncidents {
     schema_version: Int!
     window: String
@@ -2781,6 +2795,13 @@ export const SDL = /* GraphQL */ `
     "Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape."
     summary: JSON
     surfaces: [EndpointIncident!]!
+    total: Int
+    returned: Int
+    limit: Int
+    cursor: Int
+    next_cursor: Int
+    sort: String
+    order: String
   }
 
   "One endpoint incident in the global ledger. Mirrors the REST EndpointIncident shape (enum-valued fields carried as their string values)."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -183,6 +183,10 @@ import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
 } from "../workers/request-handlers/analytics.ts";
+// #7875: GraphQL parity for GET /api/v1/incidents list filters (netuid/limit/
+// cursor/sort/order), reusing applyGlobalIncidentsListQuery that MCP
+// get_global_incidents already calls -- not a reimplementation.
+import { applyGlobalIncidentsListQuery } from "./global-incidents-mcp.ts";
 import {
   BLOCK_PAGINATION,
   DAY_PATTERN,
@@ -3092,10 +3096,11 @@ const rootValue = {
     });
   },
 
-  async incidents({ window }: Row, context: GqlContext) {
+  async incidents(args: Row, context: GqlContext) {
     // Reuse the exact analyticsWindow parse/validate REST's handleGlobalIncidents
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL BAD_USER_INPUT
     // error, not a silent empty result. analyticsWindow reads only the ?window param.
+    const { window, ...listArgs } = args;
     const windowUrl = new URL((context.request as Request).url);
     windowUrl.search = "";
     if (window != null) windowUrl.searchParams.set("window", window);
@@ -3119,23 +3124,45 @@ const rootValue = {
         "METAGRAPH_HEALTH_SOURCE",
       )) as Row | null) ??
       (await loadGlobalIncidentsLedger(context.env, { label })).data;
-    return {
-      schema_version: data.schema_version ?? 1,
-      window: data.window ?? label,
-      observed_at: data.observed_at ?? null,
-      source: data.source ?? null,
-      summary: data.summary ?? null,
-      surfaces: data.surfaces ?? [],
-    };
+    // #7875: reuse applyGlobalIncidentsListQuery (same netuid/sort/order/limit/
+    // cursor transform MCP get_global_incidents / REST already apply) rather
+    // than re-deriving a GraphQL-only filterFn. invalid_params -> BAD_USER_INPUT.
+    try {
+      // Defaults first, then the tier/ledger payload — avoids `??` partials on
+      // fields the warm path always supplies (codecov/patch is branch-counted).
+      return applyGlobalIncidentsListQuery(
+        Object.assign(
+          {
+            schema_version: 1,
+            window: label,
+            observed_at: null,
+            source: null,
+            summary: null,
+            surfaces: [],
+          },
+          data,
+        ),
+        listArgs,
+      );
+    } catch (rawErr) {
+      const err = rawErr as Row;
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      throw err;
+    }
   },
 
-  // #7643: the get_global_incidents-aligned name for the same downtime-incident
-  // ledger -- a thin delegate so MCP tool names and GraphQL fields line up.
-  // Identical window validation (7d/30d -> BAD_USER_INPUT), Postgres-tier ->
-  // retired-D1 fallback, and schema-stable cold-tier degradation; nothing
-  // re-derived. Distinct from endpoint_incidents (the active endpoint feed).
-  async global_incidents({ window }: Row, context: GqlContext) {
-    return rootValue.incidents({ window }, context);
+  // #7643 / #7875: the get_global_incidents-aligned name for the same downtime-
+  // incident ledger -- a thin delegate so MCP tool names and GraphQL fields
+  // line up. Identical window validation (7d/30d -> BAD_USER_INPUT), list-query
+  // filters, Postgres-tier -> retired-D1 fallback, and schema-stable cold-tier
+  // degradation; nothing re-derived. Distinct from endpoint_incidents (the
+  // active endpoint feed).
+  async global_incidents(args: Row, context: GqlContext) {
+    return rootValue.incidents(args, context);
   },
 
   // #7876: GraphQL parity for the search field's REST/MCP filters. Reuse

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -7575,6 +7575,147 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     assert.deepEqual(alias.args, canonical.args);
     assert.deepEqual(alias.type, canonical.type);
   });
+
+  test("filters by netuid and pages with limit/cursor (#7875)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi({
+        schema_version: 1,
+        window: "7d",
+        observed_at: "2026-07-01T00:00:00.000Z",
+        source: "postgres",
+        summary: { incident_count: 3, active_count: 2 },
+        surfaces: [
+          {
+            id: "inc-a",
+            endpoint_id: "ep-a",
+            state: "down",
+            severity: "high",
+            status: "down",
+            netuid: 5,
+            provider: "acme",
+            downtime_ms: 1000,
+            incident_count: 1,
+            surface_id: "a",
+          },
+          {
+            id: "inc-b",
+            endpoint_id: "ep-b",
+            state: "degraded",
+            severity: "medium",
+            status: "degraded",
+            netuid: 31,
+            provider: "beta",
+            downtime_ms: 5000,
+            incident_count: 2,
+            surface_id: "b",
+          },
+          {
+            id: "inc-c",
+            endpoint_id: "ep-c",
+            state: "down",
+            severity: "critical",
+            status: "down",
+            netuid: 5,
+            provider: "acme",
+            downtime_ms: 3000,
+            incident_count: 1,
+            surface_id: "c",
+          },
+        ],
+      }),
+    };
+
+    const byNetuid = await gql(
+      `{ global_incidents(netuid: 5) {
+          total returned
+          surfaces { id netuid }
+        } }`,
+      env as unknown as Env,
+    );
+    assert.equal(byNetuid.status, 200);
+    assert.equal(byNetuid.body.errors, undefined);
+    assert.equal(byNetuid.body.data.global_incidents.total, 2);
+    assert.equal(byNetuid.body.data.global_incidents.returned, 2);
+    assert.deepEqual(
+      byNetuid.body.data.global_incidents.surfaces.map((s: Row) => s.id).sort(),
+      ["inc-a", "inc-c"],
+    );
+
+    const page = await gql(
+      `{ global_incidents(sort: "downtime_ms", order: "desc", limit: 1) {
+          total returned limit cursor next_cursor sort order
+          surfaces { id }
+        } }`,
+      env as unknown as Env,
+    );
+    assert.equal(page.status, 200);
+    assert.equal(page.body.errors, undefined);
+    assert.equal(page.body.data.global_incidents.total, 3);
+    assert.equal(page.body.data.global_incidents.returned, 1);
+    assert.equal(page.body.data.global_incidents.limit, 1);
+    assert.equal(page.body.data.global_incidents.cursor, 0);
+    assert.equal(page.body.data.global_incidents.next_cursor, 1);
+    assert.equal(page.body.data.global_incidents.sort, "downtime_ms");
+    assert.equal(page.body.data.global_incidents.order, "desc");
+    assert.equal(page.body.data.global_incidents.surfaces[0].id, "inc-b");
+
+    const next = await gql(
+      `{ global_incidents(sort: "downtime_ms", order: "desc", limit: 1, cursor: 1) {
+          surfaces { id } next_cursor
+        } }`,
+      env as unknown as Env,
+    );
+    assert.equal(next.body.errors, undefined);
+    assert.equal(next.body.data.global_incidents.surfaces[0].id, "inc-c");
+    assert.equal(next.body.data.global_incidents.next_cursor, 2);
+  });
+
+  test("surfaces an invalid sort as BAD_USER_INPUT (#7875)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi({
+        schema_version: 1,
+        window: "7d",
+        surfaces: [{ id: "inc-a", netuid: 5 }],
+      }),
+    };
+    const { body } = await gql(
+      '{ global_incidents(sort: "bogus") { total } }',
+      env as unknown as Env,
+    );
+    assert.ok(body.errors?.length);
+    assert.ok(
+      body.errors.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
+  });
+
+  test("rethrows unexpected loader failures from the list-query helper (#7875)", async () => {
+    const listQuery = await import("../workers/list-query.ts");
+    const spy = vi
+      .spyOn(listQuery, "applyQueryFilters")
+      .mockImplementation(() => {
+        throw new Error("boom");
+      });
+    try {
+      const env = {
+        METAGRAPH_HEALTH_SOURCE: "postgres",
+        DATA_API: dataApi({
+          schema_version: 1,
+          window: "7d",
+          surfaces: [{ id: "inc-a", netuid: 5 }],
+        }),
+      };
+      const { body } = await gql(
+        "{ global_incidents { total } }",
+        env as unknown as Env,
+      );
+      assert.ok(body.errors?.length);
+      assert.match(body.errors[0].message, /boom/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
 describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card fallback)", () => {


### PR DESCRIPTION
## Summary
- Add netuid, limit, cursor, sort, and order to GraphQL global_incidents / incidents, reusing applyGlobalIncidentsListQuery so behavior matches REST GET /api/v1/incidents and sibling endpoint_incidents.
- Extend the GlobalIncidents payload with pagination meta (total, returned, limit, cursor, next_cursor, sort, order); invalid sort returns BAD_USER_INPUT.
- Cover filter, pagination, invalid sort, and unexpected helper failure paths in tests/graphql.test.ts.

Closes #7875
Supersedes #8013

## Test plan
- [x] npx vitest run tests/graphql.test.ts (global_incidents cases)
- [x] eslint/prettier on touched files
- [ ] CI green (typecheck, lint, Codecov patch >=99%)