### PR TITLE
feat(api): GraphQL search_index filter/sort/page parity

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2596,8 +2596,8 @@ export type Query = {
   schemas?: Maybe<Scalars['JSON']['output']>;
   /** The full compact search index: one document per subnet/surface/provider/doc, each with its id, type, title, subtitle, url, and the per-document token blob that widens server-side recall. Filter by type/netuid, keyword-search with q, sort with sort/order, and page with limit (1-100)/cursor -- the same list-query transforms REST and MCP apply. An invalid type/sort/order/limit/cursor is a GraphQL error, not a silently substituted default. Documents are heterogeneous by type, so each is passed through as opaque JSON. Mirrors GET /api/v1/search. */
   search: SearchDocumentList;
-  /** The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index. */
-  search_index: SearchDocumentList;
+  /** The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Filter by type/netuid/q, sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Mirrors GET /api/v1/search-index. */
+  search_index: SearchIndexList;
   /** The per-provider source-health rollup: for each provider/source, the candidate-surface count and its live/redirected/dead classification, endpoint and RPC-endpoint counts, verification-result count, and an overall status. Null when the rollup has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_source_health MCP/REST shape. Mirrors GET /api/v1/source-health. */
   source_health?: Maybe<Scalars['JSON']['output']>;
   /** Per-source input-hash ledger -- each registry data source's captured input hash and record count at ingest time, for detecting hash drift or seeing per-source contribution volume. Filter with q (keyword search across id/kind/path), sort with sort/order, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/source-snapshots. */
@@ -3506,8 +3506,13 @@ export type QuerySearchArgs = {
 
 
 export type QuerySearch_IndexArgs = {
-  cursor?: InputMaybe<Scalars['String']['input']>;
+  cursor?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  q?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4124,6 +4129,20 @@ export type SearchDocumentList = {
   /** Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON. */
   documents: Array<Scalars['JSON']['output']>;
   next_cursor?: Maybe<Scalars['String']['output']>;
+  total: Scalars['Int']['output'];
+};
+
+/** Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index). */
+export type SearchIndexList = {
+  __typename?: 'SearchIndexList';
+  cursor: Scalars['Int']['output'];
+  documents: Array<Scalars['JSON']['output']>;
+  generated_at?: Maybe<Scalars['String']['output']>;
+  limit: Scalars['Int']['output'];
+  next_cursor?: Maybe<Scalars['Int']['output']>;
+  order?: Maybe<Scalars['String']['output']>;
+  returned: Scalars['Int']['output'];
+  sort?: Maybe<Scalars['String']['output']>;
   total: Scalars['Int']['output'];
 };
 
@@ -5451,6 +5470,7 @@ export type ResolversTypes = ResolversObject<{
   RuntimeVersionHistory: ResolverTypeWrapper<RuntimeVersionHistory>;
   ScoreDistribution: ResolverTypeWrapper<ScoreDistribution>;
   SearchDocumentList: ResolverTypeWrapper<SearchDocumentList>;
+  SearchIndexList: ResolverTypeWrapper<SearchIndexList>;
   SourceSnapshotList: ResolverTypeWrapper<SourceSnapshotList>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   Subnet: ResolverTypeWrapper<Subnet>;
@@ -5740,6 +5760,7 @@ export type ResolversParentTypes = ResolversObject<{
   RuntimeVersionHistory: RuntimeVersionHistory;
   ScoreDistribution: ScoreDistribution;
   SearchDocumentList: SearchDocumentList;
+  SearchIndexList: SearchIndexList;
   SourceSnapshotList: SourceSnapshotList;
   String: Scalars['String']['output'];
   Subnet: Subnet;
@@ -7847,7 +7868,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   saved_query?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, RequireFields<QuerySaved_QueryArgs, 'id'>>;
   schemas?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   search?: Resolver<ResolversTypes['SearchDocumentList'], ParentType, ContextType, Partial<QuerySearchArgs>>;
-  search_index?: Resolver<ResolversTypes['SearchDocumentList'], ParentType, ContextType, Partial<QuerySearch_IndexArgs>>;
+  search_index?: Resolver<ResolversTypes['SearchIndexList'], ParentType, ContextType, Partial<QuerySearch_IndexArgs>>;
   source_health?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   source_snapshots?: Resolver<ResolversTypes['SourceSnapshotList'], ParentType, ContextType, Partial<QuerySource_SnapshotsArgs>>;
   subnet?: Resolver<Maybe<ResolversTypes['Subnet']>, ParentType, ContextType, RequireFields<QuerySubnetArgs, 'netuid'>>;
@@ -8097,6 +8118,18 @@ export type ScoreDistributionResolvers<ContextType = GqlContext, ParentType exte
 export type SearchDocumentListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SearchDocumentList'] = ResolversParentTypes['SearchDocumentList']> = ResolversObject<{
   documents?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type SearchIndexListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SearchIndexList'] = ResolversParentTypes['SearchIndexList']> = ResolversObject<{
+  cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  documents?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
@@ -9147,6 +9180,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   RuntimeVersionHistory?: RuntimeVersionHistoryResolvers<ContextType>;
   ScoreDistribution?: ScoreDistributionResolvers<ContextType>;
   SearchDocumentList?: SearchDocumentListResolvers<ContextType>;
+  SearchIndexList?: SearchIndexListResolvers<ContextType>;
   SourceSnapshotList?: SourceSnapshotListResolvers<ContextType>;
   Subnet?: SubnetResolvers<ContextType>;
   SubnetAxonRemovals?: SubnetAxonRemovalsResolvers<ContextType>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -114,8 +114,16 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: Int
     ): SearchDocumentList!
-    "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Mirrors GET /api/v1/search-index."
-    search_index(limit: Int, cursor: String): SearchDocumentList!
+    "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Filter by type/netuid/q, sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Mirrors GET /api/v1/search-index."
+    search_index(
+      type: String
+      netuid: Int
+      q: String
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): SearchIndexList!
     "The per-domain rollup overview: every tag in the fixed 14-tag capability taxonomy with its member subnet count, total stake, total emission share, and within-domain emission concentration. Computed live from the subnets index + economics tier. Mirrors GET /api/v1/domains."
     domains: DomainOverview!
     "One domain/capability tag's own rollup. tag must be one of the 14 fixed domain tags (the same enum ?domain= validates on subnets); an unknown tag is a BAD_USER_INPUT error. Mirrors GET /api/v1/domains/{tag}/summary."
@@ -2895,6 +2903,19 @@ export const SDL = /* GraphQL */ `
     documents: [JSON!]!
     total: Int!
     next_cursor: String
+  }
+
+  "Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index)."
+  type SearchIndexList {
+    documents: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+    generated_at: String
   }
 
   "One domain/capability tag's rollup (#6989). Mirrors GET /api/v1/domains/{tag}/summary."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -28,6 +28,11 @@ import { loadEvidenceList } from "./evidence-mcp.ts";
 // baked /metagraph/search.json read + list-query transforms REST and MCP
 // already apply) -- not a reimplementation.
 import { loadSearchList } from "./search-mcp.ts";
+// #7877: GraphQL parity for the search_index field's type/netuid/q/sort/order
+// filters, reusing list_search_index's own loadSearchIndexList loader unchanged
+// (same baked /metagraph/search-index.json read + list-query transforms REST
+// and MCP already apply) -- not a reimplementation.
+import { loadSearchIndexList } from "./search-index-mcp.ts";
 // #7171: GraphQL parity for GET /api/v1/chain-events (paginated Query feed),
 // reusing loadChainEventsFeed that MCP list_chain_events already calls.
 // Distinct from Subscription.chainEvents (live WebSocket firehose).
@@ -3316,15 +3321,13 @@ const rootValue = {
     return loadSearchList(mcpCtx(context), args, { readArtifact });
   },
 
-  search_index({ limit, cursor }: Row, context: GqlContext) {
-    // The slim companion: identical documents minus the per-document token
-    // blobs, served from its own artifact exactly as REST serves it.
-    return listPage(context, ARTIFACT.searchIndex, "documents", {
-      limit,
-      cursor,
-      resultKey: "documents",
-      keyFn: (d: Row) => d.id,
-    });
+  // #7877: reuse loadSearchIndexList (the same loader MCP list_search_index +
+  // REST GET /api/v1/search-index call) unchanged. type/netuid/q/sort/order/
+  // limit/cursor validation and filtering are all handled by the loader --
+  // an invalid arg throws and becomes a GraphQL error, matching every other
+  // filtered field's convention (search/source_snapshots/evidence/profiles).
+  search_index(args: Row, context: GqlContext) {
+    return loadSearchIndexList(mcpCtx(context), args, { readArtifact });
   },
 
   async domains(_args: unknown, context: GqlContext) {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8763,7 +8763,48 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     assert.equal(body.data.search_index.documents.length, 1);
     // The slim index drops the per-document token blob the full index keeps.
     assert.equal(body.data.search_index.documents[0].tokens, undefined);
-    assert.ok(body.data.search_index.next_cursor);
+    // next_cursor is an integer offset (1) from loadSearchIndexList (#7877)
+    assert.equal(body.data.search_index.next_cursor, 1);
+  });
+
+  test("search_index q filter narrows documents by keyword (#7877)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/search-index.json": {
+        documents: [
+          { id: "subnet:1", type: "subnet", title: "Alpha network" },
+          { id: "subnet:2", type: "subnet", title: "Beta protocol" },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      '{ search_index(q: "Alpha") { documents total returned } }',
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.search_index.total, 1);
+    assert.equal(body.data.search_index.returned, 1);
+    assert.equal(body.data.search_index.documents[0].id, "subnet:1");
+  });
+
+  test("search_index type and netuid filters combine with AND semantics (#7877)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/search-index.json": {
+        documents: [
+          { id: "subnet:1", type: "subnet", netuid: 1, title: "Alpha" },
+          { id: "subnet:2", type: "subnet", netuid: 2, title: "Beta" },
+          { id: "provider:datura", type: "provider", title: "Datura" },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      '{ search_index(type: "subnet", netuid: 1) { documents total returned } }',
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.search_index.total, 1);
+    assert.equal(body.data.search_index.documents[0].id, "subnet:1");
   });
 
   test("search errors on a cold artifact, matching REST/MCP (#7876)", async () => {


### PR DESCRIPTION
## Summary

Adds `type`, `netuid`, `q`, `sort`, and `order` to the GraphQL `search_index` field so it matches `list_search_index` / `GET /api/v1/search-index`.

Closes #7877

## Why previous PRs were closed

| PR | Closed reason |
|---|---|
| [#7989](https://github.com/JSONbored/metagraphed/pull/7989) | **CI failing** (`checks`, `test`) — auto-closed |
| [#8001](https://github.com/JSONbored/metagraphed/pull/8001) | **CI failing** (`checks`) — auto-closed |
| [#8012](https://github.com/JSONbored/metagraphed/pull/8012) | **Base-branch conflicts** (`DIRTY`) — CI green, review approved; gate could not merge |

Reimplementation on a fresh branch off current `main` (no competing open PR). SDL lives in `graphql-sdl.ts` (split from the monolithic file #8012 targeted).

## What changed (4 files)

### `src/graphql-sdl.ts`

- `search_index` args: `type`, `netuid`, `q`, `sort`, `order`, `limit`, `cursor` (`cursor: Int`, matching REST/MCP)
- New `SearchIndexList` return type with full list-query pagination meta (`returned`/`limit`/`cursor`/`next_cursor`/`sort`/`order`/`generated_at`)

### `src/graphql.ts`

- Resolver delegates to `loadSearchIndexList` (same loader MCP `list_search_index` + REST already use) — no local filter logic

### `generated/graphql/types.ts`

- Regenerated (`npm run build:graphql-types`)

### `tests/graphql.test.ts`

- Existing slim-artifact test expects integer `next_cursor`
- Keyword `q` filter test
- `type` + `netuid` AND-combination test

## Validation

- [x] `vitest run tests/graphql.test.ts -t 'search_index'` — 3/3 passed
- [x] `vitest run tests/graphql.test.ts -t 'discovery parity'` — 16/16 passed
- [ ] Gittensory Gate + full CI green (incl. `codecov/patch` ≥99%)

## Test plan

- [ ] `search_index(q: "…")` narrows documents by keyword
- [ ] `search_index(type: "subnet", netuid: N)` combines filters with AND
- [ ] `search_index(limit: 1)` returns integer `next_cursor` pagination
- [ ] Invalid `sort` / `type` / `limit` / `cursor` surface as GraphQL errors
