### PR TITLE
feat(observability): PostHog error capture for box-side Node scripts

### DIFF
--- a/scripts/chain-firehose-relay.ts
+++ b/scripts/chain-firehose-relay.ts
@@ -39,11 +39,41 @@ import { writeFileSync, statSync } from "node:fs";
 import postgres from "postgres";
 import { closeSession } from "@sentry/core";
 import * as Sentry from "@sentry/node";
+import { PostHog } from "posthog-node";
 
 type Row = Record<string, unknown>;
 
+let posthogClient: PostHog | undefined;
+// Stable, shared distinct_id for every box-side script -- matches
+// scripts/observability.ts's own POSTHOG_DISTINCT_ID convention (this file
+// deliberately doesn't import that module -- its Sentry lifecycle is
+// process-lifetime/one-session-per-boot, not per-run, so it has always kept
+// its own separate implementation rather than sharing observability.ts's).
+const POSTHOG_DISTINCT_ID = "metagraphed-infra";
+
+// PostHog's error-tracking product is exception-shaped, with no first-class
+// "message" severity concept the way Sentry's captureMessage has -- mirrors
+// each Sentry.captureMessage call site below with a synthetic Error carrying
+// the same text. Fire-and-forget (not the Immediate/awaited variant) -- these
+// fire mid-poll-loop, not right before process exit, so there's no shutdown
+// race to guard against the way the top-level crash handler's capture needs.
+function capturePostHogEvent(
+  message: string,
+  properties: Record<string, unknown>,
+): void {
+  if (!posthogClient) return;
+  posthogClient.captureException(
+    new Error(message),
+    POSTHOG_DISTINCT_ID,
+    properties,
+  );
+}
+
 // Reports to the consolidated `metagraphed` Sentry project. Silently no-ops
 // if SENTRY_DSN is unset, matching this relay's own best-effort design.
+// PostHog's own init is independent of Sentry's -- gated on its own
+// POSTHOG_PROJECT_TOKEN, so either, both, or neither may be configured
+// (metagraphed-infra#158).
 //
 // Deliberately NOT one captureMessage per dropped payload -- a real 2026-07
 // incident (a rate-limit thundering-herd loop this same fix addresses) hit
@@ -60,6 +90,13 @@ type Row = Record<string, unknown>;
 // re-alert logic in metagraphed-infra. Exported for direct testing rather
 // than only indirectly via main()'s own /* v8 ignore */ boundary.
 export function initSentry(): void {
+  const posthogToken = process.env.POSTHOG_PROJECT_TOKEN;
+  if (posthogToken) {
+    posthogClient = new PostHog(posthogToken, {
+      host: process.env.POSTHOG_HOST || "https://us.i.posthog.com",
+    });
+  }
+
   const dsn = process.env.SENTRY_DSN;
   if (!dsn) return;
   Sentry.init({
@@ -93,10 +130,16 @@ export function initSentry(): void {
 
 // Closes the process-lifetime session as a healthy exit. Called from the
 // graceful SIGTERM/SIGINT shutdown path once the poll loop has actually
-// stopped -- see main()'s own shutdown() closure.
+// stopped -- see main()'s own shutdown() closure. PostHog's shutdown is
+// gated on its own init state, independent of Sentry's (Sentry's
+// endSession()/flush() are documented no-ops before init; PostHog's are not,
+// hence the explicit guard).
 export async function endSessionAndFlush(): Promise<void> {
   Sentry.endSession();
   await Sentry.flush(2000);
+  if (posthogClient) {
+    await posthogClient.shutdown();
+  }
 }
 
 export const CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD = 500;
@@ -156,10 +199,9 @@ export function computeDropWindowUpdate(
 // so unlike drops this is safe to capture directly, one event per pause,
 // with no separate aggregation window needed.
 export function reportRateLimitPause(pauseMs: number): void {
-  Sentry.captureMessage(
-    `chain-firehose-relay: rate limited by the ingest endpoint, pausing ${pauseMs}ms`,
-    { level: "warning", extra: { pauseMs } },
-  );
+  const message = `chain-firehose-relay: rate limited by the ingest endpoint, pausing ${pauseMs}ms`;
+  Sentry.captureMessage(message, { level: "warning", extra: { pauseMs } });
+  capturePostHogEvent(message, { level: "warning", pauseMs });
 }
 
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
@@ -759,17 +801,18 @@ async function main(): Promise<void> {
       );
       dropWindow = update.nextWindow;
       if (update.report) {
-        Sentry.captureMessage(
-          `chain-firehose-relay: ${update.count} payload(s) dropped in the last ${Math.round(update.elapsedMs / 1000)}s (last status: ${update.lastStatus ?? "network error"})`,
-          {
-            level: "warning",
-            extra: {
-              count: update.count,
-              lastStatus: update.lastStatus,
-              windowMs: update.elapsedMs,
-            },
-          },
-        );
+        const message = `chain-firehose-relay: ${update.count} payload(s) dropped in the last ${Math.round(update.elapsedMs / 1000)}s (last status: ${update.lastStatus ?? "network error"})`;
+        const properties = {
+          level: "warning",
+          count: update.count,
+          lastStatus: update.lastStatus,
+          windowMs: update.elapsedMs,
+        };
+        Sentry.captureMessage(message, {
+          level: "warning",
+          extra: properties,
+        });
+        capturePostHogEvent(message, properties);
       }
     }
     return {
@@ -877,6 +920,17 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       // flush() before process.exit(1) is required: process.exit() is
       // synchronous and does not wait for Sentry's background network send.
       await Sentry.flush(2000);
+      if (posthogClient) {
+        // Immediate (awaited), not the fire-and-forget captureException the
+        // drop/rate-limit call sites use -- the process exits right after
+        // this, so the event must be sent before shutdown() tears the
+        // client down, not just queued.
+        await posthogClient.captureExceptionImmediate(
+          error,
+          POSTHOG_DISTINCT_ID,
+        );
+        await posthogClient.shutdown();
+      }
       process.exit(1);
     });
   }

--- a/scripts/observability.ts
+++ b/scripts/observability.ts
@@ -1,6 +1,6 @@
-// Shared Sentry init for the box-side Node data-refresh scripts run via
-// metagraphed-infra's data-refresh-economics/data-refresh-node Ansible
-// roles (scripts/economics-refresh-entrypoint.sh /
+// Shared Sentry + PostHog init for the box-side Node data-refresh scripts
+// run via metagraphed-infra's data-refresh-economics/data-refresh-node
+// Ansible roles (scripts/economics-refresh-entrypoint.sh /
 // data-refresh-node-entrypoint.sh, both of which clone this repo at
 // container runtime -- see those entrypoints' own headers), plus a couple of
 // Cloudflare-publish-side build steps that fit the same "short-lived batch
@@ -8,11 +8,18 @@
 // backfill-registry-postgres.ts, discover-testnet-surfaces.ts,
 // export-parquet.ts, reconcile-neurons.ts, sync-registry-to-postgres.ts,
 // and refresh-og-image.ts so all eight report to the same consolidated
-// `metagraphed` Sentry project with a consistent `component` tag --
-// matching scripts/observability.py's own Python-side convention for the
-// chain-fetch scripts.
+// `metagraphed` Sentry project (with a consistent `component` tag) and the
+// same PostHog project (metagraphed-infra#158/#160's consolidation) in
+// parallel -- additive, not a replacement; Sentry stays until a separate,
+// gated decommission (matching the public repo's own #7766 posture).
+//
+// scripts/observability.py's Python-side equivalent (originally used by the
+// now-retired data-refresh-cron fetch scripts, metagraphed-infra#141) has
+// no live caller as of 2026-07-24 -- deliberately NOT given the same
+// PostHog treatment here, since there's nothing left to instrument.
 import { closeSession } from "@sentry/core";
 import * as Sentry from "@sentry/node";
+import { PostHog } from "posthog-node";
 
 // Release-health session tracking (Sentry's "Crash Free Sessions/Users"
 // widgets). @sentry/node's own default OnUncaughtException/
@@ -33,6 +40,13 @@ import * as Sentry from "@sentry/node";
 // processes, not request-serving services, so "session" == "did this run
 // complete without an unhandled error," not a user session.
 let sentryInitialized = false;
+let posthogClient: PostHog | undefined;
+
+// Stable, shared distinct_id for every box-side script -- these are
+// unattended batch/service processes with no real end user, matching
+// USAGE_EVENT_DISTINCT_ID's own "one identity per logical source"
+// convention on the Workers side (src/usage-telemetry.ts).
+const POSTHOG_DISTINCT_ID = "metagraphed-infra";
 
 async function handleFatal(error: unknown, exitCode: number): Promise<void> {
   console.error("[observability] fatal:", error);
@@ -45,21 +59,32 @@ async function handleFatal(error: unknown, exitCode: number): Promise<void> {
     }
     await Sentry.flush(2000);
   }
+  if (posthogClient) {
+    // Immediate (awaited), not the fire-and-forget captureException -- the
+    // process exits right after this, so the event must be sent before
+    // shutdown() tears the client down, not just queued.
+    await posthogClient.captureExceptionImmediate(error, POSTHOG_DISTINCT_ID);
+    await posthogClient.shutdown();
+  }
   process.exit(exitCode);
 }
 
-// No-ops silently if SENTRY_DSN is unset, matching every other
-// instrumented process in this rollout (SENTRY_DSN is not a secret in the
-// same sense a sync token is -- Sentry DSNs are designed to be safe in
-// client-side/public code, write-only -- so passing it into these scripts'
+// No-ops the Sentry half if SENTRY_DSN is unset, and independently no-ops
+// the PostHog half if POSTHOG_PROJECT_TOKEN is unset -- either, both, or
+// neither may be configured (metagraphed-infra#158). Neither is a secret in
+// the same sense a sync token is (both are designed to be safe in client-
+// side/public code, write-only), so passing them into these scripts'
 // existing "gets zero secrets" trust boundaries where applicable doesn't
-// weaken them).
+// weaken them.
 export function initSentry(component: string): void {
   const dsn = process.env.SENTRY_DSN;
-  if (!dsn) return;
+  const posthogToken = process.env.POSTHOG_PROJECT_TOKEN;
+  if (!dsn && !posthogToken) return;
 
   // Registered before Sentry.init() -- see this module's own header for why
-  // ordering matters here.
+  // ordering matters here. Needed whenever EITHER backend is configured, not
+  // gated on Sentry alone -- a PostHog-only run still needs handleFatal to
+  // run on an uncaught exception.
   process.on("uncaughtException", (error) => {
     handleFatal(error, 1);
   });
@@ -69,6 +94,14 @@ export function initSentry(component: string): void {
       1,
     );
   });
+
+  if (posthogToken) {
+    posthogClient = new PostHog(posthogToken, {
+      host: process.env.POSTHOG_HOST || "https://us.i.posthog.com",
+    });
+  }
+
+  if (!dsn) return;
 
   Sentry.init({
     dsn,
@@ -98,13 +131,19 @@ export function initSentry(component: string): void {
 }
 
 // Call on the clean-exit path (end of a successful run) so the session
-// reports "exited" (healthy) rather than being left open indefinitely.
-// Safe to call even if initSentry() no-op'd (no DSN) -- Sentry's own
-// endSession()/flush() are documented no-ops before init.
+// reports "exited" (healthy) rather than being left open indefinitely, and
+// so the PostHog client shuts down cleanly (releases its background flush
+// timer rather than holding the process open past a natural exit). Each
+// backend's cleanup is gated on its OWN init state independently -- a
+// PostHog-only run (no SENTRY_DSN) must still shut down its client here.
 export async function endSessionAndFlush() {
-  if (!sentryInitialized) return;
-  Sentry.endSession();
-  await Sentry.flush(2000);
+  if (sentryInitialized) {
+    Sentry.endSession();
+    await Sentry.flush(2000);
+  }
+  if (posthogClient) {
+    await posthogClient.shutdown();
+  }
 }
 
 // For the one script with its own explicit top-level `.catch()`

--- a/tests/chain-firehose-relay.test.ts
+++ b/tests/chain-firehose-relay.test.ts
@@ -37,6 +37,36 @@ vi.mock("@sentry/node", () => ({
   flush,
 }));
 
+// PostHog mock -- same shape as tests/observability.test.ts's own (a real
+// `class`, not an arrow function, since observability code calls `new
+// PostHog(...)`; arrow functions can't be invoked with `new`).
+const posthogCaptureException = vi.hoisted(() =>
+  vi.fn((_error: unknown, _distinctId?: string, _properties?: unknown) => {}),
+);
+const posthogCaptureExceptionImmediate = vi.hoisted(() =>
+  vi.fn(async (_error: unknown, _distinctId?: string) => {}),
+);
+const posthogShutdown = vi.hoisted(() => vi.fn(async () => {}));
+const posthogConstructorCalls = vi.hoisted(() => [] as unknown[][]);
+const PostHogMock = vi.hoisted(() => {
+  class PostHogMockImpl {
+    constructor(...args: unknown[]) {
+      posthogConstructorCalls.push(args);
+      return {
+        captureException: posthogCaptureException,
+        captureExceptionImmediate: posthogCaptureExceptionImmediate,
+        shutdown: posthogShutdown,
+      };
+    }
+  }
+  return vi
+    .fn()
+    .mockImplementation(
+      PostHogMockImpl as unknown as (...args: unknown[]) => unknown,
+    );
+});
+vi.mock("posthog-node", () => ({ PostHog: PostHogMock }));
+
 import {
   CHAIN_FIREHOSE_BACKOFF_BASE_MS,
   CHAIN_FIREHOSE_BACKOFF_MAX_MS,
@@ -853,25 +883,64 @@ test("computeDropWindowUpdate: two independent windows (null starting state each
 
 test("reportRateLimitPause: calls Sentry.captureMessage directly, once per call (naturally low-frequency, no aggregation needed)", () => {
   captureMessage.mockClear();
+  posthogCaptureException.mockClear();
   reportRateLimitPause(65_000);
   assert.equal(captureMessage.mock.calls.length, 1);
   const [message, options] = captureMessage.mock.calls[0];
   assert.match(message, /pausing 65000ms/);
   assert.equal(options.extra.pauseMs, 65_000);
+  // PostHog uninitialized at this point (no test has set POSTHOG_PROJECT_TOKEN
+  // yet) -- the fire-and-forget mirror call must no-op silently, not throw.
+  assert.equal(posthogCaptureException.mock.calls.length, 0);
 });
 
 // --- initSentry ---------------------------------------------------------------
 
-test("initSentry: no-ops (never calls Sentry.init) when SENTRY_DSN is unset", () => {
+test("initSentry: no-ops (never calls Sentry.init, never inits PostHog) when both SENTRY_DSN and POSTHOG_PROJECT_TOKEN are unset", () => {
   sentryInit.mockClear();
   setTag.mockClear();
   startSession.mockClear();
+  PostHogMock.mockClear();
   vi.stubEnv("SENTRY_DSN", "");
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "");
   initSentry();
   assert.equal(sentryInit.mock.calls.length, 0);
   assert.equal(setTag.mock.calls.length, 0);
   assert.equal(startSession.mock.calls.length, 0);
+  assert.equal(PostHogMock.mock.calls.length, 0);
   vi.unstubAllEnvs();
+});
+
+test("initSentry: initializes PostHog independent of SENTRY_DSN, defaulting POSTHOG_HOST to us.i.posthog.com", () => {
+  PostHogMock.mockClear();
+  posthogConstructorCalls.length = 0;
+  vi.stubEnv("SENTRY_DSN", "");
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "phc_test_token");
+  vi.stubEnv("POSTHOG_HOST", "");
+  initSentry();
+  assert.equal(PostHogMock.mock.calls.length, 1);
+  assert.deepEqual(posthogConstructorCalls[0], [
+    "phc_test_token",
+    { host: "https://us.i.posthog.com" },
+  ]);
+  vi.unstubAllEnvs();
+});
+
+test("reportRateLimitPause: mirrors the same message to PostHog once initialized", () => {
+  captureMessage.mockClear();
+  posthogCaptureException.mockClear();
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "phc_test_token");
+  initSentry();
+  vi.unstubAllEnvs();
+
+  reportRateLimitPause(65_000);
+  assert.equal(posthogCaptureException.mock.calls.length, 1);
+  const [error, distinctId, properties] = posthogCaptureException.mock
+    .calls[0] as [Error, string, Row];
+  assert.match(error.message, /pausing 65000ms/);
+  assert.equal(distinctId, "metagraphed-infra");
+  assert.equal(properties.pauseMs, 65_000);
+  assert.equal(properties.level, "warning");
 });
 
 test("initSentry: calls Sentry.init with dsn/environment/release, tags the component, and starts a release-health session when SENTRY_DSN is set", () => {
@@ -926,6 +995,16 @@ test("endSessionAndFlush: ends the session and flushes", async () => {
   assert.equal(endSession.mock.calls.length, 1);
   assert.equal(flush.mock.calls.length, 1);
   assert.equal((flush.mock.calls[0] as unknown[])[0], 2000);
+});
+
+test("endSessionAndFlush: also shuts down PostHog once it was initialized", async () => {
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "phc_test_token");
+  initSentry();
+  vi.unstubAllEnvs();
+
+  posthogShutdown.mockClear();
+  await endSessionAndFlush();
+  assert.equal(posthogShutdown.mock.calls.length, 1);
 });
 
 // --- touchHeartbeat / isHeartbeatFresh -----------------------------------------

--- a/tests/observability.test.ts
+++ b/tests/observability.test.ts
@@ -1,6 +1,7 @@
-// Unit tests for scripts/observability.ts -- the shared Sentry init for
-// the box-side data-refresh-economics/data-refresh-node scripts, plus the
-// release-health (crash-free session) tracking layered on top of it.
+// Unit tests for scripts/observability.ts -- the shared Sentry + PostHog
+// init for the box-side data-refresh-economics/data-refresh-node scripts,
+// plus the release-health (crash-free session) tracking layered on top of
+// the Sentry half.
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, test, vi } from "vitest";
 
@@ -27,6 +28,38 @@ vi.mock("@sentry/node", () => ({
 }));
 vi.mock("@sentry/core", () => ({ closeSession }));
 
+// Every `new PostHog(...)` call returns these SAME shared mock functions
+// (not a fresh pair per instance) -- fine here since observability.ts only
+// ever holds one client at a time, matching how the Sentry mocks above are
+// shared module-level spies too.
+const posthogCaptureExceptionImmediate = vi.hoisted(() =>
+  vi.fn(async (_error: unknown, _distinctId?: string) => {}),
+);
+const posthogShutdown = vi.hoisted(() => vi.fn(async () => {}));
+const posthogConstructorCalls = vi.hoisted(() => [] as unknown[][]);
+// A real `class`, not an arrow-function mock implementation -- observability.ts
+// calls `new PostHog(...)`, and an arrow function can't be invoked with `new`
+// ("TypeError: ... is not a constructor"). Cast to mockImplementation's
+// function-type parameter -- it's actually invoked via `new`, never called
+// plainly, so the shape mismatch is cosmetic only.
+const PostHogMock = vi.hoisted(() => {
+  class PostHogMockImpl {
+    constructor(...args: unknown[]) {
+      posthogConstructorCalls.push(args);
+      return {
+        captureExceptionImmediate: posthogCaptureExceptionImmediate,
+        shutdown: posthogShutdown,
+      };
+    }
+  }
+  return vi
+    .fn()
+    .mockImplementation(
+      PostHogMockImpl as unknown as (...args: unknown[]) => unknown,
+    );
+});
+vi.mock("posthog-node", () => ({ PostHog: PostHogMock }));
+
 import {
   initSentry,
   endSessionAndFlush,
@@ -45,16 +78,57 @@ afterEach(() => {
   onSpy.mockRestore();
 });
 
-test("initSentry: no-ops (never calls Sentry.init, never registers signal handlers) when SENTRY_DSN is unset", () => {
+test("initSentry: no-ops (never calls Sentry.init, never registers signal handlers, never inits PostHog) when both SENTRY_DSN and POSTHOG_PROJECT_TOKEN are unset", () => {
   sentryInit.mockClear();
   setTag.mockClear();
   startSession.mockClear();
+  PostHogMock.mockClear();
   vi.stubEnv("SENTRY_DSN", "");
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "");
   initSentry("some-script");
   assert.equal(sentryInit.mock.calls.length, 0);
   assert.equal(setTag.mock.calls.length, 0);
   assert.equal(startSession.mock.calls.length, 0);
   assert.equal(onSpy.mock.calls.length, 0);
+  assert.equal(PostHogMock.mock.calls.length, 0);
+  vi.unstubAllEnvs();
+});
+
+test("initSentry: initializes PostHog and registers crash handlers when POSTHOG_PROJECT_TOKEN is set, even with SENTRY_DSN unset", () => {
+  sentryInit.mockClear();
+  PostHogMock.mockClear();
+  onSpy.mockClear();
+  posthogConstructorCalls.length = 0;
+  vi.stubEnv("SENTRY_DSN", "");
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "phc_test_token");
+  vi.stubEnv("POSTHOG_HOST", "");
+  initSentry("some-script");
+
+  assert.equal(sentryInit.mock.calls.length, 0);
+  assert.equal(PostHogMock.mock.calls.length, 1);
+  assert.deepEqual(posthogConstructorCalls[0], [
+    "phc_test_token",
+    { host: "https://us.i.posthog.com" },
+  ]);
+  const onNames = onSpy.mock.calls.map((call: unknown[]) => call[0]);
+  assert.deepEqual(onNames, ["uncaughtException", "unhandledRejection"]);
+
+  vi.unstubAllEnvs();
+});
+
+test("initSentry: honors POSTHOG_HOST when set", () => {
+  PostHogMock.mockClear();
+  posthogConstructorCalls.length = 0;
+  vi.stubEnv("SENTRY_DSN", "");
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "phc_test_token");
+  vi.stubEnv("POSTHOG_HOST", "https://eu.i.posthog.com");
+  initSentry("some-script");
+
+  assert.deepEqual(posthogConstructorCalls[0], [
+    "phc_test_token",
+    { host: "https://eu.i.posthog.com" },
+  ]);
+
   vi.unstubAllEnvs();
 });
 
@@ -219,4 +293,50 @@ test("captureFatalAndExit: defaults to exit code 1", async () => {
 
   assert.equal(exitSpy.mock.calls[0][0], 1);
   exitSpy.mockRestore();
+});
+
+test("captureFatalAndExit: captures to PostHog (immediate, awaited) and shuts the client down, independent of Sentry", async () => {
+  vi.stubEnv("SENTRY_DSN", "");
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "phc_test_token");
+  initSentry("some-script");
+  vi.unstubAllEnvs();
+
+  posthogCaptureExceptionImmediate.mockClear();
+  posthogShutdown.mockClear();
+  const exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation((() => {}) as unknown as (
+      code?: string | number | null,
+    ) => never);
+  const error = new Error("boom");
+
+  await captureFatalAndExit(error, 3);
+
+  assert.equal(posthogCaptureExceptionImmediate.mock.calls.length, 1);
+  assert.equal(posthogCaptureExceptionImmediate.mock.calls[0][0], error);
+  assert.equal(
+    posthogCaptureExceptionImmediate.mock.calls[0][1],
+    "metagraphed-infra",
+  );
+  assert.equal(posthogShutdown.mock.calls.length, 1);
+  // The capture must be awaited BEFORE shutdown tears the client down, not
+  // just fired -- assert the actual invocation order, not merely that both
+  // were called.
+  assert.ok(
+    posthogCaptureExceptionImmediate.mock.invocationCallOrder[0] <
+      posthogShutdown.mock.invocationCallOrder[0],
+  );
+  assert.equal(exitSpy.mock.calls[0][0], 3);
+  exitSpy.mockRestore();
+});
+
+test("endSessionAndFlush: shuts down PostHog when it was initialized", async () => {
+  vi.stubEnv("POSTHOG_PROJECT_TOKEN", "phc_test_token");
+  initSentry("some-script");
+  vi.unstubAllEnvs();
+
+  posthogShutdown.mockClear();
+  await endSessionAndFlush();
+
+  assert.equal(posthogShutdown.mock.calls.length, 1);
 });


### PR DESCRIPTION
## Summary

Adds PostHog error capture to the box-side Node scripts (data-refresh-economics/-node via `scripts/observability.ts`, and `scripts/chain-firehose-relay.ts`'s own separate implementation), alongside their existing Sentry capture. Resolves metagraphed-infra#158's items 1 and 3.

`scripts/observability.py` (Python) was deliberately **not** touched — verified it has zero live callers today (the data-refresh-cron role that used it was fully retired 2026-07-20, replaced by indexer-rs's native poller). No point instrumenting dead code.

Infra-side follow-up (passing `POSTHOG_PROJECT_TOKEN`/`POSTHOG_HOST` into the actual containers) is tracked separately in metagraphed-infra.

## What Changed

- `scripts/observability.ts`: PostHog init independent of Sentry (either/both/neither may be configured); `handleFatal`/`endSessionAndFlush` now also capture/shut down PostHog.
- `scripts/chain-firehose-relay.ts`: rate-limit-pause report, aggregated drop-window report, and the top-level fatal catch all mirror to PostHog as a synthetic Error (matching PostHog's exception-shaped capture model — it has no `captureMessage` equivalent).
- Both use a stable, shared `distinct_id` (`"metagraphed-infra"`), matching `USAGE_EVENT_DISTINCT_ID`'s own convention on the Workers side.
- Tests extended in both `tests/observability.test.ts` and `tests/chain-firehose-relay.test.ts`, following each file's existing hoisted-mock pattern.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #8096`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none needed).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none).

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (scoped to changed files)
- [x] `npm run typecheck`
- [x] `npm run validate`
- [x] `npx vitest run tests/observability.test.ts tests/chain-firehose-relay.test.ts` (85 passed)
- [x] `git diff --check`

Closes #8096