### PR TITLE
feat(api): add subnet_endpoints root field

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2618,6 +2618,8 @@ export type Query = {
   subnet_conviction: SubnetConviction;
   /** Per-subnet neuron-deregistration activity over a 7d/30d window (distinct deregistered hotkeys, NeuronDeregistered count, and deregistrations per hotkey); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/deregistrations. */
   subnet_deregistrations: SubnetDeregistrations;
+  /** One subnet's endpoint/resource registry as a filtered/sorted/paged list — the baked per-subnet /metagraph/endpoints/{netuid}.json artifact the REST route and list_subnet_endpoints MCP tool read. Filter with kind, layer, provider, publication_state, status, and pool_eligible (a true/false string); threshold with min_/max_latency_ms and min_/max_score; project with fields; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the endpoints rows. Null when no endpoint artifact has been baked for the netuid (rather than a GraphQL error). Distinct from endpoints(...) (the filterable network-wide endpoint registry). Mirrors GET /api/v1/subnets/{netuid}/endpoints. */
+  subnet_endpoints?: Maybe<Scalars['JSON']['output']>;
   /** One subnet's chain-event activity summary over a 7d/30d/90d window (default 30d): total events, the per-kind and per-category breakdowns with hotkey/coldkey participation and TAO/alpha amounts, and a bounded newest-first recent-event list (limit 1-50, default 10). A subnet with no events resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/event-summary. */
   subnet_event_summary: SubnetEventSummary;
   /** One subnet's paginated first-party chain-event feed (newest first): each event's kind, block, UID, hot/cold keys, amount, and timestamp. Filter by kind and by block_start/block_end (inclusive block bounds); page with limit (1-1000, default 100)/offset. event_count is the page count, not a grand total. A subnet with no matching events resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/subnets/{netuid}/events. */
@@ -3574,6 +3576,26 @@ export type QuerySubnet_DeregistrationsArgs = {
 };
 
 
+export type QuerySubnet_EndpointsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
+  kind?: InputMaybe<Scalars['String']['input']>;
+  layer?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  max_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  max_score?: InputMaybe<Scalars['Float']['input']>;
+  min_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  min_score?: InputMaybe<Scalars['Float']['input']>;
+  netuid: Scalars['Int']['input'];
+  order?: InputMaybe<Scalars['String']['input']>;
+  pool_eligible?: InputMaybe<Scalars['String']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
+  publication_state?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type QuerySubnet_Event_SummaryArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid: Scalars['Int']['input'];
@@ -4151,7 +4173,7 @@ export type Subnet = {
   docs_url?: Maybe<Scalars['String']['output']>;
   /** Per-subnet economic + validator metrics. */
   economics?: Maybe<SubnetEconomics>;
-  /** Endpoint/resource registry rows for this subnet. */
+  /** Endpoint/resource registry rows for this subnet. Filter with kind, layer, provider, publication_state, status, and pool_eligible; threshold with min_/max_latency_ms and min_/max_score; sort with sort + order; and page with limit / cursor, exactly as GET /api/v1/subnets/{netuid}/endpoints does -- an unsupported filter/sort value is a GraphQL error, not a silently substituted default. With no arguments the full list is returned unchanged. */
   endpoints: Array<Endpoint>;
   first_party?: Maybe<Scalars['Boolean']['output']>;
   gap_count?: Maybe<Scalars['Int']['output']>;
@@ -4172,6 +4194,24 @@ export type Subnet = {
   surfaces: Array<Surface>;
   symbol?: Maybe<Scalars['String']['output']>;
   website_url?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type SubnetEndpointsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  kind?: InputMaybe<Scalars['String']['input']>;
+  layer?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  max_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  max_score?: InputMaybe<Scalars['Float']['input']>;
+  min_latency_ms?: InputMaybe<Scalars['Int']['input']>;
+  min_score?: InputMaybe<Scalars['Float']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  pool_eligible?: InputMaybe<Scalars['Boolean']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
+  publication_state?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -7858,6 +7898,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   subnet_concentration_history?: Resolver<ResolversTypes['SubnetConcentrationHistory'], ParentType, ContextType, RequireFields<QuerySubnet_Concentration_HistoryArgs, 'netuid'>>;
   subnet_conviction?: Resolver<ResolversTypes['SubnetConviction'], ParentType, ContextType, RequireFields<QuerySubnet_ConvictionArgs, 'netuid'>>;
   subnet_deregistrations?: Resolver<ResolversTypes['SubnetDeregistrations'], ParentType, ContextType, RequireFields<QuerySubnet_DeregistrationsArgs, 'netuid'>>;
+  subnet_endpoints?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, RequireFields<QuerySubnet_EndpointsArgs, 'netuid'>>;
   subnet_event_summary?: Resolver<ResolversTypes['SubnetEventSummary'], ParentType, ContextType, RequireFields<QuerySubnet_Event_SummaryArgs, 'netuid'>>;
   subnet_events?: Resolver<ResolversTypes['SubnetEvents'], ParentType, ContextType, RequireFields<QuerySubnet_EventsArgs, 'netuid'>>;
   subnet_evidence?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, RequireFields<QuerySubnet_EvidenceArgs, 'netuid'>>;
@@ -8121,7 +8162,7 @@ export type SubnetResolvers<ContextType = GqlContext, ParentType extends Resolve
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   docs_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   economics?: Resolver<Maybe<ResolversTypes['SubnetEconomics']>, ParentType, ContextType>;
-  endpoints?: Resolver<Array<ResolversTypes['Endpoint']>, ParentType, ContextType>;
+  endpoints?: Resolver<Array<ResolversTypes['Endpoint']>, ParentType, ContextType, Partial<SubnetEndpointsArgs>>;
   first_party?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   gap_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   health?: Resolver<Maybe<ResolversTypes['SubnetHealth']>, ParentType, ContextType>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -168,6 +168,25 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: Int
     ): JSON
+    "One subnet's endpoint/resource registry as a filtered/sorted/paged list — the baked per-subnet /metagraph/endpoints/{netuid}.json artifact the REST route and list_subnet_endpoints MCP tool read. Filter with kind, layer, provider, publication_state, status, and pool_eligible (a true/false string); threshold with min_/max_latency_ms and min_/max_score; project with fields; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the endpoints rows. Null when no endpoint artifact has been baked for the netuid (rather than a GraphQL error). Distinct from endpoints(...) (the filterable network-wide endpoint registry). Mirrors GET /api/v1/subnets/{netuid}/endpoints."
+    subnet_endpoints(
+      netuid: Int!
+      kind: String
+      layer: String
+      provider: String
+      publication_state: String
+      status: String
+      pool_eligible: String
+      min_latency_ms: Int
+      max_latency_ms: Int
+      min_score: Float
+      max_score: Float
+      sort: String
+      order: String
+      fields: String
+      limit: Int
+      cursor: Int
+    ): JSON
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
@@ -885,8 +904,23 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: Int
     ): [Surface!]!
-    "Endpoint/resource registry rows for this subnet."
-    endpoints: [Endpoint!]!
+    "Endpoint/resource registry rows for this subnet. Filter with kind, layer, provider, publication_state, status, and pool_eligible; threshold with min_/max_latency_ms and min_/max_score; sort with sort + order; and page with limit / cursor, exactly as GET /api/v1/subnets/{netuid}/endpoints does -- an unsupported filter/sort value is a GraphQL error, not a silently substituted default. With no arguments the full list is returned unchanged."
+    endpoints(
+      kind: String
+      layer: String
+      provider: String
+      publication_state: String
+      status: String
+      pool_eligible: Boolean
+      min_latency_ms: Int
+      max_latency_ms: Int
+      min_score: Float
+      max_score: Float
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): [Endpoint!]!
   }
 
   type ProviderList {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -78,6 +78,10 @@ import { loadReviewEnrichmentTargetsList } from "./review-enrichment-targets-mcp
 // loadSubnetCandidatesList that MCP list_subnet_candidates already calls
 // (#7899) -- not a reimplementation.
 import { loadSubnetCandidatesList } from "./subnet-candidates-mcp.ts";
+// #7869: GraphQL parity for GET /api/v1/subnets/{netuid}/endpoints, reusing
+// loadSubnetEndpointsList that MCP list_subnet_endpoints already calls -- not
+// a reimplementation.
+import { loadSubnetEndpointsList } from "./subnet-endpoints-mcp.ts";
 // #7879: GraphQL parity for GET /api/v1/subnets/{netuid}/evidence, reusing
 // loadSubnetEvidenceList that MCP list_subnet_evidence already calls -- not a
 // reimplementation.
@@ -622,6 +626,64 @@ const SUBNET_SURFACES_FILTER_NAMES = ["kind", "provider", "id"];
     return (transformed.data as Row).surfaces;
   };
 
+// #7869: the nested Subnet.endpoints field takes the same filter/sort/page
+// arguments as GET /api/v1/subnets/{netuid}/endpoints, mirroring the nested
+// Subnet.surfaces field above. A nested field needs an explicit resolve to see
+// its own args (the default field resolver ignores them and just reads the
+// parent property). Filtering runs through applyQueryFilters against the same
+// "endpoints" query-collection config the root endpoints(...) field (#7887) and
+// the REST route use, so the allowlists cannot drift and an unsupported
+// filter/sort value is a BAD_USER_INPUT GraphQL error rather than a silently
+// substituted default. With no arguments the parent's endpoints pass through
+// untouched. cursor is Int, matching the list query's offset cursor and the
+// sibling nested Subnet.surfaces field.
+(schema.getType("Subnet") as GraphQLObjectType).getFields().endpoints.resolve =
+  async function subnetEndpoints(
+    parent: Row,
+    args: Row,
+    context: GqlContext,
+    info: unknown,
+  ) {
+    // subnetNode -- the only producer of Subnet objects -- always exposes
+    // `endpoints` as a thunk (bundled rows via `() => rows ?? []`, or a lazy
+    // per-netuid artifact load), which the default field resolver would have
+    // invoked. Do the same here so adding arguments does not turn the lazy path
+    // into an empty list.
+    const endpoints = (await parent.endpoints(args, context, info)) as Row[];
+    const queryUrl = new URL("https://graphql.internal/subnets/endpoints");
+    for (const [name, value] of [
+      ["kind", args?.kind],
+      ["layer", args?.layer],
+      ["provider", args?.provider],
+      ["publication_state", args?.publication_state],
+      ["status", args?.status],
+      ["pool_eligible", args?.pool_eligible],
+      ["min_latency_ms", args?.min_latency_ms],
+      ["max_latency_ms", args?.max_latency_ms],
+      ["min_score", args?.min_score],
+      ["max_score", args?.max_score],
+      ["sort", args?.sort],
+      ["order", args?.order],
+      ["limit", args?.limit],
+      ["cursor", args?.cursor],
+    ] as const) {
+      if (value != null) queryUrl.searchParams.set(name, String(value));
+    }
+    if ([...queryUrl.searchParams].length === 0) return endpoints;
+    const transformed = applyQueryFilters(
+      { endpoints },
+      queryUrl,
+      "endpoints",
+      [],
+    );
+    if (transformed.error) {
+      throw new GraphQLError(transformed.error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return (transformed.data as Row).endpoints;
+  };
+
 export const GRAPHQL_SUBSCRIPTION_CONTEXT_KEY = "chainFirehose";
 schema.getSubscriptionType()!.getFields().chainEvents.subscribe =
   async function* chainEventsSubscribe(
@@ -779,6 +841,7 @@ export const FIELD_COMPLEXITY = {
   subnet_gaps: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_evidence: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_candidates: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3764,6 +3827,38 @@ const rootValue = {
       // preserving this field's documented cold-artifact contract --
       // loadArtifact, which this resolver used before, swallowed those the
       // same way.
+      if (err?.toolError) return null;
+      throw err;
+    }
+  },
+
+  // #7869: reuse loadSubnetEndpointsList -- the same loader the
+  // list_subnet_endpoints MCP tool calls -- rather than reimplementing the
+  // filter/sort/page pass here, so this field cannot drift from
+  // GET /api/v1/subnets/{netuid}/endpoints. It reads the same baked per-subnet
+  // artifact (distinct from the network-wide endpoints(...) registry) and
+  // validates netuid and every filter/sort value against the REST allowlists,
+  // throwing on an unsupported one; that throw surfaces as a BAD_USER_INPUT
+  // GraphQL error, matching the subnet_candidates sibling's convention. A cold/
+  // absent per-subnet artifact stays null (the documented per-subnet contract),
+  // never a silently substituted empty list.
+  async subnet_endpoints(args: Row, context: GqlContext) {
+    try {
+      return await loadSubnetEndpointsList(mcpCtx(context), args, {
+        readArtifact,
+      });
+    } catch (rawErr) {
+      const err = rawErr as Row;
+      // An invalid netuid or unsupported filter/sort value is BAD_USER_INPUT,
+      // matching every other field's "not a silently substituted default"
+      // convention.
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      // Any other loader miss (not baked / cold R2 / unavailable) stays null,
+      // preserving this field's documented cold-artifact contract.
       if (err?.toolError) return null;
       throw err;
     }

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, test, vi } from "vitest";
 import * as listQuery from "../workers/list-query.ts";
 import * as subnetCandidatesMcp from "../src/subnet-candidates-mcp.ts";
+import * as subnetEndpointsMcp from "../src/subnet-endpoints-mcp.ts";
 import * as subnetEvidenceMcp from "../src/subnet-evidence-mcp.ts";
 import {
   FIELD_COMPLEXITY,
@@ -10528,6 +10529,295 @@ describe("graphql — subnet_candidates (#7641, baked per-subnet candidate artif
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe("graphql — subnet_endpoints (#7869, baked per-subnet endpoint artifact)", () => {
+  // #7869: full REST filter/sort/page parity, reusing the same loader
+  // list_subnet_endpoints calls.
+  const FILTER_ENV = () =>
+    fixtureEnv({
+      "/metagraph/endpoints/5.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        netuid: 5,
+        endpoints: [
+          {
+            id: "alpha-api",
+            netuid: 5,
+            kind: "subnet-api",
+            layer: "bittensor-base",
+            provider: "alpha",
+            status: "ok",
+            latency_ms: 120,
+            score: 92,
+            pool_eligible: true,
+          },
+          {
+            id: "alpha-openapi",
+            netuid: 5,
+            kind: "openapi",
+            layer: "bittensor-base",
+            provider: "alpha",
+            status: "degraded",
+            latency_ms: 450,
+            score: 70,
+            pool_eligible: false,
+          },
+          {
+            id: "beta-api",
+            netuid: 5,
+            kind: "subnet-api",
+            layer: "bittensor-base",
+            provider: "beta",
+            status: "ok",
+            latency_ms: 200,
+            score: 85,
+            pool_eligible: true,
+          },
+        ],
+      },
+    });
+
+  test("resolves the baked per-subnet endpoints artifact", async () => {
+    const { status, body } = await gql(
+      "{ subnet_endpoints(netuid: 5) }",
+      FILTER_ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints.netuid, 5);
+    assert.equal(body.data.subnet_endpoints.returned, 3);
+    assert.equal(body.data.subnet_endpoints.endpoints[0].kind, "subnet-api");
+  });
+
+  test("degrades to null when no endpoint artifact is baked, never an error", async () => {
+    const { status, body } = await gql("{ subnet_endpoints(netuid: 999) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints, null);
+  });
+
+  test("a negative netuid is a BAD_USER_INPUT GraphQL error", async () => {
+    const { body } = await gql("{ subnet_endpoints(netuid: -1) }");
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+  });
+
+  test("is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_endpoints, 5);
+  });
+
+  test("combines two filters (kind + status) (#7869)", async () => {
+    const { status, body } = await gql(
+      '{ subnet_endpoints(netuid: 5, kind: "subnet-api", status: "ok") }',
+      FILTER_ENV(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const out = body.data.subnet_endpoints;
+    assert.equal(out.returned, 2);
+    assert.deepEqual(
+      out.endpoints.map((e: Row) => e.id),
+      ["alpha-api", "beta-api"],
+    );
+  });
+
+  test("filters by provider, pool_eligible, and score range (#7869)", async () => {
+    const { body } = await gql(
+      '{ subnet_endpoints(netuid: 5, provider: "alpha", pool_eligible: "true") }',
+      FILTER_ENV(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_endpoints.returned, 1);
+    assert.equal(body.data.subnet_endpoints.endpoints[0].id, "alpha-api");
+
+    const byScore = await gql(
+      "{ subnet_endpoints(netuid: 5, min_score: 85) }",
+      FILTER_ENV(),
+    );
+    assert.equal(byScore.body.errors, undefined);
+    assert.deepEqual(
+      byScore.body.data.subnet_endpoints.endpoints.map((e: Row) => e.id).sort(),
+      ["alpha-api", "beta-api"],
+    );
+  });
+
+  test("sorts, pages, and round-trips next_cursor (#7869)", async () => {
+    const first = await gql(
+      '{ subnet_endpoints(netuid: 5, kind: "subnet-api", sort: "provider", order: "asc", limit: 1) }',
+      FILTER_ENV(),
+    );
+    assert.equal(first.body.errors, undefined);
+    const page1 = first.body.data.subnet_endpoints;
+    assert.equal(page1.total, 2);
+    assert.equal(page1.returned, 1);
+    assert.equal(page1.endpoints[0].id, "alpha-api");
+    assert.equal(page1.next_cursor, 1);
+
+    const second = await gql(
+      '{ subnet_endpoints(netuid: 5, kind: "subnet-api", sort: "provider", order: "asc", limit: 1, cursor: 1) }',
+      FILTER_ENV(),
+    );
+    const page2 = second.body.data.subnet_endpoints;
+    assert.equal(page2.endpoints[0].id, "beta-api");
+    assert.equal(page2.next_cursor, null);
+  });
+
+  test("an unsupported filter or sort value is a GraphQL error (#7869)", async () => {
+    const badKind = await gql(
+      '{ subnet_endpoints(netuid: 5, kind: "bogus") }',
+      FILTER_ENV(),
+    );
+    assert.ok(badKind.body.errors, "expected a GraphQL error for kind");
+    assert.equal(badKind.body.errors[0].extensions.code, "BAD_USER_INPUT");
+
+    const badSort = await gql(
+      '{ subnet_endpoints(netuid: 5, sort: "not_a_column") }',
+      FILTER_ENV(),
+    );
+    assert.ok(badSort.body.errors, "expected a GraphQL error for sort");
+    assert.equal(badSort.body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("an unexpected loader failure propagates (#7869)", async () => {
+    // Only the loader's own toolErrors map to null/BAD_USER_INPUT; anything
+    // else is a real fault and must surface rather than being masked as
+    // "no endpoints baked".
+    const spy = vi
+      .spyOn(subnetEndpointsMcp, "loadSubnetEndpointsList")
+      .mockRejectedValue(new Error("loader exploded"));
+    try {
+      const { body } = await gql(
+        "{ subnet_endpoints(netuid: 5) }",
+        FILTER_ENV(),
+      );
+      assert.ok(body.errors, "expected the raw failure to surface");
+      assert.match(body.errors[0].message, /loader exploded/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("graphql — nested Subnet.endpoints filter/sort/page (#7869)", () => {
+  function nestedEndpointsEnv(reads?: Map<string, number>) {
+    return fixtureEnv(
+      {
+        "/metagraph/subnets/7.json": {
+          subnet: { netuid: 7, name: "Allways", slug: "allways" },
+          surfaces: [],
+          endpoints: [
+            {
+              id: "e-a",
+              netuid: 7,
+              kind: "subnet-api",
+              provider: "alpha",
+              status: "ok",
+            },
+            {
+              id: "e-b",
+              netuid: 7,
+              kind: "openapi",
+              provider: "alpha",
+              status: "degraded",
+            },
+            {
+              id: "e-c",
+              netuid: 7,
+              kind: "subnet-api",
+              provider: "beta",
+              status: "ok",
+            },
+          ],
+        },
+      },
+      reads ? { reads } : {},
+    ) as unknown as Env;
+  }
+
+  test("filters the bundled list by kind (#7869)", async () => {
+    const { status, body } = await gql(
+      `{ subnet(netuid: 7) { endpoints(kind: "subnet-api") { id kind } } }`,
+      nestedEndpointsEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(
+      body.data.subnet.endpoints.map((e: Row) => e.id),
+      ["e-a", "e-c"],
+    );
+  });
+
+  test("combines a filter with sort + order + limit + cursor (#7869)", async () => {
+    const first = await gql(
+      `{ subnet(netuid: 7) { endpoints(kind: "subnet-api", sort: "provider", order: "asc", limit: 1) { id } } }`,
+      nestedEndpointsEnv(),
+    );
+    assert.equal(first.body.errors, undefined);
+    assert.deepEqual(
+      first.body.data.subnet.endpoints.map((e: Row) => e.id),
+      ["e-a"],
+    );
+
+    const second = await gql(
+      `{ subnet(netuid: 7) { endpoints(kind: "subnet-api", sort: "provider", order: "asc", limit: 1, cursor: 1) { id } } }`,
+      nestedEndpointsEnv(),
+    );
+    assert.deepEqual(
+      second.body.data.subnet.endpoints.map((e: Row) => e.id),
+      ["e-c"],
+    );
+  });
+
+  test("returns the full list unchanged with no arguments (#7869)", async () => {
+    const { body } = await gql(
+      "{ subnet(netuid: 7) { endpoints { id } } }",
+      nestedEndpointsEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(
+      body.data.subnet.endpoints.map((e: Row) => e.id),
+      ["e-a", "e-b", "e-c"],
+    );
+  });
+
+  test("rejects an unsupported filter or sort (#7869)", async () => {
+    for (const arg of ['kind: "bogus"', 'sort: "not_a_column"']) {
+      const { body } = await gql(
+        `{ subnet(netuid: 7) { endpoints(${arg}) { id } } }`,
+        nestedEndpointsEnv(),
+      );
+      assert.ok(body.errors, `expected a GraphQL error for ${arg}`);
+      assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+    }
+  });
+
+  test("still filters the lazily-loaded list (#7869)", async () => {
+    // A subnet reached through the list has no bundled endpoints -- the thunk
+    // loads them per-netuid. Filtering must apply to that path too, not
+    // collapse it to an empty list.
+    const env = fixtureEnv({
+      "/metagraph/subnets.json": {
+        subnets: [{ netuid: 7, name: "Allways", slug: "allways" }],
+      },
+      "/metagraph/endpoints.json": {
+        endpoints: [
+          { id: "e-a", netuid: 7, kind: "subnet-api", provider: "alpha" },
+          { id: "e-b", netuid: 7, kind: "openapi", provider: "alpha" },
+        ],
+      },
+    });
+    const { body } = await gql(
+      `{ subnets { items { netuid endpoints(kind: "openapi") { id kind } } } }`,
+      env as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    const item = body.data.subnets.items[0];
+    assert.deepEqual(
+      item.endpoints.map((e: Row) => e.id),
+      ["e-b"],
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

`GET /api/v1/subnets/{netuid}/endpoints` and the `list_subnet_endpoints` MCP tool expose one subnet's endpoint/resource registry with full REST filter/sort/page parity, but GraphQL had no equivalent. The only per-subnet endpoint access was the nested `Subnet.endpoints` field, which took no arguments and always returned the full list.

This adds a root `subnet_endpoints(netuid, ...)` field and parameterizes the nested `Subnet.endpoints` field, both wired to the shared list-query engine — the same pattern the just-merged `subnet_candidates` (#7878/#8044) and nested `Subnet.surfaces` (#7885/#8037) fields established.

Closes #7869

## What this adds

**Root `subnet_endpoints(netuid: Int!, ...)` → `JSON`**
- Reuses `loadSubnetEndpointsList` unchanged — the exact loader `list_subnet_endpoints` calls — so REST, MCP, and GraphQL share one filter/sort/page contract and cannot drift. It reads the baked per-subnet `/metagraph/endpoints/{netuid}.json` artifact (distinct from the network-wide `endpoints(...)` registry).
- Filters: `kind`, `layer`, `provider`, `publication_state`, `status`, `pool_eligible` (a `true`/`false` string, matching the reused loader's enum); ranges `min_/max_latency_ms` and `min_/max_score`; `fields` projection; `sort` + `order`; `limit` (1–100) / `cursor` (Int).
- Returns the same pagination envelope REST returns: `{ endpoints, total, returned, limit, cursor, next_cursor, sort, order }`.
- A cold/absent per-subnet artifact stays `null` (the documented per-subnet contract, mirroring `subnet_candidates`), never a silently substituted empty list. An invalid `netuid` or an unsupported filter/sort value surfaces as a `BAD_USER_INPUT` GraphQL error — not swallowed to `[]`.

**Nested `Subnet.endpoints(...)` → `[Endpoint!]!`**
- Gains the same filter/sort/page arguments, filtered through `applyQueryFilters` against the shared `endpoints` query-collection config (the same one the root `endpoints(...)` field #7887 uses), so the allowlists cannot drift.
- Mirrors the nested `Subnet.surfaces` implementation (#7885): an explicit resolve is attached to the built schema (a nested field needs one to see its own args), and it awaits the parent thunk first so **both** the bundled (single-subnet detail artifact) and lazy (per-netuid list) paths keep working — adding arguments does not collapse the lazy path to an empty list.
- With no arguments the full list passes through unchanged. An unsupported filter/sort is a `BAD_USER_INPUT` error. `pool_eligible` is a `Boolean` here and `cursor` is `Int` (offset), matching the sibling nested field.

## Schema / tooling notes

- `generated/graphql/types.ts` regenerated via `npm run build:graphql-types`; `npm run validate:graphql-types-drift` passes (types are current with the SDL).
- The `endpoints` collection's valid `sort` fields are `kind`, `last_checked`, `latency_ms`, `layer`, `netuid`, `pool_eligible`, `provider`, `publication_state`, `score`, `status` (no `id`) — reflected in the tests.
- `subnet_endpoints` is registered in `FIELD_COMPLEXITY` as a fan-out (relationship) field, matching `subnet_candidates`.

## Tests

Added to `tests/graphql.test.ts`, covering every added runtime line and branch (100% patch coverage):
- Root: baked-artifact resolution; `null` on absent artifact; negative-netuid and unsupported-filter/sort → `BAD_USER_INPUT`; combined filters; provider / `pool_eligible` / score-range filtering; sort + page + `next_cursor` round-trip; unexpected-loader-failure propagation; complexity weight.
- Nested: filter by kind; filter + sort + limit + cursor paging; full list with no args; unsupported filter/sort → `BAD_USER_INPUT`; filtering the lazily-loaded (non-bundled) path.

Local gates green: `vitest run tests/graphql.test.ts` (1015 pass), `eslint`, `prettier --check`, `tsc --noEmit` (no new errors), `validate:graphql-types-drift`, and the public-safety scan.
