### PR TITLE
feat(ui): author the caption/data type-scale tier (batch 1 of #7844)

### DIFF
--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -134,6 +134,8 @@
   --mg-type-label: 11px;
   --mg-tracking-label: 0.14em;
   --mg-tracking-micro: 0.18em;
+  --mg-type-caption: 12px;
+  --mg-type-caption-lg: 13px;
 }
 .mg-panel-pad {
   padding: var(--mg-panel-pad);
@@ -156,6 +158,24 @@
   font-size: var(--mg-type-label);
   line-height: 1.25;
   letter-spacing: var(--mg-tracking-label);
+}
+.mg-type-caption {
+  font-size: var(--mg-type-caption);
+  line-height: 1.45;
+}
+.mg-type-caption-lg {
+  font-size: var(--mg-type-caption-lg);
+  line-height: 1.5;
+}
+.mg-type-data {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.mg-type-data-sm {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.35;
 }
 @keyframes mg-skel-pulse {
   0%, 100% {

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -291,6 +291,12 @@
   --mg-type-label: 11px;
   --mg-tracking-label: 0.14em;
   --mg-tracking-micro: 0.18em;
+
+  /* #7844: the 12/13px body-adjacent band and the mono data/numeric band --
+     both had a bare-arbitrary-text-size guardrail warning at every site (no
+     utility class existed to reach for), unlike mg-type-micro/label above. */
+  --mg-type-caption: 12px;
+  --mg-type-caption-lg: 13px;
 }
 
 .mg-panel-pad {
@@ -314,6 +320,31 @@
   font-size: var(--mg-type-label);
   line-height: 1.25;
   letter-spacing: var(--mg-tracking-label);
+}
+/* Sans/inherited family -- captions, descriptions, secondary prose. Not the
+   uppercase-tracking label idiom above; a set line-height replaces today's
+   bare text-[12px]/[13px]'s inherited one, so a dense-row sweep site may
+   need an explicit leading-* override to avoid a layout shift (#7844). */
+.mg-type-caption {
+  font-size: var(--mg-type-caption);
+  line-height: 1.45;
+}
+.mg-type-caption-lg {
+  font-size: var(--mg-type-caption-lg);
+  line-height: 1.5;
+}
+/* Mono data/numeric idiom (timestamps, hashes, tabular values) -- deliberately
+   NOT uppercase/tracked, which is exactly why #7808 correctly left these
+   sites alone when it converted every eyebrow label to mg-type-micro/label. */
+.mg-type-data {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.mg-type-data-sm {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.35;
 }
 @keyframes mg-skel-pulse {
   0%,


### PR DESCRIPTION
## Summary

#7808 converted every UPPERCASE eyebrow label to `mg-type-micro`/`mg-type-label`, but the bare-arbitrary-text-size guardrail still reports ~1,181 warnings in `apps/ui` (52 in `ui-kit`) — the bulk being body-adjacent sizes that have **no utility class to reach for**: `text-[12px]` and `text-[13px]`, plus widespread `font-mono text-[10px]`/`[11px]` data/numeric text (timestamps, hashes, tabular values) that #7808 deliberately left alone since it isn't the uppercase-label idiom.

This is **batch 1 of #7844** ("Batch PRs — utilities first, then sweeps"): tokens + utility classes + the classification pass, no `.tsx` sites converted yet.

## New utilities (`packages/ui-kit/src/styles.css`)

- `--mg-type-caption` (12px) / `.mg-type-caption` — sans, line-height 1.45
- `--mg-type-caption-lg` (13px) / `.mg-type-caption-lg` — sans, line-height 1.5
- `.mg-type-data` — mono, 11px, line-height 1.4, no uppercase/tracking
- `.mg-type-data-sm` — mono, 10px, line-height 1.35, no uppercase/tracking

The mono pair is deliberately not uppercase/tracked, unlike `mg-type-micro`/`label` — that distinction is exactly why #7808 correctly skipped these sites.

## Classification pass (2026-07-24, both packages)

Bucketed every `text-[10px]`/`[11px]`/`[12px]`/`[13px]` site by whether `font-mono` co-occurs on the same class string (the mono/sans split heuristic — `data`/`data-sm` vs `caption`/`caption-lg`):

| Size | apps/ui total | mono → data/data-sm | non-mono → caption/caption-lg |
|---|---|---|---|
| `text-[10px]` | 295 | 198 | 97 |
| `text-[11px]` | 582 | 412 | 170 |
| `text-[12px]` | 231 | 127 | 104 |
| `text-[13px]` | 47 | 8 | 39 |

`ui-kit` adds its own smaller counts on top (22/31/9/5 respectively). Combined `text-[12px]` + `text-[13px]` across both packages = 240 + 52, matching the issue's own 2026-07-24 baseline exactly.

Follow-up sweep PRs will convert by directory, carrying the same per-site line-height-regression check the issue calls out: today's bare `text-[12px]` inherits its container's line-height, while `.mg-type-caption` sets its own (1.45) — a dense table row may need an explicit `leading-*` override or become a documented exception rather than silently reflowing.

## Verification

- `tsc --noEmit` clean in both packages
- `eslint .` (full package) — 0 errors, warning counts unchanged (this PR adds no `.tsx` conversions, so nothing should drop yet)
- `vitest run` — 191 files / 1465 tests in `apps/ui`, 16 files / 88 tests in `ui-kit`, all passing
- `packages/ui-kit` rebuilt (`dist/index.css`)
- Live preview: `getComputedStyle` confirms all four new classes resolve to their intended font-size/line-height/font-family

Part of #7844