### PR TITLE
feat(mcp): types-epic E — Zod schemas for 17 subnet-detail-core MCP tools (#8065)

### DIFF
--- a/schemas-src/mcp-tools/find-subnets-by-capability.ts
+++ b/schemas-src/mcp-tools/find-subnets-by-capability.ts
@@ -1,0 +1,44 @@
+// MCP tool `find_subnets_by_capability` (types-epic E batch 2, #8065). No
+// REST mirror -- src/mcp-server.ts's own handler builds this shape directly
+// from /metagraph/agent-catalog.json + a keyword score, it isn't a route
+// response. Modeled field-for-field from the hand-written literals this
+// replaces, same as search-subnets.ts in the pilot batch.
+import { z } from "zod";
+
+export const FindSubnetsByCapabilityInputSchema = z
+  .object({
+    capability: z.string(),
+    cursor: z.int().min(0).optional(),
+    limit: z.int().min(1).max(50).optional(),
+  })
+  .strict();
+export type FindSubnetsByCapabilityInput = z.infer<
+  typeof FindSubnetsByCapabilityInputSchema
+>;
+
+const FindSubnetsByCapabilityResultItemSchema = z
+  .object({
+    netuid: z.int().optional(),
+    slug: z.string().optional(),
+    name: z.string().nullable().optional(),
+    categories: z.array(z.unknown()).optional(),
+    service_kinds: z.array(z.unknown()).optional(),
+    callable_count: z.int().optional(),
+    integration_readiness: z.unknown().optional(),
+  })
+  .passthrough();
+
+export const FindSubnetsByCapabilityOutputSchema = z
+  .object({
+    capability: z.string(),
+    total: z.int(),
+    count: z.int(),
+    cursor: z.int(),
+    limit: z.int(),
+    next_cursor: z.int().nullable(),
+    results: z.array(FindSubnetsByCapabilityResultItemSchema),
+  })
+  .passthrough();
+export type FindSubnetsByCapabilityOutput = z.infer<
+  typeof FindSubnetsByCapabilityOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-health-history.ts
+++ b/schemas-src/mcp-tools/get-health-history.ts
@@ -1,0 +1,89 @@
+// MCP tool `get_health_history` (types-epic E batch 2, #8065). Mirrors GET
+// /api/v1/health/history/{date}, which is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// shallow, from the hand-written literal it replaces (src/health-history-mcp.ts).
+// Enum values hardcoded from src/contracts.ts's QUERY_ENUMS.{surfaceKind,
+// healthStatus,healthClassification} and API_QUERY_COLLECTIONS["health-surfaces"]
+// .sort_fields at the time of writing (mirrors the pilot batch's
+// ECONOMICS_SORT_FIELDS precedent -- not cross-imported).
+import { z } from "zod";
+import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+
+const SURFACE_KIND = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+const HEALTH_STATUS = ["ok", "degraded", "failed", "unknown"] as const;
+const HEALTH_CLASSIFICATION = [
+  "auth-required",
+  "content-mismatch",
+  "dead",
+  "live",
+  "rate-limited",
+  "redirected",
+  "timeout",
+  "transient",
+  "unsupported",
+  "unsafe",
+  "wrong-chain",
+] as const;
+const HEALTH_SURFACE_SORT_FIELDS = [
+  "classification",
+  "kind",
+  "last_checked",
+  "last_ok",
+  "latency_ms",
+  "netuid",
+  "provider",
+  "status",
+  "status_code",
+  "surface_id",
+  "verified_at",
+] as const;
+
+export const GetHealthHistoryInputSchema = z
+  .object({
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    netuid: z.int().min(0).optional(),
+    kind: z.enum(SURFACE_KIND).optional(),
+    provider: z.string().optional(),
+    status: z.enum(HEALTH_STATUS).optional(),
+    classification: z.enum(HEALTH_CLASSIFICATION).optional(),
+    sort: z.enum(HEALTH_SURFACE_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(1000).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type GetHealthHistoryInput = z.infer<typeof GetHealthHistoryInputSchema>;
+
+export const GetHealthHistoryOutputSchema = z
+  .object({
+    date: z.string().nullable(),
+    summary: OpenObjectSchema.nullable().optional(),
+    surfaces: OpenObjectArraySchema,
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetHealthHistoryOutput = z.infer<
+  typeof GetHealthHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-health-trends.ts
+++ b/schemas-src/mcp-tools/get-health-trends.ts
@@ -1,0 +1,19 @@
+// MCP tool `get_health_trends` (types-epic E batch 2, #8065). Mirrors GET
+// /api/v1/health/trends, which is not one of schemas-src/routes/'s covered
+// pilot routes -- no existing Zod schema to reuse. Modeled fresh, shallow,
+// from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetHealthTrendsInputSchema = z.object({}).strict();
+export type GetHealthTrendsInput = z.infer<typeof GetHealthTrendsInputSchema>;
+
+export const GetHealthTrendsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    observed_at: z.string().nullable().optional(),
+    source: z.string().nullable().optional(),
+    windows: OpenObjectSchema,
+  })
+  .passthrough();
+export type GetHealthTrendsOutput = z.infer<typeof GetHealthTrendsOutputSchema>;

--- a/schemas-src/mcp-tools/get-stake-action-preview.ts
+++ b/schemas-src/mcp-tools/get-stake-action-preview.ts
@@ -1,0 +1,48 @@
+// MCP tool `get_stake_action_preview` (types-epic E batch 2, #8065). A
+// presentation layer over the same computeStakeQuote() result
+// get_subnet_stake_quote returns (see get-subnet-stake-quote.ts, pilot
+// batch) but reshaped into a human-readable preview with its own distinct
+// fields (summary, estimated_out, warnings, ok, disclaimer) -- not the same
+// wire shape, so not reused. Modeled from the hand-written literal it
+// replaces, which (unlike most tools in this batch) already declared its
+// own outputSchema inline rather than via TOOL_OUTPUT_SCHEMAS.
+import { z } from "zod";
+
+const STAKE_QUOTE_DIRECTIONS = ["stake", "unstake"] as const;
+
+export const GetStakeActionPreviewInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    amount: z.number().gt(0),
+    direction: z.enum(STAKE_QUOTE_DIRECTIONS).optional(),
+  })
+  .strict();
+export type GetStakeActionPreviewInput = z.infer<
+  typeof GetStakeActionPreviewInputSchema
+>;
+
+const EstimatedOutSchema = z
+  .object({
+    amount: z.number(),
+    unit: z.string(),
+  })
+  .strict();
+
+export const GetStakeActionPreviewOutputSchema = z
+  .object({
+    netuid: z.int(),
+    direction: z.string(),
+    amount: z.number(),
+    summary: z.string(),
+    estimated_out: EstimatedOutSchema.optional(),
+    spot_price_tao: z.number().optional(),
+    effective_price_tao: z.number().optional(),
+    price_impact_pct: z.number().optional(),
+    warnings: z.array(z.string()),
+    ok: z.boolean(),
+    disclaimer: z.string(),
+  })
+  .passthrough();
+export type GetStakeActionPreviewOutput = z.infer<
+  typeof GetStakeActionPreviewOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-concentration.ts
+++ b/schemas-src/mcp-tools/get-subnet-concentration.ts
@@ -1,0 +1,34 @@
+// MCP tool `get_subnet_concentration` (types-epic E batch 2, #8065). Mirrors
+// GET /api/v1/subnets/{netuid}/concentration, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetConcentrationInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetConcentrationInput = z.infer<
+  typeof GetSubnetConcentrationInputSchema
+>;
+
+export const GetSubnetConcentrationOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    neuron_count: z.int(),
+    entity_count: z.int().optional(),
+    uids_per_entity: z.number().nullable().optional(),
+    captured_at: z.string().nullable().optional(),
+    stake: OpenObjectSchema.nullable().optional(),
+    emission: OpenObjectSchema.nullable().optional(),
+    entity_stake: OpenObjectSchema.nullable().optional(),
+    entity_emission: OpenObjectSchema.nullable().optional(),
+    validator_stake: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetConcentrationOutput = z.infer<
+  typeof GetSubnetConcentrationOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-detail.ts
+++ b/schemas-src/mcp-tools/get-subnet-detail.ts
@@ -1,0 +1,35 @@
+// MCP tool `get_subnet_detail` (types-epic E batch 2, #8065). Despite
+// "Mirrors GET /api/v1/subnets/{netuid}" in its description, the handler
+// reads the RAW /metagraph/subnets/{netuid}.json artifact and nests it under
+// a `subnet` key (`{schema_version, generated_at, subnet: {...}, ...}`) --
+// a different top-level wrapper shape than schemas-src/routes/subnet-detail.ts's
+// SubnetDetailArtifactSchema (the REST route's own `data`, which is the
+// subnet's fields directly, not nested under `subnet`). Not reusable;
+// modeled fresh, shallow, from the hand-written literal it replaces (same
+// look-but-don't-reuse finding as get-network-health.ts/get-economics.ts in
+// the pilot batch).
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetDetailInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetDetailInput = z.infer<typeof GetSubnetDetailInputSchema>;
+
+export const GetSubnetDetailOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    generated_at: z.string().nullable().optional(),
+    subnet: OpenObjectSchema,
+    candidate_surfaces: z.array(z.unknown()).optional(),
+    candidates: z.array(z.unknown()).optional(),
+    endpoints: z.array(z.unknown()).optional(),
+    gaps: z.unknown().optional(),
+    surfaces: z.array(z.unknown()).optional(),
+    verified_surfaces: z.array(z.unknown()).optional(),
+    economics: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetDetailOutput = z.infer<typeof GetSubnetDetailOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-economics.ts
+++ b/schemas-src/mcp-tools/get-subnet-economics.ts
@@ -1,0 +1,29 @@
+// MCP tool `get_subnet_economics` (types-epic E batch 2, #8065). No REST
+// mirror named in its description; the handler calls loadSubnetEconomics()
+// directly and returns its own compact shape, distinct from schemas-src's
+// SubnetEconomicsSchema (schemas-src/shared.ts) or EconomicsArtifactSchema.
+// Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetEconomicsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetEconomicsInput = z.infer<
+  typeof GetSubnetEconomicsInputSchema
+>;
+
+export const GetSubnetEconomicsOutputSchema = z
+  .object({
+    netuid: z.int(),
+    source: z.string().nullable().optional(),
+    captured_at: z.string().nullable().optional(),
+    summary: OpenObjectSchema.nullable().optional(),
+    economics: OpenObjectSchema.nullable(),
+  })
+  .passthrough();
+export type GetSubnetEconomicsOutput = z.infer<
+  typeof GetSubnetEconomicsOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-health-incidents.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-incidents.ts
@@ -1,0 +1,51 @@
+// MCP tool `get_subnet_health_incidents` (types-epic E batch 2, #8065).
+// Mirrors GET /api/v1/subnets/{netuid}/health/incidents, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+
+const HEALTH_WINDOWS = ["7d", "30d"] as const;
+
+export const GetSubnetHealthIncidentsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    window: z.enum(HEALTH_WINDOWS).optional(),
+  })
+  .strict();
+export type GetSubnetHealthIncidentsInput = z.infer<
+  typeof GetSubnetHealthIncidentsInputSchema
+>;
+
+const GetSubnetHealthIncidentSchema = z
+  .object({
+    started_at: z.int().nullable().optional(),
+    ended_at: z.int().nullable().optional(),
+    duration_ms: z.int().nullable().optional(),
+    failed_samples: z.int().optional(),
+  })
+  .passthrough();
+
+const GetSubnetHealthIncidentsSurfaceSchema = z
+  .object({
+    surface_id: z.string().nullable().optional(),
+    samples: z.int().optional(),
+    uptime_ratio: z.number().nullable().optional(),
+    incident_count: z.int().optional(),
+    downtime_ms: z.int().optional(),
+    incidents: z.array(GetSubnetHealthIncidentSchema).optional(),
+  })
+  .passthrough();
+
+export const GetSubnetHealthIncidentsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    source: z.string().nullable().optional(),
+    surfaces: z.array(GetSubnetHealthIncidentsSurfaceSchema),
+  })
+  .passthrough();
+export type GetSubnetHealthIncidentsOutput = z.infer<
+  typeof GetSubnetHealthIncidentsOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-health-percentiles.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-percentiles.ts
@@ -1,0 +1,50 @@
+// MCP tool `get_subnet_health_percentiles` (types-epic E batch 2, #8065).
+// Mirrors GET /api/v1/subnets/{netuid}/health/percentiles, which is not one
+// of schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+
+const HEALTH_WINDOWS = ["7d", "30d"] as const;
+
+export const GetSubnetHealthPercentilesInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    window: z.enum(HEALTH_WINDOWS).optional(),
+  })
+  .strict();
+export type GetSubnetHealthPercentilesInput = z.infer<
+  typeof GetSubnetHealthPercentilesInputSchema
+>;
+
+const LatencyPercentilesSchema = z
+  .object({
+    p50: z.int().nullable().optional(),
+    p95: z.int().nullable().optional(),
+    p99: z.int().nullable().optional(),
+    avg: z.int().nullable().optional(),
+    min: z.int().nullable().optional(),
+    max: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+const GetSubnetHealthPercentilesSurfaceSchema = z
+  .object({
+    surface_id: z.string().nullable().optional(),
+    samples: z.int().optional(),
+    latency_ms: LatencyPercentilesSchema.optional(),
+  })
+  .passthrough();
+
+export const GetSubnetHealthPercentilesOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    source: z.string().nullable().optional(),
+    surfaces: z.array(GetSubnetHealthPercentilesSurfaceSchema),
+  })
+  .passthrough();
+export type GetSubnetHealthPercentilesOutput = z.infer<
+  typeof GetSubnetHealthPercentilesOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-health-trends.ts
+++ b/schemas-src/mcp-tools/get-subnet-health-trends.ts
@@ -1,0 +1,28 @@
+// MCP tool `get_subnet_health_trends` (types-epic E batch 2, #8065). Mirrors
+// GET /api/v1/subnets/{netuid}/health/trends, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetHealthTrendsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetHealthTrendsInput = z.infer<
+  typeof GetSubnetHealthTrendsInputSchema
+>;
+
+export const GetSubnetHealthTrendsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    observed_at: z.string().nullable().optional(),
+    source: z.string().nullable().optional(),
+    windows: OpenObjectSchema,
+  })
+  .passthrough();
+export type GetSubnetHealthTrendsOutput = z.infer<
+  typeof GetSubnetHealthTrendsOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-health.ts
+++ b/schemas-src/mcp-tools/get-subnet-health.ts
@@ -1,0 +1,37 @@
+// MCP tool `get_subnet_health` (types-epic E batch 2, #8065). "Mirrors" the
+// health domain conceptually but the REST route it names isn't one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetHealthInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetHealthInput = z.infer<typeof GetSubnetHealthInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const GetSubnetHealthSurfaceSchema = z
+  .object({
+    surface_id: z.string().optional(),
+    netuid: z.int().optional(),
+    kind: z.string().nullable().optional(),
+    status: z.string().optional(),
+    latency_ms: z.int().nullable().optional(),
+    last_checked: z.string().nullable().optional(),
+    last_ok: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetHealthOutputSchema = z
+  .object({
+    netuid: z.int(),
+    summary: OpenObjectSchema,
+    operational_observed_at: z.string().nullable().optional(),
+    surfaces: z.array(GetSubnetHealthSurfaceSchema),
+  })
+  .passthrough();
+export type GetSubnetHealthOutput = z.infer<typeof GetSubnetHealthOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-idle-stake.ts
+++ b/schemas-src/mcp-tools/get-subnet-idle-stake.ts
@@ -1,0 +1,28 @@
+// MCP tool `get_subnet_idle_stake` (types-epic E batch 2, #8065). Mirrors
+// GET /api/v1/subnets/{netuid}/idle-stake, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+
+export const GetSubnetIdleStakeInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetIdleStakeInput = z.infer<
+  typeof GetSubnetIdleStakeInputSchema
+>;
+
+export const GetSubnetIdleStakeOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    captured_at: z.string().nullable().optional(),
+    neuron_count: z.int(),
+    idle_neuron_count: z.int(),
+    idle_stake_tao: z.number(),
+  })
+  .passthrough();
+export type GetSubnetIdleStakeOutput = z.infer<
+  typeof GetSubnetIdleStakeOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-movers.ts
+++ b/schemas-src/mcp-tools/get-subnet-movers.ts
@@ -1,0 +1,57 @@
+// MCP tool `get_subnet_movers` (types-epic E batch 2, #8065). Mirrors GET
+// /api/v1/subnets/movers, which is not one of schemas-src/routes/'s covered
+// pilot routes -- no existing Zod schema to reuse. Modeled fresh, shallow,
+// from the hand-written literal it replaces. Window/sort enums hardcoded
+// from src/movers.ts's MOVERS_WINDOWS/MOVERS_SORTS at the time of writing
+// (mirrors the pilot batch's ECONOMICS_SORT_FIELDS precedent -- not
+// cross-imported, to avoid a runtime dependency for what is purely a wire-
+// schema enum).
+import { z } from "zod";
+
+const MOVERS_WINDOW_KEYS = ["7d", "30d", "90d"] as const;
+const MOVERS_SORTS = ["stake", "emission", "validators", "neurons"] as const;
+const MOVERS_LIMIT_MAX = 100;
+
+export const GetSubnetMoversInputSchema = z
+  .object({
+    window: z.enum(MOVERS_WINDOW_KEYS).optional(),
+    sort: z.enum(MOVERS_SORTS).optional(),
+    limit: z.int().min(1).max(MOVERS_LIMIT_MAX).optional(),
+  })
+  .strict();
+export type GetSubnetMoversInput = z.infer<typeof GetSubnetMoversInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const GetSubnetMoverItemSchema = z
+  .object({
+    netuid: z.int().optional(),
+    stake_start_tao: z.unknown().optional(),
+    stake_end_tao: z.unknown().optional(),
+    stake_delta_tao: z.unknown().optional(),
+    stake_pct_change: z.number().nullable().optional(),
+    emission_start_tao: z.unknown().optional(),
+    emission_end_tao: z.unknown().optional(),
+    emission_delta_tao: z.unknown().optional(),
+    emission_pct_change: z.number().nullable().optional(),
+    validators_start: z.int().optional(),
+    validators_end: z.int().optional(),
+    validators_delta: z.int().optional(),
+    neurons_start: z.int().optional(),
+    neurons_end: z.int().optional(),
+    neurons_delta: z.int().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetMoversOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable(),
+    start_date: z.string().nullable().optional(),
+    end_date: z.string().nullable().optional(),
+    sort: z.string().nullable(),
+    subnet_count: z.int(),
+    movers: z.array(GetSubnetMoverItemSchema),
+  })
+  .passthrough();
+export type GetSubnetMoversOutput = z.infer<typeof GetSubnetMoversOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-performance.ts
+++ b/schemas-src/mcp-tools/get-subnet-performance.ts
@@ -1,0 +1,34 @@
+// MCP tool `get_subnet_performance` (types-epic E batch 2, #8065). Mirrors
+// GET /api/v1/subnets/{netuid}/performance, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetPerformanceInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetPerformanceInput = z.infer<
+  typeof GetSubnetPerformanceInputSchema
+>;
+
+export const GetSubnetPerformanceOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    neuron_count: z.int(),
+    validator_count: z.int().optional(),
+    active_count: z.int().optional(),
+    captured_at: z.string().nullable().optional(),
+    incentive: OpenObjectSchema.nullable().optional(),
+    dividends: OpenObjectSchema.nullable().optional(),
+    trust: OpenObjectSchema.nullable().optional(),
+    consensus: OpenObjectSchema.nullable().optional(),
+    validator_trust: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetPerformanceOutput = z.infer<
+  typeof GetSubnetPerformanceOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-snapshot.ts
+++ b/schemas-src/mcp-tools/get-subnet-snapshot.ts
@@ -1,0 +1,32 @@
+// MCP tool `get_subnet_snapshot` (types-epic E batch 2, #8065). Fans out to
+// 5 live views (hyperparameters, concentration, performance, top_validators,
+// recent_events) with its own compound handler -- no single REST route or
+// schemas-src schema to reuse. Modeled fresh, shallow, from the hand-written
+// literal it replaces.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetSnapshotInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    top_validators_limit: z.int().min(1).optional(),
+    recent_events_limit: z.int().min(1).max(1000).optional(),
+  })
+  .strict();
+export type GetSubnetSnapshotInput = z.infer<
+  typeof GetSubnetSnapshotInputSchema
+>;
+
+export const GetSubnetSnapshotOutputSchema = z
+  .object({
+    netuid: z.int(),
+    hyperparameters: OpenObjectSchema,
+    concentration: OpenObjectSchema,
+    performance: OpenObjectSchema,
+    top_validators: OpenObjectSchema,
+    recent_events: OpenObjectSchema,
+  })
+  .passthrough();
+export type GetSubnetSnapshotOutput = z.infer<
+  typeof GetSubnetSnapshotOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-trajectory.ts
+++ b/schemas-src/mcp-tools/get-subnet-trajectory.ts
@@ -1,0 +1,27 @@
+// MCP tool `get_subnet_trajectory` (types-epic E batch 2, #8065). No
+// "Mirrors" claim in its description and no covered REST route to reuse.
+// Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetTrajectoryInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetTrajectoryInput = z.infer<
+  typeof GetSubnetTrajectoryInputSchema
+>;
+
+export const GetSubnetTrajectoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    point_count: z.int(),
+    points: z.array(OpenObjectSchema),
+    deltas: OpenObjectSchema.optional(),
+  })
+  .passthrough();
+export type GetSubnetTrajectoryOutput = z.infer<
+  typeof GetSubnetTrajectoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-uptime.ts
+++ b/schemas-src/mcp-tools/get-subnet-uptime.ts
@@ -1,0 +1,29 @@
+// MCP tool `get_subnet_uptime` (types-epic E batch 2, #8065). Mirrors GET
+// /api/v1/subnets/{netuid}/uptime, which is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+
+const UPTIME_WINDOWS = ["90d", "1y"] as const;
+
+export const GetSubnetUptimeInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    window: z.enum(UPTIME_WINDOWS).optional(),
+    min_samples: z.int().min(0).optional(),
+  })
+  .strict();
+export type GetSubnetUptimeInput = z.infer<typeof GetSubnetUptimeInputSchema>;
+
+export const GetSubnetUptimeOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    window: z.string().nullable(),
+    observed_at: z.string().nullable().optional(),
+    surfaces: OpenObjectArraySchema,
+    reliability: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetUptimeOutput = z.infer<typeof GetSubnetUptimeOutputSchema>;

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -1,0 +1,21 @@
+// Shared building blocks for schemas-src/mcp-tools/*.ts (types-epic E,
+// #7863). Every hand-written MCP output schema this epic has converted so
+// far leaves nested objects/arrays shallow (bare `{type:"object"}` /
+// `{type:"array", items:{type:"object"}}`, no per-field constraints) even on
+// tools whose description says they "mirror" a REST route -- reusing a
+// deeper schemas-src/routes/ schema for those fields would silently accept
+// LESS than the original wire contract did, a regression per #7863's "hard
+// wire-compatibility constraint" (see e.g. get-network-health.ts's header
+// for the fuller rationale, first established in the pilot batch). These
+// two helpers are the Zod equivalent of that same shallow-on-purpose shape.
+import { z } from "zod";
+
+// Bare `{type:"object"}` (hand-written, no `properties`/`additionalProperties`
+// declared -- JSON Schema's own default for an omitted additionalProperties
+// is `true`, i.e. "any object, any keys").
+export const OpenObjectSchema = z.object({}).passthrough();
+
+// Bare `{type:"array"}` or `{type:"array", items:{type:"object"}}` (no
+// items-shape constraint beyond "each item is some object", or none at all).
+export const OpenArraySchema = z.array(z.unknown());
+export const OpenObjectArraySchema = z.array(OpenObjectSchema);

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -1,5 +1,5 @@
 // Equivalence-diff audit for the Zod-generated MCP tool schemas (types-epic
-// E, #7863 requirement 3): compares each pilot-batch tool's Zod-generated
+// E, #7863 requirement 3): compares each converted tool's Zod-generated
 // input/output JSON Schema against the hand-written literal it replaces,
 // after normalizing the specific cosmetic differences z.toJSONSchema()
 // introduces (documented inline below, mirroring
@@ -7,14 +7,22 @@
 // Anything left after normalization is a real difference and must be
 // resolved before merge, not silenced here.
 //
-// The "old" schemas are hand-transcribed from the literals this PR's
-// conversion commit replaced (see that commit's diff for
-// src/mcp-server.ts / src/global-operational-health.ts /
-// src/network-economics.ts) -- there is no structured old artifact to read
+// The "old" schemas are hand-transcribed from the literals each batch's
+// conversion commit replaced (see that commit's diff for src/mcp-server.ts /
+// src/global-operational-health.ts / src/network-economics.ts /
+// src/health-history-mcp.ts) -- there is no structured old artifact to read
 // (unlike B's hand-edited JSON Schema files), since the originals were
 // inline JS object literals inside .ts source, not their own JSON files.
 // Kept here as the audit's fixed baseline; add a new OLD_SCHEMAS entry
 // (never edit an existing one) for each future batch under this issue.
+// Batch 1 (pilot, #7863, PR #8087): search_subnets, list_subnets,
+// get_subnet, get_network_health, get_subnet_stake_quote, get_economics.
+// Batch 2 (#8065): find_subnets_by_capability, get_subnet_detail,
+// get_subnet_snapshot, get_subnet_health(+trends/percentiles/incidents),
+// get_health_trends, get_subnet_economics, get_stake_action_preview,
+// get_subnet_trajectory, get_subnet_concentration, get_subnet_performance,
+// get_subnet_idle_stake, get_subnet_movers, get_subnet_uptime,
+// get_health_history.
 import { z } from "zod";
 import {
   SearchSubnetsInputSchema,
@@ -40,11 +48,80 @@ import {
   GetEconomicsInputSchema,
   GetEconomicsOutputSchema,
 } from "../schemas-src/mcp-tools/get-economics.ts";
+import {
+  FindSubnetsByCapabilityInputSchema,
+  FindSubnetsByCapabilityOutputSchema,
+} from "../schemas-src/mcp-tools/find-subnets-by-capability.ts";
+import {
+  GetSubnetDetailInputSchema,
+  GetSubnetDetailOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-detail.ts";
+import {
+  GetSubnetSnapshotInputSchema,
+  GetSubnetSnapshotOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-snapshot.ts";
+import {
+  GetSubnetHealthInputSchema,
+  GetSubnetHealthOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-health.ts";
+import {
+  GetSubnetHealthTrendsInputSchema,
+  GetSubnetHealthTrendsOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-health-trends.ts";
+import {
+  GetHealthTrendsInputSchema,
+  GetHealthTrendsOutputSchema,
+} from "../schemas-src/mcp-tools/get-health-trends.ts";
+import {
+  GetSubnetHealthPercentilesInputSchema,
+  GetSubnetHealthPercentilesOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-health-percentiles.ts";
+import {
+  GetSubnetHealthIncidentsInputSchema,
+  GetSubnetHealthIncidentsOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-health-incidents.ts";
+import {
+  GetSubnetEconomicsInputSchema,
+  GetSubnetEconomicsOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-economics.ts";
+import {
+  GetStakeActionPreviewInputSchema,
+  GetStakeActionPreviewOutputSchema,
+} from "../schemas-src/mcp-tools/get-stake-action-preview.ts";
+import {
+  GetSubnetTrajectoryInputSchema,
+  GetSubnetTrajectoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-trajectory.ts";
+import {
+  GetSubnetConcentrationInputSchema,
+  GetSubnetConcentrationOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-concentration.ts";
+import {
+  GetSubnetPerformanceInputSchema,
+  GetSubnetPerformanceOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-performance.ts";
+import {
+  GetSubnetIdleStakeInputSchema,
+  GetSubnetIdleStakeOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-idle-stake.ts";
+import {
+  GetSubnetMoversInputSchema,
+  GetSubnetMoversOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-movers.ts";
+import {
+  GetSubnetUptimeInputSchema,
+  GetSubnetUptimeOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-uptime.ts";
+import {
+  GetHealthHistoryInputSchema,
+  GetHealthHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-health-history.ts";
 
 type Row = Record<string, unknown>;
 
 const NULLABLE_STRING = { type: ["string", "null"] };
 const NULLABLE_INT = { type: ["integer", "null"] };
+const ANY = {};
 const objectItems = (properties: Row = {}) => ({
   type: "array",
   items: { type: "object", additionalProperties: true, properties },
@@ -93,6 +170,58 @@ const ECONOMICS_SORT_FIELDS = [
   "subnet_volume_tao",
   "total_stake_tao",
   "validator_count",
+];
+// Batch-2 (#8065) resolved enum values, same treatment as above -- symbolic
+// in the hand-written originals (src/movers.ts's MOVERS_WINDOWS/MOVERS_SORTS,
+// src/contracts.ts's QUERY_ENUMS/API_QUERY_COLLECTIONS), cross-checked
+// against the actual runtime source at the time of writing.
+const HEALTH_WINDOWS = ["7d", "30d"];
+const UPTIME_WINDOWS = ["90d", "1y"];
+const MOVERS_WINDOW_KEYS = ["7d", "30d", "90d"];
+const MOVERS_SORTS = ["stake", "emission", "validators", "neurons"];
+const MOVERS_LIMIT_MAX = 100;
+const SURFACE_KIND = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+];
+const HEALTH_STATUS = ["ok", "degraded", "failed", "unknown"];
+const HEALTH_CLASSIFICATION = [
+  "auth-required",
+  "content-mismatch",
+  "dead",
+  "live",
+  "rate-limited",
+  "redirected",
+  "timeout",
+  "transient",
+  "unsupported",
+  "unsafe",
+  "wrong-chain",
+];
+const HEALTH_SURFACE_SORT_FIELDS = [
+  "classification",
+  "kind",
+  "last_checked",
+  "last_ok",
+  "latency_ms",
+  "netuid",
+  "provider",
+  "status",
+  "status_code",
+  "surface_id",
+  "verified_at",
 ];
 
 const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
@@ -345,6 +474,512 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  find_subnets_by_capability: {
+    input: {
+      type: "object",
+      properties: {
+        capability: { type: "string" },
+        cursor: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 50 },
+      },
+      required: ["capability"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "capability",
+        "total",
+        "count",
+        "cursor",
+        "limit",
+        "next_cursor",
+        "results",
+      ],
+      properties: {
+        capability: { type: "string" },
+        total: { type: "integer" },
+        count: { type: "integer" },
+        cursor: { type: "integer" },
+        limit: { type: "integer" },
+        next_cursor: { type: ["integer", "null"] },
+        results: objectItems({
+          netuid: { type: "integer" },
+          slug: { type: "string" },
+          name: NULLABLE_STRING,
+          categories: { type: "array" },
+          service_kinds: { type: "array" },
+          callable_count: { type: "integer" },
+          integration_readiness: ANY,
+        }),
+      },
+    },
+  },
+  get_subnet_detail: {
+    input: {
+      type: "object",
+      properties: { netuid: { type: "integer", minimum: 0 } },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet"],
+      properties: {
+        schema_version: { type: "integer" },
+        generated_at: NULLABLE_STRING,
+        subnet: { type: "object" },
+        candidate_surfaces: { type: "array" },
+        candidates: { type: "array" },
+        endpoints: { type: "array" },
+        gaps: ANY,
+        surfaces: { type: "array" },
+        verified_surfaces: { type: "array" },
+        economics: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_subnet_snapshot: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        top_validators_limit: { type: "integer", minimum: 1 },
+        recent_events_limit: { type: "integer", minimum: 1, maximum: 1000 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "netuid",
+        "hyperparameters",
+        "concentration",
+        "performance",
+        "top_validators",
+        "recent_events",
+      ],
+      properties: {
+        netuid: { type: "integer" },
+        hyperparameters: { type: "object" },
+        concentration: { type: "object" },
+        performance: { type: "object" },
+        top_validators: { type: "object" },
+        recent_events: { type: "object" },
+      },
+    },
+  },
+  get_subnet_health: {
+    input: {
+      type: "object",
+      properties: { netuid: { type: "integer", minimum: 0 } },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "summary", "surfaces"],
+      properties: {
+        netuid: { type: "integer" },
+        summary: { type: "object" },
+        operational_observed_at: NULLABLE_STRING,
+        surfaces: objectItems({
+          surface_id: { type: "string" },
+          netuid: { type: "integer" },
+          kind: NULLABLE_STRING,
+          status: { type: "string" },
+          latency_ms: NULLABLE_INT,
+          last_checked: NULLABLE_STRING,
+          last_ok: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_subnet_health_trends: {
+    input: {
+      type: "object",
+      properties: { netuid: { type: "integer", minimum: 0 } },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "windows"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        observed_at: NULLABLE_STRING,
+        source: NULLABLE_STRING,
+        windows: { type: "object" },
+      },
+    },
+  },
+  get_health_trends: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["windows"],
+      properties: {
+        schema_version: { type: "integer" },
+        observed_at: NULLABLE_STRING,
+        source: NULLABLE_STRING,
+        windows: { type: "object" },
+      },
+    },
+  },
+  get_subnet_health_percentiles: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        window: { type: "string", enum: HEALTH_WINDOWS },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "surfaces"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        source: NULLABLE_STRING,
+        surfaces: objectItems({
+          surface_id: NULLABLE_STRING,
+          samples: { type: "integer" },
+          latency_ms: {
+            type: "object",
+            additionalProperties: true,
+            properties: {
+              p50: NULLABLE_INT,
+              p95: NULLABLE_INT,
+              p99: NULLABLE_INT,
+              avg: NULLABLE_INT,
+              min: NULLABLE_INT,
+              max: NULLABLE_INT,
+            },
+          },
+        }),
+      },
+    },
+  },
+  get_subnet_health_incidents: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        window: { type: "string", enum: HEALTH_WINDOWS },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "surfaces"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        source: NULLABLE_STRING,
+        surfaces: objectItems({
+          surface_id: NULLABLE_STRING,
+          samples: { type: "integer" },
+          uptime_ratio: { type: ["number", "null"] },
+          incident_count: { type: "integer" },
+          downtime_ms: { type: "integer" },
+          incidents: objectItems({
+            started_at: NULLABLE_INT,
+            ended_at: NULLABLE_INT,
+            duration_ms: NULLABLE_INT,
+            failed_samples: { type: "integer" },
+          }),
+        }),
+      },
+    },
+  },
+  get_subnet_economics: {
+    input: {
+      type: "object",
+      properties: { netuid: { type: "integer", minimum: 0 } },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "economics"],
+      properties: {
+        netuid: { type: "integer" },
+        source: NULLABLE_STRING,
+        captured_at: NULLABLE_STRING,
+        summary: { type: ["object", "null"] },
+        economics: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_stake_action_preview: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        amount: { type: "number", exclusiveMinimum: 0 },
+        direction: { type: "string", enum: STAKE_QUOTE_DIRECTIONS },
+      },
+      required: ["netuid", "amount"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer" },
+        direction: { type: "string" },
+        amount: { type: "number" },
+        summary: { type: "string" },
+        estimated_out: {
+          type: "object",
+          properties: {
+            amount: { type: "number" },
+            unit: { type: "string" },
+          },
+          required: ["amount", "unit"],
+          additionalProperties: false,
+        },
+        spot_price_tao: { type: "number" },
+        effective_price_tao: { type: "number" },
+        price_impact_pct: { type: "number" },
+        warnings: { type: "array", items: { type: "string" } },
+        ok: { type: "boolean" },
+        disclaimer: { type: "string" },
+      },
+      required: [
+        "netuid",
+        "direction",
+        "amount",
+        "summary",
+        "warnings",
+        "ok",
+        "disclaimer",
+      ],
+      additionalProperties: true,
+    },
+  },
+  get_subnet_trajectory: {
+    input: {
+      type: "object",
+      properties: { netuid: { type: "integer", minimum: 0 } },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "point_count", "points"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        point_count: { type: "integer" },
+        points: { type: "array", items: { type: "object" } },
+        deltas: { type: "object" },
+      },
+    },
+  },
+  get_subnet_concentration: {
+    input: {
+      type: "object",
+      properties: { netuid: { type: "integer", minimum: 0 } },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "neuron_count"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        neuron_count: { type: "integer" },
+        entity_count: { type: "integer" },
+        uids_per_entity: { type: ["number", "null"] },
+        captured_at: NULLABLE_STRING,
+        stake: { type: ["object", "null"] },
+        emission: { type: ["object", "null"] },
+        entity_stake: { type: ["object", "null"] },
+        entity_emission: { type: ["object", "null"] },
+        validator_stake: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_subnet_performance: {
+    input: {
+      type: "object",
+      properties: { netuid: { type: "integer", minimum: 0 } },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "neuron_count"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        neuron_count: { type: "integer" },
+        validator_count: { type: "integer" },
+        active_count: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        incentive: { type: ["object", "null"] },
+        dividends: { type: ["object", "null"] },
+        trust: { type: ["object", "null"] },
+        consensus: { type: ["object", "null"] },
+        validator_trust: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_subnet_idle_stake: {
+    input: {
+      type: "object",
+      properties: { netuid: { type: "integer", minimum: 0 } },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "netuid",
+        "neuron_count",
+        "idle_neuron_count",
+        "idle_stake_tao",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        neuron_count: { type: "integer" },
+        idle_neuron_count: { type: "integer" },
+        idle_stake_tao: { type: "number" },
+      },
+    },
+  },
+  get_subnet_movers: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: MOVERS_WINDOW_KEYS },
+        sort: { type: "string", enum: MOVERS_SORTS },
+        limit: { type: "integer", minimum: 1, maximum: MOVERS_LIMIT_MAX },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["window", "sort", "subnet_count", "movers"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        start_date: NULLABLE_STRING,
+        end_date: NULLABLE_STRING,
+        sort: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        movers: objectItems({
+          netuid: { type: "integer" },
+          stake_start_tao: ANY,
+          stake_end_tao: ANY,
+          stake_delta_tao: ANY,
+          stake_pct_change: { type: ["number", "null"] },
+          emission_start_tao: ANY,
+          emission_end_tao: ANY,
+          emission_delta_tao: ANY,
+          emission_pct_change: { type: ["number", "null"] },
+          validators_start: { type: "integer" },
+          validators_end: { type: "integer" },
+          validators_delta: { type: "integer" },
+          neurons_start: { type: "integer" },
+          neurons_end: { type: "integer" },
+          neurons_delta: { type: "integer" },
+        }),
+      },
+    },
+  },
+  get_subnet_uptime: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        window: { type: "string", enum: UPTIME_WINDOWS },
+        min_samples: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "window", "surfaces"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        surfaces: { type: "array", items: { type: "object" } },
+        reliability: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_health_history: {
+    input: {
+      type: "object",
+      properties: {
+        date: { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$" },
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string", enum: SURFACE_KIND },
+        provider: { type: "string" },
+        status: { type: "string", enum: HEALTH_STATUS },
+        classification: { type: "string", enum: HEALTH_CLASSIFICATION },
+        sort: { type: "string", enum: HEALTH_SURFACE_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      required: ["date"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["date", "surfaces"],
+      properties: {
+        date: NULLABLE_STRING,
+        summary: { type: ["object", "null"] },
+        surfaces: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -368,6 +1003,74 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
   get_economics: {
     input: GetEconomicsInputSchema,
     output: GetEconomicsOutputSchema,
+  },
+  find_subnets_by_capability: {
+    input: FindSubnetsByCapabilityInputSchema,
+    output: FindSubnetsByCapabilityOutputSchema,
+  },
+  get_subnet_detail: {
+    input: GetSubnetDetailInputSchema,
+    output: GetSubnetDetailOutputSchema,
+  },
+  get_subnet_snapshot: {
+    input: GetSubnetSnapshotInputSchema,
+    output: GetSubnetSnapshotOutputSchema,
+  },
+  get_subnet_health: {
+    input: GetSubnetHealthInputSchema,
+    output: GetSubnetHealthOutputSchema,
+  },
+  get_subnet_health_trends: {
+    input: GetSubnetHealthTrendsInputSchema,
+    output: GetSubnetHealthTrendsOutputSchema,
+  },
+  get_health_trends: {
+    input: GetHealthTrendsInputSchema,
+    output: GetHealthTrendsOutputSchema,
+  },
+  get_subnet_health_percentiles: {
+    input: GetSubnetHealthPercentilesInputSchema,
+    output: GetSubnetHealthPercentilesOutputSchema,
+  },
+  get_subnet_health_incidents: {
+    input: GetSubnetHealthIncidentsInputSchema,
+    output: GetSubnetHealthIncidentsOutputSchema,
+  },
+  get_subnet_economics: {
+    input: GetSubnetEconomicsInputSchema,
+    output: GetSubnetEconomicsOutputSchema,
+  },
+  get_stake_action_preview: {
+    input: GetStakeActionPreviewInputSchema,
+    output: GetStakeActionPreviewOutputSchema,
+  },
+  get_subnet_trajectory: {
+    input: GetSubnetTrajectoryInputSchema,
+    output: GetSubnetTrajectoryOutputSchema,
+  },
+  get_subnet_concentration: {
+    input: GetSubnetConcentrationInputSchema,
+    output: GetSubnetConcentrationOutputSchema,
+  },
+  get_subnet_performance: {
+    input: GetSubnetPerformanceInputSchema,
+    output: GetSubnetPerformanceOutputSchema,
+  },
+  get_subnet_idle_stake: {
+    input: GetSubnetIdleStakeInputSchema,
+    output: GetSubnetIdleStakeOutputSchema,
+  },
+  get_subnet_movers: {
+    input: GetSubnetMoversInputSchema,
+    output: GetSubnetMoversOutputSchema,
+  },
+  get_subnet_uptime: {
+    input: GetSubnetUptimeInputSchema,
+    output: GetSubnetUptimeOutputSchema,
+  },
+  get_health_history: {
+    input: GetHealthHistoryInputSchema,
+    output: GetHealthHistoryOutputSchema,
   },
 };
 

--- a/src/health-history-mcp.ts
+++ b/src/health-history-mcp.ts
@@ -2,14 +2,17 @@
 // GET /api/v1/health/history/{date}. Artifact-backed list-query over dated
 // health/history snapshots with health-surfaces filters.
 
+import { z } from "zod";
 import { DAY_PATTERN } from "../workers/request-params.ts";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  GetHealthHistoryInputSchema,
+  GetHealthHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-health-history.ts";
 
 const HEALTH_SURFACE_SORT_FIELDS =
   API_QUERY_COLLECTIONS["health-surfaces"].sort_fields;
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
 
 export interface HealthHistoryMcpError extends Error {
   healthHistoryMcp: true;
@@ -194,85 +197,12 @@ export const GET_HEALTH_HISTORY_MCP_TOOL = {
     "classification; sort with sort + order; page with limit (1-1000) / cursor. " +
     "Use get_network_health for the live rollup and get_health_trends for the " +
     "7d/30d matrix. Mirrors GET /api/v1/health/history/{date}.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      date: {
-        type: "string",
-        description: "UTC snapshot date inclusive, YYYY-MM-DD.",
-        pattern: "^\\d{4}-\\d{2}-\\d{2}$",
-      },
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      kind: {
-        type: "string",
-        enum: QUERY_ENUMS.surfaceKind,
-        description: "Filter by surface kind.",
-      },
-      provider: {
-        type: "string",
-        description: "Filter by provider slug.",
-      },
-      status: {
-        type: "string",
-        enum: QUERY_ENUMS.healthStatus,
-        description: "Filter by probe status.",
-      },
-      classification: {
-        type: "string",
-        enum: QUERY_ENUMS.healthClassification,
-        description: "Filter by health classification.",
-      },
-      sort: {
-        type: "string",
-        enum: HEALTH_SURFACE_SORT_FIELDS,
-        description:
-          "Field to sort by (bare name only). Pair with order for direction.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of surface row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max surface rows to return (1-1000). Enables pagination.",
-        minimum: 1,
-        maximum: 1000,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    required: ["date"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetHealthHistoryInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-export const GET_HEALTH_HISTORY_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["date", "surfaces"],
-  properties: {
-    date: NULLABLE_STRING,
-    summary: { type: ["object", "null"] },
-    surfaces: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
-  },
-};
+export const GET_HEALTH_HISTORY_OUTPUT_SCHEMA = z.toJSONSchema(
+  GetHealthHistoryOutputSchema,
+  { target: "draft-2020-12" },
+);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -56,6 +56,70 @@ import {
 } from "../schemas-src/mcp-tools/get-subnet-stake-quote.ts";
 import { GetEconomicsInputSchema } from "../schemas-src/mcp-tools/get-economics.ts";
 import {
+  FindSubnetsByCapabilityInputSchema,
+  FindSubnetsByCapabilityOutputSchema,
+} from "../schemas-src/mcp-tools/find-subnets-by-capability.ts";
+import {
+  GetSubnetDetailInputSchema,
+  GetSubnetDetailOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-detail.ts";
+import {
+  GetSubnetSnapshotInputSchema,
+  GetSubnetSnapshotOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-snapshot.ts";
+import {
+  GetSubnetHealthInputSchema,
+  GetSubnetHealthOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-health.ts";
+import {
+  GetSubnetHealthTrendsInputSchema,
+  GetSubnetHealthTrendsOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-health-trends.ts";
+import {
+  GetHealthTrendsInputSchema,
+  GetHealthTrendsOutputSchema,
+} from "../schemas-src/mcp-tools/get-health-trends.ts";
+import {
+  GetSubnetHealthPercentilesInputSchema,
+  GetSubnetHealthPercentilesOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-health-percentiles.ts";
+import {
+  GetSubnetHealthIncidentsInputSchema,
+  GetSubnetHealthIncidentsOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-health-incidents.ts";
+import {
+  GetSubnetEconomicsInputSchema,
+  GetSubnetEconomicsOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-economics.ts";
+import {
+  GetStakeActionPreviewInputSchema,
+  GetStakeActionPreviewOutputSchema,
+} from "../schemas-src/mcp-tools/get-stake-action-preview.ts";
+import {
+  GetSubnetTrajectoryInputSchema,
+  GetSubnetTrajectoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-trajectory.ts";
+import {
+  GetSubnetConcentrationInputSchema,
+  GetSubnetConcentrationOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-concentration.ts";
+import {
+  GetSubnetPerformanceInputSchema,
+  GetSubnetPerformanceOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-performance.ts";
+import {
+  GetSubnetIdleStakeInputSchema,
+  GetSubnetIdleStakeOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-idle-stake.ts";
+import {
+  GetSubnetMoversInputSchema,
+  GetSubnetMoversOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-movers.ts";
+import {
+  GetSubnetUptimeInputSchema,
+  GetSubnetUptimeOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-uptime.ts";
+import {
   isUsageTelemetryConfigured,
   recordExceptionEvent,
   recordMcpInitializeEvent,
@@ -327,6 +391,7 @@ import {
   GET_HEALTH_HISTORY_OUTPUT_SCHEMA,
   loadHealthHistory,
 } from "./health-history-mcp.ts";
+import { GetHealthHistoryInputSchema } from "../schemas-src/mcp-tools/get-health-history.ts";
 import {
   buildChainConcentration,
   buildConcentration,
@@ -710,7 +775,7 @@ import {
   DEFAULT_OHLC_WINDOW_DAYS,
   MAX_OHLC_WINDOW_DAYS,
 } from "./subnet-ohlc.ts";
-import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.ts";
+import { computeStakeQuote } from "./stake-quote.ts";
 import { buildAccountPositionHistory } from "./account-position-history.ts";
 import { buildAccountIdentity } from "./account-identity.ts";
 import { buildAccountIdentityHistory } from "./account-identity-history.ts";
@@ -2578,31 +2643,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "list_subnets: pass `cursor` to page past the first results; the response " +
       "carries `total` and a `next_cursor` (null at the end) so the whole " +
       "ranked match set is reachable.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        capability: {
-          type: "string",
-          description:
-            "Capability/category to match, e.g. 'inference', 'data', 'bitcoin'.",
-        },
-        cursor: {
-          type: "integer",
-          description:
-            "Pagination cursor from a prior response's next_cursor. Default 0.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Max results per page (1-50, default 10).",
-          minimum: 1,
-          maximum: 50,
-        },
-      },
-      required: ["capability"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(FindSubnetsByCapabilityInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof FindSubnetsByCapabilityInputSchema>,
+      ctx: McpCtx,
+    ) {
       const capability = requireString(args, "capability");
       const staticCatalog = await loadArtifactData(
         ctx,
@@ -2680,15 +2727,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "view (profile + health + curation + gaps + counts); use this for the " +
       "raw structural record itself, or get_subnet_economics for economics " +
       "alone. Mirrors GET /api/v1/subnets/{netuid}.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetDetailInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetDetailInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const detail = await loadArtifactData(
         ctx,
@@ -2716,27 +2761,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "than drilling into just one facet (which the individual tools remain " +
       "better suited for, since each carries its own full parameter set this " +
       "compound view intentionally simplifies).",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        top_validators_limit: {
-          type: "integer",
-          description:
-            "Max validators in the top-validators slice. Default 10.",
-          minimum: 1,
-        },
-        recent_events_limit: {
-          type: "integer",
-          description: "Max events in the recent-events slice. Default 10.",
-          minimum: 1,
-          maximum: 1000,
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetSnapshotInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetSnapshotInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const topValidatorsLimit =
         optionalPositiveInt(args, "top_validators_limit") ?? 10;
@@ -2816,7 +2847,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...GET_HEALTH_HISTORY_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof GetHealthHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       try {
         return await loadHealthHistory(ctx, args, {
           readArtifact: loadArtifactData as AnyFn,
@@ -2836,15 +2870,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     description:
       "Fetch live operational health for one subnet's surfaces (probed every " +
       "~15 minutes): per-surface status, latency, and last-ok timestamps.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetHealthInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetHealthInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const [live, reliability] = await Promise.all([
         mcpLiveHealth(ctx),
@@ -2875,15 +2907,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "latency per surface for each window. Use it to see whether a surface is " +
       "regressing or recovering, where get_subnet_health only gives current " +
       "status. Mirrors GET /api/v1/subnets/{netuid}/health/trends.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetHealthTrendsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetHealthTrendsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -2907,12 +2937,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "latency, sample counts) for sparklines and cross-subnet sorting. Use " +
       "get_subnet_health_trends for one subnet's per-surface breakdown. " +
       "Mirrors GET /api/v1/health/trends.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args: unknown, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetHealthTrendsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      _args: z.infer<typeof GetHealthTrendsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const postgres = await tryPostgresTier(
         ctx.env,
         mcpNeuronsTierRequest("/api/v1/health/trends"),
@@ -2935,20 +2966,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "to see a surface's latency distribution and tail behavior, where " +
       "get_subnet_health_trends gives the uptime+latency trend and get_subnet_health " +
       "the current status. Mirrors GET /api/v1/subnets/{netuid}/health/percentiles.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Lookback window (default 7d).",
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetHealthPercentilesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetHealthPercentilesInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
@@ -2983,20 +3007,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "and how long a surface was actually down, where get_subnet_health_trends " +
       "gives the uptime trend and get_subnet_health_percentiles the latency " +
       "distribution. Mirrors GET /api/v1/subnets/{netuid}/health/incidents.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Lookback window (default 7d).",
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetHealthIncidentsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetHealthIncidentsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
@@ -3028,15 +3045,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "share, and pool reserves. Served live from the economics tier " +
       "(refreshed ~3h), falling back to the latest committed snapshot. Use it " +
       "to decide whether (and where) to register, mine, or validate.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetEconomicsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetEconomicsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadSubnetEconomics(ctx, netuid);
     },
@@ -3093,77 +3108,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "artifact, and never touches a wallet or key. Submitting a stake requires " +
       "a separate signed extrinsic outside this tool. Use it to explain a " +
       "prospective stake's outcome to a user, not to act on-chain.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        amount: {
-          type: "number",
-          description:
-            "Amount to preview, in TAO for direction=stake or alpha for " +
-            "direction=unstake. Must be a finite number greater than 0.",
-          exclusiveMinimum: 0,
-        },
-        direction: {
-          type: "string",
-          enum: STAKE_QUOTE_DIRECTIONS,
-          description: 'Action direction: stake or unstake (default "stake").',
-        },
-      },
-      required: ["netuid", "amount"],
-      additionalProperties: false,
-    },
-    outputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer" },
-        direction: { type: "string" },
-        amount: { type: "number" },
-        summary: {
-          type: "string",
-          description: "Human-readable one-line preview of the action.",
-        },
-        estimated_out: {
-          type: "object",
-          properties: {
-            amount: { type: "number" },
-            unit: { type: "string" },
-          },
-          required: ["amount", "unit"],
-          additionalProperties: false,
-        },
-        spot_price_tao: { type: "number" },
-        effective_price_tao: { type: "number" },
-        price_impact_pct: { type: "number" },
-        warnings: {
-          type: "array",
-          items: { type: "string" },
-          description:
-            "Plan-shaped, non-fatal cautions computed from the preview (e.g. " +
-            "high price impact / slippage). Empty array when none apply, never " +
-            "null or omitted.",
-        },
-        ok: {
-          type: "boolean",
-          description:
-            "Plan-style policy-compliance flag: false when a documented safety " +
-            "threshold is exceeded (estimated price impact >= 5%), true " +
-            "otherwise. Purely advisory — the tool still executes nothing.",
-        },
-        disclaimer: { type: "string" },
-      },
-      required: [
-        "netuid",
-        "direction",
-        "amount",
-        "summary",
-        "warnings",
-        "ok",
-        "disclaimer",
-      ],
-      additionalProperties: true,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetStakeActionPreviewInputSchema, {
+      target: "draft-2020-12",
+    }),
+    outputSchema: z.toJSONSchema(GetStakeActionPreviewOutputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetStakeActionPreviewInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const amount = args?.amount;
       const direction = optionalString(args, "direction") ?? "stake";
@@ -3234,15 +3188,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "total stake, alpha price, and emission share over time, plus 7d/30d " +
       "deltas. Use it to see whether a subnet is growing or contracting before " +
       "committing resources.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetTrajectoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetTrajectoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -3302,15 +3254,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "per-UID, per-entity (coldkey-collapsed), and validator-only distributions. " +
       "Use it to see whether a subnet is broadly distributed or captured by a few " +
       "large holders. Mirrors GET /api/v1/subnets/{netuid}/concentration.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetConcentrationInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetConcentrationInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -3333,15 +3283,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(which measures stake/emission): use it to see whether a subnet's emissions " +
       "are broadly earned or captured by a few UIDs. Mirrors GET " +
       "/api/v1/subnets/{netuid}/performance.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetPerformanceInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetPerformanceInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -3362,15 +3310,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "this covers both a hotkey with no validator permit and a permitted hotkey " +
       "whose weight-setting output is currently zero — both pay every delegator " +
       "nothing right now. Mirrors GET /api/v1/subnets/{netuid}/idle-stake.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetIdleStakeInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetIdleStakeInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -4891,29 +4837,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "neuron_daily snapshots. Sort by stake (default), emission, or " +
       "validators; cap with limit (1-100, default 20). Mirrors " +
       "GET /api/v1/subnets/movers.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: MOVERS_WINDOW_KEYS,
-          description: `Comparison window (default ${DEFAULT_MOVERS_WINDOW}).`,
-        },
-        sort: {
-          type: "string",
-          enum: MOVERS_SORTS,
-          description: `Rank metric (default ${DEFAULT_MOVERS_SORT}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max movers to return (1-${MOVERS_LIMIT_MAX}, default ${MOVERS_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: MOVERS_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetMoversInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetMoversInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window = optionalString(args, "window") ?? DEFAULT_MOVERS_WINDOW;
       if (!Object.hasOwn(MOVERS_WINDOWS, window)) {
         throw toolError(
@@ -4963,26 +4893,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "requested window (90d or 1y). ?min_samples drops low-sample day rows " +
       "(daily probe count below the threshold, incl. zero-sample 'unknown' days). " +
       "Mirrors GET /api/v1/subnets/{netuid}/uptime.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        window: {
-          type: "string",
-          enum: ["90d", "1y"],
-          description: "History window (default 90d).",
-        },
-        min_samples: {
-          type: "integer",
-          minimum: 0,
-          description:
-            "Drop day rows whose daily probe count is below this threshold.",
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetUptimeInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetUptimeInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const window = parseUptimeWindow(args?.window);
       if (args?.window !== undefined && window === null) {
@@ -11828,183 +11745,39 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_subnets: z.toJSONSchema(ListSubnetsOutputSchema, {
     target: "draft-2020-12",
   }),
-  find_subnets_by_capability: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "capability",
-      "total",
-      "count",
-      "cursor",
-      "limit",
-      "next_cursor",
-      "results",
-    ],
-    properties: {
-      capability: { type: "string" },
-      total: { type: "integer" },
-      count: { type: "integer" },
-      cursor: { type: "integer" },
-      limit: { type: "integer" },
-      next_cursor: { type: ["integer", "null"] },
-      results: objectItems({
-        netuid: { type: "integer" },
-        slug: { type: "string" },
-        name: NULLABLE_STRING,
-        categories: { type: "array" },
-        service_kinds: { type: "array" },
-        callable_count: { type: "integer" },
-        integration_readiness: ANY,
-      }),
-    },
-  },
+  find_subnets_by_capability: z.toJSONSchema(
+    FindSubnetsByCapabilityOutputSchema,
+    { target: "draft-2020-12" },
+  ),
   get_subnet: z.toJSONSchema(GetSubnetOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_subnet_detail: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet"],
-    properties: {
-      schema_version: { type: "integer" },
-      generated_at: NULLABLE_STRING,
-      subnet: { type: "object" },
-      candidate_surfaces: { type: "array" },
-      candidates: { type: "array" },
-      endpoints: { type: "array" },
-      gaps: ANY,
-      surfaces: { type: "array" },
-      verified_surfaces: { type: "array" },
-      economics: { type: ["object", "null"] },
-    },
-  },
-  get_subnet_snapshot: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "netuid",
-      "hyperparameters",
-      "concentration",
-      "performance",
-      "top_validators",
-      "recent_events",
-    ],
-    properties: {
-      netuid: { type: "integer" },
-      hyperparameters: { type: "object" },
-      concentration: { type: "object" },
-      performance: { type: "object" },
-      top_validators: { type: "object" },
-      recent_events: { type: "object" },
-    },
-  },
-  get_subnet_health: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "summary", "surfaces"],
-    properties: {
-      netuid: { type: "integer" },
-      summary: { type: "object" },
-      operational_observed_at: NULLABLE_STRING,
-      surfaces: objectItems({
-        surface_id: { type: "string" },
-        netuid: { type: "integer" },
-        kind: NULLABLE_STRING,
-        status: { type: "string" },
-        latency_ms: NULLABLE_INT,
-        last_checked: NULLABLE_STRING,
-        last_ok: NULLABLE_STRING,
-      }),
-    },
-  },
-  get_subnet_health_trends: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "windows"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      observed_at: NULLABLE_STRING,
-      source: NULLABLE_STRING,
-      windows: { type: "object" },
-    },
-  },
-  get_health_trends: {
-    type: "object",
-    additionalProperties: true,
-    required: ["windows"],
-    properties: {
-      schema_version: { type: "integer" },
-      observed_at: NULLABLE_STRING,
-      source: NULLABLE_STRING,
-      windows: { type: "object" },
-    },
-  },
-  get_subnet_health_percentiles: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "surfaces"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      source: NULLABLE_STRING,
-      surfaces: objectItems({
-        surface_id: NULLABLE_STRING,
-        samples: { type: "integer" },
-        latency_ms: {
-          type: "object",
-          additionalProperties: true,
-          properties: {
-            p50: NULLABLE_INT,
-            p95: NULLABLE_INT,
-            p99: NULLABLE_INT,
-            avg: NULLABLE_INT,
-            min: NULLABLE_INT,
-            max: NULLABLE_INT,
-          },
-        },
-      }),
-    },
-  },
-  get_subnet_health_incidents: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "surfaces"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      source: NULLABLE_STRING,
-      surfaces: objectItems({
-        surface_id: NULLABLE_STRING,
-        samples: { type: "integer" },
-        uptime_ratio: { type: ["number", "null"] },
-        incident_count: { type: "integer" },
-        downtime_ms: { type: "integer" },
-        incidents: objectItems({
-          started_at: NULLABLE_INT,
-          ended_at: NULLABLE_INT,
-          duration_ms: NULLABLE_INT,
-          failed_samples: { type: "integer" },
-        }),
-      }),
-    },
-  },
-  get_subnet_economics: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "economics"],
-    properties: {
-      netuid: { type: "integer" },
-      source: NULLABLE_STRING,
-      captured_at: NULLABLE_STRING,
-      summary: { type: ["object", "null"] },
-      economics: { type: ["object", "null"] },
-    },
-  },
+  get_subnet_detail: z.toJSONSchema(GetSubnetDetailOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_snapshot: z.toJSONSchema(GetSubnetSnapshotOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_health: z.toJSONSchema(GetSubnetHealthOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_health_trends: z.toJSONSchema(GetSubnetHealthTrendsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_health_trends: z.toJSONSchema(GetHealthTrendsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_health_percentiles: z.toJSONSchema(
+    GetSubnetHealthPercentilesOutputSchema,
+    { target: "draft-2020-12" },
+  ),
+  get_subnet_health_incidents: z.toJSONSchema(
+    GetSubnetHealthIncidentsOutputSchema,
+    { target: "draft-2020-12" },
+  ),
+  get_subnet_economics: z.toJSONSchema(GetSubnetEconomicsOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_subnet_stake_quote: z.toJSONSchema(GetSubnetStakeQuoteOutputSchema, {
     target: "draft-2020-12",
   }),
@@ -12013,18 +11786,9 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_profiles: LIST_PROFILES_OUTPUT_SCHEMA,
   get_subnet_profile: GET_SUBNET_PROFILE_OUTPUT_SCHEMA,
   get_health_history: GET_HEALTH_HISTORY_OUTPUT_SCHEMA,
-  get_subnet_trajectory: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "point_count", "points"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      point_count: { type: "integer" },
-      points: { type: "array", items: { type: "object" } },
-      deltas: { type: "object" },
-    },
-  },
+  get_subnet_trajectory: z.toJSONSchema(GetSubnetTrajectoryOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_economics_trends: {
     type: "object",
     additionalProperties: true,
@@ -12045,55 +11809,15 @@ const TOOL_OUTPUT_SCHEMAS = {
       }),
     },
   },
-  get_subnet_concentration: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "neuron_count"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      neuron_count: { type: "integer" },
-      entity_count: { type: "integer" },
-      uids_per_entity: { type: ["number", "null"] },
-      captured_at: NULLABLE_STRING,
-      stake: { type: ["object", "null"] },
-      emission: { type: ["object", "null"] },
-      entity_stake: { type: ["object", "null"] },
-      entity_emission: { type: ["object", "null"] },
-      validator_stake: { type: ["object", "null"] },
-    },
-  },
-  get_subnet_performance: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "neuron_count"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      neuron_count: { type: "integer" },
-      validator_count: { type: "integer" },
-      active_count: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      incentive: { type: ["object", "null"] },
-      dividends: { type: ["object", "null"] },
-      trust: { type: ["object", "null"] },
-      consensus: { type: ["object", "null"] },
-      validator_trust: { type: ["object", "null"] },
-    },
-  },
-  get_subnet_idle_stake: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "neuron_count", "idle_neuron_count", "idle_stake_tao"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      neuron_count: { type: "integer" },
-      idle_neuron_count: { type: "integer" },
-      idle_stake_tao: { type: "number" },
-    },
-  },
+  get_subnet_concentration: z.toJSONSchema(GetSubnetConcentrationOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_performance: z.toJSONSchema(GetSubnetPerformanceOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_idle_stake: z.toJSONSchema(GetSubnetIdleStakeOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_chain_concentration: {
     type: "object",
     additionalProperties: true,
@@ -13285,36 +13009,9 @@ const TOOL_OUTPUT_SCHEMAS = {
       points: { type: "array", items: { type: "object" } },
     },
   },
-  get_subnet_movers: {
-    type: "object",
-    additionalProperties: true,
-    required: ["window", "sort", "subnet_count", "movers"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      start_date: NULLABLE_STRING,
-      end_date: NULLABLE_STRING,
-      sort: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      movers: objectItems({
-        netuid: { type: "integer" },
-        stake_start_tao: ANY,
-        stake_end_tao: ANY,
-        stake_delta_tao: ANY,
-        stake_pct_change: { type: ["number", "null"] },
-        emission_start_tao: ANY,
-        emission_end_tao: ANY,
-        emission_delta_tao: ANY,
-        emission_pct_change: { type: ["number", "null"] },
-        validators_start: { type: "integer" },
-        validators_end: { type: "integer" },
-        validators_delta: { type: "integer" },
-        neurons_start: { type: "integer" },
-        neurons_end: { type: "integer" },
-        neurons_delta: { type: "integer" },
-      }),
-    },
-  },
+  get_subnet_movers: z.toJSONSchema(GetSubnetMoversOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_subnet_turnover: {
     type: "object",
     additionalProperties: true,
@@ -13359,19 +13056,9 @@ const TOOL_OUTPUT_SCHEMAS = {
       },
     },
   },
-  get_subnet_uptime: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "window", "surfaces"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      surfaces: { type: "array", items: { type: "object" } },
-      reliability: { type: ["object", "null"] },
-    },
-  },
+  get_subnet_uptime: z.toJSONSchema(GetSubnetUptimeOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_registry_leaderboards: {
     type: "object",
     additionalProperties: true,


### PR DESCRIPTION
Closes #8065

## Summary

Converts 17 more MCP tools (`find_subnets_by_capability`, `get_subnet_detail`, `get_subnet_snapshot`, `get_subnet_health`, `get_subnet_health_trends`, `get_health_trends`, `get_subnet_health_percentiles`, `get_subnet_health_incidents`, `get_subnet_economics`, `get_stake_action_preview`, `get_subnet_trajectory`, `get_subnet_concentration`, `get_subnet_performance`, `get_subnet_idle_stake`, `get_subnet_movers`, `get_subnet_uptime`, `get_health_history`) from hand-written JSON Schema 2020-12 object literals to Zod-defined schemas (`schemas-src/mcp-tools/`, one file per tool), following the exact process #7863's pilot batch ([#8087](https://github.com/JSONbored/metagraphed/pull/8087)) established.

## Reuse decisions

None of these 17 reuse a REST route's schema — every one is modeled fresh and shallow, field-for-field, from the hand-written literal it replaces (each file's header comment says so explicitly). Two are worth calling out specifically:

- **`get_subnet_detail`**: despite "Mirrors GET /api/v1/subnets/{netuid}" in its description, the handler nests the raw artifact under a `subnet` key (`{schema_version, generated_at, subnet: {...}, ...}`) — a different top-level wrapper than `schemas-src/routes/subnet-detail.ts`'s `SubnetDetailArtifactSchema` (the REST route's own `data`, not nested). Not reusable — same "look-but-don't-reuse" finding #8087 documented for `get_network_health`/`get_economics`.
- **`get_stake_action_preview`**: a presentation layer over the same `computeStakeQuote()` result `get_subnet_stake_quote` returns, but reshaped into distinct fields (`summary`, `estimated_out`, `warnings`, `ok`, `disclaimer`) — not the same wire shape. Its original literal (unlike most tools in this batch) already declared its own `outputSchema` inline rather than via `TOOL_OUTPUT_SCHEMAS`; that stays true after conversion.

## A real dead-code finding

Converting `get_stake_action_preview`'s `inputSchema` removed the last usage of `STAKE_QUOTE_DIRECTIONS` in `src/mcp-server.ts` (its sibling `get_subnet_stake_quote` had already stopped using it in #8087, since that tool's schema reuses `GetSubnetStakeQuoteInputSchema`'s own local copy of the same enum). Removed the now-dead import; the export itself is untouched and still used by `src/stake-quote.ts` and `src/graphql.ts`.

## Equivalence-diff audit (46/46 PASS)

`npm run diff:mcp-tool-schemas` extended with this batch's 17 tools (34 checks) alongside the pilot batch's existing 6 (12 checks) — 46/46 PASS, **zero DIFFs**. No tightenings, no `ACCEPTED_TIGHTENINGS` entries needed this batch (unlike `get_subnet_stake_quote`'s reuse-driven tightening in #8087) — every schema here is a fresh, exact transcription, not a reuse of a stricter existing schema.

```
$ npm run diff:mcp-tool-schemas
...
46/46 schemas PASS; 0 DIFF.
```

## Verification

- `tests/mcp-server.test.ts` passes **UNCHANGED** — 1213 tests, its own Ajv validation of every tool's `outputSchema` against real tool output is the independent referee acceptance criterion 1 calls for.
- `tests/health-history-mcp.test.ts`, `tests/mcp-server-branch-coverage.test.ts`, `tests/graphql.test.ts` — all pass, no edits needed.
- `tsc --noEmit`, `eslint`, `prettier --check` — clean.
- `validate:mcp`, `validate:contract-drift` — pass.
- Full local suite: 488 files / 11,805 tests pass.
- Zero JSON Schema object literals remain for these 17 tools (grep-verified).

## Scope

This PR satisfies #8065's own acceptance criteria in full. 11 more MCP-tool sub-issues ([#8066](https://github.com/JSONbored/metagraphed/issues/8066)–[#8076](https://github.com/JSONbored/metagraphed/issues/8076)) and all 10 REST-route sub-issues ([#8055](https://github.com/JSONbored/metagraphed/issues/8055)–[#8064](https://github.com/JSONbored/metagraphed/issues/8064)) remain, tracked under parent #7863 / #7860 respectively.
