### PR TITLE
feat(ui-kit): Panel API — rest-prop forwarding, ok tone, tintBorderOnly, glow

### DIFF
--- a/apps/ui/src/routes/design.primitives.tsx
+++ b/apps/ui/src/routes/design.primitives.tsx
@@ -187,6 +187,30 @@ function PrimitivesPreview() {
               evidenceHref="https://github.com/JSONbored/metagraphed"
             />
           </Panel>
+          {/* #7848: ok tone + tintBorderOnly + glow + rest-prop forwarding. */}
+          <Panel
+            title="Ok tone"
+            tone="ok"
+            id="design-primitives-ok-tone-panel"
+            aria-label="Healthy status summary"
+          >
+            <StatusBadge status="ok" live />
+            <p className="mt-2 mg-type-caption text-ink-muted">
+              tone="ok" — tinted border + background. id/aria-label above land on the outer element
+              via rest-prop forwarding.
+            </p>
+          </Panel>
+          <Panel title="Border-only tint" tone="warn" tintBorderOnly>
+            <p className="mg-type-caption text-ink-muted">
+              tintBorderOnly keeps the warn border but skips the tinted fill — bg-card instead.
+            </p>
+          </Panel>
+          <Panel title="Glow" glow>
+            <p className="mg-type-caption text-ink-muted">
+              glow appends the existing --mg-card-glow soft-elevation shadow (accent tone picks
+              --mg-card-glow-accent automatically).
+            </p>
+          </Panel>
         </div>
       </Section>
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -4407,12 +4407,13 @@ function SectionLabel({
     }
   );
 }
-var TONE_CLASSES3 = {
-  default: "border-border bg-card",
-  accent: "border-accent/40 bg-primary-soft",
-  warn: "border-health-warn/40 bg-health-warn/5",
-  down: "border-health-down/40 bg-health-down/5",
-  muted: "border-border bg-surface-2"
+var TONE_STYLES = {
+  default: { border: "border-border", bg: "bg-card" },
+  accent: { border: "border-accent/40", bg: "bg-primary-soft" },
+  warn: { border: "border-health-warn/40", bg: "bg-health-warn/5" },
+  down: { border: "border-health-down/40", bg: "bg-health-down/5" },
+  ok: { border: "border-health-ok/40", bg: "bg-health-ok/5" },
+  muted: { border: "border-border", bg: "bg-surface-2" }
 };
 function Panel({
   title,
@@ -4422,21 +4423,28 @@ function Panel({
   flush,
   interactive,
   tone = "default",
+  tintBorderOnly,
+  glow,
   as,
   className,
   bodyClassName,
-  children
+  children,
+  ...rest
 }) {
   const Cmp = as ?? "section";
   const hasHeader = title != null || action != null || caption != null;
   const padClass = flush ? "mg-panel-pad-flush" : dense ? "mg-panel-pad-dense" : "mg-panel-pad";
+  const toneStyle = TONE_STYLES[tone];
   return /* @__PURE__ */ jsxRuntime.jsxs(
     Cmp,
     {
+      ...rest,
       className: classNames(
         "rounded border",
-        TONE_CLASSES3[tone],
+        toneStyle.border,
+        tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,
+        glow ? tone === "accent" ? "mg-card-glow-accent" : "mg-card-glow" : null,
         className
       ),
       children: [

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -4378,12 +4378,13 @@ function SectionLabel({
     }
   );
 }
-var TONE_CLASSES3 = {
-  default: "border-border bg-card",
-  accent: "border-accent/40 bg-primary-soft",
-  warn: "border-health-warn/40 bg-health-warn/5",
-  down: "border-health-down/40 bg-health-down/5",
-  muted: "border-border bg-surface-2"
+var TONE_STYLES = {
+  default: { border: "border-border", bg: "bg-card" },
+  accent: { border: "border-accent/40", bg: "bg-primary-soft" },
+  warn: { border: "border-health-warn/40", bg: "bg-health-warn/5" },
+  down: { border: "border-health-down/40", bg: "bg-health-down/5" },
+  ok: { border: "border-health-ok/40", bg: "bg-health-ok/5" },
+  muted: { border: "border-border", bg: "bg-surface-2" }
 };
 function Panel({
   title,
@@ -4393,21 +4394,28 @@ function Panel({
   flush,
   interactive,
   tone = "default",
+  tintBorderOnly,
+  glow,
   as,
   className,
   bodyClassName,
-  children
+  children,
+  ...rest
 }) {
   const Cmp = as ?? "section";
   const hasHeader = title != null || action != null || caption != null;
   const padClass = flush ? "mg-panel-pad-flush" : dense ? "mg-panel-pad-dense" : "mg-panel-pad";
+  const toneStyle = TONE_STYLES[tone];
   return /* @__PURE__ */ jsxs(
     Cmp,
     {
+      ...rest,
       className: classNames(
         "rounded border",
-        TONE_CLASSES3[tone],
+        toneStyle.border,
+        tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,
+        glow ? tone === "accent" ? "mg-card-glow-accent" : "mg-card-glow" : null,
         className
       ),
       children: [

--- a/packages/ui-kit/src/components/metagraphed/panel.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/panel.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Panel, type PanelProps } from "@/components/metagraphed/panel";
+
+// #7848: Panel gained rest-prop forwarding, a new "ok" tone, tintBorderOnly,
+// and glow so the 31 documented #7817 skips (ids/aria-*/role, tone
+// mismatches, mg-card-glow shells) could finally convert to it instead of a
+// hand-rolled `rounded border bg-card` shell. Rendered via react-dom/server:
+// this package's suite is node-environment with no jsdom.
+const html = (element: React.ReactElement) => renderToStaticMarkup(element);
+
+describe("Panel rest-prop forwarding (#7848)", () => {
+  it("forwards id/aria-*/role/data-* to the outer element, not the body wrapper", () => {
+    // data-* has no dedicated TS type on HTMLAttributes (only real JSX syntax
+    // gets the compiler's special-cased data-*/aria-* leniency, not a plain
+    // React.createElement props object) -- cast rather than drop the case, so
+    // this still proves the real runtime spread forwards it.
+    const props = {
+      id: "endpoints-panel",
+      "aria-label": "Endpoint list",
+      "aria-live": "polite",
+      role: "region",
+      "data-testid": "endpoints-panel",
+    } as PanelProps;
+    const markup = html(React.createElement(Panel, props, "content"));
+    // The outer element (first tag in the markup) carries the forwarded attrs.
+    const outerTagMatch = markup.match(/^<section[^>]*>/);
+    expect(outerTagMatch).not.toBeNull();
+    const outerTag = outerTagMatch![0];
+    expect(outerTag).toContain('id="endpoints-panel"');
+    expect(outerTag).toContain('aria-label="Endpoint list"');
+    expect(outerTag).toContain('aria-live="polite"');
+    expect(outerTag).toContain('role="region"');
+    expect(outerTag).toContain('data-testid="endpoints-panel"');
+  });
+
+  it("keeps forwarded attributes off the body wrapper div", () => {
+    const markup = html(
+      React.createElement(Panel, { id: "outer-only" }, "content"),
+    );
+    // Only one element in the tree should carry the forwarded id.
+    const idOccurrences = markup.match(/id="outer-only"/g) ?? [];
+    expect(idOccurrences.length).toBe(1);
+  });
+
+  it("still renders children inside the padded body wrapper, not the outer element directly", () => {
+    const markup = html(
+      React.createElement(
+        Panel,
+        { dense: true },
+        React.createElement("span", null, "hi"),
+      ),
+    );
+    expect(markup).toContain('class="mg-panel-pad-dense"');
+    expect(markup).toMatch(
+      /<div class="mg-panel-pad-dense"><span>hi<\/span><\/div>/,
+    );
+  });
+
+  it("does not let a caller override className/bodyClassName via rest (type-level, not just runtime)", () => {
+    // className/bodyClassName are still the only className hooks — this is
+    // a compile-time guarantee (PanelOwnProps is Omit'd out of the rest
+    // props' type), asserted here by confirming normal className usage
+    // still composes correctly with the tone/rest classes.
+    const markup = html(
+      React.createElement(Panel, { className: "custom-class", id: "x" }, "y"),
+    );
+    expect(markup).toContain("custom-class");
+    expect(markup).toContain('id="x"');
+  });
+});
+
+describe("Panel tone + tintBorderOnly (#7848)", () => {
+  it("adds the ok tone's tinted border and background", () => {
+    const markup = html(React.createElement(Panel, { tone: "ok" }, "x"));
+    expect(markup).toContain("border-health-ok/40");
+    expect(markup).toContain("bg-health-ok/5");
+  });
+
+  it("tintBorderOnly keeps the tone's border but swaps the tinted bg for bg-card", () => {
+    const markup = html(
+      React.createElement(Panel, { tone: "warn", tintBorderOnly: true }, "x"),
+    );
+    expect(markup).toContain("border-health-warn/40");
+    expect(markup).toContain("bg-card");
+    expect(markup).not.toContain("bg-health-warn/5");
+  });
+
+  it("tintBorderOnly works with the accent tone too", () => {
+    const markup = html(
+      React.createElement(Panel, { tone: "accent", tintBorderOnly: true }, "x"),
+    );
+    expect(markup).toContain("border-accent/40");
+    expect(markup).toContain("bg-card");
+    expect(markup).not.toContain("bg-primary-soft");
+  });
+});
+
+describe("Panel glow (#7848)", () => {
+  it("appends mg-card-glow for the default tone", () => {
+    const markup = html(React.createElement(Panel, { glow: true }, "x"));
+    expect(markup).toContain("mg-card-glow");
+    expect(markup).not.toContain("mg-card-glow-accent");
+  });
+
+  it("appends mg-card-glow-accent when tone is accent", () => {
+    const markup = html(
+      React.createElement(Panel, { glow: true, tone: "accent" }, "x"),
+    );
+    expect(markup).toContain("mg-card-glow-accent");
+  });
+
+  it("omits any glow class when glow is not set", () => {
+    const markup = html(React.createElement(Panel, {}, "x"));
+    expect(markup).not.toContain("mg-card-glow");
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/panel.tsx
+++ b/packages/ui-kit/src/components/metagraphed/panel.tsx
@@ -1,18 +1,24 @@
-import type { ReactNode, ElementType } from "react";
+import type { ReactNode, ElementType, ComponentPropsWithoutRef } from "react";
 import { classNames } from "@/lib/format";
 import { SectionLabel } from "./section-label";
 
-export type PanelTone = "default" | "accent" | "warn" | "down" | "muted";
+export type PanelTone = "default" | "accent" | "warn" | "down" | "ok" | "muted";
 
-const TONE_CLASSES: Record<PanelTone, string> = {
-  default: "border-border bg-card",
-  accent: "border-accent/40 bg-primary-soft",
-  warn: "border-health-warn/40 bg-health-warn/5",
-  down: "border-health-down/40 bg-health-down/5",
-  muted: "border-border bg-surface-2",
+interface ToneStyle {
+  border: string;
+  bg: string;
+}
+
+const TONE_STYLES: Record<PanelTone, ToneStyle> = {
+  default: { border: "border-border", bg: "bg-card" },
+  accent: { border: "border-accent/40", bg: "bg-primary-soft" },
+  warn: { border: "border-health-warn/40", bg: "bg-health-warn/5" },
+  down: { border: "border-health-down/40", bg: "bg-health-down/5" },
+  ok: { border: "border-health-ok/40", bg: "bg-health-ok/5" },
+  muted: { border: "border-border", bg: "bg-surface-2" },
 };
 
-export interface PanelProps {
+interface PanelOwnProps {
   /** Optional uppercase-mono title, rendered via <SectionLabel>. */
   title?: ReactNode;
   /** Right-aligned header slot (buttons, toggles, freshness pill). */
@@ -26,17 +32,34 @@ export interface PanelProps {
   /** Adds the standard hairline hover-lift interaction. */
   interactive?: boolean;
   tone?: PanelTone;
+  /** Keep the tone's border but skip its tinted background (bg-card instead).
+   * Covers shells that deliberately want an ok/warn/down/accent border
+   * without the matching tinted fill (#7848). */
+  tintBorderOnly?: boolean;
+  /** Appends the existing --mg-card-glow(-accent) soft-elevation shadow
+   * class (#6398) — picks the accent variant automatically when
+   * tone="accent". Does not reimplement the CSS; that class stays
+   * canonical in styles.css. */
+  glow?: boolean;
   as?: ElementType;
   className?: string;
   bodyClassName?: string;
   children?: ReactNode;
 }
 
+export type PanelProps = PanelOwnProps &
+  Omit<ComponentPropsWithoutRef<"section">, keyof PanelOwnProps>;
+
 /**
  * Batch B primitive. Replaces the ~500 ad-hoc
  * `rounded border border-border bg-card p-4` shells scattered across
  * routes and panels. Reads --mg-panel-pad tokens so density stays
  * consistent site-wide and contributors stop reinventing card headers.
+ *
+ * Forwards any other HTML/ARIA attribute (id, aria-label, aria-live,
+ * role, data-*, …) to the outer element, so a shell that needs one no
+ * longer has to hand-roll `rounded border bg-card` instead of using
+ * this primitive (#7848).
  */
 export function Panel({
   title,
@@ -46,10 +69,13 @@ export function Panel({
   flush,
   interactive,
   tone = "default",
+  tintBorderOnly,
+  glow,
   as,
   className,
   bodyClassName,
   children,
+  ...rest
 }: PanelProps) {
   const Cmp: ElementType = as ?? "section";
   const hasHeader = title != null || action != null || caption != null;
@@ -58,12 +84,20 @@ export function Panel({
     : dense
       ? "mg-panel-pad-dense"
       : "mg-panel-pad";
+  const toneStyle = TONE_STYLES[tone];
   return (
     <Cmp
+      {...rest}
       className={classNames(
         "rounded border",
-        TONE_CLASSES[tone],
+        toneStyle.border,
+        tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,
+        glow
+          ? tone === "accent"
+            ? "mg-card-glow-accent"
+            : "mg-card-glow"
+          : null,
         className,
       )}
     >


### PR DESCRIPTION
## Summary

#7817 closed with **31 documented skips across 26 files** — ad-hoc `rounded border bg-card` shells that couldn't convert because Panel's API couldn't express them:

1. Elements needing `id`/`aria-label`/`aria-live`/`role`/`data-testid` — Panel had no rest-props spread, so it couldn't forward arbitrary HTML attributes.
2. Tone mismatches — no `ok` tone, and `warn`/`down` forced a tinted background some shells deliberately avoid (border-tint-only).
3. `bg-card/NN` translucent variants — tokenized separately as `.mg-glass*` in #7842 (not a Panel concern, unaffected by this PR).
4. `mg-card-glow` soft-elevation shells (25 occurrences / 5 files) — a real, documented variant (#6398) Panel had no equivalent for.
5. `role="tablist"`/`"radiogroup"` segmented controls — not panels, stay permanently out of scope.

This is **part 1 of 2**: it closes gaps 1, 2, and 4 on the Panel component itself. Part 2 (converting the actual skip sites) follows in a second PR.

## Changes

- `PanelProps` now extends `ComponentPropsWithoutRef<"section">` (minus the props Panel owns) and spreads the rest onto the outer element. `as` polymorphism, `className`/`bodyClassName` behavior, and the header/body wrapper split are all unchanged — this was exactly the regression class #7819's flush/bodyClassName bug came from, so it's unit-tested directly (see below).
- New **`ok`** tone: `border-health-ok/40 bg-health-ok/5`, matching `warn`/`down`'s construction.
- New **`tintBorderOnly`** boolean: keeps the tone's border, swaps its tinted background for `bg-card` — covers the "wants the border, not the fill" skips without exploding the tone enum.
- New **`glow`** boolean: appends the existing `mg-card-glow` class (or `mg-card-glow-accent` when `tone="accent"`, matching how the two variants already pair with neutral vs. accent-tinted borders in raw usage across the codebase). Doesn't reimplement the CSS — those classes stay canonical in `styles.css`.

## Tests

10 unit tests (node-environment via `renderToStaticMarkup`, matching this package's existing convention — see `copy-a11y.test.ts`):
- Forwarded attributes (`id`, `aria-label`, `aria-live`, `role`, `data-*`) land on the outer element and never leak onto the body wrapper `div`.
- Children still render inside the correct padded wrapper.
- Each new `tone`/`tintBorderOnly`/`glow` combination produces the expected class list.

`/design/primitives` showcase gained three panels demonstrating `ok` tone + rest-prop forwarding, `tintBorderOnly`, and `glow`.

## Verification

- `tsc --noEmit` clean in both packages
- `eslint .` (full package) — 0 errors in both
- `prettier --check .` clean in both
- `vitest run` — 191 files / 1465 tests in `apps/ui`, 17 files / 98 tests in `ui-kit` (10 new), all passing
- `packages/ui-kit` rebuilt (`dist/index.{js,cjs,css}`)
- Live preview: `id`/`aria-label` forward onto the real rendered `<section>` (not the body div, confirmed via `getComputedStyle`/DOM inspection); `tone="ok"` renders `border-health-ok/40 bg-health-ok/5`; `tintBorderOnly` renders `border-health-warn/40 bg-card` with no tinted fill

Part 1 of #7848