### PR TITLE
refactor(ui): fast-refresh compliance batch 1/N — lib/metagraphed context modules

### DIFF
--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -231,5 +231,17 @@ export default tseslint.config(
     files: ["src/components/**/*.{ts,tsx}"],
     rules: { "react-refresh/only-export-components": "off" },
   },
+  {
+    // These three lib/ files are React context modules: the provider
+    // component and its useXCtx/useX hook both need direct access to the
+    // same module-private createContext() value, so the hook can't move to
+    // a sibling file without exporting the context object itself (#7850).
+    files: [
+      "src/lib/metagraphed/api-source-context.tsx",
+      "src/lib/metagraphed/subnet-window.tsx",
+      "src/lib/metagraphed/value-unit.tsx",
+    ],
+    rules: { "react-refresh/only-export-components": "off" },
+  },
   eslintPluginPrettier,
 );

--- a/apps/ui/src/lib/metagraphed/api-source-context.tsx
+++ b/apps/ui/src/lib/metagraphed/api-source-context.tsx
@@ -9,26 +9,9 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
+import { dedupeApiSources, type ApiSource } from "./api-source-helpers";
 
-export interface ApiSource {
-  path: string;
-  artifact?: string;
-  label?: string;
-}
-
-/** Merges registered source groups with first-wins path deduplication. */
-export function dedupeApiSources(groups: Iterable<ApiSource[]>): ApiSource[] {
-  const out: ApiSource[] = [];
-  const seen = new Set<string>();
-  for (const arr of groups) {
-    for (const s of arr) {
-      if (seen.has(s.path)) continue;
-      seen.add(s.path);
-      out.push(s);
-    }
-  }
-  return out;
-}
+export type { ApiSource };
 
 interface Ctx {
   sources: ApiSource[];

--- a/apps/ui/src/lib/metagraphed/api-source-helpers.test.ts
+++ b/apps/ui/src/lib/metagraphed/api-source-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { dedupeApiSources, type ApiSource } from "./api-source-context";
+import { dedupeApiSources, type ApiSource } from "./api-source-helpers";
 
 describe("dedupeApiSources", () => {
   it("returns an empty list for no registrations", () => {

--- a/apps/ui/src/lib/metagraphed/api-source-helpers.ts
+++ b/apps/ui/src/lib/metagraphed/api-source-helpers.ts
@@ -1,0 +1,19 @@
+export interface ApiSource {
+  path: string;
+  artifact?: string;
+  label?: string;
+}
+
+/** Merges registered source groups with first-wins path deduplication. */
+export function dedupeApiSources(groups: Iterable<ApiSource[]>): ApiSource[] {
+  const out: ApiSource[] = [];
+  const seen = new Set<string>();
+  for (const arr of groups) {
+    for (const s of arr) {
+      if (seen.has(s.path)) continue;
+      seen.add(s.path);
+      out.push(s);
+    }
+  }
+  return out;
+}

--- a/apps/ui/src/lib/metagraphed/download-csv-button.test.ts
+++ b/apps/ui/src/lib/metagraphed/download-csv-button.test.ts
@@ -1,16 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import * as csvExport from "./csv-export";
-import { DownloadCsvButton, onDownloadCsvButtonClick } from "./download-csv-button";
-
-describe("onDownloadCsvButtonClick", () => {
-  it("delegates to downloadCsvFromUrl", () => {
-    const spy = vi.spyOn(csvExport, "downloadCsvFromUrl").mockImplementation(() => {});
-    onDownloadCsvButtonClick("/api/v1/subnets?sort=emission");
-    expect(spy).toHaveBeenCalledWith("/api/v1/subnets?sort=emission");
-    spy.mockRestore();
-  });
-});
+import { DownloadCsvButton } from "./download-csv-button";
 
 describe("DownloadCsvButton", () => {
   it("exports a component function", () => {

--- a/apps/ui/src/lib/metagraphed/download-csv-button.tsx
+++ b/apps/ui/src/lib/metagraphed/download-csv-button.tsx
@@ -11,11 +11,6 @@ export interface DownloadCsvButtonProps {
   className?: string;
 }
 
-/** Click handler shared by {@link DownloadCsvButton} and unit tests. */
-export function onDownloadCsvButtonClick(url: string): void {
-  downloadCsvFromUrl(url);
-}
-
 /** Presentational CSV export trigger — not wired into any page yet (#3403–#3409). */
 export function DownloadCsvButton({
   url,
@@ -27,7 +22,7 @@ export function DownloadCsvButton({
   return (
     <button
       type="button"
-      onClick={() => onDownloadCsvButtonClick(url)}
+      onClick={() => downloadCsvFromUrl(url)}
       aria-label={label}
       title={title}
       className={classNames(

--- a/apps/ui/src/lib/metagraphed/subnet-window-helpers.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-window-helpers.ts
@@ -1,0 +1,7 @@
+export type SubnetWindow = "7d" | "30d" | "90d";
+
+export const SUBNET_WINDOWS: SubnetWindow[] = ["7d", "30d", "90d"];
+
+export function isSubnetWindow(v: unknown): v is SubnetWindow {
+  return v === "7d" || v === "30d" || v === "90d";
+}

--- a/apps/ui/src/lib/metagraphed/subnet-window.test.tsx
+++ b/apps/ui/src/lib/metagraphed/subnet-window.test.tsx
@@ -1,7 +1,8 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isSubnetWindow, SubnetWindowProvider, useSubnetWindow } from "./subnet-window";
+import { SubnetWindowProvider, useSubnetWindow } from "./subnet-window";
+import { isSubnetWindow } from "./subnet-window-helpers";
 
 const navigate = vi.fn();
 

--- a/apps/ui/src/lib/metagraphed/subnet-window.tsx
+++ b/apps/ui/src/lib/metagraphed/subnet-window.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo, type ReactNode } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { SegmentedToggle } from "@jsonbored/ui-kit";
+import { SUBNET_WINDOWS, isSubnetWindow, type SubnetWindow } from "./subnet-window-helpers";
 
 /**
  * Shared time-window state for the /subnets/:netuid detail page. Persisted
@@ -11,13 +12,7 @@ import { SegmentedToggle } from "@jsonbored/ui-kit";
  * Values are intentionally aligned with the /subnets list route so the
  * user's window carries over when they drill in.
  */
-export type SubnetWindow = "7d" | "30d" | "90d";
-
-export const SUBNET_WINDOWS: SubnetWindow[] = ["7d", "30d", "90d"];
-
-export function isSubnetWindow(v: unknown): v is SubnetWindow {
-  return v === "7d" || v === "30d" || v === "90d";
-}
+export type { SubnetWindow };
 
 interface Ctx {
   window: SubnetWindow;

--- a/apps/ui/src/lib/metagraphed/value-unit-helpers.test.ts
+++ b/apps/ui/src/lib/metagraphed/value-unit-helpers.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { readStoredValueUnit } from "./value-unit";
+import { readStoredValueUnit } from "./value-unit-helpers";
 
 const STORAGE_KEY = "mg:value-unit";
 

--- a/apps/ui/src/lib/metagraphed/value-unit-helpers.ts
+++ b/apps/ui/src/lib/metagraphed/value-unit-helpers.ts
@@ -1,0 +1,21 @@
+export type ValueUnit = "tao" | "usd" | "both";
+
+export const VALUE_UNIT_STORAGE_KEY = "mg:value-unit";
+export const DEFAULT_VALUE_UNIT: ValueUnit = "both";
+
+/**
+ * Read the persisted τ/USD/Both preference. SSR-safe and corrupt-data-safe:
+ * missing window, blocked storage, or values outside the 3-way allowlist all
+ * fall back to DEFAULT_VALUE_UNIT without throwing.
+ */
+export function readStoredValueUnit(): ValueUnit {
+  if (typeof window === "undefined") return DEFAULT_VALUE_UNIT;
+  try {
+    const raw = window.localStorage.getItem(VALUE_UNIT_STORAGE_KEY);
+    if (raw === "tao" || raw === "usd" || raw === "both") return raw;
+    return DEFAULT_VALUE_UNIT;
+  } catch {
+    /* storage blocked — keep default */
+    return DEFAULT_VALUE_UNIT;
+  }
+}

--- a/apps/ui/src/lib/metagraphed/value-unit.tsx
+++ b/apps/ui/src/lib/metagraphed/value-unit.tsx
@@ -1,33 +1,22 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import {
+  readStoredValueUnit,
+  VALUE_UNIT_STORAGE_KEY,
+  DEFAULT_VALUE_UNIT,
+  type ValueUnit,
+} from "./value-unit-helpers";
 
-export type ValueUnit = "tao" | "usd" | "both";
-
-const STORAGE_KEY = "mg:value-unit";
-const DEFAULT: ValueUnit = "both";
+export type { ValueUnit };
 
 interface Ctx {
   unit: ValueUnit;
   setUnit: (u: ValueUnit) => void;
 }
 
-const ValueUnitContext = createContext<Ctx>({ unit: DEFAULT, setUnit: () => {} });
-
-/**
- * Read the persisted τ/USD/Both preference. SSR-safe and corrupt-data-safe:
- * missing window, blocked storage, or values outside the 3-way allowlist all
- * fall back to DEFAULT without throwing.
- */
-export function readStoredValueUnit(): ValueUnit {
-  if (typeof window === "undefined") return DEFAULT;
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw === "tao" || raw === "usd" || raw === "both") return raw;
-    return DEFAULT;
-  } catch {
-    /* storage blocked — keep default */
-    return DEFAULT;
-  }
-}
+const ValueUnitContext = createContext<Ctx>({
+  unit: DEFAULT_VALUE_UNIT,
+  setUnit: () => {},
+});
 
 /**
  * Provides the τ/USD/Both display preference for money values on the current
@@ -35,7 +24,7 @@ export function readStoredValueUnit(): ValueUnit {
  * choice from localStorage in an effect (so server/client HTML match).
  */
 export function ValueUnitProvider({ children }: { children: ReactNode }) {
-  const [unit, setUnitState] = useState<ValueUnit>(DEFAULT);
+  const [unit, setUnitState] = useState<ValueUnit>(DEFAULT_VALUE_UNIT);
 
   useEffect(() => {
     setUnitState(readStoredValueUnit());
@@ -44,7 +33,7 @@ export function ValueUnitProvider({ children }: { children: ReactNode }) {
   const setUnit = (u: ValueUnit) => {
     setUnitState(u);
     try {
-      window.localStorage.setItem(STORAGE_KEY, u);
+      window.localStorage.setItem(VALUE_UNIT_STORAGE_KEY, u);
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
## Summary

Batch 1 of #7850 (245-warning fast-refresh compliance sweep). Fixes the
9 `react-refresh/only-export-components` warnings in `src/lib/metagraphed`'s
4 flagged files — the smallest, most self-contained batch, establishing
the pattern before the much larger `src/routes/**` batches.

- `api-source-context.tsx`, `subnet-window.tsx`, `value-unit.tsx`: each
  is a React context module (provider component + a `useXCtx`/`useX`
  hook needing direct access to the same module-private
  `createContext()` value). Per-file: moved the pure, non-context-bound
  exports (a dedup helper, a window-validity helper + constant, a
  localStorage-read helper — each with its accompanying type) to a new
  `*-helpers.ts` sibling; left the hook co-located with its context
  (can't move without exporting the context object itself) and added
  these 3 files to the eslint exemption already used for
  `src/components/**`'s documented tightly-coupled-helper cases.
- `download-csv-button.tsx`: `onDownloadCsvButtonClick` was a same-file
  wrapper that just called `downloadCsvFromUrl()` — deleted it, the
  button's `onClick` calls `downloadCsvFromUrl()` directly. Its
  dedicated test was fully redundant with `csv-export.test.ts`'s
  existing `downloadCsvFromUrl` coverage, so it's gone too (1 fewer
  test, no coverage lost).

Zero behavior change; import sites updated mechanically (only each
file's own co-located test imported the moved exports directly —
external consumers only ever imported the still-co-located hooks).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint .` (whole package) — 0 errors; `react-refresh/only-export-components` 246 → 237
- [x] `prettier --check .` clean
- [x] `vitest run` green (191 files / 1464 tests, 1 fewer from the redundant test removal)

Part of #7850.