### PR TITLE
feat(api): add REST filter parity to GraphQL subnet_gaps

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2624,7 +2624,7 @@ export type Query = {
   subnet_events: SubnetEvents;
   /** One subnet's curation evidence record — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry. Search with q across subject, claim, source_url, and support_summary; sort with sort + order; project with fields; and page with limit (1-100) / cursor, exactly as REST does — an unsupported sort/limit/cursor is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the claims rows. Null when no evidence record has been baked for the netuid (rather than a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/evidence. */
   subnet_evidence?: Maybe<Scalars['JSON']['output']>;
-  /** One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps. */
+  /** One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Filter with curation_level, missing_kinds, and review_state; sort with sort + order; project with fields; and page with limit (1-100) / cursor, exactly as REST does -- an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the priorities rows. Mirrors GET /api/v1/subnets/{netuid}/gaps. */
   subnet_gaps?: Maybe<Scalars['JSON']['output']>;
   /** One subnet's current live operational-health card: the per-surface status/latency/last-ok rows from the latest ~15-minute cron probe (summarized into ok/degraded/failed/unknown counts) plus the cross-window reliability score. The at-a-glance base card completing the health family whose windowed views are subnet_health_trends/subnet_health_incidents/subnet_health_percentiles. A subnet with no live health data resolves to the same schema-stable unknown card (summary.status of unknown, empty surfaces), never null. Filter with kind, provider, status, and classification; sort with sort + order; project with fields; and page with limit (1-100) / cursor, exactly as REST does -- an unsupported value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST reports (total, returned, limit, cursor, next_cursor, sort, order) alongside the surfaces. Opaque JSON otherwise matching the get_subnet_health MCP/REST shape (the existing typed SubnetHealth is the flat health-list item, a different shape, so this base card is JSON like the sibling surfaces payloads). Mirrors GET /api/v1/subnets/{netuid}/health. */
   subnet_health?: Maybe<Scalars['JSON']['output']>;
@@ -3581,7 +3581,15 @@ export type QuerySubnet_EvidenceArgs = {
 
 
 export type QuerySubnet_GapsArgs = {
+  curation_level?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  missing_kinds?: InputMaybe<Scalars['String']['input']>;
   netuid: Scalars['Int']['input'];
+  order?: InputMaybe<Scalars['String']['input']>;
+  review_state?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -138,8 +138,18 @@ export const SDL = /* GraphQL */ `
       window: String
       limit: Int
     ): SubnetEventSummary!
-    "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps."
-    subnet_gaps(netuid: Int!): JSON
+    "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Filter with curation_level, missing_kinds, and review_state; sort with sort + order; project with fields; and page with limit (1-100) / cursor, exactly as REST does -- an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the priorities rows. Mirrors GET /api/v1/subnets/{netuid}/gaps."
+    subnet_gaps(
+      netuid: Int!
+      curation_level: String
+      missing_kinds: String
+      review_state: String
+      sort: String
+      order: String
+      fields: String
+      limit: Int
+      cursor: Int
+    ): JSON
     "One subnet's curation evidence record — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry. Search with q across subject, claim, source_url, and support_summary; sort with sort + order; project with fields; and page with limit (1-100) / cursor, exactly as REST does — an unsupported sort/limit/cursor is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the claims rows. Null when no evidence record has been baked for the netuid (rather than a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/evidence."
     subnet_evidence(
       netuid: Int!

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3587,17 +3587,68 @@ const rootValue = {
     };
   },
 
-  async subnet_gaps({ netuid }: Row, context: GqlContext) {
+  async subnet_gaps(args: Row, context: GqlContext) {
+    const { netuid } = args;
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
     // Same baked review-gaps artifact the REST route + get_subnet_gaps MCP tool
-    // read. The MCP tool raises not_found for a netuid with no report; GraphQL
-    // degrades to null instead, matching how every other artifact-backed
-    // resolver here treats a cold/absent artifact.
-    return loadArtifact(context, `/metagraph/review/gaps/${netuid}.json`);
+    // read; null when no report has been baked, matching how every other
+    // artifact-backed resolver here treats a cold/absent artifact.
+    const report = (await loadArtifact(
+      context,
+      `/metagraph/review/gaps/${netuid}.json`,
+    )) as Row | null;
+    if (!report) return null;
+    // #7880: apply the same list query GET /api/v1/subnets/{netuid}/gaps runs
+    // over the report's priorities (csvListQuery("review-gap-priorities", {
+    // exclude: ["netuid"] })) -- curation_level/missing_kinds/review_state
+    // filters plus sort/order, fields projection, and limit/cursor paging.
+    // applyQueryFilters is the same helper the REST pipeline and
+    // list_subnet_gaps (#7900) run on, so the allowlists cannot drift.
+    //
+    // The whole report is returned, with only `priorities` filtered -- the
+    // envelope also carries `enrichment_queue`, which list_subnet_gaps' own
+    // narrower result drops, and existing consumers still read it.
+    const queryUrl = new URL("https://graphql.internal/subnets/gaps");
+    for (const [name, value] of [
+      ["curation_level", args?.curation_level],
+      ["missing_kinds", args?.missing_kinds],
+      ["review_state", args?.review_state],
+      ["sort", args?.sort],
+      ["order", args?.order],
+      ["fields", args?.fields],
+      ["limit", args?.limit],
+      ["cursor", args?.cursor],
+    ] as const) {
+      if (value != null) queryUrl.searchParams.set(name, String(value));
+    }
+    const transformed = applyQueryFilters(
+      report,
+      queryUrl,
+      "review-gap-priorities",
+      ["curation_level", "missing_kinds", "review_state"],
+    );
+    if (transformed.error) {
+      throw new GraphQLError(transformed.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const data = transformed.data as Row;
+    const page = ((transformed.meta as Row)?.pagination ?? {}) as Row;
+    const priorities = Array.isArray(data.priorities) ? data.priorities : [];
+    return {
+      ...data,
+      total: page.total ?? priorities.length,
+      returned: page.returned ?? priorities.length,
+      limit: page.limit ?? priorities.length,
+      cursor: page.cursor ?? 0,
+      next_cursor: page.next_cursor ?? null,
+      sort: page.sort ?? null,
+      order: page.order ?? null,
+    };
   },
 
   async subnet_evidence(args: Row, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -9873,6 +9873,102 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
     assert.equal(body.data.subnet_gaps.gaps[0].kind, "api");
   });
 
+  test("subnet_gaps filters, sorts and pages priorities like the REST route (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/7.json": {
+        netuid: 7,
+        enrichment_queue: [{ netuid: 7, reason: "no-verified-api" }],
+        priorities: [
+          {
+            netuid: 7,
+            name: "beta",
+            curation_level: "native",
+            missing_kinds: "docs",
+            review_state: "open",
+            priority_score: 9,
+          },
+          {
+            netuid: 7,
+            name: "alpha",
+            curation_level: "community-seeded",
+            missing_kinds: "docs",
+            review_state: "open",
+            priority_score: 4,
+          },
+          {
+            netuid: 7,
+            name: "gamma",
+            curation_level: "community-seeded",
+            missing_kinds: "sdk",
+            review_state: "closed",
+            priority_score: 1,
+          },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      '{ subnet_gaps(netuid: 7, curation_level: "community-seeded", missing_kinds: "docs", review_state: "open", sort: "priority_score", order: "desc", fields: "name,priority_score", limit: 1, cursor: 0) }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const report = body.data.subnet_gaps;
+    assert.deepEqual(report.priorities, [{ name: "alpha", priority_score: 4 }]);
+    assert.equal(report.total, 1);
+    assert.equal(report.returned, 1);
+    assert.equal(report.limit, 1);
+    assert.equal(report.cursor, 0);
+    assert.equal(report.next_cursor, null);
+    assert.equal(report.sort, "priority_score");
+    assert.equal(report.order, "desc");
+    // The rest of the envelope survives the list pass -- enrichment_queue is
+    // part of this artifact and existing consumers still read it.
+    assert.equal(report.netuid, 7);
+    assert.equal(report.enrichment_queue[0].reason, "no-verified-api");
+  });
+
+  test("subnet_gaps rejects an unsupported filter value with BAD_USER_INPUT (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/7.json": {
+        netuid: 7,
+        priorities: [{ netuid: 7, curation_level: "native" }],
+      },
+    });
+    const { status, body } = await gql(
+      '{ subnet_gaps(netuid: 7, curation_level: "not-a-level") }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.subnet_gaps, null);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("subnet_gaps paging reports the next cursor when a page is truncated (#7880)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/7.json": {
+        netuid: 7,
+        priorities: [
+          { netuid: 7, name: "a", priority_score: 3 },
+          { netuid: 7, name: "b", priority_score: 2 },
+          { netuid: 7, name: "c", priority_score: 1 },
+        ],
+      },
+    });
+    const { body } = await gql(
+      '{ subnet_gaps(netuid: 7, sort: "name", order: "asc", limit: 2) }',
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    const report = body.data.subnet_gaps;
+    assert.deepEqual(
+      report.priorities.map((row: Row) => row.name),
+      ["a", "b"],
+    );
+    assert.equal(report.total, 3);
+    assert.equal(report.returned, 2);
+    assert.equal(report.next_cursor, 2);
+  });
+
   test("subnet_gaps degrades to null when no report is baked, never an error", async () => {
     const { status, body } = await gql("{ subnet_gaps(netuid: 999) }");
     assert.equal(status, 200);


### PR DESCRIPTION
Closes #7880

## What

`subnet_gaps` returned the baked gap report as an unparameterized JSON blob, while `GET /api/v1/subnets/{netuid}/gaps` pages the same artifact through `csvListQuery("review-gap-priorities", { exclude: ["netuid"] })`. This adds the missing arguments so the two surfaces agree.

- **Filters**: `curation_level`, `missing_kinds`, `review_state` — the exact three the REST route exposes (`netuid` is the path param, excluded there and here).
- **Sort/order/projection/paging**: `sort`, `order`, `fields`, `limit`, `cursor`.
- **Pagination meta**: `total`, `returned`, `limit`, `cursor`, `next_cursor`, `sort`, `order`, matching REST's envelope.

An unsupported filter or sort value is a `BAD_USER_INPUT` GraphQL error, not a silently substituted default — the convention `subnet_evidence` and `subnet_candidates` already follow in this file.

## How

The resolver passes the report to `applyQueryFilters(report, url, "review-gap-priorities", [...])` — the same shared helper the REST pipeline runs, sourced from the same `API_QUERY_COLLECTIONS` entry, so the filter and sort allowlists cannot drift from REST.

**Only `priorities` is filtered; the rest of the envelope is returned unchanged.** This is deliberate. The artifact also carries `enrichment_queue`, which is part of the documented response and which existing consumers of the unparameterized field read today. Routing the field through `loadSubnetGapsList` instead would have returned that loader's narrower result and silently dropped `enrichment_queue` — a breaking change well outside the scope of adding filter parity. No loader or MCP file is touched by this PR, so MCP `list_subnet_gaps` and its error classification are byte-for-byte unchanged.

## Tests

`tests/graphql.test.ts` — filter + sort + `fields` projection + `limit`/`cursor` in one query, asserting the envelope (`enrichment_queue` included) survives; truncated-page `next_cursor` round-trip; unsupported enum value → `BAD_USER_INPUT`. The pre-existing passthrough and cold-artifact-null tests are unmodified and still pass.

All 988 tests in `tests/graphql.test.ts` pass. `tsc --noEmit` clean, `eslint` clean, `validate-api` / `validate-mcp` / `validate-graphql-types-drift` all pass, generated types regenerated and committed. Local `vitest --coverage` over the changed `src/graphql.ts` lines: 0 uncovered statements, 0 partial branches across all 56 changed source lines.
