### PR TITLE
feat(api): add subnet_endpoints root field

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2602,6 +2602,8 @@ export type Query = {
   subnet_conviction: SubnetConviction;
   /** Per-subnet neuron-deregistration activity over a 7d/30d window (distinct deregistered hotkeys, NeuronDeregistered count, and deregistrations per hotkey); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/deregistrations. */
   subnet_deregistrations: SubnetDeregistrations;
+  /** One subnet's endpoint/resource registry rows with full REST filter parity — the baked per-subnet /metagraph/endpoints/{netuid}.json artifact the REST route and list_subnet_endpoints MCP tool read. Filter with kind, layer, publication_state, status, and latency (min_/max_latency_ms) / score (min_/max_score) ranges; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the endpoints rows. Null when no endpoint artifact has been baked for the netuid (rather than a GraphQL error). Distinct from endpoints(...) (the network-wide endpoint catalog) and the nested Subnet.endpoints field. Mirrors GET /api/v1/subnets/{netuid}/endpoints. */
+  subnet_endpoints?: Maybe<Scalars['JSON']['output']>;
   /** One subnet's chain-event activity summary over a 7d/30d/90d window (default 30d): total events, the per-kind and per-category breakdowns with hotkey/coldkey participation and TAO/alpha amounts, and a bounded newest-first recent-event list (limit 1-50, default 10). A subnet with no events resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/event-summary. */
   subnet_event_summary: SubnetEventSummary;
   /** One subnet's paginated first-party chain-event feed (newest first): each event's kind, block, UID, hot/cold keys, amount, and timestamp. Filter by kind and by block_start/block_end (inclusive block bounds); page with limit (1-1000, default 100)/offset. event_count is the page count, not a grand total. A subnet with no matching events resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/subnets/{netuid}/events. */
@@ -3521,6 +3523,23 @@ export type QuerySubnet_DeregistrationsArgs = {
 };
 
 
+export type QuerySubnet_EndpointsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  kind?: InputMaybe<Scalars['String']['input']>;
+  layer?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  max_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  max_score?: InputMaybe<Scalars['Float']['input']>;
+  min_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  min_score?: InputMaybe<Scalars['Float']['input']>;
+  netuid: Scalars['Int']['input'];
+  order?: InputMaybe<Scalars['String']['input']>;
+  publication_state?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type QuerySubnet_Event_SummaryArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid: Scalars['Int']['input'];
@@ -4094,7 +4113,7 @@ export type Subnet = {
   docs_url?: Maybe<Scalars['String']['output']>;
   /** Per-subnet economic + validator metrics. */
   economics?: Maybe<SubnetEconomics>;
-  /** Endpoint/resource registry rows for this subnet. */
+  /** Endpoint/resource registry rows for this subnet. Accepts the same filter/sort/page arguments as the root subnet_endpoints(...) field (netuid comes from the parent Subnet); when any is supplied the field is served through the same list_subnet_endpoints loader, and an unsupported filter/sort value is a GraphQL error. With no arguments it returns the subnet's full unfiltered endpoint list. */
   endpoints: Array<Endpoint>;
   first_party?: Maybe<Scalars['Boolean']['output']>;
   gap_count?: Maybe<Scalars['Int']['output']>;
@@ -4115,6 +4134,22 @@ export type Subnet = {
   surfaces: Array<Surface>;
   symbol?: Maybe<Scalars['String']['output']>;
   website_url?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type SubnetEndpointsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  kind?: InputMaybe<Scalars['String']['input']>;
+  layer?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  max_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  max_score?: InputMaybe<Scalars['Float']['input']>;
+  min_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  min_score?: InputMaybe<Scalars['Float']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  publication_state?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type SubnetAxonRemovals = {
@@ -7782,6 +7817,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   subnet_concentration_history?: Resolver<ResolversTypes['SubnetConcentrationHistory'], ParentType, ContextType, RequireFields<QuerySubnet_Concentration_HistoryArgs, 'netuid'>>;
   subnet_conviction?: Resolver<ResolversTypes['SubnetConviction'], ParentType, ContextType, RequireFields<QuerySubnet_ConvictionArgs, 'netuid'>>;
   subnet_deregistrations?: Resolver<ResolversTypes['SubnetDeregistrations'], ParentType, ContextType, RequireFields<QuerySubnet_DeregistrationsArgs, 'netuid'>>;
+  subnet_endpoints?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, RequireFields<QuerySubnet_EndpointsArgs, 'netuid'>>;
   subnet_event_summary?: Resolver<ResolversTypes['SubnetEventSummary'], ParentType, ContextType, RequireFields<QuerySubnet_Event_SummaryArgs, 'netuid'>>;
   subnet_events?: Resolver<ResolversTypes['SubnetEvents'], ParentType, ContextType, RequireFields<QuerySubnet_EventsArgs, 'netuid'>>;
   subnet_evidence?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, RequireFields<QuerySubnet_EvidenceArgs, 'netuid'>>;
@@ -8045,7 +8081,7 @@ export type SubnetResolvers<ContextType = GqlContext, ParentType extends Resolve
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   docs_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   economics?: Resolver<Maybe<ResolversTypes['SubnetEconomics']>, ParentType, ContextType>;
-  endpoints?: Resolver<Array<ResolversTypes['Endpoint']>, ParentType, ContextType>;
+  endpoints?: Resolver<Array<ResolversTypes['Endpoint']>, ParentType, ContextType, Partial<SubnetEndpointsArgs>>;
   first_party?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   gap_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   health?: Resolver<Maybe<ResolversTypes['SubnetHealth']>, ParentType, ContextType>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -162,6 +162,22 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: Int
     ): JSON
+    "One subnet's endpoint/resource registry rows with full REST filter parity — the baked per-subnet /metagraph/endpoints/{netuid}.json artifact the REST route and list_subnet_endpoints MCP tool read. Filter with kind, layer, publication_state, status, and latency (min_/max_latency_ms) / score (min_/max_score) ranges; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the endpoints rows. Null when no endpoint artifact has been baked for the netuid (rather than a GraphQL error). Distinct from endpoints(...) (the network-wide endpoint catalog) and the nested Subnet.endpoints field. Mirrors GET /api/v1/subnets/{netuid}/endpoints."
+    subnet_endpoints(
+      netuid: Int!
+      kind: String
+      layer: String
+      publication_state: String
+      status: String
+      min_latency_ms: Int
+      max_latency_ms: Int
+      min_score: Float
+      max_score: Float
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): JSON
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
@@ -831,8 +847,21 @@ export const SDL = /* GraphQL */ `
     economics: SubnetEconomics
     "Curated public interface surfaces of this subnet."
     surfaces: [Surface!]!
-    "Endpoint/resource registry rows for this subnet."
-    endpoints: [Endpoint!]!
+    "Endpoint/resource registry rows for this subnet. Accepts the same filter/sort/page arguments as the root subnet_endpoints(...) field (netuid comes from the parent Subnet); when any is supplied the field is served through the same list_subnet_endpoints loader, and an unsupported filter/sort value is a GraphQL error. With no arguments it returns the subnet's full unfiltered endpoint list."
+    endpoints(
+      kind: String
+      layer: String
+      publication_state: String
+      status: String
+      min_latency_ms: Int
+      max_latency_ms: Int
+      min_score: Float
+      max_score: Float
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): [Endpoint!]!
   }
 
   type ProviderList {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -73,6 +73,10 @@ import { loadReviewEnrichmentTargetsList } from "./review-enrichment-targets-mcp
 // loadSubnetCandidatesList that MCP list_subnet_candidates already calls
 // (#7899) -- not a reimplementation.
 import { loadSubnetCandidatesList } from "./subnet-candidates-mcp.ts";
+// #7869: GraphQL parity for GET /api/v1/subnets/{netuid}/endpoints, reusing
+// loadSubnetEndpointsList that MCP list_subnet_endpoints already calls -- not a
+// reimplementation.
+import { loadSubnetEndpointsList } from "./subnet-endpoints-mcp.ts";
 // #7879: GraphQL parity for GET /api/v1/subnets/{netuid}/evidence, reusing
 // loadSubnetEvidenceList that MCP list_subnet_evidence already calls -- not a
 // reimplementation.
@@ -720,6 +724,7 @@ export const FIELD_COMPLEXITY = {
   subnet_gaps: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_evidence: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1214,7 +1219,12 @@ function subnetNode(identity: Row, prefetch: Row = {}) {
     economics: (_args: unknown, context: GqlContext) =>
       loadSubnetEconomics(context, netuid),
     surfaces: bundledOr(prefetch.surfaces, loadSubnetSurfaces),
-    endpoints: bundledOr(prefetch.endpoints, loadSubnetEndpoints),
+    // #7869: filter/sort/page args route to the shared loader; with no args the
+    // field keeps its original bundled-or-lazy full-list behaviour.
+    endpoints: (args: Row, context: GqlContext) =>
+      hasSubnetEndpointsFilterArgs(args)
+        ? loadFilteredSubnetEndpoints(context, netuid, args)
+        : bundledOr(prefetch.endpoints, loadSubnetEndpoints)(args, context),
   };
 }
 
@@ -1386,6 +1396,64 @@ function loadSubnetSurfaces(context: GqlContext, netuid: number) {
 
 function loadSubnetEndpoints(context: GqlContext, netuid: number) {
   return loadRows(context, ARTIFACT.endpoints, "endpoints", netuid);
+}
+
+// #7869: the nested Subnet.endpoints field's filter args mirror the root
+// subnet_endpoints(...) set minus netuid (which comes from the parent Subnet).
+// The presence of any one routes the field through loadSubnetEndpointsList --
+// the same loader the root subnet_endpoints field and the list_subnet_endpoints
+// MCP tool call -- so the filtered nested field cannot drift from
+// GET /api/v1/subnets/{netuid}/endpoints; with no arguments the field keeps its
+// original unbounded full-list behaviour (served from the bundled detail
+// artifact when present, matching the pre-#7869 shape byte-for-byte).
+const SUBNET_ENDPOINTS_FILTER_ARG_NAMES = [
+  "kind",
+  "layer",
+  "publication_state",
+  "status",
+  "min_latency_ms",
+  "max_latency_ms",
+  "min_score",
+  "max_score",
+  "sort",
+  "order",
+  "limit",
+  "cursor",
+];
+
+function hasSubnetEndpointsFilterArgs(args: Row): boolean {
+  return SUBNET_ENDPOINTS_FILTER_ARG_NAMES.some(
+    (name) => args?.[name] !== undefined && args?.[name] !== null,
+  );
+}
+
+// The filtered nested path returns just the endpoint rows (preserving the
+// [Endpoint!]! shape), whereas the root subnet_endpoints field returns the full
+// paginated envelope. An unsupported filter/sort is BAD_USER_INPUT; a
+// cold/absent per-subnet artifact degrades to an empty list because the field
+// is non-null, matching the unfiltered path's cold behaviour.
+async function loadFilteredSubnetEndpoints(
+  context: GqlContext,
+  netuid: number,
+  args: Row,
+): Promise<Row[]> {
+  try {
+    const result = await loadSubnetEndpointsList(
+      mcpCtx(context),
+      { ...args, netuid },
+      { readArtifact },
+    );
+    return result.endpoints as Row[];
+  } catch (rawErr) {
+    const err = rawErr as Row;
+    if (err?.toolError && err.code === "invalid_params") {
+      throw new GraphQLError(err.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    if (err?.toolError) return [];
+    throw err;
+  }
 }
 
 async function loadProviderSubnets(context: GqlContext, netuids: number[]) {
@@ -3596,6 +3664,40 @@ const rootValue = {
       // preserving this field's documented cold-artifact contract --
       // loadArtifact, which this resolver used before, swallowed those the
       // same way.
+      if (err?.toolError) return null;
+      throw err;
+    }
+  },
+
+  async subnet_endpoints(args: Row, context: GqlContext) {
+    const { netuid } = args;
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // #7869: reuse loadSubnetEndpointsList -- the same loader the
+    // list_subnet_endpoints MCP tool calls -- rather than reimplementing the
+    // filter/sort/page pass here, so this field cannot drift from
+    // GET /api/v1/subnets/{netuid}/endpoints. It reads the same baked per-subnet
+    // artifact (distinct from the network-wide endpoints(...) catalog) and
+    // validates every filter/sort value against the REST allowlists, throwing on
+    // an unsupported one; that throw surfaces as a normal GraphQL error.
+    try {
+      return await loadSubnetEndpointsList(mcpCtx(context), args, {
+        readArtifact,
+      });
+    } catch (rawErr) {
+      const err = rawErr as Row;
+      // An unsupported filter/sort value is BAD_USER_INPUT, matching every other
+      // field's "not a silently substituted default" convention.
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      // Any other loader miss (not baked / cold R2 / unavailable) stays null,
+      // preserving this field's documented cold-artifact contract.
       if (err?.toolError) return null;
       throw err;
     }

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, test, vi } from "vitest";
 import * as listQuery from "../workers/list-query.ts";
 import * as subnetCandidatesMcp from "../src/subnet-candidates-mcp.ts";
+import * as subnetEndpointsMcp from "../src/subnet-endpoints-mcp.ts";
 import * as subnetEvidenceMcp from "../src/subnet-evidence-mcp.ts";
 import {
   FIELD_COMPLEXITY,
@@ -9857,6 +9858,257 @@ describe("graphql — subnet_candidates (#7641, baked per-subnet candidate artif
       );
       assert.ok(body.errors, "expected the raw failure to surface");
       assert.match(body.errors[0].message, /loader exploded/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("graphql — subnet_endpoints (#7869, baked per-subnet endpoint artifact)", () => {
+  const ENDPOINTS_ENV = () =>
+    fixtureEnv({
+      "/metagraph/endpoints/5.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 5,
+        endpoints: [
+          {
+            id: "ep-a",
+            netuid: 5,
+            kind: "subnet-api",
+            layer: "subnet-app",
+            publication_state: "monitored",
+            status: "ok",
+            latency_ms: 100,
+            score: 90,
+          },
+          {
+            id: "ep-b",
+            netuid: 5,
+            kind: "openapi",
+            layer: "subnet-app",
+            publication_state: "verified",
+            status: "degraded",
+            latency_ms: 300,
+            score: 40,
+          },
+          {
+            id: "ep-c",
+            netuid: 5,
+            kind: "subnet-api",
+            layer: "data-provider",
+            publication_state: "monitored",
+            status: "ok",
+            latency_ms: 200,
+            score: 70,
+          },
+        ],
+      },
+    });
+
+  test("resolves the baked per-subnet endpoints artifact", async () => {
+    const { status, body } = await gql(
+      "{ subnet_endpoints(netuid: 5) }",
+      ENDPOINTS_ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints.netuid, 5);
+    assert.equal(body.data.subnet_endpoints.total, 3);
+    assert.equal(body.data.subnet_endpoints.endpoints[0].id, "ep-a");
+  });
+
+  test("degrades to null when no endpoint artifact is baked, never an error", async () => {
+    const { status, body } = await gql("{ subnet_endpoints(netuid: 999) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints, null);
+  });
+
+  test("a negative netuid is a GraphQL error", async () => {
+    const { body } = await gql("{ subnet_endpoints(netuid: -1) }");
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+  });
+
+  test("is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_endpoints, 5);
+  });
+
+  test("filters by kind, reusing the shared loader", async () => {
+    const { status, body } = await gql(
+      '{ subnet_endpoints(netuid: 5, kind: "subnet-api") }',
+      ENDPOINTS_ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const out = body.data.subnet_endpoints;
+    assert.equal(out.returned, 2);
+    assert.deepEqual(
+      out.endpoints.map((e: Row) => e.id),
+      ["ep-a", "ep-c"],
+    );
+  });
+
+  test("bounds latency/score ranges", async () => {
+    const { body } = await gql(
+      "{ subnet_endpoints(netuid: 5, min_score: 80) }",
+      ENDPOINTS_ENV(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints.returned, 1);
+    assert.equal(body.data.subnet_endpoints.endpoints[0].id, "ep-a");
+  });
+
+  test("sorts, pages, and round-trips next_cursor", async () => {
+    const first = await gql(
+      '{ subnet_endpoints(netuid: 5, status: "ok", sort: "score", order: "desc", limit: 1) }',
+      ENDPOINTS_ENV(),
+    );
+    assert.equal(first.body.errors, undefined);
+    const page1 = first.body.data.subnet_endpoints;
+    assert.equal(page1.total, 2);
+    assert.equal(page1.returned, 1);
+    assert.equal(page1.endpoints[0].id, "ep-a");
+    assert.equal(page1.next_cursor, 1);
+
+    const second = await gql(
+      '{ subnet_endpoints(netuid: 5, status: "ok", sort: "score", order: "desc", limit: 1, cursor: 1) }',
+      ENDPOINTS_ENV(),
+    );
+    const page2 = second.body.data.subnet_endpoints;
+    assert.equal(page2.endpoints[0].id, "ep-c");
+    assert.equal(page2.next_cursor, null);
+  });
+
+  test("an unsupported filter or sort value is a GraphQL error", async () => {
+    const badKind = await gql(
+      '{ subnet_endpoints(netuid: 5, kind: "not-a-kind") }',
+      ENDPOINTS_ENV(),
+    );
+    assert.ok(badKind.body.errors, "expected a GraphQL error for kind");
+
+    const badSort = await gql(
+      '{ subnet_endpoints(netuid: 5, sort: "not_a_column") }',
+      ENDPOINTS_ENV(),
+    );
+    assert.ok(badSort.body.errors, "expected a GraphQL error for sort");
+  });
+
+  test("an unexpected loader failure propagates", async () => {
+    // Only the loader's own toolErrors map to null/BAD_USER_INPUT; anything else
+    // is a real fault and must surface rather than being masked as "no endpoints
+    // baked".
+    const spy = vi
+      .spyOn(subnetEndpointsMcp, "loadSubnetEndpointsList")
+      .mockRejectedValue(new Error("loader exploded"));
+    try {
+      const { body } = await gql(
+        "{ subnet_endpoints(netuid: 5) }",
+        ENDPOINTS_ENV(),
+      );
+      assert.ok(body.errors, "expected the raw failure to surface");
+      assert.match(body.errors[0].message, /loader exploded/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("graphql — nested Subnet.endpoints filter args (#7869)", () => {
+  const NESTED_ENV = () =>
+    fixtureEnv({
+      "/metagraph/subnets/5.json": {
+        subnet: { netuid: 5, name: "Five", slug: "five" },
+        surfaces: [],
+        endpoints: [{ id: "bundled-1", netuid: 5, kind: "rpc", status: "ok" }],
+      },
+      "/metagraph/endpoints/5.json": {
+        netuid: 5,
+        endpoints: [
+          {
+            id: "ep-a",
+            netuid: 5,
+            kind: "subnet-api",
+            layer: "subnet-app",
+            status: "ok",
+            latency_ms: 100,
+            score: 90,
+          },
+          {
+            id: "ep-b",
+            netuid: 5,
+            kind: "openapi",
+            layer: "subnet-app",
+            status: "degraded",
+            latency_ms: 300,
+            score: 40,
+          },
+        ],
+      },
+    });
+
+  test("with no arguments returns the bundled full list unchanged", async () => {
+    const { status, body } = await gql(
+      "{ subnet(netuid: 5) { endpoints { id } } }",
+      NESTED_ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(
+      body.data.subnet.endpoints.map((e: Row) => e.id),
+      ["bundled-1"],
+    );
+  });
+
+  test("a filter arg routes through the shared loader and returns just the rows", async () => {
+    const { status, body } = await gql(
+      '{ subnet(netuid: 5) { endpoints(kind: "subnet-api") { id kind } } }',
+      NESTED_ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(
+      body.data.subnet.endpoints.map((e: Row) => e.id),
+      ["ep-a"],
+    );
+  });
+
+  test("an unsupported filter value on the nested field is a GraphQL error", async () => {
+    const { body } = await gql(
+      '{ subnet(netuid: 5) { endpoints(kind: "not-a-kind") { id } } }',
+      NESTED_ENV(),
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+  });
+
+  test("a cold per-subnet endpoint artifact degrades to an empty list", async () => {
+    const env = fixtureEnv({
+      "/metagraph/subnets/5.json": {
+        subnet: { netuid: 5, name: "Five" },
+        surfaces: [],
+        endpoints: [{ id: "bundled-1", netuid: 5 }],
+      },
+    });
+    const { status, body } = await gql(
+      '{ subnet(netuid: 5) { endpoints(status: "ok") { id } } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet.endpoints, []);
+  });
+
+  test("an unexpected loader failure on the nested field propagates", async () => {
+    const spy = vi
+      .spyOn(subnetEndpointsMcp, "loadSubnetEndpointsList")
+      .mockRejectedValue(new Error("nested loader exploded"));
+    try {
+      const { body } = await gql(
+        '{ subnet(netuid: 5) { endpoints(kind: "subnet-api") { id } } }',
+        NESTED_ENV(),
+      );
+      assert.ok(body.errors, "expected the raw failure to surface");
+      assert.match(body.errors[0].message, /nested loader exploded/);
     } finally {
       spy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Adds a root `subnet_endpoints(netuid!, ...)` GraphQL query field and parameterizes the nested
`Subnet.endpoints` field with the same filter/sort/page argument set, closing the last GraphQL
parity gap on `GET /api/v1/subnets/{netuid}/endpoints`. Both delegate to the existing
`loadSubnetEndpointsList` loader from `src/subnet-endpoints-mcp.ts` — the same loader the
`list_subnet_endpoints` MCP tool and the REST route call — so neither surface can drift from
REST/MCP. This is the same loader-reuse pattern as the root `subnet_candidates(...)` field
(#7878) and `provider_endpoints`/`endpoint_pools`.

Closes #7869

## What this adds

- **Root `subnet_endpoints(netuid: Int!, kind, layer, publication_state, status, min_latency_ms,
  max_latency_ms, min_score, max_score, sort, order, limit, cursor): JSON`** on `type Query`.
  Returns the same paginated envelope REST returns (`total`, `returned`, `limit`, `cursor`,
  `next_cursor`, `sort`, `order`) alongside the `endpoints` rows. `null` when no per-subnet
  endpoint artifact has been baked for the netuid; an unsupported filter/sort value is a
  `BAD_USER_INPUT` GraphQL error (not a silently substituted default).
- **Nested `Subnet.endpoints(kind, layer, publication_state, status, min_latency_ms,
  max_latency_ms, min_score, max_score, sort, order, limit, cursor): [Endpoint!]!`** — the
  filter args mirror the root field minus `netuid` (which comes from the parent `Subnet`). When
  any argument is supplied the field routes through the same shared loader and returns just the
  endpoint rows (preserving the `[Endpoint!]!` shape); with **no** arguments it keeps its exact
  pre-existing unbounded behaviour (bundled prefetch when present, otherwise the lazy
  `loadSubnetEndpoints` path) — byte-for-byte unchanged for existing queries.
- `FIELD_COMPLEXITY.subnet_endpoints` weighted as a fan-out relationship field (5), matching the
  sibling per-subnet list fields.
- Regenerated `generated/graphql/types.ts` via `npm run build:graphql-types`;
  `npm run validate:graphql-types-drift` passes (no SDL/types drift).

## Design notes

- **`cursor: Int`, not the issue's literal `cursor: String`.** The shared loader's cursor is a
  non-negative integer (`subnetEndpointsQueryUrl` rejects a non-numeric cursor), and the sibling
  per-subnet list field `subnet_candidates` (#7878) already exposes `cursor: Int`. Declaring
  `String` here would make pagination unusable, so this follows the loader contract and sibling
  convention. `next_cursor` round-trips as an integer, verified in tests.
- **Invalid filters surface as errors on the nested path too.** The nested resolver
  distinguishes the loader's `invalid_params` tool-error (→ `BAD_USER_INPUT` GraphQL error) from
  a cold/absent artifact (→ empty list, since the field is non-null). A caller typo like
  `endpoints(sort: "bogus")` returns a GraphQL error rather than silently empty data — covered by
  a dedicated test.
- Argument presence is detected with an explicit non-`null`/non-`undefined` check, so
  `endpoints(kind: null)` is treated as an unfiltered request (does not needlessly route through
  the filtered loader).

## Tests

New `graphql.test.ts` coverage (all green; 100% patch coverage on the added runtime lines/branches):

- Root `subnet_endpoints`: baked-artifact resolve, cold → `null`, negative-netuid error,
  complexity weight, `kind` filter, latency/score range bound, sort + limit + `cursor`
  round-trip, unsupported filter/sort error, and unexpected-loader-failure propagation.
- Nested `Subnet.endpoints`: no-arg bundled full-list unchanged, `kind`-filtered path via the
  shared loader, unsupported-filter error, cold per-subnet artifact → empty list, and
  unexpected-loader-failure propagation.

## Validation (local)

- `npm run validate:graphql-types-drift` — pass (types regenerated).
- `tsc --noEmit`, `eslint`, `prettier --check` on all changed files — clean.
- `vitest run tests/graphql.test.ts` — 984/984 pass.
- `tests/pipeline-validator-parity.test.ts` — pass.
