### PR TITLE
fix(ui): fix all 19 react-hooks/exhaustive-deps warnings

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -49,8 +49,8 @@ const CELL_TONE: Record<Cell, { bg: string; ring: string; label: string }> = {
 export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
   const { data: cRes } = useSuspenseQuery(reviewProfileCompletenessQuery());
   const { data: sRes } = useSuspenseQuery(subnetsQuery({ limit: 250 }));
-  const profiles = cRes.data ?? [];
-  const subnets = (sRes.data ?? []) as Subnet[];
+  const profiles = useMemo(() => cRes.data ?? [], [cRes.data]);
+  const subnets = useMemo(() => (sRes.data ?? []) as Subnet[], [sRes.data]);
 
   const [sort, setSort] = useState<"missing-desc" | "missing-asc" | "netuid">("missing-desc");
 
@@ -271,7 +271,7 @@ function Legend({ cell, count }: { cell: Cell; count: number }) {
  */
 export function CompletenessHistogram() {
   const { data } = useSuspenseQuery(reviewProfileCompletenessQuery());
-  const rows = data.data ?? [];
+  const rows = useMemo(() => data.data ?? [], [data.data]);
 
   const buckets = useMemo(() => {
     const arr = new Array(10).fill(0) as number[];

--- a/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
@@ -45,9 +45,9 @@ export function IncidentsTimeline({ className }: { className?: string }) {
   const { data: eRes } = useSuspenseQuery(endpointsQuery({ limit: 500 }));
   const { data: pRes } = useSuspenseQuery(rpcPoolsQuery());
 
-  const incidents = (iRes.data ?? []) as EndpointIncident[];
-  const endpoints = (eRes.data ?? []) as Endpoint[];
-  const pools = (pRes.data ?? []) as RpcPool[];
+  const incidents = useMemo(() => (iRes.data ?? []) as EndpointIncident[], [iRes.data]);
+  const endpoints = useMemo(() => (eRes.data ?? []) as Endpoint[], [eRes.data]);
+  const pools = useMemo(() => (pRes.data ?? []) as RpcPool[], [pRes.data]);
 
   // Map endpoint_id → endpoint metadata so each incident can deep-link.
   const endpointMap = useMemo(() => {

--- a/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
@@ -42,7 +42,7 @@ export function NetworkPulseBand({ className }: { className?: string }) {
   const { data: iRes } = useSuspenseQuery(endpointIncidentsQuery());
   const { data: tRes } = useSuspenseQuery(bulkHealthTrendsQuery());
   const h = hRes.data;
-  const incidents = (iRes.data ?? []) as EndpointIncident[];
+  const incidents = useMemo(() => (iRes.data ?? []) as EndpointIncident[], [iRes.data]);
 
   const total = (h?.total ?? 0) || 1;
   const ok = h?.ok ?? 0;

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -84,7 +84,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
   const navigate = useNavigate();
   const { data: sRes } = useSuspenseQuery(schemasQuery());
   const { data: eRes } = useSuspenseQuery(evidenceQuery({ limit: 500 }));
-  const schemas = (sRes.data ?? []) as SchemaInfo[];
+  const schemas = useMemo(() => (sRes.data ?? []) as SchemaInfo[], [sRes.data]);
   const evidence = (eRes.data ?? []) as EvidenceItem[];
 
   const [filter, setFilter] = useState<"all" | DriftKind>("all");

--- a/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
@@ -24,7 +24,7 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
   const { range } = useTimeRange();
   const cutoff = Date.now() - RANGE_HOURS[range] * 3_600_000;
   const { data: res } = useSuspenseQuery(endpointsQuery({ limit }));
-  const allEndpoints = (res.data ?? []) as Endpoint[];
+  const allEndpoints = useMemo(() => (res.data ?? []) as Endpoint[], [res.data]);
   const endpoints = useMemo(
     () =>
       allEndpoints.filter((e) => {

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -319,7 +319,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
     ...searchQuery(debounced, 20),
     retry: 0,
   });
-  const allHits = (data?.data ?? []) as SearchHit[];
+  const allHits = useMemo(() => (data?.data ?? []) as SearchHit[], [data?.data]);
 
   // Semantic (vector-similarity) fallback/complement to the keyword hits above.
   // Isolated in its own query so a 503 (AI disabled) or 502 (AI error) just

--- a/apps/ui/src/components/metagraphed/hero-feature-row.tsx
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.tsx
@@ -106,7 +106,10 @@ function ChainThroughputCard() {
 function LiveSubnetsCard() {
   const hydrated = useHydrated();
   const { data } = useQuery({ ...subnetsQuery({ limit: 128 }), enabled: hydrated });
-  const subnets = hydrated ? ((data?.data as Subnet[] | undefined) ?? []) : [];
+  const subnets = useMemo(
+    () => (hydrated ? ((data?.data as Subnet[] | undefined) ?? []) : []),
+    [hydrated, data?.data],
+  );
 
   const featured = useMemo(() => pickFeatured(subnets, 6), [subnets]);
 

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -336,7 +336,7 @@ function GapsKpiStrip() {
  */
 function MissingKindsAtAGlance() {
   const gapsRes = useSuspenseQuery(gapsQuery()).data;
-  const rows = (gapsRes.data ?? []) as Gap[];
+  const rows = useMemo(() => (gapsRes.data ?? []) as Gap[], [gapsRes.data]);
   const navigate = useNavigate({ from: Route.fullPath });
   const search = Route.useSearch();
   const activeMissing = useMemo<Set<string>>(
@@ -482,7 +482,7 @@ function OpenGapsSection() {
     for (const s of (snRes.data ?? []) as Subnet[]) m.set(s.netuid, s);
     return m;
   }, [snRes]);
-  const rows = (data.data ?? []) as Gap[];
+  const rows = useMemo(() => (data.data ?? []) as Gap[], [data.data]);
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
 

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -306,7 +306,7 @@ function SchemaExplorer() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const { data } = useSuspenseQuery(schemasQuery());
-  const all = (data.data ?? []) as SchemaInfo[];
+  const all = useMemo(() => (data.data ?? []) as SchemaInfo[], [data.data]);
 
   const filtered = useMemo(() => {
     const needle = search.q.trim().toLowerCase();

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -5613,7 +5613,10 @@ function QueryBarFilterTrigger(props) {
   } = props;
   const id = React3.useId();
   const [open, setOpen] = React3.useState(false);
-  const selected = props.multi ? props.value : props.value ? [props.value] : [];
+  const selected = React3.useMemo(
+    () => props.multi ? props.value : props.value ? [props.value] : [],
+    [props.multi, props.value]
+  );
   const active = selected.length > 0;
   const preview = React3.useMemo(() => {
     if (!active) return placeholder;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -5584,7 +5584,10 @@ function QueryBarFilterTrigger(props) {
   } = props;
   const id = useId();
   const [open, setOpen] = useState(false);
-  const selected = props.multi ? props.value : props.value ? [props.value] : [];
+  const selected = useMemo(
+    () => props.multi ? props.value : props.value ? [props.value] : [],
+    [props.multi, props.value]
+  );
   const active = selected.length > 0;
   const preview = useMemo(() => {
     if (!active) return placeholder;

--- a/packages/ui-kit/src/components/metagraphed/query-bar.tsx
+++ b/packages/ui-kit/src/components/metagraphed/query-bar.tsx
@@ -280,11 +280,10 @@ function QueryBarFilterTrigger(props: QueryBarFilterTriggerProps) {
   const id = useId();
   const [open, setOpen] = useState(false);
 
-  const selected: string[] = props.multi
-    ? props.value
-    : props.value
-      ? [props.value]
-      : [];
+  const selected: string[] = useMemo(
+    () => (props.multi ? props.value : props.value ? [props.value] : []),
+    [props.multi, props.value],
+  );
   const active = selected.length > 0;
 
   const preview = useMemo(() => {


### PR DESCRIPTION
## Summary

Closes #7849.

Every warning had the same shape: an inline conditional/logical-expression computation (`data.data ?? []`, `hydrated ? x : []`, etc.) recomputed fresh on every render, then listed as a `useMemo`/`useCallback` dependency — so the memo's own dependency was never referentially stable and recomputed every render regardless of whether the underlying data actually changed. Fixed by wrapping each flagged initializer in its own `useMemo` keyed on the real primitive inputs, per the fix the lint rule itself suggests.

**9 files in apps/ui (17 warnings):** `analytics/coverage-matrix.tsx` (`profiles`/`subnets` feeding one useMemo, plus a second component's `rows` feeding two memos), `analytics/incidents-timeline.tsx` (`incidents`/`endpoints`/`pools`), `analytics/network-pulse-band.tsx` (`incidents`), `analytics/schema-drift-matrix.tsx` (`schemas` — `evidence` on the same line was left alone, it was never flagged since nothing memoizes on it), `analytics/status-mosaic.tsx` (`allEndpoints`), `command-palette-body.tsx` (`allHits`), `hero-feature-row.tsx` (`subnets`, a hydration-gated ternary), `routes/gaps.tsx` (`rows` in two separate components), `routes/schemas.tsx` (`all` — two other identical-looking `const all = (data.data ?? []) as SchemaInfo[]` sites in the same file were left alone since they don't feed any memo/callback and were never flagged).

**Plus packages/ui-kit's `query-bar.tsx` (2 warnings):** `QueryBarFilterTrigger`'s `selected` ternary (over a discriminated single/multi prop union) fed both a `useMemo` and a `useCallback`; same fix, TS narrowing verified to still work with the check moved inside the memo callback.

## Verification

- `tsc --noEmit` clean in both packages
- `eslint` 0 errors (react-hooks/exhaustive-deps count: apps/ui 17→0, ui-kit 2→0; total problem counts apps/ui 1508→1491, ui-kit 67→65 — exact deltas)
- Full `vitest run` green (ui-kit 16/16 files, apps/ui 191/191 files)
- No `eslint-disable` added anywhere