### PR TITLE
feat(observability): capture registry-sync write failures to Sentry+PostHog

### DIFF
--- a/tests/registry-sync-api.test.ts
+++ b/tests/registry-sync-api.test.ts
@@ -627,6 +627,30 @@ test("maps a DB failure to a clean 502 instead of throwing", async () => {
   expect((await jsonBody(res)).error).toBe("write failed");
 });
 
+test("captures a write failure as a PostHog $exception (previously only console.error, no Sentry/PostHog capture at all)", async () => {
+  failure.error = new Error("connection reset");
+  const calls: Row[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (_url: unknown, init: Row) => {
+    calls.push(JSON.parse(init.body));
+    return { ok: true };
+  }) as unknown as typeof fetch;
+  try {
+    const res = await worker.fetch(
+      post({ providers: [provider()] }, { secret: SECRET }),
+      baseEnv({ POSTHOG_PROJECT_TOKEN: "phc_test" }),
+    );
+    expect(res.status).toBe(502);
+  } finally {
+    globalThis.fetch = original;
+  }
+  expect(calls.length).toBe(1);
+  expect(calls[0].event).toBe("$exception");
+  expect(calls[0].properties.route).toBe("registry-sync");
+  expect(calls[0].properties.error_code).toBe("internal_error");
+  expect(calls[0].properties.$exception_list[0].value).toBe("connection reset");
+});
+
 test("retries with a fresh client after a Hyperdrive CONNECTION_CLOSED and lands the batch (METAGRAPHED-7 second recurrence)", async () => {
   connectionFailure.remainingFailures = 1;
   const res = await worker.fetch(

--- a/workers/registry-sync-api.ts
+++ b/workers/registry-sync-api.ts
@@ -19,8 +19,10 @@
 // endpoint; the database itself stays exactly as private as it already was
 // (bound to 127.0.0.1 on its host, reachable only via the Cloudflare Tunnel
 // + Workers VPC Service + Hyperdrive path already proven for reads).
+import * as Sentry from "@sentry/cloudflare";
 import type postgres from "postgres";
 import { syncBeginWithConnectionRetry } from "./hyperdrive-sync-retry.ts";
+import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 import { timingSafeEqual } from "../src/webhooks.ts";
 import { resolveClientIp } from "./config.ts";
 
@@ -85,6 +87,21 @@ function json(
 
 function isValidRow(row: unknown): row is Record<string, unknown> {
   return Boolean(row) && typeof row === "object" && !Array.isArray(row);
+}
+
+// This Worker's Sentry wrap (registry-sync-api.sentry.ts's withSentry())
+// only ever sees an exception that escapes fetch() entirely -- the write
+// batch below is already caught and converted to a clean 502, so nothing
+// reached Sentry OR PostHog for the write-failure path until now. Same gap,
+// same fix, as workers/api.ts's captureAiRouteError / workers/data-api.ts's
+// captureDataApiError.
+async function captureRegistrySyncError(error: unknown, env: Env) {
+  Sentry.captureException(error, { tags: { route: "registry-sync" } });
+  await recordExceptionEvent(env, {
+    error,
+    route: "registry-sync",
+    errorCode: "internal_error",
+  });
 }
 
 export default {
@@ -375,6 +392,7 @@ export default {
       });
     } catch (err) {
       console.error("registry-sync-api write failed:", err);
+      await captureRegistrySyncError(err, env);
       return json({ error: "write failed" }, 502);
     }
     // No sql.end() here: Hyperdrive automatically cleans up the connection


### PR DESCRIPTION
## Summary

- `workers/registry-sync-api.ts`'s write-failure catch block only did `console.error(...)` -- adds `captureRegistrySyncError()` matching the existing `captureDataApiError`/`captureAiRouteError` pattern (Sentry.captureException + recordExceptionEvent/PostHog `$exception`).
- Also provisioned `POSTHOG_PROJECT_TOKEN` as a Worker secret on `metagraphed-data-api` and `metagraphed-registry-sync-api` (via `wrangler secret put`) -- data-api's own capture code was already wired but silently no-op since the secret was never set.

## What Changed

- `workers/registry-sync-api.ts`: new `Sentry`/`recordExceptionEvent` imports, `captureRegistrySyncError()` helper, called from the existing catch block.
- `tests/registry-sync-api.test.ts`: new regression test verifying a write failure posts a well-formed `$exception` event (route, error_code, exception value) via a global-fetch stub.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8093`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state (secrets were set via `wrangler secret put`, never committed).
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none needed).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none).

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (scoped to changed files)
- [x] `npm run typecheck`
- [x] `npm run validate`
- [x] `npx vitest run tests/registry-sync-api.test.ts` (30 passed), 100% statement/branch/function/line coverage on the changed file
- [x] `git diff --check`

Closes #8093