### PR TITLE
feat(api): GraphQL parity for candidates field args

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2420,7 +2420,7 @@ export type Query = {
   blocks_summary: BlocksSummary;
   /** The generated build summary: artifact inventory counts and sizes, subnet/provider/surface totals, coverage rollup, and publish metadata. Resolves to a GraphQL error (not null) when the build-summary artifact has not been baked in this environment, matching the REST route's 404 and the get_build MCP tool. Mirrors GET /api/v1/build. */
   build: BuildSummary;
-  /** The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state and page with limit/cursor, exactly like the REST route. Resolves to {items,total,next_cursor} as opaque JSON. Mirrors GET /api/v1/candidates. */
+  /** The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state/id/confidence, sort with sort + order, and page with limit (1-1000) / cursor, exactly like the REST route — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the candidates rows, as opaque JSON. A cold/absent artifact is a GraphQL error (matching REST/MCP not_found). Mirrors GET /api/v1/candidates. */
   candidates?: Maybe<Scalars['JSON']['output']>;
   /** Per-UTC-day network activity series over a 7d/30d window (default 7d): each UTC day's block count, extrinsic count (with its successful-extrinsic count and success rate), on-chain event count, and distinct signer count, newest day first. Computed live from the extrinsics/blocks tiers; a cold store yields a schema-stable empty series, never a GraphQL error. Mirrors GET /api/v1/chain/activity. */
   chain_activity: ChainActivity;
@@ -2924,11 +2924,15 @@ export type QueryBlocksArgs = {
 
 
 export type QueryCandidatesArgs = {
-  cursor?: InputMaybe<Scalars['String']['input']>;
+  confidence?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
   kind?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
   provider?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
   state?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -79,14 +79,18 @@ export const SDL = /* GraphQL */ `
     agent_resources: JSON
     "Curation states by subnet — each subnet's registry curation level and review state. Null when the artifact has not been baked. Opaque JSON passed through verbatim, matching the list_curation MCP/REST shape. Mirrors GET /api/v1/curation."
     curation: JSON
-    "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state and page with limit/cursor, exactly like the REST route. Resolves to {items,total,next_cursor} as opaque JSON. Mirrors GET /api/v1/candidates."
+    "The discovered candidate-surface ledger: every machine-discovered surface awaiting review, with its subnet (netuid), kind, provider, and review state. Filter by netuid/kind/provider/state/id/confidence, sort with sort + order, and page with limit (1-1000) / cursor, exactly like the REST route — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the candidates rows, as opaque JSON. A cold/absent artifact is a GraphQL error (matching REST/MCP not_found). Mirrors GET /api/v1/candidates."
     candidates(
       netuid: Int
       kind: String
       provider: String
       state: String
+      id: String
+      confidence: String
+      sort: String
+      order: String
       limit: Int
-      cursor: String
+      cursor: Int
     ): JSON
     "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}."
     saved_query(id: String!, params: JSON): JSON

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -66,6 +66,10 @@ import { loadProvidersList } from "./providers-mcp.ts";
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
 // and page logic REST and MCP already use) -- not a reimplementation.
 import { loadAdapterCandidatesList } from "./adapter-candidates-mcp.ts";
+// #7871: GraphQL parity for GET /api/v1/candidates' id/confidence/sort/order
+// filters, reusing loadCandidatesList that MCP list_candidates already calls --
+// not a reimplementation.
+import { loadCandidatesList } from "./candidates-mcp.ts";
 import { loadEnrichmentEvidenceList } from "./enrichment-evidence-mcp.ts";
 import { loadEnrichmentQueueList } from "./enrichment-queue-mcp.ts";
 import { loadReviewEnrichmentTargetsList } from "./review-enrichment-targets-mcp.ts";
@@ -1679,26 +1683,13 @@ const rootValue = {
   // #6991: five registry-meta routes that had an MCP tool but no GraphQL
   // field. Each reads the same baked artifact (and applies the same overlay /
   // builder) its MCP tool does, so REST, MCP, and GraphQL can't drift.
-  async candidates(
-    { netuid, kind, provider, state, limit, cursor }: Row,
-    context: GqlContext,
-  ) {
-    const data = await loadArtifact(context, "/metagraph/candidates.json");
-    const all = Array.isArray(data?.candidates) ? data.candidates : [];
-    const filtered = all.filter(
-      (c: Row) =>
-        (netuid == null || c.netuid === netuid) &&
-        (kind == null || c.kind === kind) &&
-        (provider == null || c.provider === provider) &&
-        (state == null || c.state === state),
-    );
-    const { page, total, nextCursor } = paginate(
-      filtered,
-      limit,
-      cursor,
-      (c: Row) => c.id ?? c.key,
-    );
-    return { items: page, total, next_cursor: nextCursor };
+  // #7871: reuse list_candidates' own loader unchanged so REST, MCP, and
+  // GraphQL share one filter/sort/page contract -- id/confidence/sort/order now
+  // included, matching GET /api/v1/candidates. An invalid filter/sort value or a
+  // cold/absent artifact throws, becoming a GraphQL error (matching the sibling
+  // gaps / subnet_candidates convention), rather than a silent default.
+  candidates(args: Row, context: GqlContext) {
+    return loadCandidatesList(mcpCtx(context), args, { readArtifact });
   },
 
   fixtures(_args: unknown, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8471,69 +8471,95 @@ describe("graphql — agent_resources (#6987, baked AI-resources index)", () => 
 
 describe("graphql — candidates / fixtures / agent_catalog / freshness / top_holders (#6991)", () => {
   const CANDIDATES = {
+    generated_at: "2026-07-01T00:00:00.000Z",
     candidates: [
-      { id: "c1", netuid: 1, kind: "docs", provider: "acme", state: "new" },
-      { id: "c2", netuid: 2, kind: "api", provider: "beta", state: "verified" },
+      {
+        id: "c1",
+        netuid: 1,
+        kind: "docs",
+        provider: "acme",
+        state: "schema-valid",
+        confidence: "low",
+      },
+      {
+        id: "c2",
+        netuid: 2,
+        kind: "openapi",
+        provider: "beta",
+        state: "verified",
+        confidence: "high",
+      },
     ],
   };
 
-  test("candidates resolves the ledger with total and next_cursor", async () => {
+  test("candidates resolves the ledger with the REST pagination envelope", async () => {
     const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
     const { status, body } = await gql("{ candidates }", env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     assert.equal(body.data.candidates.total, 2);
-    assert.equal(body.data.candidates.items.length, 2);
+    assert.equal(body.data.candidates.candidates.length, 2);
+    assert.equal(body.data.candidates.generated_at, "2026-07-01T00:00:00.000Z");
   });
 
   test("candidates applies the netuid/kind/provider/state filters", async () => {
     const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
     const { body } = await gql(
-      '{ candidates(netuid: 2, kind: "api", provider: "beta", state: "verified") }',
+      '{ candidates(netuid: 2, kind: "openapi", provider: "beta", state: "verified") }',
       env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.equal(body.data.candidates.total, 1);
-    assert.equal(body.data.candidates.items[0].id, "c2");
+    assert.equal(body.data.candidates.candidates[0].id, "c2");
   });
 
-  test("candidates keys the cursor off `key` when a row has no id", async () => {
-    const env = fixtureEnv({
-      "/metagraph/candidates.json": {
-        candidates: [
-          {
-            key: "k1",
-            netuid: 1,
-            kind: "docs",
-            provider: "acme",
-            state: "new",
-          },
-          { key: "k2", netuid: 2, kind: "api", provider: "beta", state: "new" },
-        ],
-      },
-    });
-    const { body } = await gql("{ candidates(limit: 1) }", env);
+  test("candidates filters by id (#7871)", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(id: "c1") }', env);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.candidates.next_cursor, "k1");
+    assert.equal(body.data.candidates.total, 1);
+    assert.equal(body.data.candidates.candidates[0].id, "c1");
+  });
+
+  test("candidates filters by confidence (#7871)", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(confidence: "high") }', env);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.total, 1);
+    assert.equal(body.data.candidates.candidates[0].id, "c2");
+  });
+
+  test("candidates sorts with sort + order (#7871)", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql(
+      '{ candidates(sort: "netuid", order: "desc") }',
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.candidates.candidates[0].id, "c2");
+    assert.equal(body.data.candidates.candidates[1].id, "c1");
   });
 
   test("candidates pages with limit and hands back a next_cursor", async () => {
     const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
     const { body } = await gql("{ candidates(limit: 1) }", env);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.candidates.items.length, 1);
+    assert.equal(body.data.candidates.candidates.length, 1);
     assert.equal(body.data.candidates.total, 2);
-    assert.equal(body.data.candidates.next_cursor, "c1");
+    assert.equal(body.data.candidates.returned, 1);
+    assert.ok(body.data.candidates.next_cursor != null);
   });
 
-  test("candidates resolves an empty ledger when the artifact is cold", async () => {
-    const { body } = await gql("{ candidates }");
-    assert.equal(body.errors, undefined);
-    assert.deepEqual(body.data.candidates, {
-      items: [],
-      total: 0,
-      next_cursor: null,
-    });
+  test("candidates surfaces an invalid sort as a GraphQL error (#7871)", async () => {
+    const env = fixtureEnv({ "/metagraph/candidates.json": CANDIDATES });
+    const { body } = await gql('{ candidates(sort: "bogus") }', env);
+    assert.ok(body.errors?.length);
+  });
+
+  test("candidates surfaces a cold/missing artifact as a GraphQL error", async () => {
+    const { body } = await gql("{ candidates }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data.candidates, null);
   });
 
   test("fixtures resolves the baked fixture index", async () => {


### PR DESCRIPTION
## Summary

Brings the GraphQL `candidates` field to parity with `GET /api/v1/candidates` by
reusing the **same loader the REST route and `list_candidates` MCP tool already call**
(`loadCandidatesList`) instead of the earlier inline filter/paginate pass. This mirrors
the sibling `gaps(...)` field exactly (the precedent the issue points at), the same way
`subnet_candidates` (#7878) and `gaps` (#7171) were done — so the three surfaces
(REST / MCP / GraphQL) can't drift.

Closes #7871

## What this changes

- **SDL (`src/graphql-sdl.ts`):** the `candidates` field now accepts `id`, `confidence`,
  `sort`, and `order`, matching `GET /api/v1/candidates` and the `gaps` field's
  filter/sort/page pattern. Its description is updated to document the new filters and
  the REST pagination-meta envelope.
- **Resolver (`src/graphql.ts`):** replaced the hand-rolled `loadArtifact` +
  `Array.filter` + `paginate` body with a one-line pass-through that mirrors `gaps(...)`:
  `return loadCandidatesList(mcpCtx(context), args, { readArtifact });`.
  Every filter/sort/limit/cursor value is now validated against the REST allowlists
  inside the loader; an unsupported value (or a cold catalog artifact) surfaces as a
  GraphQL error, not a silently substituted default — identical to `gaps`.
- **Generated types (`generated/graphql/types.ts`):** regenerated with
  `npm run build:graphql-types` so `QueryCandidatesArgs` reflects the new SDL;
  `npm run validate:graphql-types-drift` passes.

## Two argument types follow REST, not the issue's illustrative sketch

The issue sketched `confidence: Float` and the field previously typed `cursor: String`.
Both are set to what `GET /api/v1/candidates` actually accepts, so the field genuinely
"matches REST":

- **`confidence: String`** — the shared `candidates` query collection
  (`src/contracts.ts`) validates `confidence` as an enum of `low` / `medium` / `high`,
  and the direct sibling `subnet_candidates` field already exposes it as `String`.
  A `Float` would be rejected by the loader's confidence enum and could never match a
  row, so it would not mirror REST.
- **`cursor: Int`** — REST / `loadCandidatesList` paginate by integer offset (`gaps`
  uses `cursor: Int` too); the old `cursor: String` key-based cursor was specific to the
  removed inline implementation.

## Test coverage (`tests/graphql.test.ts`)

Rewrote the `candidates` tests onto the loader's pagination envelope and added the
coverage the issue asks for:

- filter by `id` (exact match)
- filter by `confidence`
- `sort` + `order` combination
- existing `netuid`/`kind`/`provider`/`state` filters, pagination meta
  (`total`/`returned`/`next_cursor`), invalid-sort → GraphQL error, and cold-artifact →
  GraphQL error (matching REST/MCP `not_found`).

## Verification

- `vitest run tests/graphql.test.ts` + `graphql-sentry-and-error-code.test.ts` — 979 passing; full suite green.
- Patch coverage 100% on the changed `src/graphql.ts` lines (the file's only uncovered
  line is pre-existing and outside this diff).
- `validate:graphql-types-drift`, `validate:contract-drift`, `validate:generated-client`,
  and `scan-public-safety` all pass.
- `eslint`, `prettier --check`, and `tsc --noEmit` all clean.
- Rebases cleanly on `main`.

No rendered UI output changes (GraphQL schema/resolver + tests only).
