### PR TITLE
refactor(ui): consolidate the duplicated Bone & Ink token block into ui-kit

### DIFF
--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -32,48 +32,30 @@
 }
 
 /* ============================================================
- * Bone & Ink rhythm + type tokens (Batch B, plan step 1).
- * Named so components and route heros read semantic rhythm
- * ("section gap", "panel pad") instead of raw utilities.
+ * Page-level rhythm tokens (Batch B, plan step 1; consolidated #7846).
+ * The --mg-space-*, --mg-panel-pad*, --mg-type-micro/label, and
+ * --mg-tracking-* tokens, their utility classes, and the mg-skel-pulse
+ * keyframes now live solely in packages/ui-kit/src/styles.css (imported
+ * above) -- this
+ * block only keeps the tokens that describe apps/ui's own page shell
+ * (section/stack/hero/toolbar rhythm), not a reusable component concern.
  * Contributors must reach for these — the ESLint guardrails in
  * eslint.config.js now block raw p-* / gap-* / space-y-* outside
  * the primitives folder and the vendor snapshot.
  * ============================================================ */
 :root {
-  /* 4pt base scale — the only allowed padding/gap steps. */
-  --mg-space-3xs: 0.125rem; /* 2  */
-  --mg-space-2xs: 0.25rem; /* 4  */
-  --mg-space-xs: 0.5rem; /* 8  */
-  --mg-space-sm: 0.75rem; /* 12 */
-  --mg-space-md: 1rem; /* 16 */
-  --mg-space-lg: 1.5rem; /* 24 */
-  --mg-space-xl: 2rem; /* 32 */
-  --mg-space-2xl: 3rem; /* 48 */
-  --mg-space-3xl: 4rem; /* 64 */
-
-  /* Semantic layout rhythm — use in page/panel/hero shells. */
+  /* Semantic layout rhythm — use in page/panel/hero shells. Reference the
+     --mg-space-* base scale defined in ui-kit's styles.css (imported above);
+     custom properties resolve across the cascade regardless of which
+     stylesheet declares them, as long as that stylesheet loads first. */
   --mg-section-gap: var(--mg-space-2xl);
   --mg-section-gap-sm: var(--mg-space-xl);
   --mg-stack-gap: var(--mg-space-md);
   --mg-stack-gap-tight: var(--mg-space-sm);
-  --mg-panel-pad: var(--mg-space-lg);
-  --mg-panel-pad-dense: var(--mg-space-md);
   --mg-hero-pad-y: var(--mg-space-2xl);
   --mg-hero-pad-y-sm: var(--mg-space-xl);
   --mg-toolbar-pad-y: var(--mg-space-sm);
   --mg-gutter-x: clamp(1rem, 4vw, 1.5rem);
-
-  /* Type scale — locks the micro/label idiom into named tokens. */
-  --mg-type-micro: 9.5px;
-  --mg-type-label: 11px;
-  --mg-type-body: 14px;
-  --mg-type-body-lg: 15px;
-  --mg-type-h4: 16px;
-  --mg-type-h3: 18px;
-  --mg-type-h2: 22px;
-  --mg-type-h1: 28px;
-  --mg-tracking-label: 0.14em;
-  --mg-tracking-micro: 0.18em;
 }
 
 /* Page-level rhythm helpers — reserved for Panel / PageHero / route shells. */
@@ -85,15 +67,6 @@
     margin-top: var(--mg-section-gap-sm);
   }
 }
-.mg-panel-pad {
-  padding: var(--mg-panel-pad);
-}
-.mg-panel-pad-dense {
-  padding: var(--mg-panel-pad-dense);
-}
-.mg-panel-pad-flush {
-  padding: 0;
-}
 .mg-stack-gap > * + * {
   margin-top: var(--mg-stack-gap);
 }
@@ -103,20 +76,6 @@
 .mg-gutter-x {
   padding-left: var(--mg-gutter-x);
   padding-right: var(--mg-gutter-x);
-}
-
-.mg-type-micro {
-  font-family: var(--font-mono);
-  font-size: var(--mg-type-micro);
-  line-height: 1.2;
-  text-transform: uppercase;
-  letter-spacing: var(--mg-tracking-micro);
-}
-.mg-type-label {
-  font-family: var(--font-mono);
-  font-size: var(--mg-type-label);
-  line-height: 1.25;
-  letter-spacing: var(--mg-tracking-label);
 }
 
 /* Horizontal scroll fade for mobile tables — apply to overflow-x containers
@@ -186,22 +145,6 @@
     z-index: 10;
     background: color-mix(in oklab, var(--card) 94%, transparent);
     backdrop-filter: blur(8px);
-  }
-}
-
-/* Skeleton pulse used by TableSkeleton primitive. */
-@keyframes mg-skel-pulse {
-  0%,
-  100% {
-    opacity: 0.55;
-  }
-  50% {
-    opacity: 0.9;
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  [style*="mg-skel-pulse"] {
-    animation: none !important;
   }
 }
 

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -136,6 +136,12 @@
   --mg-tracking-micro: 0.18em;
   --mg-type-caption: 12px;
   --mg-type-caption-lg: 13px;
+  --mg-type-body: 14px;
+  --mg-type-body-lg: 15px;
+  --mg-type-h4: 16px;
+  --mg-type-h3: 18px;
+  --mg-type-h2: 22px;
+  --mg-type-h1: 28px;
 }
 .mg-panel-pad {
   padding: var(--mg-panel-pad);

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -266,12 +266,15 @@
 }
 
 /* ============================================================
- * Bone & Ink rhythm + type tokens, relocated (2026-07-23) from
- * apps/ui/src/styles.css alongside <Panel>/<SectionLabel> and the
- * other dependency-free primitives that moved into this package so
- * ui-kit's own components can use them too. Kept in sync with
- * apps/ui/src/styles.css's copy of the same block — see that file if
- * either drifts.
+ * Bone & Ink rhythm + type tokens. Relocated (2026-07-23) from
+ * apps/ui/src/styles.css alongside <Panel>/<SectionLabel> and the other
+ * dependency-free primitives that moved into this package so ui-kit's own
+ * components can use them too; briefly duplicated in both files to keep
+ * that move shippable, then consolidated here as the sole source of truth
+ * (#7846) -- apps/ui/src/styles.css now only keeps the page-shell-specific
+ * rhythm tokens (--mg-section-gap*, --mg-stack-gap*, --mg-hero-pad-y*,
+ * --mg-toolbar-pad-y, --mg-gutter-x) that describe its own layout, not a
+ * reusable component concern.
  * ============================================================ */
 :root {
   --mg-space-3xs: 0.125rem; /* 2  */
@@ -287,6 +290,7 @@
   --mg-panel-pad: var(--mg-space-lg);
   --mg-panel-pad-dense: var(--mg-space-md);
 
+  /* Type scale — locks the micro/label/caption/data idiom into named tokens. */
   --mg-type-micro: 9.5px;
   --mg-type-label: 11px;
   --mg-tracking-label: 0.14em;
@@ -297,6 +301,18 @@
      utility class existed to reach for), unlike mg-type-micro/label above. */
   --mg-type-caption: 12px;
   --mg-type-caption-lg: 13px;
+
+  /* #7846: moved from apps/ui/src/styles.css -- part of the same type scale
+     as micro/label/caption above, so it belongs alongside them here rather
+     than in apps/ui's page-shell-only rhythm block. Not yet consumed by any
+     utility class in either package (no .mg-type-body/-h1..-h4 exists) --
+     kept as the reserved next step up the scale above mg-type-caption-lg. */
+  --mg-type-body: 14px;
+  --mg-type-body-lg: 15px;
+  --mg-type-h4: 16px;
+  --mg-type-h3: 18px;
+  --mg-type-h2: 22px;
+  --mg-type-h1: 28px;
 }
 
 .mg-panel-pad {


### PR DESCRIPTION
## Summary

#7833 ported a subset of the Bone & Ink token block (`--mg-space-*`, `--mg-panel-pad*`, `--mg-type-micro/label`, `--mg-tracking-*`, their utility classes, and the `mg-skel-pulse` keyframes) from `apps/ui/src/styles.css` into `packages/ui-kit/src/styles.css` so the relocated primitives worked, leaving byte-identical copies in both files with a "kept in sync" comment. Since `apps/ui/src/styles.css` imports `@jsonbored/ui-kit/styles.css`, both copies loaded on every page and the later one silently won — divergence would have been invisible until it broke something.

## Reconciliation table

| Block | apps/ui vs ui-kit | Disposition |
|---|---|---|
| `--mg-space-3xs`..`3xl` (9 tokens) | byte-identical | deleted from apps/ui |
| `--mg-panel-pad`, `--mg-panel-pad-dense` | byte-identical | deleted from apps/ui |
| `--mg-type-micro`, `--mg-type-label` | byte-identical | deleted from apps/ui |
| `--mg-tracking-label`, `--mg-tracking-micro` | byte-identical | deleted from apps/ui |
| `.mg-panel-pad`, `.mg-panel-pad-dense`, `.mg-panel-pad-flush` | byte-identical | deleted from apps/ui |
| `.mg-type-micro`, `.mg-type-label` | byte-identical | deleted from apps/ui |
| `@keyframes mg-skel-pulse` + reduced-motion guard | byte-identical | deleted from apps/ui |
| `--mg-section-gap*`, `--mg-stack-gap*`, `--mg-hero-pad-y*`, `--mg-toolbar-pad-y`, `--mg-gutter-x` + their utility classes | apps/ui-only | **stays in apps/ui** — describes its own page shell, not a reusable component concern (still `var()`-references ui-kit's `--mg-space-*` base scale across the file boundary) |
| `--mg-type-body`, `--mg-type-body-lg`, `--mg-type-h1`..`-h4` | apps/ui-only, never wrapped in a utility class in either package | **moved to ui-kit**, alongside the rest of the `mg-type-*` scale (`micro`/`label`/`caption`/`caption-lg` from #7844) rather than living apart from it |

No genuine drift anywhere — every shared block diffed byte-for-byte identical, so there was no "which side wins" call to make.

## Verification

- `tsc --noEmit` clean in both packages
- `eslint .` (full package) — 0 errors in both
- `prettier --check .` clean in both (caught a real bug in my own first draft — see below)
- `vitest run` — 191 files / 1465 tests in `apps/ui`, 16 files / 88 tests in `ui-kit`, all passing
- `packages/ui-kit` rebuilt (`dist/index.css`)
- Zero "kept in sync" comments remain; zero token/utility/keyframe defined in both files

### Computed-style probes (live subnet detail page, per the issue's requirement)

```
--mg-space-3xs..3xl: .125rem, .25rem, .5rem, .75rem, 1rem, 1.5rem, 2rem, 3rem, 4rem
--mg-panel-pad: 1.5rem   --mg-panel-pad-dense: 1rem
--mg-type-micro: 9.5px   --mg-type-label: 11px
--mg-tracking-label: .14em   --mg-tracking-micro: .18em
--mg-type-body: 14px  --mg-type-body-lg: 15px
--mg-type-h4: 16px  --mg-type-h3: 18px  --mg-type-h2: 22px  --mg-type-h1: 28px
--mg-section-gap: 3rem (cross-file var() reference to ui-kit's --mg-space-2xl, resolves correctly)
--mg-toolbar-pad-y: .75rem

.mg-panel-pad-dense rendered padding: 16px
.mg-type-micro rendered: fontSize 9.5px, letterSpacing 1.71px, font-family JetBrains Mono
```
All identical in light and dark theme (expected — these are size/spacing tokens, not color tokens). Visual spot-check on the same page in both themes showed no layout regression.

## A bug found along the way

My first draft's comment describing the removed `--mg-panel-pad*` wildcard contained a literal `*/` mid-sentence, which prematurely closed the CSS comment block — `prettier --check` caught it as a `CssSyntaxError` before it ever reached a real build. Fixed by rewording to avoid the sequence.

Closes #7846