### PR TITLE
refactor(ui): tokenize bg-card/NN opacity one-offs into surface-translucency tiers

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -127,6 +127,19 @@ const Z_INDEX_RULES = [
   },
 ];
 
+// #7842: ad-hoc bg-card/NN opacity fractions collapsed into two named
+// surface-translucency tiers (styles.css): .mg-glass (the sticky-header/
+// drawer-shell blur idiom) and .mg-glass-soft (flat 60%, no blur). A small,
+// documented set of sites couldn't cleanly snap to either tier and were left
+// as bare fractions with an inline comment -- those will still warn here,
+// same residual-worklist convention the other token rules already use.
+const GLASS_SURFACE_RULES = [
+  {
+    selector: "Literal[value=/\\bbg-card\\/[0-9]+\\b/]",
+    message: "Raw bg-card opacity. Use .mg-glass or .mg-glass-soft (see styles.css).",
+  },
+];
+
 export default tseslint.config(
   // .source is fumadocs-mdx's generated content collection output (see
   // source.config.ts) -- codegen, not authored code, same treatment as dist.
@@ -196,6 +209,7 @@ export default tseslint.config(
         ...SSR_SAFETY_RULES,
         ...ELEVATION_RULES,
         ...Z_INDEX_RULES,
+        ...GLASS_SURFACE_RULES,
       ],
     },
   },

--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -168,6 +168,10 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
       {availableNetuids.length > 0 ? (
         <div className="flex flex-wrap items-center gap-2">
           <span className="mg-type-micro text-ink-muted">scope</span>
+          {/* #7842: documented exception -- 80% doesn't cleanly snap to either
+              glass tier (mg-glass would add unwanted blur; mg-glass-soft's 60%
+              visibly lightens this segmented-toggle track). Kept as a bare
+              fraction rather than a wrong tier. */}
           <div className="inline-flex flex-wrap rounded-full border border-border/80 bg-card/80 p-1 shadow-[var(--mg-shadow-pill)]">
             <button
               type="button"

--- a/apps/ui/src/components/metagraphed/analytics/time-range-scrub.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/time-range-scrub.tsx
@@ -27,7 +27,7 @@ export function TimeRangeScrub({
   return (
     <div
       className={classNames(
-        "inline-flex items-center rounded border border-border bg-card/60 p-0.5",
+        "inline-flex items-center rounded border border-border mg-glass-soft p-0.5",
         className,
       )}
       role="radiogroup"

--- a/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
+++ b/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
@@ -118,7 +118,7 @@ export function CallModuleExtrinsicsTable({
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
+          <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Hash</th>
               <th className="px-4 py-2.5">Block</th>

--- a/apps/ui/src/components/metagraphed/delegate-cta.tsx
+++ b/apps/ui/src/components/metagraphed/delegate-cta.tsx
@@ -61,7 +61,7 @@ export function DelegateCTA({ netuid, variant = "inline", className }: Props) {
     return (
       <Link
         to="/delegate"
-        className={`inline-flex items-center gap-1.5 rounded-full border border-border bg-card/50 text-sm font-medium text-ink hover:border-ink/30 hover:text-ink-strong transition-colors ${className ?? "px-3.5 py-1.5 text-[12px]"}`}
+        className={`inline-flex items-center gap-1.5 rounded-full border border-border mg-glass-soft text-sm font-medium text-ink hover:border-ink/30 hover:text-ink-strong transition-colors ${className ?? "px-3.5 py-1.5 text-[12px]"}`}
       >
         <Coins aria-hidden className="size-3.5" />
         Delegate & Earn

--- a/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
@@ -171,7 +171,7 @@ export function EndpointOperationalList({
               </div>
             </header>
 
-            <div className="border-y border-border bg-card/40">
+            <div className="border-y border-border mg-glass-soft">
               {group.rows.map((endpoint, idx) => {
                 const open = expandedId === endpoint.id;
                 const providerSlug = endpoint.provider_slug;

--- a/apps/ui/src/components/metagraphed/hero-subnet-chips.tsx
+++ b/apps/ui/src/components/metagraphed/hero-subnet-chips.tsx
@@ -78,6 +78,10 @@ export function HeroSubnetChips({ limit = 14 }: { limit?: number }) {
             role="listitem"
             className={classNames(
               "mg-metric-tile mg-focus-ring snap-start shrink-0",
+              // #7842: documented exception -- 80% doesn't cleanly snap to either
+              // glass tier (mg-glass would add unwanted blur + drop to 80/95%
+              // depending on browser support; mg-glass-soft's 60% visibly lightens
+              // this chip). Kept as a bare fraction rather than a wrong tier.
               "inline-flex items-center gap-2 rounded-full border border-border bg-card/80",
               "px-2.5 py-1.5 hover:border-accent/40 transition-colors",
             )}

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -421,7 +421,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                 </div>
               </div>
 
-              <div className="mx-3 mb-2 rounded-lg border border-border/60 bg-card/50 px-3 py-2">
+              <div className="mx-3 mb-2 rounded-lg border border-border/60 mg-glass-soft px-3 py-2">
                 <p className="text-[11px] text-ink-muted leading-relaxed">
                   <span className="font-medium text-ink">Paste anything:</span> wallet address
                   (ss58), block number, transaction hash (0x…) or block hash to jump directly.

--- a/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
@@ -180,7 +180,7 @@ function EvidenceSection({
   if (links.length === 0) return null;
 
   return (
-    <div className="rounded-lg border border-border bg-card/60 p-3">
+    <div className="rounded-lg border border-border mg-glass-soft p-3">
       <div className="mb-2 flex items-center gap-2 mg-type-micro text-ink-muted">
         evidence &amp; sources
         <InfoTooltip label="Where the snapshot diff was derived from. Open or copy these to verify the change against the source." />

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -66,7 +66,7 @@ export function ShortcutsPopover() {
               aria-label="Keyboard shortcuts"
               className={classNames(
                 "hidden md:inline-flex fixed z-[var(--mg-z-overlay)] bottom-5 left-5 md:bottom-7 md:left-7",
-                "items-center justify-center rounded-full border border-border bg-card/95 backdrop-blur",
+                "items-center justify-center rounded-full border border-border mg-glass",
                 "size-10 text-ink-muted shadow-[var(--mg-shadow-pop)]",
                 "hover:border-accent/60 hover:text-accent transition-colors",
               )}

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -24,7 +24,7 @@ export function SubnetsCompareDrawer() {
       <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
         <div
           className={classNames(
-            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[var(--mg-shadow-drawer)]",
+            "pointer-events-auto rounded-xl border border-border mg-glass shadow-[var(--mg-shadow-drawer)]",
             "mg-fade-in",
           )}
         >
@@ -229,9 +229,9 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
     <div className="border-t border-border max-h-[55vh] overflow-auto">
       <table className="min-w-full text-[12px]">
         {/* local stacking context: sticky corner cell over sticky row/col — not a global layer (#7841) */}
-        <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
+        <thead className="sticky top-0 mg-glass z-[1]">
           <tr>
-            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left mg-type-micro text-ink-muted backdrop-blur">
+            <th className="sticky left-0 z-[2] w-40 mg-glass px-3 py-2 text-left mg-type-micro text-ink-muted">
               Metric
             </th>
             {netuids.map((n) => (

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -65,7 +65,7 @@ export function ValidatorGuide() {
   const [open, setOpen] = useState(false);
 
   return (
-    <aside aria-label={HEADING} className="mb-6 rounded-lg border border-border bg-card/60">
+    <aside aria-label={HEADING} className="mb-6 rounded-lg border border-border mg-glass-soft">
       {/* Desktop / tablet: collapsible callout with the full grid. */}
       <div className="hidden sm:block">
         <button

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -114,7 +114,7 @@ export function ValidatorNominatorsTable({ queryOptions, search, setSearch }: Pr
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
+          <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Coldkey</th>
               <th className="px-4 py-2.5 text-right">Net staked</th>

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -28,7 +28,7 @@ export function ValidatorsCompareDrawer() {
       <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
         <div
           className={classNames(
-            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[var(--mg-shadow-drawer)]",
+            "pointer-events-auto rounded-xl border border-border mg-glass shadow-[var(--mg-shadow-drawer)]",
             "mg-fade-in",
           )}
         >
@@ -212,9 +212,9 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
     <div className="border-t border-border max-h-[55vh] overflow-auto">
       <table className="min-w-full text-[12px]">
         {/* local stacking context: sticky corner cell over sticky row/col — not a global layer (#7841) */}
-        <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
+        <thead className="sticky top-0 mg-glass z-[1]">
           <tr>
-            <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left mg-type-micro text-ink-muted backdrop-blur">
+            <th className="sticky left-0 z-[2] w-40 mg-glass px-3 py-2 text-left mg-type-micro text-ink-muted">
               Metric
             </th>
             {hotkeys.map((hotkey) => (

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -496,7 +496,7 @@ function BlocksTable() {
         ))}
         table={
           <table className="w-full text-left text-sm">
-            <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
+            <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
               <tr>
                 <th className="px-4 py-2.5">Block</th>
                 <th className="px-4 py-2.5">Hash</th>

--- a/apps/ui/src/routes/delegate.tsx
+++ b/apps/ui/src/routes/delegate.tsx
@@ -102,7 +102,7 @@ function DelegatePage() {
       </section>
 
       {/* Disclosure */}
-      <section className="mt-10 rounded-xl border border-border bg-card/60 p-4">
+      <section className="mt-10 rounded-xl border border-border mg-glass-soft p-4">
         <div className="mg-label mb-2">Disclosure</div>
         <p className="text-[13px] text-ink-muted leading-relaxed">{PARTNER_ORG.disclosure}</p>
       </section>
@@ -112,7 +112,7 @@ function DelegatePage() {
 
 function TrustCell({ icon, title, body }: { icon: React.ReactNode; title: string; body: string }) {
   return (
-    <div className="rounded-lg border border-border bg-card/60 px-4 py-3">
+    <div className="rounded-lg border border-border mg-glass-soft px-4 py-3">
       <div className="flex items-center gap-2 text-ink-strong">
         <span className="text-accent" aria-hidden>
           {icon}

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -304,7 +304,7 @@ function ExtrinsicsTable() {
       ))}
       table={
         <table className="w-full text-left text-sm">
-          <thead className="sticky top-0 z-[var(--mg-z-sticky)] bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[var(--mg-shadow-hairline)]">
+          <thead className="sticky top-0 z-[var(--mg-z-sticky)] mg-glass shadow-[var(--mg-shadow-hairline)]">
             <tr>
               <th className="px-4 py-2.5">Hash</th>
               <th className="px-4 py-2.5">Block</th>

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -683,7 +683,7 @@ function BackToTop({ threshold = 600 }) {
       tabIndex: visible ? 0 : -1,
       className: classNames(
         "fixed z-[var(--mg-z-overlay)] bottom-5 right-5 md:bottom-7 md:right-7",
-        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
+        "inline-flex items-center gap-1.5 rounded-full border border-border mg-glass",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
         "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",
         "transition-[opacity,transform,border-color,color] duration-200",
@@ -2954,7 +2954,7 @@ function MethodologyCallout({
     "aside",
     {
       "aria-label": "Data freshness and methodology",
-      className: "mb-6 rounded-lg border border-border bg-card/60",
+      className: "mb-6 rounded-lg border border-border mg-glass-soft",
       children: [
         /* @__PURE__ */ jsxRuntime.jsxs(
           "button",
@@ -5474,7 +5474,7 @@ function QueryBarRoot({
       className: classNames(
         "mg-query-shell",
         "flex w-full items-center gap-1 min-w-0",
-        "h-10 rounded-lg border border-border bg-card/60",
+        "h-10 rounded-lg border border-border mg-glass-soft",
         "px-1 transition-colors",
         "focus-within:border-[color-mix(in_oklab,var(--accent)_45%,var(--border))]",
         "focus-within:ring-2 focus-within:ring-ring/60",

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -188,6 +188,20 @@
   --mg-z-progress: 60;
   --mg-z-skip-link: 100;
 }
+.mg-glass {
+  background: color-mix(in oklab, var(--card) 95%, transparent);
+}
+@supports (backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0)) {
+  .mg-glass {
+    background: color-mix(in oklab, var(--card) 80%, transparent);
+  }
+}
+.mg-glass {
+  backdrop-filter: blur(8px);
+}
+.mg-glass-soft {
+  background: color-mix(in oklab, var(--card) 60%, transparent);
+}
 .dark {
   --paper: oklch(0.14 0.003 250);
   --surface: oklch(0.175 0.003 250);

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -654,7 +654,7 @@ function BackToTop({ threshold = 600 }) {
       tabIndex: visible ? 0 : -1,
       className: classNames(
         "fixed z-[var(--mg-z-overlay)] bottom-5 right-5 md:bottom-7 md:right-7",
-        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
+        "inline-flex items-center gap-1.5 rounded-full border border-border mg-glass",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
         "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",
         "transition-[opacity,transform,border-color,color] duration-200",
@@ -2925,7 +2925,7 @@ function MethodologyCallout({
     "aside",
     {
       "aria-label": "Data freshness and methodology",
-      className: "mb-6 rounded-lg border border-border bg-card/60",
+      className: "mb-6 rounded-lg border border-border mg-glass-soft",
       children: [
         /* @__PURE__ */ jsxs(
           "button",
@@ -5445,7 +5445,7 @@ function QueryBarRoot({
       className: classNames(
         "mg-query-shell",
         "flex w-full items-center gap-1 min-w-0",
-        "h-10 rounded-lg border border-border bg-card/60",
+        "h-10 rounded-lg border border-border mg-glass-soft",
         "px-1 transition-colors",
         "focus-within:border-[color-mix(in_oklab,var(--accent)_45%,var(--border))]",
         "focus-within:ring-2 focus-within:ring-ring/60",

--- a/packages/ui-kit/eslint.config.ts
+++ b/packages/ui-kit/eslint.config.ts
@@ -82,6 +82,14 @@ const DESIGN_RULES = [
     message:
       "Raw z-index step. Use one of the --mg-z-* layer tokens (see styles.css).",
   },
+  {
+    // #7842: ad-hoc bg-card/NN opacity fractions collapsed into two named
+    // surface-translucency tiers (styles.css): .mg-glass (the sticky-header/
+    // drawer-shell blur idiom) and .mg-glass-soft (flat 60%, no blur).
+    selector: "Literal[value=/\\bbg-card\\/[0-9]+\\b/]",
+    message:
+      "Raw bg-card opacity. Use .mg-glass or .mg-glass-soft (see styles.css).",
+  },
 ];
 
 // SSR footguns -- see apps/ui/docs/ssr-safety.md. ui-kit's own components

--- a/packages/ui-kit/src/components/metagraphed/back-to-top.tsx
+++ b/packages/ui-kit/src/components/metagraphed/back-to-top.tsx
@@ -64,7 +64,7 @@ export function BackToTop({ threshold = 600 }: { threshold?: number }) {
       tabIndex={visible ? 0 : -1}
       className={classNames(
         "fixed z-[var(--mg-z-overlay)] bottom-5 right-5 md:bottom-7 md:right-7",
-        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card/95 backdrop-blur",
+        "inline-flex items-center gap-1.5 rounded-full border border-border mg-glass",
         "px-3 py-2 mg-type-label uppercase text-ink-strong",
         "shadow-[var(--mg-shadow-pop)] hover:border-accent/60 hover:text-accent",
         "transition-[opacity,transform,border-color,color] duration-200",

--- a/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
+++ b/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
@@ -29,7 +29,7 @@ export function MethodologyCallout({
   return (
     <aside
       aria-label="Data freshness and methodology"
-      className="mb-6 rounded-lg border border-border bg-card/60"
+      className="mb-6 rounded-lg border border-border mg-glass-soft"
     >
       <button
         type="button"

--- a/packages/ui-kit/src/components/metagraphed/query-bar.tsx
+++ b/packages/ui-kit/src/components/metagraphed/query-bar.tsx
@@ -65,7 +65,7 @@ function QueryBarRoot({
       className={classNames(
         "mg-query-shell",
         "flex w-full items-center gap-1 min-w-0",
-        "h-10 rounded-lg border border-border bg-card/60",
+        "h-10 rounded-lg border border-border mg-glass-soft",
         "px-1 transition-colors",
         "focus-within:border-[color-mix(in_oklab,var(--accent)_45%,var(--border))]",
         "focus-within:ring-2 focus-within:ring-ring/60",

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -371,6 +371,41 @@
   --mg-z-skip-link: 100; /* a11y skip-link -- must beat everything */
 }
 
+/* ============================================================
+ * Surface-translucency tiers (#7842) — the recurring
+ * `bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80` idiom
+ * (copy-pasted across every sticky table header and the compare-drawer
+ * shells) collapsed into one class, plus a second, blur-free tier for the
+ * softer `bg-card/60` inset panels. Both compose var(--card), so they
+ * theme automatically -- no separate dark-mode override needed.
+ * ============================================================ */
+.mg-glass {
+  background: color-mix(in oklab, var(--card) 95%, transparent);
+}
+@supports (backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0)) {
+  .mg-glass {
+    background: color-mix(in oklab, var(--card) 80%, transparent);
+  }
+}
+/* Kept as its own unconditional, unnested rule rather than folded into the
+   @supports block above -- the CSS build (Lightning CSS, via tsup, and again
+   via apps/ui's own Tailwind pipeline) nests an additional color-mix()
+   feature-query fallback inside that block, which doesn't mix cleanly with
+   backdrop-filter there. A plain unsupported `backdrop-filter` declaration is
+   simply ignored by browsers that lack it, so this alone still achieves the
+   same progressive-enhancement result. No -webkit- fallback: Safari has
+   shipped unprefixed backdrop-filter since 18 (2024), and Lightning CSS's
+   minifier collapses two textually-identical blur(8px) declarations down to
+   just the prefixed one when both are present -- dropping the standard
+   property entirely, which is the opposite of what every other browser
+   needs. */
+.mg-glass {
+  backdrop-filter: blur(8px);
+}
+.mg-glass-soft {
+  background: color-mix(in oklab, var(--card) 60%, transparent);
+}
+
 /* ============ DARK — Ink + dialed mint ============ */
 .dark {
   --paper: oklch(0.14 0.003 250);


### PR DESCRIPTION
## Summary

52 sites across 21 files used ad-hoc `bg-card/NN` opacity fractions with no semantic meaning — 5 different values, the dominant cluster being one repeated three-class idiom (`bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80`) copy-pasted across every sticky table header and the compare-drawer shells.

## Tokens

Added to `packages/ui-kit/src/styles.css`:

- `.mg-glass` — the sticky-header/drawer-shell blur idiom collapsed into one class (95% opaque fallback, 80% + `blur(8px)` where `backdrop-filter` is supported).
- `.mg-glass-soft` — a flat 60%, no blur, for inset panels.

Both compose `var(--card)`, so they theme automatically — verified via `getComputedStyle` in both light and dark.

## Sweep

- **`mg-glass`** (12 sites): the full triple-idiom sticky headers (`call-module-extrinsics-table.tsx`, `validator-nominators-table.tsx`, `blocks.index.tsx`, `extrinsics.index.tsx`) and the standalone blur-paired `/95` sites (both compare-drawer shells + theads, `shortcuts-popover.tsx`, `back-to-top.tsx`).
- **`mg-glass-soft`** (10 sites): the 7 clean `/60` sites, plus 3 outliers (`delegate-cta.tsx` and `nav-omnibox.tsx` at `/50`, `endpoint-operational-list.tsx` at `/40`) that snap cleanly without a visible regression — `/50`/`/40` are both closer to 60% than 95%, and none of them had blur to begin with.
- **Documented exceptions** (2 sites, left as bare fractions with an inline comment): `hero-subnet-chips.tsx`'s homepage chip carousel and `account-history-chart.tsx`'s segmented-toggle track, both at `/80` — neither cleanly snaps to either tier without a visible regression (mg-glass would add unwanted blur; mg-glass-soft's 60% visibly lightens them). Same documented-exception treatment #7841 used for its own two non-literal reassignments.
- **Left untouched** (~24 sites): the `rounded-2xl bg-card/95 ... mg-card-glow[-accent]` KPI-tile family in `accounts.$ss58.tsx` and `validators.$hotkey.tsx`. Mixing blur into cards that never had it would be a real visual regression, and this exact pattern is already scheduled for its own Panel `glow`-prop consolidation in #7848 — converting it here would just be double churn. The warn-tier guardrail still flags these, same residual-worklist convention every other token rule already uses.

## A real build bug found along the way

Writing `.mg-glass`'s `backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);` together in one rule silently dropped the *standard* property in the compiled CSS — both in ui-kit's own tsup/Lightning CSS build and again in apps/ui's Tailwind pipeline (which re-processes the imported CSS). Lightning CSS's minifier treats the two textually-identical `blur(8px)` values as duplicates and collapses them down to just the prefixed one. Fixed by dropping the `-webkit-` fallback entirely — Safari has shipped unprefixed `backdrop-filter` since version 18 (2024), so nothing needs it anymore, and with only one declaration present there's nothing left for the minifier to (mis)merge.

## Verification

- `tsc --noEmit` clean in both packages
- `eslint .` (full package) — 0 errors in both; exactly 26 warnings in `apps/ui` from the documented/deferred sites, exactly matching the audit above
- `prettier --check .` clean
- `vitest run` — 191 files / 1465 tests in `apps/ui`, 16 files / 88 tests in `ui-kit`, all passing
- `packages/ui-kit` rebuilt (`dist/index.{js,cjs,css}`)
- Live preview: `getComputedStyle` on a sticky thead confirms `backdrop-filter: blur(8px)` + 80% opacity background in dark mode, and the 95%/60% fallback/soft tiers resolve correctly composing `--card` in both themes
- `grep -rn 'bg-card/[0-9]' apps/ui/src packages/ui-kit/src --include='*.tsx'` → only the 2 documented exceptions + the ~24 deferred-to-#7848 sites remain, 0 unaccounted-for

Closes #7842