### PR TITLE
refactor(ui): sweep text-[10-13px] arbitrary sizes onto the mg-type-* scale

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -235,7 +235,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
               ariaLabel="Daily account activity history"
               formatValue={eventCountLabel}
             />
-            <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1 font-mono text-[11px] text-ink-muted">
+            <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1 mg-type-data text-ink-muted">
               <span>
                 {scope === "all" ? "aggregated across subnets" : `filtered to SN${scope}`}
               </span>

--- a/apps/ui/src/components/metagraphed/analytics/coverage-funnel.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-funnel.tsx
@@ -94,13 +94,13 @@ export function CoverageFunnel({ className }: { className?: string }) {
                     <span className="font-display font-medium text-ink-strong truncate">
                       {s.label}
                     </span>
-                    <span className="font-mono text-[10px] text-ink-muted truncate">{s.hint}</span>
+                    <span className="mg-type-data-sm text-ink-muted truncate">{s.hint}</span>
                   </div>
                   <div className="flex items-baseline gap-2 shrink-0 tabular-nums">
                     {conv != null ? (
                       <span
                         className={classNames(
-                          "font-mono text-[10px]",
+                          "mg-type-data-sm",
                           conv >= 90
                             ? "text-health-ok"
                             : conv >= 50

--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -134,7 +134,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
           right-edge fade signals there's more to scroll. */}
       <div className="relative">
         <div className="overflow-x-auto">
-          <table className="w-full border-collapse text-[11px] font-mono">
+          <table className="w-full border-collapse mg-type-data">
             <thead>
               <tr className="bg-paper/30">
                 <th className="sticky left-0 z-[var(--mg-z-sticky)] bg-paper/30 text-left px-3 py-2 mg-type-micro text-ink-muted border-b border-border">
@@ -166,7 +166,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
                         params={{ netuid: r.netuid }}
                         className="inline-flex min-w-0 items-center gap-1.5 hover:text-accent"
                       >
-                        <span className="font-mono text-[10px] text-ink-muted">SN{r.netuid}</span>
+                        <span className="mg-type-data-sm text-ink-muted">SN{r.netuid}</span>
                         <span className="truncate max-w-[110px] sm:max-w-[160px]">{r.name}</span>
                       </Link>
                       <CompletenessChip value={r.completeness} netuid={r.netuid} />
@@ -210,7 +210,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
         </div>
       </div>
 
-      <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-border bg-paper/30 px-4 py-2 font-mono text-[10px] text-ink-muted">
+      <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-border bg-paper/30 px-4 py-2 mg-type-data-sm text-ink-muted">
         <div className="flex items-center gap-3">
           <Legend cell="present" count={totals.present} />
           <Legend cell="candidate" count={totals.candidate} />
@@ -309,7 +309,7 @@ export function CompletenessHistogram() {
           </h3>
         </div>
         {stats ? (
-          <div className="flex items-center gap-3 font-mono text-[10px] text-ink-muted">
+          <div className="flex items-center gap-3 mg-type-data-sm text-ink-muted">
             <Stat label="p25" value={`${Math.round(stats.p25 * 100)}%`} />
             <Stat label="p50" value={`${Math.round(stats.p50 * 100)}%`} />
             <Stat label="p75" value={`${Math.round(stats.p75 * 100)}%`} />
@@ -381,7 +381,7 @@ export function CompletenessHistogram() {
             })
           : null}
       </svg>
-      <p className="mt-1 font-mono text-[10px] text-ink-muted">
+      <p className="mt-1 mg-type-data-sm text-ink-muted">
         {rows.length} subnets bucketed in 10% bins. Median (p50) marks the middle of the registry;
         long tail to the right is the goal.
       </p>

--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -85,7 +85,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
           />
           <span>drift activity</span>
         </div>
-        <div className="font-mono text-[11px] text-ink">
+        <div className="mg-type-data text-ink">
           <span className="text-health-warn">{drifting.length} drifting</span>
           <span className="text-ink-muted"> · {stable.length} stable</span>
         </div>
@@ -159,7 +159,7 @@ export function DriftActivity({ schemas, fromPath }: Props) {
         </div>
       ) : null}
 
-      <div className="border-t border-border px-4 py-2 font-mono text-[10px] text-ink-muted">
+      <div className="border-t border-border px-4 py-2 mg-type-data-sm text-ink-muted">
         click a drifting row for change details · stable rows open in the explorer below
       </div>
     </Panel>
@@ -186,7 +186,7 @@ function DriftRow({ schema, onClick }: { schema: SchemaInfo; onClick: () => void
         <WeightBar weight={w} tone="warn" />
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <span className="min-w-0 break-words font-display text-[13px] font-medium text-ink-strong">
+            <span className="min-w-0 break-words font-display mg-type-caption-lg font-medium text-ink-strong">
               {label}
             </span>
             {schema.netuid != null ? (
@@ -234,7 +234,7 @@ function StableRow({ schema, onClick }: { schema: SchemaInfo; onClick: () => voi
           className="inline-block size-1.5 shrink-0 rounded-full bg-ink-subtle/50"
           aria-hidden
         />
-        <span className="truncate text-[12px] text-ink-muted group-hover:text-ink-strong">
+        <span className="truncate mg-type-caption text-ink-muted group-hover:text-ink-strong">
           {label}
         </span>
         {schema.netuid != null ? (

--- a/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
@@ -208,9 +208,11 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                       )}
                       aria-hidden
                     />
-                    <span className="font-mono text-[12px] text-ink-strong truncate">{r.host}</span>
+                    <span className="font-mono mg-type-caption text-ink-strong truncate">
+                      {r.host}
+                    </span>
                   </div>
-                  <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-ink-muted">
+                  <div className="mt-0.5 flex items-center gap-2 mg-type-data-sm text-ink-muted">
                     {r.ongoing > 0 ? (
                       <span className="text-health-down">{r.ongoing} ongoing</span>
                     ) : null}

--- a/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
@@ -188,7 +188,7 @@ export function NetworkPulseBand({ className }: { className?: string }) {
             );
           })}
         </svg>
-        <div className="mt-2 flex items-center justify-between font-mono text-[10px] text-ink-muted">
+        <div className="mt-2 flex items-center justify-between mg-type-data-sm text-ink-muted">
           <span>-{RANGE_LABEL[range]}</span>
           <span>
             {usingTrend ? "daily uptime · incident markers" : "current snapshot · incident markers"}
@@ -202,7 +202,7 @@ export function NetworkPulseBand({ className }: { className?: string }) {
 
 function Legend({ swatch, label }: { swatch: string; label: string }) {
   return (
-    <span className="inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted">
+    <span className="inline-flex items-center gap-1 mg-type-data-sm text-ink-muted">
       <span className={classNames("inline-block size-2 rounded-sm", swatch)} aria-hidden />
       {label}
     </span>

--- a/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
@@ -49,7 +49,7 @@ export function RegistryScoreHistogram({ className }: { className?: string }) {
               Score distribution
             </h3>
           </div>
-          <div className="flex items-center gap-3 font-mono text-[10px] text-ink-muted">
+          <div className="flex items-center gap-3 mg-type-data-sm text-ink-muted">
             {cov.median_score != null ? <Stat label="p50" value={`${cov.median_score}`} /> : null}
             {cov.average_score != null ? <Stat label="μ" value={`${cov.average_score}`} /> : null}
             <InfoTooltip label="Per-subnet completeness_score (0–100) bucketed by /api/v1/registry/summary. The rightmost bin (100) is the fully-complete set." />
@@ -103,7 +103,7 @@ export function RegistryScoreHistogram({ className }: { className?: string }) {
             );
           })}
         </svg>
-        <p className="mt-1 font-mono text-[10px] text-ink-muted">
+        <p className="mt-1 mg-type-data-sm text-ink-muted">
           {scored != null ? `${scored} subnets scored.` : ""} Each bin is a completeness band; the
           goal is to push the registry rightward.
         </p>
@@ -177,7 +177,7 @@ export function DimensionCoverageHeatmap({ className }: { className?: string }) 
           <InfoTooltip label="Share of subnets with at least one surface of each kind, registry-wide (/api/v1/registry/summary). Green ≥75%, amber/red are the enrichment frontier." />
         </header>
         <BarMini data={data} max={100} showValue />
-        <div className="mt-3 flex items-center justify-between font-mono text-[10px] text-ink-muted">
+        <div className="mt-3 flex items-center justify-between mg-type-data-sm text-ink-muted">
           <span>% of {subnetCount ?? "all"} subnets covered</span>
           <span className="inline-flex items-center gap-2">
             <Swatch color="var(--health-ok)" label="≥75" />
@@ -304,14 +304,14 @@ function QueueRow({ row }: { row: CoverageDepthQueueRow }) {
   const tone = SEVERITY_TONE[row.severity ?? ""] ?? "text-ink-muted border-border";
   return (
     <tr className="mg-row-hover">
-      <td className="px-3 py-2.5 font-mono text-[11px] tabular-nums text-ink-muted">{row.rank}</td>
+      <td className="px-3 py-2.5 mg-type-data tabular-nums text-ink-muted">{row.rank}</td>
       <td className="px-3 py-2.5">
         <Link
           to="/subnets/$netuid"
           params={{ netuid: row.netuid }}
           className="inline-flex items-center gap-2 font-medium text-ink-strong hover:underline"
         >
-          <span className="font-mono text-[11px] text-ink-muted">
+          <span className="mg-type-data text-ink-muted">
             #{String(row.netuid).padStart(3, "0")}
           </span>
           <span className="truncate">{row.name ?? `Subnet ${row.netuid}`}</span>
@@ -331,13 +331,13 @@ function QueueRow({ row }: { row: CoverageDepthQueueRow }) {
           "—"
         )}
       </td>
-      <td className="px-3 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+      <td className="px-3 py-2.5 text-right mg-type-data tabular-nums text-ink-strong">
         {row.priority_score ?? "—"}
       </td>
-      <td className="px-3 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+      <td className="px-3 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
         {row.score ?? "—"}
       </td>
-      <td className="px-3 py-2.5 text-[12px] text-ink">
+      <td className="px-3 py-2.5 mg-type-caption text-ink">
         <span className="line-clamp-1" title={row.recommended_next_action}>
           {row.recommended_next_action ?? "—"}
         </span>

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -188,14 +188,14 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
       </header>
 
       {grouped.length === 0 ? (
-        <div className="p-8 text-center font-mono text-[11px] text-ink-muted">
+        <div className="p-8 text-center mg-type-data text-ink-muted">
           No schemas match this filter.
         </div>
       ) : (
         <div className="divide-y divide-border">
           {grouped.map((g) => (
             <div key={g.label} className="grid grid-cols-[88px_1fr] gap-3 px-4 py-3 items-start">
-              <div className="font-mono text-[11px] text-ink-muted pt-1">
+              <div className="mg-type-data text-ink-muted pt-1">
                 {g.netuid != null ? (
                   <Link
                     to="/subnets/$netuid"
@@ -229,7 +229,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
         </div>
       )}
 
-      <footer className="flex flex-wrap items-center justify-between gap-2 border-t border-border bg-paper/30 px-4 py-2 font-mono text-[10px] text-ink-muted">
+      <footer className="flex flex-wrap items-center justify-between gap-2 border-t border-border bg-paper/30 px-4 py-2 mg-type-data-sm text-ink-muted">
         <div className="flex items-center gap-3">
           <KindLegend kind="breaking" />
           <KindLegend kind="additive" />
@@ -291,9 +291,7 @@ function DriftTile({
           )}
           aria-hidden
         />
-        <span className="font-mono text-[11px] text-ink-strong truncate max-w-[180px]">
-          {label}
-        </span>
+        <span className="mg-type-data text-ink-strong truncate max-w-[180px]">{label}</span>
         {schema.updated_at ? (
           <span className="font-mono text-[9px] text-ink-muted shrink-0">
             <TimeAgo at={schema.updated_at} />

--- a/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
@@ -121,7 +121,7 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
             );
           })}
           {rows.length === 0 ? (
-            <div className="col-span-full py-6 text-center font-mono text-[10px] text-ink-muted">
+            <div className="col-span-full py-6 text-center mg-type-data-sm text-ink-muted">
               No endpoints match this filter.
             </div>
           ) : null}

--- a/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
@@ -150,7 +150,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
           <span className="font-mono text-[9.5px] text-ink-muted/70">· {freshLine}</span>
         ) : null}
         {/* Aggregate window stats. */}
-        <div className="ml-auto flex items-center gap-3 font-mono text-[10px] text-ink-muted">
+        <div className="ml-auto flex items-center gap-3 mg-type-data-sm text-ink-muted">
           <span className="inline-flex items-center gap-1">
             <span
               className="inline-block size-2 rounded-full"
@@ -179,16 +179,10 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
           return (
             <li key={s.surface_id} className="px-4 py-2">
               <div className="flex items-baseline justify-between gap-3">
-                <span
-                  className="truncate font-mono text-[11px] text-ink-strong"
-                  title={s.surface_id}
-                >
+                <span className="truncate mg-type-data text-ink-strong" title={s.surface_id}>
                   {shortSurfaceId(s.surface_id)}
                 </span>
-                <span
-                  className="shrink-0 font-mono text-[10px] tabular-nums"
-                  style={{ color: tint }}
-                >
+                <span className="shrink-0 mg-type-data-sm tabular-nums" style={{ color: tint }}>
                   {pct(ratio)}
                 </span>
               </div>
@@ -291,7 +285,7 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
                       {sev} · {dur}
                     </div>
                     <div className="mt-1 break-all">{i.surface_id}</div>
-                    <div className="mt-1 font-mono text-[10px] text-primary-foreground/70">
+                    <div className="mt-1 mg-type-data-sm text-primary-foreground/70">
                       started <TimeAgo at={i.started_at} />
                       <br />
                       {i.ended_at ? (

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -78,7 +78,7 @@ export function WhatChangedFeed({ className, limit = 10 }: { className?: string;
               Recent registry signal
             </h3>
           </div>
-          <span className="inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted">
+          <span className="inline-flex items-center gap-1 mg-type-data-sm text-ink-muted">
             <Sparkles className="size-3" aria-hidden />
             live
           </span>
@@ -115,7 +115,7 @@ export function WhatChangedFeed({ className, limit = 10 }: { className?: string;
                         <span className="mg-type-micro text-ink-muted truncate">{it.detail}</span>
                       ) : null}
                       {it.at ? (
-                        <span className="font-mono text-[10px] text-ink-muted">
+                        <span className="mg-type-data-sm text-ink-muted">
                           <TimeAgo at={it.at} />
                         </span>
                       ) : null}

--- a/apps/ui/src/components/metagraphed/api-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/api-drawer.tsx
@@ -162,7 +162,7 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
       <section className="space-y-2">
         <div className="mg-type-micro text-ink-muted">Request</div>
         <Panel as="div" flush>
-          <div className="p-3 font-mono text-[12px] text-ink-strong break-all flex items-start gap-2">
+          <div className="p-3 font-mono mg-type-caption text-ink-strong break-all flex items-start gap-2">
             <span className="shrink-0 rounded bg-curation-verified/15 text-curation-verified px-1.5 py-0.5 mg-type-micro">
               GET
             </span>
@@ -204,23 +204,23 @@ function ApiSourceBody({ source }: { source: ApiSource }) {
           <Panel
             as="div"
             dense
-            bodyClassName="text-[12px] text-ink-muted inline-flex items-center gap-2"
+            bodyClassName="mg-type-caption text-ink-muted inline-flex items-center gap-2"
           >
             <Loader2 className="size-3.5 animate-spin" /> Loading…
           </Panel>
         ) : error ? (
-          <div className="rounded border border-health-down/40 bg-health-down/5 p-3 text-[12px] text-health-down">
+          <div className="rounded border border-health-down/40 bg-health-down/5 p-3 mg-type-caption text-health-down">
             <div className="font-medium">Request failed</div>
-            <div className="mt-1 font-mono text-[11px] opacity-80">{(error as Error).message}</div>
+            <div className="mt-1 mg-type-data opacity-80">{(error as Error).message}</div>
           </div>
         ) : (
-          <pre className="max-h-[60vh] overflow-auto rounded border border-border bg-card p-3 font-mono text-[11px] leading-relaxed text-ink-strong whitespace-pre">
+          <pre className="max-h-[60vh] overflow-auto rounded border border-border bg-card p-3 font-mono mg-type-data leading-relaxed text-ink-strong whitespace-pre">
             {json}
           </pre>
         )}
       </section>
 
-      <div className="text-[10px] font-mono text-ink-muted">
+      <div className="mg-type-data-sm text-ink-muted">
         Press <Kbd>Esc</Kbd> to close · <Kbd>⌘</Kbd>
         <Kbd>J</Kbd> to reopen
       </div>

--- a/apps/ui/src/components/metagraphed/api-keys-manager.tsx
+++ b/apps/ui/src/components/metagraphed/api-keys-manager.tsx
@@ -94,7 +94,7 @@ function SignInPrompt({
 }) {
   return (
     <div className="space-y-3">
-      <p className="text-[12px] text-ink-muted">
+      <p className="mg-type-caption text-ink-muted">
         Sign a one-time message with your connected wallet to manage your API keys. This never
         constructs or broadcasts a transaction -- it only proves you control this address.
       </p>
@@ -110,7 +110,7 @@ function SignInPrompt({
         type="button"
         onClick={onSignIn}
         disabled={signingIn}
-        className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[12px] font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
+        className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
       >
         {signingIn ? "Signing in…" : "Sign in with wallet"}
       </button>
@@ -181,7 +181,7 @@ function ApiKeysPanel({
         type="button"
         onClick={() => createMutation.mutate()}
         disabled={createMutation.isPending}
-        className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[12px] font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
+        className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
       >
         {createMutation.isPending ? "Generating…" : "Generate new key"}
       </button>
@@ -189,7 +189,7 @@ function ApiKeysPanel({
       {createMutation.isError ? (
         <div
           role="alert"
-          className="rounded border border-health-down/30 bg-health-down/5 p-3 text-[12px] text-health-down"
+          className="rounded border border-health-down/30 bg-health-down/5 p-3 mg-type-caption text-health-down"
         >
           {describeApiError(createMutation.error)}
         </div>
@@ -197,7 +197,7 @@ function ApiKeysPanel({
 
       {createMutation.data ? (
         <div className="space-y-2 rounded border border-accent/40 bg-primary-soft/40 p-4">
-          <p className="text-[12px] font-medium text-health-warn">
+          <p className="mg-type-caption font-medium text-health-warn">
             This key is shown once and is never echoed back -- store it now.
           </p>
           {/* ph-no-capture: excludes this one-time secret reveal from
@@ -217,7 +217,7 @@ function ApiKeysPanel({
         {listQuery.isError ? (
           <div
             role="alert"
-            className="rounded border border-health-down/30 bg-health-down/5 p-3 text-[12px] text-health-down"
+            className="rounded border border-health-down/30 bg-health-down/5 p-3 mg-type-caption text-health-down"
           >
             {describeApiError(listQuery.error)}
           </div>
@@ -231,7 +231,7 @@ function ApiKeysPanel({
             className="flex flex-wrap items-center justify-between gap-2 rounded border border-border bg-surface/40 px-3 py-2"
           >
             <div className="min-w-0">
-              <div className="font-mono text-[12px] text-ink-strong truncate">{key.key_id}</div>
+              <div className="font-mono mg-type-caption text-ink-strong truncate">{key.key_id}</div>
               <div className="text-[10px] text-ink-muted">
                 Created {formatTimestamp(key.created_at)} · Last used{" "}
                 {formatTimestamp(key.last_used_at)}

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -368,7 +368,7 @@ export function AppShell({
                 <Link
                   to="/settings"
                   onClick={() => setMobileOpen(false)}
-                  className="inline-flex flex-1 items-center gap-2 rounded border border-border bg-card px-3 py-2 text-[13px] text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                  className="inline-flex flex-1 items-center gap-2 rounded border border-border bg-card px-3 py-2 mg-type-caption-lg text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
                 >
                   <Webhook className="size-3.5" aria-hidden="true" /> Developer settings
                 </Link>
@@ -436,7 +436,7 @@ function SiteFooter() {
         aria-hidden
         className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/60 to-transparent"
       />
-      <div className="max-w-shell-max mx-auto px-4 md:px-10 py-12 grid gap-10 md:grid-cols-5 text-[12px] text-ink-muted">
+      <div className="max-w-shell-max mx-auto px-4 md:px-10 py-12 grid gap-10 md:grid-cols-5 mg-type-caption text-ink-muted">
         <div className="md:col-span-2">
           <div className="font-display text-base font-semibold text-ink-strong inline-flex items-baseline gap-1">
             Metagraphed
@@ -526,7 +526,7 @@ function SiteFooter() {
         </div>
       </div>
       <div className="border-t border-border/70">
-        <div className="max-w-shell-max mx-auto px-4 md:px-10 py-4 flex flex-wrap items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
+        <div className="max-w-shell-max mx-auto px-4 md:px-10 py-4 flex flex-wrap items-center justify-between gap-2 mg-type-data text-ink-muted">
           <span>
             © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
           </span>

--- a/apps/ui/src/components/metagraphed/ask-box.tsx
+++ b/apps/ui/src/components/metagraphed/ask-box.tsx
@@ -35,12 +35,10 @@ export function citationMeta(citation: AskCitation): string {
 function CitationRow({ citation }: { citation: AskCitation }) {
   return (
     <li className="flex items-center justify-between gap-3 px-3 py-2">
-      <ExternalLink href={citation.url ?? ""} className="min-w-0 text-[12px]">
+      <ExternalLink href={citation.url ?? ""} className="min-w-0 mg-type-caption">
         {citationLabel(citation)}
       </ExternalLink>
-      <span className="shrink-0 font-mono text-[10px] text-ink-muted">
-        {citationMeta(citation)}
-      </span>
+      <span className="shrink-0 mg-type-data-sm text-ink-muted">{citationMeta(citation)}</span>
     </li>
   );
 }
@@ -53,7 +51,7 @@ export function sourceCountLabel(contextCount: number, model: string): string {
 function AskResult({ result }: { result: AskAnswerData }) {
   return (
     <div className="mt-4 space-y-3 rounded-lg border border-accent/30 bg-accent-surface p-4">
-      <p className="text-[13px] leading-relaxed text-ink-strong">{result.answer}</p>
+      <p className="mg-type-caption-lg leading-relaxed text-ink-strong">{result.answer}</p>
       {result.citations.length > 0 ? (
         <ul className="divide-y divide-border rounded border border-border bg-card">
           {result.citations.map((c: AskCitation) => (
@@ -61,7 +59,7 @@ function AskResult({ result }: { result: AskAnswerData }) {
           ))}
         </ul>
       ) : null}
-      <p className="font-mono text-[10px] text-ink-muted">
+      <p className="mg-type-data-sm text-ink-muted">
         {sourceCountLabel(result.context_count, result.model)}
       </p>
     </div>
@@ -92,14 +90,14 @@ export function AskBox() {
             placeholder="Which subnet does image generation?"
             value={question}
             onChange={(e) => setQuestion(e.target.value)}
-            className="w-full resize-none rounded-lg border border-border bg-card px-3 py-2 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
+            className="w-full resize-none rounded-lg border border-border bg-card px-3 py-2 mg-type-caption-lg text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
           />
         </label>
         <button
           type="submit"
           disabled={mutation.isPending || !question.trim()}
           className={classNames(
-            "shrink-0 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 text-[13px] font-medium text-accent hover:bg-accent/15",
+            "shrink-0 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15",
             "disabled:cursor-not-allowed disabled:opacity-50",
           )}
         >
@@ -108,7 +106,7 @@ export function AskBox() {
       </form>
 
       {mutation.isError ? (
-        <p role="alert" className="mt-3 font-mono text-[12px] text-health-warn">
+        <p role="alert" className="mt-3 font-mono mg-type-caption text-health-warn">
           {describeAskError(mutation.error)}
         </p>
       ) : null}

--- a/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
@@ -70,7 +70,7 @@ export function AuthorSharePanel({ rows }: { rows: Block[] }) {
                 <button
                   type="button"
                   onClick={filterByAuthor}
-                  className="mg-focus-ring shrink-0 text-right font-mono text-[11px] tabular-nums text-ink-strong"
+                  className="mg-focus-ring shrink-0 text-right mg-type-data tabular-nums text-ink-strong"
                   title="Filter by this author"
                 >
                   <div>{formatNumber(count)}</div>

--- a/apps/ui/src/components/metagraphed/blocks/block-metadata-panel.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/block-metadata-panel.tsx
@@ -37,18 +37,18 @@ export function BlockMetadataPanel({ block }: { block: Block }) {
               {r.mono ? (
                 <>
                   <span
-                    className="font-mono text-[12px] text-ink-strong break-all md:hidden"
+                    className="font-mono mg-type-caption text-ink-strong break-all md:hidden"
                     title={r.value}
                   >
                     {truncate(r.value, 28)}
                   </span>
-                  <span className="hidden md:inline font-mono text-[12px] text-ink-strong break-all">
+                  <span className="hidden md:inline font-mono mg-type-caption text-ink-strong break-all">
                     {r.value}
                   </span>
                   <CopyButton value={r.value} label={r.label} compact />
                 </>
               ) : (
-                <span className="font-mono text-[12px] text-ink-strong tabular-nums">
+                <span className="font-mono mg-type-caption text-ink-strong tabular-nums">
                   {r.value}
                 </span>
               )}

--- a/apps/ui/src/components/metagraphed/blocks/chain-walk-ribbon.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/chain-walk-ribbon.tsx
@@ -89,7 +89,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
                     className="flex h-full flex-col items-center gap-1 rounded border border-accent/60 bg-accent/10 px-2 py-2"
                   >
                     <span className="mg-type-micro text-accent-text">This</span>
-                    <span className="font-mono text-[12px] font-semibold tabular-nums text-ink-strong truncate w-full text-center">
+                    <span className="font-mono mg-type-caption font-semibold tabular-nums text-ink-strong truncate w-full text-center">
                       #{formatNumber(slot.n)}
                     </span>
                     <DensityBar level={density} accent />
@@ -108,7 +108,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
                     <span className="mg-type-micro text-ink-muted">
                       {slot.n < current.block_number ? "prev" : "next"}
                     </span>
-                    <span className="font-mono text-[12px] tabular-nums text-ink-strong truncate w-full text-center">
+                    <span className="font-mono mg-type-caption tabular-nums text-ink-strong truncate w-full text-center">
                       #{formatNumber(slot.n)}
                     </span>
                     <DensityBar level={density} />
@@ -119,7 +119,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
                     className="flex h-full flex-col items-center gap-1 rounded border border-dashed border-border/60 px-2 py-2 opacity-40"
                   >
                     <span className="mg-type-micro text-ink-muted">—</span>
-                    <span className="font-mono text-[12px] tabular-nums text-ink-muted truncate w-full text-center">
+                    <span className="font-mono mg-type-caption tabular-nums text-ink-muted truncate w-full text-center">
                       #{formatNumber(slot.n)}
                     </span>
                     <DensityBar level={0} />
@@ -158,7 +158,7 @@ export function ChainWalkRibbon({ current, radius = 3 }: Props) {
                 formatValue={(v) => humaniseSeconds(v / 1000)}
               />
             ) : (
-              <span className="font-mono text-[11px] text-ink-muted">—</span>
+              <span className="mg-type-data text-ink-muted">—</span>
             )}
           </div>
           <div className="flex items-center gap-1.5 mg-type-micro text-ink-muted shrink-0">

--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -60,11 +60,11 @@ export function LiveBlockRail() {
             >
               #{formatNumber(latest.block_number)}
             </Link>
-            <span className="font-mono text-[10px] text-ink-muted">
+            <span className="mg-type-data-sm text-ink-muted">
               <TimeAgo at={latest.observed_at} />
             </span>
           </div>
-          <div className="mt-0.5 flex items-center gap-2 font-mono text-[11px] text-ink-muted">
+          <div className="mt-0.5 flex items-center gap-2 mg-type-data text-ink-muted">
             <span className="truncate" title={latest.block_hash}>
               {shortHash(latest.block_hash) ?? "—"}
             </span>
@@ -73,7 +73,7 @@ export function LiveBlockRail() {
               <AccountAddress ss58={latest.author} compact fallback="no author" />
             </span>
           </div>
-          <div className="mt-0.5 font-mono text-[10px] text-ink-muted">
+          <div className="mt-0.5 mg-type-data-sm text-ink-muted">
             {formatNumber(latest.extrinsic_count ?? 0)} ext ·{" "}
             {formatNumber(latest.event_count ?? 0)} evt
           </div>

--- a/apps/ui/src/components/metagraphed/blocks/neighbor-compare.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/neighbor-compare.tsx
@@ -44,9 +44,7 @@ function NeighborCard({
             <Icon className="size-3.5" />
             <span className="mg-type-micro">{label}</span>
           </span>
-          <span className="font-mono text-[11px]">
-            {direction === "prev" ? "genesis" : "chain tip"}
-          </span>
+          <span className="mg-type-data">{direction === "prev" ? "genesis" : "chain tip"}</span>
         </div>
       </Panel>
     );
@@ -70,11 +68,11 @@ function NeighborCard({
             {label}
             {direction === "next" ? <Icon className="size-3.5" /> : null}
           </span>
-          <span className="font-mono text-[12px] font-semibold tabular-nums text-ink-strong">
+          <span className="font-mono mg-type-caption font-semibold tabular-nums text-ink-strong">
             #{formatNumber(Number(ref))}
           </span>
         </div>
-        <div className="mt-2 grid grid-cols-2 gap-2 font-mono text-[11px] tabular-nums">
+        <div className="mt-2 grid grid-cols-2 gap-2 mg-type-data tabular-nums">
           <DeltaChip label="ext" value={ext} delta={extDelta} loading={q.isPending} />
           <DeltaChip label="evt" value={evt} delta={evtDelta} loading={q.isPending} />
         </div>

--- a/apps/ui/src/components/metagraphed/blocks/pallet-method-breakdown.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/pallet-method-breakdown.tsx
@@ -53,7 +53,10 @@ export function PalletMethodBreakdown({ events }: { events: ChainEvent[] }) {
                   <span className="mg-type-micro shrink-0 text-ink-subtle tabular-nums">
                     #{i + 1}
                   </span>
-                  <span className="font-mono text-[12px] text-ink-strong truncate" title={r.label}>
+                  <span
+                    className="font-mono mg-type-caption text-ink-strong truncate"
+                    title={r.label}
+                  >
                     <span className="text-ink-muted">{pallet}.</span>
                     {method}
                   </span>
@@ -71,9 +74,9 @@ export function PalletMethodBreakdown({ events }: { events: ChainEvent[] }) {
                   />
                 </div>
               </div>
-              <div className="shrink-0 text-right font-mono text-[11px] tabular-nums">
+              <div className="shrink-0 text-right mg-type-data tabular-nums">
                 <div className="text-ink-strong">{formatNumber(r.count)}</div>
-                <div className="text-[10px] text-ink-muted">{share.toFixed(1)}%</div>
+                <div className="mg-type-data-sm text-ink-muted">{share.toFixed(1)}%</div>
               </div>
             </li>
           );

--- a/apps/ui/src/components/metagraphed/blocks/runtime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/runtime-timeline.tsx
@@ -41,7 +41,7 @@ export function RuntimeTimeline() {
       }
       caption={
         payload.coverage_from_block != null ? (
-          <span className="font-mono text-[11px] text-ink-muted">
+          <span className="mg-type-data text-ink-muted">
             Coverage from #{formatNumber(payload.coverage_from_block)} ·{" "}
             <TimeAgo at={payload.coverage_from_at} />
           </span>
@@ -63,16 +63,16 @@ export function RuntimeTimeline() {
             >
               <span
                 className={
-                  "font-mono text-[11px] font-semibold tabular-nums " +
+                  "font-mono mg-type-data font-semibold tabular-nums " +
                   (isLatest ? "text-accent-text" : "text-ink-strong")
                 }
               >
                 v{t.spec_version ?? "?"}
               </span>
-              <span className="font-mono text-[10px] tabular-nums text-ink-muted">
+              <span className="mg-type-data-sm tabular-nums text-ink-muted">
                 #{t.block_number != null ? formatNumber(t.block_number) : "—"}
               </span>
-              <span className="font-mono text-[10px] text-ink-subtle">
+              <span className="mg-type-data-sm text-ink-subtle">
                 <TimeAgo at={t.observed_at} />
               </span>
             </div>

--- a/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/shortcuts-dialog.tsx
@@ -91,7 +91,7 @@ export function ShortcutsDialog({ blockRef }: { blockRef: string }) {
         <dl className="divide-y divide-border/60">
           {SHORTCUTS.map((s) => (
             <div key={s.label} className="flex items-center justify-between gap-3 px-4 py-2.5">
-              <dt className="text-[13px] text-ink">{s.label}</dt>
+              <dt className="mg-type-caption-lg text-ink">{s.label}</dt>
               <dd className="flex items-center gap-1">
                 {s.keys.map((k) => (
                   <Kbd key={k}>{k}</Kbd>

--- a/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
+++ b/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
@@ -98,7 +98,7 @@ export function CallModuleExtrinsicsTable({
   );
 
   const footerNode = (
-    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 text-[11px] font-mono text-ink-muted">
+    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 mg-type-data text-ink-muted">
       <span>
         {rows.length
           ? `${formatNumber(search.offset + 1)}–${formatNumber(search.offset + rows.length)}`
@@ -131,7 +131,7 @@ export function CallModuleExtrinsicsTable({
           <tbody className="divide-y divide-border">
             {rows.map((x) => (
               <tr key={rowKey(x)} className="mg-row-accent hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                   {x.extrinsic_hash ? (
                     <span className="inline-flex items-center gap-1 min-w-0">
                       <Link
@@ -148,7 +148,7 @@ export function CallModuleExtrinsicsTable({
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[12px]">
+                <td className="px-4 py-2.5 font-mono mg-type-caption">
                   {x.block_number != null ? (
                     <Link
                       to="/blocks/$ref"
@@ -164,16 +164,16 @@ export function CallModuleExtrinsicsTable({
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
+                <td className="px-4 py-2.5 mg-type-data text-ink">
                   {extrinsicCall(x.call_module, x.call_function)}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                   {x.signer ? <CopyableCode value={x.signer} className="max-w-full" /> : "—"}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px]">
+                <td className="px-4 py-2.5 mg-type-data">
                   <SuccessBadge success={x.success} />
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
                   <TimeAgo at={x.observed_at} />
                 </td>
               </tr>
@@ -194,7 +194,7 @@ function RowCard({ x }: { x: Extrinsic }) {
         <div className="flex items-center gap-1 min-w-0 flex-1">
           {x.extrinsic_hash ? (
             <>
-              <span className="font-mono text-[12px] font-medium text-ink-strong truncate">
+              <span className="font-mono mg-type-caption font-medium text-ink-strong truncate">
                 {shortHash(x.extrinsic_hash)}
               </span>
               <span
@@ -208,17 +208,17 @@ function RowCard({ x }: { x: Extrinsic }) {
               </span>
             </>
           ) : (
-            <span className="font-mono text-[12px] font-medium text-ink-strong">(no hash)</span>
+            <span className="font-mono mg-type-caption font-medium text-ink-strong">(no hash)</span>
           )}
         </div>
-        <span className="font-mono text-[11px] text-ink-muted shrink-0">
+        <span className="mg-type-data text-ink-muted shrink-0">
           <TimeAgo at={x.observed_at} />
         </span>
       </div>
-      <div className="mt-1 font-mono text-[11px] text-ink truncate">
+      <div className="mt-1 mg-type-data text-ink truncate">
         {extrinsicCall(x.call_module, x.call_function)}
       </div>
-      <div className="mt-2 flex items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
+      <div className="mt-2 flex items-center justify-between gap-2 mg-type-data text-ink-muted">
         <span className="shrink-0">
           {x.block_number != null ? `#${formatNumber(x.block_number)}` : "—"}
         </span>

--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -105,13 +105,13 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
         // override regardless of prop order (classNames() is a plain string-join,
         // not tailwind-merge-aware -- see #6904); the trailing `!` forces this
         // narrower floor to actually apply for these compact pallet/method filters.
-        className="min-w-[140px]! flex-none font-mono text-[11px]"
+        className="min-w-[140px]! flex-none mg-type-data"
       />
       <SearchInput
         value={method}
         onChange={(v) => onFilter({ method: v })}
         placeholder={pallet.trim() ? "Filter by method" : "Method (requires pallet)"}
-        className="min-w-[140px]! flex-none font-mono text-[11px]"
+        className="min-w-[140px]! flex-none mg-type-data"
       />
       {/* #6387: a filtered /events?pallet=X or /explorer?pallet=X link is
           URL-persisted and otherwise stuck until manually cleared, unlike every
@@ -181,10 +181,10 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
       <tbody className="divide-y divide-border">
         {events.map((event) => (
           <tr key={`${event.block_number}-${event.event_index}`} className="hover:bg-surface/40">
-            <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+            <td className="px-4 py-2.5 mg-type-data text-ink-strong">
               {extrinsicCall(event.pallet, event.method)}
             </td>
-            <td className="px-4 py-2.5 font-mono text-[11px]">
+            <td className="px-4 py-2.5 mg-type-data">
               {event.block_number != null ? (
                 <Link
                   to="/blocks/$ref"
@@ -197,7 +197,7 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
                 "—"
               )}
             </td>
-            <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+            <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
               <TimeAgo at={event.observed_at} />
             </td>
           </tr>
@@ -213,10 +213,10 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
       key={`${event.block_number}-${event.event_index}-card`}
       className="min-h-11"
     >
-      <div className="font-mono text-[11px] text-ink-strong">
+      <div className="mg-type-data text-ink-strong">
         {extrinsicCall(event.pallet, event.method)}
       </div>
-      <div className="mt-1 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-muted">
+      <div className="mt-1 flex items-center justify-between gap-2 mg-type-data-sm text-ink-muted">
         {event.block_number != null ? (
           <Link
             to="/blocks/$ref"

--- a/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/activity-heatmap.tsx
@@ -112,7 +112,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
           <span className="mg-type-micro text-ink-muted">Registry activity</span>
           <InfoTooltip label="Daily probe samples and recorded incidents — not GitHub commits. Drives the registry's freshness signal." />
         </div>
-        <span className="font-mono text-[10px] text-ink-muted">
+        <span className="mg-type-data-sm text-ink-muted">
           {activeDays}/{cells.length} active · streak {streak}d
         </span>
       </div>
@@ -136,7 +136,7 @@ export function ActivityHeatmap({ netuid, weeks = 12 }: Props) {
                       aria-label={`${c.key}: ${c.probes} probes, ${c.incidents} incidents`}
                     />
                   </TooltipTrigger>
-                  <TooltipContent side="top" className="font-mono text-[10px]">
+                  <TooltipContent side="top" className="mg-type-data-sm">
                     <div className="text-[11px] text-ink-strong">{c.key}</div>
                     <div>
                       {c.probes} probe{c.probes === 1 ? "" : "s"}

--- a/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
@@ -103,7 +103,7 @@ export function EconomicsMini({ netuid }: Props) {
               </span>
             </div>
             {ratio != null ? (
-              <span className="inline-flex items-center gap-2 font-mono text-[10px] text-ink-muted">
+              <span className="inline-flex items-center gap-2 mg-type-data-sm text-ink-muted">
                 Pool {ratio.toFixed(0)}% in · {(100 - ratio).toFixed(0)}% out
                 <Maximize2 className="size-3 opacity-60 transition-opacity group-hover:opacity-100" />
               </span>
@@ -134,7 +134,7 @@ export function EconomicsMini({ netuid }: Props) {
               </div>
             </div>
           ) : (
-            <div className="p-4 font-mono text-[11px] text-ink-muted">
+            <div className="p-4 mg-type-data text-ink-muted">
               No AMM pool reserves recorded — price shown from the latest snapshot.
             </div>
           )}
@@ -213,7 +213,7 @@ function EconomicsDrilldown({
             <DonutLegend segments={poolSegments} />
           </div>
         ) : (
-          <p className="font-mono text-[11px] text-ink-muted">
+          <p className="mg-type-data text-ink-muted">
             No AMM pool reserves recorded for this subnet.
           </p>
         )}
@@ -254,7 +254,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
             SN{netuid}
           </span>
         </div>
-        <span className="font-mono text-[10px] text-ink-muted">showing probe trend instead</span>
+        <span className="mg-type-data-sm text-ink-muted">showing probe trend instead</span>
       </div>
       {uptime.length > 1 ? (
         <div className="grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)] divide-x divide-border">
@@ -283,7 +283,7 @@ function EconomicsFallback({ netuid, surfaces }: { netuid: number; surfaces?: Su
           </div>
         </div>
       ) : (
-        <div className="p-6 text-center font-mono text-[11px] text-ink-muted">
+        <div className="p-6 text-center mg-type-data text-ink-muted">
           No probe samples yet — economics + health series will populate as the registry runs more
           probes.
         </div>

--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -141,7 +141,7 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
         <div className="px-4 py-2.5 border-b border-border flex flex-wrap items-center justify-between gap-2">
           <div className="mg-type-micro text-ink-muted">Latency heatmap · provider × kind</div>
           <div
-            className="flex flex-wrap items-center gap-2.5 text-[10px] font-mono text-ink-muted"
+            className="flex flex-wrap items-center gap-2.5 mg-type-data-sm text-ink-muted"
             role="list"
             aria-label="Latency legend"
           >
@@ -161,7 +161,7 @@ export function LatencyHeatmap({ endpoints, minEndpoints = 1, maxProviders = 20 
         </div>
         <div className="w-full overflow-x-auto [scrollbar-gutter:stable]">
           <table
-            className="w-full min-w-[480px] text-[11px] font-mono"
+            className="w-full min-w-[480px] mg-type-data"
             role="table"
             aria-label="Endpoint latency by provider and kind"
           >
@@ -311,12 +311,12 @@ function Cell({ cell }: { cell: Cell }) {
             <h3 className="m-0 min-w-0 mg-type-micro text-ink-muted truncate">
               {cell.provider} · {cell.kind}
             </h3>
-            <span className="font-mono text-[10px] text-ink-strong tabular-nums shrink-0">
+            <span className="mg-type-data-sm text-ink-strong tabular-nums shrink-0">
               {cell.avgLatency != null ? `${Math.round(cell.avgLatency)}ms avg` : "—"}
             </span>
           </div>
           <div
-            className="grid grid-cols-3 gap-1.5 text-[10px] font-mono"
+            className="grid grid-cols-3 gap-1.5 mg-type-data-sm"
             role="list"
             aria-label="Health breakdown"
           >
@@ -329,7 +329,7 @@ function Cell({ cell }: { cell: Cell }) {
               <Link
                 to="/providers/$slug"
                 params={{ slug: cell.provider }}
-                className="inline-flex items-center gap-1 font-mono text-[11px] text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded"
+                className="inline-flex items-center gap-1 mg-type-data text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded"
               >
                 open provider <ExternalLink className="size-3" />
               </Link>
@@ -357,7 +357,7 @@ function Cell({ cell }: { cell: Cell }) {
                         params={{ netuid: n }}
                         search={{ tab: "endpoints" } as never}
                         hash="endpoints"
-                        className="inline-flex h-6 items-center rounded border border-border bg-paper px-2 font-mono text-[10px] text-ink hover:border-accent/60 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
+                        className="inline-flex h-6 items-center rounded border border-border bg-paper px-2 mg-type-data-sm text-ink hover:border-accent/60 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
                         aria-label={`Jump to subnet ${n} endpoints`}
                       >
                         SN{n}
@@ -379,16 +379,13 @@ function Cell({ cell }: { cell: Cell }) {
                         to="/endpoints"
                         search={{ q: p } as never}
                         hash={`pool-${p}`}
-                        className="inline-flex h-6 max-w-[16ch] items-center truncate rounded border border-border bg-paper px-2 font-mono text-[10px] text-ink hover:border-accent/60 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
+                        className="inline-flex h-6 max-w-[16ch] items-center truncate rounded border border-border bg-paper px-2 mg-type-data-sm text-ink hover:border-accent/60 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
                         aria-label={`Scroll to pool ${p} in endpoints`}
                       >
                         {p}
                       </Link>
                     </TooltipTrigger>
-                    <TooltipContent
-                      side="top"
-                      className="font-mono text-[11px] break-all max-w-[90vw]"
-                    >
+                    <TooltipContent side="top" className="mg-type-data break-all max-w-[90vw]">
                       {p}
                     </TooltipContent>
                   </Tooltip>
@@ -418,7 +415,7 @@ function ChipGroup({ label, id, children }: { label: string; id: string; childre
 function CellStat({ label, value, color }: { label: string; value: number; color: string }) {
   return (
     <div className="rounded border border-border bg-paper px-2 py-1 text-center" role="listitem">
-      <div className={classNames("tabular-nums text-[12px] font-semibold", color)}>{value}</div>
+      <div className={classNames("tabular-nums mg-type-caption font-semibold", color)}>{value}</div>
       <div className="mg-type-micro text-ink-muted">{label}</div>
     </div>
   );

--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
@@ -51,7 +51,7 @@ export function ValidatorDominanceChart() {
     <Panel as="div" dense>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
         <span className="mg-type-micro text-ink-muted">Stake dominance · top {rows.length}</span>
-        <span className="font-mono text-[10px] text-ink-muted">
+        <span className="mg-type-data-sm text-ink-muted">
           {coveredPct.toFixed(1)}% of network stake
         </span>
       </div>

--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -66,7 +66,7 @@ export function ValidatorSubnetHeatmap() {
       </div>
       <div className="w-full overflow-x-auto [scrollbar-gutter:stable]">
         <TooltipProvider delayDuration={150}>
-          <table className="w-full min-w-[640px] text-[11px] font-mono">
+          <table className="w-full min-w-[640px] mg-type-data">
             <thead>
               <tr>
                 <th className="sticky left-0 z-[var(--mg-z-sticky)] border-b border-border bg-card px-3 py-2 text-left mg-type-micro text-ink-muted">

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -638,7 +638,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
           );
         })}
         {(isFetching || isSemanticFetching) && debounced ? (
-          <span className="ml-auto font-mono text-[10px] text-ink-muted">searching…</span>
+          <span className="ml-auto mg-type-data-sm text-ink-muted">searching…</span>
         ) : null}
       </div>
 
@@ -655,7 +655,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
 
         {showNoMatches ? (
           <div className="px-3 py-3 space-y-3 border-b border-border">
-            <p className="font-mono text-[11px] text-ink-muted">
+            <p className="mg-type-data text-ink-muted">
               Try a suggested query or filter a list by your search.
             </p>
             <div>
@@ -767,7 +767,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                   <Icon className="size-4 text-ink-muted shrink-0" />
                   <div className="flex-1 min-w-0">
                     <div className="text-sm text-ink-strong truncate">{n.label}</div>
-                    <div className="font-mono text-[10px] text-ink-muted truncate">{n.hint}</div>
+                    <div className="mg-type-data-sm text-ink-muted truncate">{n.hint}</div>
                   </div>
                   <ItemActions
                     onCopy={() => copyLink(n.target, n.label)}
@@ -796,14 +796,14 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                   <div className="flex-1 min-w-0">
                     <div className="text-sm text-ink-strong truncate">{r.label}</div>
                     {r.hint ? (
-                      <div className="font-mono text-[10px] text-ink-muted truncate">{r.hint}</div>
+                      <div className="mg-type-data-sm text-ink-muted truncate">{r.hint}</div>
                     ) : null}
                   </div>
                   <ItemActions
                     onCopy={() => copyLink(target, r.label)}
                     onNewTab={() => openInNewTab(target, "route")}
                   />
-                  <CommandShortcut className="font-mono text-[10px]">page</CommandShortcut>
+                  <CommandShortcut className="mg-type-data-sm">page</CommandShortcut>
                 </CommandItem>
               );
             })}
@@ -835,9 +835,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                     <div className="flex-1 min-w-0">
                       <div className="text-sm text-ink-strong truncate">{title}</div>
                       {subtitle ? (
-                        <div className="font-mono text-[10px] text-ink-muted truncate">
-                          {subtitle}
-                        </div>
+                        <div className="mg-type-data-sm text-ink-muted truncate">{subtitle}</div>
                       ) : null}
                     </div>
                     <ItemActions
@@ -887,9 +885,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                   <div className="flex-1 min-w-0">
                     <div className="text-sm text-ink-strong truncate">{title}</div>
                     {subtitle ? (
-                      <div className="font-mono text-[10px] text-ink-muted truncate">
-                        {subtitle}
-                      </div>
+                      <div className="mg-type-data-sm text-ink-muted truncate">{subtitle}</div>
                     ) : null}
                   </div>
                   <ItemActions
@@ -929,7 +925,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
           </>
         ) : null}
       </CommandList>
-      <div className="border-t border-border px-3 py-2 flex items-center justify-between text-[10px] font-mono text-ink-muted">
+      <div className="border-t border-border px-3 py-2 flex items-center justify-between mg-type-data-sm text-ink-muted">
         <span className="inline-flex items-center gap-2 flex-wrap">
           <Kbd>↑</Kbd>
           <Kbd>↓</Kbd> move <Kbd>⏎</Kbd> open <Kbd>⌘</Kbd>

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -133,7 +133,7 @@ function SharePanel({
     <Panel as="div" dense>
       <div className="mb-3 mg-type-micro text-ink-muted">{title}</div>
       {allEmpty ? (
-        <p className="font-mono text-[11px] text-ink-muted">Not enough data yet.</p>
+        <p className="mg-type-data text-ink-muted">Not enough data yet.</p>
       ) : (
         <BarMini data={bars} max={100} />
       )}

--- a/apps/ui/src/components/metagraphed/continue-exploring.tsx
+++ b/apps/ui/src/components/metagraphed/continue-exploring.tsx
@@ -111,7 +111,7 @@ export function ContinueExploring() {
                 ) : (
                   <span
                     aria-hidden
-                    className="shrink-0 inline-flex items-center justify-center size-[22px] rounded-md border border-border bg-paper text-[10px] font-mono text-ink-muted"
+                    className="shrink-0 inline-flex items-center justify-center size-[22px] rounded-md border border-border bg-paper mg-type-data-sm text-ink-muted"
                   >
                     {v.kind === "provider" ? "PR" : "•"}
                   </span>
@@ -142,7 +142,7 @@ export function ContinueExploring() {
                 <Link
                   to="/subnets"
                   search={{ q } as never}
-                  className="group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-[12px] text-ink hover:border-accent/40 hover:text-accent transition-colors"
+                  className="group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 mg-type-caption text-ink hover:border-accent/40 hover:text-accent transition-colors"
                 >
                   <Search className="size-3 text-ink-muted group-hover:text-accent transition-colors" />
                   <span className="truncate max-w-[200px]">{q}</span>

--- a/apps/ui/src/components/metagraphed/copy-markdown-button.tsx
+++ b/apps/ui/src/components/metagraphed/copy-markdown-button.tsx
@@ -16,7 +16,7 @@ export function CopyMarkdownButton({ markdown }: { markdown: string | undefined 
       onClick={() => markdown && copy(markdown)}
       disabled={!markdown}
       className={classNames(
-        "inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded border border-border bg-card px-2.5 py-1.5 text-[12px] text-ink-muted",
+        "inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded border border-border bg-card px-2.5 py-1.5 mg-type-caption text-ink-muted",
         "hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50 disabled:pointer-events-none",
       )}
     >

--- a/apps/ui/src/components/metagraphed/delegate-cta.tsx
+++ b/apps/ui/src/components/metagraphed/delegate-cta.tsx
@@ -51,7 +51,7 @@ export function DelegateCTA({ netuid, variant = "inline", className }: Props) {
               Delegate & Earn
               <ArrowUpRight className="ml-1 inline size-3.5 text-ink-muted transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
             </span>
-            <span className="mt-0.5 block text-[12px] text-ink-muted">
+            <span className="mt-0.5 block mg-type-caption text-ink-muted">
               Stake τ to a validator across supported subnets
             </span>
           </span>
@@ -61,7 +61,7 @@ export function DelegateCTA({ netuid, variant = "inline", className }: Props) {
     return (
       <Link
         to="/delegate"
-        className={`inline-flex items-center gap-1.5 rounded-full border border-border mg-glass-soft text-sm font-medium text-ink hover:border-ink/30 hover:text-ink-strong transition-colors ${className ?? "px-3.5 py-1.5 text-[12px]"}`}
+        className={`inline-flex items-center gap-1.5 rounded-full border border-border mg-glass-soft text-sm font-medium text-ink hover:border-ink/30 hover:text-ink-strong transition-colors ${className ?? "px-3.5 py-1.5 mg-type-caption"}`}
       >
         <Coins aria-hidden className="size-3.5" />
         Delegate & Earn
@@ -97,7 +97,7 @@ export function DelegateCTA({ netuid, variant = "inline", className }: Props) {
             {label}
             <ArrowUpRight className="ml-1 inline size-3.5 text-accent transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
           </span>
-          <span className="mt-0.5 block text-[12px] text-ink-muted">{sub}</span>
+          <span className="mt-0.5 block mg-type-caption text-ink-muted">{sub}</span>
         </span>
       </Link>
     );
@@ -106,7 +106,7 @@ export function DelegateCTA({ netuid, variant = "inline", className }: Props) {
   return (
     <Link
       {...href}
-      className={`inline-flex items-center gap-1.5 rounded-full border border-accent/60 bg-primary-soft/60 px-3.5 py-1.5 text-[12px] font-medium text-ink-strong transition-colors hover:border-accent hover:bg-primary-soft ${className ?? ""}`}
+      className={`inline-flex items-center gap-1.5 rounded-full border border-accent/60 bg-primary-soft/60 px-3.5 py-1.5 mg-type-caption font-medium text-ink-strong transition-colors hover:border-accent hover:bg-primary-soft ${className ?? ""}`}
     >
       <Sparkles aria-hidden className="size-3 text-accent" />
       {label}

--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -61,7 +61,7 @@ function StakeMovesTile({ netuid }: { netuid: number }) {
           staleness="Counts settle as the chain-events indexer catches up; the bar hides when no re-delegations occurred in the window."
         >
           <span className="flex w-[72px] items-center gap-1.5">
-            <span className="w-6 text-right font-mono text-[11px] tabular-nums text-ink">
+            <span className="w-6 text-right mg-type-data tabular-nums text-ink">
               {m.perMover != null ? `${m.perMover.toFixed(1)}×` : "—"}
             </span>
             <span className="max-w-[56px] flex-1">
@@ -100,7 +100,7 @@ function StakeTransfersTile({ netuid }: { netuid: number }) {
           staleness="Counts settle as the chain-events indexer catches up; the bar hides when no transfers occurred in the window."
         >
           <span className="flex w-[72px] items-center gap-1.5">
-            <span className="w-6 text-right font-mono text-[11px] tabular-nums text-ink">
+            <span className="w-6 text-right mg-type-data tabular-nums text-ink">
               {m.perSender != null ? `${m.perSender.toFixed(1)}×` : "—"}
             </span>
             <span className="max-w-[56px] flex-1">

--- a/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-card-list.tsx
@@ -57,7 +57,7 @@ export function EndpointCardList({
                 <HealthPill state={e.health} />
               </SparkLegend>
             </div>
-            <div className="font-mono text-[11px] min-w-0">
+            <div className="mg-type-data min-w-0">
               {e.url ? (
                 <div className="flex items-center gap-1.5 min-w-0">
                   <ExternalLink href={e.url} className="min-w-0 text-[11px]">
@@ -127,7 +127,7 @@ export function EndpointCardList({
               updatedAt={e.last_probed_at}
               staleness="Rows older than the probe cycle are dimmed in tooltips elsewhere."
             >
-              <span className="font-mono text-[10px] text-ink-muted">
+              <span className="mg-type-data-sm text-ink-muted">
                 probed <TimeAgo at={e.last_probed_at} />
               </span>
             </SparkLegend>

--- a/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
@@ -47,7 +47,7 @@ export function EndpointComparePanel({
     >
       <header className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
         <div className="flex items-center gap-2">
-          <span className="font-display text-[12px] font-medium text-ink-strong">
+          <span className="font-display mg-type-caption font-medium text-ink-strong">
             Compare — {endpoints.length} endpoint{endpoints.length === 1 ? "" : "s"}
           </span>
           <span className="mg-type-micro text-ink-muted">side-by-side</span>
@@ -128,7 +128,7 @@ function CompareColumn({
                 ? `SN${endpoint.netuid}${subnet?.name ? ` · ${subnet.name}` : ""}`
                 : "Unassigned"}
           </div>
-          <div className="truncate font-mono text-[12px] font-medium text-ink-strong">
+          <div className="truncate font-mono mg-type-caption font-medium text-ink-strong">
             {endpoint.url ?? endpoint.id}
           </div>
           {endpoint.provider_slug ? (
@@ -165,7 +165,7 @@ function CompareColumn({
         <Field label="Health">
           <span
             className={classNames(
-              "inline-flex items-center gap-1 font-mono text-[11px] uppercase",
+              "inline-flex items-center gap-1 mg-type-data uppercase",
               endpoint.health === "ok"
                 ? "text-health-ok"
                 : endpoint.health === "warn"
@@ -184,7 +184,7 @@ function CompareColumn({
           </span>
         </Field>
         <Field label="Latency">
-          <span className="font-mono text-[11px] tabular-nums text-ink-strong">
+          <span className="mg-type-data tabular-nums text-ink-strong">
             {endpoint.latency_ms != null ? `${Math.round(endpoint.latency_ms)}ms` : "—"}
           </span>
         </Field>
@@ -194,7 +194,7 @@ function CompareColumn({
         <Field label="Incidents (retained)">
           <span
             className={classNames(
-              "font-mono text-[11px] tabular-nums",
+              "mg-type-data tabular-nums",
               incidentCount > 0 ? "text-health-warn-text" : "text-ink-strong",
             )}
           >
@@ -202,7 +202,7 @@ function CompareColumn({
           </span>
         </Field>
         <Field label="Freshness">
-          <span className="font-mono text-[10px] text-ink-muted">
+          <span className="mg-type-data-sm text-ink-muted">
             probed <TimeAgo at={endpoint.last_probed_at} />
           </span>
         </Field>

--- a/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
@@ -111,7 +111,7 @@ export function EndpointDetailDrawer({
           <div className="flex items-center gap-1.5 min-w-0">
             {endpoint.url ? (
               <>
-                <ExternalLink href={endpoint.url} className="truncate font-mono text-[12px]">
+                <ExternalLink href={endpoint.url} className="truncate font-mono mg-type-caption">
                   {endpoint.url}
                 </ExternalLink>
                 <CopyButton value={endpoint.url} label="URL" />
@@ -122,7 +122,7 @@ export function EndpointDetailDrawer({
                 />
               </>
             ) : (
-              <span className="font-mono text-[12px] text-ink-muted">no url</span>
+              <span className="font-mono mg-type-caption text-ink-muted">no url</span>
             )}
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -149,7 +149,7 @@ export function EndpointDetailDrawer({
                 samples as you monitor the endpoint.
               </p>
             </div>
-            <span className="font-mono text-[11px] text-ink-strong">
+            <span className="mg-type-data text-ink-strong">
               {endpoint.latency_ms != null ? `${endpoint.latency_ms}ms latest` : "No latest sample"}
             </span>
           </div>
@@ -178,9 +178,7 @@ export function EndpointDetailDrawer({
               .map((p, index) => (
                 <div key={`${p.t}-${index}`} className="min-w-0 border-l border-border pl-2">
                   <div className="mg-label">{index === 0 ? "Latest" : `Prior ${index}`}</div>
-                  <div className="mt-1 font-mono text-[11px] text-ink-strong">
-                    {Math.round(p.v)}ms
-                  </div>
+                  <div className="mt-1 mg-type-data text-ink-strong">{Math.round(p.v)}ms</div>
                   <div className="mt-0.5 truncate font-mono text-[9px] text-ink-muted">
                     {new Date(p.t).toLocaleString()}
                   </div>
@@ -194,7 +192,7 @@ export function EndpointDetailDrawer({
             <div id={`incidents-${endpoint.id}`} className="mg-label">
               Incident timeline
             </div>
-            <span className="font-mono text-[10px] text-ink-muted tabular-nums">
+            <span className="mg-type-data-sm text-ink-muted tabular-nums">
               {allRows.length} total
             </span>
           </div>
@@ -270,11 +268,11 @@ export function EndpointDetailDrawer({
                     />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-baseline justify-between gap-2">
-                        <span className="font-mono text-[11px] text-ink-strong">
+                        <span className="mg-type-data text-ink-strong">
                           {String(inc.state ?? "incident")}
                         </span>
                         <span className="flex items-center gap-1">
-                          <span className="font-mono text-[10px] text-ink-muted tabular-nums">
+                          <span className="mg-type-data-sm text-ink-muted tabular-nums">
                             {inc.started_at ? new Date(inc.started_at).toLocaleString() : "—"}
                           </span>
                           <CopyLinkButton
@@ -289,7 +287,7 @@ export function EndpointDetailDrawer({
                           {inc.message}
                         </div>
                       ) : null}
-                      <div className="mt-0.5 flex flex-wrap items-center gap-2 font-mono text-[10px] text-ink-subtle-text">
+                      <div className="mt-0.5 flex flex-wrap items-center gap-2 mg-type-data-sm text-ink-subtle-text">
                         <a
                           href={`#endpoint-${affected}`}
                           className="mg-focus-ring hover:text-accent-text"

--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -189,7 +189,7 @@ function Row({
   return (
     <tr className="mg-row-hover border-t border-border/60">
       {showNetuid ? (
-        <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted tabular-nums">
+        <td className="px-4 py-2.5 mg-type-data text-ink-muted tabular-nums">
           {e.netuid != null ? (
             <Link
               to="/subnets/$netuid"
@@ -205,12 +205,10 @@ function Row({
       ) : null}
       <td className="px-4 py-2.5">
         <div className="font-mono text-[11.5px] text-ink truncate max-w-[42ch]">{e.url ?? "—"}</div>
-        {e.region ? (
-          <div className="font-mono text-[10px] text-ink-muted mt-0.5">{e.region}</div>
-        ) : null}
+        {e.region ? <div className="mg-type-data-sm text-ink-muted mt-0.5">{e.region}</div> : null}
       </td>
       {showProvider ? (
-        <td className="px-4 py-2.5 text-[12px]">
+        <td className="px-4 py-2.5 mg-type-caption">
           {e.provider ? (
             <Link
               to="/providers/$slug"
@@ -248,14 +246,14 @@ function Row({
               ariaLabel="Recent probe trend"
             />
           ) : (
-            <span className="font-mono text-[10px] text-ink-muted">—</span>
+            <span className="mg-type-data-sm text-ink-muted">—</span>
           )}
         </div>
       </td>
-      <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted tabular-nums">
+      <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted tabular-nums">
         {e.latency_ms != null ? `${e.latency_ms}ms` : "—"}
       </td>
-      <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+      <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
         <TimeAgo at={e.last_probed_at} />
       </td>
       <td className="px-4 py-2.5 text-right">
@@ -322,14 +320,14 @@ function MobileCard({
               <Link
                 to="/subnets/$netuid"
                 params={{ netuid: e.netuid }}
-                className="font-mono text-[10px] text-ink-muted hover:text-ink-strong"
+                className="mg-type-data-sm text-ink-muted hover:text-ink-strong"
               >
                 sn{String(e.netuid).padStart(3, "0")}
               </Link>
             ) : null}
             <EligibilityChip eligibility={endpointEligibility(e, poolsById)} size="xs" />
           </div>
-          <div className="font-mono text-[11px] text-ink break-all">{e.url ?? "—"}</div>
+          <div className="mg-type-data text-ink break-all">{e.url ?? "—"}</div>
         </div>
         <HealthDot state={e.health} />
       </div>

--- a/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-operational-list.tsx
@@ -148,7 +148,7 @@ export function EndpointOperationalList({
                 )}
                 <h3
                   id={`group-${group.netuid}`}
-                  className="truncate font-display text-[13px] font-medium text-ink-strong"
+                  className="truncate font-display mg-type-caption-lg font-medium text-ink-strong"
                 >
                   {group.label}
                 </h3>
@@ -280,14 +280,14 @@ export function EndpointOperationalList({
                                 <>
                                   <ExternalLink
                                     href={endpoint.url}
-                                    className="truncate font-mono text-[13px] font-medium text-ink-strong hover:text-accent-text"
+                                    className="truncate font-mono mg-type-caption-lg font-medium text-ink-strong hover:text-accent-text"
                                   >
                                     {endpoint.url}
                                   </ExternalLink>
                                   <CopyButton value={endpoint.url} label="endpoint URL" />
                                 </>
                               ) : (
-                                <span className="font-mono text-[13px] text-ink-muted">
+                                <span className="font-mono mg-type-caption-lg text-ink-muted">
                                   URL unavailable
                                 </span>
                               )}
@@ -359,7 +359,7 @@ export function EndpointOperationalList({
                           <div className="min-w-0">
                             <div className="mg-label mb-1 lg:hidden">7d uptime</div>
                             <EndpointUptimeBar endpointId={endpoint.id} incidents={incidents} />
-                            <div className="mt-1 font-mono text-[10px] text-ink-muted">
+                            <div className="mt-1 mg-type-data-sm text-ink-muted">
                               probed <TimeAgo at={endpoint.last_probed_at} />
                             </div>
                           </div>

--- a/apps/ui/src/components/metagraphed/endpoint-snippet.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-snippet.tsx
@@ -82,7 +82,7 @@ export function EndpointSnippet({ rows }: { rows: EndpointSnippetRow[] }) {
         ))}
       </div>
       {lang === "python" ? (
-        <p className="mt-2 font-mono text-[10px] text-ink-muted">
+        <p className="mt-2 mg-type-data-sm text-ink-muted">
           requires <code className="text-ink-strong">pip install requests</code>
         </p>
       ) : null}

--- a/apps/ui/src/components/metagraphed/endpoints-glance.tsx
+++ b/apps/ui/src/components/metagraphed/endpoints-glance.tsx
@@ -122,7 +122,7 @@ export function EndpointsGlance({
                     {items.length}
                   </span>
                 </div>
-                <div className="mt-0.5 truncate font-mono text-[11px] text-ink-muted">
+                <div className="mt-0.5 truncate mg-type-data text-ink-muted">
                   {top ? maskHost(top.url) : "—"}
                 </div>
               </div>

--- a/apps/ui/src/components/metagraphed/endpoints-priority-strip.tsx
+++ b/apps/ui/src/components/metagraphed/endpoints-priority-strip.tsx
@@ -121,7 +121,7 @@ function PriorityCard({ item }: { item: Item }) {
               <HealthDot state={r.health ?? "unknown"} />
               <span className="truncate font-mono">{r.provider ?? r.provider_slug ?? r.id}</span>
               {r.latency_ms != null ? (
-                <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums">
+                <span className="ml-auto shrink-0 mg-type-data-sm tabular-nums">
                   {r.latency_ms}ms
                 </span>
               ) : null}

--- a/apps/ui/src/components/metagraphed/entity-hover-card.tsx
+++ b/apps/ui/src/components/metagraphed/entity-hover-card.tsx
@@ -114,9 +114,7 @@ function SubnetMiniProfile({ netuid }: { netuid: number }) {
       </div>
       <div className="flex items-center gap-2 flex-wrap">
         <CurationChip level={s.curation_level} />
-        {s.type ? (
-          <span className="font-mono text-[10px] uppercase text-ink-muted">{s.type}</span>
-        ) : null}
+        {s.type ? <span className="mg-type-data-sm uppercase text-ink-muted">{s.type}</span> : null}
       </div>
       <dl className="grid grid-cols-3 gap-2 pt-1">
         <Mini label="Participants" value={formatNumber(s.participants)} />
@@ -127,7 +125,7 @@ function SubnetMiniProfile({ netuid }: { netuid: number }) {
         />
       </dl>
       {s.updated_at || s.freshness ? (
-        <div className="pt-1 border-t border-border font-mono text-[10px] text-ink-muted">
+        <div className="pt-1 border-t border-border mg-type-data-sm text-ink-muted">
           updated <TimeAgo at={s.updated_at ?? s.freshness} />
         </div>
       ) : null}
@@ -161,7 +159,7 @@ function ProviderMiniProfile({ slug }: { slug: string }) {
           <div className="font-display text-sm font-semibold text-ink-strong truncate">
             {p.name ?? slug}
           </div>
-          <div className="font-mono text-[10px] text-ink-muted truncate">{slug}</div>
+          <div className="mg-type-data-sm text-ink-muted truncate">{slug}</div>
         </div>
       </div>
       {p.notes ? <p className="text-[11px] text-ink-muted line-clamp-3">{p.notes}</p> : null}
@@ -186,14 +184,14 @@ function AccountMiniProfile({ ss58 }: { ss58: string }) {
     <div className="space-y-2">
       <div className="min-w-0">
         <div className="mg-type-micro text-ink-muted">account</div>
-        <div className="font-mono text-[10px] text-ink-muted truncate">{ss58}</div>
+        <div className="mg-type-data-sm text-ink-muted truncate">{ss58}</div>
       </div>
       <dl className="grid grid-cols-2 gap-2 pt-1">
         <Mini label="Events" value={formatNumber(a.event_count)} />
         <Mini label="Subnets" value={formatNumber(a.subnet_count)} />
       </dl>
       {a.last_seen_at ? (
-        <div className="pt-1 border-t border-border font-mono text-[10px] text-ink-muted">
+        <div className="pt-1 border-t border-border mg-type-data-sm text-ink-muted">
           last seen <TimeAgo at={a.last_seen_at} />
         </div>
       ) : null}
@@ -205,7 +203,7 @@ function Mini({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="rounded border border-border/60 bg-paper/40 px-2 py-1">
       <dt className="mg-type-micro text-ink-muted">{label}</dt>
-      <dd className="font-mono text-[12px] text-ink-strong truncate">{value}</dd>
+      <dd className="font-mono mg-type-caption text-ink-strong truncate">{value}</dd>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -149,7 +149,7 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
         <Panel as="div" dense key={source}>
           <div className="flex items-center justify-between mb-2 gap-3">
             <span className="mg-label">{source}</span>
-            <span className="flex items-center gap-2 font-mono text-[10px] text-ink-muted">
+            <span className="flex items-center gap-2 mg-type-data-sm text-ink-muted">
               <span>
                 latest <TimeAgo at={items[0]?.recorded_at} />
               </span>
@@ -171,12 +171,12 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
                         {item.netuid != null ? <> · SN{item.netuid}</> : null}
                       </div>
                       {item.note ? (
-                        <div className="text-[12px] text-ink-strong">{item.note}</div>
+                        <div className="mg-type-caption text-ink-strong">{item.note}</div>
                       ) : null}
                       {item.url ? (
-                        <div className="font-mono text-[10px] text-ink break-all">{item.url}</div>
+                        <div className="mg-type-data-sm text-ink break-all">{item.url}</div>
                       ) : null}
-                      <div className="font-mono text-[10px] text-ink-muted">
+                      <div className="mg-type-data-sm text-ink-muted">
                         recorded <TimeAgo at={item.recorded_at} />
                       </div>
                     </div>
@@ -202,7 +202,7 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
       ))}
 
       <div className="flex items-center justify-between gap-3 pt-1">
-        <span className="font-mono text-[10px] text-ink-muted">
+        <span className="mg-type-data-sm text-ink-muted">
           loaded {allRows.length}
           {totalKnown != null ? ` of ${totalKnown}` : ""}
         </span>
@@ -216,7 +216,7 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
             {query.isFetchingNextPage ? "Loading…" : `Load ${pageSize} more`}
           </button>
         ) : (
-          <span className="font-mono text-[10px] text-ink-muted">end of evidence</span>
+          <span className="mg-type-data-sm text-ink-muted">end of evidence</span>
         )}
       </div>
     </div>

--- a/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
+++ b/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
@@ -51,7 +51,7 @@ export function GittensorRegisteredRepos({ slug }: { slug: string }) {
       <div className="mb-3 flex items-center justify-between gap-2">
         <span className="mg-type-micro text-ink-muted">Registered repositories</span>
         {total ? (
-          <span className="shrink-0 font-mono text-[10px] text-ink-muted tabular-nums">
+          <span className="shrink-0 mg-type-data-sm text-ink-muted tabular-nums">
             {total} total
           </span>
         ) : null}
@@ -69,13 +69,13 @@ export function GittensorRegisteredRepos({ slug }: { slug: string }) {
                 className="mg-row-hover flex items-center justify-between gap-2 rounded-md px-2 py-1.5"
               >
                 <span className="flex min-w-0 items-center gap-2">
-                  <span className="w-4 shrink-0 text-right font-mono text-[10px] text-ink-muted tabular-nums">
+                  <span className="w-4 shrink-0 text-right mg-type-data-sm text-ink-muted tabular-nums">
                     {i + 1}
                   </span>
                   <BrandIcon size={18} name={row.repository} repoUrl={repoUrl} fallback={i + 1} />
                   <span className="truncate text-sm text-ink-strong">{row.repository}</span>
                 </span>
-                <span className="shrink-0 font-mono text-[12px] tabular-nums text-ink-muted">
+                <span className="shrink-0 font-mono mg-type-caption tabular-nums text-ink-muted">
                   {sharePct !== null ? `${sharePct.toFixed(1)}%` : "—"}
                 </span>
               </a>

--- a/apps/ui/src/components/metagraphed/global-error-boundary.tsx
+++ b/apps/ui/src/components/metagraphed/global-error-boundary.tsx
@@ -93,7 +93,7 @@ export class GlobalErrorBoundary extends Component<Props, State> {
 
             <Panel as="div" dense className="mt-6">
               <div className="mg-label">Error message</div>
-              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-paper p-2 font-mono text-[12px] text-ink">
+              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-paper p-2 font-mono mg-type-caption text-ink">
                 {message || "Unknown error"}
               </pre>
             </Panel>

--- a/apps/ui/src/components/metagraphed/header-actions-menu.tsx
+++ b/apps/ui/src/components/metagraphed/header-actions-menu.tsx
@@ -40,7 +40,7 @@ export function HeaderActionsMenu() {
                 setMenuOpen(false);
                 open();
               }}
-              className="w-full flex items-center gap-2 rounded border border-border bg-card px-2 py-2 text-left text-[12px] text-ink hover:border-ink/30 hover:text-ink-strong transition-colors min-h-9"
+              className="w-full flex items-center gap-2 rounded border border-border bg-card px-2 py-2 text-left mg-type-caption text-ink hover:border-ink/30 hover:text-ink-strong transition-colors min-h-9"
             >
               <Code2 className="size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
               <span>View API source</span>
@@ -49,7 +49,7 @@ export function HeaderActionsMenu() {
           <Link
             to="/settings"
             onClick={() => setMenuOpen(false)}
-            className="w-full flex items-center gap-2 rounded border border-border bg-card px-2 py-2 text-left text-[12px] text-ink hover:border-ink/30 hover:text-ink-strong transition-colors min-h-9"
+            className="w-full flex items-center gap-2 rounded border border-border bg-card px-2 py-2 text-left mg-type-caption text-ink hover:border-ink/30 hover:text-ink-strong transition-colors min-h-9"
           >
             <Webhook className="size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
             <span>Developer settings</span>

--- a/apps/ui/src/components/metagraphed/hero-feature-row.tsx
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.tsx
@@ -197,13 +197,13 @@ function LiveSubnetRow({ sn }: { sn: Subnet }) {
         </div>
         <div className="shrink-0 flex flex-col items-end gap-0.5">
           <span
-            className="font-mono text-[11px] tabular-nums text-ink-strong"
+            className="mg-type-data tabular-nums text-ink-strong"
             title="Latest alpha price in TAO"
           >
             {closes.length ? `${formatAlpha(closes.at(-1)!)} τ` : "—"}
           </span>
           <span
-            className={`font-mono text-[10px] tabular-nums ${deltaTone}`}
+            className={`mg-type-data-sm tabular-nums ${deltaTone}`}
             title="Alpha price change over the last 7 days"
           >
             {deltaPct == null ? "—" : `${deltaPct >= 0 ? "+" : ""}${deltaPct.toFixed(1)}%`}

--- a/apps/ui/src/components/metagraphed/hero-subnet-chips.tsx
+++ b/apps/ui/src/components/metagraphed/hero-subnet-chips.tsx
@@ -94,7 +94,7 @@ export function HeroSubnetChips({ limit = 14 }: { limit?: number }) {
               url={s.website}
               netuid={s.netuid}
             />
-            <span className="font-medium text-[12px] text-ink-strong truncate max-w-[120px]">
+            <span className="font-medium mg-type-caption text-ink-strong truncate max-w-[120px]">
               {s.name ?? `Subnet ${s.netuid}`}
             </span>
             <span className="mg-type-micro text-ink-muted">SN{s.netuid}</span>

--- a/apps/ui/src/components/metagraphed/incident-card.tsx
+++ b/apps/ui/src/components/metagraphed/incident-card.tsx
@@ -14,16 +14,16 @@ export function IncidentCard({ incident }: { incident: EndpointIncident }) {
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
           <HealthPill state={i.state} />
-          <span className="font-mono text-[11px] text-ink-strong truncate">
-            {i.endpoint_id ?? "—"}
-          </span>
+          <span className="mg-type-data text-ink-strong truncate">{i.endpoint_id ?? "—"}</span>
         </div>
         <span className={`mg-type-micro ${ongoing ? "text-health-down" : "text-ink-muted"}`}>
           {ongoing ? "ongoing" : "resolved"} · {durationLabel(i.started_at, i.ended_at)}
         </span>
       </div>
-      {i.message ? <p className="text-[12px] text-ink-muted line-clamp-2">{i.message}</p> : null}
-      <div className="flex items-center justify-between font-mono text-[10px] text-ink-muted">
+      {i.message ? (
+        <p className="mg-type-caption text-ink-muted line-clamp-2">{i.message}</p>
+      ) : null}
+      <div className="flex items-center justify-between mg-type-data-sm text-ink-muted">
         <span>
           started <TimeAgo at={i.started_at} />
         </span>

--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -91,7 +91,7 @@ export function IncidentStrip() {
     <div
       role="alert"
       className={classNames(
-        "border-b text-[12px] mg-fade-in",
+        "border-b mg-type-caption mg-fade-in",
         isDown
           ? "bg-health-down/10 border-health-down/30 text-ink-strong"
           : "bg-health-warn/10 border-health-warn/30 text-ink-strong",

--- a/apps/ui/src/components/metagraphed/leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards.tsx
@@ -106,7 +106,7 @@ function BoardCard({
               className="mg-row-hover flex items-center justify-between gap-2 rounded-md px-2 py-1.5"
             >
               <span className="flex min-w-0 items-center gap-2">
-                <span className="w-4 shrink-0 text-right font-mono text-[10px] text-ink-muted tabular-nums">
+                <span className="w-4 shrink-0 text-right mg-type-data-sm text-ink-muted tabular-nums">
                   {i + 1}
                 </span>
                 <BrandIcon
@@ -120,7 +120,7 @@ function BoardCard({
                   {row.name ?? `Subnet ${row.netuid}`}
                 </span>
               </span>
-              <span className="shrink-0 font-mono text-[12px] tabular-nums text-ink-muted">
+              <span className="shrink-0 font-mono mg-type-caption tabular-nums text-ink-muted">
                 {metric(row) ?? "—"}
               </span>
             </Link>

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -98,7 +98,7 @@ export function MetagraphTableLoader({
               Stake distribution · top {stakeBars.length} UIDs
             </span>
             <span className="ml-auto flex items-center gap-2">
-              <span className="font-mono text-[10px] text-ink-muted">
+              <span className="mg-type-data-sm text-ink-muted">
                 peak {taoCompact(stakeBars[0]?.value)} τ
               </span>
               {freshness}

--- a/apps/ui/src/components/metagraphed/move-stake-destination-input.tsx
+++ b/apps/ui/src/components/metagraphed/move-stake-destination-input.tsx
@@ -89,7 +89,7 @@ export function MoveStakeDestinationInput({
         <select
           value={destinationNetuidInput}
           onChange={(e) => onDestinationNetuidChange(e.target.value)}
-          className="h-9 rounded border border-border bg-card px-2 font-mono text-[12px] text-ink-strong"
+          className="h-9 rounded border border-border bg-card px-2 font-mono mg-type-caption text-ink-strong"
         >
           {knownSubnets.map((s) => (
             <option key={s.netuid} value={s.netuid}>
@@ -122,7 +122,7 @@ export function MoveStakeDestinationInput({
       </div>
 
       {axisIssueMessage ? (
-        <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+        <p className="inline-flex items-center gap-1.5 mg-type-data text-health-down">
           <AlertTriangle className="size-3.5 shrink-0" aria-hidden />
           {axisIssueMessage}
         </p>
@@ -130,22 +130,22 @@ export function MoveStakeDestinationInput({
 
       {axis === "subnet" && hasValidAmount ? (
         quoteError ? (
-          <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+          <p className="inline-flex items-center gap-1.5 mg-type-data text-health-down">
             <AlertCircle className="size-3.5 shrink-0" aria-hidden />
             {quoteError}
           </p>
         ) : quoteIsPending ? (
-          <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+          <p className="inline-flex items-center gap-1.5 mg-type-data text-ink-muted">
             <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden />
             Calculating…
           </p>
         ) : quote ? (
-          <p className="font-mono text-[11px] text-ink-strong">{formatQuoteHint(quote)}</p>
+          <p className="mg-type-data text-ink-strong">{formatQuoteHint(quote)}</p>
         ) : null
       ) : null}
 
       {axis === "hotkey" ? (
-        <p className="font-mono text-[10px] text-ink-muted">
+        <p className="mg-type-data-sm text-ink-muted">
           Same-subnet hotkey moves are a pure reassignment — no AMM, no slippage.
         </p>
       ) : null}
@@ -155,7 +155,7 @@ export function MoveStakeDestinationInput({
           {validationMessages.map((message) => (
             <li
               key={message}
-              className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down"
+              className="inline-flex items-center gap-1.5 mg-type-data text-health-down"
             >
               <AlertCircle className="size-3.5 shrink-0" aria-hidden />
               {message}

--- a/apps/ui/src/components/metagraphed/move-stake-modal.tsx
+++ b/apps/ui/src/components/metagraphed/move-stake-modal.tsx
@@ -175,7 +175,7 @@ function MoveStakeFlowBody({
               type="button"
               onClick={flow.confirm}
               disabled={!flow.canConfirm}
-              className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
+              className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
             >
               Review move
             </button>
@@ -225,11 +225,13 @@ function MoveStakeFlowBody({
       return (
         <div className="flex flex-col items-center gap-4 py-10 text-center">
           <AlertTriangle className="size-6 text-health-down" aria-hidden />
-          <p className="text-[13px] text-ink-strong">{describeTxError(flow.txStatus.error)}</p>
+          <p className="mg-type-caption-lg text-ink-strong">
+            {describeTxError(flow.txStatus.error)}
+          </p>
           <button
             type="button"
             onClick={flow.editAmount}
-            className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+            className="rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink/30"
           >
             Edit and try again
           </button>
@@ -262,13 +264,13 @@ function StatusView({
   return (
     <div className="flex flex-col items-center gap-4 py-10 text-center">
       {icon}
-      <p className="text-[13px] text-ink-strong">{message}</p>
+      <p className="mg-type-caption-lg text-ink-strong">{message}</p>
       {txHash ? (
         <div className="space-y-1">
           <Link
             to="/extrinsics/$hash"
             params={{ hash: txHash }}
-            className="font-mono text-[11px] text-accent hover:underline"
+            className="mg-type-data text-accent hover:underline"
           >
             {shortHash(txHash, 8)}
           </Link>
@@ -281,7 +283,7 @@ function StatusView({
         <button
           type="button"
           onClick={onClose}
-          className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+          className="rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink/30"
         >
           Done
         </button>

--- a/apps/ui/src/components/metagraphed/movers-band.tsx
+++ b/apps/ui/src/components/metagraphed/movers-band.tsx
@@ -76,7 +76,7 @@ export function MoversBand() {
       <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
         <div>
           <h2 className="font-display text-lg font-semibold text-ink-strong">Biggest movers</h2>
-          <p className="font-mono text-[11px] text-ink-muted">
+          <p className="mg-type-data text-ink-muted">
             Subnets by {sortLabel.toLowerCase()} change · {res.data.window} window
             {network ? ` · ${network.gainers} up · ${network.losers} down` : ""}
           </p>
@@ -109,13 +109,13 @@ export function MoversBand() {
                 params={{ netuid: m.netuid }}
                 className="grid grid-cols-[2rem_1fr_auto] items-center gap-2 rounded border border-border bg-card px-3 py-2 hover:bg-surface/40"
               >
-                <span className="font-mono text-[10px] text-ink-muted">#{i + 1}</span>
-                <span className="font-mono text-[12px] text-ink-strong">SN{m.netuid}</span>
+                <span className="mg-type-data-sm text-ink-muted">#{i + 1}</span>
+                <span className="font-mono mg-type-caption text-ink-strong">SN{m.netuid}</span>
                 <span
                   className={
                     up
-                      ? "font-mono text-[11px] tabular-nums text-health-ok"
-                      : "font-mono text-[11px] tabular-nums text-health-down"
+                      ? "mg-type-data tabular-nums text-health-ok"
+                      : "mg-type-data tabular-nums text-health-down"
                   }
                 >
                   {formatted}

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
@@ -441,7 +441,7 @@ export function MegaPanelBody({
           Open {panel.label}
           <ArrowUpRight className="size-3.5" />
         </Link>
-        <div className="flex items-center gap-2 text-[11px] font-mono text-ink-muted">
+        <div className="flex items-center gap-2 mg-type-data text-ink-muted">
           <span>{panel.apiPath}</span>
           <CopyButton value={`${API_BASE}${panel.apiPath}`} label={`${panel.apiPath} URL`} />
           <a

--- a/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
@@ -300,7 +300,7 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
                 <span className="font-display text-sm font-semibold text-ink-strong">
                   {activePanel.label}
                 </span>
-                <span className="text-[12px] text-ink-muted">— {activePanel.blurb}</span>
+                <span className="mg-type-caption text-ink-muted">— {activePanel.blurb}</span>
               </div>
               <Suspense fallback={<MegaPanelFallback />}>
                 <MegaPanelBody

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -411,7 +411,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                     >
                       <r.Icon className="size-3.5 shrink-0 text-ink-muted group-hover/jump:text-accent transition-colors" />
                       <span className="min-w-0">
-                        <span className="block text-[12px] font-medium text-ink-strong truncate">
+                        <span className="block mg-type-caption font-medium text-ink-strong truncate">
                           {r.label}
                         </span>
                         <span className="block text-[10px] text-ink-muted truncate">{r.hint}</span>
@@ -454,13 +454,13 @@ export function NavOmnibox({ onOpenPalette }: Props) {
               ) : null}
 
               <div className="px-3 py-2 border-t border-border flex items-center justify-between">
-                <span className="font-mono text-[10px] text-ink-muted">
+                <span className="mg-type-data-sm text-ink-muted">
                   <Kbd>↑</Kbd> <Kbd>↓</Kbd> navigate · <Kbd>↵</Kbd> open
                 </span>
                 <button
                   type="button"
                   onClick={onOpenPalette}
-                  className="inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted hover:text-ink-strong transition-colors"
+                  className="inline-flex items-center gap-1 mg-type-data-sm text-ink-muted hover:text-ink-strong transition-colors"
                 >
                   Full search
                   <ArrowRight className="size-2.5" />
@@ -499,7 +499,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                           <span className="block text-sm font-medium text-ink-strong">
                             {n.label}
                           </span>
-                          <span className="block font-mono text-[10px] text-ink-muted truncate">
+                          <span className="block mg-type-data-sm text-ink-muted truncate">
                             {n.hint}
                           </span>
                         </span>
@@ -514,11 +514,9 @@ export function NavOmnibox({ onOpenPalette }: Props) {
 
               {/* Search hits */}
               {isFetching && hits.length === 0 ? (
-                <div className="px-3 py-4 text-center font-mono text-[11px] text-ink-muted">
-                  Searching…
-                </div>
+                <div className="px-3 py-4 text-center mg-type-data text-ink-muted">Searching…</div>
               ) : hits.length === 0 && navTargets.length === 0 ? (
-                <div className="px-3 py-4 text-center font-mono text-[11px] text-ink-muted">
+                <div className="px-3 py-4 text-center mg-type-data text-ink-muted">
                   No results. Try pasting a wallet address, block number, or tx hash.
                 </div>
               ) : hits.length > 0 ? (
@@ -555,7 +553,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                                 <span className="block text-sm text-ink-strong truncate">
                                   {h.title ?? h.url ?? h.id}
                                 </span>
-                                <span className="block font-mono text-[10px] text-ink-muted truncate">
+                                <span className="block mg-type-data-sm text-ink-muted truncate">
                                   {h.netuid != null
                                     ? `netuid ${h.netuid}`
                                     : (h.slug ?? h.url ?? "")}
@@ -590,7 +588,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                       Filter /subnets by{" "}
                       <span className="font-mono text-accent-text">"{debounced}"</span>
                     </span>
-                    <span className="ml-auto font-mono text-[10px] text-ink-muted">
+                    <span className="ml-auto mg-type-data-sm text-ink-muted">
                       <Kbd>↵</Kbd>
                     </span>
                   </button>

--- a/apps/ui/src/components/metagraphed/network-mood-gauge.tsx
+++ b/apps/ui/src/components/metagraphed/network-mood-gauge.tsx
@@ -64,7 +64,7 @@ export function NetworkMoodGauge() {
       </div>
       <span
         className={classNames(
-          "shrink-0 font-mono text-[11px] tabular-nums",
+          "shrink-0 mg-type-data tabular-nums",
           sentiment === "neutral" ? "text-ink-muted" : "",
         )}
         style={sentiment !== "neutral" ? { color: meta.color } : undefined}

--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -111,7 +111,9 @@ export function NetworkSwitcher() {
                     <Globe2 className="mt-0.5 size-3.5 text-ink-muted shrink-0" />
                     <span className="min-w-0 flex-1">
                       <span className="flex items-center gap-2">
-                        <span className="text-[12px] font-medium text-ink-strong">{n.label}</span>
+                        <span className="mg-type-caption font-medium text-ink-strong">
+                          {n.label}
+                        </span>
                         {active ? <Check className="size-3 text-health-ok" /> : null}
                       </span>
                       <span className="mt-0.5 block text-[10px] text-ink-muted">
@@ -127,7 +129,7 @@ export function NetworkSwitcher() {
                 <div className="px-2 py-2">
                   <div className="flex items-center gap-2">
                     <TerminalSquare className="size-3.5 text-ink-muted shrink-0" />
-                    <span className="text-[12px] font-medium text-ink-strong">
+                    <span className="mg-type-caption font-medium text-ink-strong">
                       {LOCAL_DEV.label}
                     </span>
                   </div>
@@ -135,9 +137,7 @@ export function NetworkSwitcher() {
                     {LOCAL_DEV.description}
                   </span>
                   <div className="mt-1 flex items-center justify-between gap-2">
-                    <code className="font-mono text-[10px] text-ink-muted truncate">
-                      {LOCAL_DEV.rpc}
-                    </code>
+                    <code className="mg-type-data-sm text-ink-muted truncate">{LOCAL_DEV.rpc}</code>
                     <a
                       href={LOCAL_DEV.guideUrl}
                       target="_blank"
@@ -204,7 +204,7 @@ export function NetworkSwitcher() {
                   // the field needs its own aria-label -- matching SearchInput's
                   // convention in table-controls.tsx.
                   aria-label="Custom API origin"
-                  className="flex-1 rounded border border-border bg-card px-2 py-1 font-mono text-[11px] focus:outline-none focus:border-ink/30"
+                  className="flex-1 rounded border border-border bg-card px-2 py-1 mg-type-data focus:outline-none focus:border-ink/30"
                 />
                 <button
                   type="submit"
@@ -214,7 +214,7 @@ export function NetworkSwitcher() {
                 </button>
               </form>
               <div className="flex items-center justify-between gap-2">
-                <code className="font-mono text-[10px] text-ink-muted truncate">{base}</code>
+                <code className="mg-type-data-sm text-ink-muted truncate">{base}</code>
                 {!baseIsDefault ? (
                   <button
                     type="button"

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -111,7 +111,7 @@ export function NeuronDetailCard({
             <Link
               to="/blocks/$ref"
               params={{ ref: String(n.registered_at_block) }}
-              className="font-mono text-[12px] text-ink hover:text-accent hover:underline"
+              className="font-mono mg-type-caption text-ink hover:text-accent hover:underline"
             >
               #{formatNumber(n.registered_at_block)}
             </Link>
@@ -138,7 +138,7 @@ function KeyRow({ label, value }: { label: string; value?: string }) {
     <div className="flex items-center justify-between gap-3">
       <span className="mg-type-micro text-ink-muted">{label}</span>
       {value ? (
-        <span className="font-mono text-[12px] text-ink">
+        <span className="font-mono mg-type-caption text-ink">
           <AccountAddress
             ss58={value}
             compact
@@ -146,7 +146,7 @@ function KeyRow({ label, value }: { label: string; value?: string }) {
           />
         </span>
       ) : (
-        <span className="font-mono text-[12px] text-ink-muted">—</span>
+        <span className="font-mono mg-type-caption text-ink-muted">—</span>
       )}
     </div>
   );

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -192,7 +192,7 @@ export function NeuronTable({
                     active && "bg-accent-surface",
                   )}
                 >
-                  <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink-strong">
+                  <td className="px-3 py-2.5 font-mono mg-type-caption tabular-nums text-ink-strong">
                     {onSelect ? (
                       <button
                         type="button"
@@ -205,7 +205,7 @@ export function NeuronTable({
                       n.uid
                     )}
                   </td>
-                  <td className="px-3 py-2.5 font-mono text-[11px]">
+                  <td className="px-3 py-2.5 mg-type-data">
                     <div className="flex items-center gap-1.5">
                       {n.featured ? <SponsoredBadge /> : null}
                       {n.hotkey ? (
@@ -236,24 +236,24 @@ export function NeuronTable({
                       )}
                     </div>
                   </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                  <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
                     {taoCompact(n.stake_tao)}
                   </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                  <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
                     {taoCompact(n.emission_tao)}
                   </td>
                   {isValidator ? (
                     <>
-                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                      <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
                         {scoreStr(n.dividends)}
                       </td>
-                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                      <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                         {scoreStr(validatorTrustValue(n))}
                       </td>
-                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                      <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                         {formatTakePct(n.take)}
                       </td>
-                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                      <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                         {formatApyPct(
                           annualizedDelegatorApyPct(n.emission_tao ?? 0, n.stake_tao ?? 0, n.take),
                         )}
@@ -261,13 +261,13 @@ export function NeuronTable({
                     </>
                   ) : (
                     <>
-                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                      <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                         {n.rank == null ? "—" : n.rank}
                       </td>
-                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                      <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                         {scoreStr(n.trust)}
                       </td>
-                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                      <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                         {scoreStr(n.consensus)}
                       </td>
                     </>
@@ -278,7 +278,7 @@ export function NeuronTable({
                         Validator
                       </span>
                     ) : (
-                      <span className="font-mono text-[10px] text-ink-subtle-text">—</span>
+                      <span className="mg-type-data-sm text-ink-subtle-text">—</span>
                     )}
                   </td>
                   {isValidator ? (
@@ -348,7 +348,7 @@ function NeuronCard({
   return (
     <li className={classNames("min-w-0 space-y-2 p-3", active && "bg-accent-surface")}>
       <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-1.5 font-mono text-[12px] tabular-nums text-ink-strong">
+        <div className="flex items-center gap-1.5 font-mono mg-type-caption tabular-nums text-ink-strong">
           <span className="mg-type-micro text-ink-muted">UID</span>
           {onSelect ? (
             <button
@@ -368,7 +368,7 @@ function NeuronCard({
           </span>
         ) : null}
       </div>
-      <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+      <div className="flex min-w-0 items-center gap-1.5 mg-type-data text-ink-muted">
         {n.featured ? <SponsoredBadge /> : null}
         {n.hotkey ? (
           <>

--- a/apps/ui/src/components/metagraphed/operational-panel.tsx
+++ b/apps/ui/src/components/metagraphed/operational-panel.tsx
@@ -229,7 +229,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                         )}
                       />
                     </TooltipTrigger>
-                    <TooltipContent side="top" className="font-mono text-[10px]">
+                    <TooltipContent side="top" className="mg-type-data-sm">
                       <div className="text-ink-strong">{e.kind?.toUpperCase() ?? "—"}</div>
                       <div className="text-ink">{e.url?.replace(/^https?:\/\//, "") ?? "—"}</div>
                       <div className="text-ink-muted">
@@ -301,12 +301,12 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                         <span className="shrink-0 mt-0.5">{sevIcon(inc.severity)}</span>
                         <div className="min-w-0 flex-1">
                           <div
-                            className="truncate text-[12px] text-ink-strong"
+                            className="truncate mg-type-caption text-ink-strong"
                             title={inc.surface_id}
                           >
                             {shortSurfaceId(inc.surface_id, netuid)}
                           </div>
-                          <div className="mt-0.5 font-mono text-[10px] text-ink-muted">
+                          <div className="mt-0.5 mg-type-data-sm text-ink-muted">
                             {inc.started_at ? (
                               <>
                                 <TimeAgo at={inc.started_at} />
@@ -476,7 +476,7 @@ function SegBtn({
           style={{ width: `${pct}%` }}
         />
       </TooltipTrigger>
-      <TooltipContent side="top" className="font-mono text-[10px]">
+      <TooltipContent side="top" className="mg-type-data-sm">
         {count} {sev} · click to filter (shift+click to add)
       </TooltipContent>
     </Tooltip>

--- a/apps/ui/src/components/metagraphed/panel-shell.tsx
+++ b/apps/ui/src/components/metagraphed/panel-shell.tsx
@@ -87,7 +87,7 @@ export function PanelShell({
         {showFreshnessPill ? (
           <span
             className={
-              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[10px] " +
+              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 mg-type-data-sm " +
               (stale
                 ? "border-health-warn/40 bg-health-warn/10 text-health-warn"
                 : "border-border bg-paper/60 text-ink-muted")
@@ -104,7 +104,7 @@ export function PanelShell({
             onClick={onRefresh}
             disabled={refreshing}
             aria-label="Refresh panel"
-            className="inline-flex items-center gap-1 rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted hover:text-ink-strong hover:border-ink/30 disabled:cursor-progress disabled:opacity-60"
+            className="inline-flex items-center gap-1 rounded border border-border bg-card px-1.5 py-0.5 mg-type-data-sm text-ink-muted hover:text-ink-strong hover:border-ink/30 disabled:cursor-progress disabled:opacity-60"
           >
             <RefreshCw className={classNames("size-3", refreshing && "animate-spin")} />
           </button>

--- a/apps/ui/src/components/metagraphed/pre-sign-confirmation.tsx
+++ b/apps/ui/src/components/metagraphed/pre-sign-confirmation.tsx
@@ -113,7 +113,7 @@ export function PreSignConfirmation({
           type="button"
           onClick={onCancel}
           disabled={confirming}
-          className="flex-1 rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-60"
+          className="flex-1 rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-60"
         >
           Cancel
         </button>
@@ -121,7 +121,7 @@ export function PreSignConfirmation({
           type="button"
           onClick={onConfirm}
           disabled={confirming || feeTao === null}
-          className="flex-1 inline-flex items-center justify-center gap-1.5 rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong hover:border-ink-strong/60 transition-colors disabled:opacity-60"
+          className="flex-1 inline-flex items-center justify-center gap-1.5 rounded border border-ink-strong/40 bg-surface px-3 py-2 mg-type-caption font-medium text-ink-strong hover:border-ink-strong/60 transition-colors disabled:opacity-60"
         >
           {confirming ? (
             <>
@@ -157,7 +157,7 @@ function SummaryRow({
       <span className="text-right">
         <span
           className={classNames(
-            "block text-[12px] font-medium text-ink-strong",
+            "block mg-type-caption font-medium text-ink-strong",
             loading && "animate-pulse text-ink-muted",
           )}
         >

--- a/apps/ui/src/components/metagraphed/primitives/chart-card.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/chart-card.tsx
@@ -52,7 +52,7 @@ export function ChartCard({
         {loading ? (
           <div className="absolute inset-0 mg-skel animate-pulse rounded" />
         ) : empty ? (
-          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-ink-muted">
+          <div className="absolute inset-0 flex items-center justify-center mg-type-caption-lg text-ink-muted">
             {emptyLabel}
           </div>
         ) : (
@@ -62,7 +62,7 @@ export function ChartCard({
       {footer != null ? (
         <div
           className={classNames(
-            "mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-border/70 pt-3 text-[12px] text-ink-muted",
+            "mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-border/70 pt-3 mg-type-caption text-ink-muted",
           )}
         >
           {footer}

--- a/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
@@ -111,7 +111,7 @@ export function PageMasthead({
             // renders identically for the plain-text case this line-clamp
             // styling targets, while staying valid for the richer one.
             <div
-              className="mt-1 max-w-3xl text-[13px] text-ink-muted leading-snug line-clamp-2"
+              className="mt-1 max-w-3xl mg-type-caption-lg text-ink-muted leading-snug line-clamp-2"
               title={typeof description === "string" ? description : undefined}
             >
               {description}
@@ -134,7 +134,7 @@ export function PageMasthead({
                   {k.value}
                 </span>
                 {k.hint ? (
-                  <span className="font-mono text-[10px] text-ink-muted truncate">{k.hint}</span>
+                  <span className="mg-type-data-sm text-ink-muted truncate">{k.hint}</span>
                 ) : null}
               </div>
               {k.chart ? <div className="mt-1 -ml-0.5">{k.chart}</div> : null}

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -91,7 +91,7 @@ export function ProfileTabs({
                     onKeyDown={onKeyDown(i)}
                     onClick={() => selectAt(i)}
                     className={classNames(
-                      "relative inline-flex items-center gap-1.5 px-1 py-3 text-[13px] font-medium whitespace-nowrap transition-colors mg-focus-ring",
+                      "relative inline-flex items-center gap-1.5 px-1 py-3 mg-type-caption-lg font-medium whitespace-nowrap transition-colors mg-focus-ring",
                       isActive
                         ? "text-ink-strong after:absolute after:left-1 after:right-1 after:-bottom-[1.5px] after:h-[1.5px] after:rounded-full after:bg-accent after:content-['']"
                         : "text-ink-muted hover:text-ink-strong",
@@ -100,9 +100,7 @@ export function ProfileTabs({
                   >
                     <span>{t.label}</span>
                     {t.count != null ? (
-                      <span className="font-mono text-[10px] text-ink-muted tabular-nums">
-                        {t.count}
-                      </span>
+                      <span className="mg-type-data-sm text-ink-muted tabular-nums">{t.count}</span>
                     ) : null}
                     {isActive ? (
                       <span

--- a/apps/ui/src/components/metagraphed/providers-pulse-rail.tsx
+++ b/apps/ui/src/components/metagraphed/providers-pulse-rail.tsx
@@ -49,7 +49,7 @@ function Tile({ label, value, hint }: { label: string; value: number; hint?: str
       <div className="mt-1 font-display text-xl tabular-nums text-ink-strong">
         {formatNumber(value)}
       </div>
-      {hint ? <div className="mt-0.5 font-mono text-[10px] text-ink-muted">{hint}</div> : null}
+      {hint ? <div className="mt-0.5 mg-type-data-sm text-ink-muted">{hint}</div> : null}
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/quick-actions-row.tsx
+++ b/apps/ui/src/components/metagraphed/quick-actions-row.tsx
@@ -85,7 +85,7 @@ export function QuickActionsRow() {
               <div className="space-y-1">
                 <div className="mg-type-micro text-ink-muted">{a.eyebrow}</div>
                 <div className="font-display text-sm font-semibold text-ink-strong">{a.title}</div>
-                <p className="text-[12px] leading-relaxed text-ink-muted">{a.description}</p>
+                <p className="mg-type-caption leading-relaxed text-ink-muted">{a.description}</p>
               </div>
             </Link>
           );

--- a/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
+++ b/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
@@ -63,10 +63,10 @@ export function RecentIdentityChanges() {
               {c.symbol ? <span className="ml-1.5 text-ink-muted">({c.symbol})</span> : null}
             </div>
             {c.description ? (
-              <div className="truncate font-mono text-[10px] text-ink-muted">{c.description}</div>
+              <div className="truncate mg-type-data-sm text-ink-muted">{c.description}</div>
             ) : null}
           </div>
-          <span className="shrink-0 font-mono text-[10px] text-ink-muted">
+          <span className="shrink-0 mg-type-data-sm text-ink-muted">
             <TimeAgo at={c.observed_at} />
           </span>
         </li>

--- a/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
+++ b/apps/ui/src/components/metagraphed/registry-leaderboards.tsx
@@ -185,7 +185,7 @@ function BoardCard({
                 className="mg-row-hover flex items-center justify-between gap-2 rounded-md px-2 py-1.5"
               >
                 <span className="flex min-w-0 items-center gap-2">
-                  <span className="w-4 shrink-0 text-right font-mono text-[10px] text-ink-muted tabular-nums">
+                  <span className="w-4 shrink-0 text-right mg-type-data-sm text-ink-muted tabular-nums">
                     {i + 1}
                   </span>
                   <BrandIcon
@@ -199,7 +199,7 @@ function BoardCard({
                     {row.name ?? `Subnet ${row.netuid}`}
                   </span>
                 </span>
-                <span className="shrink-0 font-mono text-[12px] tabular-nums text-ink-muted">
+                <span className="shrink-0 font-mono mg-type-caption tabular-nums text-ink-muted">
                   {metric(row) ?? "—"}
                 </span>
               </Link>

--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -55,7 +55,7 @@ export function RegistryTicker() {
 
   return (
     <div className="hidden md:block border-t border-border/60 bg-surface/40">
-      <div className="max-w-shell-max mx-auto px-4 md:px-8 h-9 flex items-center justify-between gap-6 text-[11px] font-mono">
+      <div className="max-w-shell-max mx-auto px-4 md:px-8 h-9 flex items-center justify-between gap-6 mg-type-data">
         {/* Left cluster */}
         <div className="flex items-center gap-4 min-w-0 overflow-visible">
           <span className="inline-flex items-center gap-1.5 shrink-0 pl-1">

--- a/apps/ui/src/components/metagraphed/reliability-panel.tsx
+++ b/apps/ui/src/components/metagraphed/reliability-panel.tsx
@@ -103,7 +103,7 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
               aria-selected={w === window}
               onClick={() => setWindow(w)}
               className={classNames(
-                "rounded px-2 py-0.5 font-mono text-[11px] transition-colors",
+                "rounded px-2 py-0.5 mg-type-data transition-colors",
                 w === window ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",
               )}
             >
@@ -131,7 +131,7 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
         </div>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full font-mono text-[11px]">
+          <table className="w-full mg-type-data">
             <thead>
               <tr className="mg-type-micro text-ink-muted">
                 <th className="border-b border-border px-3 py-2 text-left">Surface</th>

--- a/apps/ui/src/components/metagraphed/resource-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/resource-explorer.tsx
@@ -137,7 +137,7 @@ function FiltersTrigger({ filter }: { filter: ReturnType<typeof useSubnetFilter>
           <Filter className="size-3" />
           <span className="hidden sm:inline">Filters</span>
           {activeCount > 0 ? (
-            <span className="rounded-full bg-accent/15 px-1.5 font-mono text-[10px] text-accent-text">
+            <span className="rounded-full bg-accent/15 px-1.5 mg-type-data-sm text-accent-text">
               {activeCount}
             </span>
           ) : null}
@@ -157,7 +157,7 @@ function FiltersTrigger({ filter }: { filter: ReturnType<typeof useSubnetFilter>
                 onClick={() => filter.toggle(s)}
                 aria-pressed={active}
                 className={classNames(
-                  "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors",
+                  "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 mg-type-caption font-medium transition-colors",
                   active
                     ? "border-accent bg-accent/10 text-ink-strong"
                     : "border-border bg-card text-ink-muted hover:text-ink-strong",
@@ -365,16 +365,14 @@ function EndpointsView({
           <li key={g.kind}>
             <div className="flex items-center gap-2 px-4 py-1.5 bg-surface/30">
               <span className="mg-type-micro text-ink-strong">{KIND_LABEL[g.kind] ?? g.kind}</span>
-              <span className="font-mono text-[10px] text-ink-muted tabular-nums">
-                {g.items.length}
-              </span>
+              <span className="mg-type-data-sm text-ink-muted tabular-nums">{g.items.length}</span>
             </div>
             <ul>
               {g.items.slice(0, 5).map((e) => (
                 <EndpointRow key={e.id} e={e} />
               ))}
               {g.items.length > 5 ? (
-                <li className="px-4 py-1.5 font-mono text-[10px] text-ink-muted">
+                <li className="px-4 py-1.5 mg-type-data-sm text-ink-muted">
                   + {g.items.length - 5} more — open the Endpoints tab
                 </li>
               ) : null}
@@ -396,22 +394,22 @@ function EndpointRow({ e }: { e: Endpoint }) {
         <Tooltip delayDuration={200}>
           <TooltipTrigger asChild>
             <div className="flex items-baseline gap-1 min-w-0 cursor-default">
-              <span className="font-mono text-[12px] text-ink-strong truncate">{host(e.url)}</span>
+              <span className="font-mono mg-type-caption text-ink-strong truncate">
+                {host(e.url)}
+              </span>
               {pathOf(e.url) ? (
-                <span className="font-mono text-[11px] text-ink-muted truncate">
-                  {pathOf(e.url)}
-                </span>
+                <span className="mg-type-data text-ink-muted truncate">{pathOf(e.url)}</span>
               ) : null}
             </div>
           </TooltipTrigger>
           {e.url ? (
-            <TooltipContent side="top" className="max-w-md break-all font-mono text-[11px]">
+            <TooltipContent side="top" className="max-w-md break-all mg-type-data">
               {e.url}
             </TooltipContent>
           ) : null}
         </Tooltip>
         {e.provider || e.region ? (
-          <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-ink-muted">
+          <div className="mt-0.5 flex items-center gap-2 mg-type-data-sm text-ink-muted">
             {e.provider ? (
               <Link
                 to="/providers/$slug"
@@ -425,10 +423,10 @@ function EndpointRow({ e }: { e: Endpoint }) {
           </div>
         ) : null}
       </div>
-      <span className="font-mono text-[10px] text-ink-muted tabular-nums">
+      <span className="mg-type-data-sm text-ink-muted tabular-nums">
         {e.latency_ms != null ? `${e.latency_ms}ms` : "—"}
       </span>
-      <span className="hidden sm:inline font-mono text-[10px] text-ink-muted">
+      <span className="hidden sm:inline mg-type-data-sm text-ink-muted">
         <TimeAgo at={e.last_probed_at} />
       </span>
       <div className="inline-flex items-center gap-0.5">
@@ -581,16 +579,14 @@ function SurfacesView({
           <li key={kind}>
             <div className="flex items-center gap-2 px-4 py-1.5 bg-surface/30">
               <span className="mg-type-micro text-ink-strong">{kind}</span>
-              <span className="font-mono text-[10px] text-ink-muted tabular-nums">
-                {items.length}
-              </span>
+              <span className="mg-type-data-sm text-ink-muted tabular-nums">{items.length}</span>
             </div>
             <ul>
               {items.slice(0, 4).map((s) => (
                 <SurfaceRow key={s.id} s={s} />
               ))}
               {items.length > 4 ? (
-                <li className="px-4 py-1.5 font-mono text-[10px] text-ink-muted">
+                <li className="px-4 py-1.5 mg-type-data-sm text-ink-muted">
                   + {items.length - 4} more
                 </li>
               ) : null}
@@ -609,7 +605,7 @@ function SurfaceRow({ s }: { s: Surface }) {
     <li className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2 mg-row-hover">
       <div className="min-w-0">
         <div className="flex items-center gap-2 min-w-0">
-          <span className="truncate text-[12px] font-medium text-ink-strong">
+          <span className="truncate mg-type-caption font-medium text-ink-strong">
             {s.name ?? s.url}
           </span>
           <CurationChip level={s.curation_level} />
@@ -623,25 +619,25 @@ function SurfaceRow({ s }: { s: Surface }) {
                   href={safeUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-0.5 block truncate font-mono text-[11px] text-ink-muted hover:text-ink-strong"
+                  className="mt-0.5 block truncate mg-type-data text-ink-muted hover:text-ink-strong"
                 >
                   {host(s.url)}
                   {pathOf(s.url) ? <span className="opacity-70">{pathOf(s.url)}</span> : null}
                 </a>
               ) : (
-                <span className="mt-0.5 block cursor-not-allowed truncate font-mono text-[11px] text-ink-muted/50">
+                <span className="mt-0.5 block cursor-not-allowed truncate mg-type-data text-ink-muted/50">
                   {host(s.url)}
                   {pathOf(s.url) ? <span className="opacity-70">{pathOf(s.url)}</span> : null}
                 </span>
               )}
             </TooltipTrigger>
-            <TooltipContent side="top" className="max-w-md break-all font-mono text-[11px]">
+            <TooltipContent side="top" className="max-w-md break-all mg-type-data">
               {safeUrl ? s.url : "Blocked unsafe URL"}
             </TooltipContent>
           </Tooltip>
         ) : null}
       </div>
-      <span className="font-mono text-[10px] text-ink-muted">
+      <span className="mg-type-data-sm text-ink-muted">
         <TimeAgo at={s.updated_at} />
       </span>
     </li>

--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -78,7 +78,7 @@ export function ProxyHero() {
       <h2 className="mt-2 font-display text-lg font-semibold text-ink-strong">
         One endpoint for Bittensor RPC
       </h2>
-      <p className="mt-1 max-w-2xl text-[13px] text-ink-muted">
+      <p className="mt-1 max-w-2xl mg-type-caption-lg text-ink-muted">
         POST JSON-RPC to a single URL and Metagraphed routes it across the healthiest, most in-sync
         public endpoints — with failover, edge caching, and abuse controls. No key, no account, no
         single point of failure.
@@ -87,7 +87,9 @@ export function ProxyHero() {
       <Panel as="div" flush className="mt-4">
         <div className="flex items-center gap-2 px-3 py-2">
           <span className="mg-label">POST</span>
-          <code className="flex-1 truncate font-mono text-[13px] text-ink-strong">{proxyUrl}</code>
+          <code className="flex-1 truncate font-mono mg-type-caption-lg text-ink-strong">
+            {proxyUrl}
+          </code>
           <CopyButton value={proxyUrl} label="proxy URL" />
         </div>
       </Panel>
@@ -97,7 +99,7 @@ export function ProxyHero() {
           <span className="mg-label">Try it</span>
           <CopyButton value={curlExample} label="curl command" />
         </div>
-        <pre className="overflow-x-auto px-3 py-2 font-mono text-[11px] leading-relaxed text-ink">
+        <pre className="overflow-x-auto px-3 py-2 mg-type-data leading-relaxed text-ink">
           {curlExample}
         </pre>
       </div>
@@ -107,7 +109,7 @@ export function ProxyHero() {
           <li key={title} className="flex gap-2.5">
             <Icon className="mt-0.5 size-4 shrink-0 text-accent" aria-hidden />
             <div>
-              <p className="text-[12px] font-medium text-ink-strong">{title}</p>
+              <p className="mg-type-caption font-medium text-ink-strong">{title}</p>
               <p className="text-[11px] leading-snug text-ink-muted">{body}</p>
             </div>
           </li>
@@ -152,7 +154,7 @@ function UsageStat({
         <span className="mg-type-micro">{eyebrow}</span>
       </div>
       <div className="mt-1 font-mono text-lg font-semibold text-ink-strong">{value}</div>
-      {hint ? <div className="font-mono text-[10px] text-ink-muted">{hint}</div> : null}
+      {hint ? <div className="mg-type-data-sm text-ink-muted">{hint}</div> : null}
     </div>
   );
 }
@@ -171,7 +173,7 @@ export function ProxyUsagePanel() {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between gap-2">
-        <p className="font-mono text-[11px] text-ink-muted">
+        <p className="mg-type-data text-ink-muted">
           {usage.observed_at ? (
             <>
               Updated <TimeAgo at={usage.observed_at} />
@@ -253,7 +255,7 @@ export function ProxyUsagePanel() {
               {usage.networks.map((n) => (
                 <span
                   key={n.network}
-                  className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-0.5 font-mono text-[11px]"
+                  className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-0.5 mg-type-data"
                 >
                   <span className="text-ink-strong">{n.network}</span>
                   <span className="text-ink-muted">{formatNumber(n.requests)}</span>
@@ -283,10 +285,10 @@ export function ProxyUsagePanel() {
                     const share = s.total_requests ? e.requests / s.total_requests : null;
                     return (
                       <tr key={e.endpoint_id ?? e.rank} className="mg-row-hover">
-                        <td className="px-3 py-2 font-mono text-[12px] text-ink-strong">
+                        <td className="px-3 py-2 font-mono mg-type-caption text-ink-strong">
                           {e.endpoint_id ?? "—"}
                         </td>
-                        <td className="px-3 py-2 text-[12px] text-ink-muted">
+                        <td className="px-3 py-2 mg-type-caption text-ink-muted">
                           {e.provider ?? "—"}
                         </td>
                         <td className="px-3 py-2 text-right font-mono">

--- a/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
@@ -42,13 +42,13 @@ export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardLi
         >
           <div className="flex items-baseline justify-between gap-2">
             <span className="mg-type-micro text-ink-muted">Spec Version</span>
-            <span className="font-mono text-[13px] tabular-nums text-ink-strong">
+            <span className="font-mono mg-type-caption-lg tabular-nums text-ink-strong">
               {formatNumber(row.spec_version)}
             </span>
           </div>
           <div className="flex items-baseline justify-between gap-2">
             <span className="mg-type-micro text-ink-muted">Block</span>
-            <span className="font-mono text-[12px] tabular-nums">
+            <span className="font-mono mg-type-caption tabular-nums">
               {row.block_number != null ? (
                 <Link
                   to="/blocks/$ref"
@@ -64,7 +64,7 @@ export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardLi
           </div>
           <div className="flex items-baseline justify-between gap-2">
             <span className="mg-type-micro text-ink-muted">Observed</span>
-            <span className="font-mono text-[12px] text-ink-muted">
+            <span className="font-mono mg-type-caption text-ink-muted">
               {row.observed_at ? <TimeAgo at={row.observed_at} /> : "—"}
             </span>
           </div>

--- a/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
@@ -101,7 +101,7 @@ function DriftBody({
             <Link
               to="/subnets/$netuid"
               params={{ netuid: schema.netuid }}
-              className="font-mono text-[10px] text-accent hover:underline"
+              className="mg-type-data-sm text-accent hover:underline"
               onClick={onClose}
             >
               SN{schema.netuid}
@@ -109,7 +109,7 @@ function DriftBody({
           ) : null}
         </DialogTitle>
         <DialogDescription>
-          <span className="font-mono text-[11px]">
+          <span className="mg-type-data">
             {freshLine ?? "snapshot"}
             {freshAbs ? ` · last checked ${freshAbs}` : ""}
           </span>
@@ -187,7 +187,7 @@ function EvidenceSection({
       </div>
       <ul className="space-y-1.5">
         {links.map((l) => (
-          <li key={l.href} className="flex items-center gap-2 font-mono text-[11px] text-ink">
+          <li key={l.href} className="flex items-center gap-2 mg-type-data text-ink">
             <span className="shrink-0 rounded border border-border bg-paper px-1.5 py-0.5 mg-type-micro text-ink-muted">
               {l.label}
             </span>

--- a/apps/ui/src/components/metagraphed/schema-drift.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift.tsx
@@ -68,13 +68,13 @@ export function SchemaDriftSummary({ netuid, compact }: { netuid: number; compac
             <span className="font-display text-xs font-semibold uppercase tracking-wider text-ink-strong">
               Schema drift
             </span>
-            <span className="font-mono text-[10px] text-ink-muted">{schemas.length} tracked</span>
+            <span className="mg-type-data-sm text-ink-muted">{schemas.length} tracked</span>
           </div>
           <Link
             to="/subnets/$netuid"
             params={{ netuid: netuid }}
             search={(prev: Record<string, unknown>) => ({ ...prev, tab: "schemas" })}
-            className="font-mono text-[10px] text-ink-muted hover:text-ink-strong"
+            className="mg-type-data-sm text-ink-muted hover:text-ink-strong"
           >
             view all →
           </Link>
@@ -83,10 +83,7 @@ export function SchemaDriftSummary({ netuid, compact }: { netuid: number; compac
           {Object.entries(counts).map(([k, v]) => (
             <span
               key={k}
-              className={classNames(
-                "rounded border px-1.5 py-0.5 font-mono text-[10px]",
-                driftTone(k),
-              )}
+              className={classNames("rounded border px-1.5 py-0.5 mg-type-data-sm", driftTone(k))}
             >
               {k} · {v}
             </span>
@@ -120,14 +117,14 @@ export function SchemaDriftSummary({ netuid, compact }: { netuid: number; compac
               </span>
               <span
                 className={classNames(
-                  "rounded border px-1.5 py-0.5 font-mono text-[10px]",
+                  "rounded border px-1.5 py-0.5 mg-type-data-sm",
                   driftTone(s.drift_status),
                 )}
               >
                 {s.drift_status ?? "unknown"}
               </span>
             </div>
-            <span className="font-mono text-[10px] text-ink-muted shrink-0">
+            <span className="mg-type-data-sm text-ink-muted shrink-0">
               <TimeAgo at={s.updated_at} />
             </span>
           </div>
@@ -145,7 +142,7 @@ export function SchemaDriftSummary({ netuid, compact }: { netuid: number; compac
             ) : null}
           </div>
           {s.hash && s.previous_hash && s.hash !== s.previous_hash ? (
-            <div className="mt-1.5 font-mono text-[10px] text-ink-muted truncate">
+            <div className="mt-1.5 mg-type-data-sm text-ink-muted truncate">
               hash {s.previous_hash.slice(0, 8)} → {s.hash.slice(0, 8)}
             </div>
           ) : null}

--- a/apps/ui/src/components/metagraphed/schema-snapshot-summary.tsx
+++ b/apps/ui/src/components/metagraphed/schema-snapshot-summary.tsx
@@ -61,7 +61,7 @@ function MetaCell({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border border-border bg-paper px-3 py-2">
       <div className="mg-type-micro text-ink-muted">{label}</div>
-      <div className="mt-0.5 font-mono text-[12px] text-ink-strong tabular-nums truncate">
+      <div className="mt-0.5 font-mono mg-type-caption text-ink-strong tabular-nums truncate">
         {value}
       </div>
     </div>
@@ -88,7 +88,7 @@ export function SchemaSnapshotSummary({ schema }: { schema: SchemaInfo }) {
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-2 font-mono text-[11px]">
+      <div className="flex flex-wrap items-center gap-2 mg-type-data">
         <span
           className={classNames(
             "inline-flex items-center rounded-full border px-2 py-0.5 mg-type-micro",
@@ -104,7 +104,7 @@ export function SchemaSnapshotSummary({ schema }: { schema: SchemaInfo }) {
       </div>
 
       {/* Hash transition (the registry's canonical drift signal). */}
-      <div className="rounded-lg border border-border bg-paper p-3 font-mono text-[11px]">
+      <div className="rounded-lg border border-border bg-paper p-3 mg-type-data">
         {hashChanged ? (
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-ink-muted">{schema.previous_hash!.slice(0, 12)}</span>

--- a/apps/ui/src/components/metagraphed/search-box.tsx
+++ b/apps/ui/src/components/metagraphed/search-box.tsx
@@ -39,7 +39,7 @@ function ResultRow({ result }: { result: SemanticSearchResult }) {
   const content = (
     <div className="flex items-center justify-between gap-3 px-3 py-2.5">
       <div className="min-w-0">
-        <p className="truncate text-[13px] text-ink-strong">{resultLabel(result)}</p>
+        <p className="truncate mg-type-caption-lg text-ink-strong">{resultLabel(result)}</p>
         {result.subtitle ? (
           <p className="truncate text-[11px] text-ink-muted">{result.subtitle}</p>
         ) : null}
@@ -48,7 +48,7 @@ function ResultRow({ result }: { result: SemanticSearchResult }) {
             {tags.map((tag) => (
               <span
                 key={tag}
-                className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+                className="rounded border border-border px-1.5 py-0.5 mg-type-data-sm text-ink-muted"
               >
                 {tag}
               </span>
@@ -56,7 +56,7 @@ function ResultRow({ result }: { result: SemanticSearchResult }) {
           </div>
         ) : null}
       </div>
-      <span className="shrink-0 font-mono text-[10px] text-ink-muted">{resultMeta(result)}</span>
+      <span className="shrink-0 mg-type-data-sm text-ink-muted">{resultMeta(result)}</span>
     </div>
   );
 
@@ -78,7 +78,9 @@ function ResultRow({ result }: { result: SemanticSearchResult }) {
 
 function SearchResults({ results }: { results: SemanticSearchResult[] }) {
   if (results.length === 0) {
-    return <p className="mt-3 text-[12px] text-ink-muted">No matches — try a different phrase.</p>;
+    return (
+      <p className="mt-3 mg-type-caption text-ink-muted">No matches — try a different phrase.</p>
+    );
   }
   return (
     <ul className="mt-4 divide-y divide-border rounded-lg border border-border bg-card">
@@ -117,14 +119,14 @@ export function SearchBox() {
             placeholder="video generation"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="w-full rounded-lg border border-border bg-card px-3 py-2 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
+            className="w-full rounded-lg border border-border bg-card px-3 py-2 mg-type-caption-lg text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
           />
         </label>
         <button
           type="submit"
           disabled={isFetching || !query.trim()}
           className={classNames(
-            "shrink-0 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 text-[13px] font-medium text-accent hover:bg-accent/15",
+            "shrink-0 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15",
             "disabled:cursor-not-allowed disabled:opacity-50",
           )}
         >
@@ -133,7 +135,7 @@ export function SearchBox() {
       </form>
 
       {isError ? (
-        <p role="alert" className="mt-3 font-mono text-[12px] text-health-warn">
+        <p role="alert" className="mt-3 font-mono mg-type-caption text-health-warn">
           {describeSearchError(error)}
         </p>
       ) : null}

--- a/apps/ui/src/components/metagraphed/settings-popover.tsx
+++ b/apps/ui/src/components/metagraphed/settings-popover.tsx
@@ -204,7 +204,7 @@ function PaletteRow({
           ))}
         </span>
         <span className="flex-1 min-w-0">
-          <span className="block text-[12px] font-medium text-ink-strong">{label}</span>
+          <span className="block mg-type-caption font-medium text-ink-strong">{label}</span>
           <span className="block text-[10px] text-ink-muted truncate">{description}</span>
         </span>
       </button>

--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -81,7 +81,7 @@ export function ShortcutsPopover() {
       </Tooltip>
       <PopoverContent align="start" side="top" className="w-80 p-4">
         <div className="mg-type-micro text-ink-muted mb-3">Shortcuts</div>
-        <ul className="space-y-1.5 text-[12px]">
+        <ul className="space-y-1.5 mg-type-caption">
           <Row label="Focus search">
             <Kbd>/</Kbd>
             <span className="text-ink-muted">or</span>
@@ -96,7 +96,7 @@ export function ShortcutsPopover() {
           </Row>
         </ul>
         <div className="mg-type-micro text-ink-muted mt-4 mb-2">Go to</div>
-        <ul className="space-y-1.5 text-[12px]">
+        <ul className="space-y-1.5 mg-type-caption">
           {GOTO.map((g) => (
             <Row key={g.keys} label={g.label}>
               {g.keys.split(" ").map((k, i) => (
@@ -110,7 +110,7 @@ export function ShortcutsPopover() {
             shortcut above, so it gets its own labeled section instead of
             reading as a global binding. */}
         <div className="mg-type-micro text-ink-muted mt-4 mb-2">On block pages</div>
-        <ul className="space-y-1.5 text-[12px]">
+        <ul className="space-y-1.5 mg-type-caption">
           <Row label="Previous / next block">
             <Kbd>←</Kbd>
             <Kbd>→</Kbd>

--- a/apps/ui/src/components/metagraphed/sponsored-validator-callout.tsx
+++ b/apps/ui/src/components/metagraphed/sponsored-validator-callout.tsx
@@ -46,7 +46,7 @@ export function SponsoredValidatorCallout({
     <div className="rounded-xl border border-ink-muted/30 bg-surface/40 p-4">
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <SponsoredBadge />
-        <span className="font-mono text-[10px] text-ink-muted">
+        <span className="mg-type-data-sm text-ink-muted">
           Paid placement — not ranked or endorsed by Metagraphed.
         </span>
       </div>
@@ -55,14 +55,14 @@ export function SponsoredValidatorCallout({
           <Link
             to="/validators/$hotkey"
             params={{ hotkey: validator.hotkey }}
-            className="truncate font-mono text-[13px] text-ink-strong hover:text-accent hover:underline"
+            className="truncate font-mono mg-type-caption-lg text-ink-strong hover:text-accent hover:underline"
             title={validator.hotkey}
           >
             {shortHash(validator.hotkey, 6) ?? validator.hotkey}
           </Link>
           <CopyButton value={validator.hotkey} label="hotkey" />
         </div>
-        <div className="flex flex-wrap items-center gap-4 font-mono text-[11px] text-ink-muted">
+        <div className="flex flex-wrap items-center gap-4 mg-type-data text-ink-muted">
           <span>
             Stake{" "}
             <span className="text-ink-strong tabular-nums">

--- a/apps/ui/src/components/metagraphed/stake-amount-input.tsx
+++ b/apps/ui/src/components/metagraphed/stake-amount-input.tsx
@@ -210,27 +210,25 @@ export function StakeAmountInput({
       </div>
 
       {action === "unstake" ? (
-        <p className="font-mono text-[10px] text-ink-muted">
+        <p className="mg-type-data-sm text-ink-muted">
           {unstakeMax.note ?? (positionAge ? `Recorded position ${positionAge}.` : null)}
         </p>
       ) : null}
 
       {!hasValidAmount ? (
-        <p className="font-mono text-[11px] text-ink-muted">
-          Enter an amount to see the expected outcome.
-        </p>
+        <p className="mg-type-data text-ink-muted">Enter an amount to see the expected outcome.</p>
       ) : quoteError ? (
-        <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+        <p className="inline-flex items-center gap-1.5 mg-type-data text-health-down">
           <AlertCircle className="size-3.5 shrink-0" aria-hidden />
           {quoteError}
         </p>
       ) : quoteIsPending ? (
-        <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+        <p className="inline-flex items-center gap-1.5 mg-type-data text-ink-muted">
           <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden />
           Calculating…
         </p>
       ) : quote ? (
-        <p className="font-mono text-[11px] text-ink-strong">{formatQuoteHint(quote)}</p>
+        <p className="mg-type-data text-ink-strong">{formatQuoteHint(quote)}</p>
       ) : null}
 
       {validationMessages.length > 0 ? (
@@ -238,7 +236,7 @@ export function StakeAmountInput({
           {validationMessages.map((message) => (
             <li
               key={message}
-              className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down"
+              className="inline-flex items-center gap-1.5 mg-type-data text-health-down"
             >
               <AlertCircle className="size-3.5 shrink-0" aria-hidden />
               {message}

--- a/apps/ui/src/components/metagraphed/stake-unstake-modal.tsx
+++ b/apps/ui/src/components/metagraphed/stake-unstake-modal.tsx
@@ -204,7 +204,7 @@ function StakeFlowBody({
               type="button"
               onClick={flow.confirm}
               disabled={!flow.canConfirm}
-              className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
+              className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
             >
               Review {ACTION_VERB[flow.action].toLowerCase()}
             </button>
@@ -254,11 +254,13 @@ function StakeFlowBody({
       return (
         <div className="flex flex-col items-center gap-4 py-10 text-center">
           <AlertTriangle className="size-6 text-health-down" aria-hidden />
-          <p className="text-[13px] text-ink-strong">{describeTxError(flow.txStatus.error)}</p>
+          <p className="mg-type-caption-lg text-ink-strong">
+            {describeTxError(flow.txStatus.error)}
+          </p>
           <button
             type="button"
             onClick={flow.editAmount}
-            className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+            className="rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink/30"
           >
             Edit amount and try again
           </button>
@@ -291,13 +293,13 @@ function StatusView({
   return (
     <div className="flex flex-col items-center gap-4 py-10 text-center">
       {icon}
-      <p className="text-[13px] text-ink-strong">{message}</p>
+      <p className="mg-type-caption-lg text-ink-strong">{message}</p>
       {txHash ? (
         <div className="space-y-1">
           <Link
             to="/extrinsics/$hash"
             params={{ hash: txHash }}
-            className="font-mono text-[11px] text-accent hover:underline"
+            className="mg-type-data text-accent hover:underline"
           >
             {shortHash(txHash, 8)}
           </Link>
@@ -310,7 +312,7 @@ function StatusView({
         <button
           type="button"
           onClick={onClose}
-          className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+          className="rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink/30"
         >
           Done
         </button>

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -99,14 +99,14 @@ export function ErrorState({
           Couldn't load {context ?? "this data"}
         </span>
         {status ? (
-          <code className="rounded bg-surface px-1.5 py-0.5 font-mono text-[10px] text-ink-muted">
+          <code className="rounded bg-surface px-1.5 py-0.5 mg-type-data-sm text-ink-muted">
             HTTP {status}
           </code>
         ) : null}
       </div>
       <p className="mx-auto mt-1 max-w-md text-xs leading-relaxed text-ink-muted">{message}</p>
       {url ? (
-        <code className="mx-auto mt-1 block max-w-md truncate font-mono text-[10px] text-ink-muted">
+        <code className="mx-auto mt-1 block max-w-md truncate mg-type-data-sm text-ink-muted">
           {url}
         </code>
       ) : null}
@@ -175,7 +175,7 @@ export function EmptyState({
         <p className="mt-1 text-xs text-ink-muted max-w-md mx-auto">{description}</p>
       ) : null}
       {isUsableTimestamp(lastChecked) ? (
-        <div className="mt-2 font-mono text-[10px] text-ink-muted">
+        <div className="mt-2 mg-type-data-sm text-ink-muted">
           Last checked <TimeAgo at={lastChecked} />
         </div>
       ) : null}
@@ -242,7 +242,7 @@ export function StaleBanner({
   if (!hasTimestamp) {
     if (hideText) return null;
     return (
-      <p className="flex items-center gap-1.5 font-mono text-[10px] text-ink-muted">
+      <p className="flex items-center gap-1.5 mg-type-data-sm text-ink-muted">
         <Clock className="size-3 shrink-0" aria-hidden />
         Snapshot freshness unknown — verify before relying on this data.
       </p>
@@ -271,7 +271,7 @@ export function StaleBanner({
     <div
       role="status"
       aria-live="polite"
-      className={`flex items-center font-mono text-[10px] text-ink-muted ${
+      className={`flex items-center mg-type-data-sm text-ink-muted ${
         compact ? "gap-2" : "flex-wrap gap-x-3 gap-y-1.5"
       }`}
     >

--- a/apps/ui/src/components/metagraphed/states/registry-empty.tsx
+++ b/apps/ui/src/components/metagraphed/states/registry-empty.tsx
@@ -108,7 +108,7 @@ export function RegistryEmpty({
               {tone.label}
             </span>
             {variant === "stale" && fresh ? (
-              <span className="font-mono text-[10px] text-ink-muted">
+              <span className="mg-type-data-sm text-ink-muted">
                 {fresh}
                 {freshAbs ? ` · last checked ${freshAbs}` : ""}
               </span>
@@ -116,7 +116,7 @@ export function RegistryEmpty({
           </div>
 
           {description ? (
-            <p className="text-[13px] leading-relaxed text-ink-muted">{description}</p>
+            <p className="mg-type-caption-lg leading-relaxed text-ink-muted">{description}</p>
           ) : null}
 
           {freshnessHint ? (

--- a/apps/ui/src/components/metagraphed/status-diagnostics.tsx
+++ b/apps/ui/src/components/metagraphed/status-diagnostics.tsx
@@ -165,7 +165,7 @@ function HealthHistoryBody({ date }: { date: string }) {
       <div className="grid gap-3 md:grid-cols-2">
         <Panel as="div" dense>
           <div className="mg-label mb-1">Status counts</div>
-          <div className="flex items-center gap-4 font-mono text-[12px] tabular-nums">
+          <div className="flex items-center gap-4 font-mono mg-type-caption tabular-nums">
             <span className="text-health-ok">{okCount} ok</span>
             <span className="text-health-warn">{degraded} degraded</span>
             <span className="text-health-down">{failed} failed</span>
@@ -199,7 +199,7 @@ function HealthHistoryBody({ date }: { date: string }) {
           active={Boolean(kind || status)}
           onReset={() => navigate({ search: (prev) => ({ ...prev, kind: "", status: "" }) })}
         />
-        <span className="ml-auto font-mono text-[10px] text-ink-muted">
+        <span className="ml-auto mg-type-data-sm text-ink-muted">
           {rows.length} of {res.data.surfaces.length} surfaces
         </span>
       </div>
@@ -275,7 +275,7 @@ function HealthHistoryBody({ date }: { date: string }) {
 function SurfaceHistoryRow({ surface }: { surface: HealthHistorySurface }) {
   return (
     <tr className="mg-row-hover">
-      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+      <td className="px-3 py-2.5 mg-type-data text-ink-muted">
         {surface.netuid != null ? (
           <Link
             to="/subnets/$netuid"
@@ -288,27 +288,25 @@ function SurfaceHistoryRow({ surface }: { surface: HealthHistorySurface }) {
           "—"
         )}
       </td>
-      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-strong">
+      <td className="px-3 py-2.5 mg-type-data text-ink-strong">
         <span className="truncate" title={surface.surface_id}>
           {surface.surface_id ?? "—"}
         </span>
       </td>
-      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
-        {surface.provider ?? "—"}
-      </td>
-      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">{surface.kind ?? "—"}</td>
+      <td className="px-3 py-2.5 mg-type-data text-ink-muted">{surface.provider ?? "—"}</td>
+      <td className="px-3 py-2.5 mg-type-data text-ink-muted">{surface.kind ?? "—"}</td>
       <td className="px-3 py-2.5">
         <span className="inline-flex items-center gap-1.5">
           <HealthPill state={statusState(surface.status)} />
           {surface.classification ? (
-            <span className="font-mono text-[10px] text-ink-muted">{surface.classification}</span>
+            <span className="mg-type-data-sm text-ink-muted">{surface.classification}</span>
           ) : null}
         </span>
       </td>
-      <td className="px-3 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
+      <td className="px-3 py-2.5 text-right mg-type-data tabular-nums text-ink">
         {surface.latency_ms != null ? `${surface.latency_ms} ms` : "—"}
       </td>
-      <td className="px-3 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+      <td className="px-3 py-2.5 text-right mg-type-data text-ink-muted">
         {surface.last_ok ? <TimeAgo at={surface.last_ok} /> : "—"}
       </td>
     </tr>
@@ -367,7 +365,7 @@ export function SourceHealthTable() {
     <div className="space-y-3">
       <Panel
         dense
-        bodyClassName="flex flex-wrap items-center gap-4 font-mono text-[12px] tabular-nums"
+        bodyClassName="flex flex-wrap items-center gap-4 font-mono mg-type-caption tabular-nums"
       >
         <span className="text-health-ok">{summary.status_counts.ok ?? 0} ok</span>
         <span className="text-health-warn">{summary.status_counts.degraded ?? 0} degraded</span>
@@ -391,7 +389,7 @@ export function SourceHealthTable() {
             { value: "unknown", label: "unknown" },
           ]}
         />
-        <span className="ml-auto font-mono text-[10px] text-ink-muted">
+        <span className="ml-auto mg-type-data-sm text-ink-muted">
           {rows.length} of {res.data.providers.length} providers
         </span>
       </div>
@@ -483,17 +481,17 @@ function ProviderRow({ provider }: { provider: SourceHealthProvider }) {
       <td className="px-3 py-2.5">
         <span className="font-medium text-ink-strong">{provider.name ?? provider.id}</span>
         {provider.authority ? (
-          <span className="ml-1.5 font-mono text-[10px] text-ink-muted">{provider.authority}</span>
+          <span className="ml-1.5 mg-type-data-sm text-ink-muted">{provider.authority}</span>
         ) : null}
       </td>
-      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">{provider.kind ?? "—"}</td>
+      <td className="px-3 py-2.5 mg-type-data text-ink-muted">{provider.kind ?? "—"}</td>
       <td className="px-3 py-2.5">
         <HealthPill state={statusState(provider.status)} />
       </td>
-      <td className="px-3 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
+      <td className="px-3 py-2.5 text-right mg-type-data tabular-nums text-ink">
         {provider.endpoint_count ?? 0}
       </td>
-      <td className="px-3 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+      <td className="px-3 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
         {provider.candidate_count ?? 0}
       </td>
       <td className="px-3 py-2.5">
@@ -516,7 +514,7 @@ function ProviderRow({ provider }: { provider: SourceHealthProvider }) {
             ))}
           </div>
         ) : (
-          <span className="font-mono text-[10px] text-ink-muted">—</span>
+          <span className="mg-type-data-sm text-ink-muted">—</span>
         )}
       </td>
     </tr>

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
@@ -69,7 +69,7 @@ export function SubnetCompareDrawer({ netuid }: { netuid: number }) {
             <GitCompare className="size-3 text-ink-muted" />
             Compare
             {peer != null ? (
-              <span className="font-mono text-[10px] text-ink-muted">
+              <span className="mg-type-data-sm text-ink-muted">
                 · SN{String(peer).padStart(3, "0")}
               </span>
             ) : null}
@@ -126,7 +126,7 @@ export function SubnetCompareDrawer({ netuid }: { netuid: number }) {
 
           <div className="mt-4">
             {peer == null ? (
-              <p className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center text-[12px] text-ink-muted">
+              <p className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center mg-type-caption text-ink-muted">
                 Enter a netuid above to load a side-by-side comparison.
               </p>
             ) : (
@@ -262,7 +262,7 @@ function Header({ label, name, netuid }: { label: string; name?: string; netuid:
         <div className="mt-0.5 truncate font-display text-sm font-semibold text-ink-strong">
           {name ?? `Subnet ${netuid}`}
         </div>
-        <div className="font-mono text-[10px] text-ink-muted">
+        <div className="mg-type-data-sm text-ink-muted">
           netuid {String(netuid).padStart(3, "0")}
         </div>
       </div>
@@ -295,7 +295,7 @@ function DiffRow({
         <span className="font-display text-sm font-semibold tabular-nums text-ink-strong">
           {baseValue}
         </span>
-        <span className="font-mono text-[10px] text-ink-muted">{delta ?? "vs"}</span>
+        <span className="mg-type-data-sm text-ink-muted">{delta ?? "vs"}</span>
         <span className="text-right font-display text-sm font-semibold tabular-nums text-ink-strong">
           {peerValue}
         </span>
@@ -313,7 +313,7 @@ function ProviderColumn({
 }) {
   const otherSet = new Set(other.map((r) => r.slug));
   if (rows.length === 0)
-    return <div className="px-3 py-3 font-mono text-[10px] text-ink-muted">no providers</div>;
+    return <div className="px-3 py-3 mg-type-data-sm text-ink-muted">no providers</div>;
   return (
     <ul className="divide-y divide-border">
       {rows.slice(0, 5).map((r) => {
@@ -322,12 +322,12 @@ function ProviderColumn({
           <li
             key={r.slug}
             className={classNames(
-              "flex items-center justify-between gap-2 px-3 py-1.5 text-[12px]",
+              "flex items-center justify-between gap-2 px-3 py-1.5 mg-type-caption",
               unique && "bg-accent/5",
             )}
           >
             <span className="truncate text-ink-strong">{r.name}</span>
-            <span className="font-mono text-[10px] tabular-nums text-ink-muted">
+            <span className="mg-type-data-sm tabular-nums text-ink-muted">
               {r.count}
               {unique ? (
                 <span className="ml-1 rounded border border-accent/40 px-1 mg-type-micro text-accent">

--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -108,7 +108,7 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-3">
       {data?.queried_at_block != null ? (
-        <p className="font-mono text-[11px] text-ink-muted">
+        <p className="mg-type-data text-ink-muted">
           Rolled forward to block #{formatNumber(data.queried_at_block)}
           {data.unlock_rate != null ? ` · unlock_rate ${formatNumber(data.unlock_rate)}` : ""}
           {data.maturity_rate != null ? ` · maturity_rate ${formatNumber(data.maturity_rate)}` : ""}
@@ -162,7 +162,7 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
                         {!isKing && gap != null ? (
                           <div
                             className={classNames(
-                              "flex items-center gap-1.5 font-mono text-[11px] tabular-nums",
+                              "flex items-center gap-1.5 mg-type-data tabular-nums",
                               tone?.className ?? "text-ink-muted",
                             )}
                           >
@@ -177,10 +177,10 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
                         ) : null}
                       </div>
                     </td>
-                    <td className="px-4 py-2.5 align-top text-right font-mono text-[12px] tabular-nums text-ink">
+                    <td className="px-4 py-2.5 align-top text-right font-mono mg-type-caption tabular-nums text-ink">
                       {fmtAlpha(entry.locked_mass)}
                     </td>
-                    <td className="px-4 py-2.5 align-top text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                    <td className="px-4 py-2.5 align-top text-right font-mono mg-type-caption tabular-nums text-ink-strong">
                       {fmtAlpha(entry.conviction)}
                     </td>
                   </tr>

--- a/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
@@ -132,10 +132,10 @@ function LeaseStatusCard({
           <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 mg-type-micro text-accent-text">
             Leased
           </span>
-          <span className="font-mono text-[11px] text-ink-muted">lease #{lease.lease_id}</span>
+          <span className="mg-type-data text-ink-muted">lease #{lease.lease_id}</span>
         </div>
         {queriedAt ? (
-          <span className="font-mono text-[11px] text-ink-muted">
+          <span className="mg-type-data text-ink-muted">
             queried <TimeAgo at={queriedAt} />
           </span>
         ) : null}
@@ -245,10 +245,10 @@ function LeaseHistorySection({
                   {ev.beneficiary ? (
                     <CopyableCode value={ev.beneficiary} className="max-w-full" />
                   ) : (
-                    <span className="font-mono text-[11px] text-ink-muted">no beneficiary</span>
+                    <span className="mg-type-data text-ink-muted">no beneficiary</span>
                   )}
                 </div>
-                <span className="shrink-0 font-mono text-[11px] text-ink-muted">
+                <span className="shrink-0 mg-type-data text-ink-muted">
                   {ev.block_number != null ? `block #${formatNumber(ev.block_number)} · ` : ""}
                   {ev.observed_at ? <TimeAgo at={ev.observed_at} /> : "unknown time"}
                 </span>

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -446,7 +446,7 @@ export function SubnetMasthead({
                         </span>
                       )}
                     </TooltipTrigger>
-                    <TooltipContent side="bottom" className="font-mono text-[11px]">
+                    <TooltipContent side="bottom" className="mg-type-data">
                       {safeHref ? host(safeHref) : "Blocked unsafe external URL"}
                     </TooltipContent>
                   </Tooltip>

--- a/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
@@ -104,7 +104,7 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
             formatValue={fmtOhlcPrice}
             ariaLabel={`Subnet ${netuid} alpha price, ${candles.length} ${interval} candles`}
           />
-          <div className="mt-2 flex items-center justify-between font-mono text-[10px] text-ink-muted">
+          <div className="mt-2 flex items-center justify-between mg-type-data-sm text-ink-muted">
             <span>{candles.length} candles</span>
             <span>
               latest close {fmtOhlcPrice(candles[candles.length - 1]!.close)} τ/α · vol{" "}

--- a/apps/ui/src/components/metagraphed/subnet-ownership-history.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ownership-history.tsx
@@ -57,16 +57,16 @@ export function SubnetOwnershipHistory({ netuid }: { netuid: number }) {
               {change.old_coldkey ? (
                 <CopyableCode value={change.old_coldkey} className="max-w-full" />
               ) : (
-                <span className="font-mono text-[11px] text-ink-muted">unknown</span>
+                <span className="mg-type-data text-ink-muted">unknown</span>
               )}
               <ArrowRight aria-hidden className="size-3.5 shrink-0 text-ink-muted" />
               {change.new_coldkey ? (
                 <CopyableCode value={change.new_coldkey} className="max-w-full" />
               ) : (
-                <span className="font-mono text-[11px] text-ink-muted">unknown</span>
+                <span className="mg-type-data text-ink-muted">unknown</span>
               )}
             </div>
-            <span className="shrink-0 font-mono text-[11px] text-ink-muted">
+            <span className="shrink-0 mg-type-data text-ink-muted">
               {change.block_number != null ? `block #${formatNumber(change.block_number)} · ` : ""}
               {change.observed_at ? <TimeAgo at={change.observed_at} /> : "unknown time"}
             </span>

--- a/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
@@ -139,7 +139,7 @@ export function SubnetPriceTicker({ limit = 12 }: { limit?: number }) {
                   </span>
                 ) : null}
                 {t.changePct != null ? (
-                  <span className="font-mono tabular-nums text-[10px]" style={{ color: t.color }}>
+                  <span className="tabular-nums mg-type-data-sm" style={{ color: t.color }}>
                     {arrow} {t.changePct >= 0 ? "+" : ""}
                     {t.changePct.toFixed(1)}%
                   </span>

--- a/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
@@ -80,7 +80,7 @@ function Stat({ field, trailing }: { field: Field; trailing?: React.ReactNode })
             </span>
           </TooltipTrigger>
           {hasValue ? (
-            <TooltipContent side="top" className="font-mono text-[11px]">
+            <TooltipContent side="top" className="mg-type-data">
               {full}
               {field.unit ? ` ${field.unit}` : ""}
             </TooltipContent>
@@ -227,7 +227,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
         {hydrated && lineagePeer ? (
           <div className="flex flex-wrap items-center gap-2 px-4 py-2.5 border-b border-border bg-surface/20">
             <GitMerge className="size-3.5 text-accent" />
-            <span className="text-[12px] text-ink">
+            <span className="mg-type-caption text-ink">
               Paired with its {lineagePeer.label.toLowerCase()} counterpart
             </span>
             <ArrowRight className="size-3 text-ink-muted" />
@@ -265,7 +265,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                       Pool composition
                       <InfoTooltip label="Alpha In ÷ (Alpha In + Alpha Out) from the latest on-chain AMM reserves snapshot, taken from /api/v1/economics. Tile shows a `stale` chip when the snapshot is older than the refresh budget; numbers still render from the last known values." />
                     </div>
-                    <div className="mt-1 space-y-1 font-mono text-[10px] text-ink-muted">
+                    <div className="mt-1 space-y-1 mg-type-data-sm text-ink-muted">
                       <div className="flex items-center gap-1.5">
                         <span
                           aria-hidden
@@ -292,7 +292,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                   </div>
                 </>
               ) : (
-                <div className="font-mono text-[10px] text-ink-muted">No pool data</div>
+                <div className="mg-type-data-sm text-ink-muted">No pool data</div>
               )}
             </div>
             <div className="flex items-center gap-4 p-4">
@@ -314,7 +314,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                   </div>
                 </>
               ) : (
-                <div className="font-mono text-[10px] text-ink-muted">No endpoints tracked</div>
+                <div className="mg-type-data-sm text-ink-muted">No endpoints tracked</div>
               )}
             </div>
             <div className="p-4">
@@ -336,14 +336,14 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                       >
                         {p.name}
                       </Link>
-                      <span className="ml-auto font-mono text-[10px] tabular-nums text-ink-muted">
+                      <span className="ml-auto mg-type-data-sm tabular-nums text-ink-muted">
                         {p.count}
                       </span>
                     </li>
                   ))}
                 </ul>
               ) : (
-                <div className="mt-2 font-mono text-[10px] text-ink-muted">
+                <div className="mt-2 mg-type-data-sm text-ink-muted">
                   No provider attribution yet.
                 </div>
               )}
@@ -399,7 +399,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
             {completenessPct != null ? (
               <div>
                 <div className="flex items-baseline justify-between mb-1">
-                  <span className="font-mono text-[10px] text-ink-muted">Completeness</span>
+                  <span className="mg-type-data-sm text-ink-muted">Completeness</span>
                   <span className="font-display text-sm font-semibold tabular-nums text-ink-strong">
                     {completenessPct}%
                   </span>
@@ -418,7 +418,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                 </div>
               </div>
             ) : null}
-            <div className="flex flex-wrap items-center gap-1.5 text-[10px] font-mono text-ink-muted">
+            <div className="flex flex-wrap items-center gap-1.5 mg-type-data-sm text-ink-muted">
               {profile?.coverage_level ? (
                 <span className="rounded border border-border bg-surface/50 px-1.5 py-0.5 uppercase tracking-wider">
                   {profile.coverage_level}

--- a/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
@@ -104,14 +104,14 @@ function ValidatorPreviewRow({
         <Link
           to="/validators/$hotkey"
           params={{ hotkey: validator.hotkey }}
-          className="truncate font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+          className="truncate font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
           title={validator.hotkey}
         >
           {shortHash(validator.hotkey, 6) ?? validator.hotkey}
         </Link>
         <CopyButton value={validator.hotkey} label="hotkey" compact />
       </div>
-      <div className="flex flex-wrap items-center gap-3 font-mono text-[11px] text-ink-muted">
+      <div className="flex flex-wrap items-center gap-3 mg-type-data text-ink-muted">
         <span>
           <span className="text-ink-strong tabular-nums">{taoCompact(validator.stake_tao)}</span> τ
         </span>

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -42,7 +42,7 @@ export function SubnetsCompareDrawer() {
               {selected.map((netuid) => (
                 <span
                   key={netuid}
-                  className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-paper pl-2.5 pr-1 font-mono text-[10px] text-ink-strong"
+                  className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-paper pl-2.5 pr-1 mg-type-data-sm text-ink-strong"
                 >
                   SN{netuid}
                   <button
@@ -200,7 +200,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
         const ok = h.ok_count ?? 0;
         const down = Math.max(0, h.surface_count - ok);
         return (
-          <span className="font-mono text-[11px] tabular-nums">
+          <span className="mg-type-data tabular-nums">
             <span className="text-health-ok">{ok}</span>
             {" · "}
             <span className="text-health-down">{down}</span>
@@ -213,7 +213,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
   if (isError) {
     return (
       <div className="border-t border-border px-3 py-6 text-center">
-        <p className="font-mono text-[11px] text-ink-muted">Could not load comparison.</p>
+        <p className="mg-type-data text-ink-muted">Could not load comparison.</p>
         <button
           type="button"
           onClick={() => refetch()}
@@ -227,7 +227,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
 
   return (
     <div className="border-t border-border max-h-[55vh] overflow-auto">
-      <table className="min-w-full text-[12px]">
+      <table className="min-w-full mg-type-caption">
         {/* local stacking context: sticky corner cell over sticky row/col — not a global layer (#7841) */}
         <thead className="sticky top-0 mg-glass z-[1]">
           <tr>

--- a/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
@@ -122,7 +122,7 @@ export function SubnetsSavedViews() {
                 aria-pressed={active}
                 onClick={() => apply(p.patch)}
                 className={classNames(
-                  "relative inline-flex shrink-0 items-center px-3 py-2 text-[13px] transition-colors",
+                  "relative inline-flex shrink-0 items-center px-3 py-2 mg-type-caption-lg transition-colors",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm",
                   active ? "text-ink-strong" : "text-ink-muted hover:text-ink-strong",
                 )}

--- a/apps/ui/src/components/metagraphed/surface-fixture.tsx
+++ b/apps/ui/src/components/metagraphed/surface-fixture.tsx
@@ -48,9 +48,9 @@ export function SurfaceFixture({
         />
         <span className="mg-label">sample response</span>
         {entry.response_status != null ? (
-          <span className="font-mono text-[10px] text-health-ok">{entry.response_status}</span>
+          <span className="mg-type-data-sm text-health-ok">{entry.response_status}</span>
         ) : null}
-        <span className="ml-auto font-mono text-[10px] text-ink-muted">
+        <span className="ml-auto mg-type-data-sm text-ink-muted">
           <TimeAgo at={entry.captured_at ?? undefined} />
         </span>
       </button>
@@ -73,12 +73,12 @@ export function SurfaceFixture({
                 <div className="mb-1 flex items-center gap-2">
                   <span className="mg-label">response</span>
                   {fixture.response?.status != null ? (
-                    <span className="font-mono text-[10px] text-health-ok">
+                    <span className="mg-type-data-sm text-health-ok">
                       {fixture.response.status}
                     </span>
                   ) : null}
                   {fixture.response?.content_type ? (
-                    <span className="font-mono text-[10px] text-ink-muted">
+                    <span className="mg-type-data-sm text-ink-muted">
                       {fixture.response.content_type}
                     </span>
                   ) : null}
@@ -87,7 +87,7 @@ export function SurfaceFixture({
                   ) : null}
                 </div>
                 {bodyText ? (
-                  <pre className="max-h-64 overflow-auto rounded bg-card p-2 font-mono text-[11px] leading-relaxed text-ink-strong">
+                  <pre className="max-h-64 overflow-auto rounded bg-card p-2 mg-type-data leading-relaxed text-ink-strong">
                     {bodyText}
                   </pre>
                 ) : (

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -112,7 +112,7 @@ export function SearchInput({
       {shortcut ? (
         <kbd
           aria-hidden
-          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 mg-type-data-sm text-ink-muted"
         >
           /
         </kbd>
@@ -220,7 +220,7 @@ export function FilterChip({
       {label ? <span className="mg-type-micro opacity-80 shrink-0">{label}</span> : null}
       <span
         className={classNames(
-          "font-mono text-[11px] truncate max-w-[100px]",
+          "mg-type-data truncate max-w-[100px]",
           active ? "text-ink-strong" : "text-ink-muted",
         )}
       >

--- a/apps/ui/src/components/metagraphed/take-management-modal.tsx
+++ b/apps/ui/src/components/metagraphed/take-management-modal.tsx
@@ -168,11 +168,13 @@ function TakeFlowBody({
       return (
         <div className="flex flex-col items-center gap-4 py-10 text-center">
           <AlertTriangle className="size-6 text-health-down" aria-hidden />
-          <p className="text-[13px] text-ink-strong">{describeTxError(flow.txStatus.error)}</p>
+          <p className="mg-type-caption-lg text-ink-strong">
+            {describeTxError(flow.txStatus.error)}
+          </p>
           <button
             type="button"
             onClick={flow.editAmount}
-            className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+            className="rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink/30"
           >
             Edit and try again
           </button>
@@ -252,7 +254,7 @@ function TakeAmountStep({ flow }: { flow: UseTakeFlowResult }) {
         </dl>
 
         {flow.direction === "increase" && flow.cooldownDurationLabel ? (
-          <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+          <p className="inline-flex items-center gap-1.5 mg-type-data text-health-down">
             <AlertCircle className="size-3.5 shrink-0" aria-hidden />
             Take was changed too recently — try again in {flow.cooldownDurationLabel}. (Decreasing
             take has no cooldown.)
@@ -260,9 +262,7 @@ function TakeAmountStep({ flow }: { flow: UseTakeFlowResult }) {
         ) : null}
 
         {!hasValidPercentInput ? (
-          <p className="font-mono text-[11px] text-ink-muted">
-            Enter a new take percentage to continue.
-          </p>
+          <p className="mg-type-data text-ink-muted">Enter a new take percentage to continue.</p>
         ) : null}
 
         {flow.validationMessages.length > 0 ? (
@@ -270,7 +270,7 @@ function TakeAmountStep({ flow }: { flow: UseTakeFlowResult }) {
             {flow.validationMessages.map((message) => (
               <li
                 key={message}
-                className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down"
+                className="inline-flex items-center gap-1.5 mg-type-data text-health-down"
               >
                 <AlertCircle className="size-3.5 shrink-0" aria-hidden />
                 {message}
@@ -285,7 +285,7 @@ function TakeAmountStep({ flow }: { flow: UseTakeFlowResult }) {
           type="button"
           onClick={flow.confirm}
           disabled={!flow.canConfirm}
-          className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
+          className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
         >
           Review {DIRECTION_VERB[flow.direction].toLowerCase()}
         </button>
@@ -340,7 +340,7 @@ function TakeConfirmationStep({
           type="button"
           onClick={flow.editAmount}
           disabled={confirming}
-          className="flex-1 rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-muted transition-colors hover:border-ink/30 hover:text-ink-strong disabled:opacity-60"
+          className="flex-1 rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-muted transition-colors hover:border-ink/30 hover:text-ink-strong disabled:opacity-60"
         >
           Cancel
         </button>
@@ -348,7 +348,7 @@ function TakeConfirmationStep({
           type="button"
           onClick={onConfirm}
           disabled={confirming || flow.feeTao === null}
-          className="flex-1 inline-flex items-center justify-center gap-1.5 rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-60"
+          className="flex-1 inline-flex items-center justify-center gap-1.5 rounded border border-ink-strong/40 bg-surface px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-60"
         >
           {confirming ? (
             <>
@@ -381,7 +381,7 @@ function SummaryRow({
       <span className="text-[11px] text-ink-muted">{label}</span>
       <span
         className={classNames(
-          "block text-[12px] font-medium text-ink-strong",
+          "block mg-type-caption font-medium text-ink-strong",
           loading && "animate-pulse text-ink-muted",
         )}
       >
@@ -405,13 +405,13 @@ function StatusView({
   return (
     <div className="flex flex-col items-center gap-4 py-10 text-center">
       {icon}
-      <p className="text-[13px] text-ink-strong">{message}</p>
+      <p className="mg-type-caption-lg text-ink-strong">{message}</p>
       {txHash ? (
         <div className="space-y-1">
           <Link
             to="/extrinsics/$hash"
             params={{ hash: txHash }}
-            className="font-mono text-[11px] text-accent hover:underline"
+            className="mg-type-data text-accent hover:underline"
           >
             {shortHash(txHash, 8)}
           </Link>
@@ -424,7 +424,7 @@ function StatusView({
         <button
           type="button"
           onClick={onClose}
-          className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+          className="rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-strong transition-colors hover:border-ink/30"
         >
           Done
         </button>

--- a/apps/ui/src/components/metagraphed/tao-value.tsx
+++ b/apps/ui/src/components/metagraphed/tao-value.tsx
@@ -31,7 +31,7 @@ export function TaoValue({
   const { unit } = useValueUnit();
 
   if (amount == null || Number.isNaN(amount)) {
-    return <span className="font-mono text-[11px] text-ink-muted">—</span>;
+    return <span className="mg-type-data text-ink-muted">—</span>;
   }
 
   const tao = `τ ${formatNumber(Number(amount.toFixed(precision)))}`;
@@ -47,11 +47,11 @@ export function TaoValue({
   const taoClass =
     size === "md"
       ? "font-display text-base sm:text-xl md:text-2xl font-semibold tabular-nums leading-none text-ink-strong"
-      : "font-mono text-[11px] tabular-nums text-ink-strong";
+      : "mg-type-data tabular-nums text-ink-strong";
   const usdClass =
     size === "md"
-      ? "font-mono text-[10px] tabular-nums text-ink-muted"
-      : "font-mono text-[10px] tabular-nums text-ink-muted";
+      ? "mg-type-data-sm tabular-nums text-ink-muted"
+      : "mg-type-data-sm tabular-nums text-ink-muted";
 
   const taoNode = showTao ? <span className={taoClass}>{tao}</span> : null;
   const usdNode = showUsd ? (

--- a/apps/ui/src/components/metagraphed/top-active-accounts-ranking.ts
+++ b/apps/ui/src/components/metagraphed/top-active-accounts-ranking.ts
@@ -55,4 +55,4 @@ export function formatTopActiveShare(share: number): string {
 export const TOP_ACTIVE_ACCOUNTS_LIST_CLASS = "flex flex-col gap-1.5";
 
 export const TOP_ACTIVE_ACCOUNT_LINK_CLASS =
-  "group flex w-full items-center justify-between gap-3 rounded border border-border bg-paper/40 px-3 py-2 font-mono text-[11px] text-ink-strong hover:border-ink/30 hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 min-h-11";
+  "group flex w-full items-center justify-between gap-3 rounded border border-border bg-paper/40 px-3 py-2 mg-type-data text-ink-strong hover:border-ink/30 hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 min-h-11";

--- a/apps/ui/src/components/metagraphed/top-active-accounts.tsx
+++ b/apps/ui/src/components/metagraphed/top-active-accounts.tsx
@@ -19,7 +19,7 @@ export function TopActiveAccounts() {
 
   if (rows.length === 0) {
     return (
-      <p className="font-mono text-[12px] text-ink-muted">
+      <p className="font-mono mg-type-caption text-ink-muted">
         No account activity in this window yet.
       </p>
     );

--- a/apps/ui/src/components/metagraphed/turnover-panel.tsx
+++ b/apps/ui/src/components/metagraphed/turnover-panel.tsx
@@ -88,7 +88,7 @@ export function TurnoverLoader({ netuid }: { netuid: number }) {
         />
       </div>
       {t.start_date && t.end_date ? (
-        <p className="font-mono text-[11px] text-ink-muted">
+        <p className="mg-type-data text-ink-muted">
           Compared {t.start_date} → {t.end_date}
           {t.window ? ` (${t.window})` : ""}
         </p>

--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -34,7 +34,7 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
                 to="/validators/$hotkey"
                 params={{ hotkey: v.hotkey }}
                 title={v.hotkey}
-                className="truncate font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+                className="truncate font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
               >
                 {f.hotkeyShort}
               </Link>
@@ -47,7 +47,7 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
             {/* Mirrors the hotkey row above: a flex row so the copy button's 44px
                 touch target centers against the value. `compact` folds that height
                 back into the row so it does not add vertical spacing. */}
-            <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+            <div className="flex min-w-0 items-center gap-1.5 mg-type-data text-ink-muted">
               <span className="mg-type-micro">coldkey</span>
               {/* Same AccountAddress hover-card treatment as the desktop column (#6338). */}
               <AccountAddress ss58={v.coldkey} compact fallback="—" />

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -10,7 +10,7 @@ import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 const TH_BASE = "px-3 py-2 mg-type-micro text-ink-muted";
-const TD_BASE = "px-3 py-2 font-mono text-[11px]";
+const TD_BASE = "px-3 py-2 mg-type-data";
 const TD_NUM = `${TD_BASE} text-right tabular-nums`;
 
 /**

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -77,9 +77,7 @@ export function ValidatorGuide() {
           <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
           <span className="min-w-0 flex-1">
             <span className="block mg-type-micro text-ink-muted">{HEADING}</span>
-            <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
-              {SUBHEADING}
-            </span>
+            <span className="mt-0.5 block mg-type-data-sm text-ink-muted/80">{SUBHEADING}</span>
           </span>
           <ChevronDown
             className={classNames(
@@ -111,15 +109,13 @@ export function ValidatorGuide() {
           <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
           <span className="min-w-0 flex-1">
             <span className="block mg-type-micro text-ink-muted">{HEADING}</span>
-            <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
-              {SUBHEADING}
-            </span>
+            <span className="mt-0.5 block mg-type-data-sm text-ink-muted/80">{SUBHEADING}</span>
           </span>
         </div>
         <div className="divide-y divide-border border-t border-border">
           {METRICS.map((m) => (
             <details key={m.term} className="group px-3">
-              <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2.5 text-[12px] font-medium text-ink-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-2 py-2.5 mg-type-caption font-medium text-ink-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
                 <span>{m.term}</span>
                 <ChevronDown className="size-3.5 shrink-0 text-ink-muted transition-transform group-open:rotate-180" />
               </summary>

--- a/apps/ui/src/components/metagraphed/validator-identity-chip.tsx
+++ b/apps/ui/src/components/metagraphed/validator-identity-chip.tsx
@@ -28,7 +28,7 @@ export function ValidatorIdentityChip({
         size={size}
       />
       {showName ? (
-        <span className="truncate font-medium text-ink-strong text-[12px]" title={name}>
+        <span className="truncate font-medium text-ink-strong mg-type-caption" title={name}>
           {name}
         </span>
       ) : null}

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -87,7 +87,7 @@ export function ValidatorNominatorsTable({ queryOptions, search, setSearch }: Pr
   );
 
   const footerNode = (
-    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 text-[11px] font-mono text-ink-muted">
+    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 mg-type-data text-ink-muted">
       <span>
         {rows.length
           ? `${formatNumber(search.offset + 1)}–${formatNumber(search.offset + rows.length)}`
@@ -127,22 +127,22 @@ export function ValidatorNominatorsTable({ queryOptions, search, setSearch }: Pr
           <tbody className="divide-y divide-border">
             {rows.map((n) => (
               <tr key={n.coldkey} className="mg-row-accent hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono text-[11px]">
+                <td className="px-4 py-2.5 mg-type-data">
                   <CopyableCode value={n.coldkey} className="max-w-full" />
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
                   {taoCompact(n.net_staked_tao)}
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
                   {taoCompact(n.gross_staked_tao)}
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                   {taoCompact(n.unstaked_tao)}
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
                   {formatNumber(n.event_count)}
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
                   <TimeAgo at={n.last_observed_at} />
                 </td>
               </tr>
@@ -160,11 +160,11 @@ function NominatorCard({ n }: { n: ValidatorNominatorEntry }) {
     <Panel as="div" dense className="block min-h-11">
       <div className="flex items-center justify-between gap-2">
         <CopyableCode value={n.coldkey} className="max-w-[70%]" />
-        <span className="font-mono text-[11px] text-ink-muted shrink-0">
+        <span className="mg-type-data text-ink-muted shrink-0">
           <TimeAgo at={n.last_observed_at} />
         </span>
       </div>
-      <div className="mt-2 flex items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
+      <div className="mt-2 flex items-center justify-between gap-2 mg-type-data text-ink-muted">
         <span>net {taoCompact(n.net_staked_tao)}</span>
         <span>gross {taoCompact(n.gross_staked_tao)}</span>
         <span>{formatNumber(n.event_count)} events</span>

--- a/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/validators-compare-drawer.tsx
@@ -49,7 +49,7 @@ export function ValidatorsCompareDrawer() {
                   <span
                     key={hotkey}
                     title={hotkey}
-                    className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-paper pl-2.5 pr-1 font-mono text-[10px] text-ink-strong"
+                    className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-paper pl-2.5 pr-1 mg-type-data-sm text-ink-strong"
                   >
                     {short}
                     <button
@@ -196,7 +196,7 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
   if (isError) {
     return (
       <div className="border-t border-border px-3 py-6 text-center">
-        <p className="font-mono text-[11px] text-ink-muted">Could not load comparison.</p>
+        <p className="mg-type-data text-ink-muted">Could not load comparison.</p>
         <button
           type="button"
           onClick={() => refetch()}
@@ -210,7 +210,7 @@ function CompareValidatorsGrid({ hotkeys }: { hotkeys: string[] }) {
 
   return (
     <div className="border-t border-border max-h-[55vh] overflow-auto">
-      <table className="min-w-full text-[12px]">
+      <table className="min-w-full mg-type-caption">
         {/* local stacking context: sticky corner cell over sticky row/col — not a global layer (#7841) */}
         <thead className="sticky top-0 mg-glass z-[1]">
           <tr>

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -80,7 +80,7 @@ export function ValidatorsTableLoader({
               Validator stake · top {stakeBars.length}
             </span>
             <span className="ml-auto flex items-center gap-2">
-              <span className="font-mono text-[10px] text-ink-muted">
+              <span className="mg-type-data-sm text-ink-muted">
                 peak {taoCompact(stakeBars[0]?.value)} τ
               </span>
               {freshness}

--- a/apps/ui/src/components/metagraphed/wallet-connect.tsx
+++ b/apps/ui/src/components/metagraphed/wallet-connect.tsx
@@ -59,7 +59,7 @@ export function WalletConnectButton() {
           aria-label={connected ? `Wallet connected: ${wallet.address}` : "Connect wallet"}
           title={connected ? `Connected · ${wallet.source} · ${wallet.address}` : "Connect wallet"}
           className={classNames(
-            "inline-flex items-center gap-1.5 rounded border px-2 py-1.5 min-h-11 text-[11px] font-mono transition-colors",
+            "inline-flex items-center gap-1.5 rounded border px-2 py-1.5 min-h-11 mg-type-data transition-colors",
             connected
               ? "border-ink-strong/40 bg-surface text-ink-strong"
               : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",
@@ -128,7 +128,7 @@ export function WalletConnectPanel({ onConnected }: { onConnected?: () => void }
           await connect();
         }}
         disabled={status === "connecting"}
-        className="w-full inline-flex items-center justify-center gap-1.5 rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-60"
+        className="w-full inline-flex items-center justify-center gap-1.5 rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-60"
       >
         {status === "connecting" ? (
           <>
@@ -205,7 +205,7 @@ function AccountPicker({
               className="w-full flex items-center gap-2 rounded border border-border bg-card px-2 py-1.5 text-left transition-colors hover:border-ink/30 min-h-9"
             >
               <span className="min-w-0 flex-1">
-                <span className="block text-[12px] font-medium text-ink-strong truncate">
+                <span className="block mg-type-caption font-medium text-ink-strong truncate">
                   {account.meta.name || shortHash(account.address, 6)}
                 </span>
                 <span className="block text-[10px] text-ink-muted truncate">
@@ -235,7 +235,7 @@ function ConnectedView({
         <div className="flex items-center gap-2">
           <Check className="size-3.5 text-health-ok shrink-0" aria-hidden="true" />
           <span className="min-w-0 flex-1">
-            <span className="block text-[12px] font-medium text-ink-strong font-mono truncate">
+            <span className="block mg-type-caption font-medium text-ink-strong font-mono truncate">
               {shortHash(wallet.address, 6)}
             </span>
             <span className="block text-[10px] text-ink-muted">Connected via {wallet.source}</span>

--- a/apps/ui/src/components/metagraphed/watch-alert-form.tsx
+++ b/apps/ui/src/components/metagraphed/watch-alert-form.tsx
@@ -15,7 +15,7 @@ export const CHANNELS = ["webhook", "discord"] as const;
 export type Channel = (typeof CHANNELS)[number];
 
 export const inputCls =
-  "w-full rounded border border-border bg-card px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
+  "w-full rounded border border-border bg-card px-2.5 py-1.5 mg-type-caption-lg text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
 
 /** Distinguishes the create-token gate, validation, and rate-limit rejections. */
 export function describeApiError(error: unknown): string {
@@ -35,7 +35,7 @@ export function ErrorPanel({ message }: { message: string }) {
   return (
     <div
       role="alert"
-      className="rounded border border-health-down/30 bg-health-down/5 p-3 text-[12px] text-health-down"
+      className="rounded border border-health-down/30 bg-health-down/5 p-3 mg-type-caption text-health-down"
     >
       {message}
     </div>
@@ -83,7 +83,7 @@ export function ChannelAndDestinationFields({
       <Field label="Delivery channel">
         <div className="flex gap-4">
           {CHANNELS.map((c) => (
-            <label key={c} className="inline-flex items-center gap-1.5 text-[12px] text-ink">
+            <label key={c} className="inline-flex items-center gap-1.5 mg-type-caption text-ink">
               <input
                 type="radio"
                 name="channel"
@@ -125,7 +125,7 @@ export function ChannelAndDestinationFields({
 export function CreatedTokenPanel({ id, ownerToken }: { id: string; ownerToken: string }) {
   return (
     <div className="space-y-2 rounded border border-accent/40 bg-primary-soft/40 p-4">
-      <p className="text-[12px] font-medium text-health-warn">
+      <p className="mg-type-caption font-medium text-health-warn">
         The owner token below is shown once and is never echoed back by GET — store it now to manage
         or delete this alert later via the API.
       </p>

--- a/apps/ui/src/components/metagraphed/watch-subnet-alert.tsx
+++ b/apps/ui/src/components/metagraphed/watch-subnet-alert.tsx
@@ -76,7 +76,7 @@ export function WatchSubnetAlert({ netuid }: { netuid: number }) {
 
   return (
     <div className="space-y-3">
-      <p className="max-w-2xl text-[13px] text-ink-muted">
+      <p className="max-w-2xl mg-type-caption-lg text-ink-muted">
         Get a webhook or Discord notification for on-chain activity on SN{netuid}. Creation requires
         a trigger token issued by a metagraphed operator — this app never bundles one.
       </p>
@@ -117,7 +117,7 @@ export function WatchSubnetAlert({ netuid }: { netuid: number }) {
         <button
           type="submit"
           disabled={mutation.isPending}
-          className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[12px] font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
         >
           {mutation.isPending ? "Creating…" : "Watch this subnet"}
         </button>

--- a/apps/ui/src/components/metagraphed/watch-validator-alert.tsx
+++ b/apps/ui/src/components/metagraphed/watch-validator-alert.tsx
@@ -75,7 +75,7 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
 
   return (
     <div className="space-y-3">
-      <p className="max-w-2xl text-[13px] text-ink-muted">
+      <p className="max-w-2xl mg-type-caption-lg text-ink-muted">
         Get a webhook or Discord notification when this validator receives new delegations or stake.
         Creation requires a trigger token issued by a metagraphed operator — this app never bundles
         one.
@@ -120,7 +120,7 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
         <button
           type="submit"
           disabled={mutation.isPending}
-          className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[12px] font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
         >
           {mutation.isPending ? "Creating…" : "Watch this validator"}
         </button>

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -19,7 +19,7 @@ const SUBSCRIPTION_TOKEN_HEADER = "x-metagraph-webhook-subscription-token";
 const SUBSCRIPTION_SECRET_HEADER = "x-metagraph-webhook-secret";
 
 const inputCls =
-  "w-full rounded border border-border bg-card px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
+  "w-full rounded border border-border bg-card px-2.5 py-1.5 mg-type-caption-lg text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
 
 /** Comma-separated netuids -> integers, or an error describing the offending token. Empty input is valid (no filter). */
 export function parseNetuidsInput(
@@ -209,7 +209,10 @@ function CreateSubscriptionSection() {
         <Field label="Kinds filter" hint="Optional — leave unchecked to receive all change kinds.">
           <div className="flex gap-4">
             {CHANGE_KINDS.map((kind) => (
-              <label key={kind} className="inline-flex items-center gap-1.5 text-[12px] text-ink">
+              <label
+                key={kind}
+                className="inline-flex items-center gap-1.5 mg-type-caption text-ink"
+              >
                 <input
                   type="checkbox"
                   checked={kinds.has(kind)}
@@ -236,7 +239,7 @@ function CreateSubscriptionSection() {
         <button
           type="submit"
           disabled={mutation.isPending}
-          className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[12px] font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
         >
           {mutation.isPending ? "Creating…" : "Create subscription"}
         </button>
@@ -248,7 +251,7 @@ function CreateSubscriptionSection() {
 
       {result ? (
         <div className="mt-3 space-y-3 rounded border border-accent/40 bg-primary-soft/40 p-4">
-          <p className="text-[12px] font-medium text-health-warn">
+          <p className="mg-type-caption font-medium text-health-warn">
             The secret below is shown once and is never echoed back by GET — store it now.
           </p>
           <CopyableCode label="id" value={result.id} truncate={false} className="w-full" />
@@ -324,7 +327,7 @@ function LookupSubscriptionSection() {
         <button
           type="submit"
           disabled={mutation.isPending}
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 text-[12px] font-medium text-ink-muted hover:text-ink-strong hover:border-ink/30 disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:border-ink/30 disabled:opacity-50"
         >
           {mutation.isPending ? "Looking up…" : "Look up"}
         </button>
@@ -347,14 +350,14 @@ function LookupSubscriptionSection() {
             <DeliveryStatusPill status={result.delivery.status} />
             <span
               className={classNames(
-                "font-mono text-[11px]",
+                "mg-type-data",
                 result.active ? "text-health-ok" : "text-ink-muted",
               )}
             >
               {result.active ? "active" : "inactive"}
             </span>
           </div>
-          <dl className="grid gap-2 text-[12px]">
+          <dl className="grid gap-2 mg-type-caption">
             <Row label="URL" value={result.url} />
             <Row label="Created" value={result.created_at ?? "—"} />
             <Row
@@ -443,7 +446,7 @@ function DeleteSubscriptionSection() {
         <button
           type="submit"
           disabled={mutation.isPending}
-          className="inline-flex items-center gap-1.5 rounded border border-health-down/40 bg-health-down/5 px-3 py-1.5 text-[12px] font-medium text-health-down hover:bg-health-down/10 disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded border border-health-down/40 bg-health-down/5 px-3 py-1.5 mg-type-caption font-medium text-health-down hover:bg-health-down/10 disabled:opacity-50"
         >
           {mutation.isPending ? "Deleting…" : "Delete subscription"}
         </button>
@@ -456,7 +459,7 @@ function DeleteSubscriptionSection() {
       {mutation.data?.deleted ? (
         <div
           role="status"
-          className="mt-3 rounded border border-health-ok/30 bg-health-ok/5 p-3 text-[12px] text-health-ok"
+          className="mt-3 rounded border border-health-ok/30 bg-health-ok/5 p-3 mg-type-caption text-health-ok"
         >
           Subscription {mutation.data.id} deleted.
         </div>
@@ -494,7 +497,7 @@ function ErrorPanel({ message }: { message: string }) {
   return (
     <div
       role="alert"
-      className="mt-3 rounded border border-health-down/30 bg-health-down/5 p-3 text-[12px] text-health-down"
+      className="mt-3 rounded border border-health-down/30 bg-health-down/5 p-3 mg-type-caption text-health-down"
     >
       {message}
     </div>

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -117,7 +117,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
           {splitBars.length ? (
             <BarMini data={splitBars} />
           ) : (
-            <p className="font-mono text-[11px] text-ink-muted">Not enough data yet.</p>
+            <p className="mg-type-data text-ink-muted">Not enough data yet.</p>
           )}
         </Panel>
 
@@ -141,7 +141,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
             <div key={n.uid} className="p-3">
               <div className="flex items-center justify-between gap-2">
                 <div className="flex min-w-0 items-center gap-2">
-                  <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                  <span className="shrink-0 mg-type-data tabular-nums text-ink-muted">
                     #{n.uid}
                   </span>
                   {n.hotkey ? (
@@ -149,7 +149,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                       <Link
                         to="/accounts/$ss58"
                         params={{ ss58: n.hotkey }}
-                        className="truncate font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+                        className="truncate font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
                         title={n.hotkey}
                       >
                         {shortHash(n.hotkey) ?? n.hotkey}
@@ -157,7 +157,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                       <CopyButton value={n.hotkey} label="hotkey" compact />
                     </>
                   ) : (
-                    <span className="font-mono text-[12px] text-ink-muted">—</span>
+                    <span className="font-mono mg-type-caption text-ink-muted">—</span>
                   )}
                 </div>
                 {n.role === "validator" ? (
@@ -168,7 +168,7 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                   <span className="shrink-0 mg-type-micro text-ink-muted">Miner</span>
                 )}
               </div>
-              <div className="mt-2 flex items-center justify-between gap-2 font-mono text-[11px] tabular-nums">
+              <div className="mt-2 flex items-center justify-between gap-2 mg-type-data tabular-nums">
                 <span className="text-ink-muted">{taoCompact(n.stake_tao)} τ stake</span>
                 <span className="text-ink-muted">{taoCompact(n.emission_tao)} τ emission</span>
                 <span className="flex items-center gap-1 text-ink-strong">
@@ -195,10 +195,10 @@ export function YieldLoader({ netuid }: { netuid: number }) {
             <tbody>
               {ranked.map((n) => (
                 <tr key={n.uid} className="mg-row-hover border-t border-border/60">
-                  <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink-strong">
+                  <td className="px-3 py-2.5 font-mono mg-type-caption tabular-nums text-ink-strong">
                     {n.uid}
                   </td>
-                  <td className="px-3 py-2.5 font-mono text-[11px]">
+                  <td className="px-3 py-2.5 mg-type-data">
                     {n.hotkey ? (
                       <div className="flex items-center gap-1.5">
                         <Link
@@ -224,13 +224,13 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                       <span className="mg-type-micro text-ink-muted">Miner</span>
                     )}
                   </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                  <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
                     {taoCompact(n.stake_tao)}
                   </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                  <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
                     {taoCompact(n.emission_tao)}
                   </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                  <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
                     {fmtYield(n.yield)}
                   </td>
                   <td className="px-3 py-2.5 text-center">

--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -190,7 +190,7 @@ export function YourPositionsPanel({ address }: { address: string }) {
           <tbody>
             {positions.map((p, i) => (
               <tr key={p.key} className="mg-row-hover border-t border-border/60">
-                <td className="px-3 py-2.5 font-mono text-[12px]">
+                <td className="px-3 py-2.5 font-mono mg-type-caption">
                   <Link
                     to="/subnets/$netuid"
                     params={{ netuid: p.netuid }}
@@ -202,16 +202,16 @@ export function YourPositionsPanel({ address }: { address: string }) {
                 <td className="px-3 py-2.5">
                   <SourceBadge source={p.source} />
                 </td>
-                <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                <td className="px-3 py-2.5 mg-type-data text-ink-muted">
                   {p.hotkey ? <HotkeyCell hotkey={p.hotkey} /> : "—"}
                 </td>
-                <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
                   {taoCompact(p.spotTao)}
                 </td>
-                <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
                   {taoCompact(exitTaoFor(i, p))}
                 </td>
-                <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                   {pct(p.yield)}
                 </td>
                 <td className="px-3 py-2.5 text-right">
@@ -239,14 +239,14 @@ export function YourPositionsPanel({ address }: { address: string }) {
               <Link
                 to="/subnets/$netuid"
                 params={{ netuid: p.netuid }}
-                className="font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+                className="font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
               >
                 {p.isRoot ? "Root" : `SN${p.netuid}`}
               </Link>
               <SourceBadge source={p.source} />
             </div>
             {p.hotkey ? (
-              <div className="font-mono text-[11px] text-ink-muted">
+              <div className="mg-type-data text-ink-muted">
                 <HotkeyCell hotkey={p.hotkey} />
               </div>
             ) : null}
@@ -303,7 +303,7 @@ function HotkeyCell({ hotkey }: { hotkey: string }) {
 }
 
 function ManageButton({ hotkey, netuid }: { hotkey: string | null; netuid: number }) {
-  if (!hotkey) return <span className="font-mono text-[10px] text-ink-subtle-text">—</span>;
+  if (!hotkey) return <span className="mg-type-data-sm text-ink-subtle-text">—</span>;
   return (
     <StakeUnstakeModal
       hotkey={hotkey}

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -95,7 +95,7 @@ function NotFoundComponent() {
               <AlertTriangle className="size-3.5 text-health-warn" /> Attempted URL
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-2">
-              <code className="min-w-0 flex-1 truncate rounded border border-border bg-paper px-2 py-1.5 font-mono text-[12px] text-ink">
+              <code className="min-w-0 flex-1 truncate rounded border border-border bg-paper px-2 py-1.5 font-mono mg-type-caption text-ink">
                 {attempted}
               </code>
               <button
@@ -163,7 +163,7 @@ function NotFoundComponent() {
                     className="flex items-center justify-between gap-3 rounded-md border border-border bg-card px-3 py-2 hover:border-accent/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     <span className="min-w-0">
-                      <span className="block truncate font-mono text-[12px] text-ink-strong">
+                      <span className="block truncate font-mono mg-type-caption text-ink-strong">
                         {ex.label}
                       </span>
                       <span className="block truncate text-[11px] text-ink-muted">{ex.note}</span>
@@ -236,7 +236,7 @@ function ErrorComponent({ error, reset }: { error: Error; reset: () => void }) {
             <div className="flex items-center gap-2 mg-label">
               <AlertTriangle className="size-3.5 text-health-warn" /> Diagnostic
             </div>
-            <code className="mt-2 block break-words font-mono text-[11px]">{error.message}</code>
+            <code className="mt-2 block break-words mg-type-data">{error.message}</code>
           </div>
           <div className="mt-6 flex flex-wrap gap-2">
             <button

--- a/apps/ui/src/routes/about.tsx
+++ b/apps/ui/src/routes/about.tsx
@@ -273,13 +273,13 @@ function AtAGlance() {
       <div className="mt-4 border-t border-border pt-3 grid gap-1.5">
         <Link
           to="/schemas"
-          className="font-mono text-[11px] text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
+          className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
         >
           → API & schemas
         </Link>
         <Link
           to="/gaps"
-          className="font-mono text-[11px] text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
+          className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
         >
           → Registry gaps
         </Link>

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -373,7 +373,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
               >
                 <div className="mg-type-micro text-ink-muted">event kind</div>
                 <div className="mt-2 flex items-end justify-between gap-3">
-                  <span className="min-w-0 truncate font-mono text-[12px] text-ink-strong">
+                  <span className="min-w-0 truncate font-mono mg-type-caption text-ink-strong">
                     {entry.kind}
                   </span>
                   <span className="font-display text-xl font-semibold tabular-nums text-ink-strong">
@@ -604,7 +604,7 @@ function AccountExtrinsicsSection({
                 key={x.extrinsic_hash ?? `${x.block_number}-${x.extrinsic_index}-${i}`}
                 className="hover:bg-surface/30"
               >
-                <td className="px-4 py-4 font-mono text-[12px]">
+                <td className="px-4 py-4 font-mono mg-type-caption">
                   {x.block_number != null ? (
                     <Link
                       to="/blocks/$ref"
@@ -620,7 +620,7 @@ function AccountExtrinsicsSection({
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-4 font-mono text-[11px] text-ink">
+                <td className="px-4 py-4 mg-type-data text-ink">
                   {x.extrinsic_hash ? (
                     <Link
                       to="/extrinsics/$hash"
@@ -633,7 +633,7 @@ function AccountExtrinsicsSection({
                     extrinsicCall(x.call_module, x.call_function)
                   )}
                 </td>
-                <td className="px-4 py-4 font-mono text-[11px]">
+                <td className="px-4 py-4 mg-type-data">
                   {x.success == null ? (
                     <span className="text-ink-muted">—</span>
                   ) : x.success ? (
@@ -642,7 +642,7 @@ function AccountExtrinsicsSection({
                     <span className="text-health-down">fail</span>
                   )}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-4 text-right mg-type-data text-ink-muted">
                   <TimeAgo at={x.observed_at} />
                 </td>
               </tr>
@@ -731,7 +731,7 @@ function AccountTransfersSection({
               const counterparty = t.direction === "sent" ? t.to : t.from;
               return (
                 <tr key={`${t.block_number}-${t.event_index}-${i}`} className="hover:bg-surface/30">
-                  <td className="px-4 py-4 font-mono text-[12px]">
+                  <td className="px-4 py-4 font-mono mg-type-caption">
                     {t.block_number != null ? (
                       <Link
                         to="/blocks/$ref"
@@ -744,7 +744,7 @@ function AccountTransfersSection({
                       "—"
                     )}
                   </td>
-                  <td className="px-4 py-4 font-mono text-[11px]">
+                  <td className="px-4 py-4 mg-type-data">
                     {t.direction === "received" ? (
                       <span className="text-health-ok">received</span>
                     ) : t.direction === "sent" ? (
@@ -754,7 +754,7 @@ function AccountTransfersSection({
                     )}
                   </td>
                   <td
-                    className="px-4 py-4 font-mono text-[11px] text-ink-muted"
+                    className="px-4 py-4 mg-type-data text-ink-muted"
                     title={counterparty ?? undefined}
                   >
                     {counterparty && counterparty !== ss58 ? (
@@ -769,10 +769,10 @@ function AccountTransfersSection({
                       (shortHash(counterparty) ?? "—")
                     )}
                   </td>
-                  <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                     {t.amount_tao != null ? `${formatNumber(t.amount_tao)} τ` : "—"}
                   </td>
-                  <td className="px-4 py-4 text-right font-mono text-[11px] text-ink-muted">
+                  <td className="px-4 py-4 text-right mg-type-data text-ink-muted">
                     <TimeAgo at={t.observed_at} />
                   </td>
                 </tr>
@@ -905,7 +905,7 @@ function AccountStakeMovesSection({ ss58 }: { ss58: string }) {
           <tbody className="divide-y divide-border">
             {rows.map((s) => (
               <tr key={s.netuid} className="hover:bg-surface/30">
-                <td className="px-4 py-4 font-mono text-[12px]">
+                <td className="px-4 py-4 font-mono mg-type-caption">
                   <Link
                     to="/subnets/$netuid"
                     params={{ netuid: s.netuid }}
@@ -914,13 +914,13 @@ function AccountStakeMovesSection({ ss58 }: { ss58: string }) {
                     SN{s.netuid}
                   </Link>
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                <td className="px-4 py-4 text-right font-mono mg-type-caption tabular-nums text-ink">
                   {formatNumber(s.movements)}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-4 text-right mg-type-data text-ink-muted">
                   {s.last_moved_at ? <TimeAgo at={s.last_moved_at} /> : "—"}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink-muted">
                   {fmtAlphaPrice(s.price_tao_at_last_move)}
                 </td>
               </tr>
@@ -929,7 +929,7 @@ function AccountStakeMovesSection({ ss58 }: { ss58: string }) {
         </table>
       </DataPanel>
       {subnets.length > rows.length ? (
-        <p className="mt-3 font-mono text-[10px] text-ink-muted">
+        <p className="mt-3 mg-type-data-sm text-ink-muted">
           Showing the {rows.length} most-active of {formatNumber(subnets.length)} subnets.
         </p>
       ) : null}
@@ -1027,7 +1027,7 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
           <tbody className="divide-y divide-border">
             {rows.map((p, i) => (
               <tr key={`${p.address}-${i}`} className="hover:bg-surface/30">
-                <td className="px-4 py-4 font-mono text-[11px] text-ink-muted" title={p.address}>
+                <td className="px-4 py-4 mg-type-data text-ink-muted" title={p.address}>
                   {p.address !== ss58 ? (
                     <Link
                       to="/accounts/$ss58"
@@ -1040,13 +1040,13 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
                     (shortHash(p.address) ?? "—")
                   )}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                   {p.sent_tao != null ? `${formatNumber(p.sent_tao)} τ` : "—"}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                   {p.received_tao != null ? `${formatNumber(p.received_tao)} τ` : "—"}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums">
+                <td className="px-4 py-4 text-right mg-type-data tabular-nums">
                   {p.net_tao == null ? (
                     <span className="text-ink-muted">—</span>
                   ) : (
@@ -1056,10 +1056,10 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
                     </span>
                   )}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                   {formatNumber(p.transfer_count ?? 0)}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[12px]">
+                <td className="px-4 py-4 text-right font-mono mg-type-caption">
                   {p.last_block != null ? (
                     <Link
                       to="/blocks/$ref"
@@ -1078,7 +1078,7 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
         </table>
       </DataPanel>
       {parties.length > rows.length ? (
-        <p className="mt-3 font-mono text-[10px] text-ink-muted">
+        <p className="mt-3 mg-type-data-sm text-ink-muted">
           Showing the {rows.length} highest-volume of {formatNumber(parties.length)} counterparties.
         </p>
       ) : null}
@@ -1171,12 +1171,12 @@ function DelegationEdgeList({ ss58, rows }: { ss58: string; rows: DelegationRow[
             <Link
               to="/subnets/$netuid"
               params={{ netuid: r.netuid }}
-              className="shrink-0 whitespace-nowrap font-mono text-[11px] text-ink hover:text-accent hover:underline"
+              className="shrink-0 whitespace-nowrap mg-type-data text-ink hover:text-accent hover:underline"
             >
               SN{r.netuid}
             </Link>
             <div
-              className="min-w-0 flex-1 truncate font-mono text-[11px] text-ink-muted"
+              className="min-w-0 flex-1 truncate mg-type-data text-ink-muted"
               title={r.counterpart}
             >
               {r.counterpart !== ss58 ? (
@@ -1198,7 +1198,7 @@ function DelegationEdgeList({ ss58, rows }: { ss58: string; rows: DelegationRow[
                   style={{ width: `${pct == null ? 0 : pct * 100}%` }}
                 />
               </div>
-              <span className="w-11 whitespace-nowrap text-right font-mono text-[11px] tabular-nums text-ink">
+              <span className="w-11 whitespace-nowrap text-right mg-type-data tabular-nums text-ink">
                 {fmtProportionPct(r.proportion_fraction)}
               </span>
             </div>
@@ -1350,14 +1350,14 @@ function EntityLabelCard({ label }: { label: AccountEntityLabel }) {
           </span>
         ) : null}
       </div>
-      {label.notes ? <p className="mt-2 text-[12px] text-ink-muted">{label.notes}</p> : null}
+      {label.notes ? <p className="mt-2 mg-type-caption text-ink-muted">{label.notes}</p> : null}
       {label.source_urls.length > 0 ? (
         <div className="mt-3 flex flex-wrap gap-3">
           {label.source_urls.map((url, i) => (
             <ExternalLink
               key={`${url}-${i}`}
               href={url}
-              className="font-mono text-[10px] text-accent-text hover:underline"
+              className="mg-type-data-sm text-accent-text hover:underline"
             >
               source{label.source_urls.length > 1 ? ` ${i + 1}` : ""}
             </ExternalLink>
@@ -1431,7 +1431,7 @@ function AccountEntitiesSection({ ss58 }: { ss58: string }) {
                     key={`${tie.netuid}-${tie.block_number}-${i}`}
                     className="hover:bg-surface/30"
                   >
-                    <td className="whitespace-nowrap px-4 py-4 font-mono text-[12px]">
+                    <td className="whitespace-nowrap px-4 py-4 font-mono mg-type-caption">
                       {tie.netuid != null ? (
                         <Link
                           to="/subnets/$netuid"
@@ -1457,7 +1457,7 @@ function AccountEntitiesSection({ ss58 }: { ss58: string }) {
                         {ownershipRoleLabel(tie.role)}
                       </span>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-4 text-right font-mono text-[12px]">
+                    <td className="whitespace-nowrap px-4 py-4 text-right font-mono mg-type-caption">
                       {tie.block_number != null ? (
                         <Link
                           to="/blocks/$ref"
@@ -1470,7 +1470,7 @@ function AccountEntitiesSection({ ss58 }: { ss58: string }) {
                         <span className="text-ink-muted">—</span>
                       )}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-4 text-right font-mono text-[11px] text-ink-muted">
+                    <td className="whitespace-nowrap px-4 py-4 text-right mg-type-data text-ink-muted">
                       {tie.observed_at ? <TimeAgo at={tie.observed_at} /> : "—"}
                     </td>
                   </tr>
@@ -1644,7 +1644,7 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
                 .slice(0, 20)
                 .map((s) => (
                   <tr key={s.netuid} className="hover:bg-surface/30">
-                    <td className="px-4 py-4 font-mono text-[12px]">
+                    <td className="px-4 py-4 font-mono mg-type-caption">
                       <Link
                         to="/subnets/$netuid"
                         params={{ netuid: s.netuid }}
@@ -1653,10 +1653,10 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
                         SN{s.netuid}
                       </Link>
                     </td>
-                    <td className="px-4 py-4 font-mono text-[11px]">
+                    <td className="px-4 py-4 mg-type-data">
                       <span className={stakeFlowDirClass(s.direction)}>{s.direction ?? "—"}</span>
                     </td>
-                    <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums">
+                    <td className="px-4 py-4 text-right mg-type-data tabular-nums">
                       {s.net_flow_tao == null ? (
                         <span className="text-ink-muted">—</span>
                       ) : (
@@ -1670,10 +1670,10 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
                         </span>
                       )}
                     </td>
-                    <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                    <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                       {fmtStake(s.gross_flow_tao)}
                     </td>
-                    <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink-muted">
                       {formatNumber((s.stake_events ?? 0) + (s.unstake_events ?? 0))}
                     </td>
                   </tr>
@@ -1682,7 +1682,7 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
           </table>
         </DataPanel>
       ) : (
-        <p className="rounded-2xl border border-border/80 bg-card/95 px-4 py-4 font-mono text-[11px] text-ink-muted">
+        <p className="rounded-2xl border border-border/80 bg-card/95 px-4 py-4 mg-type-data text-ink-muted">
           No stake or unstake flow recorded for this account over the {f?.window ?? window} window.
         </p>
       )}
@@ -1802,7 +1802,7 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
                         />
                       </button>
                     </td>
-                    <td className="px-4 py-4 font-mono text-[12px]">
+                    <td className="px-4 py-4 font-mono mg-type-caption">
                       <Link
                         to="/subnets/$netuid"
                         params={{ netuid: pos.netuid }}
@@ -1811,7 +1811,7 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
                         SN{pos.netuid}
                       </Link>
                     </td>
-                    <td className="px-4 py-4 font-mono text-[11px]">
+                    <td className="px-4 py-4 mg-type-data">
                       {pos.role === "validator" ? (
                         <span className="text-health-ok">validator</span>
                       ) : pos.role === "miner" ? (
@@ -1820,13 +1820,13 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
                         <span className="text-ink-muted">{"—"}</span>
                       )}
                     </td>
-                    <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                    <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                       {fmtStake(pos.stake_tao)}
                     </td>
-                    <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                    <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                       {fmtStake(pos.emission_tao)}
                     </td>
-                    <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink-muted">
                       {pos.incentive != null ? pos.incentive.toFixed(4) : "—"}
                     </td>
                   </tr>
@@ -1890,7 +1890,7 @@ function AccountIdentitySection({ ss58 }: { ss58: string }) {
             {identity.name ?? "Unnamed identity"}
           </span>
           {identity.captured_at ? (
-            <span className="font-mono text-[11px] text-ink-muted">
+            <span className="mg-type-data text-ink-muted">
               captured <TimeAgo at={identity.captured_at} />
             </span>
           ) : null}
@@ -1924,7 +1924,7 @@ function AccountIdentitySection({ ss58 }: { ss58: string }) {
           </div>
         ) : null}
         {identity.additional ? (
-          <p className="mt-2 font-mono text-[11px] text-ink-muted">{identity.additional}</p>
+          <p className="mt-2 mg-type-data text-ink-muted">{identity.additional}</p>
         ) : null}
       </div>
     </SectionAnchor>
@@ -2233,7 +2233,7 @@ function AccountWeightSettingSection({ ss58 }: { ss58: string }) {
               <tbody className="divide-y divide-border">
                 {subnets.map((row) => (
                   <tr key={row.netuid} className="hover:bg-surface/30">
-                    <td className="px-4 py-4 font-mono text-[12px]">
+                    <td className="px-4 py-4 font-mono mg-type-caption">
                       <Link
                         to="/subnets/$netuid"
                         params={{ netuid: row.netuid }}
@@ -2242,10 +2242,10 @@ function AccountWeightSettingSection({ ss58 }: { ss58: string }) {
                         SN{row.netuid}
                       </Link>
                     </td>
-                    <td className="px-4 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                    <td className="px-4 py-4 text-right font-mono mg-type-caption tabular-nums text-ink">
                       {formatNumber(row.weight_sets)}
                     </td>
-                    <td className="px-4 py-4 text-right font-mono text-[11px] text-ink-muted">
+                    <td className="px-4 py-4 text-right mg-type-data text-ink-muted">
                       <TimeAgo at={row.last_set_at ?? undefined} />
                     </td>
                   </tr>
@@ -2465,7 +2465,7 @@ function AccountFootprintSection({
           <tbody className="divide-y divide-border">
             {rows.map((r) => (
               <tr key={`${r.netuid}-${r.uid}`} className="hover:bg-surface/30">
-                <td className="px-4 py-4 font-mono text-[12px]">
+                <td className="px-4 py-4 font-mono mg-type-caption">
                   {r.netuid != null ? (
                     <Link
                       to="/subnets/$netuid"
@@ -2481,20 +2481,20 @@ function AccountFootprintSection({
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                <td className="px-4 py-4 text-right font-mono mg-type-caption tabular-nums text-ink">
                   {r.uid != null ? formatNumber(r.uid) : "—"}
                 </td>
-                <td className="px-4 py-4 text-right font-mono text-[12px] tabular-nums text-ink">
+                <td className="px-4 py-4 text-right font-mono mg-type-caption tabular-nums text-ink">
                   {fmtStake(r.stake_tao)}
                 </td>
-                <td className="px-4 py-4 font-mono text-[11px]">
+                <td className="px-4 py-4 mg-type-data">
                   {r.validator_permit ? (
                     <ValidatorPermitBadge ss58={ss58} />
                   ) : (
                     <span className="text-ink-muted">—</span>
                   )}
                 </td>
-                <td className="px-4 py-4 font-mono text-[11px]">
+                <td className="px-4 py-4 mg-type-data">
                   {r.active ? (
                     <span className="inline-flex rounded-full bg-health-ok/10 px-2 py-0.5 text-health-ok">
                       active
@@ -2520,21 +2520,21 @@ function AccountFootprintSection({
                   <Link
                     to="/subnets/$netuid"
                     params={{ netuid: r.netuid }}
-                    className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 font-mono text-[12px] font-medium text-ink-strong transition-colors hover:border-accent/30 hover:text-accent"
+                    className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 font-mono mg-type-caption font-medium text-ink-strong transition-colors hover:border-accent/30 hover:text-accent"
                   >
                     SN{r.netuid}
                   </Link>
                 ) : (
-                  <span className="font-mono text-[12px] text-ink-muted">—</span>
+                  <span className="font-mono mg-type-caption text-ink-muted">—</span>
                 )}
                 {r.validator_permit ? <ValidatorPermitBadge ss58={ss58} /> : null}
               </div>
               {r.active ? (
-                <span className="inline-flex shrink-0 rounded-full bg-health-ok/10 px-2 py-0.5 font-mono text-[11px] text-health-ok">
+                <span className="inline-flex shrink-0 rounded-full bg-health-ok/10 px-2 py-0.5 mg-type-data text-health-ok">
                   active
                 </span>
               ) : (
-                <span className="inline-flex shrink-0 rounded-full bg-surface px-2 py-0.5 font-mono text-[11px] text-ink-muted">
+                <span className="inline-flex shrink-0 rounded-full bg-surface px-2 py-0.5 mg-type-data text-ink-muted">
                   idle
                 </span>
               )}
@@ -2574,7 +2574,7 @@ function ValidatorPermitBadge({ ss58 }: { ss58: string }) {
       to="/validators/$hotkey"
       params={{ hotkey: ss58 }}
       title={`Validator profile for ${ss58}`}
-      className="inline-flex shrink-0 rounded-full bg-health-ok/10 px-2 py-0.5 font-mono text-[11px] text-health-ok transition-colors hover:bg-health-ok/20"
+      className="inline-flex shrink-0 rounded-full bg-health-ok/10 px-2 py-0.5 mg-type-data text-health-ok transition-colors hover:bg-health-ok/20"
     >
       validator
     </Link>
@@ -2690,7 +2690,7 @@ function AccountEventsSection({
                   key={`${ev.block_number}-${ev.event_index}-${i}`}
                   className="hover:bg-surface/30"
                 >
-                  <td className="px-4 py-4 font-mono text-[12px]">
+                  <td className="px-4 py-4 font-mono mg-type-caption">
                     {ev.block_number != null ? (
                       <Link
                         to="/blocks/$ref"
@@ -2704,12 +2704,12 @@ function AccountEventsSection({
                     )}
                   </td>
                   <td
-                    className="px-4 py-4 font-mono text-[11px] text-ink-strong"
+                    className="px-4 py-4 mg-type-data text-ink-strong"
                     title={ev.event_kind ?? undefined}
                   >
                     {eventKindLabel(ev.event_kind)}
                   </td>
-                  <td className="px-4 py-4 font-mono text-[11px] text-ink-muted">
+                  <td className="px-4 py-4 mg-type-data text-ink-muted">
                     {ev.netuid != null ? (
                       <Link
                         to="/subnets/$netuid"
@@ -2722,17 +2722,17 @@ function AccountEventsSection({
                       "—"
                     )}
                   </td>
-                  <td className="px-4 py-4 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                     {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
                   </td>
-                  <td className="px-4 py-4 text-right font-mono text-[11px] text-ink-muted">
+                  <td className="px-4 py-4 text-right mg-type-data text-ink-muted">
                     <TimeAgo at={ev.observed_at} />
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
-          <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-3 font-mono text-[11px] text-ink-muted">
+          <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-3 mg-type-data text-ink-muted">
             <span>
               {events.length
                 ? `${formatNumber(offset + 1)}–${formatNumber(offset + events.length)}`
@@ -2775,7 +2775,7 @@ function AccountEventsSection({
               <button
                 type="button"
                 onClick={() => setSearch({ ev_offset: undefined, ev_kind: undefined })}
-                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 mg-type-data text-ink-muted hover:border-ink/30 hover:text-ink-strong"
               >
                 <ChevronLeft className="size-3" /> Back to newest
               </button>
@@ -2869,7 +2869,7 @@ function HeroAsideRow({
           <span className="truncate font-display text-lg font-semibold tabular-nums text-ink-strong">
             {value}
           </span>
-          <span className="font-mono text-[10px] text-ink-muted">{accent}</span>
+          <span className="mg-type-data-sm text-ink-muted">{accent}</span>
         </div>
       </div>
     </div>

--- a/apps/ui/src/routes/accounts.index.tsx
+++ b/apps/ui/src/routes/accounts.index.tsx
@@ -85,7 +85,7 @@ function AccountsPage() {
             Look up
           </button>
         </div>
-        <p className="mt-2 font-mono text-[11px] text-ink-muted">
+        <p className="mt-2 mg-type-data text-ink-muted">
           {touched && !valid
             ? "That doesn't look like a valid ss58 address."
             : "Paste a hotkey or coldkey ss58 address to view its activity."}
@@ -96,7 +96,7 @@ function AccountsPage() {
         data-testid="top-active-accounts-section"
       >
         <h2 className="mb-1 mg-type-label uppercase text-ink-muted">Most active accounts</h2>
-        <p className="mb-4 font-mono text-[11px] text-ink-muted">
+        <p className="mb-4 mg-type-data text-ink-muted">
           Ranked by extrinsics signed on-chain in the last {TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS} days —
           jump straight to an account below.
         </p>

--- a/apps/ui/src/routes/agents.tsx
+++ b/apps/ui/src/routes/agents.tsx
@@ -131,12 +131,12 @@ function AgentsBody() {
         />
         <div className="flex items-center gap-3 rounded-lg border border-accent/30 bg-accent-surface px-4 py-3.5">
           <Terminal className="size-4 shrink-0 text-accent" aria-hidden />
-          <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono text-[13px] text-ink-strong">
+          <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono mg-type-caption-lg text-ink-strong">
             {mcp.install}
           </code>
           <CopyButton value={mcp.install} label="MCP install command" />
         </div>
-        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[11px]">
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 mg-type-data">
           <ExternalLink href={mcp.endpoint} className="text-ink-muted hover:text-ink-strong">
             {mcp.endpoint.replace("https://", "")}
           </ExternalLink>
@@ -178,10 +178,10 @@ function AgentsBody() {
                 <div className="flex items-center gap-3 px-4 py-3">
                   <Package className="size-4 shrink-0 text-ink-muted" aria-hidden />
                   <div className="min-w-0 flex-1">
-                    <code className="block overflow-x-auto whitespace-nowrap font-mono text-[12px] text-ink-strong">
+                    <code className="block overflow-x-auto whitespace-nowrap font-mono mg-type-caption text-ink-strong">
                       {sdk.install}
                     </code>
-                    <ExternalLink href={sdk.url} className="font-mono text-[10px] text-ink-muted">
+                    <ExternalLink href={sdk.url} className="mg-type-data-sm text-ink-muted">
                       {sdk.lang} · {sdk.pkg}
                     </ExternalLink>
                   </div>
@@ -199,7 +199,7 @@ function AgentsBody() {
               href={CLAUDE_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-accent/40 bg-accent/10 px-3.5 py-2 text-[13px] font-medium text-accent hover:bg-accent/15"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-accent/40 bg-accent/10 px-3.5 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15"
             >
               Open in Claude <ArrowUpRight className="size-3.5" />
             </a>
@@ -207,12 +207,12 @@ function AgentsBody() {
               href={CHATGPT_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3.5 py-2 text-[13px] font-medium text-ink-strong hover:border-ink/30"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3.5 py-2 mg-type-caption-lg font-medium text-ink-strong hover:border-ink/30"
             >
               Open in ChatGPT <ArrowUpRight className="size-3.5" />
             </a>
           </div>
-          <p className="mt-3 font-mono text-[11px] text-ink-muted">
+          <p className="mt-3 mg-type-data text-ink-muted">
             system prompt{" "}
             <ExternalLink href={res.copyable_agent.url} className="text-ink-strong">
               {res.copyable_agent.url.replace("https://", "")}
@@ -238,7 +238,7 @@ function AgentsBody() {
                 <span className="flex-1 truncate text-[14px] text-ink-strong">{r.title}</span>
                 <ExternalLink
                   href={r.url}
-                  className="hidden shrink-0 font-mono text-[11px] text-ink-muted hover:text-ink-strong sm:inline-flex"
+                  className="hidden shrink-0 mg-type-data text-ink-muted hover:text-ink-strong sm:inline-flex"
                 >
                   {r.url.replace("https://api.metagraph.sh", "")}
                 </ExternalLink>
@@ -259,7 +259,7 @@ function AgentsBody() {
                 <span className="mg-label">{q.label}</span>
                 <CopyButton value={q.cmd} label={q.label} compact />
               </div>
-              <pre className="overflow-x-auto px-4 py-3 font-mono text-[11px] leading-relaxed text-ink">
+              <pre className="overflow-x-auto px-4 py-3 mg-type-data leading-relaxed text-ink">
                 {q.cmd}
               </pre>
             </Panel>

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -323,12 +323,12 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
               {block.block_hash ? (
                 <div className="flex min-w-0 items-center gap-1.5">
                   <span
-                    className="font-mono text-[12px] text-ink-strong break-all md:hidden"
+                    className="font-mono mg-type-caption text-ink-strong break-all md:hidden"
                     title={block.block_hash}
                   >
                     {shortHash(block.block_hash, 10)}
                   </span>
-                  <span className="hidden md:inline font-mono text-[12px] text-ink-strong break-all">
+                  <span className="hidden md:inline font-mono mg-type-caption text-ink-strong break-all">
                     {block.block_hash}
                   </span>
                   <CopyButton value={block.block_hash} label="block hash" compact />
@@ -343,7 +343,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                   <Link
                     to="/blocks/$ref"
                     params={{ ref: block.parent_hash }}
-                    className="font-mono text-[12px] text-ink-strong hover:underline break-all md:hidden"
+                    className="font-mono mg-type-caption text-ink-strong hover:underline break-all md:hidden"
                     title={block.parent_hash}
                   >
                     {shortHash(block.parent_hash, 10)}
@@ -351,7 +351,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                   <Link
                     to="/blocks/$ref"
                     params={{ ref: block.parent_hash }}
-                    className="hidden md:inline font-mono text-[12px] text-ink-strong hover:underline break-all"
+                    className="hidden md:inline font-mono mg-type-caption text-ink-strong hover:underline break-all"
                   >
                     {block.parent_hash}
                   </Link>
@@ -393,7 +393,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
               </span>
             </FieldRow>
             <FieldRow label="Observed at">
-              <span className="font-mono text-[12px] text-ink-muted">
+              <span className="font-mono mg-type-caption text-ink-muted">
                 <TimeAgo at={block.observed_at} />
               </span>
             </FieldRow>
@@ -468,12 +468,12 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                         }
                         className="mg-row-accent hover:bg-surface/40"
                       >
-                        <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                        <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
                           {extrinsic.extrinsic_index != null
                             ? formatNumber(extrinsic.extrinsic_index)
                             : "—"}
                         </td>
-                        <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted break-all">
+                        <td className="px-4 py-2.5 mg-type-data text-ink-muted break-all">
                           {extrinsic.extrinsic_hash ? (
                             <Link
                               to="/extrinsics/$hash"
@@ -486,12 +486,10 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                             "—"
                           )}
                         </td>
-                        <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+                        <td className="px-4 py-2.5 mg-type-data text-ink-strong">
                           {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
                         </td>
-                        <td className={`px-4 py-2.5 font-mono text-[11px] ${resultClass}`}>
-                          {result}
-                        </td>
+                        <td className={`px-4 py-2.5 mg-type-data ${resultClass}`}>{result}</td>
                       </tr>
                     );
                   })}
@@ -593,18 +591,18 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                           key={`${event.block_number}-${event.event_index}`}
                           className="mg-row-accent hover:bg-surface/40"
                         >
-                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+                          <td className="px-4 py-2.5 mg-type-data text-ink-strong">
                             {extrinsicCall(event.pallet, event.method)}
                           </td>
-                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                          <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                             {event.phase ?? "—"}
                           </td>
-                          <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
+                          <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink">
                             {event.extrinsic_index != null
                               ? formatNumber(event.extrinsic_index)
                               : "—"}
                           </td>
-                          <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                          <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                             <div className="flex max-w-xs items-center gap-1.5">
                               <span className="truncate" title={formatChainEventArgs(event.args)}>
                                 {formatChainEventArgs(event.args)}
@@ -827,10 +825,10 @@ function GroupedEvents({
                 ) : (
                   <ChevronRight className="size-3.5 shrink-0 text-ink-muted" />
                 )}
-                <span className="font-mono text-[11px] tabular-nums text-ink-muted w-8 sm:w-10 shrink-0">
+                <span className="mg-type-data tabular-nums text-ink-muted w-8 sm:w-10 shrink-0">
                   {g.isSystem ? "sys" : `#${g.index}`}
                 </span>
-                <span className="font-mono text-[11px] text-ink-strong truncate min-w-0 flex-1">
+                <span className="mg-type-data text-ink-strong truncate min-w-0 flex-1">
                   {title}
                 </span>
                 {success != null ? (
@@ -848,7 +846,7 @@ function GroupedEvents({
                     to="/extrinsics/$hash"
                     params={{ hash: g.extrinsic.extrinsic_hash }}
                     onClick={(e) => e.stopPropagation()}
-                    className="hidden sm:inline font-mono text-[10px] text-ink-muted hover:text-ink-strong hover:underline shrink-0"
+                    className="hidden sm:inline mg-type-data-sm text-ink-muted hover:text-ink-strong hover:underline shrink-0"
                     title={g.extrinsic.extrinsic_hash}
                   >
                     {shortHash(g.extrinsic.extrinsic_hash, 6)}
@@ -871,13 +869,13 @@ function GroupedEvents({
                           key={`${event.block_number}-${event.event_index}-${event.event_kind ?? "unknown"}`}
                         >
                           <td
-                            className="px-2 py-1.5 font-mono text-[11px] text-ink-strong"
+                            className="px-2 py-1.5 mg-type-data text-ink-strong"
                             title={event.event_kind ?? undefined}
                           >
                             {eventKindLabel(event.event_kind)}
                           </td>
                           {showHotkeyCol ? (
-                            <td className="px-2 py-1.5 font-mono text-[11px] text-ink">
+                            <td className="px-2 py-1.5 mg-type-data text-ink">
                               <AccountAddress
                                 ss58={event.hotkey}
                                 keep={10}
@@ -890,7 +888,7 @@ function GroupedEvents({
                             {event.amount_tao != null ? (
                               <TaoValue amount={event.amount_tao} layout="stacked" precision={4} />
                             ) : (
-                              <span className="font-mono text-[11px] text-ink-muted">—</span>
+                              <span className="mg-type-data text-ink-muted">—</span>
                             )}
                           </td>
                         </tr>
@@ -980,15 +978,11 @@ function JumpToBlock() {
         placeholder="Jump to # or 0x…"
         aria-invalid={error ? true : undefined}
         aria-describedby={error ? "jump-to-block-err" : undefined}
-        className="mg-focus-ring h-8 w-40 rounded border border-border bg-paper px-2 font-mono text-[12px] tabular-nums text-ink-strong placeholder:text-ink-subtle sm:w-48"
+        className="mg-focus-ring h-8 w-40 rounded border border-border bg-paper px-2 font-mono mg-type-caption tabular-nums text-ink-strong placeholder:text-ink-subtle sm:w-48"
       />
       <Kbd>↵</Kbd>
       {error ? (
-        <span
-          id="jump-to-block-err"
-          role="alert"
-          className="ml-1 font-mono text-[10px] text-health-down"
-        >
+        <span id="jump-to-block-err" role="alert" className="ml-1 mg-type-data-sm text-health-down">
           {error}
         </span>
       ) : null}

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -480,14 +480,14 @@ function BlocksTable() {
               <div className="font-mono text-sm font-medium text-ink-strong">
                 #{formatNumber(b.block_number)}
               </div>
-              <span className="font-mono text-[11px] text-ink-muted">
+              <span className="mg-type-data text-ink-muted">
                 <TimeAgo at={b.observed_at} />
               </span>
             </div>
-            <div className="mt-1 font-mono text-[11px] text-ink-muted truncate">
+            <div className="mt-1 mg-type-data text-ink-muted truncate">
               {shortHash(b.block_hash)}
             </div>
-            <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
+            <div className="mt-2 flex items-center justify-between mg-type-data text-ink-muted">
               <span>{shortHash(b.author) ?? "no author"}</span>
               <span>{formatNumber(b.extrinsic_count ?? 0)} ext</span>
               <span>{formatNumber(b.event_count ?? 0)} evt</span>
@@ -534,7 +534,7 @@ function BlocksTable() {
                     key={b.block_hash || b.block_number}
                     className="group mg-row-accent odd:bg-surface/30 hover:bg-surface/60"
                   >
-                    <td className="px-4 py-2.5 font-mono text-[12px] align-top">
+                    <td className="px-4 py-2.5 font-mono mg-type-caption align-top">
                       <Link
                         to="/blocks/$ref"
                         params={{ ref: String(b.block_number) }}
@@ -551,7 +551,7 @@ function BlocksTable() {
                         </div>
                       ) : null}
                     </td>
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted align-top">
+                    <td className="px-4 py-2.5 mg-type-data text-ink-muted align-top">
                       <span className="inline-flex items-center gap-1 min-w-0">
                         <Link
                           to="/blocks/$ref"
@@ -569,7 +569,7 @@ function BlocksTable() {
                       </span>
                     </td>
                     <td
-                      className="px-4 py-2.5 font-mono text-[11px] text-ink-muted align-top"
+                      className="px-4 py-2.5 mg-type-data text-ink-muted align-top"
                       title={b.author ?? undefined}
                     >
                       <div className="flex items-center gap-1.5 min-w-0">
@@ -594,14 +594,14 @@ function BlocksTable() {
                         ) : null}
                       </div>
                     </td>
-                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink align-top">
+                    <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink align-top">
                       <ActivityCell value={b.extrinsic_count ?? 0} max={maxExt} tone="accent" />
                     </td>
-                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink align-top">
+                    <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink align-top">
                       <ActivityCell value={b.event_count ?? 0} max={maxEvt} tone="ink" />
                     </td>
                     <td
-                      className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted align-top"
+                      className="px-4 py-2.5 text-right mg-type-data text-ink-muted align-top"
                       title={b.observed_at ?? undefined}
                     >
                       <TimeAgo at={b.observed_at} />

--- a/apps/ui/src/routes/delegate.tsx
+++ b/apps/ui/src/routes/delegate.tsx
@@ -90,8 +90,8 @@ function DelegatePage() {
                     {p.live ? "Live" : "Coming soon"}
                   </span>
                 </div>
-                <p className="mt-3 text-[13px] text-ink-muted leading-relaxed">{p.blurb}</p>
-                <div className="mt-4 inline-flex items-center gap-1.5 self-start rounded-full border border-accent/50 bg-primary-soft/50 px-3 py-1.5 text-[12px] font-medium text-ink-strong transition-colors group-hover:border-accent">
+                <p className="mt-3 mg-type-caption-lg text-ink-muted leading-relaxed">{p.blurb}</p>
+                <div className="mt-4 inline-flex items-center gap-1.5 self-start rounded-full border border-accent/50 bg-primary-soft/50 px-3 py-1.5 mg-type-caption font-medium text-ink-strong transition-colors group-hover:border-accent">
                   {p.live ? "Stake / redelegate" : "Open subnet"}
                   <ArrowUpRight className="size-3" />
                 </div>
@@ -104,7 +104,9 @@ function DelegatePage() {
       {/* Disclosure */}
       <section className="mt-10 rounded-xl border border-border mg-glass-soft p-4">
         <div className="mg-label mb-2">Disclosure</div>
-        <p className="text-[13px] text-ink-muted leading-relaxed">{PARTNER_ORG.disclosure}</p>
+        <p className="mg-type-caption-lg text-ink-muted leading-relaxed">
+          {PARTNER_ORG.disclosure}
+        </p>
       </section>
     </AppShell>
   );
@@ -119,7 +121,7 @@ function TrustCell({ icon, title, body }: { icon: React.ReactNode; title: string
         </span>
         <span className="mg-type-micro">{title}</span>
       </div>
-      <p className="mt-1.5 text-[12px] text-ink-muted leading-relaxed">{body}</p>
+      <p className="mt-1.5 mg-type-caption text-ink-muted leading-relaxed">{body}</p>
     </div>
   );
 }

--- a/apps/ui/src/routes/docs.$.tsx
+++ b/apps/ui/src/routes/docs.$.tsx
@@ -116,7 +116,7 @@ const clientLoader = browserCollections.docs.createClientLoader<{ markdownUrl: s
               own caching/token and could rate-limit. Baked in at compile
               time instead, same as frontmatter/toc already are. */}
           {lastModified ? (
-            <p className="text-[12px] text-ink-muted">
+            <p className="mg-type-caption text-ink-muted">
               Last updated <TimeAgo at={lastModified.toISOString()} />
             </p>
           ) : (

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -421,7 +421,7 @@ function PoolsTable() {
                   className="mg-row-hover scroll-mt-24 target:bg-accent/10"
                 >
                   <td className="px-3 py-2 font-medium text-ink-strong">{p.name ?? p.id}</td>
-                  <td className="px-3 py-2 text-[12px]">{p.region ?? "—"}</td>
+                  <td className="px-3 py-2 mg-type-caption">{p.region ?? "—"}</td>
                   <td className="px-3 py-2 text-right font-mono">{p.members_count ?? "—"}</td>
                   <td className="px-3 py-2 text-center text-[11px] text-ink-muted">
                     {p.archive_capable ? "yes" : "—"}
@@ -442,7 +442,7 @@ function PoolsTable() {
           </tbody>
         </table>
       </ResponsiveTable>
-      <p className="px-1 font-mono text-[10px] text-ink-muted">
+      <p className="px-1 mg-type-data-sm text-ink-muted">
         Proxy-eligible members serve live traffic through the reverse proxy above; the proxy prefers
         in-sync, healthy nodes and fails over automatically.
       </p>
@@ -503,24 +503,22 @@ function EndpointPoolsTable() {
                   className="mg-row-hover scroll-mt-24 target:bg-accent/10"
                 >
                   <td className="px-3 py-2 font-medium text-ink-strong">{p.id}</td>
-                  <td className="px-3 py-2 font-mono text-[11px]">{String(p.kind ?? "—")}</td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px]">
+                  <td className="px-3 py-2 mg-type-data">{String(p.kind ?? "—")}</td>
+                  <td className="px-3 py-2 text-right mg-type-data">
                     {eligible != null && total != null
                       ? `${eligible}/${total} eligible`
                       : total != null
                         ? String(total)
                         : "—"}
                   </td>
-                  <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                    {bestId ?? "—"}
-                  </td>
+                  <td className="px-3 py-2 mg-type-data text-ink-muted">{bestId ?? "—"}</td>
                 </tr>
               );
             })}
           </tbody>
         </table>
       </ResponsiveTable>
-      <p className="px-1 font-mono text-[10px] text-ink-muted">
+      <p className="px-1 mg-type-data-sm text-ink-muted">
         Covers all pool kinds (subtensor-rpc, subtensor-wss, archive) from the generalized
         endpoint-pools artifact — distinct from the Bittensor RPC proxy pools above.
       </p>
@@ -575,7 +573,7 @@ function RpcEndpointsTable() {
             {rows.map((e: RpcEndpoint) => (
               <tr key={e.id} className="mg-row-hover">
                 <td className="px-3 py-2 font-medium text-ink-strong">{e.provider ?? "—"}</td>
-                <td className="px-3 py-2 font-mono text-[11px]">{e.kind ?? "—"}</td>
+                <td className="px-3 py-2 mg-type-data">{e.kind ?? "—"}</td>
                 <td className="px-3 py-2">
                   <span
                     className={classNames(
@@ -593,7 +591,7 @@ function RpcEndpointsTable() {
                 <td className="px-3 py-2 text-center text-[11px] text-ink-muted">
                   {e.archive_support == null ? "—" : e.archive_support ? "yes" : "no"}
                 </td>
-                <td className="px-3 py-2 text-right font-mono text-[11px]">
+                <td className="px-3 py-2 text-right mg-type-data">
                   {e.latency_ms != null ? `${e.latency_ms}ms` : "—"}
                 </td>
               </tr>
@@ -601,9 +599,7 @@ function RpcEndpointsTable() {
           </tbody>
         </table>
       </ResponsiveTable>
-      {summaryLine ? (
-        <p className="px-1 font-mono text-[10px] text-ink-muted">{summaryLine}</p>
-      ) : null}
+      {summaryLine ? <p className="px-1 mg-type-data-sm text-ink-muted">{summaryLine}</p> : null}
     </div>
   );
 }
@@ -997,7 +993,7 @@ function EndpointsTable() {
                   }
                   inputMode="numeric"
                   placeholder="Any subnet"
-                  className="h-9 rounded border border-border bg-paper px-2 font-mono text-[12px] text-ink-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="h-9 rounded border border-border bg-paper px-2 font-mono mg-type-caption text-ink-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 />
               </label>
               <QueryBar.FilterTrigger

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -73,7 +73,7 @@ function ChainHeadTip() {
     <Link
       to="/blocks/$ref"
       params={{ ref: String(head.block_number) }}
-      className="mg-fade-in mg-fade-in-delay-3 inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted hover:text-accent transition-colors"
+      className="mg-fade-in mg-fade-in-delay-3 inline-flex items-center gap-1.5 mg-type-data text-ink-muted hover:text-accent transition-colors"
     >
       <span className="mg-live-dot" />
       head #{formatNumber(head.block_number)} · <TimeAgo at={head.observed_at} />
@@ -189,7 +189,7 @@ function MiniSeries({
     <div>
       <div className="mb-1.5 flex items-baseline justify-between gap-2">
         <span className="mg-type-micro text-ink-muted">{label}</span>
-        <span className="font-mono text-[11px] tabular-nums text-ink-strong">
+        <span className="mg-type-data tabular-nums text-ink-strong">
           {latest == null ? "—" : formatValue(latest)}
         </span>
       </div>
@@ -239,7 +239,7 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h2 className="mg-type-label uppercase text-ink-muted">Call mix</h2>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(calls.total_extrinsics)} calls
         </span>
       </div>
@@ -279,7 +279,7 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
                       >
                         {c.call_module}
                       </span>
-                      <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums text-ink-strong">
+                      <span className="ml-auto shrink-0 mg-type-data-sm tabular-nums text-ink-strong">
                         {formatNumber(c.count)}
                       </span>
                     </button>
@@ -302,7 +302,7 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
               />
             </div>
           ) : (
-            <p className="border-t border-border pt-3 font-mono text-[11px] text-ink-muted">
+            <p className="border-t border-border pt-3 mg-type-data text-ink-muted">
               {selected
                 ? "No per-function breakdown for this module at the current grouping."
                 : "Tap a module to drill into its functions (function rows appear when the chain-calls aggregate is grouped by function)."}
@@ -329,7 +329,7 @@ function PalletEventMixSection({ stats }: { stats: ChainEventsStats }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h2 className="mg-type-label uppercase text-ink-muted">Pallet event mix</h2>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(stats.groups)} groups · {formatNumber(stats.window_blocks)} blocks
         </span>
       </div>
@@ -349,7 +349,7 @@ function PalletEventMixSection({ stats }: { stats: ChainEventsStats }) {
                     style={{ width: `${pct}%`, background: "var(--chart-1)" }}
                   />
                 </span>
-                <span className="font-mono text-[10px] tabular-nums text-ink-strong">
+                <span className="mg-type-data-sm tabular-nums text-ink-strong">
                   {formatNumber(r.count)}
                 </span>
               </li>
@@ -404,7 +404,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h2 className="mg-type-label uppercase text-ink-muted">Stake flow</h2>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(flow.subnet_count)} subnets
         </span>
       </div>
@@ -459,7 +459,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
                       />
                     </span>
                     <span
-                      className={`text-right font-mono text-[10px] tabular-nums ${
+                      className={`text-right mg-type-data-sm tabular-nums ${
                         inflow ? "text-health-ok" : "text-health-down"
                       }`}
                     >
@@ -476,7 +476,7 @@ function StakeFlowSection({ flow }: { flow: ChainStakeFlow }) {
       )}
 
       {dist ? (
-        <p className="mt-4 border-t border-border pt-3 font-mono text-[10px] text-ink-muted">
+        <p className="mt-4 border-t border-border pt-3 mg-type-data-sm text-ink-muted">
           Median net flow {fmtTaoSigned(dist.median ?? 0)}, largest single outflow{" "}
           {fmtTaoSigned(dist.min ?? 0)} across {formatNumber(dist.count)} subnets.
         </p>
@@ -502,7 +502,7 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h2 className="mg-type-label uppercase text-ink-muted">Stake moves</h2>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(moves.subnet_count)} subnets
         </span>
       </div>
@@ -537,7 +537,7 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
                         style={{ width: `${pct}%`, background: "var(--accent)" }}
                       />
                     </span>
-                    <span className="text-right font-mono text-[10px] tabular-nums text-ink-strong">
+                    <span className="text-right mg-type-data-sm tabular-nums text-ink-strong">
                       {formatNumber(s.movements)}
                     </span>
                   </Link>
@@ -551,7 +551,7 @@ function StakeMovesSection({ moves }: { moves: ChainStakeMoves }) {
       )}
 
       {dist ? (
-        <p className="mt-4 border-t border-border pt-3 font-mono text-[10px] text-ink-muted">
+        <p className="mt-4 border-t border-border pt-3 mg-type-data-sm text-ink-muted">
           Median {(dist.median ?? 0).toFixed(1)} moves per mover, up to {(dist.max ?? 0).toFixed(1)}{" "}
           in the busiest subnet, across {formatNumber(dist.count)} subnets.
         </p>
@@ -590,7 +590,7 @@ function ChainServingLeaderboard({ board }: { board: ChainServing }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h3 className="mg-type-label uppercase text-ink-muted">Axon serving</h3>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(board.subnet_count)} subnets
         </span>
       </div>
@@ -620,7 +620,7 @@ function ChainServingLeaderboard({ board }: { board: ChainServing }) {
             <tbody className="divide-y divide-border">
               {board.subnets.map((s) => (
                 <tr key={s.netuid} className="hover:bg-surface/40">
-                  <td className="px-4 py-2 font-mono text-[11px]">
+                  <td className="px-4 py-2 mg-type-data">
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: s.netuid }}
@@ -629,13 +629,13 @@ function ChainServingLeaderboard({ board }: { board: ChainServing }) {
                       SN{s.netuid}
                     </Link>
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                     {formatNumber(s.announcements)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {formatNumber(s.distinct_servers)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {s.announcements_per_server != null
                       ? s.announcements_per_server.toFixed(2)
                       : "—"}
@@ -659,7 +659,7 @@ function ChainPrometheusLeaderboard({ board }: { board: ChainPrometheus }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h3 className="mg-type-label uppercase text-ink-muted">Prometheus telemetry</h3>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(board.subnet_count)} subnets
         </span>
       </div>
@@ -689,7 +689,7 @@ function ChainPrometheusLeaderboard({ board }: { board: ChainPrometheus }) {
             <tbody className="divide-y divide-border">
               {board.subnets.map((s) => (
                 <tr key={s.netuid} className="hover:bg-surface/40">
-                  <td className="px-4 py-2 font-mono text-[11px]">
+                  <td className="px-4 py-2 mg-type-data">
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: s.netuid }}
@@ -698,13 +698,13 @@ function ChainPrometheusLeaderboard({ board }: { board: ChainPrometheus }) {
                       SN{s.netuid}
                     </Link>
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                     {formatNumber(s.announcements)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {formatNumber(s.distinct_exporters)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {s.announcements_per_exporter != null
                       ? s.announcements_per_exporter.toFixed(2)
                       : "—"}
@@ -733,12 +733,12 @@ function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <div>
           <h2 className="mg-type-label uppercase text-ink-muted">Axon churn leaderboard</h2>
-          <p className="mt-1 font-mono text-[11px] text-ink-muted">
+          <p className="mt-1 mg-type-data text-ink-muted">
             {formatNumber(churn.network.removals)} axon teardowns across{" "}
             {formatNumber(churn.network.distinct_removers)} removers network-wide
           </p>
         </div>
-        <span className="font-mono text-[11px] text-ink-muted">{churn.subnets.length} subnets</span>
+        <span className="mg-type-data text-ink-muted">{churn.subnets.length} subnets</span>
       </div>
       {churn.subnets.length > 0 ? (
         <div className="overflow-x-auto">
@@ -754,7 +754,7 @@ function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
             <tbody className="divide-y divide-border">
               {churn.subnets.map((s) => (
                 <tr key={s.netuid} className="hover:bg-surface/40">
-                  <td className="px-4 py-2 font-mono text-[11px]">
+                  <td className="px-4 py-2 mg-type-data">
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: s.netuid }}
@@ -763,13 +763,13 @@ function AxonChurnSection({ churn }: { churn: ChainAxonRemovals }) {
                       SN{s.netuid}
                     </Link>
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                     {formatNumber(s.removals)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {formatNumber(s.distinct_removers)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {s.removals_per_remover != null ? s.removals_per_remover.toFixed(2) : "—"}
                   </td>
                 </tr>
@@ -799,11 +799,11 @@ function NetworkIdleStakeSection({ idleStake }: { idleStake: ChainIdleStake }) {
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <div>
           <h2 className="mg-type-label uppercase text-ink-muted">Idle stake</h2>
-          <p className="mt-1 font-mono text-[11px] text-ink-muted">
+          <p className="mt-1 mg-type-data text-ink-muted">
             Stake delegated to hotkeys currently earning zero dividends
           </p>
         </div>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(idleStake.subnet_count)} subnets
         </span>
       </div>
@@ -844,7 +844,7 @@ function NetworkIdleStakeSection({ idleStake }: { idleStake: ChainIdleStake }) {
             <tbody className="divide-y divide-border">
               {idleStake.subnets.map((s) => (
                 <tr key={s.netuid} className="hover:bg-surface/40">
-                  <td className="px-4 py-2 font-mono text-[11px]">
+                  <td className="px-4 py-2 mg-type-data">
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: s.netuid }}
@@ -853,13 +853,13 @@ function NetworkIdleStakeSection({ idleStake }: { idleStake: ChainIdleStake }) {
                       SN{s.netuid}
                     </Link>
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                     {formatTao(s.idle_stake_tao)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                     {formatNumber(s.idle_neuron_count)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {formatNumber(s.neuron_count)}
                   </td>
                 </tr>
@@ -885,7 +885,7 @@ function NetworkRegistrationsSection({ registrations }: { registrations: ChainRe
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h2 className="mg-type-label uppercase text-ink-muted">Network registrations</h2>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(registrations.subnet_count)} subnets
         </span>
       </div>
@@ -930,7 +930,7 @@ function NetworkRegistrationsSection({ registrations }: { registrations: ChainRe
             <tbody className="divide-y divide-border">
               {registrations.subnets.map((s) => (
                 <tr key={s.netuid} className="hover:bg-surface/40">
-                  <td className="px-4 py-2 font-mono text-[11px]">
+                  <td className="px-4 py-2 mg-type-data">
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: s.netuid }}
@@ -939,13 +939,13 @@ function NetworkRegistrationsSection({ registrations }: { registrations: ChainRe
                       SN{s.netuid}
                     </Link>
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                     {formatNumber(s.registrations)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {formatNumber(s.distinct_registrants)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {s.registrations_per_registrant != null
                       ? s.registrations_per_registrant.toFixed(2)
                       : "—"}
@@ -980,7 +980,7 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h2 className="mg-type-label uppercase text-ink-muted">Validator turnover</h2>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(turnover.subnet_count)} subnets
         </span>
       </div>
@@ -1030,7 +1030,7 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
                         style={{ width: `${pct}%`, background: "var(--health-warn)" }}
                       />
                     </span>
-                    <span className="text-right font-mono text-[10px] tabular-nums text-ink-strong">
+                    <span className="text-right mg-type-data-sm tabular-nums text-ink-strong">
                       {s.validator_retention != null
                         ? `${Math.round(s.validator_retention * 100)}% kept`
                         : "—"}
@@ -1046,7 +1046,7 @@ function ValidatorTurnoverSection({ turnover }: { turnover: ChainTurnover }) {
       )}
 
       {net ? (
-        <p className="mt-4 border-t border-border pt-3 font-mono text-[10px] text-ink-muted">
+        <p className="mt-4 border-t border-border pt-3 mg-type-data-sm text-ink-muted">
           Validator set {formatNumber(net.validators_start)} to {formatNumber(net.validators_end)}{" "}
           over {turnover.window}, across {formatNumber(turnover.subnet_count)} subnets.
         </p>
@@ -1067,7 +1067,7 @@ function EconomicsTrendsSection({ trends }: { trends: EconomicsTrends }) {
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h2 className="mg-type-label uppercase text-ink-muted">Network economics trend</h2>
-        <span className="font-mono text-[11px] text-ink-muted">{trends.day_count} days</span>
+        <span className="mg-type-data text-ink-muted">{trends.day_count} days</span>
       </div>
       {chrono.length > 0 ? (
         <div className="grid gap-x-8 gap-y-6 sm:grid-cols-2 xl:grid-cols-3">
@@ -1142,7 +1142,7 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
     <Panel className="min-w-0">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
         <h2 className="mg-type-label uppercase text-ink-muted">Transfers leaderboard</h2>
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(transfers.transfer_count)} transfers
         </span>
       </div>
@@ -1173,7 +1173,7 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
                 <tbody className="divide-y divide-border">
                   {transfers.top_senders.map((s) => (
                     <tr key={s.address} className="hover:bg-surface/40">
-                      <td className="px-4 py-2 font-mono text-[11px]">
+                      <td className="px-4 py-2 mg-type-data">
                         <div className="flex items-center gap-1.5">
                           <Link
                             to="/accounts/$ss58"
@@ -1186,10 +1186,10 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
                           <CopyButton value={s.address} label="address" compact />
                         </div>
                       </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                         {formatTao(s.volume_tao)}
                       </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                         {formatNumber(s.transfer_count)}
                       </td>
                     </tr>
@@ -1198,7 +1198,9 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
               </table>
             </div>
           ) : (
-            <p className="font-mono text-[12px] text-ink-muted">No senders in this window yet.</p>
+            <p className="font-mono mg-type-caption text-ink-muted">
+              No senders in this window yet.
+            </p>
           )}
         </div>
 
@@ -1217,7 +1219,7 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
                 <tbody className="divide-y divide-border">
                   {transfers.top_receivers.map((r) => (
                     <tr key={r.address} className="hover:bg-surface/40">
-                      <td className="px-4 py-2 font-mono text-[11px]">
+                      <td className="px-4 py-2 mg-type-data">
                         <div className="flex items-center gap-1.5">
                           <Link
                             to="/accounts/$ss58"
@@ -1230,10 +1232,10 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
                           <CopyButton value={r.address} label="address" compact />
                         </div>
                       </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                         {formatTao(r.volume_tao)}
                       </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                         {formatNumber(r.transfer_count)}
                       </td>
                     </tr>
@@ -1242,7 +1244,9 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
               </table>
             </div>
           ) : (
-            <p className="font-mono text-[12px] text-ink-muted">No receivers in this window yet.</p>
+            <p className="font-mono mg-type-caption text-ink-muted">
+              No receivers in this window yet.
+            </p>
           )}
         </div>
       </div>
@@ -1443,9 +1447,7 @@ function ExplorerDashboard() {
           <Panel className="min-w-0">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
               <h2 className="mg-type-label uppercase text-ink-muted">Daily activity</h2>
-              <span className="font-mono text-[11px] text-ink-muted">
-                {activity.day_count} days
-              </span>
+              <span className="mg-type-data text-ink-muted">{activity.day_count} days</span>
             </div>
             {chrono.length > 0 ? (
               <div className="grid gap-x-8 gap-y-6 sm:grid-cols-2 xl:grid-cols-3">
@@ -1512,7 +1514,7 @@ function ExplorerDashboard() {
                   <tbody className="divide-y divide-border">
                     {signers.signers.slice(0, 12).map((s) => (
                       <tr key={s.signer} className="hover:bg-surface/40">
-                        <td className="px-4 py-2 font-mono text-[11px]">
+                        <td className="px-4 py-2 mg-type-data">
                           <div className="flex items-center gap-1.5">
                             <Link
                               to="/accounts/$ss58"
@@ -1525,16 +1527,16 @@ function ExplorerDashboard() {
                             <CopyButton value={s.signer} label="signer" compact />
                           </div>
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                           {formatNumber(s.tx_count)}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                           {formatTao(s.total_fee_tao)}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                           {formatTao(s.total_tip_tao)}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                           {s.last_tx_block != null ? (
                             <Link
                               to="/blocks/$ref"
@@ -1567,7 +1569,7 @@ function ExplorerDashboard() {
           <Panel className="min-w-0">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
               <h2 className="mg-type-label uppercase text-ink-muted">Daily fees &amp; tips</h2>
-              <span className="font-mono text-[11px] text-ink-muted">{fees.day_count} days</span>
+              <span className="mg-type-data text-ink-muted">{fees.day_count} days</span>
             </div>
             {feeChrono.length > 0 ? (
               <div className="grid gap-x-8 gap-y-6 sm:grid-cols-2">
@@ -1607,7 +1609,7 @@ function ExplorerDashboard() {
           <Panel className="min-w-0">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
               <h2 className="mg-type-label uppercase text-ink-muted">Top fee payers</h2>
-              <span className="font-mono text-[11px] text-ink-muted">
+              <span className="mg-type-data text-ink-muted">
                 {fees.top_fee_payers.length} accounts
               </span>
             </div>
@@ -1626,7 +1628,7 @@ function ExplorerDashboard() {
                 <tbody className="divide-y divide-border">
                   {fees.top_fee_payers.map((p) => (
                     <tr key={p.signer} className="hover:bg-surface/40">
-                      <td className="px-4 py-2 font-mono text-[11px]">
+                      <td className="px-4 py-2 mg-type-data">
                         <div className="flex items-center gap-1.5">
                           <Link
                             to="/accounts/$ss58"
@@ -1639,13 +1641,13 @@ function ExplorerDashboard() {
                           <CopyButton value={p.signer} label="signer" compact />
                         </div>
                       </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                         {formatTao(p.total_fee_tao)}
                       </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                         {formatTao(p.total_tip_tao)}
                       </td>
-                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                         {formatNumber(p.extrinsic_count)}
                       </td>
                     </tr>
@@ -1677,12 +1679,12 @@ function ExplorerDashboard() {
                 <h2 className="mg-type-label uppercase text-ink-muted">
                   Stake-transfer leaderboard
                 </h2>
-                <p className="mt-1 font-mono text-[11px] text-ink-muted">
+                <p className="mt-1 mg-type-data text-ink-muted">
                   {formatNumber(stakeTransfers.network.transfers)} transfers across{" "}
                   {formatNumber(stakeTransfers.network.distinct_senders)} senders network-wide
                 </p>
               </div>
-              <span className="font-mono text-[11px] text-ink-muted">
+              <span className="mg-type-data text-ink-muted">
                 {stakeTransfers.subnets.length} subnets
               </span>
             </div>
@@ -1699,17 +1701,17 @@ function ExplorerDashboard() {
                         <Link
                           to="/subnets/$netuid"
                           params={{ netuid: s.netuid }}
-                          className="font-mono text-[12px] font-medium text-ink-strong hover:text-accent hover:underline"
+                          className="font-mono mg-type-caption font-medium text-ink-strong hover:text-accent hover:underline"
                         >
                           SN{s.netuid}
                         </Link>
-                        <span className="font-mono text-[11px] tabular-nums text-ink-muted">
+                        <span className="mg-type-data tabular-nums text-ink-muted">
                           {s.transfers_per_sender != null
                             ? `${s.transfers_per_sender.toFixed(2)} / sender`
                             : "—"}
                         </span>
                       </div>
-                      <div className="mt-2 flex items-center justify-between font-mono text-[11px] tabular-nums text-ink-muted">
+                      <div className="mt-2 flex items-center justify-between mg-type-data tabular-nums text-ink-muted">
                         <span>{formatNumber(s.transfers)} transfers</span>
                         <span>{formatNumber(s.distinct_senders)} senders</span>
                       </div>
@@ -1731,7 +1733,7 @@ function ExplorerDashboard() {
                   <tbody className="divide-y divide-border">
                     {stakeTransfers.subnets.map((s) => (
                       <tr key={s.netuid} className="hover:bg-surface/40">
-                        <td className="px-4 py-2 font-mono text-[11px]">
+                        <td className="px-4 py-2 mg-type-data">
                           <Link
                             to="/subnets/$netuid"
                             params={{ netuid: s.netuid }}
@@ -1740,13 +1742,13 @@ function ExplorerDashboard() {
                             SN{s.netuid}
                           </Link>
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                           {formatNumber(s.transfers)}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                           {formatNumber(s.distinct_senders)}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                           {s.transfers_per_sender != null ? s.transfers_per_sender.toFixed(2) : "—"}
                         </td>
                       </tr>
@@ -1766,7 +1768,7 @@ function ExplorerDashboard() {
           <Panel className="min-w-0 lg:col-span-2">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-y-1">
               <h2 className="mg-type-label uppercase text-ink-muted">Network weight-setters</h2>
-              <span className="font-mono text-[11px] text-ink-muted">
+              <span className="mg-type-data text-ink-muted">
                 {formatNumber(weightSetters.distinct_setters)} validators
               </span>
             </div>
@@ -1784,7 +1786,7 @@ function ExplorerDashboard() {
                   <tbody className="divide-y divide-border">
                     {weightSetters.setters.map((setter) => (
                       <tr key={weightSetterKey(setter)} className="hover:bg-surface/40">
-                        <td className="px-4 py-2 font-mono text-[11px]">
+                        <td className="px-4 py-2 mg-type-data">
                           {setter.hotkey ? (
                             <div className="flex items-center gap-1.5">
                               <Link
@@ -1806,13 +1808,13 @@ function ExplorerDashboard() {
                             </span>
                           )}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                           {formatNumber(setter.weight_sets)}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                           {fmtShare(setter.share)}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                           {setter.last_set_at ? <TimeAgo at={setter.last_set_at} /> : "—"}
                         </td>
                       </tr>
@@ -1847,7 +1849,7 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
         <div>
           <h2 className="mg-type-label uppercase text-ink-muted">Transfer pairs</h2>
           {pairs ? (
-            <p className="mt-1 font-mono text-[11px] text-ink-muted">
+            <p className="mt-1 mg-type-data text-ink-muted">
               {formatNumber(pairs.unique_pairs)} sender→receiver corridors ·{" "}
               {formatTao(pairs.total_volume_tao)} moved
             </p>
@@ -1896,10 +1898,10 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
             <tbody className="divide-y divide-border">
               {rows.map((p, i) => (
                 <tr key={`${p.from}-${p.to}`} className="hover:bg-surface/40">
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {i + 1}
                   </td>
-                  <td className="px-4 py-2 font-mono text-[11px]">
+                  <td className="px-4 py-2 mg-type-data">
                     <div className="flex items-center gap-1.5">
                       <Link
                         to="/accounts/$ss58"
@@ -1912,7 +1914,7 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
                       <CopyButton value={p.from} label="address" compact />
                     </div>
                   </td>
-                  <td className="px-4 py-2 font-mono text-[11px]">
+                  <td className="px-4 py-2 mg-type-data">
                     <div className="flex items-center gap-1.5">
                       <Link
                         to="/accounts/$ss58"
@@ -1925,13 +1927,13 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
                       <CopyButton value={p.to} label="address" compact />
                     </div>
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink">
                     {formatTao(p.volume_tao)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {formatNumber(p.transfer_count)}
                   </td>
-                  <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                  <td className="px-4 py-2 text-right mg-type-data tabular-nums text-ink-muted">
                     {p.last_block != null ? (
                       <Link
                         to="/blocks/$ref"
@@ -1971,7 +1973,7 @@ function ChainEventsFeedSection() {
     <Panel className="mt-10">
       <div className="mb-4">
         <h2 className="mg-type-label uppercase text-ink-muted">Chain events</h2>
-        <p className="mt-1 font-mono text-[11px] text-ink-muted">
+        <p className="mt-1 mg-type-data text-ink-muted">
           Browse individual pallet events newest-first — distinct from aggregate activity stats.
         </p>
       </div>

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -293,7 +293,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             </span>
           </FieldRow>
           <FieldRow label="Observed at">
-            <span className="font-mono text-[12px] text-ink-muted">
+            <span className="font-mono mg-type-caption text-ink-muted">
               <TimeAgo at={extrinsic.observed_at} />
             </span>
           </FieldRow>
@@ -307,7 +307,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
       >
         {renderCallArgs(callArgs, extrinsic.call_module, extrinsic.call_function)}
         {callArgsOmitted > 0 ? (
-          <p className="mt-2 font-mono text-[11px] text-ink-muted">
+          <p className="mt-2 mg-type-data text-ink-muted">
             Showing 64 of {formatNumber(callArgsTotal)} call args — {formatNumber(callArgsOmitted)}{" "}
             more omitted.
           </p>
@@ -349,7 +349,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                       {extrinsicCall(e.call_module, e.call_function)}
                     </span>
                     <span className="text-ink-muted">·</span>
-                    <span className="font-mono text-[11px] text-ink-muted">
+                    <span className="mg-type-data text-ink-muted">
                       #{formatNumber(e.block_number ?? 0)}
                     </span>
                     <TimeAgo at={e.observed_at} className="ml-auto text-[11px] text-ink-muted" />
@@ -384,7 +384,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                     key={`${ev.block_number}-${ev.event_index}-${i}`}
                     className="hover:bg-surface/40"
                   >
-                    <td className="px-4 py-2.5 font-mono text-[12px]">
+                    <td className="px-4 py-2.5 font-mono mg-type-caption">
                       {ev.block_number != null ? (
                         <Link
                           to="/blocks/$ref"
@@ -398,18 +398,18 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                       )}
                     </td>
                     <td
-                      className="px-4 py-2.5 font-mono text-[11px] text-ink-strong"
+                      className="px-4 py-2.5 mg-type-data text-ink-strong"
                       title={ev.event_kind ?? undefined}
                     >
                       {eventKindLabel(ev.event_kind)}
                     </td>
-                    <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                    <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                       <AccountAddress ss58={ev.hotkey} compact fallback="—" />
                     </td>
-                    <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
+                    <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink">
                       {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
                     </td>
-                    <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+                    <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
                       <TimeAgo at={ev.observed_at} />
                     </td>
                   </tr>
@@ -424,7 +424,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           />
         )}
         {eventsOmitted > 0 ? (
-          <p className="mt-2 font-mono text-[11px] text-ink-muted">
+          <p className="mt-2 mg-type-data text-ink-muted">
             Showing 100 of {formatNumber(eventsTotal)} events — {formatNumber(eventsOmitted)} more
             omitted.
           </p>
@@ -493,10 +493,10 @@ function renderCallArgs(
           <tbody className="divide-y divide-border">
             {args.map((arg, i) => (
               <tr key={`${arg.name ?? i}`} className="hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong align-top">
+                <td className="px-4 py-2.5 mg-type-data text-ink-strong align-top">
                   {arg.name ?? `arg_${i + 1}`}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                   {renderCallArgValue(arg.value, arg.name, callModule, callFunction, depth)}
                 </td>
               </tr>
@@ -524,10 +524,8 @@ function renderCallArgs(
           <tbody className="divide-y divide-border">
             {entries.map(([key, value]) => (
               <tr key={key} className="hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong align-top">
-                  {key}
-                </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-data text-ink-strong align-top">{key}</td>
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                   {renderCallArgValue(value, key, callModule, callFunction, depth)}
                 </td>
               </tr>
@@ -601,7 +599,7 @@ function NestedCallCard({ call, depth }: { call: DecodedCall; depth: number }) {
   return (
     <div className="rounded border border-border/70 bg-surface/30 p-3">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-        <span className="font-mono text-[11px] font-semibold text-ink-strong">
+        <span className="mg-type-data font-semibold text-ink-strong">
           {extrinsicCall(call.call_module, call.call_function)}
         </span>
         {typeof call.call_hash === "string" && call.call_hash ? (

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -135,9 +135,9 @@ function FeesTrendCard() {
         <div className="mb-2 flex items-baseline justify-between gap-2">
           <div className="flex items-baseline gap-2">
             <h2 className="mg-type-micro text-ink-muted">Fees, last 7d</h2>
-            <span className="font-mono text-[11px] text-ink-muted">{fees.day_count} days</span>
+            <span className="mg-type-data text-ink-muted">{fees.day_count} days</span>
           </div>
-          <span className="font-mono text-[11px] tabular-nums text-ink-strong">
+          <span className="mg-type-data tabular-nums text-ink-strong">
             {latest == null ? "—" : formatTao(latest)}
           </span>
         </div>
@@ -207,7 +207,7 @@ function ExtrinsicsTable() {
         onClick={() => setFiltersOpen((open) => !open)}
         aria-expanded={filtersOpen}
         aria-controls="extrinsics-filter-fields"
-        className="md:hidden inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-2.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors"
+        className="md:hidden inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-2.5 mg-type-data text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors"
       >
         <SlidersHorizontal className="size-3" aria-hidden="true" />
         {filterToggleLabel(activeCount)}
@@ -317,7 +317,7 @@ function ExtrinsicsTable() {
           <tbody className="divide-y divide-border">
             {rows.map((x) => (
               <tr key={rowKey(x)} className="mg-row-accent hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                   {x.extrinsic_hash ? (
                     <span className="inline-flex items-center gap-1 min-w-0">
                       <Link
@@ -334,7 +334,7 @@ function ExtrinsicsTable() {
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[12px]">
+                <td className="px-4 py-2.5 font-mono mg-type-caption">
                   {x.block_number != null ? (
                     <Link
                       to="/blocks/$ref"
@@ -350,10 +350,10 @@ function ExtrinsicsTable() {
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
+                <td className="px-4 py-2.5 mg-type-data text-ink">
                   {extrinsicCall(x.call_module, x.call_function)}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                   <AccountAddress
                     ss58={x.signer}
                     compact
@@ -362,10 +362,10 @@ function ExtrinsicsTable() {
                     }
                   />
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px]">
+                <td className="px-4 py-2.5 mg-type-data">
                   <SuccessBadge success={x.success} />
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
                   <TimeAgo at={x.observed_at} />
                 </td>
               </tr>
@@ -386,7 +386,7 @@ function HashCardOrLink({ x }: { x: Extrinsic }) {
         <div className="flex items-center gap-1 min-w-0 flex-1">
           {x.extrinsic_hash ? (
             <>
-              <span className="font-mono text-[12px] font-medium text-ink-strong truncate">
+              <span className="font-mono mg-type-caption font-medium text-ink-strong truncate">
                 {shortHash(x.extrinsic_hash)}
               </span>
               <span
@@ -400,17 +400,17 @@ function HashCardOrLink({ x }: { x: Extrinsic }) {
               </span>
             </>
           ) : (
-            <span className="font-mono text-[12px] font-medium text-ink-strong">(no hash)</span>
+            <span className="font-mono mg-type-caption font-medium text-ink-strong">(no hash)</span>
           )}
         </div>
-        <span className="font-mono text-[11px] text-ink-muted shrink-0">
+        <span className="mg-type-data text-ink-muted shrink-0">
           <TimeAgo at={x.observed_at} />
         </span>
       </div>
-      <div className="mt-1 font-mono text-[11px] text-ink truncate">
+      <div className="mt-1 mg-type-data text-ink truncate">
         {extrinsicCall(x.call_module, x.call_function)}
       </div>
-      <div className="mt-2 flex items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
+      <div className="mt-2 flex items-center justify-between gap-2 mg-type-data text-ink-muted">
         <span className="shrink-0">
           {x.block_number != null ? `#${formatNumber(x.block_number)}` : "—"}
         </span>

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -429,9 +429,7 @@ function MissingKindsAtAGlance() {
                   style={{ width: `${pct}%` }}
                   aria-hidden
                 />
-                <span className="font-mono text-[11px] tabular-nums text-ink-muted">
-                  {n} subnets
-                </span>
+                <span className="mg-type-data tabular-nums text-ink-muted">{n} subnets</span>
               </button>
             </li>
           );
@@ -550,7 +548,7 @@ function OpenGapsSection() {
           value={search.q}
           onChange={(e) => setSearch({ q: e.target.value })}
           placeholder="Search title, description, netuid…"
-          className="w-full rounded-full border border-border bg-card pl-8 pr-3 py-1.5 text-[12px] focus:outline-none focus:border-accent/50"
+          className="w-full rounded-full border border-border bg-card pl-8 pr-3 py-1.5 mg-type-caption focus:outline-none focus:border-accent/50"
           aria-label="Search gaps"
         />
       </div>
@@ -576,7 +574,7 @@ function OpenGapsSection() {
         active={hasFilters}
         onReset={() => navigate({ search: {} as never, replace: true })}
       />
-      <span className="ml-auto font-mono text-[10px] text-ink-muted">
+      <span className="ml-auto mg-type-data-sm text-ink-muted">
         {sorted.length} of {rows.length}
       </span>
     </>
@@ -618,7 +616,7 @@ function OpenGapsSection() {
       </div>
 
       {missingSet.size > 0 ? (
-        <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-accent/30 bg-primary-soft/40 px-3 py-2 font-mono text-[11px] text-ink-strong">
+        <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-accent/30 bg-primary-soft/40 px-3 py-2 mg-type-data text-ink-strong">
           <span className="mg-type-micro text-ink-muted">filtered by missing kind:</span>
           {Array.from(missingSet).map((k) => (
             <span
@@ -760,7 +758,7 @@ function GapRow({
             <Link
               to="/subnets/$netuid"
               params={{ netuid: gap.netuid }}
-              className="inline-flex items-center gap-1.5 font-mono text-[10px] text-accent hover:underline"
+              className="inline-flex items-center gap-1.5 mg-type-data-sm text-accent hover:underline"
             >
               <BrandIcon
                 url={subnet?.website}
@@ -781,12 +779,12 @@ function GapRow({
         </div>
         <div className="font-medium text-ink-strong">{gap.title ?? gap.id}</div>
         {gap.description ? (
-          <p className="mt-1 text-[13px] text-ink-muted leading-relaxed line-clamp-2">
+          <p className="mt-1 mg-type-caption-lg text-ink-muted leading-relaxed line-clamp-2">
             {gap.description}
           </p>
         ) : null}
         {gap.suggested_action ? (
-          <p className="mt-1.5 text-[12px] text-ink">↳ {gap.suggested_action}</p>
+          <p className="mt-1.5 mg-type-caption text-ink">↳ {gap.suggested_action}</p>
         ) : null}
         {matchedKind && (rawSources.length > 0 || gap.netuid != null) ? (
           <div className="mg-type-micro mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-ink-muted">
@@ -911,7 +909,7 @@ function CompletenessList() {
           <Link
             to="/subnets/$netuid"
             params={{ netuid: r.netuid }}
-            className="font-mono text-[11px] text-ink-muted hover:text-accent w-12"
+            className="mg-type-data text-ink-muted hover:text-accent w-12"
           >
             SN{r.netuid}
           </Link>
@@ -921,7 +919,7 @@ function CompletenessList() {
               style={{ width: `${Math.round((r.completeness ?? 0) * 100)}%` }}
             />
           </div>
-          <span className="font-mono text-[11px] text-ink-strong w-10 text-right tabular-nums">
+          <span className="mg-type-data text-ink-strong w-10 text-right tabular-nums">
             {Math.round((r.completeness ?? 0) * 100)}%
           </span>
         </li>
@@ -955,21 +953,18 @@ function AdapterCandidates() {
             <Link
               to="/subnets/$netuid"
               params={{ netuid: r.netuid }}
-              className="font-mono text-[11px] text-ink-muted hover:text-accent w-12"
+              className="mg-type-data text-ink-muted hover:text-accent w-12"
             >
               SN{r.netuid}
             </Link>
           ) : (
-            <span className="font-mono text-[11px] text-ink-muted w-12">—</span>
+            <span className="mg-type-data text-ink-muted w-12">—</span>
           )}
-          <span className="flex-1 text-[13px] text-ink">
+          <span className="flex-1 mg-type-caption-lg text-ink">
             {r.reason ?? <span className="text-ink-muted">No recommendation recorded</span>}
           </span>
           {r.score != null ? (
-            <span
-              className="font-mono text-[11px] text-ink-strong tabular-nums"
-              title="Priority score"
-            >
+            <span className="mg-type-data text-ink-strong tabular-nums" title="Priority score">
               {Math.round(r.score)}
             </span>
           ) : null}
@@ -1008,8 +1003,8 @@ function EnrichmentQueue() {
           <tbody className="divide-y divide-border">
             {rows.map((r) => (
               <tr key={r.id} className="mg-row-hover">
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">{r.id}</td>
-                <td className="px-4 py-2.5 font-mono text-[11px]">
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">{r.id}</td>
+                <td className="px-4 py-2.5 mg-type-data">
                   {r.netuid != null ? (
                     <Link
                       to="/subnets/$netuid"
@@ -1022,8 +1017,8 @@ function EnrichmentQueue() {
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
-                <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-data">{r.priority ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-caption text-ink-muted">{r.note ?? "—"}</td>
               </tr>
             ))}
           </tbody>
@@ -1066,7 +1061,7 @@ function EnrichmentTargets() {
           <tbody className="divide-y divide-border">
             {rows.map((r) => (
               <tr key={r.id} className="mg-row-hover">
-                <td className="px-4 py-2.5 font-mono text-[11px]">
+                <td className="px-4 py-2.5 mg-type-data">
                   {r.netuid != null ? (
                     <Link
                       to="/subnets/$netuid"
@@ -1079,15 +1074,11 @@ function EnrichmentTargets() {
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-2.5 text-[12px] text-ink-strong">{r.name ?? "—"}</td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {r.targetType ?? "—"}
-                </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {r.targetAction ?? "—"}
-                </td>
-                <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
-                <td className="px-4 py-2.5 text-[12px] text-ink-muted">{r.note ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-caption text-ink-strong">{r.name ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">{r.targetType ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">{r.targetAction ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-data">{r.priority ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-caption text-ink-muted">{r.note ?? "—"}</td>
               </tr>
             ))}
           </tbody>
@@ -1131,7 +1122,7 @@ function EnrichmentEvidence() {
           <tbody className="divide-y divide-border">
             {rows.map((r) => (
               <tr key={r.id} className="mg-row-hover">
-                <td className="px-4 py-2.5 font-mono text-[11px]">
+                <td className="px-4 py-2.5 mg-type-data">
                   {r.netuid != null ? (
                     <Link
                       to="/subnets/$netuid"
@@ -1144,19 +1135,17 @@ function EnrichmentEvidence() {
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                  {r.lane ?? "—"}
-                </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">{r.lane ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-data text-ink-muted">
                   {r.evidenceAction ?? "—"}
                 </td>
-                <td className="px-4 py-2.5 text-[12px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-caption text-ink-muted">
                   {r.missingKinds.length > 0 ? r.missingKinds.join(", ") : "—"}
                 </td>
-                <td className="px-4 py-2.5 text-[12px] text-ink-muted">
+                <td className="px-4 py-2.5 mg-type-caption text-ink-muted">
                   {r.directSubmissionKinds.length > 0 ? r.directSubmissionKinds.join(", ") : "—"}
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px]">{r.priority ?? "—"}</td>
+                <td className="px-4 py-2.5 mg-type-data">{r.priority ?? "—"}</td>
               </tr>
             ))}
           </tbody>
@@ -1195,21 +1184,21 @@ function GapPriorityList() {
             <Link
               to="/subnets/$netuid"
               params={{ netuid: r.netuid }}
-              className="font-mono text-[11px] text-ink-muted hover:text-accent w-12 shrink-0"
+              className="mg-type-data text-ink-muted hover:text-accent w-12 shrink-0"
             >
               SN{r.netuid}
             </Link>
           ) : (
-            <span className="font-mono text-[11px] text-ink-muted w-12 shrink-0">—</span>
+            <span className="mg-type-data text-ink-muted w-12 shrink-0">—</span>
           )}
-          <span className="flex-1 text-[13px] text-ink truncate">{r.name ?? "—"}</span>
+          <span className="flex-1 mg-type-caption-lg text-ink truncate">{r.name ?? "—"}</span>
           <CurationChip level={r.curation_level} />
           <span className="hidden sm:block max-w-[240px] truncate text-[11px] text-ink-muted">
             {r.missing_kinds && r.missing_kinds.length > 0 ? r.missing_kinds.join(", ") : "—"}
           </span>
           {r.priority_score != null ? (
             <span
-              className="font-mono text-[11px] text-ink-strong tabular-nums shrink-0"
+              className="mg-type-data text-ink-strong tabular-nums shrink-0"
               title="Priority score"
             >
               {Math.round(r.priority_score)}

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -484,7 +484,7 @@ function StatusBoard({ interval }: { interval: number | false }) {
           </div>
         </BoardCard>
       </div>
-      <div className="text-[11px] font-mono text-ink-muted">
+      <div className="mg-type-data text-ink-muted">
         snapshot <TimeAgo at={hRes.meta?.generated_at} />
       </div>
     </div>
@@ -556,7 +556,7 @@ function SourceHealth({ interval }: { interval: number | false }) {
               <td className="px-4 py-3">
                 <HealthPill state={s.ok === false ? "down" : s.ok ? "ok" : "unknown"} />
               </td>
-              <td className="px-4 py-3 text-right font-mono text-[11px] text-ink-muted">
+              <td className="px-4 py-3 text-right mg-type-data text-ink-muted">
                 <TimeAgo at={s.last_seen} />
               </td>
             </tr>
@@ -727,7 +727,7 @@ function Incidents({ interval }: { interval: number | false }) {
             <span className="text-[10px] tabular-nums opacity-80">{opt.count}</span>
           </button>
         ))}
-        <span className="ml-auto font-mono text-[10px] text-ink-muted">
+        <span className="ml-auto mg-type-data-sm text-ink-muted">
           {groups.length} {groups.length === 1 ? "host" : "hosts"} · {filtered.length} incidents
         </span>
       </div>
@@ -758,7 +758,9 @@ function Incidents({ interval }: { interval: number | false }) {
                       <ChevronRight className="size-3.5 text-ink-muted shrink-0" />
                     )}
                     <HealthPill state={g.dominantState} />
-                    <span className="font-mono text-[12px] text-ink-strong truncate">{g.host}</span>
+                    <span className="font-mono mg-type-caption text-ink-strong truncate">
+                      {g.host}
+                    </span>
                     <span className="mg-type-micro ml-auto inline-flex items-center gap-2 text-[10px] text-ink-muted shrink-0">
                       {g.ongoing > 0 ? (
                         <span className="text-health-down">{g.ongoing} ongoing</span>

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -294,7 +294,7 @@ function OverviewPage() {
               <div className="mg-type-micro text-ink-muted mb-2">Try it</div>
               <CopyableCode
                 value={`curl ${API_BASE}/api/v1/subnets`}
-                className="w-full text-[12px]"
+                className="w-full mg-type-caption"
                 truncate={false}
               />
               <div className="mt-3 flex gap-4 text-xs">
@@ -363,7 +363,7 @@ function ChainHeadTip() {
     <Link
       to="/blocks/$ref"
       params={{ ref: String(head.block_number) }}
-      className="mg-fade-in mg-fade-in-delay-3 mt-4 inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted hover:text-accent transition-colors"
+      className="mg-fade-in mg-fade-in-delay-3 mt-4 inline-flex items-center gap-1.5 mg-type-data text-ink-muted hover:text-accent transition-colors"
     >
       <span className="mg-live-dot" />
       head #{formatNumber(head.block_number)} · <TimeAgo at={head.observed_at} />
@@ -452,7 +452,7 @@ function HomeHero() {
           </div>
         </div>
 
-        <div className="mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-col items-center gap-3 sm:flex-row sm:gap-4 text-[13px]">
+        <div className="mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-col items-center gap-3 sm:flex-row sm:gap-4 mg-type-caption-lg">
           <Link
             to="/subnets"
             className="mg-focus-ring inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 font-medium text-accent-foreground transition-opacity hover:opacity-90"
@@ -658,7 +658,7 @@ function PerfCard({
       <div className="p-4">
         <div className="flex items-baseline justify-between mb-3">
           <div className="mg-type-micro text-ink-muted">{label}</div>
-          <div className="font-mono text-[10px] text-ink-muted">{hint}</div>
+          <div className="mg-type-data-sm text-ink-muted">{hint}</div>
         </div>
         <div
           className={`font-display text-3xl md:text-4xl font-semibold leading-none tabular-nums ${accent ? "text-accent" : "text-ink-strong"}`}
@@ -814,7 +814,7 @@ function PilotCard({
           {metricEntries.map(([k, v]) => (
             <div key={k} className="rounded-md border border-border bg-surface/40 px-3 py-2">
               <dt className="mg-type-micro text-ink-muted truncate">{k}</dt>
-              <dd className="font-mono text-[12px] text-ink-strong truncate">
+              <dd className="font-mono mg-type-caption text-ink-strong truncate">
                 {typeof v === "object" ? JSON.stringify(v) : String(v)}
               </dd>
             </div>
@@ -824,7 +824,7 @@ function PilotCard({
         <p className="text-xs text-ink-muted">Adapter connected. Open subnet for detail.</p>
       )}
       {generated ? (
-        <div className="mt-3 font-mono text-[10px] text-ink-muted">
+        <div className="mt-3 mg-type-data-sm text-ink-muted">
           updated <TimeAgo at={generated} />
         </div>
       ) : null}
@@ -895,7 +895,7 @@ function SubnetPreviewTable() {
           <tbody className="divide-y divide-border">
             {subnets.slice(0, 12).map((s) => (
               <tr key={s.netuid} className="mg-row-hover">
-                <td className="px-4 py-3 font-mono text-[12px] text-ink-muted">
+                <td className="px-4 py-3 font-mono mg-type-caption text-ink-muted">
                   <EntityHoverCard kind="subnet" netuid={s.netuid}>
                     <Link
                       to="/subnets/$netuid"
@@ -924,22 +924,20 @@ function SubnetPreviewTable() {
                     </Link>
                   </EntityHoverCard>
                 </td>
-                <td className="px-4 py-3 font-mono text-[11px] text-ink-muted">
-                  {s.symbol ?? "—"}
-                </td>
-                <td className="px-4 py-3 text-right font-mono text-[12px] text-ink">
+                <td className="px-4 py-3 mg-type-data text-ink-muted">{s.symbol ?? "—"}</td>
+                <td className="px-4 py-3 text-right font-mono mg-type-caption text-ink">
                   {formatNumber(s.participants)}
                 </td>
                 <td className="px-4 py-3">
                   <CurationChip level={s.curation_level} />
                 </td>
-                <td className="px-4 py-3 text-right font-mono text-[12px]">
+                <td className="px-4 py-3 text-right font-mono mg-type-caption">
                   {s.surfaces_count ?? "—"}
                 </td>
                 <td className="px-4 py-3">
                   <HealthPill state={healthBySubnet.get(s.netuid) ?? s.health ?? "unknown"} />
                 </td>
-                <td className="px-4 py-3 text-right font-mono text-[11px] text-ink-muted">
+                <td className="px-4 py-3 text-right mg-type-data text-ink-muted">
                   <TimeAgo at={s.updated_at ?? s.freshness} />
                 </td>
               </tr>
@@ -947,7 +945,7 @@ function SubnetPreviewTable() {
           </tbody>
         </table>
       </div>
-      <div className="border-t border-border bg-surface/30 px-4 py-2.5 flex justify-between text-[11px] font-mono text-ink-muted">
+      <div className="border-t border-border bg-surface/30 px-4 py-2.5 flex justify-between mg-type-data text-ink-muted">
         <span>
           Showing {Math.min(12, subnets.length)}
           {total ? ` of ${formatNumber(total)}` : ""} ·{" "}

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -234,7 +234,7 @@ function CsvExportMenu({ win }: { win: LeaderboardWindow }) {
               setOpen(false);
               window.location.href = buildCsvDownloadUrl(exp.url);
             }}
-            className="w-full flex items-center gap-2 rounded px-2 py-2 text-left text-[12px] text-ink hover:bg-surface hover:text-ink-strong transition-colors min-h-9"
+            className="w-full flex items-center gap-2 rounded px-2 py-2 text-left mg-type-caption text-ink hover:bg-surface hover:text-ink-strong transition-colors min-h-9"
           >
             <Download className="size-3.5 shrink-0 text-ink-muted" aria-hidden />
             <span>{exp.label}</span>
@@ -313,7 +313,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
         <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
             <span className="mg-type-label uppercase text-ink-muted">Per-subnet rankings</span>
-            <span className="font-mono text-[11px] text-ink-muted">
+            <span className="mg-type-data text-ink-muted">
               {formatNumber(board.subnet_count)} subnets
               {board.observed_at ? (
                 <>
@@ -339,7 +339,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                       params={{ netuid: row.netuid }}
                       className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                     >
-                      <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                      <span className="shrink-0 mg-type-data tabular-nums text-ink-muted">
                         {i + 1}
                       </span>
                       <BrandIcon
@@ -351,13 +351,13 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                       />
                       <span className="truncate text-sm text-ink-strong">{name}</span>
                     </Link>
-                    <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                    <span className="shrink-0 mg-type-data tabular-nums text-ink-muted">
                       {row.sets_per_setter != null
                         ? `${row.sets_per_setter.toFixed(2)} / setter`
                         : "—"}
                     </span>
                   </div>
-                  <div className="mt-2 flex items-center justify-between font-mono text-[11px] tabular-nums text-ink-muted">
+                  <div className="mt-2 flex items-center justify-between mg-type-data tabular-nums text-ink-muted">
                     <span>{formatNumber(row.weight_sets)} weight-sets</span>
                     <span>{formatNumber(row.distinct_setters)} setters</span>
                   </div>
@@ -382,7 +382,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                   const name = subnet?.name ?? `Subnet ${row.netuid}`;
                   return (
                     <tr key={row.netuid} className="hover:bg-surface/40">
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
                         {i + 1}
                       </td>
                       <td className="px-4 py-2.5">
@@ -401,13 +401,13 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                           <span className="truncate text-sm text-ink-strong">{name}</span>
                         </Link>
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-strong">
                         {formatNumber(row.weight_sets)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
                         {formatNumber(row.distinct_setters)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
                         {row.sets_per_setter != null ? row.sets_per_setter.toFixed(2) : "—"}
                       </td>
                     </tr>
@@ -487,7 +487,7 @@ function EmissionsLeaderboard() {
         <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
             <span className="mg-type-label uppercase text-ink-muted">Per-subnet rankings</span>
-            <span className="font-mono text-[11px] text-ink-muted">
+            <span className="mg-type-data text-ink-muted">
               top {top.length} of {formatNumber(ranked.length)} subnets
             </span>
           </div>
@@ -503,7 +503,7 @@ function EmissionsLeaderboard() {
                       params={{ netuid: row.netuid }}
                       className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                     >
-                      <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                      <span className="shrink-0 mg-type-data tabular-nums text-ink-muted">
                         {i + 1}
                       </span>
                       <BrandIcon
@@ -515,7 +515,7 @@ function EmissionsLeaderboard() {
                       />
                       <span className="truncate text-sm text-ink-strong">{name}</span>
                     </Link>
-                    <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-strong">
+                    <span className="shrink-0 mg-type-data tabular-nums text-ink-strong">
                       {pct(row.emission_share)}
                     </span>
                   </div>
@@ -538,7 +538,7 @@ function EmissionsLeaderboard() {
                   const name = subnet?.name ?? row.name ?? `Subnet ${row.netuid}`;
                   return (
                     <tr key={row.netuid} className="hover:bg-surface/40">
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
                         {i + 1}
                       </td>
                       <td className="px-4 py-2.5">
@@ -557,7 +557,7 @@ function EmissionsLeaderboard() {
                           <span className="truncate text-sm text-ink-strong">{name}</span>
                         </Link>
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-strong">
                         {pct(row.emission_share)}
                       </td>
                     </tr>
@@ -624,7 +624,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
         <Panel flush>
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
             <span className="mg-type-label uppercase text-ink-muted">Per-subnet rankings</span>
-            <span className="font-mono text-[11px] text-ink-muted">
+            <span className="mg-type-data text-ink-muted">
               {formatNumber(board.subnet_count)} subnets
               {board.observed_at ? (
                 <>
@@ -647,7 +647,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
                       params={{ netuid: row.netuid }}
                       className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                     >
-                      <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                      <span className="shrink-0 mg-type-data tabular-nums text-ink-muted">
                         {i + 1}
                       </span>
                       <BrandIcon
@@ -659,13 +659,13 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
                       />
                       <span className="truncate text-sm text-ink-strong">{name}</span>
                     </Link>
-                    <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                    <span className="shrink-0 mg-type-data tabular-nums text-ink-muted">
                       {row.deregistrations_per_hotkey != null
                         ? `${row.deregistrations_per_hotkey.toFixed(2)} / hotkey`
                         : "—"}
                     </span>
                   </div>
-                  <div className="mt-2 flex items-center justify-between font-mono text-[11px] tabular-nums text-ink-muted">
+                  <div className="mt-2 flex items-center justify-between mg-type-data tabular-nums text-ink-muted">
                     <span>{formatNumber(row.deregistrations)} deregistrations</span>
                     <span>{formatNumber(row.distinct_deregistered_hotkeys)} hotkeys</span>
                   </div>
@@ -690,7 +690,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
                   const name = subnet?.name ?? `Subnet ${row.netuid}`;
                   return (
                     <tr key={row.netuid} className="hover:bg-surface/40">
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
                         {i + 1}
                       </td>
                       <td className="px-4 py-2.5">
@@ -709,13 +709,13 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
                           <span className="truncate text-sm text-ink-strong">{name}</span>
                         </Link>
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-strong">
                         {formatNumber(row.deregistrations)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
                         {formatNumber(row.distinct_deregistered_hotkeys)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink-muted">
                         {row.deregistrations_per_hotkey != null
                           ? row.deregistrations_per_hotkey.toFixed(2)
                           : "—"}

--- a/apps/ui/src/routes/portfolio.tsx
+++ b/apps/ui/src/routes/portfolio.tsx
@@ -54,7 +54,7 @@ function PortfolioPage() {
           <h2 className="text-sm font-medium text-ink-strong">
             Connect a wallet to see your positions
           </h2>
-          <p className="mx-auto mt-1 mb-4 max-w-md text-[13px] text-ink-muted">
+          <p className="mx-auto mt-1 mb-4 max-w-md mg-type-caption-lg text-ink-muted">
             This app is read-only — it never constructs or signs a transaction. Connecting only
             reads your public on-chain positions from a browser wallet extension.
           </p>

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -155,7 +155,7 @@ function ProviderShell({ slug }: { slug: string }) {
         }
       />
       {shouldShowProviderSlugSubtitle(p?.name, slug) ? (
-        <div className="-mt-2 mb-3 font-mono text-[11px] text-ink-muted">{slug}</div>
+        <div className="-mt-2 mb-3 mg-type-data text-ink-muted">{slug}</div>
       ) : null}
 
       <div className="mg-kpi-strip">
@@ -391,11 +391,11 @@ function SubnetsServedGrid({ slug, compact }: { slug: string; compact?: boolean 
                     <span className="truncate font-display text-sm font-semibold text-ink-strong">
                       {sn?.name ?? "Subnet"}
                     </span>
-                    <span className="shrink-0 font-mono text-[11px] text-ink-muted tabular-nums">
+                    <span className="shrink-0 mg-type-data text-ink-muted tabular-nums">
                       {String(netuid).padStart(3, "0")}
                     </span>
                   </div>
-                  <div className="mt-0.5 font-mono text-[10px] text-ink-muted">
+                  <div className="mt-0.5 mg-type-data-sm text-ink-muted">
                     {items.length} endpoint{items.length === 1 ? "" : "s"}
                   </div>
                 </div>
@@ -426,8 +426,8 @@ function BreakdownCard({ title, data }: { title: string; data: Record<string, nu
         {entries.map(([kk, v]) => (
           <li key={kk}>
             <div className="flex items-baseline justify-between gap-2 mb-0.5">
-              <span className="font-mono text-[11px] text-ink truncate">{kk}</span>
-              <span className="font-mono text-[11px] text-ink-muted tabular-nums">{v}</span>
+              <span className="mg-type-data text-ink truncate">{kk}</span>
+              <span className="mg-type-data text-ink-muted tabular-nums">{v}</span>
             </div>
             <div className="h-1 w-full overflow-hidden rounded bg-surface">
               <div

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -439,7 +439,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                       />
                       <span className="min-w-0">
                         <span className="block truncate font-medium text-ink-strong">{f.name}</span>
-                        <span className="block truncate font-mono text-[10px] text-ink-muted">
+                        <span className="block truncate mg-type-data-sm text-ink-muted">
                           {p.slug}
                         </span>
                       </span>
@@ -455,7 +455,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                       </span>
                     ) : null}
                   </div>
-                  <div className="mt-2 flex items-center justify-between gap-2 font-mono text-[11px] text-ink-muted">
+                  <div className="mt-2 flex items-center justify-between gap-2 mg-type-data text-ink-muted">
                     <span className="inline-flex min-w-0 items-center gap-2">
                       <span className="shrink-0">{f.kindLabel}</span>
                       {host ? <span className="max-w-[20ch] truncate">{host}</span> : null}
@@ -519,14 +519,10 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                           <span className="font-medium text-ink-strong truncate">
                             {p.name ?? p.slug}
                           </span>
-                          <span className="font-mono text-[10px] text-ink-muted truncate">
-                            {p.slug}
-                          </span>
+                          <span className="mg-type-data-sm text-ink-muted truncate">{p.slug}</span>
                         </Link>
                       </td>
-                      <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                        {p.kind ?? "—"}
-                      </td>
+                      <td className="px-3 py-2 mg-type-data text-ink-muted">{p.kind ?? "—"}</td>
                       <td className="px-3 py-2">
                         {p.authority ? (
                           <span
@@ -541,19 +537,19 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                           <span className="text-ink-muted">—</span>
                         )}
                       </td>
-                      <td className="px-3 py-2 font-mono text-[11px] text-ink-muted truncate max-w-[22ch]">
+                      <td className="px-3 py-2 mg-type-data text-ink-muted truncate max-w-[22ch]">
                         {host ?? "—"}
                       </td>
-                      <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
+                      <td className="px-3 py-2 text-right mg-type-data tabular-nums">
                         {c?.subnets ?? 0}
                       </td>
-                      <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
+                      <td className="px-3 py-2 text-right mg-type-data tabular-nums">
                         {c?.surfaces ?? 0}
                       </td>
-                      <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
+                      <td className="px-3 py-2 text-right mg-type-data tabular-nums">
                         {c?.endpoints ?? 0}
                       </td>
-                      <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
+                      <td className="px-3 py-2 text-right mg-type-data text-ink-muted">
                         <div className="inline-flex items-center gap-1 justify-end">
                           <TimeAgo
                             at={typeof p.updated_at === "string" ? p.updated_at : undefined}
@@ -617,9 +613,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                             {p.name ?? p.slug}
                           </div>
                         </div>
-                        <div className="font-mono text-[10px] text-ink-muted truncate">
-                          {p.slug}
-                        </div>
+                        <div className="mg-type-data-sm text-ink-muted truncate">{p.slug}</div>
                       </div>
                     </div>
                     {p.authority ? (
@@ -634,7 +628,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                     ) : null}
                   </div>
                   {p.notes ? (
-                    <p className="mt-3 text-[12px] text-ink-muted leading-relaxed line-clamp-2">
+                    <p className="mt-3 mg-type-caption text-ink-muted leading-relaxed line-clamp-2">
                       {p.notes}
                     </p>
                   ) : null}
@@ -658,7 +652,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                       </span>
                     ) : null}
                     {!webHost && !repoHost && !docsHost ? (
-                      <span className="font-mono text-[10px]">no public links yet</span>
+                      <span className="mg-type-data-sm">no public links yet</span>
                     ) : null}
                     <TimeAgo
                       at={typeof p.updated_at === "string" ? p.updated_at : undefined}
@@ -697,7 +691,7 @@ function ProviderCardStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex flex-col">
       <span className="mg-type-micro text-ink-muted">{label}</span>
-      <span className="font-mono text-[13px] tabular-nums text-ink-strong">{value}</span>
+      <span className="font-mono mg-type-caption-lg tabular-nums text-ink-strong">{value}</span>
     </div>
   );
 }
@@ -733,7 +727,7 @@ function SourceHealthRollup() {
       as="div"
       dense
       className="mt-3"
-      bodyClassName="flex flex-wrap items-center gap-4 font-mono text-[12px] tabular-nums"
+      bodyClassName="flex flex-wrap items-center gap-4 font-mono mg-type-caption tabular-nums"
     >
       <span className="mg-label">Source health</span>
       <span className="text-health-ok">{status.ok ?? 0} ok</span>

--- a/apps/ui/src/routes/runtime.index.tsx
+++ b/apps/ui/src/routes/runtime.index.tsx
@@ -101,10 +101,10 @@ function RuntimeContent() {
                       key={`${row.spec_version}-${row.block_number}`}
                       className="mg-row-hover border-t border-border/60"
                     >
-                      <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink-strong">
+                      <td className="px-3 py-2.5 font-mono mg-type-caption tabular-nums text-ink-strong">
                         {formatNumber(row.spec_version)}
                       </td>
-                      <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums">
+                      <td className="px-3 py-2.5 font-mono mg-type-caption tabular-nums">
                         {row.block_number != null ? (
                           <Link
                             to="/blocks/$ref"
@@ -117,7 +117,7 @@ function RuntimeContent() {
                           "—"
                         )}
                       </td>
-                      <td className="px-3 py-2.5 font-mono text-[12px] text-ink-muted">
+                      <td className="px-3 py-2.5 font-mono mg-type-caption text-ink-muted">
                         {row.observed_at ? <TimeAgo at={row.observed_at} /> : "—"}
                       </td>
                     </tr>

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -281,7 +281,7 @@ function ContractsList() {
               <div className="min-w-0">
                 <div className="font-display text-sm font-semibold text-ink-strong">{c.id}</div>
                 {c.description ? (
-                  <div className="font-mono text-[10px] text-ink-muted mt-0.5">{c.description}</div>
+                  <div className="mg-type-data-sm text-ink-muted mt-0.5">{c.description}</div>
                 ) : null}
               </div>
               <FileCode className="size-4 text-ink-muted shrink-0" />
@@ -442,12 +442,12 @@ function SchemaExplorer() {
                           {s.name ?? s.id}
                         </span>
                         {s.netuid != null ? (
-                          <span className="ml-auto font-mono text-[10px] text-ink-muted shrink-0">
+                          <span className="ml-auto mg-type-data-sm text-ink-muted shrink-0">
                             SN{s.netuid}
                           </span>
                         ) : null}
                       </div>
-                      <div className="font-mono text-[10px] text-ink-muted truncate mt-1">
+                      <div className="mg-type-data-sm text-ink-muted truncate mt-1">
                         {s.url ?? s.id}
                       </div>
                     </button>
@@ -522,13 +522,13 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
                 <Link
                   to="/subnets/$netuid"
                   params={{ netuid: schema.netuid }}
-                  className="font-mono text-[10px] text-accent hover:underline"
+                  className="mg-type-data-sm text-accent hover:underline"
                 >
                   SN{schema.netuid}
                 </Link>
               ) : null}
             </div>
-            <div className="font-mono text-[11px] text-ink-muted mt-1.5">
+            <div className="mg-type-data text-ink-muted mt-1.5">
               snapshot <TimeAgo at={schema.updated_at} />
             </div>
           </div>

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -319,7 +319,7 @@ function Verdict() {
           />
           <div className="min-w-0 flex-1">
             <div className="mg-label mb-1">Status mix</div>
-            <div className="mb-1 font-mono text-[11px] tabular-nums text-ink-muted">
+            <div className="mb-1 mg-type-data tabular-nums text-ink-muted">
               {ok} of {total} healthy
             </div>
             <DonutLegend segments={segs} />
@@ -405,7 +405,7 @@ function RecentIncidents() {
             {ongoingCount > 0 ? <>{ongoingCount} ongoing</> : "All clear"}
           </div>
         </div>
-        <div className="text-[11px] font-mono text-ink-muted">
+        <div className="mg-type-data text-ink-muted">
           <AnimatedNumber value={summary?.incident_count} /> sustained event
           {summary?.incident_count === 1 ? "" : "s"} · {window} · across {affected}{" "}
           {affected === 1 ? "surface" : "surfaces"}
@@ -480,7 +480,7 @@ function IncidentsFeedSubscribe() {
             return (
               <div key={suffix} className="flex flex-wrap items-center gap-2">
                 <span className="mg-label w-12 shrink-0">{label}</span>
-                <ExternalLink href={url} className="font-mono text-[11px] hover:text-ink-strong">
+                <ExternalLink href={url} className="mg-type-data hover:text-ink-strong">
                   {path}
                 </ExternalLink>
                 <CopyableCode value={url} label="copy" className="px-1.5 py-0.5" />
@@ -511,7 +511,9 @@ function SurfaceRow({ surface, ongoing }: { surface: GlobalIncidentSurface; ongo
         {ongoing ? "Ongoing" : "Resolved"}
       </span>
       <span className="mg-label shrink-0">SN{surface.netuid}</span>
-      <span className="font-mono text-[12px] text-ink-strong truncate">{surface.surface_id}</span>
+      <span className="font-mono mg-type-caption text-ink-strong truncate">
+        {surface.surface_id}
+      </span>
       <span className="ml-auto inline-flex items-center gap-3 mg-label shrink-0">
         <span className="text-ink-muted tabular-nums">
           {surface.incident_count} {surface.incident_count === 1 ? "event" : "events"}

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -703,9 +703,7 @@ function OverviewSummaryStrip({ netuid }: { netuid: number }) {
           visible while scrolling) in the tab-bar badges above, so they're not
           restated as StatTiles here — the strip keeps only the status/curation
           chips and the top-gap hint the badges don't cover (#5316). */}
-      {topGapHint ? (
-        <p className="font-mono text-[11px] text-ink-muted">Top gap: {topGapHint}</p>
-      ) : null}
+      {topGapHint ? <p className="mg-type-data text-ink-muted">Top gap: {topGapHint}</p> : null}
     </div>
   );
 }
@@ -763,7 +761,7 @@ function SubnetLineageSection({ netuid }: { netuid: number }) {
           <span className="font-mono text-xs text-ink-muted">#{counterpartNetuid}</span>
         </div>
         {matchedBy ? (
-          <span className="rounded-full border border-border px-2 py-0.5 text-[11px] font-mono text-ink-muted">
+          <span className="rounded-full border border-border px-2 py-0.5 mg-type-data text-ink-muted">
             matched by {matchedBy}
           </span>
         ) : null}
@@ -816,7 +814,7 @@ function IdentityHistoryList({ netuid }: { netuid: number }) {
                 <span className="ml-1.5 font-mono text-xs text-ink-muted">{entry.symbol}</span>
               ) : null}
             </span>
-            <span className="font-mono text-[11px] text-ink-muted">
+            <span className="mg-type-data text-ink-muted">
               {entry.observed_at ? <TimeAgo at={entry.observed_at} /> : "unknown time"}
               {entry.block_number != null ? ` · block #${formatNumber(entry.block_number)}` : ""}
             </span>
@@ -992,16 +990,16 @@ function StakeQuoteCalculator({ netuid }: { netuid: number }) {
       </div>
 
       {!hasValidAmount ? (
-        <p className="font-mono text-[11px] text-ink-muted">
+        <p className="mg-type-data text-ink-muted">
           Enter an amount to estimate slippage against the subnet's live pool reserves.
         </p>
       ) : result.isError ? (
-        <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+        <p className="inline-flex items-center gap-1.5 mg-type-data text-health-down">
           <AlertCircle className="size-3.5 shrink-0" aria-hidden />
           {result.error instanceof Error ? result.error.message : "Could not compute a quote."}
         </p>
       ) : result.isPending ? (
-        <p className="font-mono text-[11px] text-ink-muted">Calculating…</p>
+        <p className="mg-type-data text-ink-muted">Calculating…</p>
       ) : quote ? (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <StatTile
@@ -1267,7 +1265,7 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
                   replace: true,
                 })
               }
-              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 mg-type-data text-ink-muted hover:border-ink/30 hover:text-ink-strong"
             >
               Clear filter
             </button>
@@ -1298,7 +1296,7 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
           <tbody className="divide-y divide-border">
             {events.map((ev, i) => (
               <tr key={`${ev.block_number}-${ev.event_index}-${i}`} className="hover:bg-surface/40">
-                <td className="px-4 py-2.5 font-mono text-[12px] whitespace-nowrap">
+                <td className="px-4 py-2.5 font-mono mg-type-caption whitespace-nowrap">
                   {ev.block_number != null ? (
                     <Link
                       to="/blocks/$ref"
@@ -1314,7 +1312,7 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
                 <td className="px-4 py-2.5 whitespace-nowrap">
                   <EventKindCell kind={ev.event_kind} />
                 </td>
-                <td className="px-4 py-2.5 font-mono text-[11px] whitespace-nowrap">
+                <td className="px-4 py-2.5 mg-type-data whitespace-nowrap">
                   {ev.hotkey ? (
                     <Link
                       to="/accounts/$ss58"
@@ -1327,10 +1325,10 @@ function ActivityTableLoader({ netuid, kind }: { netuid: number; kind?: string }
                     "—"
                   )}
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink whitespace-nowrap">
+                <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink whitespace-nowrap">
                   {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
                 </td>
-                <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted whitespace-nowrap">
+                <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted whitespace-nowrap">
                   <TimeAgo at={ev.observed_at} />
                 </td>
               </tr>
@@ -1440,7 +1438,7 @@ function AgentReadinessCard({
             <span className="font-display text-2xl font-semibold tabular-nums text-ink-strong">
               {score != null ? score : "—"}
             </span>
-            <span className="font-mono text-[10px] text-ink-muted">/ 100</span>
+            <span className="mg-type-data-sm text-ink-muted">/ 100</span>
           </div>
         </div>
         {tier ? (
@@ -1460,7 +1458,7 @@ function AgentReadinessCard({
           <div className="mg-label mb-1.5">What's blocking buildability</div>
           <ul className="space-y-1.5">
             {blockers.map((b, i) => (
-              <li key={b.code ?? i} className="text-[12px] leading-relaxed text-ink">
+              <li key={b.code ?? i} className="mg-type-caption leading-relaxed text-ink">
                 <span className="font-medium text-ink-strong">{b.message ?? b.code}</span>
                 {b.next_action ? <span className="text-ink-muted"> — {b.next_action}</span> : null}
               </li>
@@ -1484,7 +1482,7 @@ function ServiceCard({ service }: { service: AgentCatalogService }) {
           {service.capability ?? service.surface_id ?? "Service"}
         </span>
         {service.provider ? (
-          <span className="font-mono text-[10px] text-ink-muted">{service.provider}</span>
+          <span className="mg-type-data-sm text-ink-muted">{service.provider}</span>
         ) : null}
         <span className="ml-auto inline-flex items-center gap-2">
           <span
@@ -1506,7 +1504,7 @@ function ServiceCard({ service }: { service: AgentCatalogService }) {
         </span>
       </div>
 
-      <div className="mt-2 flex flex-wrap items-center gap-3 font-mono text-[11px] text-ink-muted">
+      <div className="mt-2 flex flex-wrap items-center gap-3 mg-type-data text-ink-muted">
         {service.base_url ? (
           <CopyableCode label="url" value={service.base_url} className="max-w-full" />
         ) : null}
@@ -1697,7 +1695,7 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
           <span className="hidden shrink-0 mg-type-micro text-ink-muted sm:inline">
             Weight-setters · per-validator breakdown
           </span>
-          <span className="shrink-0 font-mono text-[10px] text-ink-muted whitespace-nowrap">
+          <span className="shrink-0 mg-type-data-sm text-ink-muted whitespace-nowrap">
             {formatNumber(d.setter_count)} validators · {windowLabel}
           </span>
         </div>
@@ -1716,16 +1714,16 @@ function WeightSettersLoader({ netuid }: { netuid: number }) {
             <tbody>
               {rows.map((setter, i) => (
                 <tr key={setter.uid ?? setter.hotkey ?? i} className="border-t border-border">
-                  <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink-muted">
+                  <td className="px-3 py-2.5 font-mono mg-type-caption tabular-nums text-ink-muted">
                     {i + 1}
                   </td>
-                  <td className="px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink-strong">
+                  <td className="px-3 py-2.5 font-mono mg-type-caption tabular-nums text-ink-strong">
                     {setter.uid != null ? `UID ${setter.uid}` : "validator"}
                   </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                  <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
                     {formatNumber(setter.weight_sets)}
                   </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                  <td className="px-3 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
                     {setter.share != null ? `${(setter.share * 100).toFixed(1)}%` : "0%"}
                   </td>
                 </tr>
@@ -1872,7 +1870,7 @@ function GapsList({ netuid }: { netuid: number }) {
             {missing.map((k) => (
               <span
                 key={k}
-                className="rounded border border-dashed border-ink-subtle bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+                className="rounded border border-dashed border-ink-subtle bg-paper px-1.5 py-0.5 mg-type-data-sm text-ink-muted"
               >
                 {k}
               </span>
@@ -1881,7 +1879,7 @@ function GapsList({ netuid }: { netuid: number }) {
         </div>
       ) : null}
       {notes.length > 0 ? (
-        <ul className="space-y-1 text-[12px] text-ink leading-relaxed">
+        <ul className="space-y-1 mg-type-caption text-ink leading-relaxed">
           {notes.map((n, i) => (
             <li key={i}>· {n}</li>
           ))}
@@ -2161,7 +2159,7 @@ function HyperparametersTable({ netuid }: { netuid: number }) {
   return (
     <div className="space-y-6">
       {res.data.captured_at ? (
-        <p className="font-mono text-[11px] text-ink-muted">
+        <p className="mg-type-data text-ink-muted">
           Captured <TimeAgo at={res.data.captured_at} />
           {res.data.block_number != null ? ` · block #${formatNumber(res.data.block_number)}` : ""}
         </p>
@@ -2186,7 +2184,9 @@ function HyperparamGroupsTable({ h }: { h: SubnetHyperparameters }) {
             {group.fields.map((field) => (
               <div key={field.key} className="px-4 py-2.5">
                 <div className="mg-type-micro text-[10px] text-ink-muted">{field.label}</div>
-                <div className="mt-1 font-mono text-[13px] text-ink-strong">{field.format(h)}</div>
+                <div className="mt-1 font-mono mg-type-caption-lg text-ink-strong">
+                  {field.format(h)}
+                </div>
               </div>
             ))}
           </div>
@@ -2249,7 +2249,7 @@ function HyperparamsHistoryList({ netuid }: { netuid: number }) {
                 />
                 {entry.observed_at ? <TimeAgo at={entry.observed_at} /> : "unknown time"}
               </span>
-              <span className="font-mono text-[11px] text-ink-muted">
+              <span className="mg-type-data text-ink-muted">
                 {entry.block_number != null ? `block #${formatNumber(entry.block_number)} · ` : ""}
                 {entry.hyperparams_hash.slice(0, 10)}
               </span>
@@ -2303,7 +2303,7 @@ function SurfacesList({ netuid }: { netuid: number }) {
         <div key={kind}>
           <div className="mb-1.5 flex items-center gap-2">
             <span className="mg-label">{kind}</span>
-            <span className="font-mono text-[10px] text-ink-muted">{items.length}</span>
+            <span className="mg-type-data-sm text-ink-muted">{items.length}</span>
           </div>
           <ul className="space-y-2">
             {items.map((s) => (
@@ -2318,7 +2318,7 @@ function SurfacesList({ netuid }: { netuid: number }) {
                         <Link
                           to="/providers/$slug"
                           params={{ slug: s.provider }}
-                          className="font-mono text-[10px] text-ink-muted hover:text-ink-strong"
+                          className="mg-type-data-sm text-ink-muted hover:text-ink-strong"
                         >
                           {s.provider}
                         </Link>
@@ -2335,7 +2335,7 @@ function SurfacesList({ netuid }: { netuid: number }) {
                       </ExternalLink>
                     ) : null}
                   </div>
-                  <span className="font-mono text-[10px] text-ink-muted shrink-0">
+                  <span className="mg-type-data-sm text-ink-muted shrink-0">
                     <TimeAgo at={s.updated_at} />
                   </span>
                 </div>
@@ -2376,11 +2376,9 @@ function CandidatesList({ netuid }: { netuid: number }) {
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">
                 <CandidateChip />
-                <span className="font-mono text-[10px] uppercase text-ink-muted">
-                  {c.kind ?? "lead"}
-                </span>
+                <span className="mg-type-data-sm uppercase text-ink-muted">{c.kind ?? "lead"}</span>
                 {(c as Record<string, unknown>).provider ? (
-                  <span className="font-mono text-[10px] text-ink-muted">
+                  <span className="mg-type-data-sm text-ink-muted">
                     via {(c as Record<string, unknown>).provider as string}
                   </span>
                 ) : null}
@@ -2394,7 +2392,7 @@ function CandidatesList({ netuid }: { netuid: number }) {
                 <p className="mt-1 text-xs text-ink-muted leading-relaxed">{c.notes}</p>
               ) : null}
             </div>
-            <span className="font-mono text-[10px] text-ink-muted shrink-0">
+            <span className="mg-type-data-sm text-ink-muted shrink-0">
               <TimeAgo at={c.discovered_at} />
             </span>
           </div>

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -979,7 +979,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                   size={32}
                 />
                 <div className="min-w-0">
-                  <div className="font-mono text-[11px] text-ink-muted">
+                  <div className="mg-type-data text-ink-muted">
                     #{String(s.netuid).padStart(3, "0")}
                     {s.symbol ? ` · ${s.symbol}` : ""}
                     {" · "}
@@ -992,7 +992,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
               </div>
               <HealthPill state={s.health} />
             </div>
-            <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
+            <div className="mt-2 flex items-center justify-between mg-type-data text-ink-muted">
               <span>{formatNumber(s.participants)} participants</span>
               <span>{s.surfaces_count ?? 0} surfaces</span>
               <span>
@@ -1017,7 +1017,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           const compact = density === "compact";
           const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
           const firstPad = compact ? "pl-3 pr-1 py-1.5" : "pl-4 pr-1 py-2.5";
-          const monoSize = compact ? "text-[11px]" : "text-[12px]";
+          const monoSize = compact ? "text-[11px]" : "mg-type-caption";
           return (
             <table className="w-full text-left text-sm">
               <thead>
@@ -1272,7 +1272,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                       </EntityHoverCard>
                     </td>
                     {columns.isVisible("symbol") ? (
-                      <td className={classNames(cellPad, "font-mono text-[11px] text-ink-muted")}>
+                      <td className={classNames(cellPad, "mg-type-data text-ink-muted")}>
                         {s.symbol ?? "—"}
                       </td>
                     ) : null}
@@ -1309,7 +1309,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                       <td
                         className={classNames(
                           cellPad,
-                          "text-right font-mono text-[11px] tabular-nums",
+                          "text-right mg-type-data tabular-nums",
                           // #3364: dim the cost only when registration is explicitly
                           // closed. `registration_allowed === undefined` (economics
                           // entry present but flag absent, or no entry at all) keeps
@@ -1333,12 +1333,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                       </td>
                     ) : null}
                     {columns.isVisible("emission") ? (
-                      <td
-                        className={classNames(
-                          cellPad,
-                          "text-right font-mono text-[11px] tabular-nums",
-                        )}
-                      >
+                      <td className={classNames(cellPad, "text-right mg-type-data tabular-nums")}>
                         <EmissionCell share={s.emission_share} />
                       </td>
                     ) : null}
@@ -1374,12 +1369,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
                       />
                     ) : null}
                     {columns.isVisible("updated") ? (
-                      <td
-                        className={classNames(
-                          cellPad,
-                          "text-right font-mono text-[11px] text-ink-muted",
-                        )}
-                      >
+                      <td className={classNames(cellPad, "text-right mg-type-data text-ink-muted")}>
                         <TimeAgo at={s.updated_at ?? s.freshness} />
                       </td>
                     ) : null}
@@ -1434,7 +1424,7 @@ function SubnetGrid({ rows }: { rows: Subnet[] }) {
           </div>
 
           {(s as { description?: string }).description ? (
-            <p className="text-[12px] text-ink-muted leading-relaxed line-clamp-2">
+            <p className="mg-type-caption text-ink-muted leading-relaxed line-clamp-2">
               {(s as { description?: string }).description}
             </p>
           ) : null}
@@ -1513,7 +1503,7 @@ function SubnetMatrix({ rows }: { rows: Subnet[] }) {
         <div className="mg-type-micro text-[10px] text-ink-muted">
           Health matrix · {rows.length} subnets
         </div>
-        <div className="flex items-center gap-3 text-[10px] font-mono text-ink-muted">
+        <div className="flex items-center gap-3 mg-type-data-sm text-ink-muted">
           <Legend color="bg-health-ok" label="ok" />
           <Legend color="bg-health-warn" label="warn" />
           <Legend color="bg-health-down" label="down" />
@@ -1532,7 +1522,7 @@ function SubnetMatrix({ rows }: { rows: Subnet[] }) {
               aria-label={`Subnet ${s.netuid}${s.name ? ` — ${s.name}` : ""}`}
               title={`#${s.netuid}${s.name ? ` · ${s.name}` : ""} · ${s.health ?? "unknown"}`}
               className={classNames(
-                "mg-pulse-cell flex aspect-square items-center justify-center rounded-sm font-mono text-[10px] font-medium transition-transform",
+                "mg-pulse-cell flex aspect-square items-center justify-center rounded-sm mg-type-data-sm font-medium transition-transform",
                 HEALTH_BG[s.health ?? "unknown"] ?? HEALTH_BG.unknown,
                 HEALTH_TEXT[s.health ?? "unknown"] ?? HEALTH_TEXT.unknown,
               )}
@@ -1595,7 +1585,7 @@ function ParticipantsCell({
         <span
           className={classNames(
             "font-mono tabular-nums text-ink",
-            compact ? "text-[11px]" : "text-[12px]",
+            compact ? "text-[11px]" : "mg-type-caption",
           )}
         >
           {formatNumber(value)}
@@ -1636,7 +1626,7 @@ function FinancialCell({
     <td
       className={classNames(
         compact ? "px-3 py-1.5" : "px-4 py-2.5",
-        "text-right font-mono text-[11px] tabular-nums text-ink",
+        "text-right mg-type-data tabular-nums text-ink",
       )}
     >
       <div>
@@ -1750,7 +1740,7 @@ function FinancialTrendCell({
       ref={cellRef}
       className={classNames(
         compact ? "px-3 py-1.5" : "px-4 py-2.5",
-        "text-right font-mono text-[11px] tabular-nums",
+        "text-right mg-type-data tabular-nums",
       )}
     >
       <div className="flex items-center justify-end gap-2">
@@ -1845,7 +1835,7 @@ function SurfacesCell({ subnet, density = "comfortable" }: { subnet: Subnet; den
         <span
           className={classNames(
             "font-mono tabular-nums text-ink w-6 text-right",
-            compact ? "text-[11px]" : "text-[12px]",
+            compact ? "text-[11px]" : "mg-type-caption",
           )}
         >
           {count || "—"}

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -488,7 +488,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
         <span className="font-medium text-ink-strong truncate">{s.name ?? "—"}</span>
       </div>
       {s.url ? (
-        <div className="mt-1 text-[12px] truncate">
+        <div className="mt-1 mg-type-caption truncate">
           <ExternalLink
             href={s.url}
             authRequired={s.auth_required}
@@ -498,7 +498,7 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
           </ExternalLink>
         </div>
       ) : null}
-      <div className="mt-2 flex items-center justify-between gap-2 text-[11px] font-mono text-ink-muted">
+      <div className="mt-2 flex items-center justify-between gap-2 mg-type-data text-ink-muted">
         <span className="inline-flex items-center gap-2 min-w-0">
           {renderSubnetCell(s.netuid)}
           <span aria-hidden>·</span>
@@ -598,14 +598,14 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
               <tbody className="divide-y divide-border">
                 {rows.map((s) => (
                   <tr key={s.id} className="mg-row-accent hover:bg-surface/40">
-                    <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
+                    <td className="px-3 py-2 mg-type-data text-ink-muted">
                       {renderSubnetCell(s.netuid)}
                     </td>
-                    <td className="px-3 py-2 font-mono text-[11px]">{s.kind ?? "—"}</td>
+                    <td className="px-3 py-2 mg-type-data">{s.kind ?? "—"}</td>
                     <td className="px-3 py-2 font-medium text-ink-strong">
                       <span className="truncate">{s.name ?? "—"}</span>
                     </td>
-                    <td className="px-3 py-2 text-[12px]">
+                    <td className="px-3 py-2 mg-type-caption">
                       {s.url ? (
                         <ExternalLink
                           href={s.url}
@@ -618,14 +618,14 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
                         "—"
                       )}
                     </td>
-                    <td className="px-3 py-2 text-[12px]">{renderProviderCell(s)}</td>
+                    <td className="px-3 py-2 mg-type-caption">{renderProviderCell(s)}</td>
                     <td className="px-3 py-2">
                       <div className="flex items-center gap-1.5">
                         <CurationChip level={s.curation_level} />
                         <ReviewChip state={s.review?.state} />
                       </div>
                     </td>
-                    <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
+                    <td className="px-3 py-2 text-right mg-type-data text-ink-muted">
                       <SparkLegend
                         metric="Surface verification"
                         source="/api/v1/surfaces"

--- a/apps/ui/src/routes/tools.ss58.tsx
+++ b/apps/ui/src/routes/tools.ss58.tsx
@@ -123,7 +123,7 @@ function Ss58ToolPage() {
               <dd className="text-health-ok">Valid</dd>
             </dl>
             {decoded.format !== DEFAULT_SS58_FORMAT ? (
-              <p className="mt-3 text-[13px] text-ink-muted">
+              <p className="mt-3 mg-type-caption-lg text-ink-muted">
                 This is a well-formed SS58 address, but its network prefix ({decoded.format}) is not
                 Bittensor&apos;s ({DEFAULT_SS58_FORMAT}) — it belongs to
                 {KNOWN_FORMATS[decoded.format]
@@ -136,7 +136,7 @@ function Ss58ToolPage() {
           </ResultCard>
         ) : null}
 
-        <Panel as="section" flush bodyClassName="text-[13px] leading-relaxed text-ink-muted">
+        <Panel as="section" flush bodyClassName="mg-type-caption-lg leading-relaxed text-ink-muted">
           <div className="p-4">
             <h2 className="mb-2 font-display text-sm font-semibold text-ink-strong">
               How this works
@@ -194,7 +194,7 @@ function ResultCard({
         />
         <h2 className="font-display text-sm font-semibold text-ink-strong">{title}</h2>
       </div>
-      <div className="mt-2.5 text-[13px] leading-relaxed text-ink-muted">{children}</div>
+      <div className="mt-2.5 mg-type-caption-lg leading-relaxed text-ink-muted">{children}</div>
     </div>
   );
 }

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -164,7 +164,7 @@ function SubnetPerformanceTable({
         <tbody className="divide-y divide-border">
           {sorted.map((s) => (
             <tr key={s.netuid} className="hover:bg-surface/40">
-              <td className="px-3 py-2 font-mono text-[11px]">
+              <td className="px-3 py-2 mg-type-data">
                 <Link
                   to="/subnets/$netuid"
                   params={{ netuid: s.netuid }}
@@ -177,19 +177,19 @@ function SubnetPerformanceTable({
                   SN{s.netuid}
                 </Link>
               </td>
-              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                 {s.uid}
               </td>
-              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-strong">
                 {taoCompact(s.stake_tao)}
               </td>
-              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink">
+              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink">
                 {taoCompact(s.emission_tao)}
               </td>
-              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink">
+              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink">
                 {scoreStr(s.dividends)}
               </td>
-              <td className="px-3 py-2 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+              <td className="px-3 py-2 text-right font-mono mg-type-caption tabular-nums text-ink-muted">
                 {scoreStr(s.validator_trust)}
               </td>
               <td className="px-3 py-2 text-center">
@@ -198,7 +198,7 @@ function SubnetPerformanceTable({
                     Yes
                   </span>
                 ) : (
-                  <span className="font-mono text-[10px] text-ink-subtle-text">—</span>
+                  <span className="mg-type-data-sm text-ink-subtle-text">—</span>
                 )}
               </td>
               <td className="px-3 py-2 text-right">
@@ -384,7 +384,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             <p className="text-sm font-medium text-ink-strong">
               This hotkey isn&apos;t a registered validator
             </p>
-            <p className="mt-1 max-w-2xl text-[13px] text-ink-muted">
+            <p className="mt-1 max-w-2xl mg-type-caption-lg text-ink-muted">
               The address is a valid ss58, but it has never been seen validating on any subnet —
               every figure below reads zero for that reason, not because the validator is idle. It
               may be mistyped, or a coldkey rather than a hotkey.

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -192,7 +192,7 @@ function ValidatorsTable({
       ) : null}
 
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="font-mono text-[11px] text-ink-muted">
+        <span className="mg-type-data text-ink-muted">
           {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]}
         </span>
         <DensityToggle value={density} onChange={onDensityChange} />

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1469,7 +1469,7 @@ function CopyableCode({
         title: value,
         "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
         className: classNames(
-          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
+          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left mg-type-data text-ink hover:border-ink/30 transition-colors",
           // Matches KeyChip's ring treatment -- this one is a bordered chip like
           // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
           // against the card behind it (#6371).
@@ -1778,7 +1778,7 @@ function FreshnessIndicator({
         !dotOnly ? /* @__PURE__ */ jsxRuntime.jsx(
           "span",
           {
-            className: "font-mono text-[10px] text-ink-muted",
+            className: "mg-type-data-sm text-ink-muted",
             suppressHydrationWarning: true,
             children: rel
           }
@@ -1848,7 +1848,7 @@ function Kbd({
     "kbd",
     {
       className: classNames(
-        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
+        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 mg-type-data-sm text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
         className
       ),
       children
@@ -1875,7 +1875,7 @@ function KeyChip({
             onClick: () => copy(value),
             "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
             className: classNames(
-              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
+              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left mg-type-data text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
               className
             ),
             children: [
@@ -1894,7 +1894,7 @@ function KeyChip({
           TooltipContent,
           {
             side: "top",
-            className: "max-w-[90vw] break-all font-mono text-[11px]",
+            className: "max-w-[90vw] break-all mg-type-data",
             children: [
               /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mr-1 mg-type-micro opacity-70", children: label }),
               value
@@ -2030,7 +2030,7 @@ function LoadMore({
       ] })
     ] });
   }
-  return /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 text-[11px] font-mono text-ink-muted", children: [
+  return /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 mg-type-data text-ink-muted", children: [
     /* @__PURE__ */ jsxRuntime.jsxs("span", { children: [
       shown,
       total != null ? ` of ${total}` : ""
@@ -2082,7 +2082,7 @@ function PageHero({
           /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-type-micro text-ink-muted", children: k.label }),
           /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
             /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
-            k.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
+            k.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-data text-ink-muted", children: k.hint }) : null
           ] }),
           k.chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
         ] }, k.label)) }) : null
@@ -2137,7 +2137,7 @@ function EntityHero({
                     "div",
                     {
                       className: classNames(
-                        "mg-fade-in font-mono text-[10px] uppercase text-ink-muted inline-flex items-center gap-2",
+                        "mg-fade-in mg-type-data-sm uppercase text-ink-muted inline-flex items-center gap-2",
                         display ? "tracking-[0.22em]" : "tracking-[0.2em] mb-2"
                       ),
                       children: [
@@ -2198,7 +2198,7 @@ function EntityHero({
                     children: s.value
                   }
                 ),
-                s.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: s.hint }) : null
+                s.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-data text-ink-muted", children: s.hint }) : null
               ] }),
               s.chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-2.5 -ml-0.5", children: s.chart }) : null
             ] }, s.label))
@@ -2574,11 +2574,11 @@ function TableState({
         /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mx-auto inline-flex size-10 items-center justify-center rounded-full border border-border bg-paper", children: /* @__PURE__ */ jsxRuntime.jsx(Icon, { className: classNames("size-4", iconCls) }) }),
         /* @__PURE__ */ jsxRuntime.jsx("h3", { className: "mt-4 font-display text-base font-semibold text-ink-strong tracking-tight", children: title }),
         description ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mx-auto mt-1.5 max-w-md text-sm text-ink-muted leading-relaxed", children: description }) : null,
-        variant === "stale" && generatedAt ? /* @__PURE__ */ jsxRuntime.jsxs("p", { className: "mt-3 font-mono text-[11px] text-ink-muted", children: [
+        variant === "stale" && generatedAt ? /* @__PURE__ */ jsxRuntime.jsxs("p", { className: "mt-3 mg-type-data text-ink-muted", children: [
           "Last verified ",
           /* @__PURE__ */ jsxRuntime.jsx(TimeAgo, { at: generatedAt })
         ] }) : null,
-        message ? /* @__PURE__ */ jsxRuntime.jsxs("p", { className: "mx-auto mt-3 max-w-md font-mono text-[11px] text-ink-muted", children: [
+        message ? /* @__PURE__ */ jsxRuntime.jsxs("p", { className: "mx-auto mt-3 max-w-md mg-type-data text-ink-muted", children: [
           status ? /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "text-health-down", children: [
             "HTTP ",
             status,
@@ -2592,7 +2592,7 @@ function TableState({
             {
               type: "button",
               onClick: onRetry,
-              className: "inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3.5 py-1.5 text-[12px] font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors",
+              className: "inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3.5 py-1.5 mg-type-caption font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors",
               children: [
                 /* @__PURE__ */ jsxRuntime.jsx(lucideReact.RefreshCw, { className: "size-3" }),
                 " Retry"
@@ -2604,7 +2604,7 @@ function TableState({
             {
               href: cta.href,
               ...cta.external ? { target: "_blank", rel: "noopener noreferrer" } : {},
-              className: "inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-3.5 py-1.5 text-[12px] font-medium text-paper hover:opacity-90 transition-opacity",
+              className: "inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-3.5 py-1.5 mg-type-caption font-medium text-paper hover:opacity-90 transition-opacity",
               children: [
                 cta.label,
                 cta.external ? /* @__PURE__ */ jsxRuntime.jsx(lucideReact.ExternalLink, { className: "size-3" }) : null
@@ -2617,7 +2617,7 @@ function TableState({
               href: url,
               target: "_blank",
               rel: "noopener noreferrer",
-              className: "inline-flex items-center gap-1.5 text-[11px] font-mono text-ink-muted hover:text-ink-strong",
+              className: "inline-flex items-center gap-1.5 mg-type-data text-ink-muted hover:text-ink-strong",
               children: [
                 "View API URL ",
                 /* @__PURE__ */ jsxRuntime.jsx(lucideReact.ExternalLink, { className: "size-3" })
@@ -2806,7 +2806,7 @@ function McpToolsList({
       "span",
       {
         title: t.title,
-        className: "inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted",
+        className: "inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 mg-type-data-sm text-ink-muted",
         children: t.name
       },
       t.name
@@ -2818,7 +2818,7 @@ function McpToolsList({
         onClick: () => setOpen((v) => !v),
         "aria-expanded": open,
         className: classNames(
-          "mt-2 inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted",
+          "mt-2 inline-flex items-center gap-1 mg-type-data-sm text-ink-muted",
           "hover:text-accent transition-colors"
         ),
         children: open ? /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
@@ -2848,7 +2848,7 @@ function fmtYield(v) {
 // src/components/metagraphed/yield-percentile-layout.ts
 var YIELD_PERCENTILE_STRIP_CONTAINER_CLASS = "@container rounded-xl border border-border bg-card p-4";
 var YIELD_PERCENTILE_STRIP_GRID_CLASS = "grid grid-cols-2 gap-3 @min-[28rem]:grid-cols-4";
-var YIELD_PERCENTILE_LABEL_CLASS = "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+var YIELD_PERCENTILE_LABEL_CLASS = "mg-type-data-sm uppercase tracking-[0.18em] text-ink-muted";
 var YIELD_PERCENTILE_VALUE_CLASS = "mt-1 min-w-0 truncate font-display text-sm font-semibold tabular-nums text-ink-strong leading-none @min-[20rem]:text-base @min-[28rem]:text-lg";
 var PERCENTILE_LABELS = {
   p25: "p25",
@@ -2970,7 +2970,7 @@ function MethodologyCallout({
                 freshLine ? /* @__PURE__ */ jsxRuntime.jsx(
                   "span",
                   {
-                    className: "mt-0.5 block font-mono text-[10px] text-ink-muted/80",
+                    className: "mt-0.5 block mg-type-data-sm text-ink-muted/80",
                     title: freshAbs ?? void 0,
                     children: freshLine
                   }
@@ -3073,7 +3073,7 @@ function BarMini({
                   }
                 }
               ) }),
-              showValue ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-mono text-[10px] tabular-nums text-ink-strong", children: formatValue ? formatValue(d.value) : d.value }) : null
+              showValue ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-data-sm tabular-nums text-ink-strong", children: formatValue ? formatValue(d.value) : d.value }) : null
             ]
           },
           d.label
@@ -3251,7 +3251,7 @@ function CandlestickMini({
         hoverBar && tooltipText ? /* @__PURE__ */ jsxRuntime.jsx(
           "div",
           {
-            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
               left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
               top: Math.max(0, hoverBar.wickTop - 4)
@@ -3419,7 +3419,7 @@ function SparkLegend({
               /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-micro opacity-70", children: "staleness \xB7 " }),
               staleness
             ] }) : null,
-            fresh || freshAbs ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 font-mono text-[10px] opacity-80", children: [
+            fresh || freshAbs ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 mg-type-data-sm opacity-80", children: [
               fresh ?? "",
               freshAbs ? `${fresh ? " \xB7 " : ""}last checked ${freshAbs}` : ""
             ] }) : null
@@ -3578,7 +3578,7 @@ function Sparkline({
         hoverPoint && tooltipText ? /* @__PURE__ */ jsxRuntime.jsx(
           "div",
           {
-            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
               left: Math.max(24, Math.min(width - 24, hoverPoint[0])),
               top: hoverPoint[1] - 4
@@ -3644,7 +3644,7 @@ function StatTile({
                   "span",
                   {
                     className: classNames(
-                      "min-w-0 font-mono text-[10px] text-ink-muted",
+                      "min-w-0 mg-type-data-sm text-ink-muted",
                       truncate ? "truncate" : ""
                     ),
                     children: hint
@@ -3717,7 +3717,7 @@ function StatWithSpark({
           className: "max-w-xs text-[11px] leading-relaxed",
           children: [
             /* @__PURE__ */ jsxRuntime.jsx("div", { children: full ?? hint ?? label }),
-            freshAbs || windowLabel ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 font-mono text-[10px] text-primary-foreground/70", children: [
+            freshAbs || windowLabel ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 mg-type-data-sm text-primary-foreground/70", children: [
               freshAbs ? `Last checked ${freshAbs}` : null,
               freshAbs && windowLabel ? " \xB7 " : "",
               windowLabel ? `${windowLabel} window` : null
@@ -3836,7 +3836,7 @@ function DotRow({
               )
             }
           ) }),
-          /* @__PURE__ */ jsxRuntime.jsxs(TooltipContent, { side: "top", className: "font-mono text-[10px]", children: [
+          /* @__PURE__ */ jsxRuntime.jsxs(TooltipContent, { side: "top", className: "mg-type-data-sm", children: [
             d.label,
             " ",
             d.on ? "\u2713" : "\u2014"
@@ -3991,7 +3991,7 @@ function TreemapMini({
               className: "flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5",
               style: { background: t.color ?? "var(--accent)" },
               children: t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
-                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate font-mono text-[10px] font-medium leading-none text-accent-foreground", children: t.label }),
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate mg-type-data-sm font-medium leading-none text-accent-foreground", children: t.label }),
                 t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate font-mono text-[9px] leading-none text-accent-foreground/80", children: formatValue(t.value) }) : null
               ] }) : null
             }
@@ -4029,7 +4029,7 @@ function Chip({
       onClick,
       className: classNames(
         "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5",
-        "font-mono text-[10px] leading-none whitespace-nowrap transition-colors",
+        "mg-type-data-sm leading-none whitespace-nowrap transition-colors",
         onClick ? "mg-focus-ring hover:border-ink/30 cursor-pointer" : null,
         TONE_CLASSES[tone],
         className
@@ -4119,7 +4119,7 @@ function Indicator({
             ]
           }
         ),
-        /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "font-mono text-[11px] tabular-nums text-ink-strong truncate", children: [
+        /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "mg-type-data tabular-nums text-ink-strong truncate", children: [
           value,
           hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "ml-1 text-ink-muted normal-case", children: hint }) : null
         ] })
@@ -4154,7 +4154,7 @@ function FilterField({
     }
   );
 }
-var CONTROL_CLASSES = "h-9 min-w-0 w-full rounded border border-border bg-card px-2.5 text-[12px] text-ink-strong placeholder:text-ink-subtle-text mg-focus-ring hover:border-ink/25 transition-colors";
+var CONTROL_CLASSES = "h-9 min-w-0 w-full rounded border border-border bg-card px-2.5 mg-type-caption text-ink-strong placeholder:text-ink-subtle-text mg-focus-ring hover:border-ink/25 transition-colors";
 function FilterInput({
   className,
   leadingIcon = true,
@@ -4266,7 +4266,7 @@ function ColumnCustomizer({
                 {
                   type: "button",
                   onClick: onReset,
-                  className: "mg-focus-ring inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted hover:text-ink-strong",
+                  className: "mg-focus-ring inline-flex items-center gap-1 mg-type-data-sm text-ink-muted hover:text-ink-strong",
                   title: "Reset to defaults",
                   children: [
                     /* @__PURE__ */ jsxRuntime.jsx(lucideReact.RotateCcw, { className: "size-3", "aria-hidden": true }),
@@ -4281,7 +4281,7 @@ function ColumnCustomizer({
                 "label",
                 {
                   className: classNames(
-                    "flex items-center gap-2 rounded px-2 py-1.5 text-[12px] text-ink hover:bg-surface-2 cursor-pointer",
+                    "flex items-center gap-2 rounded px-2 py-1.5 mg-type-caption text-ink hover:bg-surface-2 cursor-pointer",
                     c.required ? "opacity-60 cursor-not-allowed" : null
                   ),
                   children: [
@@ -4454,7 +4454,7 @@ function Panel({
             children: [
               /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0", children: [
                 title != null ? /* @__PURE__ */ jsxRuntime.jsx(SectionLabel, { children: title }) : null,
-                caption != null ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1 text-[13px] text-ink-muted", children: caption }) : null
+                caption != null ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1 mg-type-caption-lg text-ink-muted", children: caption }) : null
               ] }),
               action != null ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "shrink-0 flex items-center gap-2", children: action }) : null
             ]
@@ -4513,7 +4513,7 @@ function EmptyState({
         ),
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "max-w-sm space-y-1", children: [
           /* @__PURE__ */ jsxRuntime.jsx("p", { className: "font-display text-[15px] font-medium text-ink-strong", children: title }),
-          hint != null ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "text-[13px] leading-relaxed text-ink-muted", children: hint }) : null
+          hint != null ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mg-type-caption-lg leading-relaxed text-ink-muted", children: hint }) : null
         ] }),
         action != null || evidenceHref ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex flex-wrap items-center justify-center gap-2 pt-1", children: [
           action,
@@ -4741,7 +4741,7 @@ function TabStrip({
     if (it && !it.disabled) onChange(it.id);
   });
   const pad = size === "sm" ? "px-2 py-1.5" : "px-3 py-2";
-  const text = size === "sm" ? "text-[12px]" : "text-[13px]";
+  const text = size === "sm" ? "mg-type-caption" : "mg-type-caption-lg";
   return /* @__PURE__ */ jsxRuntime.jsx(
     "div",
     {
@@ -4935,7 +4935,7 @@ function PagerFooter({
     "div",
     {
       className: cn(
-        "flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-3 text-[12px] text-ink-muted",
+        "flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-3 mg-type-caption text-ink-muted",
         className
       ),
       children: [
@@ -4976,7 +4976,7 @@ function MetaStrip({
     "div",
     {
       className: cn(
-        "flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-ink-muted",
+        "flex flex-wrap items-center gap-x-2 gap-y-1 mg-type-caption text-ink-muted",
         className
       ),
       children: items.map((it, i) => /* @__PURE__ */ jsxRuntime.jsxs(
@@ -5323,7 +5323,7 @@ function MobileCollapse({
         children: [
           /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "flex min-w-0 flex-1 flex-col", children: [
             /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-micro text-ink-strong", children: label }),
-            hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mt-0.5 truncate font-mono text-[11px] text-ink-muted", children: hint }) : null
+            hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mt-0.5 truncate mg-type-data text-ink-muted", children: hint }) : null
           ] }),
           /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "flex shrink-0 items-center gap-2", children: [
             trailing,
@@ -5367,7 +5367,7 @@ function ReadinessGauge({
   className
 }) {
   if (score == null && !tier) {
-    return /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: "\u2014" });
+    return /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-data text-ink-muted", children: "\u2014" });
   }
   const value = Math.max(0, Math.min(100, score ?? 0));
   const label = tierLabels[tier ?? ""] ?? tier ?? "Not classified";
@@ -5400,7 +5400,7 @@ function ReadinessGauge({
             )
           }
         ),
-        /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-right font-mono text-[11px] tabular-nums text-ink-strong", children: value })
+        /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-right mg-type-data tabular-nums text-ink-strong", children: value })
       ]
     }
   );
@@ -5547,7 +5547,7 @@ function QueryBarSearch({
         "aria-label": placeholder,
         className: classNames(
           "peer flex-1 min-w-0 bg-transparent border-0 outline-none",
-          "py-1.5 text-[13px] text-ink-strong placeholder:text-ink-subtle-text",
+          "py-1.5 mg-type-caption-lg text-ink-strong placeholder:text-ink-subtle-text",
           "focus:outline-none focus:ring-0",
           className
         )
@@ -5570,7 +5570,7 @@ function QueryBarSearch({
       "kbd",
       {
         "aria-hidden": true,
-        className: "pointer-events-none hidden sm:inline-flex items-center rounded border border-border/70 bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ink-muted",
+        className: "pointer-events-none hidden sm:inline-flex items-center rounded border border-border/70 bg-paper px-1.5 py-0.5 mg-type-data-sm text-ink-muted",
         children: "/"
       }
     ) : null
@@ -5649,7 +5649,7 @@ function QueryBarFilterTrigger(props) {
         "aria-label": `${label} filter${active ? `, ${selected.length} selected` : ""}`,
         className: classNames(
           "mg-ghost-trigger group inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2",
-          "text-[12px] transition-colors",
+          "mg-type-caption transition-colors",
           "hover:bg-surface-2",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           active ? "text-ink-strong" : "text-ink-muted",
@@ -5891,8 +5891,8 @@ function PanelError({
       children: [
         /* @__PURE__ */ jsxRuntime.jsx("div", { className: "grid size-9 place-items-center rounded-full bg-surface-2 text-health-warn", children: /* @__PURE__ */ jsxRuntime.jsx(lucideReact.AlertTriangle, { className: "size-4", "aria-hidden": true }) }),
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "max-w-sm space-y-1", children: [
-          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-display text-[13px] font-semibold text-ink-strong", children: title }),
-          /* @__PURE__ */ jsxRuntime.jsx("p", { className: "text-[12px] leading-relaxed text-ink-muted", children: message })
+          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-display mg-type-caption-lg font-semibold text-ink-strong", children: title }),
+          /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mg-type-caption leading-relaxed text-ink-muted", children: message })
         ] }),
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex flex-wrap items-center justify-center gap-2 pt-1", children: [
           onRetry ? /* @__PURE__ */ jsxRuntime.jsx(

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1440,7 +1440,7 @@ function CopyableCode({
         title: value,
         "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
         className: classNames(
-          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
+          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left mg-type-data text-ink hover:border-ink/30 transition-colors",
           // Matches KeyChip's ring treatment -- this one is a bordered chip like
           // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
           // against the card behind it (#6371).
@@ -1749,7 +1749,7 @@ function FreshnessIndicator({
         !dotOnly ? /* @__PURE__ */ jsx(
           "span",
           {
-            className: "font-mono text-[10px] text-ink-muted",
+            className: "mg-type-data-sm text-ink-muted",
             suppressHydrationWarning: true,
             children: rel
           }
@@ -1819,7 +1819,7 @@ function Kbd({
     "kbd",
     {
       className: classNames(
-        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
+        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 mg-type-data-sm text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
         className
       ),
       children
@@ -1846,7 +1846,7 @@ function KeyChip({
             onClick: () => copy(value),
             "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
             className: classNames(
-              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
+              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left mg-type-data text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
               className
             ),
             children: [
@@ -1865,7 +1865,7 @@ function KeyChip({
           TooltipContent,
           {
             side: "top",
-            className: "max-w-[90vw] break-all font-mono text-[11px]",
+            className: "max-w-[90vw] break-all mg-type-data",
             children: [
               /* @__PURE__ */ jsx("span", { className: "mr-1 mg-type-micro opacity-70", children: label }),
               value
@@ -2001,7 +2001,7 @@ function LoadMore({
       ] })
     ] });
   }
-  return /* @__PURE__ */ jsxs("div", { className: "flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 text-[11px] font-mono text-ink-muted", children: [
+  return /* @__PURE__ */ jsxs("div", { className: "flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 mg-type-data text-ink-muted", children: [
     /* @__PURE__ */ jsxs("span", { children: [
       shown,
       total != null ? ` of ${total}` : ""
@@ -2053,7 +2053,7 @@ function PageHero({
           /* @__PURE__ */ jsx("div", { className: "mg-type-micro text-ink-muted", children: k.label }),
           /* @__PURE__ */ jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
             /* @__PURE__ */ jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
-            k.hint ? /* @__PURE__ */ jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
+            k.hint ? /* @__PURE__ */ jsx("span", { className: "mg-type-data text-ink-muted", children: k.hint }) : null
           ] }),
           k.chart ? /* @__PURE__ */ jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
         ] }, k.label)) }) : null
@@ -2108,7 +2108,7 @@ function EntityHero({
                     "div",
                     {
                       className: classNames(
-                        "mg-fade-in font-mono text-[10px] uppercase text-ink-muted inline-flex items-center gap-2",
+                        "mg-fade-in mg-type-data-sm uppercase text-ink-muted inline-flex items-center gap-2",
                         display ? "tracking-[0.22em]" : "tracking-[0.2em] mb-2"
                       ),
                       children: [
@@ -2169,7 +2169,7 @@ function EntityHero({
                     children: s.value
                   }
                 ),
-                s.hint ? /* @__PURE__ */ jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: s.hint }) : null
+                s.hint ? /* @__PURE__ */ jsx("span", { className: "mg-type-data text-ink-muted", children: s.hint }) : null
               ] }),
               s.chart ? /* @__PURE__ */ jsx("div", { className: "mt-2.5 -ml-0.5", children: s.chart }) : null
             ] }, s.label))
@@ -2545,11 +2545,11 @@ function TableState({
         /* @__PURE__ */ jsx("div", { className: "mx-auto inline-flex size-10 items-center justify-center rounded-full border border-border bg-paper", children: /* @__PURE__ */ jsx(Icon, { className: classNames("size-4", iconCls) }) }),
         /* @__PURE__ */ jsx("h3", { className: "mt-4 font-display text-base font-semibold text-ink-strong tracking-tight", children: title }),
         description ? /* @__PURE__ */ jsx("p", { className: "mx-auto mt-1.5 max-w-md text-sm text-ink-muted leading-relaxed", children: description }) : null,
-        variant === "stale" && generatedAt ? /* @__PURE__ */ jsxs("p", { className: "mt-3 font-mono text-[11px] text-ink-muted", children: [
+        variant === "stale" && generatedAt ? /* @__PURE__ */ jsxs("p", { className: "mt-3 mg-type-data text-ink-muted", children: [
           "Last verified ",
           /* @__PURE__ */ jsx(TimeAgo, { at: generatedAt })
         ] }) : null,
-        message ? /* @__PURE__ */ jsxs("p", { className: "mx-auto mt-3 max-w-md font-mono text-[11px] text-ink-muted", children: [
+        message ? /* @__PURE__ */ jsxs("p", { className: "mx-auto mt-3 max-w-md mg-type-data text-ink-muted", children: [
           status ? /* @__PURE__ */ jsxs("span", { className: "text-health-down", children: [
             "HTTP ",
             status,
@@ -2563,7 +2563,7 @@ function TableState({
             {
               type: "button",
               onClick: onRetry,
-              className: "inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3.5 py-1.5 text-[12px] font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors",
+              className: "inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3.5 py-1.5 mg-type-caption font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors",
               children: [
                 /* @__PURE__ */ jsx(RefreshCw, { className: "size-3" }),
                 " Retry"
@@ -2575,7 +2575,7 @@ function TableState({
             {
               href: cta.href,
               ...cta.external ? { target: "_blank", rel: "noopener noreferrer" } : {},
-              className: "inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-3.5 py-1.5 text-[12px] font-medium text-paper hover:opacity-90 transition-opacity",
+              className: "inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-3.5 py-1.5 mg-type-caption font-medium text-paper hover:opacity-90 transition-opacity",
               children: [
                 cta.label,
                 cta.external ? /* @__PURE__ */ jsx(ExternalLink$1, { className: "size-3" }) : null
@@ -2588,7 +2588,7 @@ function TableState({
               href: url,
               target: "_blank",
               rel: "noopener noreferrer",
-              className: "inline-flex items-center gap-1.5 text-[11px] font-mono text-ink-muted hover:text-ink-strong",
+              className: "inline-flex items-center gap-1.5 mg-type-data text-ink-muted hover:text-ink-strong",
               children: [
                 "View API URL ",
                 /* @__PURE__ */ jsx(ExternalLink$1, { className: "size-3" })
@@ -2777,7 +2777,7 @@ function McpToolsList({
       "span",
       {
         title: t.title,
-        className: "inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted",
+        className: "inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 mg-type-data-sm text-ink-muted",
         children: t.name
       },
       t.name
@@ -2789,7 +2789,7 @@ function McpToolsList({
         onClick: () => setOpen((v) => !v),
         "aria-expanded": open,
         className: classNames(
-          "mt-2 inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted",
+          "mt-2 inline-flex items-center gap-1 mg-type-data-sm text-ink-muted",
           "hover:text-accent transition-colors"
         ),
         children: open ? /* @__PURE__ */ jsxs(Fragment, { children: [
@@ -2819,7 +2819,7 @@ function fmtYield(v) {
 // src/components/metagraphed/yield-percentile-layout.ts
 var YIELD_PERCENTILE_STRIP_CONTAINER_CLASS = "@container rounded-xl border border-border bg-card p-4";
 var YIELD_PERCENTILE_STRIP_GRID_CLASS = "grid grid-cols-2 gap-3 @min-[28rem]:grid-cols-4";
-var YIELD_PERCENTILE_LABEL_CLASS = "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+var YIELD_PERCENTILE_LABEL_CLASS = "mg-type-data-sm uppercase tracking-[0.18em] text-ink-muted";
 var YIELD_PERCENTILE_VALUE_CLASS = "mt-1 min-w-0 truncate font-display text-sm font-semibold tabular-nums text-ink-strong leading-none @min-[20rem]:text-base @min-[28rem]:text-lg";
 var PERCENTILE_LABELS = {
   p25: "p25",
@@ -2941,7 +2941,7 @@ function MethodologyCallout({
                 freshLine ? /* @__PURE__ */ jsx(
                   "span",
                   {
-                    className: "mt-0.5 block font-mono text-[10px] text-ink-muted/80",
+                    className: "mt-0.5 block mg-type-data-sm text-ink-muted/80",
                     title: freshAbs ?? void 0,
                     children: freshLine
                   }
@@ -3044,7 +3044,7 @@ function BarMini({
                   }
                 }
               ) }),
-              showValue ? /* @__PURE__ */ jsx("span", { className: "font-mono text-[10px] tabular-nums text-ink-strong", children: formatValue ? formatValue(d.value) : d.value }) : null
+              showValue ? /* @__PURE__ */ jsx("span", { className: "mg-type-data-sm tabular-nums text-ink-strong", children: formatValue ? formatValue(d.value) : d.value }) : null
             ]
           },
           d.label
@@ -3222,7 +3222,7 @@ function CandlestickMini({
         hoverBar && tooltipText ? /* @__PURE__ */ jsx(
           "div",
           {
-            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
               left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
               top: Math.max(0, hoverBar.wickTop - 4)
@@ -3390,7 +3390,7 @@ function SparkLegend({
               /* @__PURE__ */ jsx("span", { className: "mg-type-micro opacity-70", children: "staleness \xB7 " }),
               staleness
             ] }) : null,
-            fresh || freshAbs ? /* @__PURE__ */ jsxs("div", { className: "mt-1 font-mono text-[10px] opacity-80", children: [
+            fresh || freshAbs ? /* @__PURE__ */ jsxs("div", { className: "mt-1 mg-type-data-sm opacity-80", children: [
               fresh ?? "",
               freshAbs ? `${fresh ? " \xB7 " : ""}last checked ${freshAbs}` : ""
             ] }) : null
@@ -3549,7 +3549,7 @@ function Sparkline({
         hoverPoint && tooltipText ? /* @__PURE__ */ jsx(
           "div",
           {
-            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            className: "pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap",
             style: {
               left: Math.max(24, Math.min(width - 24, hoverPoint[0])),
               top: hoverPoint[1] - 4
@@ -3615,7 +3615,7 @@ function StatTile({
                   "span",
                   {
                     className: classNames(
-                      "min-w-0 font-mono text-[10px] text-ink-muted",
+                      "min-w-0 mg-type-data-sm text-ink-muted",
                       truncate ? "truncate" : ""
                     ),
                     children: hint
@@ -3688,7 +3688,7 @@ function StatWithSpark({
           className: "max-w-xs text-[11px] leading-relaxed",
           children: [
             /* @__PURE__ */ jsx("div", { children: full ?? hint ?? label }),
-            freshAbs || windowLabel ? /* @__PURE__ */ jsxs("div", { className: "mt-1 font-mono text-[10px] text-primary-foreground/70", children: [
+            freshAbs || windowLabel ? /* @__PURE__ */ jsxs("div", { className: "mt-1 mg-type-data-sm text-primary-foreground/70", children: [
               freshAbs ? `Last checked ${freshAbs}` : null,
               freshAbs && windowLabel ? " \xB7 " : "",
               windowLabel ? `${windowLabel} window` : null
@@ -3807,7 +3807,7 @@ function DotRow({
               )
             }
           ) }),
-          /* @__PURE__ */ jsxs(TooltipContent, { side: "top", className: "font-mono text-[10px]", children: [
+          /* @__PURE__ */ jsxs(TooltipContent, { side: "top", className: "mg-type-data-sm", children: [
             d.label,
             " ",
             d.on ? "\u2713" : "\u2014"
@@ -3962,7 +3962,7 @@ function TreemapMini({
               className: "flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5",
               style: { background: t.color ?? "var(--accent)" },
               children: t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? /* @__PURE__ */ jsxs(Fragment, { children: [
-                /* @__PURE__ */ jsx("span", { className: "truncate font-mono text-[10px] font-medium leading-none text-accent-foreground", children: t.label }),
+                /* @__PURE__ */ jsx("span", { className: "truncate mg-type-data-sm font-medium leading-none text-accent-foreground", children: t.label }),
                 t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? /* @__PURE__ */ jsx("span", { className: "truncate font-mono text-[9px] leading-none text-accent-foreground/80", children: formatValue(t.value) }) : null
               ] }) : null
             }
@@ -4000,7 +4000,7 @@ function Chip({
       onClick,
       className: classNames(
         "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5",
-        "font-mono text-[10px] leading-none whitespace-nowrap transition-colors",
+        "mg-type-data-sm leading-none whitespace-nowrap transition-colors",
         onClick ? "mg-focus-ring hover:border-ink/30 cursor-pointer" : null,
         TONE_CLASSES[tone],
         className
@@ -4090,7 +4090,7 @@ function Indicator({
             ]
           }
         ),
-        /* @__PURE__ */ jsxs("span", { className: "font-mono text-[11px] tabular-nums text-ink-strong truncate", children: [
+        /* @__PURE__ */ jsxs("span", { className: "mg-type-data tabular-nums text-ink-strong truncate", children: [
           value,
           hint ? /* @__PURE__ */ jsx("span", { className: "ml-1 text-ink-muted normal-case", children: hint }) : null
         ] })
@@ -4125,7 +4125,7 @@ function FilterField({
     }
   );
 }
-var CONTROL_CLASSES = "h-9 min-w-0 w-full rounded border border-border bg-card px-2.5 text-[12px] text-ink-strong placeholder:text-ink-subtle-text mg-focus-ring hover:border-ink/25 transition-colors";
+var CONTROL_CLASSES = "h-9 min-w-0 w-full rounded border border-border bg-card px-2.5 mg-type-caption text-ink-strong placeholder:text-ink-subtle-text mg-focus-ring hover:border-ink/25 transition-colors";
 function FilterInput({
   className,
   leadingIcon = true,
@@ -4237,7 +4237,7 @@ function ColumnCustomizer({
                 {
                   type: "button",
                   onClick: onReset,
-                  className: "mg-focus-ring inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted hover:text-ink-strong",
+                  className: "mg-focus-ring inline-flex items-center gap-1 mg-type-data-sm text-ink-muted hover:text-ink-strong",
                   title: "Reset to defaults",
                   children: [
                     /* @__PURE__ */ jsx(RotateCcw, { className: "size-3", "aria-hidden": true }),
@@ -4252,7 +4252,7 @@ function ColumnCustomizer({
                 "label",
                 {
                   className: classNames(
-                    "flex items-center gap-2 rounded px-2 py-1.5 text-[12px] text-ink hover:bg-surface-2 cursor-pointer",
+                    "flex items-center gap-2 rounded px-2 py-1.5 mg-type-caption text-ink hover:bg-surface-2 cursor-pointer",
                     c.required ? "opacity-60 cursor-not-allowed" : null
                   ),
                   children: [
@@ -4425,7 +4425,7 @@ function Panel({
             children: [
               /* @__PURE__ */ jsxs("div", { className: "min-w-0", children: [
                 title != null ? /* @__PURE__ */ jsx(SectionLabel, { children: title }) : null,
-                caption != null ? /* @__PURE__ */ jsx("p", { className: "mt-1 text-[13px] text-ink-muted", children: caption }) : null
+                caption != null ? /* @__PURE__ */ jsx("p", { className: "mt-1 mg-type-caption-lg text-ink-muted", children: caption }) : null
               ] }),
               action != null ? /* @__PURE__ */ jsx("div", { className: "shrink-0 flex items-center gap-2", children: action }) : null
             ]
@@ -4484,7 +4484,7 @@ function EmptyState({
         ),
         /* @__PURE__ */ jsxs("div", { className: "max-w-sm space-y-1", children: [
           /* @__PURE__ */ jsx("p", { className: "font-display text-[15px] font-medium text-ink-strong", children: title }),
-          hint != null ? /* @__PURE__ */ jsx("p", { className: "text-[13px] leading-relaxed text-ink-muted", children: hint }) : null
+          hint != null ? /* @__PURE__ */ jsx("p", { className: "mg-type-caption-lg leading-relaxed text-ink-muted", children: hint }) : null
         ] }),
         action != null || evidenceHref ? /* @__PURE__ */ jsxs("div", { className: "flex flex-wrap items-center justify-center gap-2 pt-1", children: [
           action,
@@ -4712,7 +4712,7 @@ function TabStrip({
     if (it && !it.disabled) onChange(it.id);
   });
   const pad = size === "sm" ? "px-2 py-1.5" : "px-3 py-2";
-  const text = size === "sm" ? "text-[12px]" : "text-[13px]";
+  const text = size === "sm" ? "mg-type-caption" : "mg-type-caption-lg";
   return /* @__PURE__ */ jsx(
     "div",
     {
@@ -4906,7 +4906,7 @@ function PagerFooter({
     "div",
     {
       className: cn(
-        "flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-3 text-[12px] text-ink-muted",
+        "flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-3 mg-type-caption text-ink-muted",
         className
       ),
       children: [
@@ -4947,7 +4947,7 @@ function MetaStrip({
     "div",
     {
       className: cn(
-        "flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-ink-muted",
+        "flex flex-wrap items-center gap-x-2 gap-y-1 mg-type-caption text-ink-muted",
         className
       ),
       children: items.map((it, i) => /* @__PURE__ */ jsxs(
@@ -5294,7 +5294,7 @@ function MobileCollapse({
         children: [
           /* @__PURE__ */ jsxs("span", { className: "flex min-w-0 flex-1 flex-col", children: [
             /* @__PURE__ */ jsx("span", { className: "mg-type-micro text-ink-strong", children: label }),
-            hint ? /* @__PURE__ */ jsx("span", { className: "mt-0.5 truncate font-mono text-[11px] text-ink-muted", children: hint }) : null
+            hint ? /* @__PURE__ */ jsx("span", { className: "mt-0.5 truncate mg-type-data text-ink-muted", children: hint }) : null
           ] }),
           /* @__PURE__ */ jsxs("span", { className: "flex shrink-0 items-center gap-2", children: [
             trailing,
@@ -5338,7 +5338,7 @@ function ReadinessGauge({
   className
 }) {
   if (score == null && !tier) {
-    return /* @__PURE__ */ jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: "\u2014" });
+    return /* @__PURE__ */ jsx("span", { className: "mg-type-data text-ink-muted", children: "\u2014" });
   }
   const value = Math.max(0, Math.min(100, score ?? 0));
   const label = tierLabels[tier ?? ""] ?? tier ?? "Not classified";
@@ -5371,7 +5371,7 @@ function ReadinessGauge({
             )
           }
         ),
-        /* @__PURE__ */ jsx("span", { className: "text-right font-mono text-[11px] tabular-nums text-ink-strong", children: value })
+        /* @__PURE__ */ jsx("span", { className: "text-right mg-type-data tabular-nums text-ink-strong", children: value })
       ]
     }
   );
@@ -5518,7 +5518,7 @@ function QueryBarSearch({
         "aria-label": placeholder,
         className: classNames(
           "peer flex-1 min-w-0 bg-transparent border-0 outline-none",
-          "py-1.5 text-[13px] text-ink-strong placeholder:text-ink-subtle-text",
+          "py-1.5 mg-type-caption-lg text-ink-strong placeholder:text-ink-subtle-text",
           "focus:outline-none focus:ring-0",
           className
         )
@@ -5541,7 +5541,7 @@ function QueryBarSearch({
       "kbd",
       {
         "aria-hidden": true,
-        className: "pointer-events-none hidden sm:inline-flex items-center rounded border border-border/70 bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ink-muted",
+        className: "pointer-events-none hidden sm:inline-flex items-center rounded border border-border/70 bg-paper px-1.5 py-0.5 mg-type-data-sm text-ink-muted",
         children: "/"
       }
     ) : null
@@ -5620,7 +5620,7 @@ function QueryBarFilterTrigger(props) {
         "aria-label": `${label} filter${active ? `, ${selected.length} selected` : ""}`,
         className: classNames(
           "mg-ghost-trigger group inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2",
-          "text-[12px] transition-colors",
+          "mg-type-caption transition-colors",
           "hover:bg-surface-2",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           active ? "text-ink-strong" : "text-ink-muted",
@@ -5862,8 +5862,8 @@ function PanelError({
       children: [
         /* @__PURE__ */ jsx("div", { className: "grid size-9 place-items-center rounded-full bg-surface-2 text-health-warn", children: /* @__PURE__ */ jsx(AlertTriangle, { className: "size-4", "aria-hidden": true }) }),
         /* @__PURE__ */ jsxs("div", { className: "max-w-sm space-y-1", children: [
-          /* @__PURE__ */ jsx("div", { className: "font-display text-[13px] font-semibold text-ink-strong", children: title }),
-          /* @__PURE__ */ jsx("p", { className: "text-[12px] leading-relaxed text-ink-muted", children: message })
+          /* @__PURE__ */ jsx("div", { className: "font-display mg-type-caption-lg font-semibold text-ink-strong", children: title }),
+          /* @__PURE__ */ jsx("p", { className: "mg-type-caption leading-relaxed text-ink-muted", children: message })
         ] }),
         /* @__PURE__ */ jsxs("div", { className: "flex flex-wrap items-center justify-center gap-2 pt-1", children: [
           onRetry ? /* @__PURE__ */ jsx(

--- a/packages/ui-kit/src/components/metagraphed/charts/bar-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/bar-mini.tsx
@@ -61,7 +61,7 @@ export function BarMini({
               />
             </span>
             {showValue ? (
-              <span className="font-mono text-[10px] tabular-nums text-ink-strong">
+              <span className="mg-type-data-sm tabular-nums text-ink-strong">
                 {formatValue ? formatValue(d.value) : d.value}
               </span>
             ) : null}

--- a/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
@@ -225,7 +225,7 @@ export function CandlestickMini({
       </svg>
       {hoverBar && tooltipText ? (
         <div
-          className="pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap"
+          className="pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap"
           style={{
             left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
             top: Math.max(0, hoverBar.wickTop - 4),

--- a/packages/ui-kit/src/components/metagraphed/charts/spark-legend.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/spark-legend.tsx
@@ -70,7 +70,7 @@ export function SparkLegend({
             </div>
           ) : null}
           {fresh || freshAbs ? (
-            <div className="mt-1 font-mono text-[10px] opacity-80">
+            <div className="mt-1 mg-type-data-sm opacity-80">
               {fresh ?? ""}
               {freshAbs ? `${fresh ? " · " : ""}last checked ${freshAbs}` : ""}
             </div>

--- a/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
@@ -191,7 +191,7 @@ export function Sparkline({
       </svg>
       {hoverPoint && tooltipText ? (
         <div
-          className="pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap"
+          className="pointer-events-none absolute z-[var(--mg-z-sticky)] -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 mg-type-data-sm leading-tight text-ink-strong shadow-sm whitespace-nowrap"
           style={{
             left: Math.max(24, Math.min(width - 24, hoverPoint[0])),
             top: hoverPoint[1] - 4,

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
@@ -92,7 +92,7 @@ export function StatTile({
           {hint ? (
             <span
               className={classNames(
-                "min-w-0 font-mono text-[10px] text-ink-muted",
+                "min-w-0 mg-type-data-sm text-ink-muted",
                 truncate ? "truncate" : "",
               )}
             >

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-with-spark.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-with-spark.tsx
@@ -99,7 +99,7 @@ export function StatWithSpark({
         >
           <div>{full ?? hint ?? label}</div>
           {freshAbs || windowLabel ? (
-            <div className="mt-1 font-mono text-[10px] text-primary-foreground/70">
+            <div className="mt-1 mg-type-data-sm text-primary-foreground/70">
               {freshAbs ? `Last checked ${freshAbs}` : null}
               {freshAbs && windowLabel ? " · " : ""}
               {windowLabel ? `${windowLabel} window` : null}
@@ -224,7 +224,7 @@ export function DotRow({
                 )}
               />
             </TooltipTrigger>
-            <TooltipContent side="top" className="font-mono text-[10px]">
+            <TooltipContent side="top" className="mg-type-data-sm">
               {d.label} {d.on ? "✓" : "—"}
             </TooltipContent>
           </Tooltip>

--- a/packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx
@@ -173,7 +173,7 @@ export function TreemapMini({
           >
             {t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? (
               <>
-                <span className="truncate font-mono text-[10px] font-medium leading-none text-accent-foreground">
+                <span className="truncate mg-type-data-sm font-medium leading-none text-accent-foreground">
                   {t.label}
                 </span>
                 {t.w > MIN_TILE_W_FOR_VALUE && t.h > MIN_TILE_H_FOR_VALUE ? (

--- a/packages/ui-kit/src/components/metagraphed/chip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/chip.tsx
@@ -50,7 +50,7 @@ export function Chip({
       onClick={onClick}
       className={classNames(
         "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5",
-        "font-mono text-[10px] leading-none whitespace-nowrap transition-colors",
+        "mg-type-data-sm leading-none whitespace-nowrap transition-colors",
         onClick ? "mg-focus-ring hover:border-ink/30 cursor-pointer" : null,
         TONE_CLASSES[tone],
         className,

--- a/packages/ui-kit/src/components/metagraphed/column-customizer.tsx
+++ b/packages/ui-kit/src/components/metagraphed/column-customizer.tsx
@@ -59,7 +59,7 @@ export function ColumnCustomizer({
               <button
                 type="button"
                 onClick={onReset}
-                className="mg-focus-ring inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted hover:text-ink-strong"
+                className="mg-focus-ring inline-flex items-center gap-1 mg-type-data-sm text-ink-muted hover:text-ink-strong"
                 title="Reset to defaults"
               >
                 <RotateCcw className="size-3" aria-hidden /> Reset
@@ -72,7 +72,7 @@ export function ColumnCustomizer({
                   <label
                     key={c.id}
                     className={classNames(
-                      "flex items-center gap-2 rounded px-2 py-1.5 text-[12px] text-ink hover:bg-surface-2 cursor-pointer",
+                      "flex items-center gap-2 rounded px-2 py-1.5 mg-type-caption text-ink hover:bg-surface-2 cursor-pointer",
                       c.required ? "opacity-60 cursor-not-allowed" : null,
                     )}
                   >

--- a/packages/ui-kit/src/components/metagraphed/copyable-code.tsx
+++ b/packages/ui-kit/src/components/metagraphed/copyable-code.tsx
@@ -26,7 +26,7 @@ export function CopyableCode({
         title={value}
         aria-label={copied ? "Copied" : `Copy ${label ?? "value"}`}
         className={classNames(
-          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
+          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left mg-type-data text-ink hover:border-ink/30 transition-colors",
           // Matches KeyChip's ring treatment -- this one is a bordered chip like
           // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
           // against the card behind it (#6371).

--- a/packages/ui-kit/src/components/metagraphed/empty-state.tsx
+++ b/packages/ui-kit/src/components/metagraphed/empty-state.tsx
@@ -83,7 +83,9 @@ export function EmptyState({
           {title}
         </p>
         {hint != null ? (
-          <p className="text-[13px] leading-relaxed text-ink-muted">{hint}</p>
+          <p className="mg-type-caption-lg leading-relaxed text-ink-muted">
+            {hint}
+          </p>
         ) : null}
       </div>
       {action != null || evidenceHref ? (

--- a/packages/ui-kit/src/components/metagraphed/entity-hero.tsx
+++ b/packages/ui-kit/src/components/metagraphed/entity-hero.tsx
@@ -106,7 +106,7 @@ export function EntityHero({
             {eyebrow ? (
               <div
                 className={classNames(
-                  "mg-fade-in font-mono text-[10px] uppercase text-ink-muted inline-flex items-center gap-2",
+                  "mg-fade-in mg-type-data-sm uppercase text-ink-muted inline-flex items-center gap-2",
                   display ? "tracking-[0.22em]" : "tracking-[0.2em] mb-2",
                 )}
               >
@@ -185,9 +185,7 @@ export function EntityHero({
                   {s.value}
                 </span>
                 {s.hint ? (
-                  <span className="font-mono text-[11px] text-ink-muted">
-                    {s.hint}
-                  </span>
+                  <span className="mg-type-data text-ink-muted">{s.hint}</span>
                 ) : null}
               </div>
               {s.chart ? <div className="mt-2.5 -ml-0.5">{s.chart}</div> : null}

--- a/packages/ui-kit/src/components/metagraphed/filter-toolbar.tsx
+++ b/packages/ui-kit/src/components/metagraphed/filter-toolbar.tsx
@@ -47,7 +47,7 @@ export function FilterField({
 }
 
 const CONTROL_CLASSES =
-  "h-9 min-w-0 w-full rounded border border-border bg-card px-2.5 text-[12px] " +
+  "h-9 min-w-0 w-full rounded border border-border bg-card px-2.5 mg-type-caption " +
   "text-ink-strong placeholder:text-ink-subtle-text mg-focus-ring " +
   "hover:border-ink/25 transition-colors";
 

--- a/packages/ui-kit/src/components/metagraphed/freshness.tsx
+++ b/packages/ui-kit/src/components/metagraphed/freshness.tsx
@@ -56,7 +56,7 @@ export function FreshnessIndicator({
       <span className={classNames("size-1.5 rounded-full", cls)} />
       {!dotOnly ? (
         <span
-          className="font-mono text-[10px] text-ink-muted"
+          className="mg-type-data-sm text-ink-muted"
           suppressHydrationWarning
         >
           {rel}

--- a/packages/ui-kit/src/components/metagraphed/indicator.tsx
+++ b/packages/ui-kit/src/components/metagraphed/indicator.tsx
@@ -50,7 +50,7 @@ export function Indicator({
         {Icon ? <Icon className="size-3" aria-hidden /> : null}
         {label}
       </span>
-      <span className="font-mono text-[11px] tabular-nums text-ink-strong truncate">
+      <span className="mg-type-data tabular-nums text-ink-strong truncate">
         {value}
         {hint ? (
           <span className="ml-1 text-ink-muted normal-case">{hint}</span>

--- a/packages/ui-kit/src/components/metagraphed/kbd.tsx
+++ b/packages/ui-kit/src/components/metagraphed/kbd.tsx
@@ -11,7 +11,7 @@ export function Kbd({
   return (
     <kbd
       className={classNames(
-        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 font-mono text-[10px] text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
+        "inline-flex items-center justify-center rounded border border-border bg-paper px-1.5 min-w-[1.25rem] h-5 mg-type-data-sm text-ink-muted shadow-[var(--mg-shadow-hairline-inset)]",
         className,
       )}
     >

--- a/packages/ui-kit/src/components/metagraphed/key-chip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/key-chip.tsx
@@ -50,7 +50,7 @@ export function KeyChip({
             onClick={() => copy(value)}
             aria-label={copied ? `${label} copied` : `Copy ${label}: ${value}`}
             className={classNames(
-              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
+              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left mg-type-data text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
               className,
             )}
           >
@@ -63,7 +63,7 @@ export function KeyChip({
         </TooltipTrigger>
         <TooltipContent
           side="top"
-          className="max-w-[90vw] break-all font-mono text-[11px]"
+          className="max-w-[90vw] break-all mg-type-data"
         >
           <span className="mr-1 mg-type-micro opacity-70">{label}</span>
           {value}

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -182,7 +182,7 @@ export function LoadMore({
   }
 
   return (
-    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 text-[11px] font-mono text-ink-muted">
+    <div className="flex items-center justify-between gap-3 border-t border-border bg-surface/30 px-4 py-2 mg-type-data text-ink-muted">
       <span>
         {shown}
         {total != null ? ` of ${total}` : ""}

--- a/packages/ui-kit/src/components/metagraphed/mcp-tools-list.tsx
+++ b/packages/ui-kit/src/components/metagraphed/mcp-tools-list.tsx
@@ -30,7 +30,7 @@ export function McpToolsList({
           <span
             key={t.name}
             title={t.title}
-            className="inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+            className="inline-flex items-center rounded border border-border bg-card px-1.5 py-0.5 mg-type-data-sm text-ink-muted"
           >
             {t.name}
           </span>
@@ -42,7 +42,7 @@ export function McpToolsList({
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
           className={classNames(
-            "mt-2 inline-flex items-center gap-1 font-mono text-[10px] text-ink-muted",
+            "mt-2 inline-flex items-center gap-1 mg-type-data-sm text-ink-muted",
             "hover:text-accent transition-colors",
           )}
         >

--- a/packages/ui-kit/src/components/metagraphed/meta-strip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/meta-strip.tsx
@@ -30,7 +30,7 @@ export function MetaStrip({
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-ink-muted",
+        "flex flex-wrap items-center gap-x-2 gap-y-1 mg-type-caption text-ink-muted",
         className,
       )}
     >

--- a/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
+++ b/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
@@ -44,7 +44,7 @@ export function MethodologyCallout({
           </span>
           {freshLine ? (
             <span
-              className="mt-0.5 block font-mono text-[10px] text-ink-muted/80"
+              className="mt-0.5 block mg-type-data-sm text-ink-muted/80"
               title={freshAbs ?? undefined}
             >
               {freshLine}

--- a/packages/ui-kit/src/components/metagraphed/mobile-collapse.tsx
+++ b/packages/ui-kit/src/components/metagraphed/mobile-collapse.tsx
@@ -56,7 +56,7 @@ export function MobileCollapse({
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="mg-type-micro text-ink-strong">{label}</span>
           {hint ? (
-            <span className="mt-0.5 truncate font-mono text-[11px] text-ink-muted">
+            <span className="mt-0.5 truncate mg-type-data text-ink-muted">
               {hint}
             </span>
           ) : null}

--- a/packages/ui-kit/src/components/metagraphed/page-hero.tsx
+++ b/packages/ui-kit/src/components/metagraphed/page-hero.tsx
@@ -91,9 +91,7 @@ export function PageHero({
                   {k.value}
                 </span>
                 {k.hint ? (
-                  <span className="font-mono text-[11px] text-ink-muted">
-                    {k.hint}
-                  </span>
+                  <span className="mg-type-data text-ink-muted">{k.hint}</span>
                 ) : null}
               </div>
               {k.chart ? <div className="mt-2.5 -ml-0.5">{k.chart}</div> : null}

--- a/packages/ui-kit/src/components/metagraphed/pager-footer.tsx
+++ b/packages/ui-kit/src/components/metagraphed/pager-footer.tsx
@@ -31,7 +31,7 @@ export function PagerFooter({
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-3 text-[12px] text-ink-muted",
+        "flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-3 mg-type-caption text-ink-muted",
         className,
       )}
     >

--- a/packages/ui-kit/src/components/metagraphed/panel-error.tsx
+++ b/packages/ui-kit/src/components/metagraphed/panel-error.tsx
@@ -50,10 +50,12 @@ export function PanelError({
         <AlertTriangle className="size-4" aria-hidden />
       </div>
       <div className="max-w-sm space-y-1">
-        <div className="font-display text-[13px] font-semibold text-ink-strong">
+        <div className="font-display mg-type-caption-lg font-semibold text-ink-strong">
           {title}
         </div>
-        <p className="text-[12px] leading-relaxed text-ink-muted">{message}</p>
+        <p className="mg-type-caption leading-relaxed text-ink-muted">
+          {message}
+        </p>
       </div>
       <div className="flex flex-wrap items-center justify-center gap-2 pt-1">
         {onRetry ? (

--- a/packages/ui-kit/src/components/metagraphed/panel.tsx
+++ b/packages/ui-kit/src/components/metagraphed/panel.tsx
@@ -81,7 +81,9 @@ export function Panel({
           <div className="min-w-0">
             {title != null ? <SectionLabel>{title}</SectionLabel> : null}
             {caption != null ? (
-              <p className="mt-1 text-[13px] text-ink-muted">{caption}</p>
+              <p className="mt-1 mg-type-caption-lg text-ink-muted">
+                {caption}
+              </p>
             ) : null}
           </div>
           {action != null ? (

--- a/packages/ui-kit/src/components/metagraphed/query-bar.tsx
+++ b/packages/ui-kit/src/components/metagraphed/query-bar.tsx
@@ -166,7 +166,7 @@ function QueryBarSearch({
         aria-label={placeholder}
         className={classNames(
           "peer flex-1 min-w-0 bg-transparent border-0 outline-none",
-          "py-1.5 text-[13px] text-ink-strong placeholder:text-ink-subtle-text",
+          "py-1.5 mg-type-caption-lg text-ink-strong placeholder:text-ink-subtle-text",
           "focus:outline-none focus:ring-0",
           className,
         )}
@@ -187,7 +187,7 @@ function QueryBarSearch({
       ) : shortcut ? (
         <kbd
           aria-hidden
-          className="pointer-events-none hidden sm:inline-flex items-center rounded border border-border/70 bg-paper px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+          className="pointer-events-none hidden sm:inline-flex items-center rounded border border-border/70 bg-paper px-1.5 py-0.5 mg-type-data-sm text-ink-muted"
         >
           /
         </kbd>
@@ -324,7 +324,7 @@ function QueryBarFilterTrigger(props: QueryBarFilterTriggerProps) {
           aria-label={`${label} filter${active ? `, ${selected.length} selected` : ""}`}
           className={classNames(
             "mg-ghost-trigger group inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2",
-            "text-[12px] transition-colors",
+            "mg-type-caption transition-colors",
             "hover:bg-surface-2",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             active ? "text-ink-strong" : "text-ink-muted",

--- a/packages/ui-kit/src/components/metagraphed/readiness-gauge.tsx
+++ b/packages/ui-kit/src/components/metagraphed/readiness-gauge.tsx
@@ -24,7 +24,7 @@ export function ReadinessGauge({
   className,
 }: ReadinessGaugeProps) {
   if (score == null && !tier) {
-    return <span className="font-mono text-[11px] text-ink-muted">—</span>;
+    return <span className="mg-type-data text-ink-muted">—</span>;
   }
 
   const value = Math.max(0, Math.min(100, score ?? 0));
@@ -62,7 +62,7 @@ export function ReadinessGauge({
           style={{ width: `${value}%` }}
         />
       </span>
-      <span className="text-right font-mono text-[11px] tabular-nums text-ink-strong">
+      <span className="text-right mg-type-data tabular-nums text-ink-strong">
         {value}
       </span>
     </span>

--- a/packages/ui-kit/src/components/metagraphed/tab-strip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/tab-strip.tsx
@@ -43,7 +43,7 @@ export function TabStrip<T extends string = string>({
     if (it && !it.disabled) onChange(it.id);
   });
   const pad = size === "sm" ? "px-2 py-1.5" : "px-3 py-2";
-  const text = size === "sm" ? "text-[12px]" : "text-[13px]";
+  const text = size === "sm" ? "mg-type-caption" : "mg-type-caption-lg";
   return (
     <div
       role="tablist"

--- a/packages/ui-kit/src/components/metagraphed/table-state.tsx
+++ b/packages/ui-kit/src/components/metagraphed/table-state.tsx
@@ -105,12 +105,12 @@ export function TableState({
         </p>
       ) : null}
       {variant === "stale" && generatedAt ? (
-        <p className="mt-3 font-mono text-[11px] text-ink-muted">
+        <p className="mt-3 mg-type-data text-ink-muted">
           Last verified <TimeAgo at={generatedAt} />
         </p>
       ) : null}
       {message ? (
-        <p className="mx-auto mt-3 max-w-md font-mono text-[11px] text-ink-muted">
+        <p className="mx-auto mt-3 max-w-md mg-type-data text-ink-muted">
           {status ? (
             <span className="text-health-down">HTTP {status} · </span>
           ) : null}
@@ -123,7 +123,7 @@ export function TableState({
             <button
               type="button"
               onClick={onRetry}
-              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3.5 py-1.5 text-[12px] font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3.5 py-1.5 mg-type-caption font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors"
             >
               <RefreshCw className="size-3" /> Retry
             </button>
@@ -134,7 +134,7 @@ export function TableState({
               {...(cta.external
                 ? { target: "_blank", rel: "noopener noreferrer" }
                 : {})}
-              className="inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-3.5 py-1.5 text-[12px] font-medium text-paper hover:opacity-90 transition-opacity"
+              className="inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-3.5 py-1.5 mg-type-caption font-medium text-paper hover:opacity-90 transition-opacity"
             >
               {cta.label}
               {cta.external ? <ExternalLinkIcon className="size-3" /> : null}
@@ -145,7 +145,7 @@ export function TableState({
               href={url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-[11px] font-mono text-ink-muted hover:text-ink-strong"
+              className="inline-flex items-center gap-1.5 mg-type-data text-ink-muted hover:text-ink-strong"
             >
               View API URL <ExternalLinkIcon className="size-3" />
             </a>

--- a/packages/ui-kit/src/components/metagraphed/yield-percentile-layout.ts
+++ b/packages/ui-kit/src/components/metagraphed/yield-percentile-layout.ts
@@ -25,7 +25,7 @@ export const YIELD_PERCENTILE_STRIP_GRID_CLASS =
 
 /** Label row — mirrors Concentration panel `Fact` labels. */
 export const YIELD_PERCENTILE_LABEL_CLASS =
-  "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+  "mg-type-data-sm uppercase tracking-[0.18em] text-ink-muted";
 
 /**
  * Value row — slightly smaller below the four-column threshold, then steps up


### PR DESCRIPTION
## Summary

Follow-up to #8053 (the caption/data type-scale tokens). Sweeps every `text-[10px]`/`[11px]`/`[12px]`/`[13px]` site across both packages onto the new `.mg-type-caption`/`-caption-lg`/`-data`/`-data-sm` utilities.

## Conversion rules

- **`text-[12px]` → `mg-type-caption`, `text-[13px]` → `mg-type-caption-lg`** — unconditional, both packages. Neither utility touches `font-family`, so any existing `font-mono` class on the same element stays valid and unaffected.
- **`text-[10px]`/`[11px]` → `mg-type-data-sm`/`mg-type-data`** — only where `font-mono` co-occurs on the same class string (the mono-context detection the issue's classification pass calls for). The now-redundant `font-mono` utility is dropped since the token already sets that font-family.
- **`text-[10px]`/`[11px]` without `font-mono`** — left untouched. No token in this scale covers a sans 10/11px tier; forcing them into `caption` (a size up) or `data`/`data-sm` (which would wrongly switch them to mono) would both be real visual regressions. This is the issue's own "genuine exception" bucket — the warn-tier guardrail from #8053 still flags these as a residual worklist, same convention every other token rule in this codebase already uses.

## Result

- `apps/ui` bare-arbitrary-text-size warnings: 1,181 → 301 (**-74.5%**, past the issue's ≥60% target)
- `packages/ui-kit`: 52 → 44
- `text-[12px]`/`text-[13px]` count: 0 outside documented exceptions (there are none — both sizes convert unconditionally)

## Verification

- `tsc --noEmit` clean in both packages
- `eslint .` (full package) — 0 errors in both
- `prettier --check .` clean (37 files needed a targeted `--write` after the sweep shortened lines enough to change wrapping — no semantic changes, pure reformat)
- `vitest run` — 191 files / 1465 tests in `apps/ui`, 16 files / 88 tests in `ui-kit`, all passing
- `packages/ui-kit` rebuilt (`dist/index.{js,cjs,css}`)
- Live preview: `getComputedStyle` confirms all four `mg-type-*` classes resolve to their intended font-size/line-height/font-family on real rendered content (a subnet detail page); visual spot-check showed no layout regression

Closes #7844