### PR TITLE
feat(observability): enable $ai_input/$ai_output_choices content capture for ask()

### DIFF
--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -27,6 +27,7 @@ export const ASK_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 // https://developers.cloudflare.com/workers-ai/models/llama-4-scout-17b-16e-instruct/
 // (checked 2026-07-24) -- update alongside ASK_MODEL if the model ever changes.
 const ASK_PROVIDER = "cloudflare_workers_ai";
+const ASK_TRACE_NAME = "ask";
 const ASK_MODEL_INPUT_USD_PER_MILLION = 0.27;
 const ASK_MODEL_OUTPUT_USD_PER_MILLION = 0.85;
 export const VECTORIZE_INDEX_NAME = "metagraphed-registry-v2";
@@ -654,18 +655,22 @@ export async function askQuestion(
     await recordAiGenerationEvent(env, {
       provider: ASK_PROVIDER,
       model: ASK_MODEL,
+      traceName: ASK_TRACE_NAME,
       latencyMs: Date.now() - generationStart,
       isError: true,
       error,
       modelParameters,
+      input: messages,
     });
     throw error;
   });
   const inputTokens = completion?.usage?.prompt_tokens;
   const outputTokens = completion?.usage?.completion_tokens;
+  const answer = (completion?.response || "").trim();
   await recordAiGenerationEvent(env, {
     provider: ASK_PROVIDER,
     model: ASK_MODEL,
+    traceName: ASK_TRACE_NAME,
     latencyMs: Date.now() - generationStart,
     isError: false,
     inputTokens,
@@ -673,8 +678,9 @@ export async function askQuestion(
     inputCostUsd: costUsd(inputTokens, ASK_MODEL_INPUT_USD_PER_MILLION),
     outputCostUsd: costUsd(outputTokens, ASK_MODEL_OUTPUT_USD_PER_MILLION),
     modelParameters,
+    input: messages,
+    outputChoices: [{ role: "assistant", content: answer }],
   });
-  const answer = (completion?.response || "").trim();
   return {
     question: q,
     answer,

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -544,11 +544,17 @@ export async function recordExceptionEvent(
 // posthog-js-lite SDK source (posthog-ai/src/utils.ts), the same
 // verify-against-source approach #7758's $exception shape used.
 //
-// Content-free by design (#7763's explicit redaction posture): only
-// cost/token/latency/model metadata is ever sent, never the prompt or
-// completion text -- the same minimal-capture philosophy `usage_event` (top of
-// this file) already applies, extended to the one field class an LLM call
-// uniquely adds (tokens/cost).
+// #7763 started this content-free (only cost/token/latency/model metadata,
+// never prompt/completion text) as the default posture for an unscoped LLM
+// surface. #8082 is the deliberate reversal that clause called for: the one
+// caller of this function (askQuestion() in ai-search.ts) only ever answers
+// questions about public on-chain/registry data -- no private/authenticated
+// user content is ever in scope -- so the content-free default didn't earn
+// its keep here, and withholding it left PostHog's Input/Output Message
+// columns blank and Sentiment analysis unable to run (it reads the input/
+// output text). `input`/`outputChoices` below are genuinely optional on the
+// TYPE (a future caller with a real privacy-sensitive surface can simply
+// omit them and get the original #7763 behavior back).
 
 /** Inputs for one AI generation call. `error` mirrors ExceptionEvent's own
  * `error` (raw caught value, this module extracts type/message itself) --
@@ -560,6 +566,8 @@ export interface AiGenerationEvent {
    * outside a multi-step chain, so a fresh UUID is minted when omitted --
    * mirrors posthog-ai's own `uuidv4()` fallback. */
   traceId?: string;
+  /** Display label for the trace on PostHog's Traces page (e.g. "ask"). */
+  traceName?: string;
   latencyMs: number;
   isError: boolean;
   inputTokens?: number;
@@ -570,6 +578,12 @@ export interface AiGenerationEvent {
   outputCostUsd?: number;
   /** Generation config (e.g. `{ max_tokens }`), never prompt/completion text. */
   modelParameters?: Record<string, string | number | boolean>;
+  /** The prompt sent to the model, PostHog's `{role, content}[]` shape. See
+   * the module comment above for why this caller includes it. */
+  input?: Array<{ role: string; content: string }>;
+  /** The model's response, in PostHog's completion-choice shape. Same
+   * inclusion reasoning as `input` above. */
+  outputChoices?: Array<{ role: string; content: string }>;
   error?: unknown;
 }
 
@@ -611,8 +625,19 @@ export async function recordAiGenerationEvent(
       $ai_is_error: event.isError,
     };
 
+    const traceName = sanitizeLabel(event.traceName);
+    if (traceName !== undefined) properties.$ai_trace_name = traceName;
+
     if (event.modelParameters) {
       properties.$ai_model_parameters = event.modelParameters;
+    }
+
+    if (Array.isArray(event.input) && event.input.length > 0) {
+      properties.$ai_input = event.input;
+    }
+
+    if (Array.isArray(event.outputChoices) && event.outputChoices.length > 0) {
+      properties.$ai_output_choices = event.outputChoices;
     }
 
     if (

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -866,6 +866,19 @@ describe("askQuestion", () => {
     assert.ok(out.citations[0].score >= 0 && out.citations[0].score <= 1);
     assert.equal(out.context_count, 3);
   });
+  test("falls back to an empty answer when the model response has no text", async () => {
+    const noResponseAi = {
+      run(model: string) {
+        if (model === EMBED_MODEL) {
+          return Promise.resolve({ data: [new Array(1024).fill(0.02)] });
+        }
+        return Promise.resolve({});
+      },
+    };
+    const env = { AI: noResponseAi, VECTORIZE: stubVectorize() };
+    const out = await askQuestion(mockEnv(env), "Which subnet does images?");
+    assert.equal(out.answer, "");
+  });
   test("rejects a blank question", async () => {
     const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
     await assert.rejects(() => askQuestion(mockEnv(env), ""), /required/);
@@ -941,9 +954,18 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
       properties.$ai_input_cost_usd + properties.$ai_output_cost_usd,
     );
     assert.deepEqual(properties.$ai_model_parameters, { max_tokens: 512 });
-    // Content-free: never the question, the retrieved context, or the answer.
-    assert.equal("$ai_input" in properties, false);
-    assert.equal("$ai_output_choices" in properties, false);
+    // #8082: askQuestion() only ever answers questions about public
+    // registry data, so content capture is deliberately on -- the full
+    // prompt (system + user message, including retrieved context) and the
+    // generated answer both reach PostHog.
+    assert.equal(properties.$ai_trace_name, "ask");
+    assert.ok(Array.isArray(properties.$ai_input));
+    assert.equal(properties.$ai_input[0].role, "system");
+    assert.equal(properties.$ai_input[1].role, "user");
+    assert.match(properties.$ai_input[1].content, /Which subnet does images\?/);
+    assert.deepEqual(properties.$ai_output_choices, [
+      { role: "assistant", content: "Subnet 1 does images [1]." },
+    ]);
   });
 
   test("omits cost fields when the model response carries no usage object", async () => {
@@ -999,6 +1021,10 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
     assert.equal(properties.$ai_is_error, true);
     assert.equal(properties.$ai_http_status, 500);
     assert.equal(properties.$ai_error, "Error: Workers AI unavailable");
+    // The prompt is known regardless of whether the call succeeded -- still
+    // sent on the error path (there's just no answer yet to include).
+    assert.ok(Array.isArray(properties.$ai_input));
+    assert.equal("$ai_output_choices" in properties, false);
   });
 
   test("never calls fetch when PostHog is unconfigured", async () => {

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -1110,11 +1110,14 @@ describe("recordAiGenerationEvent", () => {
       {
         ...BASE,
         traceId: "11111111-1111-1111-1111-111111111111",
+        traceName: "ask",
         inputTokens: 200,
         outputTokens: 50,
         inputCostUsd: 0.000054,
         outputCostUsd: 0.0000425,
         modelParameters: { max_tokens: 512 },
+        input: [{ role: "user", content: "which subnet does X?" }],
+        outputChoices: [{ role: "assistant", content: "Subnet 5 does X." }],
       },
       { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
     );
@@ -1129,6 +1132,7 @@ describe("recordAiGenerationEvent", () => {
       properties.$ai_trace_id,
       "11111111-1111-1111-1111-111111111111",
     );
+    assert.equal(properties.$ai_trace_name, "ask");
     assert.equal(properties.$ai_model, BASE.model);
     assert.equal(properties.$ai_provider, "cloudflare_workers_ai");
     assert.equal(properties.$ai_latency, 1.5);
@@ -1137,20 +1141,39 @@ describe("recordAiGenerationEvent", () => {
     assert.equal(properties.$ai_output_tokens, 50);
     assert.equal(properties.$ai_is_error, false);
     assert.deepEqual(properties.$ai_model_parameters, { max_tokens: 512 });
+    assert.deepEqual(properties.$ai_input, [
+      { role: "user", content: "which subnet does X?" },
+    ]);
+    assert.deepEqual(properties.$ai_output_choices, [
+      { role: "assistant", content: "Subnet 5 does X." },
+    ]);
     assert.equal(properties.$ai_input_cost_usd, 0.000054);
     assert.equal(properties.$ai_output_cost_usd, 0.0000425);
     assert.equal(properties.$ai_total_cost_usd, 0.0000965);
     assert.equal("$ai_error" in properties, false);
   });
 
-  test("never captures prompt/completion content -- no field carries free text beyond the model id", async () => {
+  test("omits trace name/input/output when not supplied -- these are optional, not required", async () => {
     const calls: Row[] = [];
     await recordAiGenerationEvent(CONFIGURED, BASE, {
       fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
     });
-    const keys = Object.keys(calls[0].body.properties);
-    assert.equal(keys.includes("$ai_input"), false);
-    assert.equal(keys.includes("$ai_output_choices"), false);
+    const { properties } = calls[0].body;
+    assert.equal("$ai_trace_name" in properties, false);
+    assert.equal("$ai_input" in properties, false);
+    assert.equal("$ai_output_choices" in properties, false);
+  });
+
+  test("omits input/output when supplied as empty arrays", async () => {
+    const calls: Row[] = [];
+    await recordAiGenerationEvent(
+      CONFIGURED,
+      { ...BASE, input: [], outputChoices: [] },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const { properties } = calls[0].body;
+    assert.equal("$ai_input" in properties, false);
+    assert.equal("$ai_output_choices" in properties, false);
   });
 
   test("mints a fresh trace id when none is supplied", async () => {


### PR DESCRIPTION
## Summary

- Deliberately reverses #7763's content-free default for the one call site that uses it (`askQuestion()`'s `$ai_generation` event): the RAG prompt and generated answer now reach PostHog.
- Adds `$ai_trace_name` ("ask") so the Traces page has a readable label instead of a bare trace id.

## What Changed

- `src/usage-telemetry.ts`: `AiGenerationEvent` gains `traceName`/`input`/`outputChoices`, all optional — `recordAiGenerationEvent` sends `$ai_trace_name`/`$ai_input`/`$ai_output_choices` when present, omits them when not (so a future privacy-sensitive caller can still get the original #7763 content-free behavior by simply not passing them).
- `src/ai-search.ts`: `askQuestion()` passes the existing `messages` array as `input` (zero transform — same `{role, content}[]` shape PostHog expects) on both the success and error paths, and `[{role: "assistant", content: answer}]` as `outputChoices` on success.
- Tests updated to match: the previous "never captures content" assertions are replaced with tests for the new (default-on, still-optional) behavior, plus a regression test for the model-returns-no-text edge case surfaced while re-covering the moved `answer` extraction line.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8082`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none needed).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none).

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (scoped to changed files)
- [x] `npm run typecheck`
- [x] `npm run validate`
- [x] `npx vitest run tests/ai-search.test.ts tests/usage-telemetry.test.ts` (163 passed), full branch coverage on both changed files
- [x] `git diff --check`
- [ ] Live verification (a real `/ask` call populating PostHog's Traces page with Input/Output Message + Trace Name) pending this PR's deploy — not yet done, will confirm after merge.

Closes #8082