### PR TITLE
feat(api): nested Subnet.surfaces filter/sort/page arguments (#7885)

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -4111,10 +4111,21 @@ export type Subnet = {
   status?: Maybe<Scalars['String']['output']>;
   subnet_type?: Maybe<Scalars['String']['output']>;
   surface_count?: Maybe<Scalars['Int']['output']>;
-  /** Curated public interface surfaces of this subnet. */
+  /** Curated public interface surfaces of this subnet. Filter with kind, provider, and id; sort with sort + order; and page with limit / cursor, exactly as GET /api/v1/subnets/{netuid}/surfaces does -- an unsupported filter/sort value is a GraphQL error, not a silently substituted default. With no arguments the full list is returned unchanged. */
   surfaces: Array<Surface>;
   symbol?: Maybe<Scalars['String']['output']>;
   website_url?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type SubnetSurfacesArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  kind?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type SubnetAxonRemovals = {
@@ -8060,7 +8071,7 @@ export type SubnetResolvers<ContextType = GqlContext, ParentType extends Resolve
   status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   subnet_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   surface_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  surfaces?: Resolver<Array<ResolversTypes['Surface']>, ParentType, ContextType>;
+  surfaces?: Resolver<Array<ResolversTypes['Surface']>, ParentType, ContextType, Partial<SubnetSurfacesArgs>>;
   symbol?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   website_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -829,8 +829,16 @@ export const SDL = /* GraphQL */ `
     health: SubnetHealth
     "Per-subnet economic + validator metrics."
     economics: SubnetEconomics
-    "Curated public interface surfaces of this subnet."
-    surfaces: [Surface!]!
+    "Curated public interface surfaces of this subnet. Filter with kind, provider, and id; sort with sort + order; and page with limit / cursor, exactly as GET /api/v1/subnets/{netuid}/surfaces does -- an unsupported filter/sort value is a GraphQL error, not a silently substituted default. With no arguments the full list is returned unchanged."
+    surfaces(
+      kind: String
+      provider: String
+      id: String
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): [Surface!]!
     "Endpoint/resource registry rows for this subnet."
     endpoints: [Endpoint!]!
   }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,5 +1,6 @@
 import {
   GraphQLError,
+  type GraphQLObjectType,
   buildSchema,
   execute,
   parse,
@@ -564,6 +565,55 @@ export const schema = buildSchema(SDL);
 // that also needs subscriptions. context.chainFirehose is supplied by
 // whichever Durable Object drives the graphql-ws server (workers/chain-firehose-hub.mjs)
 // -- see GRAPHQL_SUBSCRIPTION_CONTEXT_KEY below.
+// #7885: the nested Subnet.surfaces field takes the same filter/sort/page
+// arguments as GET /api/v1/subnets/{netuid}/surfaces. A nested field needs an
+// explicit resolve to see its own args (the default field resolver ignores
+// them and just reads the parent property), attached here the same way the
+// subscription's `subscribe` is below -- buildSchema carries no resolver map.
+// The query itself runs through applyQueryFilters against the same
+// curated-surfaces collection the REST route uses, so the allowlists cannot
+// drift; with no arguments the parent's surfaces pass through untouched.
+const SUBNET_SURFACES_FILTER_NAMES = ["kind", "provider", "id"];
+(schema.getType("Subnet") as GraphQLObjectType).getFields().surfaces.resolve =
+  async function subnetSurfaces(
+    parent: Row,
+    args: Row,
+    context: GqlContext,
+    info: unknown,
+  ) {
+    // subnetNode -- the only producer of Subnet objects -- always exposes
+    // `surfaces` as a thunk (bundled rows via `() => rows ?? []`, or a lazy
+    // per-netuid artifact load), which the default field resolver would have
+    // invoked. Do the same here so adding arguments does not turn the lazy path
+    // into an empty list.
+    const surfaces = (await parent.surfaces(args, context, info)) as Row[];
+    const queryUrl = new URL("https://graphql.internal/subnets/surfaces");
+    for (const [name, value] of [
+      ["kind", args?.kind],
+      ["provider", args?.provider],
+      ["id", args?.id],
+      ["sort", args?.sort],
+      ["order", args?.order],
+      ["limit", args?.limit],
+      ["cursor", args?.cursor],
+    ] as const) {
+      if (value != null) queryUrl.searchParams.set(name, String(value));
+    }
+    if ([...queryUrl.searchParams].length === 0) return surfaces;
+    const transformed = applyQueryFilters(
+      { surfaces },
+      queryUrl,
+      "curated-surfaces",
+      SUBNET_SURFACES_FILTER_NAMES,
+    );
+    if (transformed.error) {
+      throw new GraphQLError(transformed.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return (transformed.data as Row).surfaces;
+  };
+
 export const GRAPHQL_SUBSCRIPTION_CONTEXT_KEY = "chainFirehose";
 schema.getSubscriptionType()!.getFields().chainEvents.subscribe =
   async function* chainEventsSubscribe(

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1112,6 +1112,131 @@ describe("graphql — broadened Subnet + nested relationships", () => {
     assert.equal(reads.has("latest/endpoints.json"), false);
   });
 
+  // #7885: the nested Subnet.surfaces field takes the same filter/sort/page
+  // arguments as GET /api/v1/subnets/{netuid}/surfaces.
+  function nestedSurfacesEnv(reads?: Map<string, number>) {
+    return fixtureEnv(
+      {
+        "/metagraph/subnets/7.json": {
+          subnet: { netuid: 7, name: "Allways", slug: "allways" },
+          surfaces: [
+            { id: "s-a", netuid: 7, kind: "subnet-api", provider: "alpha" },
+            { id: "s-b", netuid: 7, kind: "openapi", provider: "alpha" },
+            { id: "s-c", netuid: 7, kind: "subnet-api", provider: "beta" },
+          ],
+          endpoints: [],
+        },
+      },
+      reads ? { reads } : {},
+    ) as unknown as Env;
+  }
+
+  test("nested Subnet.surfaces filters by kind (#7885)", async () => {
+    const { status, body } = await gql(
+      `{ subnet(netuid: 7) { surfaces(kind: "subnet-api") { id kind } } }`,
+      nestedSurfacesEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(
+      body.data.subnet.surfaces.map((s: Row) => s.id),
+      ["s-a", "s-c"],
+    );
+  });
+
+  test("nested Subnet.surfaces filters by provider (#7885)", async () => {
+    const { body } = await gql(
+      `{ subnet(netuid: 7) { surfaces(provider: "alpha") { id provider } } }`,
+      nestedSurfacesEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(
+      body.data.subnet.surfaces.map((s: Row) => s.id),
+      ["s-a", "s-b"],
+    );
+  });
+
+  test("nested Subnet.surfaces combines filters, sorts, and pages (#7885)", async () => {
+    const first = await gql(
+      `{ subnet(netuid: 7) { surfaces(kind: "subnet-api", sort: "id", order: "asc", limit: 1) { id } } }`,
+      nestedSurfacesEnv(),
+    );
+    assert.equal(first.body.errors, undefined);
+    assert.deepEqual(
+      first.body.data.subnet.surfaces.map((s: Row) => s.id),
+      ["s-a"],
+    );
+
+    const second = await gql(
+      `{ subnet(netuid: 7) { surfaces(kind: "subnet-api", sort: "id", order: "asc", limit: 1, cursor: 1) { id } } }`,
+      nestedSurfacesEnv(),
+    );
+    assert.deepEqual(
+      second.body.data.subnet.surfaces.map((s: Row) => s.id),
+      ["s-c"],
+    );
+  });
+
+  test("nested Subnet.surfaces matches an exact id (#7885)", async () => {
+    const { body } = await gql(
+      `{ subnet(netuid: 7) { surfaces(id: "s-b") { id kind } } }`,
+      nestedSurfacesEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet.surfaces.length, 1);
+    assert.equal(body.data.subnet.surfaces[0].id, "s-b");
+  });
+
+  test("nested Subnet.surfaces returns the full list unchanged with no arguments (#7885)", async () => {
+    const { body } = await gql(
+      "{ subnet(netuid: 7) { surfaces { id } } }",
+      nestedSurfacesEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(
+      body.data.subnet.surfaces.map((s: Row) => s.id),
+      ["s-a", "s-b", "s-c"],
+    );
+  });
+
+  test("nested Subnet.surfaces rejects an unsupported filter or sort (#7885)", async () => {
+    for (const arg of ['kind: "bogus"', 'sort: "not_a_column"']) {
+      const { body } = await gql(
+        `{ subnet(netuid: 7) { surfaces(${arg}) { id } } }`,
+        nestedSurfacesEnv(),
+      );
+      assert.ok(body.errors, `expected a GraphQL error for ${arg}`);
+      assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+    }
+  });
+
+  test("nested Subnet.surfaces still filters the lazily-loaded list (#7885)", async () => {
+    // A subnet reached through the list has no bundled surfaces -- the thunk
+    // loads them per-netuid. Filtering must apply to that path too, not
+    // collapse it to an empty list.
+    const env = fixtureEnv({
+      "/metagraph/subnets.json": {
+        subnets: [{ netuid: 7, name: "Allways", slug: "allways" }],
+      },
+      "/metagraph/surfaces.json": {
+        surfaces: [
+          { id: "s-a", netuid: 7, kind: "subnet-api", provider: "alpha" },
+          { id: "s-b", netuid: 7, kind: "openapi", provider: "alpha" },
+        ],
+      },
+    });
+    const { body } = await gql(
+      `{ subnets { items { netuid surfaces(kind: "openapi") { id kind } } } }`,
+      env as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    const item = body.data.subnets.items[0];
+    assert.deepEqual(
+      item.surfaces.map((s: Row) => s.id),
+      ["s-b"],
+    );
+  });
+
   test("subnet.health resolves from the live health snapshot by netuid", async () => {
     const env = fixtureEnv(
       {


### PR DESCRIPTION
## Summary

The nested `Subnet.surfaces` field took **no arguments** and always returned the full list, while `GET /api/v1/subnets/{netuid}/surfaces` supports `kind, provider, id, sort, order, limit, cursor`. This adds them to the nested field.

Closes #7885.

## Approach

A nested field needs an **explicit `resolve`** to see its own args — the default field resolver ignores them and just reads the parent property. One is attached to the built schema the same way the subscription's `subscribe` already is (`buildSchema` carries no resolver map), right beside it.

Filtering runs through **`applyQueryFilters`** against the same `curated-surfaces` collection the REST route uses (`csvListQuery("curated-surfaces", { exclude: ["netuid"] })`), so the allowlists cannot drift.

## The subtlety worth reviewing

`subnetNode` — the only producer of `Subnet` objects — exposes `surfaces` as a **thunk**: bundled rows when the detail read already carried them (`() => rows ?? []`), otherwise a lazy per-netuid artifact load. The default resolver used to invoke that thunk. So the new resolve **awaits it first**; otherwise adding arguments silently turns the lazy path (subnets reached through the list) into an empty list. There's a regression test for exactly that path.

## Note on the issue's premise

The issue says to "reuse the same filtering logic the root `surfaces(netuid, ...)` field already applies", but the root GraphQL field currently exposes only `netuid`, `limit`, `cursor` (`surfaces({ netuid, limit, cursor })` → `listPage`) — the `kind`/`provider`/`id`/`sort`/`order` filters exist on the **REST route**, not on the root field. So this wires the nested field straight to the shared list query rather than reusing a root-field path that doesn't exist yet. Happy to extend the root field the same way in a follow-up if you'd like them consistent.

`cursor` is `Int`, matching the list query's offset cursor and the sibling fields merged in #7980 / #7998 / #8030.

## Behavior

- **Filters** `kind` / `provider` / `id`, **sorts** with `sort` + `order`, **pages** with `limit` / `cursor`.
- **Unsupported filter/sort value** → `BAD_USER_INPUT` GraphQL error.
- **No arguments** → the full list passes through untouched, so existing queries are unaffected.

## Validation (full CI-parity gate set, run locally on this tree)

- [x] `npx vitest run tests/graphql.test.ts` — **977 passing** (whole GraphQL suite; the existing bundled-vs-lazy relationship tests unchanged and green)
- [x] New coverage: the issue's named deliverables — **filtering by `kind` and by `provider`** — plus exact-`id` match, filters combined with sort + `limit`/`cursor` paging, the no-arguments passthrough, rejection of a bad `kind`/`sort`, and **the lazily-loaded list still filtering correctly**
- [x] New resolver at **100% statement AND branch coverage** — no missing lines, no partials
- [x] `npx tsc --noEmit` — **0 errors**; `validate:graphql-types-drift` clean
- [x] `eslint` 0 errors; repo-pinned `prettier --check` clean on staged LF content
