### PR TITLE
feat(observability): PostHog $ai_generation capture for the ask() RAG call

### DIFF
--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -11,6 +11,7 @@
 // and question length.
 
 import type { StorageReadResult } from "../workers/storage.ts";
+import { recordAiGenerationEvent } from "./usage-telemetry.ts";
 
 // Best free Workers AI models (verified available on the account):
 // - Embedding: Qwen3-Embedding-0.6B (1024-dim) — tops MTEB English; the
@@ -20,6 +21,14 @@ import type { StorageReadResult } from "../workers/storage.ts";
 export const EMBED_MODEL = "@cf/qwen/qwen3-embedding-0.6b"; // 1024-dim
 export const EMBED_DIMENSIONS = 1024;
 export const ASK_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
+// PostHog's $ai_generation cost auto-computation only recognizes well-known
+// hosted-provider model names, not Workers AI catalog ids, so recordAiGeneration
+// below supplies cost itself. Confirmed unit pricing per
+// https://developers.cloudflare.com/workers-ai/models/llama-4-scout-17b-16e-instruct/
+// (checked 2026-07-24) -- update alongside ASK_MODEL if the model ever changes.
+const ASK_PROVIDER = "cloudflare_workers_ai";
+const ASK_MODEL_INPUT_USD_PER_MILLION = 0.27;
+const ASK_MODEL_OUTPUT_USD_PER_MILLION = 0.85;
 export const VECTORIZE_INDEX_NAME = "metagraphed-registry-v2";
 export const EMBED_MANIFEST_KEY = [
   "ai:embed-manifest",
@@ -85,6 +94,15 @@ export async function withinRateLimit(env: Env, key: string): Promise<boolean> {
   } catch {
     return true;
   }
+}
+
+// Dollar cost for a token count at the given per-million rate, or undefined
+// when the count is missing/invalid -- recordAiGenerationEvent only sends
+// $ai_*_cost_usd when both input and output resolve to a finite number.
+function costUsd(tokens: unknown, ratePerMillion: number): number | undefined {
+  return typeof tokens === "number" && Number.isFinite(tokens) && tokens >= 0
+    ? (tokens / 1_000_000) * ratePerMillion
+    : undefined;
 }
 
 function clampLimit(value: unknown, fallback: number, max: number): number {
@@ -627,9 +645,34 @@ export async function askQuestion(
         "Answer using only the registry data above and cite sources as [n].",
     },
   ];
+  const modelParameters = { max_tokens: ASK_MAX_TOKENS };
+  const generationStart = Date.now();
   const completion = await env.AI.run(ASK_MODEL, {
     messages,
     max_tokens: ASK_MAX_TOKENS,
+  }).catch(async (error) => {
+    await recordAiGenerationEvent(env, {
+      provider: ASK_PROVIDER,
+      model: ASK_MODEL,
+      latencyMs: Date.now() - generationStart,
+      isError: true,
+      error,
+      modelParameters,
+    });
+    throw error;
+  });
+  const inputTokens = completion?.usage?.prompt_tokens;
+  const outputTokens = completion?.usage?.completion_tokens;
+  await recordAiGenerationEvent(env, {
+    provider: ASK_PROVIDER,
+    model: ASK_MODEL,
+    latencyMs: Date.now() - generationStart,
+    isError: false,
+    inputTokens,
+    outputTokens,
+    inputCostUsd: costUsd(inputTokens, ASK_MODEL_INPUT_USD_PER_MILLION),
+    outputCostUsd: costUsd(outputTokens, ASK_MODEL_OUTPUT_USD_PER_MILLION),
+    modelParameters,
   });
   const answer = (completion?.response || "").trim();
   return {

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -533,3 +533,120 @@ export async function recordExceptionEvent(
     return false;
   }
 }
+
+// AI generation observability via PostHog's raw `$ai_generation` event (#7763).
+// Same raw-fetch, no-throw, no-op-when-unconfigured contract as the other
+// recordX helpers above -- no SDK (posthog-ai pulls in an LLM-provider client
+// layer neither needed nor affordable inside the Worker bundle budget; see the
+// header comment). The exact property names/units below are NOT from PostHog's
+// docs pages (posthog.com/docs/ai-engineering/observability/manual-capture and
+// .../python both 404 as of this writing) -- they're read off PostHog's own
+// posthog-js-lite SDK source (posthog-ai/src/utils.ts), the same
+// verify-against-source approach #7758's $exception shape used.
+//
+// Content-free by design (#7763's explicit redaction posture): only
+// cost/token/latency/model metadata is ever sent, never the prompt or
+// completion text -- the same minimal-capture philosophy `usage_event` (top of
+// this file) already applies, extended to the one field class an LLM call
+// uniquely adds (tokens/cost).
+
+/** Inputs for one AI generation call. `error` mirrors ExceptionEvent's own
+ * `error` (raw caught value, this module extracts type/message itself) --
+ * never a caller-preformatted string. */
+export interface AiGenerationEvent {
+  provider: string;
+  model: string;
+  /** Groups an event to its call; PostHog requires one per generation even
+   * outside a multi-step chain, so a fresh UUID is minted when omitted --
+   * mirrors posthog-ai's own `uuidv4()` fallback. */
+  traceId?: string;
+  latencyMs: number;
+  isError: boolean;
+  inputTokens?: number;
+  outputTokens?: number;
+  /** Only included when BOTH are finite -- see costUsd() in ai-search.ts,
+   * which returns undefined for missing/invalid token counts. */
+  inputCostUsd?: number;
+  outputCostUsd?: number;
+  /** Generation config (e.g. `{ max_tokens }`), never prompt/completion text. */
+  modelParameters?: Record<string, string | number | boolean>;
+  error?: unknown;
+}
+
+/**
+ * Capture one LLM call as a PostHog `$ai_generation` event. Same no-throw,
+ * no-op-when-unconfigured contract as recordUsageEvent/recordExceptionEvent.
+ */
+export async function recordAiGenerationEvent(
+  env: Env | null | undefined,
+  event: AiGenerationEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+    if (typeof event.isError !== "boolean") return false;
+    if (
+      typeof event.latencyMs !== "number" ||
+      !Number.isFinite(event.latencyMs) ||
+      event.latencyMs < 0
+    ) {
+      return false;
+    }
+
+    const properties: Record<string, unknown> = {
+      $ai_trace_id: event.traceId ?? crypto.randomUUID(),
+      $ai_model: sanitizeLabel(event.model) ?? "unknown",
+      $ai_provider: sanitizeLabel(event.provider) ?? "unknown",
+      // PostHog's $ai_generation schema reports latency in SECONDS, not ms.
+      $ai_latency: event.latencyMs / 1000,
+      // env.AI.run() is a Workers RPC binding, not raw HTTP -- there is no
+      // real transport status to report, so this is derived from isError.
+      $ai_http_status: event.isError ? 500 : 200,
+      $ai_input_tokens: Number.isFinite(event.inputTokens)
+        ? event.inputTokens
+        : 0,
+      $ai_output_tokens: Number.isFinite(event.outputTokens)
+        ? event.outputTokens
+        : 0,
+      $ai_is_error: event.isError,
+    };
+
+    if (event.modelParameters) {
+      properties.$ai_model_parameters = event.modelParameters;
+    }
+
+    if (
+      Number.isFinite(event.inputCostUsd) &&
+      Number.isFinite(event.outputCostUsd)
+    ) {
+      properties.$ai_input_cost_usd = event.inputCostUsd;
+      properties.$ai_output_cost_usd = event.outputCostUsd;
+      properties.$ai_total_cost_usd =
+        (event.inputCostUsd as number) + (event.outputCostUsd as number);
+    }
+
+    if (event.isError) {
+      const { type, entry } = exceptionListEntry(event.error);
+      properties.$ai_error = `${type}: ${entry.value}`;
+    }
+
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: "$ai_generation",
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -20,6 +20,7 @@ import {
 import { handleRequest, handleScheduled } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { overlayCatalogIndex } from "../src/health-serving.ts";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
 
@@ -58,7 +59,10 @@ function stubAi() {
           data: Array.from({ length: n }, () => new Array(1024).fill(0.02)),
         });
       }
-      return Promise.resolve({ response: "Subnet 1 does images [1]." });
+      return Promise.resolve({
+        response: "Subnet 1 does images [1].",
+        usage: { prompt_tokens: 120, completion_tokens: 40, total_tokens: 160 },
+      });
     },
   };
 }
@@ -888,6 +892,122 @@ describe("askQuestion", () => {
       () => askQuestion(mockEnv(env), "q", { type: "bogus" }),
       /Unknown type/,
     );
+  });
+});
+
+describe("askQuestion AI observability ($ai_generation, #7763)", () => {
+  // A capture is one POST to PostHog's capture endpoint -- record what it was
+  // handed, same shape as usage-telemetry.test.ts's fakeFetch.
+  function fetchSpy(calls: Row[]) {
+    return (async (_url: unknown, init: Row) => {
+      calls.push(JSON.parse(init.body));
+      return { ok: true };
+    }) as unknown as typeof fetch;
+  }
+
+  async function withGlobalFetch(fn: typeof fetch, run: () => Promise<void>) {
+    const original = globalThis.fetch;
+    globalThis.fetch = fn;
+    try {
+      await run();
+    } finally {
+      globalThis.fetch = original;
+    }
+  }
+
+  test("records a well-formed $ai_generation event with token/cost metadata on success", async () => {
+    const calls: Row[] = [];
+    await withGlobalFetch(fetchSpy(calls), async () => {
+      const env = {
+        AI: stubAi(),
+        VECTORIZE: stubVectorize(),
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test",
+      };
+      await askQuestion(mockEnv(env), "Which subnet does images?");
+    });
+    assert.equal(calls.length, 1);
+    const { event, properties } = calls[0];
+    assert.equal(event, "$ai_generation");
+    assert.equal(properties.$ai_model, ASK_MODEL);
+    assert.equal(properties.$ai_provider, "cloudflare_workers_ai");
+    assert.equal(properties.$ai_is_error, false);
+    assert.equal(properties.$ai_http_status, 200);
+    assert.equal(properties.$ai_input_tokens, 120);
+    assert.equal(properties.$ai_output_tokens, 40);
+    assert.ok(properties.$ai_input_cost_usd > 0);
+    assert.ok(properties.$ai_output_cost_usd > 0);
+    assert.equal(
+      properties.$ai_total_cost_usd,
+      properties.$ai_input_cost_usd + properties.$ai_output_cost_usd,
+    );
+    assert.deepEqual(properties.$ai_model_parameters, { max_tokens: 512 });
+    // Content-free: never the question, the retrieved context, or the answer.
+    assert.equal("$ai_input" in properties, false);
+    assert.equal("$ai_output_choices" in properties, false);
+  });
+
+  test("omits cost fields when the model response carries no usage object", async () => {
+    const calls: Row[] = [];
+    const aiNoUsage = {
+      run(model: string) {
+        if (model === EMBED_MODEL) {
+          return Promise.resolve({ data: [new Array(1024).fill(0.02)] });
+        }
+        return Promise.resolve({ response: "no usage here" });
+      },
+    };
+    await withGlobalFetch(fetchSpy(calls), async () => {
+      const env = {
+        AI: aiNoUsage,
+        VECTORIZE: stubVectorize(),
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test",
+      };
+      await askQuestion(mockEnv(env), "Which subnet does images?");
+    });
+    const { properties } = calls[0];
+    assert.equal(properties.$ai_input_tokens, 0);
+    assert.equal(properties.$ai_output_tokens, 0);
+    assert.equal("$ai_input_cost_usd" in properties, false);
+  });
+
+  test("records a failed $ai_generation event and still rethrows the original error", async () => {
+    const calls: Row[] = [];
+    const failingAi = {
+      run(model: string, input: Row) {
+        if (model === EMBED_MODEL) {
+          const n = Array.isArray(input.text) ? input.text.length : 1;
+          return Promise.resolve({
+            data: Array.from({ length: n }, () => new Array(1024).fill(0.02)),
+          });
+        }
+        return Promise.reject(new Error("Workers AI unavailable"));
+      },
+    };
+    await withGlobalFetch(fetchSpy(calls), async () => {
+      const env = {
+        AI: failingAi,
+        VECTORIZE: stubVectorize(),
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test",
+      };
+      await assert.rejects(
+        () => askQuestion(mockEnv(env), "Which subnet does images?"),
+        /Workers AI unavailable/,
+      );
+    });
+    assert.equal(calls.length, 1);
+    const { properties } = calls[0];
+    assert.equal(properties.$ai_is_error, true);
+    assert.equal(properties.$ai_http_status, 500);
+    assert.equal(properties.$ai_error, "Error: Workers AI unavailable");
+  });
+
+  test("never calls fetch when PostHog is unconfigured", async () => {
+    const calls: Row[] = [];
+    await withGlobalFetch(fetchSpy(calls), async () => {
+      const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+      await askQuestion(mockEnv(env), "Which subnet does images?");
+    });
+    assert.equal(calls.length, 0);
   });
 });
 

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -7,6 +7,7 @@ import {
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
   isUsageTelemetryConfigured,
+  recordAiGenerationEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
   recordMcpToolCallEvent,
@@ -16,6 +17,7 @@ import {
 } from "../src/usage-telemetry.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 import type {
+  AiGenerationEvent,
   ExceptionEvent,
   McpToolCallEvent,
   UsageEvent,
@@ -1073,6 +1075,256 @@ describe("recordExceptionEvent", () => {
         error: thrownError(Error, "boom"),
         route: "x",
       });
+      assert.equal(recorded, true);
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe("recordAiGenerationEvent", () => {
+  const CONFIGURED = {
+    [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token",
+  } as unknown as Env;
+
+  function thrownError(ErrorClass: ErrorConstructor, message: string) {
+    try {
+      throw new ErrorClass(message);
+    } catch (e) {
+      return e;
+    }
+  }
+
+  const BASE: AiGenerationEvent = {
+    provider: "cloudflare_workers_ai",
+    model: "@cf/meta/llama-4-scout-17b-16e-instruct",
+    latencyMs: 1500,
+    isError: false,
+  };
+
+  test("posts a well-formed $ai_generation event for a successful call", async () => {
+    const calls: Row[] = [];
+    const recorded = await recordAiGenerationEvent(
+      CONFIGURED,
+      {
+        ...BASE,
+        traceId: "11111111-1111-1111-1111-111111111111",
+        inputTokens: 200,
+        outputTokens: 50,
+        inputCostUsd: 0.000054,
+        outputCostUsd: 0.0000425,
+        modelParameters: { max_tokens: 512 },
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    const { body } = calls[0];
+    assert.equal(body.event, "$ai_generation");
+    assert.equal(body.api_key, "phc_token");
+    assert.equal(body.distinct_id, USAGE_EVENT_DISTINCT_ID);
+
+    const { properties } = body;
+    assert.equal(
+      properties.$ai_trace_id,
+      "11111111-1111-1111-1111-111111111111",
+    );
+    assert.equal(properties.$ai_model, BASE.model);
+    assert.equal(properties.$ai_provider, "cloudflare_workers_ai");
+    assert.equal(properties.$ai_latency, 1.5);
+    assert.equal(properties.$ai_http_status, 200);
+    assert.equal(properties.$ai_input_tokens, 200);
+    assert.equal(properties.$ai_output_tokens, 50);
+    assert.equal(properties.$ai_is_error, false);
+    assert.deepEqual(properties.$ai_model_parameters, { max_tokens: 512 });
+    assert.equal(properties.$ai_input_cost_usd, 0.000054);
+    assert.equal(properties.$ai_output_cost_usd, 0.0000425);
+    assert.equal(properties.$ai_total_cost_usd, 0.0000965);
+    assert.equal("$ai_error" in properties, false);
+  });
+
+  test("never captures prompt/completion content -- no field carries free text beyond the model id", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(CONFIGURED, BASE, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    });
+    const keys = Object.keys(calls[0].body.properties);
+    assert.equal(keys.includes("$ai_input"), false);
+    assert.equal(keys.includes("$ai_output_choices"), false);
+  });
+
+  test("mints a fresh trace id when none is supplied", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(CONFIGURED, BASE, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    });
+    const traceId = calls[0].body.properties.$ai_trace_id;
+    assert.equal(typeof traceId, "string");
+    // A real crypto.randomUUID() shape (v4 UUID), not a placeholder.
+    assert.match(
+      traceId,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  test("defaults input/output tokens to 0 when omitted", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(CONFIGURED, BASE, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    });
+    assert.equal(calls[0].body.properties.$ai_input_tokens, 0);
+    assert.equal(calls[0].body.properties.$ai_output_tokens, 0);
+  });
+
+  test("defaults tokens to 0 when the supplied values are non-finite", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(
+      CONFIGURED,
+      { ...BASE, inputTokens: NaN, outputTokens: Infinity },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(calls[0].body.properties.$ai_input_tokens, 0);
+    assert.equal(calls[0].body.properties.$ai_output_tokens, 0);
+  });
+
+  test("omits cost fields entirely when cost is not supplied", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(CONFIGURED, BASE, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    });
+    const { properties } = calls[0].body;
+    assert.equal("$ai_input_cost_usd" in properties, false);
+    assert.equal("$ai_output_cost_usd" in properties, false);
+    assert.equal("$ai_total_cost_usd" in properties, false);
+  });
+
+  test("omits cost fields when only one side of input/output cost is supplied", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(
+      CONFIGURED,
+      { ...BASE, inputCostUsd: 0.01 },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal("$ai_input_cost_usd" in calls[0].body.properties, false);
+  });
+
+  test("omits $ai_model_parameters when not supplied", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(CONFIGURED, BASE, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    });
+    assert.equal("$ai_model_parameters" in calls[0].body.properties, false);
+  });
+
+  test("falls back to 'unknown' for a blank model/provider", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(
+      CONFIGURED,
+      { ...BASE, model: "", provider: "   " },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(calls[0].body.properties.$ai_model, "unknown");
+    assert.equal(calls[0].body.properties.$ai_provider, "unknown");
+  });
+
+  test("marks a failed generation with $ai_is_error/$ai_http_status/$ai_error", async () => {
+    const calls: Row[] = [];
+    const recorded = await recordAiGenerationEvent(
+      CONFIGURED,
+      { ...BASE, isError: true, error: thrownError(Error, "AI.run failed") },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(recorded, true);
+    const { properties } = calls[0].body;
+    assert.equal(properties.$ai_is_error, true);
+    assert.equal(properties.$ai_http_status, 500);
+    assert.equal(properties.$ai_error, "Error: AI.run failed");
+  });
+
+  test("handles a thrown non-Error value on the error path without crashing", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(
+      CONFIGURED,
+      { ...BASE, isError: true, error: "just a string" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(calls[0].body.properties.$ai_error, "Error: just a string");
+  });
+
+  test("never posts when the deployment is unconfigured", async () => {
+    let calls = 0;
+    const recorded = await recordAiGenerationEvent(mockEnv(), BASE, {
+      fetch: fakeFetch({
+        onCall: () => {
+          calls += 1;
+        },
+      }),
+    });
+    assert.equal(recorded, false);
+    assert.equal(calls, 0);
+  });
+
+  test("returns false without posting when isError is not a boolean", async () => {
+    let calls = 0;
+    const recorded = await recordAiGenerationEvent(
+      CONFIGURED,
+      { ...BASE, isError: undefined as unknown as boolean },
+      {
+        fetch: fakeFetch({
+          onCall: () => {
+            calls += 1;
+          },
+        }),
+      },
+    );
+    assert.equal(recorded, false);
+    assert.equal(calls, 0);
+  });
+
+  test("returns false without posting when latencyMs is negative/non-finite", async () => {
+    let calls = 0;
+    const onCall = () => {
+      calls += 1;
+    };
+    assert.equal(
+      await recordAiGenerationEvent(
+        CONFIGURED,
+        { ...BASE, latencyMs: -1 },
+        { fetch: fakeFetch({ onCall }) },
+      ),
+      false,
+    );
+    assert.equal(
+      await recordAiGenerationEvent(
+        CONFIGURED,
+        { ...BASE, latencyMs: NaN },
+        { fetch: fakeFetch({ onCall }) },
+      ),
+      false,
+    );
+    assert.equal(calls, 0);
+  });
+
+  test("reports a rejected capture as not recorded", async () => {
+    const recorded = await recordAiGenerationEvent(CONFIGURED, BASE, {
+      fetch: fakeFetch({ ok: false }),
+    });
+    assert.equal(recorded, false);
+  });
+
+  test("swallows a transport failure", async () => {
+    const recorded = await recordAiGenerationEvent(CONFIGURED, BASE, {
+      fetch: fakeFetch({ throws: true }),
+    });
+    assert.equal(recorded, false);
+  });
+
+  test("defaults to the platform fetch when none is injected", async () => {
+    const original = globalThis.fetch;
+    const calls: Row[] = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      const recorded = await recordAiGenerationEvent(CONFIGURED, BASE);
       assert.equal(recorded, true);
       assert.equal(calls.length, 1);
     } finally {


### PR DESCRIPTION
## Summary

- Adds `recordAiGenerationEvent()` to `src/usage-telemetry.ts`, following the same raw-fetch/no-SDK/no-throw pattern as the existing `recordUsageEvent`/`recordMcpToolCallEvent`/`recordExceptionEvent` wrappers, emitting PostHog's raw `$ai_generation` event.
- Wires it into `askQuestion()` in `src/ai-search.ts`, around the one real LLM generation call (`env.AI.run(ASK_MODEL, ...)`), covering both the success and error paths.
- Content-free by design per this issue's explicit redaction posture: only latency, token counts, computed cost, model, provider, and a trace id are ever sent — never the question, retrieved context, or answer text.

## What Changed

- `src/usage-telemetry.ts`: new `AiGenerationEvent` interface + `recordAiGenerationEvent()`. Property shape (`$ai_trace_id`, `$ai_model`, `$ai_provider`, `$ai_latency` in seconds, `$ai_http_status`, `$ai_input_tokens`/`$ai_output_tokens`, `$ai_is_error`, `$ai_error`, `$ai_model_parameters`, `$ai_*_cost_usd`) was verified against PostHog's own `posthog-js-lite` SDK source (`posthog-ai/src/utils.ts`) — the docs pages for manual/raw capture 404 as of this writing.
- `src/ai-search.ts`: wraps the `ASK_MODEL` generation call with timing + a `.catch()` that records a failed generation and rethrows (existing 502 error-mapping behavior is unchanged). On success, extracts `completion.usage.prompt_tokens`/`completion_tokens` (confirmed present on Workers AI's response for `llama-4-scout-17b-16e-instruct` via Cloudflare's docs) and computes USD cost from that model's confirmed unit pricing (PostHog's own cost auto-computation only recognizes well-known hosted-provider model ids, not Workers AI catalog ids).
- Tests: `tests/usage-telemetry.test.ts` (new `recordAiGenerationEvent` suite, 18 cases covering success/error/cost/token/trace-id/unconfigured/malformed-input paths) and `tests/ai-search.test.ts` (4 new cases verifying the capture fires correctly from `askQuestion`, including a content-free assertion and a "no usage object" fallback case).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #7763`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none needed — no schema change).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none — no route/schema change).

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (scoped to changed files)
- [x] `npm run typecheck`
- [x] `npm run validate`
- [x] `npx vitest run tests/ai-search.test.ts tests/usage-telemetry.test.ts` (161 passed) + scoped coverage (100% on both changed files' new lines)
- [x] `git diff --check`

Closes #7763