### PR TITLE
feat(api): add call_hash/block/time-range filters to extrinsics GraphQL field

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2508,7 +2508,7 @@ export type Query = {
   evm_address_mapping?: Maybe<EvmAddressMapping>;
   /** One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}. */
   extrinsic?: Maybe<ExtrinsicDetail>;
-  /** Recent-extrinsic feed (newest first), optionally filtered. Mirrors GET /api/v1/extrinsics. */
+  /** Recent-extrinsic feed (newest first), optionally filtered. Optionally narrow by call_hash, block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same filters GET /api/v1/extrinsics and the list_extrinsics MCP tool accept. Mirrors GET /api/v1/extrinsics. */
   extrinsics: ExtrinsicList;
   /** The recorded response fixtures for registered surfaces, used to replay/verify a surface without calling it. Null when no fixture index has been baked in this environment. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures. */
   fixtures?: Maybe<Scalars['JSON']['output']>;
@@ -3158,13 +3158,18 @@ export type QueryExtrinsicArgs = {
 
 export type QueryExtrinsicsArgs = {
   block?: InputMaybe<Scalars['Int']['input']>;
+  block_end?: InputMaybe<Scalars['Int']['input']>;
+  block_start?: InputMaybe<Scalars['Int']['input']>;
   call_function?: InputMaybe<Scalars['String']['input']>;
+  call_hash?: InputMaybe<Scalars['String']['input']>;
   call_module?: InputMaybe<Scalars['String']['input']>;
   cursor?: InputMaybe<Scalars['String']['input']>;
+  from?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   signer?: InputMaybe<Scalars['String']['input']>;
   success?: InputMaybe<Scalars['Boolean']['input']>;
+  to?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -506,7 +506,7 @@ export const SDL = /* GraphQL */ `
     incidents(window: String): GlobalIncidents!
     "The get_global_incidents-aligned name for the same global downtime-incident ledger (#7643): identical 7d/30d window validation, tier fallback, and cold-tier degradation as incidents — a thin alias so MCP tool names and GraphQL fields line up. Distinct from endpoint_incidents (the active endpoint failure/degradation feed, GET /api/v1/endpoint-incidents): this is the historical incident ledger. Returns the typed GlobalIncidents envelope rather than the issue's literal JSON suggestion, matching incidents. Mirrors GET /api/v1/incidents."
     global_incidents(window: String): GlobalIncidents!
-    "Recent-extrinsic feed (newest first), optionally filtered. Mirrors GET /api/v1/extrinsics."
+    "Recent-extrinsic feed (newest first), optionally filtered. Optionally narrow by call_hash, block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same filters GET /api/v1/extrinsics and the list_extrinsics MCP tool accept. Mirrors GET /api/v1/extrinsics."
     extrinsics(
       limit: Int
       offset: Int
@@ -516,6 +516,11 @@ export const SDL = /* GraphQL */ `
       call_module: String
       call_function: String
       success: Boolean
+      call_hash: String
+      block_start: Int
+      block_end: Int
+      from: String
+      to: String
     ): ExtrinsicList!
     "Paginated all-events feed (newest first) from the Postgres-backed all-events tier: each event's block, event index, pallet, method, decoded args, phase, and emitting extrinsic index. Filter by pallet/method/block/extrinsic; page with limit (1-200, default 50) and the opaque keyset cursor (or legacy before=block_number). An invalid filter combo is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty feed, never a GraphQL error. Reads the raw all-events tier -- distinct from account_events/subnet_events (the curated account-attributed streams, a different data source) and from Subscription.chainEvents (live WebSocket firehose). Mirrors GET /api/v1/chain-events."
     chain_events(

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3657,6 +3657,11 @@ const rootValue = {
       call_module: callModule,
       call_function: callFunction,
       success,
+      call_hash: callHash,
+      block_start: blockStart,
+      block_end: blockEnd,
+      from,
+      to,
     }: Row,
     context: GqlContext,
   ) {
@@ -3676,6 +3681,15 @@ const rootValue = {
     if (callModule) params.set("call_module", callModule);
     if (callFunction) params.set("call_function", callFunction);
     if (success != null) params.set("success", String(success));
+    // #7872: mirror list_extrinsics' filter set — call_hash plus block_start/
+    // block_end (inclusive height range) and from/to (observed_at epoch-ms
+    // range), forwarded to the same /api/v1/extrinsics route. from/to are String
+    // args (epoch-ms overflows GraphQL Int's 32 bits), matching account_history.
+    if (callHash) params.set("call_hash", callHash);
+    if (blockStart != null) params.set("block_start", String(blockStart));
+    if (blockEnd != null) params.set("block_end", String(blockEnd));
+    if (from != null) params.set("from", from);
+    if (to != null) params.set("to", to);
     const data =
       ((await tryPostgresTier(
         context.env,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -3439,6 +3439,75 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     assert.equal(capturedUrl!.searchParams.get("success"), "true");
   });
 
+  test("extrinsics: call_hash, block-range, and time-range filters are forwarded to the Postgres tier (#7872)", async () => {
+    let capturedUrl: URL | undefined;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 50,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ extrinsics(
+          call_hash: "0xabc"
+          block_start: 100
+          block_end: 500
+          from: "1750000000000"
+          to: "1760000000000"
+        ) { total } }`,
+      env as unknown as Env,
+    );
+    assert.equal(capturedUrl!.pathname, "/api/v1/extrinsics");
+    assert.equal(capturedUrl!.searchParams.get("call_hash"), "0xabc");
+    assert.equal(capturedUrl!.searchParams.get("block_start"), "100");
+    assert.equal(capturedUrl!.searchParams.get("block_end"), "500");
+    assert.equal(capturedUrl!.searchParams.get("from"), "1750000000000");
+    assert.equal(capturedUrl!.searchParams.get("to"), "1760000000000");
+  });
+
+  test("introspection: extrinsics exposes call_hash/from/to (String) and block_start/block_end (Int) args (#7872)", async () => {
+    const { status, body } = await gql(
+      `{ __type(name: "Query") { fields {
+          name
+          args { name type { kind name ofType { kind name } } }
+        } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const extrinsics = body.data.__type.fields.find(
+      (f: Row) => f.name === "extrinsics",
+    );
+    const argType = (name: string) => {
+      const a = extrinsics.args.find((x: Row) => x.name === name);
+      assert.ok(a, `expected a ${name} arg on extrinsics`);
+      return a.type;
+    };
+    for (const name of ["call_hash", "from", "to"]) {
+      assert.deepEqual(argType(name), {
+        kind: "SCALAR",
+        name: "String",
+        ofType: null,
+      });
+    }
+    for (const name of ["block_start", "block_end"]) {
+      assert.deepEqual(argType(name), {
+        kind: "SCALAR",
+        name: "Int",
+        ofType: null,
+      });
+    }
+  });
+
   test("extrinsics: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
     let capturedUrl: URL | undefined;
     const env = {


### PR DESCRIPTION
Closes #7872

Adds the `list_extrinsics` MCP tool + `GET /api/v1/extrinsics` filter set to the `extrinsics` GraphQL field, bringing the three surfaces to parity:

- `call_hash` — exact extrinsic hash (`String`)
- `block_start` / `block_end` — inclusive block-height range (`Int`)
- `from` / `to` — `observed_at` epoch-ms range (`String`, because epoch-ms overflows GraphQL's 32-bit `Int`, matching the existing `account_history(from/to)` convention)

The resolver forwards each straight through to `/api/v1/extrinsics` with no duplicated filtering. `generated/graphql/types.ts` is regenerated from the SDL per the types-epic D drift gate.

Tests: forwarding for all five new args (asserting the path + each param), plus an introspection guard pinning their scalar types (call_hash/from/to = String, block_start/block_end = Int).
