### PR TITLE
feat(ui): lint ratchet — promote Bone & Ink rules from warn to error, directory by directory

### DIFF
--- a/apps/ui/CONTRIBUTING.md
+++ b/apps/ui/CONTRIBUTING.md
@@ -56,7 +56,9 @@ budget — keep new dependencies/imports lean.
 - **Components** live in `src/components/metagraphed/`; route trees in `src/routes/`.
 - Reuse existing design tokens (`src/styles.css`, `packages/ui-kit/src/styles.css`) and
   shared components instead of inventing new one-off styles. The "Bone & Ink" rules,
-  mechanically flagged (as warnings — see `eslint.config.ts`) by `no-restricted-syntax`:
+  mechanically flagged by `no-restricted-syntax` (see `eslint.config.ts`) — **warning**
+  everywhere by default, but **error** inside the directories listed in each config's
+  `RATCHETED_DIRS` (see "Lint ratchet" below):
   - Semantic tokens only — `bg-paper`, `text-ink-strong`, `bg-health-ok`, `text-accent-text`,
     `border-border`, etc. Never a raw Tailwind palette color (`bg-emerald-500`,
     `text-gray-600`) and never a hex/rgb literal in code. Author new colors in OKLCH in
@@ -89,6 +91,21 @@ budget — keep new dependencies/imports lean.
     stacking context — not a global layer, so it doesn't belong on this scale.
 
   - See `docs/ssr-safety.md` for the hydration-safety rules (also partly ESLint-enforced).
+
+  **Lint ratchet.** `no-restricted-syntax` is warn-tier everywhere by default — a
+  full-codebase audit (2026-07-23) found too many pre-existing violations to make error-tier
+  safe repo-wide without blocking unrelated PRs. Both `eslint.config.ts` files (here and in
+  `packages/ui-kit/`) define a `RATCHETED_DIRS` array of glob prefixes verified at 0
+  warnings; a directory in that list is error-tier instead, so new drift there fails CI
+  rather than only annotating it. This is a **one-way ratchet**:
+  - If your PR brings a directory to 0 `no-restricted-syntax` warnings, add it to
+    `RATCHETED_DIRS` in the _same_ PR — don't leave a clean directory un-ratcheted for a
+    later PR to notice.
+  - Removing a directory from `RATCHETED_DIRS` requires its own issue explaining why
+    (e.g. a new dependency reintroduced unavoidable raw values) — never a silent drop.
+  - `RATCHETED_DIRS` globs are checked directory-by-directory, not file-by-file — a single
+    remaining violation anywhere under a glob keeps the whole directory out.
+
 - Keep diffs focused. Don't reformat or refactor unrelated files in a feature PR.
 
 ## Lovable-managed surface

--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -140,6 +140,31 @@ const GLASS_SURFACE_RULES = [
   },
 ];
 
+// The full Bone & Ink rule set applied to src/**/*.{ts,tsx} (the "warn" block
+// below) -- named so the #7851 ratchet block can apply the identical set at
+// "error" without duplicating the array.
+const FULL_DESIGN_RULES = [
+  ...BASE_DESIGN_RULES,
+  ...SPACING_TYPE_RULES,
+  ...PRIMITIVE_STEER_RULES,
+  ...SSR_SAFETY_RULES,
+  ...ELEVATION_RULES,
+  ...Z_INDEX_RULES,
+  ...GLASS_SURFACE_RULES,
+];
+
+// #7851: one-way lint ratchet. A directory enters this list only once it's
+// been verified at 0 Bone & Ink warnings (no-restricted-syntax) -- from that
+// point on, new drift in the directory fails CI instead of only annotating
+// it. Any PR that brings a directory to 0 warnings MUST add it here in the
+// same PR (see CONTRIBUTING.md); removing an entry requires an issue
+// explaining why. Initial set (2026-07-24 audit): src/hooks/** was the only
+// apps/ui directory clean end-to-end -- src/lib/** came close (2 residual
+// hits: one real text-[11px] and one false-positive string-literal match on
+// unrelated test fixture data) and is left for a follow-up PR rather than
+// bundled here.
+const RATCHETED_DIRS = ["src/hooks/**/*.{ts,tsx}"];
+
 export default tseslint.config(
   // .source is fumadocs-mdx's generated content collection output (see
   // source.config.ts) -- codegen, not authored code, same treatment as dist.
@@ -206,16 +231,19 @@ export default tseslint.config(
     ],
     rules: {
       // "warn" for the same reason as the base block above -- see its comment.
-      "no-restricted-syntax": [
-        "warn",
-        ...BASE_DESIGN_RULES,
-        ...SPACING_TYPE_RULES,
-        ...PRIMITIVE_STEER_RULES,
-        ...SSR_SAFETY_RULES,
-        ...ELEVATION_RULES,
-        ...Z_INDEX_RULES,
-        ...GLASS_SURFACE_RULES,
-      ],
+      "no-restricted-syntax": ["warn", ...FULL_DESIGN_RULES],
+    },
+  },
+  {
+    // #7851: promotes the ratcheted directories above from warn to error.
+    // Layered after the warn-tier block so it wins for files in both (flat
+    // config's last-matching-block-wins semantics); the off-exclusion blocks
+    // below stay last so primitives/showcase/health-tokens/og-image keep
+    // their existing exemption unchanged even if a ratcheted glob ever
+    // overlapped one of them.
+    files: RATCHETED_DIRS,
+    rules: {
+      "no-restricted-syntax": ["error", ...FULL_DESIGN_RULES],
     },
   },
   {

--- a/packages/ui-kit/eslint.config.ts
+++ b/packages/ui-kit/eslint.config.ts
@@ -117,6 +117,16 @@ const SSR_SAFETY_RULES = [
 // external-link.tsx/table-state.tsx are known, documented exceptions -- see
 // their own inline comments). Same treatment as apps/ui's primitives/
 // folder + design.primitives.tsx exclusion.
+// #7851: one-way lint ratchet. A directory enters this list only once it's
+// been verified at 0 Bone & Ink warnings (no-restricted-syntax) -- from that
+// point on, new drift in the directory fails CI instead of only annotating
+// it. Any PR that brings a directory to 0 warnings MUST add it here in the
+// same PR (see apps/ui/CONTRIBUTING.md); removing an entry requires an issue
+// explaining why. Initial set (2026-07-24 audit): src/hooks/** and src/lib/**
+// were the only ui-kit directories clean end-to-end -- src/components/** is
+// not (19 of 109 files still warn) and stays un-ratcheted.
+const RATCHETED_DIRS = ["src/hooks/**/*.{ts,tsx}", "src/lib/**/*.{ts,tsx}"];
+
 const PRIMITIVE_FILES = [
   "src/components/metagraphed/panel.tsx",
   "src/components/metagraphed/panel-header.tsx",
@@ -203,6 +213,17 @@ export default tseslint.config(
       // "warn", not "error" -- matching apps/ui's own rationale: fix
       // incrementally as files are touched, don't block unrelated PRs.
       "no-restricted-syntax": ["warn", ...DESIGN_RULES, ...SSR_SAFETY_RULES],
+    },
+  },
+  {
+    // #7851: promotes the ratcheted directories above from warn to error.
+    // Layered after the warn-tier block above so it wins for files in both
+    // (flat config's last-matching-block-wins semantics); the PRIMITIVE_FILES
+    // off-exclusion block below stays last so those files keep their existing
+    // exemption unchanged even if a ratcheted glob ever overlapped one.
+    files: RATCHETED_DIRS,
+    rules: {
+      "no-restricted-syntax": ["error", ...DESIGN_RULES, ...SSR_SAFETY_RULES],
     },
   },
   {


### PR DESCRIPTION
## Summary
- Adds a `RATCHETED_DIRS` mechanism to both `apps/ui/eslint.config.ts` and `packages/ui-kit/eslint.config.ts`: a glob-prefix directory verified at 0 `no-restricted-syntax` (Bone & Ink) warnings is layered into a new config block after the existing warn-tier block, promoting it to `error` — so new drift there fails CI instead of only annotating it in review. The existing `off`-exclusion blocks (primitives/showcase/health-tokens/og-image) stay last per flat-config precedence, so their exemptions are unaffected.
- Extracted the previously-inline rule array in `apps/ui/eslint.config.ts`'s full-guardrail block into a named `FULL_DESIGN_RULES` constant so the ratchet block can reuse it verbatim at `error` without duplicating the array — no behavior change for the existing warn-tier block.
- **Initial ratchet set** (per-directory eslint audit, 2026-07-24):
  - `apps/ui/src/hooks/**` — 0/38 files violating.
  - `packages/ui-kit/src/hooks/**` — 0/5 files violating.
  - `packages/ui-kit/src/lib/**` — 0/3 files violating.
  - `apps/ui/src/lib/**` was close but **not** included — 2/226 files still have residual hits (one real `text-[11px]`, one false-positive on an unrelated test-fixture string literal `"gap-5"`). Left for a follow-up PR rather than force-fixed here to keep this PR scoped to the mechanism + genuinely-clean dirs.
  - `apps/ui/src/components/**` (78/213) and `packages/ui-kit/src/components/**` (19/109) are nowhere near clean and stay un-ratcheted.
- Documents the one-way ratchet as a process rule in `apps/ui/CONTRIBUTING.md`: any PR that brings a directory to 0 warnings must add it to `RATCHETED_DIRS` in the same PR; removing an entry requires its own issue explaining why.

## Test plan
- [x] `tsc --noEmit` clean in both packages
- [x] `eslint .` in both packages: 0 errors on the unchanged codebase (534 warnings in apps/ui, 43 in ui-kit — same as before this PR, just re-tiered)
- [x] `prettier --check` clean on all touched files
- [x] `vitest run`: 1464/1464 passing in apps/ui, 98/98 passing in ui-kit
- [x] **Local CI-failure proof** (per the issue's acceptance criteria) — appended a throwaway `text-[13px]` literal to a file in each newly-ratcheted dir and confirmed `eslint` exits 1 with a real `error` (not `warning`), then reverted both:
  - `apps/ui/src/hooks/use-api-base.ts` → `1 problem (1 error, 0 warnings)`, exit code 1
  - `packages/ui-kit/src/lib/utils.ts` → `1 problem (1 error, 0 warnings)`, exit code 1

Closes #7851.