### PR TITLE
refactor(ui): de-duplicate classNames()/cn() helpers across packages

### DIFF
--- a/apps/ui/src/lib/cn.ts
+++ b/apps/ui/src/lib/cn.ts
@@ -1,6 +1,3 @@
-import clsx from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: Parameters<typeof clsx>) {
-  return twMerge(clsx(...inputs));
-}
+// Canonical implementation lives in packages/ui-kit (#7847) -- re-exported
+// here so every existing "@/lib/cn" import site is unaffected.
+export { cn } from "@jsonbored/ui-kit";

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -107,9 +107,9 @@ export function isStaleFreshness(iso?: string | null, thresholdMs = 12 * 60 * 60
   return Date.now() - Date.parse(iso) > thresholdMs;
 }
 
-export function classNames(...parts: Array<string | false | null | undefined>): string {
-  return parts.filter(Boolean).join(" ");
-}
+// Canonical implementation lives in packages/ui-kit (#7847) -- re-exported
+// here so every existing "@/lib/metagraphed/format" import site is unaffected.
+export { classNames } from "@jsonbored/ui-kit";
 
 /**
  * Humanise a duration in seconds into a compact label like "42s", "5m",

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -20,9 +20,22 @@ imports something app-specific, the extraction has silently regressed back into 
 this package exists to fix. `eslint.config.ts`'s `no-restricted-imports` rule enforces this in CI:
 importing `@tanstack/react-router`, `@tanstack/react-query`, or anything resolving into
 `apps/ui/**` fails the build. If a component genuinely needs routing/data, accept it as a prop
-from the caller instead. If it needs a small pure helper that also lives in `apps/ui` (date
-formatting, a `cn()`-style className joiner, etc.), duplicate the specific pieces needed rather
-than importing across the package boundary — see `src/lib/format.ts` for the established pattern.
+from the caller instead. If it needs a small pure helper that's genuinely app-specific (a date
+formatter tied to apps/ui's own conventions, a hook that reads apps/ui's config, etc.), duplicate
+the specific piece needed rather than importing across the package boundary — see
+`src/lib/format.ts` for the established pattern. Generic, app-agnostic helpers (a `cn()`-style
+className joiner, etc.) should instead be authored here and exported from the public barrel, with
+apps/ui re-exporting them (see `classNames`/`cn` below, #7847) — don't duplicate those.
+
+### `classNames` vs `cn`
+
+Both are exported from the package root. They have different semantics — pick deliberately:
+
+- **`classNames`** — cheap `Boolean`-filter-and-join, no Tailwind conflict resolution. Use for
+  static class assembly where nothing can collide.
+- **`cn`** — `clsx` + `tailwind-merge`; resolves conflicting Tailwind utilities (e.g. two
+  different `px-*` values collapse to the last one). Use where callers may pass a `className` prop
+  that could conflict with the component's own classes.
 
 ## Build
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1,10 +1,10 @@
 'use strict';
 
+var clsx = require('clsx');
+var tailwindMerge = require('tailwind-merge');
 var React3 = require('react');
 var AccordionPrimitive = require('@radix-ui/react-accordion');
 var lucideReact = require('lucide-react');
-var clsx = require('clsx');
-var tailwindMerge = require('tailwind-merge');
 var jsxRuntime = require('react/jsx-runtime');
 var cmdk = require('cmdk');
 var DialogPrimitive = require('@radix-ui/react-dialog');
@@ -34,15 +34,79 @@ function _interopNamespace(e) {
   return Object.freeze(n);
 }
 
+var clsx__default = /*#__PURE__*/_interopDefault(clsx);
 var React3__namespace = /*#__PURE__*/_interopNamespace(React3);
 var AccordionPrimitive__namespace = /*#__PURE__*/_interopNamespace(AccordionPrimitive);
-var clsx__default = /*#__PURE__*/_interopDefault(clsx);
 var DialogPrimitive__namespace = /*#__PURE__*/_interopNamespace(DialogPrimitive);
 var HoverCardPrimitive__namespace = /*#__PURE__*/_interopNamespace(HoverCardPrimitive);
 var PopoverPrimitive__namespace = /*#__PURE__*/_interopNamespace(PopoverPrimitive);
 var TooltipPrimitive__namespace = /*#__PURE__*/_interopNamespace(TooltipPrimitive);
 
-// src/components/ui/accordion.tsx
+// src/lib/format.ts
+function classNames(...parts) {
+  return parts.filter(Boolean).join(" ");
+}
+function isUsableTimestamp(iso) {
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return false;
+  return t > 9466848e5;
+}
+function formatRelative(iso) {
+  if (!isUsableTimestamp(iso)) return "\u2014";
+  const t = Date.parse(iso);
+  const diff = Date.now() - t;
+  const abs = Math.abs(diff);
+  const past = diff >= 0;
+  let value;
+  let unit;
+  if (abs < 6e4) {
+    value = Math.max(1, Math.round(abs / 1e3));
+    unit = "s";
+  } else if (abs < 36e5) {
+    value = Math.round(abs / 6e4);
+    unit = "m";
+  } else if (abs < 864e5) {
+    value = Math.round(abs / 36e5);
+    unit = "h";
+  } else {
+    value = Math.round(abs / 864e5);
+    unit = "d";
+  }
+  return past ? `${value}${unit} ago` : `in ${value}${unit}`;
+}
+function isStaleFreshness(iso, thresholdMs = 12 * 60 * 6e4) {
+  if (!isUsableTimestamp(iso)) return true;
+  return Date.now() - Date.parse(iso) > thresholdMs;
+}
+function formatFreshness(updatedAt, windowLabel) {
+  const parts = [];
+  if (updatedAt) {
+    const t = new Date(updatedAt);
+    if (!Number.isNaN(t.getTime())) {
+      const diffMs = Date.now() - t.getTime();
+      parts.push(`updated ${relative(diffMs)}`);
+    }
+  }
+  if (windowLabel) parts.push(`${windowLabel} window`);
+  return parts.length ? parts.join(" \xB7 ") : null;
+}
+function formatFreshnessAbsolute(updatedAt) {
+  if (!updatedAt) return null;
+  const t = new Date(updatedAt);
+  if (Number.isNaN(t.getTime())) return null;
+  return t.toLocaleString();
+}
+function relative(diffMs) {
+  const sec = Math.max(0, Math.round(diffMs / 1e3));
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 48) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  return `${day}d ago`;
+}
 function cn(...inputs) {
   return tailwindMerge.twMerge(clsx__default.default(...inputs));
 }
@@ -396,72 +460,6 @@ var SheetDescription = React3__namespace.forwardRef(({ className, ...props }, re
   }
 ));
 SheetDescription.displayName = DialogPrimitive__namespace.Description.displayName;
-
-// src/lib/format.ts
-function classNames(...parts) {
-  return parts.filter(Boolean).join(" ");
-}
-function isUsableTimestamp(iso) {
-  if (!iso) return false;
-  const t = Date.parse(iso);
-  if (Number.isNaN(t)) return false;
-  return t > 9466848e5;
-}
-function formatRelative(iso) {
-  if (!isUsableTimestamp(iso)) return "\u2014";
-  const t = Date.parse(iso);
-  const diff = Date.now() - t;
-  const abs = Math.abs(diff);
-  const past = diff >= 0;
-  let value;
-  let unit;
-  if (abs < 6e4) {
-    value = Math.max(1, Math.round(abs / 1e3));
-    unit = "s";
-  } else if (abs < 36e5) {
-    value = Math.round(abs / 6e4);
-    unit = "m";
-  } else if (abs < 864e5) {
-    value = Math.round(abs / 36e5);
-    unit = "h";
-  } else {
-    value = Math.round(abs / 864e5);
-    unit = "d";
-  }
-  return past ? `${value}${unit} ago` : `in ${value}${unit}`;
-}
-function isStaleFreshness(iso, thresholdMs = 12 * 60 * 6e4) {
-  if (!isUsableTimestamp(iso)) return true;
-  return Date.now() - Date.parse(iso) > thresholdMs;
-}
-function formatFreshness(updatedAt, windowLabel) {
-  const parts = [];
-  if (updatedAt) {
-    const t = new Date(updatedAt);
-    if (!Number.isNaN(t.getTime())) {
-      const diffMs = Date.now() - t.getTime();
-      parts.push(`updated ${relative(diffMs)}`);
-    }
-  }
-  if (windowLabel) parts.push(`${windowLabel} window`);
-  return parts.length ? parts.join(" \xB7 ") : null;
-}
-function formatFreshnessAbsolute(updatedAt) {
-  if (!updatedAt) return null;
-  const t = new Date(updatedAt);
-  if (Number.isNaN(t.getTime())) return null;
-  return t.toLocaleString();
-}
-function relative(diffMs) {
-  const sec = Math.max(0, Math.round(diffMs / 1e3));
-  if (sec < 60) return `${sec}s ago`;
-  const min = Math.round(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.round(min / 60);
-  if (hr < 48) return `${hr}h ago`;
-  const day = Math.round(hr / 24);
-  return `${day}d ago`;
-}
 function SegmentedToggle({
   options,
   value,
@@ -6217,6 +6215,8 @@ exports.ViewModeToggle = ViewModeToggle;
 exports.Wordmark = Wordmark;
 exports.YieldPercentileStrip = YieldPercentileStrip;
 exports.buildCsvDownloadUrl = buildCsvDownloadUrl;
+exports.classNames = classNames;
+exports.cn = cn;
 exports.defaultVisible = defaultVisible;
 exports.fmtYield = fmtYield;
 exports.isScrolledPast = isScrolledPast;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,9 +1,9 @@
+import clsx from 'clsx';
+import { twMerge } from 'tailwind-merge';
 import * as React3 from 'react';
 import { forwardRef, createContext, useId, useState, useMemo, useCallback, useRef, useEffect, useLayoutEffect, useContext } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDown, X, Search, Check, ArrowUp, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Columns3, RotateCcw, AlertTriangle, Filter, Loader2, MoreHorizontal, Lock } from 'lucide-react';
-import clsx from 'clsx';
-import { twMerge } from 'tailwind-merge';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
 import { Command as Command$1 } from 'cmdk';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
@@ -13,7 +13,71 @@ import { cva } from 'class-variance-authority';
 import { Toaster as Toaster$1, toast } from 'sonner';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
-// src/components/ui/accordion.tsx
+// src/lib/format.ts
+function classNames(...parts) {
+  return parts.filter(Boolean).join(" ");
+}
+function isUsableTimestamp(iso) {
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return false;
+  return t > 9466848e5;
+}
+function formatRelative(iso) {
+  if (!isUsableTimestamp(iso)) return "\u2014";
+  const t = Date.parse(iso);
+  const diff = Date.now() - t;
+  const abs = Math.abs(diff);
+  const past = diff >= 0;
+  let value;
+  let unit;
+  if (abs < 6e4) {
+    value = Math.max(1, Math.round(abs / 1e3));
+    unit = "s";
+  } else if (abs < 36e5) {
+    value = Math.round(abs / 6e4);
+    unit = "m";
+  } else if (abs < 864e5) {
+    value = Math.round(abs / 36e5);
+    unit = "h";
+  } else {
+    value = Math.round(abs / 864e5);
+    unit = "d";
+  }
+  return past ? `${value}${unit} ago` : `in ${value}${unit}`;
+}
+function isStaleFreshness(iso, thresholdMs = 12 * 60 * 6e4) {
+  if (!isUsableTimestamp(iso)) return true;
+  return Date.now() - Date.parse(iso) > thresholdMs;
+}
+function formatFreshness(updatedAt, windowLabel) {
+  const parts = [];
+  if (updatedAt) {
+    const t = new Date(updatedAt);
+    if (!Number.isNaN(t.getTime())) {
+      const diffMs = Date.now() - t.getTime();
+      parts.push(`updated ${relative(diffMs)}`);
+    }
+  }
+  if (windowLabel) parts.push(`${windowLabel} window`);
+  return parts.length ? parts.join(" \xB7 ") : null;
+}
+function formatFreshnessAbsolute(updatedAt) {
+  if (!updatedAt) return null;
+  const t = new Date(updatedAt);
+  if (Number.isNaN(t.getTime())) return null;
+  return t.toLocaleString();
+}
+function relative(diffMs) {
+  const sec = Math.max(0, Math.round(diffMs / 1e3));
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 48) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  return `${day}d ago`;
+}
 function cn(...inputs) {
   return twMerge(clsx(...inputs));
 }
@@ -367,72 +431,6 @@ var SheetDescription = React3.forwardRef(({ className, ...props }, ref) => /* @_
   }
 ));
 SheetDescription.displayName = DialogPrimitive.Description.displayName;
-
-// src/lib/format.ts
-function classNames(...parts) {
-  return parts.filter(Boolean).join(" ");
-}
-function isUsableTimestamp(iso) {
-  if (!iso) return false;
-  const t = Date.parse(iso);
-  if (Number.isNaN(t)) return false;
-  return t > 9466848e5;
-}
-function formatRelative(iso) {
-  if (!isUsableTimestamp(iso)) return "\u2014";
-  const t = Date.parse(iso);
-  const diff = Date.now() - t;
-  const abs = Math.abs(diff);
-  const past = diff >= 0;
-  let value;
-  let unit;
-  if (abs < 6e4) {
-    value = Math.max(1, Math.round(abs / 1e3));
-    unit = "s";
-  } else if (abs < 36e5) {
-    value = Math.round(abs / 6e4);
-    unit = "m";
-  } else if (abs < 864e5) {
-    value = Math.round(abs / 36e5);
-    unit = "h";
-  } else {
-    value = Math.round(abs / 864e5);
-    unit = "d";
-  }
-  return past ? `${value}${unit} ago` : `in ${value}${unit}`;
-}
-function isStaleFreshness(iso, thresholdMs = 12 * 60 * 6e4) {
-  if (!isUsableTimestamp(iso)) return true;
-  return Date.now() - Date.parse(iso) > thresholdMs;
-}
-function formatFreshness(updatedAt, windowLabel) {
-  const parts = [];
-  if (updatedAt) {
-    const t = new Date(updatedAt);
-    if (!Number.isNaN(t.getTime())) {
-      const diffMs = Date.now() - t.getTime();
-      parts.push(`updated ${relative(diffMs)}`);
-    }
-  }
-  if (windowLabel) parts.push(`${windowLabel} window`);
-  return parts.length ? parts.join(" \xB7 ") : null;
-}
-function formatFreshnessAbsolute(updatedAt) {
-  if (!updatedAt) return null;
-  const t = new Date(updatedAt);
-  if (Number.isNaN(t.getTime())) return null;
-  return t.toLocaleString();
-}
-function relative(diffMs) {
-  const sec = Math.max(0, Math.round(diffMs / 1e3));
-  if (sec < 60) return `${sec}s ago`;
-  const min = Math.round(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.round(min / 60);
-  if (hr < 48) return `${hr}h ago`;
-  const day = Math.round(hr / 24);
-  return `${day}d ago`;
-}
 function SegmentedToggle({
   options,
   value,
@@ -6047,4 +6045,4 @@ function RoutePending({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, defaultVisible, fmtYield, isScrolledPast, isTablistNavKey, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useQueryBarContext, useRovingTablist, useScrolled };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, defaultVisible, fmtYield, isScrolledPast, isTablistNavKey, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useQueryBarContext, useRovingTablist, useScrolled };

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -1,5 +1,17 @@
 import "./styles.css";
 
+// Class-assembly helpers (#7847). Two distinct semantics, both canonical
+// here -- apps/ui's own copies re-export these rather than redefining them:
+//   - classNames: cheap Boolean-filter-and-join, no Tailwind conflict
+//     resolution. Use for static class assembly.
+//   - cn: clsx + tailwind-merge, resolves conflicting Tailwind utilities
+//     (e.g. two different `px-*` values collapse to the last one). Use only
+//     where callers may pass conflicting utilities that must merge --
+//     typically prop-accepting components forwarding a caller `className`
+//     alongside the component's own classes.
+export { classNames } from "@/lib/format";
+export { cn } from "@/lib/utils";
+
 export {
   Accordion,
   AccordionItem,


### PR DESCRIPTION
## Summary

Closes #7847.

Both class-assembly helpers existed twice with identical implementations: `classNames()` (filter-Boolean-join, no twMerge) in `apps/ui/src/lib/metagraphed/format.ts` **and** `packages/ui-kit/src/lib/format.ts`, and `cn()` (clsx + twMerge) in `apps/ui/src/lib/cn.ts` **and** `packages/ui-kit/src/lib/utils.ts`. Two implementations of the same function drift silently; having both `classNames` and `cn` with different merge semantics is itself a footgun worth documenting explicitly.

ui-kit is now canonical: both are exported from its public barrel. `apps/ui/src/lib/cn.ts` is a one-line re-export; `classNames` in `apps/ui/src/lib/metagraphed/format.ts` is replaced with a re-export at the same call site (the rest of that file's ~30 other exported helpers are untouched) — every existing `"@/lib/cn"` and `"@/lib/metagraphed/format"` import site is unaffected, no import-site rewrites needed.

Documented the semantics split in `packages/ui-kit/README.md`, and corrected the README's prior "duplicate `cn()`-style helpers rather than importing across the boundary" guidance — that advice predates this issue and would have told the next contributor to re-introduce the exact duplication being removed here.

## Verification

- `tsc --noEmit` clean in both packages
- `eslint` 0 errors (1508 warnings apps/ui / 67 ui-kit, unchanged baselines — confirms no new drift introduced)
- Full `vitest run` green (ui-kit 16/16 files, apps/ui 191/191 files)
- No behavior change — both re-exports are the exact same functions