### PR TITLE
refactor(ui): tokenize raw box-shadow one-offs into an elevation scale

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -105,6 +105,17 @@ const SPACING_TYPE_RULES = [
   },
 ];
 
+// #7840: the 13 raw shadow-[…] values found across both packages collapsed
+// into a named --mg-shadow-* elevation scale (packages/ui-kit/src/styles.css).
+// Negative-lookahead excludes the token-referencing form itself
+// (shadow-[var(--mg-shadow-…)]) so the rule doesn't flag the fix.
+const ELEVATION_RULES = [
+  {
+    selector: "Literal[value=/\\bshadow-\\[(?!var\\(--mg-shadow)/]",
+    message: "Raw shadow value. Use one of the --mg-shadow-* elevation tokens (see styles.css).",
+  },
+];
+
 export default tseslint.config(
   // .source is fumadocs-mdx's generated content collection output (see
   // source.config.ts) -- codegen, not authored code, same treatment as dist.
@@ -172,6 +183,7 @@ export default tseslint.config(
         ...SPACING_TYPE_RULES,
         ...PRIMITIVE_STEER_RULES,
         ...SSR_SAFETY_RULES,
+        ...ELEVATION_RULES,
       ],
     },
   },

--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -168,14 +168,14 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
       {availableNetuids.length > 0 ? (
         <div className="flex flex-wrap items-center gap-2">
           <span className="mg-type-micro text-ink-muted">scope</span>
-          <div className="inline-flex flex-wrap rounded-full border border-border/80 bg-card/80 p-1 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.45)]">
+          <div className="inline-flex flex-wrap rounded-full border border-border/80 bg-card/80 p-1 shadow-[var(--mg-shadow-pill)]">
             <button
               type="button"
               onClick={() => setScope("all")}
               className={classNames(
                 "rounded-full px-3 py-1.5 mg-type-label uppercase transition-colors",
                 scope === "all"
-                  ? "bg-ink-strong text-paper shadow-[0_12px_30px_-24px_rgba(15,23,42,0.85)]"
+                  ? "bg-ink-strong text-paper shadow-[var(--mg-shadow-pill-active)]"
                   : "text-ink-muted hover:text-ink-strong",
               )}
             >
@@ -189,7 +189,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
                 className={classNames(
                   "rounded-full px-3 py-1.5 mg-type-label uppercase transition-colors",
                   scope === netuid
-                    ? "bg-ink-strong text-paper shadow-[0_12px_30px_-24px_rgba(15,23,42,0.85)]"
+                    ? "bg-ink-strong text-paper shadow-[var(--mg-shadow-pill-active)]"
                     : "text-ink-muted hover:text-ink-strong",
                 )}
               >

--- a/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
+++ b/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
@@ -118,7 +118,7 @@ export function CallModuleExtrinsicsTable({
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Hash</th>
               <th className="px-4 py-2.5">Block</th>

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -67,7 +67,7 @@ export function ShortcutsPopover() {
               className={classNames(
                 "hidden md:inline-flex fixed z-40 bottom-5 left-5 md:bottom-7 md:left-7",
                 "items-center justify-center rounded-full border border-border bg-card/95 backdrop-blur",
-                "size-10 text-ink-muted shadow-[0_8px_24px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
+                "size-10 text-ink-muted shadow-[var(--mg-shadow-pop)]",
                 "hover:border-accent/60 hover:text-accent transition-colors",
               )}
             >

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -24,7 +24,7 @@ export function SubnetsCompareDrawer() {
       <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
         <div
           className={classNames(
-            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
+            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[var(--mg-shadow-drawer)]",
             "mg-fade-in",
           )}
         >

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -114,7 +114,7 @@ export function ValidatorNominatorsTable({ queryOptions, search, setSearch }: Pr
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Coldkey</th>
               <th className="px-4 py-2.5 text-right">Net staked</th>

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -28,7 +28,7 @@ export function ValidatorsCompareDrawer() {
       <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
         <div
           className={classNames(
-            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
+            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[var(--mg-shadow-drawer)]",
             "mg-fade-in",
           )}
         >

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -496,7 +496,7 @@ function BlocksTable() {
         ))}
         table={
           <table className="w-full text-left text-sm">
-            <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+            <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
               <tr>
                 <th className="px-4 py-2.5">Block</th>
                 <th className="px-4 py-2.5">Hash</th>

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -304,7 +304,7 @@ function ExtrinsicsTable() {
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Hash</th>
               <th className="px-4 py-2.5">Block</th>

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -586,7 +586,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                   params={{ slug: p.slug }}
                   className={classNames(
                     "group block rounded-lg border border-border bg-card p-4 transition-colors",
-                    "hover:border-accent/60 hover:shadow-[0_0_0_1px_color-mix(in_oklab,var(--accent)_25%,transparent)]",
+                    "hover:border-accent/60 hover:shadow-[var(--mg-shadow-ring-accent)]",
                   )}
                 >
                   <div className="flex items-start justify-between gap-2">

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -687,7 +687,7 @@ function BackToTop({ threshold = 600 }) {
         "fixed z-40 bottom-5 right-5 md:bottom-7 md:right-7",
         "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
-        "shadow-[0_8px_24px_-12px_rgba(0,0,0,0.35)] hover:border-accent/60 hover:text-accent",
+        "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",
         "transition-[opacity,transform,border-color,color] duration-200",
         visible ? "opacity-100 translate-y-0 pointer-events-auto" : "opacity-0 translate-y-2 pointer-events-none"
       ),
@@ -1850,7 +1850,7 @@ function Kbd({
     "kbd",
     {
       className: classNames(
-        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[inset_0_-1px_0_var(--border)]",
+        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
         className
       ),
       children

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -170,6 +170,15 @@
     animation: none !important;
   }
 }
+:root {
+  --mg-shadow-hairline: 0 1px 0 0 var(--border);
+  --mg-shadow-hairline-inset: inset 0 -1px 0 var(--border);
+  --mg-shadow-pop: 0 8px 24px -12px color-mix(in oklab, var(--ink-strong) 35%, transparent);
+  --mg-shadow-drawer: 0 -8px 32px -12px color-mix(in oklab, var(--ink-strong) 35%, transparent);
+  --mg-shadow-pill: 0 18px 50px -44px color-mix(in oklab, var(--ink-strong) 45%, transparent);
+  --mg-shadow-pill-active: 0 12px 30px -24px color-mix(in oklab, var(--ink-strong) 85%, transparent);
+  --mg-shadow-ring-accent: 0 0 0 1px color-mix(in oklab, var(--accent) 25%, transparent);
+}
 .dark {
   --paper: oklch(0.14 0.003 250);
   --surface: oklch(0.175 0.003 250);

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -658,7 +658,7 @@ function BackToTop({ threshold = 600 }) {
         "fixed z-40 bottom-5 right-5 md:bottom-7 md:right-7",
         "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
-        "shadow-[0_8px_24px_-12px_rgba(0,0,0,0.35)] hover:border-accent/60 hover:text-accent",
+        "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",
         "transition-[opacity,transform,border-color,color] duration-200",
         visible ? "opacity-100 translate-y-0 pointer-events-auto" : "opacity-0 translate-y-2 pointer-events-none"
       ),
@@ -1821,7 +1821,7 @@ function Kbd({
     "kbd",
     {
       className: classNames(
-        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[inset_0_-1px_0_var(--border)]",
+        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
         className
       ),
       children

--- a/packages/ui-kit/eslint.config.ts
+++ b/packages/ui-kit/eslint.config.ts
@@ -64,6 +64,15 @@ const DESIGN_RULES = [
     message:
       "Use <ExternalLink> (./external-link) — it sets rel=noreferrer, the external-icon, and safeExternalUrl filtering automatically.",
   },
+  {
+    // #7840: the 13 raw shadow-[…] values found across both packages
+    // collapsed into a named --mg-shadow-* elevation scale (styles.css).
+    // Negative-lookahead excludes the token-referencing form itself
+    // (shadow-[var(--mg-shadow-…)]) so the rule doesn't flag the fix.
+    selector: "Literal[value=/\\bshadow-\\[(?!var\\(--mg-shadow)/]",
+    message:
+      "Raw shadow value. Use one of the --mg-shadow-* elevation tokens (see styles.css).",
+  },
 ];
 
 // SSR footguns -- see apps/ui/docs/ssr-safety.md. ui-kit's own components

--- a/packages/ui-kit/src/components/metagraphed/back-to-top.tsx
+++ b/packages/ui-kit/src/components/metagraphed/back-to-top.tsx
@@ -66,7 +66,7 @@ export function BackToTop({ threshold = 600 }: { threshold?: number }) {
         "fixed z-40 bottom-5 right-5 md:bottom-7 md:right-7",
         "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
-        "shadow-[0_8px_24px_-12px_rgba(0,0,0,0.35)] hover:border-accent/60 hover:text-accent",
+        "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",
         "transition-[opacity,transform,border-color,color] duration-200",
         visible
           ? "opacity-100 translate-y-0 pointer-events-auto"

--- a/packages/ui-kit/src/components/metagraphed/kbd.tsx
+++ b/packages/ui-kit/src/components/metagraphed/kbd.tsx
@@ -11,7 +11,7 @@ export function Kbd({
   return (
     <kbd
       className={classNames(
-        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[inset_0_-1px_0_var(--border)]",
+        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
         className,
       )}
     >

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -330,6 +330,31 @@
   }
 }
 
+/* ============================================================
+ * Elevation tokens (#7840) — the 8 distinct raw shadow-[…] values
+ * found across apps/ui + ui-kit collapsed into a named scale, so
+ * new shadows reach for one of these instead of inventing another
+ * bespoke recipe. color-mix(in oklab, var(--ink-strong) …) tracks
+ * the active theme automatically; two of the values converted here
+ * previously used a hard-coded rgba(15,23,42,…) that did NOT adapt
+ * in dark mode (account-history-chart.tsx's pill toggle) — this is
+ * a small visual fix alongside the token move, not just a rename.
+ * ============================================================ */
+:root {
+  --mg-shadow-hairline: 0 1px 0 0 var(--border);
+  --mg-shadow-hairline-inset: inset 0 -1px 0 var(--border);
+  --mg-shadow-pop: 0 8px 24px -12px
+    color-mix(in oklab, var(--ink-strong) 35%, transparent);
+  --mg-shadow-drawer: 0 -8px 32px -12px
+    color-mix(in oklab, var(--ink-strong) 35%, transparent);
+  --mg-shadow-pill: 0 18px 50px -44px
+    color-mix(in oklab, var(--ink-strong) 45%, transparent);
+  --mg-shadow-pill-active: 0 12px 30px -24px
+    color-mix(in oklab, var(--ink-strong) 85%, transparent);
+  --mg-shadow-ring-accent: 0 0 0 1px
+    color-mix(in oklab, var(--accent) 25%, transparent);
+}
+
 /* ============ DARK — Ink + dialed mint ============ */
 .dark {
   --paper: oklch(0.14 0.003 250);


### PR DESCRIPTION
## Summary

Closes #7840 (first sub-issue of the design-token consolidation epic, #7839).

Collapses the 13 raw `shadow-[…]` arbitrary values found across `apps/ui` + `packages/ui-kit` (8 distinct recipes) into 7 named `--mg-shadow-*` tokens in `packages/ui-kit/src/styles.css`: `--mg-shadow-hairline(-inset)`, `--mg-shadow-pop`, `--mg-shadow-drawer`, `--mg-shadow-pill(-active)`, `--mg-shadow-ring-accent`.

Two consolidations along the way, not just a rename:
- `back-to-top.tsx`'s shadow used a hard-coded `rgba(0,0,0,0.35)` with the same geometry as `shortcuts-popover.tsx`'s `color-mix(in oklab, var(--ink-strong) …)` recipe — unified onto `--mg-shadow-pop`.
- `account-history-chart.tsx`'s scope-pill toggle used `rgba(15,23,42,…)` (a hard-coded slate) that did **not** adapt to the active theme — re-expressed as `color-mix(in oklab, var(--ink-strong) …)` via `--mg-shadow-pill`/`--mg-shadow-pill-active`, so the pill now tracks light/dark like every other surface. Small visual fix, not just a token move.

Added a warn-tier ESLint guardrail to both eslint configs: `Literal[value=/\bshadow-\[(?!var\(--mg-shadow)/]` — the negative lookahead excludes the token-referencing form itself so the rule doesn't flag its own fix (verified with a standalone regex test against both a raw literal and the token form).

## Verification

- `tsc --noEmit` clean in both packages
- `eslint` 0 errors in both (67 warnings ui-kit / 1508 apps/ui — both pre-existing baselines; 0 warnings from the new elevation rule)
- Full `vitest run` green (ui-kit 16/16 files, apps/ui 191/191 files)
- Rebuilt ui-kit's `dist/` and re-verified apps/ui against it
- Live-checked computed styles on `/blocks`: the sticky `<thead>`'s `box-shadow` resolves through `--mg-shadow-hairline` → `var(--border)` to a real, non-transparent value; all 7 new tokens read back correctly resolved custom-property chains; 0 console errors