### PR TITLE
feat(api): GraphQL parity for endpoints field args

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2498,7 +2498,7 @@ export type Query = {
   endpoint_incidents: IncidentList;
   /** Generalized endpoint pool scores -- each pool's kind, eligible/total endpoint count, and probe-derived routing score. Filter by id/kind, threshold with min_/max_eligible_count and min_/max_endpoint_count, sort with sort/order, and page with limit (1-100)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/endpoint-pools. */
   endpoint_pools: PoolList;
-  /** Endpoint/resource registry, optionally scoped to one subnet. */
+  /** Endpoint/resource registry with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/layer/provider/publication_state/status/pool_eligible, threshold with min_/max_latency_ms and min_/max_score, project with fields, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error (matching endpoint_pools/rpc_pools/rpc_endpoints), not a silently substituted default. Mirrors GET /api/v1/endpoints. */
   endpoints: EndpointList;
   /** Network-wide public evidence ledger -- the append-only provenance record behind registry surfaces. Search with q across subject/claim/source_url/support_summary, sort with sort/order, project with fields, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Distinct from subnet_evidence(netuid) (one subnet's claims). Mirrors GET /api/v1/evidence. */
   evidence: EvidenceList;
@@ -3126,8 +3126,21 @@ export type QueryEndpoint_PoolsArgs = {
 
 export type QueryEndpointsArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
+  fields?: InputMaybe<Array<Scalars['String']['input']>>;
+  kind?: InputMaybe<Scalars['String']['input']>;
+  layer?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  max_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  max_score?: InputMaybe<Scalars['Float']['input']>;
+  min_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  min_score?: InputMaybe<Scalars['Float']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  pool_eligible?: InputMaybe<Scalars['Boolean']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
+  publication_state?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -249,8 +249,25 @@ export const SDL = /* GraphQL */ `
     economics(limit: Int, cursor: String): EconomicsList!
     "Curated public interface surfaces, optionally scoped to one subnet."
     surfaces(netuid: Int, limit: Int, cursor: String): SurfaceList!
-    "Endpoint/resource registry, optionally scoped to one subnet."
-    endpoints(netuid: Int, limit: Int, cursor: String): EndpointList!
+    "Endpoint/resource registry with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/layer/provider/publication_state/status/pool_eligible, threshold with min_/max_latency_ms and min_/max_score, project with fields, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error (matching endpoint_pools/rpc_pools/rpc_endpoints), not a silently substituted default. Mirrors GET /api/v1/endpoints."
+    endpoints(
+      netuid: Int
+      kind: String
+      layer: String
+      provider: String
+      publication_state: String
+      status: String
+      pool_eligible: Boolean
+      min_latency_ms: Int
+      max_latency_ms: Int
+      min_score: Float
+      max_score: Float
+      sort: String
+      order: String
+      fields: [String!]
+      limit: Int
+      cursor: String
+    ): EndpointList!
     "One provider's endpoint rows with full REST filter parity: filter by kind/layer/publication_state/status, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints."
     provider_endpoints(
       slug: String!

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1454,6 +1454,67 @@ async function listPage(
   };
 }
 
+// #7887: full REST filter parity for the root `endpoints` field, mirroring
+// the sibling rpc_endpoints (#7886)/endpoint_pools/rpc_pools fields. The baked
+// endpoints collection is filtered/sorted/projected by applyQueryFilters over
+// the very same "endpoints" query-collection config the REST route (GET
+// /api/v1/endpoints) and the list_endpoints MCP tool use -- kind/layer/
+// provider/publication_state/status/pool_eligible, the min_/max_latency_ms and
+// min_/max_score ranges, sort/order, and the fields projection -- so the
+// GraphQL filter allowlist cannot drift from REST. Only the filter/sort/
+// projection params are handed to applyQueryFilters (never limit/cursor): with
+// neither present it returns the full matching set unpaged, and the existing
+// keyFn string-cursor paginate() below then owns paging, preserving
+// EndpointList's items/total/next_cursor shape and its backward-compatible
+// String cursor unchanged. An unsupported filter/sort surfaces as a
+// BAD_USER_INPUT GraphQL error, matching endpoint_pools/rpc_pools/rpc_endpoints
+// "not a silently substituted default" convention.
+function endpointsListQueryUrl(args: Row): URL {
+  const url = new URL("https://graphql.internal/endpoints");
+  const set = (key: string, value: unknown) => {
+    if (value !== undefined) url.searchParams.set(key, String(value));
+  };
+  set("netuid", args.netuid);
+  set("kind", args.kind);
+  set("layer", args.layer);
+  set("provider", args.provider);
+  set("publication_state", args.publication_state);
+  set("status", args.status);
+  set("pool_eligible", args.pool_eligible);
+  set("min_latency_ms", args.min_latency_ms);
+  set("max_latency_ms", args.max_latency_ms);
+  set("min_score", args.min_score);
+  set("max_score", args.max_score);
+  set("sort", args.sort);
+  set("order", args.order);
+  set("fields", args.fields);
+  return url;
+}
+
+async function loadEndpointsPage(context: GqlContext, args: Row) {
+  const blob = await loadArtifact(context, ARTIFACT.endpoints);
+  const rows = Array.isArray(blob?.endpoints) ? (blob.endpoints as Row[]) : [];
+  const transformed = applyQueryFilters(
+    { endpoints: rows },
+    endpointsListQueryUrl(args),
+    "endpoints",
+    [],
+  );
+  if (transformed.error) {
+    throw new GraphQLError(transformed.error.message, {
+      extensions: { code: "BAD_USER_INPUT" },
+    });
+  }
+  const filtered = (transformed.data as Row).endpoints as Row[];
+  const { page, total, nextCursor } = paginate(
+    filtered,
+    args.limit,
+    args.cursor,
+    (e: Row) => e.id ?? e.surface_id,
+  );
+  return { items: page, total, next_cursor: nextCursor };
+}
+
 // readArtifact's static-asset tier resolves the path through a URL parser that
 // collapses "../", so an unvalidated provider id could escape the providers/
 // namespace. Constrain it to the safe slug charset the other id-bearing artifact
@@ -2808,13 +2869,8 @@ const rootValue = {
     });
   },
 
-  endpoints({ netuid, limit, cursor }: Row, context: GqlContext) {
-    return listPage(context, ARTIFACT.endpoints, "endpoints", {
-      limit,
-      cursor,
-      netuid,
-      keyFn: (e: Row) => e.id ?? e.surface_id,
-    });
+  endpoints(args: Row, context: GqlContext) {
+    return loadEndpointsPage(context, args);
   },
 
   // #7868: reuse list_provider_endpoints' own loader unchanged (provider-

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1318,6 +1318,134 @@ describe("graphql — surfaces / endpoints / health roots", () => {
     assert.equal(second.body.data.endpoints.items[0].id, "e2");
   });
 
+  test("endpoints applies combined REST filters plus sort/order (#7887)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints.json": {
+        endpoints: [
+          {
+            id: "a",
+            netuid: 1,
+            kind: "openapi",
+            layer: "subnet-app",
+            status: "ok",
+            latency_ms: 120,
+          },
+          {
+            id: "b",
+            netuid: 1,
+            kind: "openapi",
+            layer: "subnet-app",
+            status: "ok",
+            latency_ms: 40,
+          },
+          {
+            id: "c",
+            netuid: 2,
+            kind: "website",
+            layer: "data-provider",
+            status: "failed",
+            latency_ms: 200,
+          },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      '{ endpoints(kind: "openapi", layer: "subnet-app", status: "ok", sort: "latency_ms", order: "asc") { items { id latency_ms } total } }',
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.endpoints.total, 2);
+    assert.deepEqual(
+      body.data.endpoints.items.map((e: Row) => e.id),
+      ["b", "a"],
+    );
+  });
+
+  test("endpoints applies latency/score ranges and pool_eligible (#7887)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints.json": {
+        endpoints: [
+          { id: "a", latency_ms: 50, score: 80, pool_eligible: true },
+          { id: "b", latency_ms: 500, score: 80, pool_eligible: true },
+          { id: "c", latency_ms: 50, score: 10, pool_eligible: true },
+          { id: "d", latency_ms: 50, score: 80, pool_eligible: false },
+        ],
+      },
+    });
+    const { body } = await gql(
+      "{ endpoints(min_latency_ms: 0, max_latency_ms: 100, min_score: 50, max_score: 100, pool_eligible: true) { items { id } total } }",
+      env as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(
+      body.data.endpoints.items.map((e: Row) => e.id),
+      ["a"],
+    );
+    assert.equal(body.data.endpoints.total, 1);
+  });
+
+  test("endpoints filters by provider and publication_state (#7887)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints.json": {
+        endpoints: [
+          { id: "a", provider: "prov-x", publication_state: "verified" },
+          { id: "b", provider: "prov-y", publication_state: "verified" },
+          { id: "c", provider: "prov-x", publication_state: "candidate" },
+        ],
+      },
+    });
+    const { body } = await gql(
+      '{ endpoints(provider: "prov-x", publication_state: "verified") { items { id } total } }',
+      env as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.endpoints.total, 1);
+    assert.equal(body.data.endpoints.items[0].id, "a");
+  });
+
+  test("endpoints projects rows with the fields argument (#7887)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints.json": {
+        endpoints: [{ id: "a", netuid: 1, status: "ok", kind: "openapi" }],
+      },
+    });
+    const { body } = await gql(
+      '{ endpoints(fields: ["id", "status"]) { items { id status kind } } }',
+      env as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.endpoints.items[0].id, "a");
+    assert.equal(body.data.endpoints.items[0].status, "ok");
+    // kind was projected out of the row, so it resolves to null.
+    assert.equal(body.data.endpoints.items[0].kind, null);
+  });
+
+  test("endpoints maps an unsupported filter to BAD_USER_INPUT (#7887)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/endpoints.json": {
+        endpoints: [{ id: "a", kind: "openapi" }],
+      },
+    });
+    const { body } = await gql(
+      '{ endpoints(kind: "not-a-kind") { items { id } } }',
+      env as unknown as Env,
+    );
+    assert.ok(body.errors, "expected a GraphQL error for an invalid filter");
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("endpoints degrades to an empty list on a cold artifact (#7887)", async () => {
+    const { body } = await gql(
+      '{ endpoints(kind: "openapi") { items { id } total next_cursor } }',
+      emptyEnv as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.endpoints.items, []);
+    assert.equal(body.data.endpoints.total, 0);
+    assert.equal(body.data.endpoints.next_cursor, null);
+  });
+
   test("health lifts the live rollup and exposes per-subnet summaries", async () => {
     const env = fixtureEnv(
       {},


### PR DESCRIPTION
Closes #7887

## What

The root `endpoints` GraphQL field accepted only `netuid, limit, cursor`, while `GET /api/v1/endpoints` (and the `list_endpoints` MCP tool) also filter by `kind, layer, provider, publication_state, status, pool_eligible`, threshold by `min_/max_latency_ms` and `min_/max_score`, project with `fields`, and order by `sort/order`. This adds the full argument set to the `endpoints` field, mirroring the sibling `rpc_endpoints` (#7886) / `endpoint_pools` / `rpc_pools` / `endpoint_incidents` precedent.

## How

The resolver reuses **`applyQueryFilters`** — the same shared list-query machinery the REST route and the `list_*` MCP tools already apply over the `"endpoints"` query collection — for the filter/sort/projection pass, so the GraphQL filter allowlist **cannot drift** from REST/MCP (not a GraphQL-only reimplementation of the filters).

Key detail: the resolver hands `applyQueryFilters` **only the filter/sort/projection args — never `limit`/`cursor`**. With neither present, `paginateRows` returns the *full* filtered/sorted set unpaged; the field then applies its own established **keyset (`keyFn`) pagination** over that result. That preserves `EndpointList`'s `items/total/next_cursor` shape and its backward-compatible **`String` cursor** — **no breaking change** to existing `endpoints(netuid, limit, cursor)` callers, and no change to the `EndpointList` return type.

An invalid filter/sort value surfaces as a GraphQL `BAD_USER_INPUT` error, matching REST's 400 and every sibling field's "an unsupported filter/sort is a GraphQL error, not a silently substituted default" convention.

## Changes

- `src/graphql-sdl.ts` — add the 13 filter/sort/projection arguments to the `endpoints` field and update its description to document full REST parity.
- `src/graphql.ts` — replace the `endpoints` resolver with `loadEndpointsPage`, which runs the baked endpoints collection through `applyQueryFilters` (`"endpoints"` collection) for filter/sort/projection, then paginates with the existing `keyFn` string cursor.
- `generated/graphql/types.ts` — regenerated via `npm run build:graphql-types` (`npm run validate:graphql-types-drift` passes; types are current).
- `tests/graphql.test.ts` — new coverage (see below).

## Tests — `tests/graphql.test.ts`

- **Three filters combined + `sort`/`order`** (`kind` + `layer` + `status`, sorted by `latency_ms` asc) → correct subset and ordering.
- **Range filters** (`min_/max_latency_ms` + `min_/max_score`) together with `pool_eligible` → correct threshold intersection.
- **`provider` + `publication_state`** filters → the single matching endpoint.
- **`fields` projection** → projected-away fields resolve to `null`.
- **Invalid filter value** → GraphQL `BAD_USER_INPUT`.
- **Cold artifact** → schema-stable empty list (`items: []`, `total: 0`, `next_cursor: null`).
- All existing `endpoints`/`surfaces`/`health` tests (including the `netuid` filter and the `surface_id`-cursor pagination cases) still pass unchanged through the new path.

Patch coverage on the changed runtime lines is 100% (every added statement and both outcomes of every added branch are exercised). `eslint`, `prettier --check`, `tsc --noEmit`, `scan:public-safety`, `validate:docs`, and `validate:graphql-types-drift` are all clean; the `tests/graphql.test.ts` suite passes (976 tests).

## Expected outcome

A GraphQL client can filter the generalized `endpoints` list with full parity to `GET /api/v1/endpoints`.
