### PR TITLE
refactor(ui): Panel skip conversions — Part 2 of #7848

### DIFF
--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -1,6 +1,7 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AccountAddress } from "@/components/metagraphed/account-address";
+import { Panel } from "@/components/metagraphed/primitives";
 import { Sparkline, TimeAgo } from "@jsonbored/ui-kit";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { blocksQuery, chainActivityQuery } from "@/lib/metagraphed/queries";
@@ -36,8 +37,11 @@ export function LiveBlockRail() {
   const dailyPts = chrono.map((d) => ({ t: d.day, v: d.block_count }));
 
   return (
-    <div
-      className="mb-3 grid grid-cols-1 gap-3 rounded-lg border border-border bg-card p-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,0.9fr)]"
+    <Panel
+      as="div"
+      dense
+      className="mb-3"
+      bodyClassName="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,0.9fr)]"
       role="status"
       aria-live="polite"
     >
@@ -125,6 +129,6 @@ export function LiveBlockRail() {
           />
         ) : null}
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
+++ b/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { BrandIcon } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
 import { adapterQuery } from "@/lib/metagraphed/queries";
 
 // Gittensor-specific extra (netuid 74 only — see subnets.$netuid.tsx's gate).
@@ -47,7 +48,7 @@ export function GittensorRegisteredRepos({ slug }: { slug: string }) {
   const total = master?.repository_count;
 
   return (
-    <div id="registered-repos" className="rounded-xl border border-border bg-card p-4">
+    <Panel as="div" dense id="registered-repos">
       <div className="mb-3 flex items-center justify-between gap-2">
         <span className="mg-type-micro text-ink-muted">Registered repositories</span>
         {total ? (
@@ -93,6 +94,6 @@ export function GittensorRegisteredRepos({ slug }: { slug: string }) {
           View all {total} registered repositories →
         </a>
       ) : null}
-    </div>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/panel-shell.tsx
+++ b/apps/ui/src/components/metagraphed/panel-shell.tsx
@@ -1,7 +1,7 @@
 import { Component, useState, type ReactNode } from "react";
 import { RefreshCw } from "lucide-react";
 import { useQueryClient, type QueryKey } from "@tanstack/react-query";
-import { SectionAnchor, TimeAgo, type SectionTone } from "@jsonbored/ui-kit";
+import { Panel, SectionAnchor, TimeAgo, type SectionTone } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, isStaleFreshness, isUsableTimestamp } from "@/lib/metagraphed/format";
 import { reportError } from "@/lib/error-reporting";
@@ -129,16 +129,12 @@ export function PanelShell({
         context={typeof title === "string" ? title : id}
       >
         {effectiveLoading ? (
-          <div
-            className="rounded-xl border border-border bg-card p-4"
-            aria-busy="true"
-            aria-live="polite"
-          >
+          <Panel as="div" dense aria-busy="true" aria-live="polite">
             <Skeleton className="h-4 w-40" />
             <Skeleton className="mt-3 h-8 w-full" />
             <Skeleton className="mt-2 h-8 w-3/4" />
             <div style={{ height: Math.max(0, skeletonHeight - 76) }} aria-hidden />
-          </div>
+          </Panel>
         ) : isEmpty ? (
           <EmptyState
             title={emptyTitle ?? "Nothing to show"}

--- a/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
+++ b/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
@@ -1,5 +1,5 @@
 import { ArrowRight, Check, Minus } from "lucide-react";
-import { ExternalLink } from "@jsonbored/ui-kit";
+import { ExternalLink, Panel } from "@jsonbored/ui-kit";
 import { classNames } from "@/lib/metagraphed/format";
 import type { SubnetProfile } from "@/lib/metagraphed/types";
 
@@ -43,10 +43,7 @@ export function ReadinessScorecard({ profile }: { profile?: SubnetProfile }) {
   const tone = typeof score === "number" ? scoreTone(score) : null;
 
   return (
-    <section
-      className="rounded-xl border border-border bg-card p-4"
-      aria-label="Integration readiness"
-    >
+    <Panel dense aria-label="Integration readiness">
       <div className="flex items-start justify-between gap-3">
         <div>
           <div className="mg-label text-ink-subtle-text">Integration readiness</div>
@@ -114,6 +111,6 @@ export function ReadinessScorecard({ profile }: { profile?: SubnetProfile }) {
           ) : null}
         </div>
       ) : null}
-    </section>
+    </Panel>
   );
 }

--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -141,21 +141,14 @@ function UsageStat({
   tone?: "default" | "ok" | "warn";
 }) {
   return (
-    <div
-      className={classNames(
-        "rounded border bg-card px-3 py-2.5",
-        tone === "ok" && "border-health-ok/30",
-        tone === "warn" && "border-health-warn/30",
-        tone === "default" && "border-border",
-      )}
-    >
+    <Panel as="div" flush tintBorderOnly tone={tone} bodyClassName="px-3 py-2.5">
       <div className="flex items-center gap-1.5 text-ink-muted">
         <Icon className="size-3" aria-hidden />
         <span className="mg-type-micro">{eyebrow}</span>
       </div>
       <div className="mt-1 font-mono text-lg font-semibold text-ink-strong">{value}</div>
       {hint ? <div className="mg-type-data-sm text-ink-muted">{hint}</div> : null}
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
@@ -284,11 +284,12 @@ function DiffRow({
   highlight?: boolean;
 }) {
   return (
-    <div
-      className={classNames(
-        "rounded-lg border bg-card px-3 py-2.5",
-        highlight ? "border-accent/60" : "border-border",
-      )}
+    <Panel
+      as="div"
+      flush
+      tintBorderOnly
+      tone={highlight ? "accent" : "default"}
+      bodyClassName="px-3 py-2.5"
     >
       <div className="mg-type-micro text-ink-muted">{title}</div>
       <div className="mt-1 grid grid-cols-[1fr_auto_1fr] items-baseline gap-3">
@@ -300,7 +301,7 @@ function DiffRow({
           {peerValue}
         </span>
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -412,7 +412,12 @@ export function SubnetMasthead({
             // aria-label/title on each segment. Share always renders here
             // too (a resource/link action, not a status readout), so the
             // bar itself is unconditional even when there are no links yet.
-            <div className="mt-3 inline-flex items-center rounded-md border border-border bg-card divide-x divide-border overflow-hidden">
+            <Panel
+              as="div"
+              flush
+              className="mt-3"
+              bodyClassName="inline-flex items-center divide-x divide-border overflow-hidden"
+            >
               {links.map((l) => {
                 const Icon = l.icon;
                 const safeHref = safeExternalUrl(l.href);
@@ -453,7 +458,7 @@ export function SubnetMasthead({
                 );
               })}
               <ShareButton connected />
-            </div>
+            </Panel>
           }
         </div>
       </div>

--- a/apps/ui/src/routes/accounts.index.tsx
+++ b/apps/ui/src/routes/accounts.index.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from "@/components/metagraphed/states";
 import { TopActiveAccounts } from "@/components/metagraphed/top-active-accounts";
 import { TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS } from "@/components/metagraphed/top-active-accounts-ranking";
 import { ActionBar, ShareButton } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { chainSignersQuery } from "@/lib/metagraphed/queries";
 
@@ -91,8 +91,9 @@ function AccountsPage() {
             : "Paste a hotkey or coldkey ss58 address to view its activity."}
         </p>
       </form>
-      <section
-        className="mx-auto mt-10 w-full max-w-2xl rounded-lg border border-border bg-card p-4"
+      <Panel
+        dense
+        className="mx-auto mt-10 w-full max-w-2xl"
         data-testid="top-active-accounts-section"
       >
         <h2 className="mb-1 mg-type-label uppercase text-ink-muted">Most active accounts</h2>
@@ -107,7 +108,7 @@ function AccountsPage() {
         >
           <TopActiveAccounts />
         </AsyncPanel>
-      </section>
+      </Panel>
       <ApiSourceFooter paths={["/api/v1/accounts/{ss58}", "/api/v1/chain/signers"]} />
     </AppShell>
   );

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -143,7 +143,11 @@ function ProviderShell({ slug }: { slug: string }) {
         }
         live={(summary?.by_status?.ok ?? 0) > 0}
         actions={
-          <div className="inline-flex items-center rounded-md border border-border bg-card divide-x divide-border overflow-hidden">
+          <Panel
+            as="div"
+            flush
+            bodyClassName="inline-flex items-center divide-x divide-border overflow-hidden"
+          >
             <PrimaryLinksRail
               bare
               website={p?.website ?? p?.homepage}
@@ -151,7 +155,7 @@ function ProviderShell({ slug }: { slug: string }) {
               repo={p?.repo}
             />
             <ShareButton connected />
-          </div>
+          </Panel>
         }
       />
       {shouldShowProviderSlugSubtitle(p?.name, slug) ? (

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -270,11 +270,6 @@ function Verdict() {
     warn: "text-health-warn",
     down: "text-health-down",
   }[verdict.tone];
-  const toneBorder = {
-    ok: "border-health-ok/40",
-    warn: "border-health-warn/40",
-    down: "border-health-down/40",
-  }[verdict.tone];
 
   const segs = healthStatusSegments({ ok, warn, down, unknown });
   // /api/v1/health carries no real 24h uptime series — this is the share of
@@ -293,8 +288,12 @@ function Verdict() {
           refreshLabel="Refresh health now"
         />
       ) : null}
-      <div
-        className={classNames("flex items-center gap-4 rounded-lg border bg-card p-4", toneBorder)}
+      <Panel
+        as="div"
+        dense
+        tintBorderOnly
+        tone={verdict.tone}
+        bodyClassName="flex items-center gap-4"
         role="status"
       >
         <verdict.Icon className={classNames("size-9 shrink-0", toneText)} aria-hidden="true" />
@@ -306,7 +305,7 @@ function Verdict() {
             {verdict.blurb} · snapshot <TimeAgo at={hRes.meta?.generated_at} />
           </div>
         </div>
-      </div>
+      </Panel>
 
       <div className="grid gap-3 md:grid-cols-3">
         <Panel dense bodyClassName="flex items-center gap-4">

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3592,6 +3592,115 @@ function Sparkline({
     }
   );
 }
+var TONE_CLASSES = {
+  default: "text-ink-muted",
+  muted: "text-ink-subtle-text",
+  accent: "text-accent-text",
+  warn: "text-health-warn-text",
+  down: "text-health-down"
+};
+function SectionLabel({
+  children,
+  size = "micro",
+  tone = "default",
+  icon,
+  hint,
+  as,
+  className,
+  title
+}) {
+  const Cmp = as ?? "span";
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    Cmp,
+    {
+      title,
+      className: classNames(
+        size === "micro" ? "mg-type-micro" : "mg-type-label",
+        "inline-flex items-center gap-1.5",
+        TONE_CLASSES[tone],
+        className
+      ),
+      children: [
+        icon ? /* @__PURE__ */ jsxRuntime.jsx(
+          "span",
+          {
+            "aria-hidden": true,
+            className: "inline-flex size-3 items-center justify-center",
+            children: icon
+          }
+        ) : null,
+        /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate", children }),
+        hint != null ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-ink-subtle-text normal-case tracking-normal", children: hint }) : null
+      ]
+    }
+  );
+}
+var TONE_STYLES = {
+  default: { border: "border-border", bg: "bg-card" },
+  accent: { border: "border-accent/40", bg: "bg-primary-soft" },
+  warn: { border: "border-health-warn/40", bg: "bg-health-warn/5" },
+  down: { border: "border-health-down/40", bg: "bg-health-down/5" },
+  ok: { border: "border-health-ok/40", bg: "bg-health-ok/5" },
+  muted: { border: "border-border", bg: "bg-surface-2" }
+};
+function Panel({
+  title,
+  action,
+  caption,
+  dense,
+  flush,
+  interactive,
+  tone = "default",
+  tintBorderOnly,
+  glow,
+  as,
+  className,
+  bodyClassName,
+  children,
+  ...rest
+}) {
+  const Cmp = as ?? "section";
+  const hasHeader = title != null || action != null || caption != null;
+  const padClass = flush ? "mg-panel-pad-flush" : dense ? "mg-panel-pad-dense" : "mg-panel-pad";
+  const toneStyle = TONE_STYLES[tone];
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    Cmp,
+    {
+      ...rest,
+      className: classNames(
+        "rounded border",
+        toneStyle.border,
+        tintBorderOnly ? "bg-card" : toneStyle.bg,
+        interactive ? "mg-hover-lift" : null,
+        glow ? tone === "accent" ? "mg-card-glow-accent" : "mg-card-glow" : null,
+        className
+      ),
+      children: [
+        hasHeader ? /* @__PURE__ */ jsxRuntime.jsxs(
+          "header",
+          {
+            className: classNames(
+              "flex items-start justify-between gap-3 border-b border-border/70",
+              dense ? "mg-panel-pad-dense" : "mg-panel-pad"
+            ),
+            style: {
+              paddingTop: "var(--mg-space-sm)",
+              paddingBottom: "var(--mg-space-sm)"
+            },
+            children: [
+              /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0", children: [
+                title != null ? /* @__PURE__ */ jsxRuntime.jsx(SectionLabel, { children: title }) : null,
+                caption != null ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1 mg-type-caption-lg text-ink-muted", children: caption }) : null
+              ] }),
+              action != null ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "shrink-0 flex items-center gap-2", children: action }) : null
+            ]
+          }
+        ) : null,
+        /* @__PURE__ */ jsxRuntime.jsx("div", { className: classNames(padClass, bodyClassName), children })
+      ]
+    }
+  );
+}
 function StatTile({
   icon: Icon,
   eyebrow,
@@ -3604,17 +3713,14 @@ function StatTile({
   tooltip
 }) {
   return /* @__PURE__ */ jsxRuntime.jsxs(
-    "div",
+    Panel,
     {
-      className: classNames(
-        "rounded-lg border bg-card p-4 flex items-center gap-4",
-        tone === "accent" && "border-accent/40",
-        tone === "ok" && "border-health-ok/40",
-        tone === "warn" && "border-health-warn/40",
-        tone === "down" && "border-health-down/40",
-        tone === "default" && "border-border",
-        className
-      ),
+      as: "div",
+      dense: true,
+      tintBorderOnly: true,
+      tone,
+      className,
+      bodyClassName: "flex items-center gap-4",
       children: [
         Icon ? /* @__PURE__ */ jsxRuntime.jsx(
           Icon,
@@ -4002,7 +4108,7 @@ function TreemapMini({
     }
   );
 }
-var TONE_CLASSES = {
+var TONE_CLASSES2 = {
   default: "border-border bg-paper text-ink",
   ok: "border-health-ok/40 bg-health-ok/10 text-health-ok",
   warn: "border-health-warn/40 bg-health-warn/10 text-health-warn-text",
@@ -4031,7 +4137,7 @@ function Chip({
         "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5",
         "mg-type-data-sm leading-none whitespace-nowrap transition-colors",
         onClick ? "mg-focus-ring hover:border-ink/30 cursor-pointer" : null,
-        TONE_CLASSES[tone],
+        TONE_CLASSES2[tone],
         className
       ),
       children: [
@@ -4363,115 +4469,6 @@ function useColumnVisibility(pageKey, columns) {
     setVisible(defaultVisible(columns));
   }, [columns]);
   return { visible, isVisible, toggle, reset, setVisible };
-}
-var TONE_CLASSES2 = {
-  default: "text-ink-muted",
-  muted: "text-ink-subtle-text",
-  accent: "text-accent-text",
-  warn: "text-health-warn-text",
-  down: "text-health-down"
-};
-function SectionLabel({
-  children,
-  size = "micro",
-  tone = "default",
-  icon,
-  hint,
-  as,
-  className,
-  title
-}) {
-  const Cmp = as ?? "span";
-  return /* @__PURE__ */ jsxRuntime.jsxs(
-    Cmp,
-    {
-      title,
-      className: classNames(
-        size === "micro" ? "mg-type-micro" : "mg-type-label",
-        "inline-flex items-center gap-1.5",
-        TONE_CLASSES2[tone],
-        className
-      ),
-      children: [
-        icon ? /* @__PURE__ */ jsxRuntime.jsx(
-          "span",
-          {
-            "aria-hidden": true,
-            className: "inline-flex size-3 items-center justify-center",
-            children: icon
-          }
-        ) : null,
-        /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate", children }),
-        hint != null ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-ink-subtle-text normal-case tracking-normal", children: hint }) : null
-      ]
-    }
-  );
-}
-var TONE_STYLES = {
-  default: { border: "border-border", bg: "bg-card" },
-  accent: { border: "border-accent/40", bg: "bg-primary-soft" },
-  warn: { border: "border-health-warn/40", bg: "bg-health-warn/5" },
-  down: { border: "border-health-down/40", bg: "bg-health-down/5" },
-  ok: { border: "border-health-ok/40", bg: "bg-health-ok/5" },
-  muted: { border: "border-border", bg: "bg-surface-2" }
-};
-function Panel({
-  title,
-  action,
-  caption,
-  dense,
-  flush,
-  interactive,
-  tone = "default",
-  tintBorderOnly,
-  glow,
-  as,
-  className,
-  bodyClassName,
-  children,
-  ...rest
-}) {
-  const Cmp = as ?? "section";
-  const hasHeader = title != null || action != null || caption != null;
-  const padClass = flush ? "mg-panel-pad-flush" : dense ? "mg-panel-pad-dense" : "mg-panel-pad";
-  const toneStyle = TONE_STYLES[tone];
-  return /* @__PURE__ */ jsxRuntime.jsxs(
-    Cmp,
-    {
-      ...rest,
-      className: classNames(
-        "rounded border",
-        toneStyle.border,
-        tintBorderOnly ? "bg-card" : toneStyle.bg,
-        interactive ? "mg-hover-lift" : null,
-        glow ? tone === "accent" ? "mg-card-glow-accent" : "mg-card-glow" : null,
-        className
-      ),
-      children: [
-        hasHeader ? /* @__PURE__ */ jsxRuntime.jsxs(
-          "header",
-          {
-            className: classNames(
-              "flex items-start justify-between gap-3 border-b border-border/70",
-              dense ? "mg-panel-pad-dense" : "mg-panel-pad"
-            ),
-            style: {
-              paddingTop: "var(--mg-space-sm)",
-              paddingBottom: "var(--mg-space-sm)"
-            },
-            children: [
-              /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0", children: [
-                title != null ? /* @__PURE__ */ jsxRuntime.jsx(SectionLabel, { children: title }) : null,
-                caption != null ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1 mg-type-caption-lg text-ink-muted", children: caption }) : null
-              ] }),
-              action != null ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "shrink-0 flex items-center gap-2", children: action }) : null
-            ]
-          }
-        ) : null,
-        /* @__PURE__ */ jsxRuntime.jsx("div", { className: classNames(padClass, bodyClassName), children })
-      ]
-    }
-  );
 }
 var VARIANT_ICON = {
   empty: lucideReact.Inbox,

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3563,6 +3563,115 @@ function Sparkline({
     }
   );
 }
+var TONE_CLASSES = {
+  default: "text-ink-muted",
+  muted: "text-ink-subtle-text",
+  accent: "text-accent-text",
+  warn: "text-health-warn-text",
+  down: "text-health-down"
+};
+function SectionLabel({
+  children,
+  size = "micro",
+  tone = "default",
+  icon,
+  hint,
+  as,
+  className,
+  title
+}) {
+  const Cmp = as ?? "span";
+  return /* @__PURE__ */ jsxs(
+    Cmp,
+    {
+      title,
+      className: classNames(
+        size === "micro" ? "mg-type-micro" : "mg-type-label",
+        "inline-flex items-center gap-1.5",
+        TONE_CLASSES[tone],
+        className
+      ),
+      children: [
+        icon ? /* @__PURE__ */ jsx(
+          "span",
+          {
+            "aria-hidden": true,
+            className: "inline-flex size-3 items-center justify-center",
+            children: icon
+          }
+        ) : null,
+        /* @__PURE__ */ jsx("span", { className: "truncate", children }),
+        hint != null ? /* @__PURE__ */ jsx("span", { className: "text-ink-subtle-text normal-case tracking-normal", children: hint }) : null
+      ]
+    }
+  );
+}
+var TONE_STYLES = {
+  default: { border: "border-border", bg: "bg-card" },
+  accent: { border: "border-accent/40", bg: "bg-primary-soft" },
+  warn: { border: "border-health-warn/40", bg: "bg-health-warn/5" },
+  down: { border: "border-health-down/40", bg: "bg-health-down/5" },
+  ok: { border: "border-health-ok/40", bg: "bg-health-ok/5" },
+  muted: { border: "border-border", bg: "bg-surface-2" }
+};
+function Panel({
+  title,
+  action,
+  caption,
+  dense,
+  flush,
+  interactive,
+  tone = "default",
+  tintBorderOnly,
+  glow,
+  as,
+  className,
+  bodyClassName,
+  children,
+  ...rest
+}) {
+  const Cmp = as ?? "section";
+  const hasHeader = title != null || action != null || caption != null;
+  const padClass = flush ? "mg-panel-pad-flush" : dense ? "mg-panel-pad-dense" : "mg-panel-pad";
+  const toneStyle = TONE_STYLES[tone];
+  return /* @__PURE__ */ jsxs(
+    Cmp,
+    {
+      ...rest,
+      className: classNames(
+        "rounded border",
+        toneStyle.border,
+        tintBorderOnly ? "bg-card" : toneStyle.bg,
+        interactive ? "mg-hover-lift" : null,
+        glow ? tone === "accent" ? "mg-card-glow-accent" : "mg-card-glow" : null,
+        className
+      ),
+      children: [
+        hasHeader ? /* @__PURE__ */ jsxs(
+          "header",
+          {
+            className: classNames(
+              "flex items-start justify-between gap-3 border-b border-border/70",
+              dense ? "mg-panel-pad-dense" : "mg-panel-pad"
+            ),
+            style: {
+              paddingTop: "var(--mg-space-sm)",
+              paddingBottom: "var(--mg-space-sm)"
+            },
+            children: [
+              /* @__PURE__ */ jsxs("div", { className: "min-w-0", children: [
+                title != null ? /* @__PURE__ */ jsx(SectionLabel, { children: title }) : null,
+                caption != null ? /* @__PURE__ */ jsx("p", { className: "mt-1 mg-type-caption-lg text-ink-muted", children: caption }) : null
+              ] }),
+              action != null ? /* @__PURE__ */ jsx("div", { className: "shrink-0 flex items-center gap-2", children: action }) : null
+            ]
+          }
+        ) : null,
+        /* @__PURE__ */ jsx("div", { className: classNames(padClass, bodyClassName), children })
+      ]
+    }
+  );
+}
 function StatTile({
   icon: Icon,
   eyebrow,
@@ -3575,17 +3684,14 @@ function StatTile({
   tooltip
 }) {
   return /* @__PURE__ */ jsxs(
-    "div",
+    Panel,
     {
-      className: classNames(
-        "rounded-lg border bg-card p-4 flex items-center gap-4",
-        tone === "accent" && "border-accent/40",
-        tone === "ok" && "border-health-ok/40",
-        tone === "warn" && "border-health-warn/40",
-        tone === "down" && "border-health-down/40",
-        tone === "default" && "border-border",
-        className
-      ),
+      as: "div",
+      dense: true,
+      tintBorderOnly: true,
+      tone,
+      className,
+      bodyClassName: "flex items-center gap-4",
       children: [
         Icon ? /* @__PURE__ */ jsx(
           Icon,
@@ -3973,7 +4079,7 @@ function TreemapMini({
     }
   );
 }
-var TONE_CLASSES = {
+var TONE_CLASSES2 = {
   default: "border-border bg-paper text-ink",
   ok: "border-health-ok/40 bg-health-ok/10 text-health-ok",
   warn: "border-health-warn/40 bg-health-warn/10 text-health-warn-text",
@@ -4002,7 +4108,7 @@ function Chip({
         "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5",
         "mg-type-data-sm leading-none whitespace-nowrap transition-colors",
         onClick ? "mg-focus-ring hover:border-ink/30 cursor-pointer" : null,
-        TONE_CLASSES[tone],
+        TONE_CLASSES2[tone],
         className
       ),
       children: [
@@ -4334,115 +4440,6 @@ function useColumnVisibility(pageKey, columns) {
     setVisible(defaultVisible(columns));
   }, [columns]);
   return { visible, isVisible, toggle, reset, setVisible };
-}
-var TONE_CLASSES2 = {
-  default: "text-ink-muted",
-  muted: "text-ink-subtle-text",
-  accent: "text-accent-text",
-  warn: "text-health-warn-text",
-  down: "text-health-down"
-};
-function SectionLabel({
-  children,
-  size = "micro",
-  tone = "default",
-  icon,
-  hint,
-  as,
-  className,
-  title
-}) {
-  const Cmp = as ?? "span";
-  return /* @__PURE__ */ jsxs(
-    Cmp,
-    {
-      title,
-      className: classNames(
-        size === "micro" ? "mg-type-micro" : "mg-type-label",
-        "inline-flex items-center gap-1.5",
-        TONE_CLASSES2[tone],
-        className
-      ),
-      children: [
-        icon ? /* @__PURE__ */ jsx(
-          "span",
-          {
-            "aria-hidden": true,
-            className: "inline-flex size-3 items-center justify-center",
-            children: icon
-          }
-        ) : null,
-        /* @__PURE__ */ jsx("span", { className: "truncate", children }),
-        hint != null ? /* @__PURE__ */ jsx("span", { className: "text-ink-subtle-text normal-case tracking-normal", children: hint }) : null
-      ]
-    }
-  );
-}
-var TONE_STYLES = {
-  default: { border: "border-border", bg: "bg-card" },
-  accent: { border: "border-accent/40", bg: "bg-primary-soft" },
-  warn: { border: "border-health-warn/40", bg: "bg-health-warn/5" },
-  down: { border: "border-health-down/40", bg: "bg-health-down/5" },
-  ok: { border: "border-health-ok/40", bg: "bg-health-ok/5" },
-  muted: { border: "border-border", bg: "bg-surface-2" }
-};
-function Panel({
-  title,
-  action,
-  caption,
-  dense,
-  flush,
-  interactive,
-  tone = "default",
-  tintBorderOnly,
-  glow,
-  as,
-  className,
-  bodyClassName,
-  children,
-  ...rest
-}) {
-  const Cmp = as ?? "section";
-  const hasHeader = title != null || action != null || caption != null;
-  const padClass = flush ? "mg-panel-pad-flush" : dense ? "mg-panel-pad-dense" : "mg-panel-pad";
-  const toneStyle = TONE_STYLES[tone];
-  return /* @__PURE__ */ jsxs(
-    Cmp,
-    {
-      ...rest,
-      className: classNames(
-        "rounded border",
-        toneStyle.border,
-        tintBorderOnly ? "bg-card" : toneStyle.bg,
-        interactive ? "mg-hover-lift" : null,
-        glow ? tone === "accent" ? "mg-card-glow-accent" : "mg-card-glow" : null,
-        className
-      ),
-      children: [
-        hasHeader ? /* @__PURE__ */ jsxs(
-          "header",
-          {
-            className: classNames(
-              "flex items-start justify-between gap-3 border-b border-border/70",
-              dense ? "mg-panel-pad-dense" : "mg-panel-pad"
-            ),
-            style: {
-              paddingTop: "var(--mg-space-sm)",
-              paddingBottom: "var(--mg-space-sm)"
-            },
-            children: [
-              /* @__PURE__ */ jsxs("div", { className: "min-w-0", children: [
-                title != null ? /* @__PURE__ */ jsx(SectionLabel, { children: title }) : null,
-                caption != null ? /* @__PURE__ */ jsx("p", { className: "mt-1 mg-type-caption-lg text-ink-muted", children: caption }) : null
-              ] }),
-              action != null ? /* @__PURE__ */ jsx("div", { className: "shrink-0 flex items-center gap-2", children: action }) : null
-            ]
-          }
-        ) : null,
-        /* @__PURE__ */ jsx("div", { className: classNames(padClass, bodyClassName), children })
-      ]
-    }
-  );
 }
 var VARIANT_ICON = {
   empty: Inbox,

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { classNames } from "@/lib/format";
 import { InfoTooltip } from "@/components/metagraphed/info-tooltip";
+import { Panel } from "@/components/metagraphed/panel";
 
 interface Props {
   icon?: LucideIcon;
@@ -42,16 +43,13 @@ export function StatTile({
   tooltip,
 }: Props) {
   return (
-    <div
-      className={classNames(
-        "rounded-lg border bg-card p-4 flex items-center gap-4",
-        tone === "accent" && "border-accent/40",
-        tone === "ok" && "border-health-ok/40",
-        tone === "warn" && "border-health-warn/40",
-        tone === "down" && "border-health-down/40",
-        tone === "default" && "border-border",
-        className,
-      )}
+    <Panel
+      as="div"
+      dense
+      tintBorderOnly
+      tone={tone}
+      className={className}
+      bodyClassName="flex items-center gap-4"
     >
       {Icon ? (
         <Icon
@@ -102,6 +100,6 @@ export function StatTile({
         </div>
       </div>
       {chart ? <div className="shrink-0 opacity-80">{chart}</div> : null}
-    </div>
+    </Panel>
   );
 }


### PR DESCRIPTION
## Summary

Part 2 of #7848. Part 1 (#8080, merged) added Panel's rest-prop
forwarding, `ok` tone, and `tintBorderOnly` specifically to unblock the
skip categories documented in #7817. This PR spends that budget:
converts every site in the 28-site skip list that those additions
actually unblock, and leaves a documented, re-verified list of the
sites that still don't fit.

## Converted (11 of 28)

**Plain id/aria/role/data-testid forwarding** (category 1 from #7817):
- `live-block-rail.tsx` — `role="status" aria-live="polite"` rail
- `gittensor-registered-repos.tsx` — `id="registered-repos"`
- `panel-shell.tsx` — the loading-skeleton shell's `aria-busy`/`aria-live`
- `readiness-scorecard.tsx` — `aria-label="Integration readiness"`
- `accounts.index.tsx` — `data-testid="top-active-accounts-section"`

**Dynamic tone** (category 2), via `tone` + `tintBorderOnly`:
- `rpc-proxy.tsx`'s `UsageStat` — `default`/`ok`/`warn` tone
- `subnet-compare-drawer.tsx`'s `DiffRow` — `highlight`-driven accent border
- `status.tsx`'s verdict banner — `ok`/`warn`/`down` from the health snapshot
- ui-kit's `StatTile` — `default`/`accent`/`ok`/`warn`/`down`

**Connected icon bars** (`divide-x divide-border overflow-hidden`), via
`flush` + `bodyClassName` — the body wrapper div is still `divide-x`'s
direct parent, so the selector keeps working:
- `subnet-masthead.tsx`'s website/docs/repo/dashboard/share bar
- `providers.$slug.tsx`'s equivalent masthead action bar

Border-radius (`rounded-xl`/`rounded-lg` → Panel's `rounded`) and
padding (`p-3`/`p-4` → `dense`) normalize to the same values #7809/#7817
already established as the accepted conversion mapping; border-opacity
on a couple of tone borders shifts by one step (e.g. `/30` → `/40`,
`/60` → `/40`) to match Panel's fixed tone-border opacities.

## Left alone (17, re-verified against the eslint guardrail)

- 6 `role="tablist"` segmented controls (drift-activity, endpoint-snippet,
  stake-amount-input ×2, take-management-modal, blocks.$ref, subnets.$netuid)
- 4 more same-family segmented/control clusters without an explicit role:
  rpc-proxy's 7d/30d toggle, health.tsx's refresh-interval picker,
  status.tsx's incident window toggle, ui-kit's `ActionBar` (explicitly
  documented as the bare-variant sibling of `SegmentedToggle`)
- 2 interactive hover/focus-ring shells Panel's static tone can't express:
  nav-omnibox's search trigger, the homepage unified search field
- 2 `bg-card/NN` opacity-fraction shells from the #7842 glass-surface family
  (account-history-chart, accounts.$ss58's `DelegationEdgeList`)
- 2 sites #7848 itself names as permanent exceptions: `primary-links-rail`,
  `segmented-toggle`

Guardrail count: apps/ui 24 → 14, ui-kit 4 → 3.

## Test plan
- [x] `tsc --noEmit` clean in both `apps/ui` and `packages/ui-kit`
- [x] `eslint .` (whole package) clean in both — 0 errors, same pre-existing warning baseline
- [x] `prettier --check .` clean in both
- [x] `vitest run` green in both (apps/ui 1465/1465, ui-kit 98/98)
- [x] `packages/ui-kit/dist` rebuilt for the `StatTile` change
- [x] Live-verified in the browser: `/status` (verdict banner, `down` tone), `/providers/allways` (connected icon bar with dividers intact), `/endpoints` → Managed RPC (UsageStat tone tiles)

Closes #7848 (both parts now land).