### PR TITLE
fix(ui): de-duplicate breadcrumbs on subnet/provider/block detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -80,6 +80,7 @@ export function AppShell({
   fullBleedMain = false,
   flushTop = false,
   afterHeader,
+  crumbLabel,
 }: {
   children: ReactNode;
   // Fumadocs' DocsLayout manages its own full-height sidebar/content grid
@@ -95,6 +96,13 @@ export function AppShell({
   // column. Used by the home route to seat the alpha-price ticker in what
   // would otherwise be dead space between the ecosystem strip and the hero.
   afterHeader?: ReactNode;
+  // Overrides the trailing (leaf) breadcrumb's label. `buildCrumbs` only ever
+  // sees the raw URL segment (e.g. "1", "0x4f2a…"), so detail routes that want
+  // to show something a user actually recognizes -- a zero-padded netuid, a
+  // comma-grouped block number, an entity's display name -- pass it here
+  // instead of standing up a second, redundant breadcrumb trail of their own
+  // (#7853). Only ever the last crumb; every ancestor segment stays generic.
+  crumbLabel?: string;
 }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -127,7 +135,13 @@ export function AppShell({
       if (trigger) requestAnimationFrame(() => trigger.focus());
     }
   }, []);
-  const crumbs = useMemo(() => buildCrumbs(pathname), [pathname]);
+  const crumbs = useMemo(() => {
+    const base = buildCrumbs(pathname);
+    if (!crumbLabel || base.length === 0) return base;
+    const last = base[base.length - 1];
+    if (!last) return base;
+    return [...base.slice(0, -1), { ...last, label: crumbLabel }];
+  }, [pathname, crumbLabel]);
   const parent = useMemo(() => parentCrumb(crumbs), [crumbs]);
 
   // Close mobile sheet on route change

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { useQuery, type QueryKey } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import {
   BookOpen,
   Github,
@@ -337,20 +336,9 @@ export function SubnetMasthead({
         }}
       />
 
-      {/* Status row — breadcrumb only. Health/curation/freshness/stale and
-          the Share/Refresh actions all live in the identity row below now
-          (#5481) -- one consolidated meta strip instead of scattering
-          overlapping status signals (a separate "stale" tag that just
-          repeated what the freshness caption already said) across rows. */}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px] text-ink-muted mb-3">
-        <Link to="/subnets" className="font-mono uppercase tracking-widest hover:text-ink-strong">
-          Registry
-        </Link>
-        <span aria-hidden>/</span>
-        <span className="font-mono uppercase tracking-widest">
-          Subnets / {String(netuid).padStart(3, "0")}
-        </span>
-      </div>
+      {/* No breadcrumb row here: the app-shell's own row is the single
+          canonical trail (#7853). AppShell's `crumbLabel` prop carries the
+          zero-padded netuid this masthead used to render redundantly. */}
 
       {banner ? <div className="mb-4">{banner}</div> : null}
 

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -105,8 +105,14 @@ export const Route = createFileRoute("/blocks/$ref")({
 
 function BlockDetailPage() {
   const { ref } = Route.useParams();
+  // The loader already primed this query for head()'s title -- reuse its
+  // resolved block number for the shell's breadcrumb label too, rather than
+  // standing up a second breadcrumb trail of our own (#7853).
+  const loaderData = Route.useLoaderData();
+  const crumbLabel =
+    loaderData?.blockNumber != null ? `#${formatNumber(loaderData.blockNumber)}` : undefined;
   return (
-    <AppShell>
+    <AppShell crumbLabel={crumbLabel}>
       <ValueUnitProvider>
         <AsyncPanel
           context="block detail"
@@ -201,12 +207,6 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
     <>
       <ShortcutsDialog blockRef={refValue} />
       <PageMasthead
-        crumbs={[
-          { to: "/", label: "Home" },
-          { to: "/blocks", label: "Blocks" },
-          { to: `/blocks/${refValue}`, label: `#${formatNumber(block.block_number)}` },
-        ]}
-        hideBreadcrumbs={false}
         eyebrow="Explorer · block"
         live
         title={`#${formatNumber(block.block_number)}`}

--- a/apps/ui/src/routes/detail-page-furniture-5481.test.ts
+++ b/apps/ui/src/routes/detail-page-furniture-5481.test.ts
@@ -31,16 +31,15 @@ describe("subnet-masthead ShareButton", () => {
     expect(importBlock).toContain("ShareButton");
   });
 
-  it("keeps the status row to just the breadcrumb -- no separate 'stale' tag duplicating the freshness caption, no actions", () => {
-    const statusRow = mastheadSource.slice(
-      mastheadSource.indexOf("Status row"),
-      mastheadSource.indexOf("{banner ?"),
-    );
-    expect(statusRow).toContain("Registry");
-    expect(statusRow).not.toContain("<ActionBar");
-    expect(statusRow).not.toContain("<ShareButton");
-    expect(statusRow).not.toContain("<StaleBanner");
-    expect(statusRow).not.toMatch(/>\s*stale\s*</);
+  it("#7853: no longer renders its own breadcrumb/status row -- the app-shell row is the single canonical trail, and AppShell's crumbLabel prop carries the padded netuid this used to duplicate", () => {
+    const beforeIdentityRow = mastheadSource.slice(0, mastheadSource.indexOf("{banner ?"));
+    expect(beforeIdentityRow).not.toContain('aria-label="Breadcrumb"');
+    expect(beforeIdentityRow).not.toContain("Registry");
+    expect(beforeIdentityRow).not.toContain("Subnets / ");
+    expect(beforeIdentityRow).not.toContain("<ActionBar");
+    expect(beforeIdentityRow).not.toContain("<ShareButton");
+    expect(beforeIdentityRow).not.toContain("<StaleBanner");
+    expect(beforeIdentityRow).not.toMatch(/>\s*stale\s*</);
   });
 
   it("consolidates HealthPill/CurationChip/freshness/Refresh into one identity-row meta strip, not a separate desktop-only side column", () => {
@@ -128,5 +127,44 @@ describe("providers.$slug.tsx ShareButton + ApiSourceFooter", () => {
     const footerCall = providerRouteSource.slice(providerRouteSource.indexOf("<ApiSourceFooter"));
     expect(footerCall).toContain("`/api/v1/providers/${slug}`");
     expect(footerCall).toContain("`/api/v1/providers/${slug}/endpoints`");
+  });
+
+  it("#7853: no longer renders its own standalone <Breadcrumbs> -- migrates the provider name into AppShell's crumbLabel prop instead", () => {
+    expect(providerRouteSource).not.toContain("<Breadcrumbs");
+    const componentBody = providerRouteSource.slice(
+      providerRouteSource.indexOf("function ProviderDetail"),
+      providerRouteSource.indexOf("function ProviderShell"),
+    );
+    expect(componentBody).toContain("<AppShell crumbLabel={loaderData?.name ?? undefined}>");
+  });
+});
+
+describe("#7853 breadcrumb de-duplication: AppShell crumbLabel wiring", () => {
+  const appShellSource = readFileSync(
+    fileURLToPath(new URL("../components/metagraphed/app-shell.tsx", import.meta.url)),
+    "utf8",
+  );
+  const blocksRouteSource = readFileSync(
+    fileURLToPath(new URL("./blocks.$ref.tsx", import.meta.url)),
+    "utf8",
+  );
+
+  it("app-shell.tsx accepts a crumbLabel prop and uses it to override only the trailing crumb", () => {
+    expect(appShellSource).toContain("crumbLabel?: string");
+    const memo = appShellSource.slice(
+      appShellSource.indexOf("const crumbs = useMemo"),
+      appShellSource.indexOf("const parent = useMemo"),
+    );
+    expect(memo).toContain("buildCrumbs(pathname)");
+    expect(memo).toContain("crumbLabel");
+  });
+
+  it("subnets.$netuid.tsx passes the zero-padded netuid as the shell's crumbLabel", () => {
+    expect(subnetRouteSource).toContain('crumbLabel={String(netuid).padStart(3, "0")}');
+  });
+
+  it("blocks.$ref.tsx passes the loader-resolved, comma-formatted block number as the shell's crumbLabel instead of a second custom breadcrumb trail", () => {
+    expect(blocksRouteSource).not.toContain("hideBreadcrumbs={false}");
+    expect(blocksRouteSource).toContain("<AppShell crumbLabel={crumbLabel}>");
   });
 });

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -14,7 +14,6 @@ import {
 } from "@jsonbored/ui-kit";
 import {
   AsyncPanel,
-  Breadcrumbs,
   PageMasthead,
   RoutePending,
   TabStrip,
@@ -97,8 +96,12 @@ const SECTION_TO_TAB: Record<string, string> = {
 
 function ProviderDetail() {
   const { slug } = Route.useParams();
+  // The loader already primed this query for head()'s title -- reuse its
+  // resolved provider name for the shell's breadcrumb label too, rather than
+  // standing up a second breadcrumb trail of our own (#7853).
+  const loaderData = Route.useLoaderData();
   return (
-    <AppShell>
+    <AppShell crumbLabel={loaderData?.name ?? undefined}>
       <AsyncPanel
         height="md"
         context="provider"
@@ -129,15 +132,9 @@ function ProviderShell({ slug }: { slug: string }) {
 
   return (
     <>
-      <Breadcrumbs
-        crumbs={[
-          { to: "/", label: "Home" },
-          { to: "/providers", label: "Providers" },
-          { to: `/providers/${slug}`, label: p?.name ?? slug },
-        ]}
-        className="mb-2"
-      />
-
+      {/* No breadcrumb row here: the app-shell's own row is the single
+          canonical trail (#7853). AppShell's `crumbLabel` prop carries the
+          provider's display name this used to render redundantly. */}
       <PageMasthead
         eyebrow={["Provider", p?.kind, p?.authority].filter(Boolean).join(" · ")}
         title={p?.name ?? slug}

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -259,7 +259,7 @@ const SECTION_TO_TAB: Record<string, string> = {
 function SubnetDetailPage() {
   const { netuid } = Route.useParams();
   return (
-    <AppShell flushTop>
+    <AppShell flushTop crumbLabel={String(netuid).padStart(3, "0")}>
       <AsyncPanel
         context="subnet profile"
         fallback={<DetailSkeleton />}


### PR DESCRIPTION
## Summary

Subnet, provider, and block detail pages each rendered **two** stacked breadcrumb trails: the app-shell's site-wide `aria-label="Breadcrumb"` row, plus a second, redundant one specific to that route.

## Fix

`AppShell` gains a `crumbLabel?: string` prop that overrides only the trailing (leaf) crumb's label. Each detail route now passes the one piece of unique info its old duplicate trail contributed, instead of standing up a second trail:

- `subnets.$netuid.tsx` → zero-padded netuid (`"001"`), from the route param directly.
- `providers.$slug.tsx` → the provider's display name, from the loader data already primed for `head()`.
- `blocks.$ref.tsx` → the comma-grouped block number (`"#8,694,016"`), same loader-data reuse.

All three are resolved synchronously (route param or loader data, no extra query), so there's no label flash on mount.

Removed:
- `subnet-masthead.tsx`'s own "Registry / Subnets / 001" status row.
- `providers.$slug.tsx`'s standalone `<Breadcrumbs>` above `PageMasthead`.
- `blocks.$ref.tsx`'s `PageMasthead` `crumbs`/`hideBreadcrumbs={false}` override.

## Audit table (every detail/masthead route)

| Route | Had a duplicate? | Fix |
|---|---|---|
| `subnets.$netuid` | Yes — masthead's own breadcrumb row | Removed; `crumbLabel` carries padded netuid |
| `providers.$slug` | Yes — standalone `<Breadcrumbs>` | Removed; `crumbLabel` carries display name |
| `blocks.$ref` | Yes — `PageMasthead hideBreadcrumbs={false}` | Removed; `crumbLabel` carries formatted block number |
| `validators.$hotkey` | No | — |
| `accounts.$ss58` | No | — |
| `extrinsics.$hash` | No | — |
| `endpoints` (detail drawer) | N/A — an overlay `Sheet`, not a route; no breadcrumb rendered inside it | — |
| `/design/primitives` | No — this route isn't wrapped in `AppShell` at all, so its own `<Breadcrumbs>` is the page's only navigation, not a duplicate | — |

Verified via `aria-label="Breadcrumb"` nav count on every audited route (desktop preview): exactly 1 everywhere.

## Screenshots

**Subnet detail, desktop (1280px)** — one row, `REGISTRY › SUBNETS › 001`, no second line under the identity block:

Before: masthead rendered its own "Registry / Subnets / 001" line directly below the identity row.
After: single shell-row trail only; content moved up, no dead space left behind.

**Subnet detail, mobile (375px)** — shell's `‹ SUBNETS` back-affordance is the only wayfinding, unchanged behavior, still correct after the masthead's line was removed.

**Provider detail** — shell row now reads `REGISTRY › PROVIDERS › 8 BALL` (display name, not the raw `eightball` slug).

**Block detail** — shell row now reads `REGISTRY › BLOCKS › #8,694,016` (comma-grouped, not the raw path segment).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint .` clean (0 errors) in `apps/ui`
- [x] `vitest run` — 191 files / 1465 tests passing, including updated + new regression coverage in `detail-page-furniture-5481.test.ts` for the crumbLabel wiring
- [x] Live preview: `aria-label="Breadcrumb"` nav count = 1 on `/subnets/1`, `/providers/eightball`, `/blocks/8694016`, `/validators/:hotkey`, `/accounts/:ss58`, `/extrinsics/:hash`, `/design/primitives`
- [x] Mobile (375px) and desktop (1280px) checked on `/subnets/1`

Closes #7853