### PR TITLE
refactor(ui): tokenize raw z-index one-offs into a semantic layering scale

### DIFF
--- a/apps/ui/CONTRIBUTING.md
+++ b/apps/ui/CONTRIBUTING.md
@@ -73,20 +73,21 @@ budget — keep new dependencies/imports lean.
     (`packages/ui-kit/src/styles.css`), never a bare `z-10`/`z-20`/etc. or a
     one-off `z-[N]`. From lowest to highest:
 
-    | Token | Value | Use for |
-    |---|---|---|
-    | `--mg-z-sticky` | 10 | Sticky theads/toolbars, scroll shadows, in-flow progress bars |
-    | `--mg-z-raised` | 20 | Elements that must clear sticky content within the same page section |
-    | `--mg-z-nav` | 30 | Site header/nav chrome |
-    | `--mg-z-overlay` | 40 | Drawers, back-to-top, hover cards, lightweight menus |
-    | `--mg-z-modal` | 50 | Dialogs, popovers, sheets, command palette (matches Radix's own default) |
-    | `--mg-z-progress` | 60 | Route-transition progress bar — must beat modal |
-    | `--mg-z-skip-link` | 100 | a11y skip-link — must beat everything |
+    | Token              | Value | Use for                                                                  |
+    | ------------------ | ----- | ------------------------------------------------------------------------ |
+    | `--mg-z-sticky`    | 10    | Sticky theads/toolbars, scroll shadows, in-flow progress bars            |
+    | `--mg-z-raised`    | 20    | Elements that must clear sticky content within the same page section     |
+    | `--mg-z-nav`       | 30    | Site header/nav chrome                                                   |
+    | `--mg-z-overlay`   | 40    | Drawers, back-to-top, hover cards, lightweight menus                     |
+    | `--mg-z-modal`     | 50    | Dialogs, popovers, sheets, command palette (matches Radix's own default) |
+    | `--mg-z-progress`  | 60    | Route-transition progress bar — must beat modal                          |
+    | `--mg-z-skip-link` | 100   | a11y skip-link — must beat everything                                    |
 
     The only standing exception: the sticky corner cell in the two compare
     drawers (`subnets-compare-drawer.tsx`, `validators-compare-drawer.tsx`) uses
     raw `z-[1]`/`z-[2]` for micro-stacking inside the table's own local
     stacking context — not a global layer, so it doesn't belong on this scale.
+
   - See `docs/ssr-safety.md` for the hydration-safety rules (also partly ESLint-enforced).
 - Keep diffs focused. Don't reformat or refactor unrelated files in a feature PR.
 

--- a/apps/ui/CONTRIBUTING.md
+++ b/apps/ui/CONTRIBUTING.md
@@ -69,6 +69,24 @@ budget — keep new dependencies/imports lean.
     than hand-rolling `rounded border bg-card`.
   - External links: use `<ExternalLink>` from `@jsonbored/ui-kit`, not a raw
     `<a target="_blank">` — it sets `rel=noreferrer` and filters unsafe/private URLs.
+  - Stacking order: use one of the named `--mg-z-*` layer tokens
+    (`packages/ui-kit/src/styles.css`), never a bare `z-10`/`z-20`/etc. or a
+    one-off `z-[N]`. From lowest to highest:
+
+    | Token | Value | Use for |
+    |---|---|---|
+    | `--mg-z-sticky` | 10 | Sticky theads/toolbars, scroll shadows, in-flow progress bars |
+    | `--mg-z-raised` | 20 | Elements that must clear sticky content within the same page section |
+    | `--mg-z-nav` | 30 | Site header/nav chrome |
+    | `--mg-z-overlay` | 40 | Drawers, back-to-top, hover cards, lightweight menus |
+    | `--mg-z-modal` | 50 | Dialogs, popovers, sheets, command palette (matches Radix's own default) |
+    | `--mg-z-progress` | 60 | Route-transition progress bar — must beat modal |
+    | `--mg-z-skip-link` | 100 | a11y skip-link — must beat everything |
+
+    The only standing exception: the sticky corner cell in the two compare
+    drawers (`subnets-compare-drawer.tsx`, `validators-compare-drawer.tsx`) uses
+    raw `z-[1]`/`z-[2]` for micro-stacking inside the table's own local
+    stacking context — not a global layer, so it doesn't belong on this scale.
   - See `docs/ssr-safety.md` for the hydration-safety rules (also partly ESLint-enforced).
 - Keep diffs focused. Don't reformat or refactor unrelated files in a feature PR.
 

--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -116,6 +116,17 @@ const ELEVATION_RULES = [
   },
 ];
 
+// #7841: bare z-* stacking steps collapsed into a named --mg-z-* layer scale
+// (packages/ui-kit/src/styles.css). Also flags the 6 documented z-[1]/z-[2]
+// sticky-cell micro-stacking exceptions in the two compare drawers -- that's
+// intentional (matches the residual-worklist convention other guardrails use).
+const Z_INDEX_RULES = [
+  {
+    selector: "Literal[value=/\\bz-(\\[[0-9]+\\]|[0-9]+\\b)/]",
+    message: "Raw z-index step. Use one of the --mg-z-* layer tokens (see styles.css).",
+  },
+];
+
 export default tseslint.config(
   // .source is fumadocs-mdx's generated content collection output (see
   // source.config.ts) -- codegen, not authored code, same treatment as dist.
@@ -184,6 +195,7 @@ export default tseslint.config(
         ...PRIMITIVE_STEER_RULES,
         ...SSR_SAFETY_RULES,
         ...ELEVATION_RULES,
+        ...Z_INDEX_RULES,
       ],
     },
   },

--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -137,7 +137,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
           <table className="w-full border-collapse text-[11px] font-mono">
             <thead>
               <tr className="bg-paper/30">
-                <th className="sticky left-0 z-10 bg-paper/30 text-left px-3 py-2 mg-type-micro text-ink-muted border-b border-border">
+                <th className="sticky left-0 z-[var(--mg-z-sticky)] bg-paper/30 text-left px-3 py-2 mg-type-micro text-ink-muted border-b border-border">
                   Subnet
                 </th>
                 {KINDS.map((k) => (
@@ -159,7 +159,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
                   key={r.netuid}
                   className="border-b border-border last:border-b-0 hover:bg-paper/30"
                 >
-                  <td className="sticky left-0 z-10 bg-card px-3 py-1.5 border-r border-border text-ink-strong">
+                  <td className="sticky left-0 z-[var(--mg-z-sticky)] bg-card px-3 py-1.5 border-r border-border text-ink-strong">
                     <div className="flex items-center gap-2">
                       <Link
                         to="/subnets/$netuid"

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -212,14 +212,14 @@ export function AppShell({
           {/* Skip link: first focusable element, visible only on keyboard focus. */}
           <a
             href="#main-content"
-            className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded focus:bg-ink-strong focus:px-4 focus:py-2 focus:text-paper"
+            className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[var(--mg-z-skip-link)] focus:rounded focus:bg-ink-strong focus:px-4 focus:py-2 focus:text-paper"
           >
             Skip to main content
           </a>
           {/* Top bar */}
           <header
             data-scrolled={scrolled ? "true" : "false"}
-            className="mg-header sticky top-0 z-30 border-b border-border bg-paper/90 backdrop-blur supports-[backdrop-filter]:bg-paper/75"
+            className="mg-header sticky top-0 z-[var(--mg-z-nav)] border-b border-border bg-paper/90 backdrop-blur supports-[backdrop-filter]:bg-paper/75"
           >
             <div className="max-w-shell-max mx-auto px-4 md:px-8 flex h-nav items-center gap-3">
               <button

--- a/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
@@ -69,7 +69,7 @@ export function ShortcutsDialog({ blockRef }: { blockRef: string }) {
       role="dialog"
       aria-modal
       aria-labelledby="mg-shortcut-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-ink-strong/30 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[var(--mg-z-modal)] flex items-center justify-center bg-ink-strong/30 p-4 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) setOpen(false);
       }}

--- a/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
+++ b/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
@@ -118,7 +118,7 @@ export function CallModuleExtrinsicsTable({
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
+          <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Hash</th>
               <th className="px-4 py-2.5">Block</th>

--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -167,7 +167,7 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
           >
             <thead>
               <tr>
-                <th className="sticky left-0 z-10 bg-card text-left px-3 py-2 mg-type-micro text-ink-muted border-b border-border">
+                <th className="sticky left-0 z-[var(--mg-z-sticky)] bg-card text-left px-3 py-2 mg-type-micro text-ink-muted border-b border-border">
                   Provider
                 </th>
                 {kinds.map((k) => (
@@ -198,7 +198,7 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
                 const total = row.reduce((a, c) => a + c.count, 0);
                 return (
                   <tr key={p} className="border-b border-border last:border-b-0">
-                    <td className="sticky left-0 z-10 bg-card px-3 py-1.5 text-ink-strong border-r border-border">
+                    <td className="sticky left-0 z-[var(--mg-z-sticky)] bg-card px-3 py-1.5 text-ink-strong border-r border-border">
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Link

--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -69,7 +69,7 @@ export function ValidatorSubnetHeatmap() {
           <table className="w-full min-w-[640px] text-[11px] font-mono">
             <thead>
               <tr>
-                <th className="sticky left-0 z-10 border-b border-border bg-card px-3 py-2 text-left mg-type-micro text-ink-muted">
+                <th className="sticky left-0 z-[var(--mg-z-sticky)] border-b border-border bg-card px-3 py-2 text-left mg-type-micro text-ink-muted">
                   Validator
                 </th>
                 {netuids.map((n) => (
@@ -87,7 +87,7 @@ export function ValidatorSubnetHeatmap() {
                 const byNet = new Map((v.subnets ?? []).map((s) => [s.netuid, s]));
                 return (
                   <tr key={v.hotkey} className="border-b border-border last:border-b-0">
-                    <td className="sticky left-0 z-10 border-r border-border bg-card px-3 py-1.5 text-ink-strong">
+                    <td className="sticky left-0 z-[var(--mg-z-sticky)] border-r border-border bg-card px-3 py-1.5 text-ink-strong">
                       <Link
                         to="/accounts/$ss58"
                         params={{ ss58: v.hotkey }}

--- a/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
@@ -130,7 +130,7 @@ export function EndpointOperationalList({
         return (
           <section key={String(group.netuid)} aria-labelledby={`group-${group.netuid}`}>
             <header
-              className="mg-section-rule sticky z-10 -mx-1 flex items-center justify-between gap-3 bg-paper/92 px-1 py-2 backdrop-blur"
+              className="mg-section-rule sticky z-[var(--mg-z-sticky)] -mx-1 flex items-center justify-between gap-3 bg-paper/92 px-1 py-2 backdrop-blur"
               style={{ top: "calc(var(--mg-sticky-offset, 3.5rem) + 3.75rem)" }}
             >
               <div className="flex min-w-0 items-center gap-2.5">
@@ -200,7 +200,7 @@ export function EndpointOperationalList({
                       />
                       {onToggleCompare ? (
                         <label
-                          className="absolute left-2 top-2 z-10 flex items-center gap-1 rounded border border-border bg-paper/85 px-1 py-0.5 mg-type-micro text-ink-muted backdrop-blur hover:text-ink-strong"
+                          className="absolute left-2 top-2 z-[var(--mg-z-sticky)] flex items-center gap-1 rounded border border-border bg-paper/85 px-1 py-0.5 mg-type-micro text-ink-muted backdrop-blur hover:text-ink-strong"
                           onClick={(e) => e.stopPropagation()}
                           title={
                             compareIds?.has(endpoint.id)

--- a/apps/ui/src/components/metagraphed/entity-hover-card.tsx
+++ b/apps/ui/src/components/metagraphed/entity-hover-card.tsx
@@ -69,7 +69,7 @@ export function EntityHoverCard(props: EntityHoverCardProps) {
         sideOffset={placement.sideOffset}
         aria-label={ariaLabel}
         data-testid="entity-hover-card"
-        className="w-80 p-3 bg-card border-border shadow-lg z-50"
+        className="w-80 p-3 bg-card border-border shadow-lg z-[var(--mg-z-modal)]"
       >
         {props.kind === "subnet" ? (
           <SubnetMiniProfile netuid={props.netuid} />

--- a/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
@@ -281,7 +281,7 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
           <div aria-hidden className="mg-mega-scrim" onClick={() => setOpenKey(null)} />
           <div
             ref={panelRef}
-            className="absolute left-1/2 -translate-x-1/2 top-full mt-3 z-40"
+            className="absolute left-1/2 -translate-x-1/2 top-full mt-3 z-[var(--mg-z-overlay)]"
             role="dialog"
             aria-modal="true"
             aria-label={`${activePanel.label} menu`}

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -394,7 +394,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
         <div
           id="nav-omnibox-listbox"
           role="listbox"
-          className="absolute right-0 mt-1.5 w-[600px] max-w-[calc(100vw-1.5rem)] rounded-xl border border-border bg-paper shadow-2xl z-50 overflow-hidden"
+          className="absolute right-0 mt-1.5 w-[600px] max-w-[calc(100vw-1.5rem)] rounded-xl border border-border bg-paper shadow-2xl z-[var(--mg-z-modal)] overflow-hidden"
         >
           {/* ── Empty state: no query typed ─────────────────────────── */}
           {showSuggestions ? (

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -64,7 +64,7 @@ export function ProfileTabs({
   return (
     <nav
       aria-label="Profile sections"
-      className="sticky z-10 -mx-4 md:mx-0 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
+      className="sticky z-[var(--mg-z-sticky)] -mx-4 md:mx-0 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
       style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
     >
       <div className="flex items-stretch gap-3 px-4 md:px-0">

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -65,7 +65,7 @@ export function ShortcutsPopover() {
               type="button"
               aria-label="Keyboard shortcuts"
               className={classNames(
-                "hidden md:inline-flex fixed z-40 bottom-5 left-5 md:bottom-7 md:left-7",
+                "hidden md:inline-flex fixed z-[var(--mg-z-overlay)] bottom-5 left-5 md:bottom-7 md:left-7",
                 "items-center justify-center rounded-full border border-border bg-card/95 backdrop-blur",
                 "size-10 text-ink-muted shadow-[var(--mg-shadow-pop)]",
                 "hover:border-accent/60 hover:text-accent transition-colors",

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -20,7 +20,7 @@ export function SubnetsCompareDrawer() {
   if (selected.length === 0) return null;
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
+    <div className="fixed inset-x-0 bottom-0 z-[var(--mg-z-overlay)] pointer-events-none">
       <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
         <div
           className={classNames(
@@ -228,6 +228,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
   return (
     <div className="border-t border-border max-h-[55vh] overflow-auto">
       <table className="min-w-full text-[12px]">
+        {/* local stacking context: sticky corner cell over sticky row/col — not a global layer (#7841) */}
         <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
           <tr>
             <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left mg-type-micro text-ink-muted backdrop-blur">

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -114,7 +114,7 @@ export function ValidatorNominatorsTable({ queryOptions, search, setSearch }: Pr
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
+          <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Coldkey</th>
               <th className="px-4 py-2.5 text-right">Net staked</th>

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -24,7 +24,7 @@ export function ValidatorsCompareDrawer() {
   if (selected.length === 0) return null;
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
+    <div className="fixed inset-x-0 bottom-0 z-[var(--mg-z-overlay)] pointer-events-none">
       <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
         <div
           className={classNames(
@@ -211,6 +211,7 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
   return (
     <div className="border-t border-border max-h-[55vh] overflow-auto">
       <table className="min-w-full text-[12px]">
+        {/* local stacking context: sticky corner cell over sticky row/col — not a global layer (#7841) */}
         <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
           <tr>
             <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left mg-type-micro text-ink-muted backdrop-blur">

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -400,7 +400,7 @@ function RouteTransitionBar() {
   return (
     <div
       aria-hidden
-      className="fixed inset-x-0 top-0 z-[60] h-0.5 pointer-events-none overflow-hidden"
+      className="fixed inset-x-0 top-0 z-[var(--mg-z-progress)] h-0.5 pointer-events-none overflow-hidden"
       style={{ opacity: isLoading ? 1 : 0, transition: "opacity 200ms ease-out" }}
     >
       {isLoading ? (

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -496,7 +496,7 @@ function BlocksTable() {
         ))}
         table={
           <table className="w-full text-left text-sm">
-            <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
+            <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
               <tr>
                 <th className="px-4 py-2.5">Block</th>
                 <th className="px-4 py-2.5">Hash</th>

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -900,7 +900,7 @@ function EndpointsTable() {
       {/* One shared command surface replaces the previous stacked category,
           search, select, toggle, and view-control bars. */}
       <div
-        className="sticky z-20 -mx-1 bg-paper/92 px-1 py-2 backdrop-blur"
+        className="sticky z-[var(--mg-z-raised)] -mx-1 bg-paper/92 px-1 py-2 backdrop-blur"
         style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
       >
         <QueryBar ariaLabel="Filter endpoint directory">

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -304,7 +304,7 @@ function ExtrinsicsTable() {
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
+          <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Hash</th>
               <th className="px-4 py-2.5">Block</th>

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -393,7 +393,7 @@ function HomeHero() {
 
   return (
     <section className="mg-hero-slab relative overflow-hidden px-4 py-12 sm:px-6 md:py-20">
-      <div className="relative z-10 mx-auto flex max-w-4xl flex-col items-center text-center">
+      <div className="relative z-[var(--mg-z-sticky)] mx-auto flex max-w-4xl flex-col items-center text-center">
         <h1 className="mg-fade-in mt-2 font-display text-[30px] sm:text-[40px] md:text-[48px] font-semibold leading-[1.08] text-ink-strong">
           <span className="block">Bittensor,</span>
           <span className="block text-accent">de-mystified.</span>
@@ -470,7 +470,7 @@ function HomeHero() {
         <ChainHeadTip />
       </div>
 
-      <div className="relative z-10 mx-auto mt-10 max-w-6xl px-0 sm:px-2">
+      <div className="relative z-[var(--mg-z-sticky)] mx-auto mt-10 max-w-6xl px-0 sm:px-2">
         <HeroFeatureRow />
       </div>
     </section>

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -311,7 +311,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
 
       <SourceHealthRollup />
 
-      <div className="sticky top-[var(--mg-sticky-offset)] z-20 bg-paper/95 py-2 backdrop-blur-sm">
+      <div className="sticky top-[var(--mg-sticky-offset)] z-[var(--mg-z-raised)] bg-paper/95 py-2 backdrop-blur-sm">
         <QueryBar ariaLabel="Provider directory filters">
           <QueryBar.Search
             value={q}

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -155,7 +155,7 @@ var DialogOverlay = React3__namespace.forwardRef(({ className, ...props }, ref) 
   {
     ref,
     className: cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[var(--mg-z-modal)] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     ),
     ...props
@@ -169,7 +169,7 @@ var DialogContent = React3__namespace.forwardRef(({ className, children, ...prop
     {
       ref,
       className: cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className
       ),
       ...props,
@@ -339,7 +339,7 @@ var HoverCardContent = React3__namespace.forwardRef(({ className, align = "cente
     align,
     sideOffset,
     className: cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-hover-card-content-transform-origin)",
+      "z-[var(--mg-z-modal)] w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-hover-card-content-transform-origin)",
       className
     ),
     ...props
@@ -356,7 +356,7 @@ var PopoverContent = React3__namespace.forwardRef(({ className, align = "center"
     align,
     sideOffset,
     className: cn(
-      "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
+      "z-[var(--mg-z-modal)] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
       className
     ),
     ...props
@@ -371,7 +371,7 @@ var SheetOverlay = React3__namespace.forwardRef(({ className, ...props }, ref) =
   DialogPrimitive__namespace.Overlay,
   {
     className: cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[var(--mg-z-modal)] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     ),
     ...props,
@@ -380,7 +380,7 @@ var SheetOverlay = React3__namespace.forwardRef(({ className, ...props }, ref) =
 ));
 SheetOverlay.displayName = DialogPrimitive__namespace.Overlay.displayName;
 var sheetVariants = classVarianceAuthority.cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-[var(--mg-z-modal)] gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {
@@ -530,7 +530,7 @@ var TooltipContent = React3__namespace.forwardRef(({ className, sideOffset = 4, 
     ref,
     sideOffset,
     className: cn(
-      "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
+      "z-[var(--mg-z-modal)] overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
       className
     ),
     ...props
@@ -682,7 +682,7 @@ function BackToTop({ threshold = 600 }) {
       "aria-hidden": !visible,
       tabIndex: visible ? 0 : -1,
       className: classNames(
-        "fixed z-40 bottom-5 right-5 md:bottom-7 md:right-7",
+        "fixed z-[var(--mg-z-overlay)] bottom-5 right-5 md:bottom-7 md:right-7",
         "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
         "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",
@@ -1832,7 +1832,7 @@ function HoverPreview({
           "span",
           {
             role: "tooltip",
-            className: "absolute left-0 top-full z-40 mt-1.5 w-72 max-w-[80vw] rounded border border-border bg-card p-3 shadow-lg text-[11px] text-ink leading-relaxed",
+            className: "absolute left-0 top-full z-[var(--mg-z-overlay)] mt-1.5 w-72 max-w-[80vw] rounded border border-border bg-card p-3 shadow-lg text-[11px] text-ink leading-relaxed",
             children: content
           }
         ) : null
@@ -1950,7 +1950,7 @@ function ListShell({
             className: classNames(
               // Sticky filter bar. Offset reads --mg-sticky-offset (published by
               // AppShell to match real header + ticker height) with a fallback.
-              "sticky z-20 -mx-4 md:mx-0 mb-3",
+              "sticky z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
               "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
               "border-b border-border md:border md:rounded md:bg-card",
               "px-3 py-2 md:p-2.5"
@@ -3251,7 +3251,7 @@ function CandlestickMini({
         hoverBar && tooltipText ? /* @__PURE__ */ jsxRuntime.jsx(
           "div",
           {
-            className: "pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
               left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
               top: Math.max(0, hoverBar.wickTop - 4)
@@ -3578,7 +3578,7 @@ function Sparkline({
         hoverPoint && tooltipText ? /* @__PURE__ */ jsxRuntime.jsx(
           "div",
           {
-            className: "pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
               left: Math.max(24, Math.min(width - 24, hoverPoint[0])),
               top: hoverPoint[1] - 4
@@ -4249,7 +4249,7 @@ function ColumnCustomizer({
         {
           type: "button",
           "aria-label": "Close column menu",
-          className: "fixed inset-0 z-30 cursor-default",
+          className: "fixed inset-0 z-[var(--mg-z-overlay)] cursor-default",
           onClick: () => setOpen(false)
         }
       ),
@@ -4257,7 +4257,7 @@ function ColumnCustomizer({
         "div",
         {
           role: "menu",
-          className: "absolute right-0 z-40 mt-1.5 w-64 rounded border border-border bg-card p-1 mg-card-glow",
+          className: "absolute right-0 z-[var(--mg-z-overlay)] mt-1.5 w-64 rounded border border-border bg-card p-1 mg-card-glow",
           children: [
             /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-center justify-between px-2 py-1.5", children: [
               /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-micro text-ink-muted", children: "Columns" }),
@@ -4811,7 +4811,7 @@ function StickyToolbar({
     {
       style: top,
       className: cn(
-        "sticky z-20 -mx-4 border-b bg-paper/95 px-4 py-2 backdrop-blur transition-[border-color,box-shadow] sm:mx-0 sm:px-0",
+        "sticky z-[var(--mg-z-raised)] -mx-4 border-b bg-paper/95 px-4 py-2 backdrop-blur transition-[border-color,box-shadow] sm:mx-0 sm:px-0",
         hairline && scrolled ? "border-border" : "border-transparent",
         className
       ),
@@ -5048,7 +5048,7 @@ function ScrollShadow({
       {
         "aria-hidden": true,
         className: classNames(
-          "pointer-events-none absolute z-10",
+          "pointer-events-none absolute z-[var(--mg-z-sticky)]",
           isH ? "left-0 top-0 h-full w-6 bg-gradient-to-r from-card to-transparent" : "left-0 top-0 h-6 w-full bg-gradient-to-b from-card to-transparent"
         )
       }
@@ -5058,7 +5058,7 @@ function ScrollShadow({
       {
         "aria-hidden": true,
         className: classNames(
-          "pointer-events-none absolute z-10",
+          "pointer-events-none absolute z-[var(--mg-z-sticky)]",
           isH ? "right-0 top-0 h-full w-6 bg-gradient-to-l from-card to-transparent" : "bottom-0 left-0 h-6 w-full bg-gradient-to-t from-card to-transparent"
         )
       }
@@ -5137,7 +5137,7 @@ function FilterSheet({
         role: "dialog",
         "aria-modal": "true",
         "aria-label": label,
-        className: "fixed inset-0 z-50 flex items-end sm:items-center sm:justify-center",
+        className: "fixed inset-0 z-[var(--mg-z-modal)] flex items-end sm:items-center sm:justify-center",
         children: [
           /* @__PURE__ */ jsxRuntime.jsx(
             "div",
@@ -5151,7 +5151,7 @@ function FilterSheet({
             "div",
             {
               className: classNames(
-                "relative z-10 w-full max-h-[85vh] overflow-y-auto",
+                "relative z-[var(--mg-z-sticky)] w-full max-h-[85vh] overflow-y-auto",
                 "rounded-t-xl border-t border-border bg-card p-4",
                 "sm:max-w-md sm:rounded-xl sm:border sm:mx-4",
                 "mg-scroll"
@@ -5261,7 +5261,7 @@ function PageActions({
               "div",
               {
                 role: "menu",
-                className: "absolute right-0 top-full z-30 mt-2 min-w-[180px] rounded border border-border bg-card p-2 shadow-lg",
+                className: "absolute right-0 top-full z-[var(--mg-z-overlay)] mt-2 min-w-[180px] rounded border border-border bg-card p-2 shadow-lg",
                 children: /* @__PURE__ */ jsxRuntime.jsx("div", { className: "flex flex-col items-stretch gap-1 [&>*]:w-full [&>*]:justify-start", children: secondary })
               }
             ) : null
@@ -5945,9 +5945,9 @@ function QueryProgress({
       "aria-hidden": !active,
       className: classNames(
         "mg-query-progress pointer-events-none overflow-hidden",
-        position === "absolute" && "absolute inset-x-0 top-0 z-10",
-        position === "fixed" && "fixed inset-x-0 top-0 z-50",
-        position === "sticky" && "sticky top-0 z-10 -mt-px",
+        position === "absolute" && "absolute inset-x-0 top-0 z-[var(--mg-z-sticky)]",
+        position === "fixed" && "fixed inset-x-0 top-0 z-[var(--mg-z-modal)]",
+        position === "sticky" && "sticky top-0 z-[var(--mg-z-sticky)] -mt-px",
         "h-[2px]",
         active ? "opacity-100" : "opacity-0 transition-opacity duration-300",
         className

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -179,6 +179,15 @@
   --mg-shadow-pill-active: 0 12px 30px -24px color-mix(in oklab, var(--ink-strong) 85%, transparent);
   --mg-shadow-ring-accent: 0 0 0 1px color-mix(in oklab, var(--accent) 25%, transparent);
 }
+:root {
+  --mg-z-sticky: 10;
+  --mg-z-raised: 20;
+  --mg-z-nav: 30;
+  --mg-z-overlay: 40;
+  --mg-z-modal: 50;
+  --mg-z-progress: 60;
+  --mg-z-skip-link: 100;
+}
 .dark {
   --paper: oklch(0.14 0.003 250);
   --surface: oklch(0.175 0.003 250);

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -126,7 +126,7 @@ var DialogOverlay = React3.forwardRef(({ className, ...props }, ref) => /* @__PU
   {
     ref,
     className: cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[var(--mg-z-modal)] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     ),
     ...props
@@ -140,7 +140,7 @@ var DialogContent = React3.forwardRef(({ className, children, ...props }, ref) =
     {
       ref,
       className: cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className
       ),
       ...props,
@@ -310,7 +310,7 @@ var HoverCardContent = React3.forwardRef(({ className, align = "center", sideOff
     align,
     sideOffset,
     className: cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-hover-card-content-transform-origin)",
+      "z-[var(--mg-z-modal)] w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-hover-card-content-transform-origin)",
       className
     ),
     ...props
@@ -327,7 +327,7 @@ var PopoverContent = React3.forwardRef(({ className, align = "center", sideOffse
     align,
     sideOffset,
     className: cn(
-      "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
+      "z-[var(--mg-z-modal)] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
       className
     ),
     ...props
@@ -342,7 +342,7 @@ var SheetOverlay = React3.forwardRef(({ className, ...props }, ref) => /* @__PUR
   DialogPrimitive.Overlay,
   {
     className: cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[var(--mg-z-modal)] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     ),
     ...props,
@@ -351,7 +351,7 @@ var SheetOverlay = React3.forwardRef(({ className, ...props }, ref) => /* @__PUR
 ));
 SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
 var sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-[var(--mg-z-modal)] gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {
@@ -501,7 +501,7 @@ var TooltipContent = React3.forwardRef(({ className, sideOffset = 4, ...props },
     ref,
     sideOffset,
     className: cn(
-      "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
+      "z-[var(--mg-z-modal)] overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
       className
     ),
     ...props
@@ -653,7 +653,7 @@ function BackToTop({ threshold = 600 }) {
       "aria-hidden": !visible,
       tabIndex: visible ? 0 : -1,
       className: classNames(
-        "fixed z-40 bottom-5 right-5 md:bottom-7 md:right-7",
+        "fixed z-[var(--mg-z-overlay)] bottom-5 right-5 md:bottom-7 md:right-7",
         "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
         "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",
@@ -1803,7 +1803,7 @@ function HoverPreview({
           "span",
           {
             role: "tooltip",
-            className: "absolute left-0 top-full z-40 mt-1.5 w-72 max-w-[80vw] rounded border border-border bg-card p-3 shadow-lg text-[11px] text-ink leading-relaxed",
+            className: "absolute left-0 top-full z-[var(--mg-z-overlay)] mt-1.5 w-72 max-w-[80vw] rounded border border-border bg-card p-3 shadow-lg text-[11px] text-ink leading-relaxed",
             children: content
           }
         ) : null
@@ -1921,7 +1921,7 @@ function ListShell({
             className: classNames(
               // Sticky filter bar. Offset reads --mg-sticky-offset (published by
               // AppShell to match real header + ticker height) with a fallback.
-              "sticky z-20 -mx-4 md:mx-0 mb-3",
+              "sticky z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
               "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
               "border-b border-border md:border md:rounded md:bg-card",
               "px-3 py-2 md:p-2.5"
@@ -3222,7 +3222,7 @@ function CandlestickMini({
         hoverBar && tooltipText ? /* @__PURE__ */ jsx(
           "div",
           {
-            className: "pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
               left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
               top: Math.max(0, hoverBar.wickTop - 4)
@@ -3549,7 +3549,7 @@ function Sparkline({
         hoverPoint && tooltipText ? /* @__PURE__ */ jsx(
           "div",
           {
-            className: "pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
               left: Math.max(24, Math.min(width - 24, hoverPoint[0])),
               top: hoverPoint[1] - 4
@@ -4220,7 +4220,7 @@ function ColumnCustomizer({
         {
           type: "button",
           "aria-label": "Close column menu",
-          className: "fixed inset-0 z-30 cursor-default",
+          className: "fixed inset-0 z-[var(--mg-z-overlay)] cursor-default",
           onClick: () => setOpen(false)
         }
       ),
@@ -4228,7 +4228,7 @@ function ColumnCustomizer({
         "div",
         {
           role: "menu",
-          className: "absolute right-0 z-40 mt-1.5 w-64 rounded border border-border bg-card p-1 mg-card-glow",
+          className: "absolute right-0 z-[var(--mg-z-overlay)] mt-1.5 w-64 rounded border border-border bg-card p-1 mg-card-glow",
           children: [
             /* @__PURE__ */ jsxs("div", { className: "flex items-center justify-between px-2 py-1.5", children: [
               /* @__PURE__ */ jsx("span", { className: "mg-type-micro text-ink-muted", children: "Columns" }),
@@ -4782,7 +4782,7 @@ function StickyToolbar({
     {
       style: top,
       className: cn(
-        "sticky z-20 -mx-4 border-b bg-paper/95 px-4 py-2 backdrop-blur transition-[border-color,box-shadow] sm:mx-0 sm:px-0",
+        "sticky z-[var(--mg-z-raised)] -mx-4 border-b bg-paper/95 px-4 py-2 backdrop-blur transition-[border-color,box-shadow] sm:mx-0 sm:px-0",
         hairline && scrolled ? "border-border" : "border-transparent",
         className
       ),
@@ -5019,7 +5019,7 @@ function ScrollShadow({
       {
         "aria-hidden": true,
         className: classNames(
-          "pointer-events-none absolute z-10",
+          "pointer-events-none absolute z-[var(--mg-z-sticky)]",
           isH ? "left-0 top-0 h-full w-6 bg-gradient-to-r from-card to-transparent" : "left-0 top-0 h-6 w-full bg-gradient-to-b from-card to-transparent"
         )
       }
@@ -5029,7 +5029,7 @@ function ScrollShadow({
       {
         "aria-hidden": true,
         className: classNames(
-          "pointer-events-none absolute z-10",
+          "pointer-events-none absolute z-[var(--mg-z-sticky)]",
           isH ? "right-0 top-0 h-full w-6 bg-gradient-to-l from-card to-transparent" : "bottom-0 left-0 h-6 w-full bg-gradient-to-t from-card to-transparent"
         )
       }
@@ -5108,7 +5108,7 @@ function FilterSheet({
         role: "dialog",
         "aria-modal": "true",
         "aria-label": label,
-        className: "fixed inset-0 z-50 flex items-end sm:items-center sm:justify-center",
+        className: "fixed inset-0 z-[var(--mg-z-modal)] flex items-end sm:items-center sm:justify-center",
         children: [
           /* @__PURE__ */ jsx(
             "div",
@@ -5122,7 +5122,7 @@ function FilterSheet({
             "div",
             {
               className: classNames(
-                "relative z-10 w-full max-h-[85vh] overflow-y-auto",
+                "relative z-[var(--mg-z-sticky)] w-full max-h-[85vh] overflow-y-auto",
                 "rounded-t-xl border-t border-border bg-card p-4",
                 "sm:max-w-md sm:rounded-xl sm:border sm:mx-4",
                 "mg-scroll"
@@ -5232,7 +5232,7 @@ function PageActions({
               "div",
               {
                 role: "menu",
-                className: "absolute right-0 top-full z-30 mt-2 min-w-[180px] rounded border border-border bg-card p-2 shadow-lg",
+                className: "absolute right-0 top-full z-[var(--mg-z-overlay)] mt-2 min-w-[180px] rounded border border-border bg-card p-2 shadow-lg",
                 children: /* @__PURE__ */ jsx("div", { className: "flex flex-col items-stretch gap-1 [&>*]:w-full [&>*]:justify-start", children: secondary })
               }
             ) : null
@@ -5916,9 +5916,9 @@ function QueryProgress({
       "aria-hidden": !active,
       className: classNames(
         "mg-query-progress pointer-events-none overflow-hidden",
-        position === "absolute" && "absolute inset-x-0 top-0 z-10",
-        position === "fixed" && "fixed inset-x-0 top-0 z-50",
-        position === "sticky" && "sticky top-0 z-10 -mt-px",
+        position === "absolute" && "absolute inset-x-0 top-0 z-[var(--mg-z-sticky)]",
+        position === "fixed" && "fixed inset-x-0 top-0 z-[var(--mg-z-modal)]",
+        position === "sticky" && "sticky top-0 z-[var(--mg-z-sticky)] -mt-px",
         "h-[2px]",
         active ? "opacity-100" : "opacity-0 transition-opacity duration-300",
         className

--- a/packages/ui-kit/eslint.config.ts
+++ b/packages/ui-kit/eslint.config.ts
@@ -73,6 +73,15 @@ const DESIGN_RULES = [
     message:
       "Raw shadow value. Use one of the --mg-shadow-* elevation tokens (see styles.css).",
   },
+  {
+    // #7841: bare z-* stacking steps collapsed into a named --mg-z-* layer
+    // scale (styles.css). Also flags the 6 documented z-[1]/z-[2] sticky-cell
+    // micro-stacking exceptions -- intentional, matches the residual-worklist
+    // convention the shadow rule above already uses.
+    selector: "Literal[value=/\\bz-(\\[[0-9]+\\]|[0-9]+\\b)/]",
+    message:
+      "Raw z-index step. Use one of the --mg-z-* layer tokens (see styles.css).",
+  },
 ];
 
 // SSR footguns -- see apps/ui/docs/ssr-safety.md. ui-kit's own components

--- a/packages/ui-kit/src/components/metagraphed/back-to-top.tsx
+++ b/packages/ui-kit/src/components/metagraphed/back-to-top.tsx
@@ -63,7 +63,7 @@ export function BackToTop({ threshold = 600 }: { threshold?: number }) {
       aria-hidden={!visible}
       tabIndex={visible ? 0 : -1}
       className={classNames(
-        "fixed z-40 bottom-5 right-5 md:bottom-7 md:right-7",
+        "fixed z-[var(--mg-z-overlay)] bottom-5 right-5 md:bottom-7 md:right-7",
         "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
         "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",

--- a/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
@@ -225,7 +225,7 @@ export function CandlestickMini({
       </svg>
       {hoverBar && tooltipText ? (
         <div
-          className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap"
+          className="pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap"
           style={{
             left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
             top: Math.max(0, hoverBar.wickTop - 4),

--- a/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
@@ -191,7 +191,7 @@ export function Sparkline({
       </svg>
       {hoverPoint && tooltipText ? (
         <div
-          className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap"
+          className="pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap"
           style={{
             left: Math.max(24, Math.min(width - 24, hoverPoint[0])),
             top: hoverPoint[1] - 4,

--- a/packages/ui-kit/src/components/metagraphed/column-customizer.tsx
+++ b/packages/ui-kit/src/components/metagraphed/column-customizer.tsx
@@ -47,12 +47,12 @@ export function ColumnCustomizer({
           <button
             type="button"
             aria-label="Close column menu"
-            className="fixed inset-0 z-30 cursor-default"
+            className="fixed inset-0 z-[var(--mg-z-overlay)] cursor-default"
             onClick={() => setOpen(false)}
           />
           <div
             role="menu"
-            className="absolute right-0 z-40 mt-1.5 w-64 rounded border border-border bg-card p-1 mg-card-glow"
+            className="absolute right-0 z-[var(--mg-z-overlay)] mt-1.5 w-64 rounded border border-border bg-card p-1 mg-card-glow"
           >
             <div className="flex items-center justify-between px-2 py-1.5">
               <span className="mg-type-micro text-ink-muted">Columns</span>

--- a/packages/ui-kit/src/components/metagraphed/filter-sheet.tsx
+++ b/packages/ui-kit/src/components/metagraphed/filter-sheet.tsx
@@ -71,7 +71,7 @@ export function FilterSheet({
           role="dialog"
           aria-modal="true"
           aria-label={label}
-          className="fixed inset-0 z-50 flex items-end sm:items-center sm:justify-center"
+          className="fixed inset-0 z-[var(--mg-z-modal)] flex items-end sm:items-center sm:justify-center"
         >
           <div
             className="absolute inset-0 bg-ink-strong/30 backdrop-blur-sm"
@@ -80,7 +80,7 @@ export function FilterSheet({
           />
           <div
             className={classNames(
-              "relative z-10 w-full max-h-[85vh] overflow-y-auto",
+              "relative z-[var(--mg-z-sticky)] w-full max-h-[85vh] overflow-y-auto",
               "rounded-t-xl border-t border-border bg-card p-4",
               "sm:max-w-md sm:rounded-xl sm:border sm:mx-4",
               "mg-scroll",

--- a/packages/ui-kit/src/components/metagraphed/hover-preview.tsx
+++ b/packages/ui-kit/src/components/metagraphed/hover-preview.tsx
@@ -37,7 +37,7 @@ export function HoverPreview({
       {open ? (
         <span
           role="tooltip"
-          className="absolute left-0 top-full z-40 mt-1.5 w-72 max-w-[80vw] rounded border border-border bg-card p-3 shadow-lg text-[11px] text-ink leading-relaxed"
+          className="absolute left-0 top-full z-[var(--mg-z-overlay)] mt-1.5 w-72 max-w-[80vw] rounded border border-border bg-card p-3 shadow-lg text-[11px] text-ink leading-relaxed"
         >
           {content}
         </span>

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -79,7 +79,7 @@ export function ListShell({
         className={classNames(
           // Sticky filter bar. Offset reads --mg-sticky-offset (published by
           // AppShell to match real header + ticker height) with a fallback.
-          "sticky z-20 -mx-4 md:mx-0 mb-3",
+          "sticky z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
           "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
           "border-b border-border md:border md:rounded md:bg-card",
           "px-3 py-2 md:p-2.5",

--- a/packages/ui-kit/src/components/metagraphed/page-actions.tsx
+++ b/packages/ui-kit/src/components/metagraphed/page-actions.tsx
@@ -92,7 +92,7 @@ export function PageActions({
             {open ? (
               <div
                 role="menu"
-                className="absolute right-0 top-full z-30 mt-2 min-w-[180px] rounded border border-border bg-card p-2 shadow-lg"
+                className="absolute right-0 top-full z-[var(--mg-z-overlay)] mt-2 min-w-[180px] rounded border border-border bg-card p-2 shadow-lg"
               >
                 <div className="flex flex-col items-stretch gap-1 [&>*]:w-full [&>*]:justify-start">
                   {secondary}

--- a/packages/ui-kit/src/components/metagraphed/query-progress.tsx
+++ b/packages/ui-kit/src/components/metagraphed/query-progress.tsx
@@ -27,9 +27,10 @@ export function QueryProgress({
       aria-hidden={!active}
       className={classNames(
         "mg-query-progress pointer-events-none overflow-hidden",
-        position === "absolute" && "absolute inset-x-0 top-0 z-10",
-        position === "fixed" && "fixed inset-x-0 top-0 z-50",
-        position === "sticky" && "sticky top-0 z-10 -mt-px",
+        position === "absolute" &&
+          "absolute inset-x-0 top-0 z-[var(--mg-z-sticky)]",
+        position === "fixed" && "fixed inset-x-0 top-0 z-[var(--mg-z-modal)]",
+        position === "sticky" && "sticky top-0 z-[var(--mg-z-sticky)] -mt-px",
         "h-[2px]",
         active ? "opacity-100" : "opacity-0 transition-opacity duration-300",
         className,

--- a/packages/ui-kit/src/components/metagraphed/scroll-shadow.tsx
+++ b/packages/ui-kit/src/components/metagraphed/scroll-shadow.tsx
@@ -71,7 +71,7 @@ export function ScrollShadow({
         <div
           aria-hidden
           className={classNames(
-            "pointer-events-none absolute z-10",
+            "pointer-events-none absolute z-[var(--mg-z-sticky)]",
             isH
               ? "left-0 top-0 h-full w-6 bg-gradient-to-r from-card to-transparent"
               : "left-0 top-0 h-6 w-full bg-gradient-to-b from-card to-transparent",
@@ -82,7 +82,7 @@ export function ScrollShadow({
         <div
           aria-hidden
           className={classNames(
-            "pointer-events-none absolute z-10",
+            "pointer-events-none absolute z-[var(--mg-z-sticky)]",
             isH
               ? "right-0 top-0 h-full w-6 bg-gradient-to-l from-card to-transparent"
               : "bottom-0 left-0 h-6 w-full bg-gradient-to-t from-card to-transparent",

--- a/packages/ui-kit/src/components/metagraphed/sticky-toolbar.tsx
+++ b/packages/ui-kit/src/components/metagraphed/sticky-toolbar.tsx
@@ -30,7 +30,7 @@ export function StickyToolbar({
     <div
       style={top}
       className={cn(
-        "sticky z-20 -mx-4 border-b bg-paper/95 px-4 py-2 backdrop-blur transition-[border-color,box-shadow] sm:mx-0 sm:px-0",
+        "sticky z-[var(--mg-z-raised)] -mx-4 border-b bg-paper/95 px-4 py-2 backdrop-blur transition-[border-color,box-shadow] sm:mx-0 sm:px-0",
         hairline && scrolled ? "border-border" : "border-transparent",
         className,
       )}

--- a/packages/ui-kit/src/components/ui/dialog.tsx
+++ b/packages/ui-kit/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[var(--mg-z-modal)] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className,
       )}
       {...props}

--- a/packages/ui-kit/src/components/ui/hover-card.tsx
+++ b/packages/ui-kit/src/components/ui/hover-card.tsx
@@ -16,7 +16,7 @@ const HoverCardContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-hover-card-content-transform-origin)",
+      "z-[var(--mg-z-modal)] w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-hover-card-content-transform-origin)",
       className,
     )}
     {...props}

--- a/packages/ui-kit/src/components/ui/popover.tsx
+++ b/packages/ui-kit/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
+        "z-[var(--mg-z-modal)] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
         className,
       )}
       {...props}

--- a/packages/ui-kit/src/components/ui/sheet.tsx
+++ b/packages/ui-kit/src/components/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[var(--mg-z-modal)] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-[var(--mg-z-modal)] gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {

--- a/packages/ui-kit/src/components/ui/tooltip.tsx
+++ b/packages/ui-kit/src/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
+        "z-[var(--mg-z-modal)] overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
         className,
       )}
       {...props}

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -355,6 +355,22 @@
     color-mix(in oklab, var(--accent) 25%, transparent);
 }
 
+/* ============================================================
+ * Layer tokens (#7841) — a named stacking-order scale so a new
+ * component reaches for one of these instead of guessing a bare
+ * z-* step. Radix's own portals default to z-50, so --mg-z-modal
+ * stays 50 to avoid needing per-primitive overrides.
+ * ============================================================ */
+:root {
+  --mg-z-sticky: 10; /* sticky theads/toolbars, scroll shadows, in-flow progress bars */
+  --mg-z-raised: 20; /* must clear sticky content within the same page section */
+  --mg-z-nav: 30; /* site header/nav chrome */
+  --mg-z-overlay: 40; /* drawers, back-to-top, hover cards, lightweight menus */
+  --mg-z-modal: 50; /* dialogs, popovers, sheets, command palette (Radix default) */
+  --mg-z-progress: 60; /* route-transition progress bar -- must beat modal */
+  --mg-z-skip-link: 100; /* a11y skip-link -- must beat everything */
+}
+
 /* ============ DARK — Ink + dialed mint ============ */
 .dark {
   --paper: oklch(0.14 0.003 250);


### PR DESCRIPTION
## Summary

~56 sites across `apps/ui` and `packages/ui-kit` used bare Tailwind `z-*` steps (`z-10`/`20`/`30`/`40`/`50` plus `z-[60]`/`z-[100]`) with no documented layering system. Nothing was visibly broken, but undocumented stacking is how a future component silently lands behind a modal or above a toast.

## Tokens

Added to `packages/ui-kit/src/styles.css`:

| Token | Value | Use for |
|---|---|---|
| `--mg-z-sticky` | 10 | Sticky theads/toolbars, scroll shadows, in-flow progress bars |
| `--mg-z-raised` | 20 | Elements that must clear sticky content within the same page section |
| `--mg-z-nav` | 30 | Site header/nav chrome |
| `--mg-z-overlay` | 40 | Drawers, back-to-top, hover cards, lightweight menus |
| `--mg-z-modal` | 50 | Dialogs, popovers, sheets, command palette (matches Radix's own default) |
| `--mg-z-progress` | 60 | Route-transition progress bar |
| `--mg-z-skip-link` | 100 | a11y skip-link |

## Sweep

All 50 non-exception sites converted to `z-[var(--mg-z-*)]`. Two didn't transliterate literally: `column-customizer.tsx`'s click-outside backdrop and `page-actions.tsx`'s overflow menu were both bare `z-30`, but neither is nav chrome — they're popover-style overlays, so both moved to `--mg-z-overlay` instead (their DOM order already keeps the visible panel above its own backdrop at equal z-index, so no stacking change).

**Left alone (documented exception):** the 6 `z-[1]`/`z-[2]` sticky-cell sites in `subnets-compare-drawer.tsx` and `validators-compare-drawer.tsx` — a sticky corner cell over its own sticky row/col, a local stacking context rather than a global layer. Added a comment on each.

## Guardrail + docs

- Warn-tier `no-restricted-syntax` rule in both `eslint.config.ts` files flags any remaining bare `z-10`/`20`/`30`/`40`/`50` or `z-[N]` step — including the 6 documented exceptions above, same residual-worklist convention the shadow-token rule already uses.
- Full layer table documented in `apps/ui/CONTRIBUTING.md`'s Bone & Ink section.

## Verification

- `tsc --noEmit` clean in both packages
- `eslint .` (full package, not just `src`) — 0 errors in both packages; exactly 6 warnings from the documented z-index exceptions, no others
- `vitest run` — 191 files / 1461 tests in `apps/ui`, 16 files / 88 tests in `ui-kit`, all passing
- `packages/ui-kit` rebuilt (`dist/index.{js,cjs,css}`)
- Live preview: `getComputedStyle` confirms all 7 `--mg-z-*` custom properties resolve to their intended numeric values, and the sticky table header (`z-index: 10`) / site nav (`z-index: 30`) report the correct resolved values on a real rendered page

Closes #7841