### PR TITLE
feat(ui): design tokens 4/5 — semantic border-radius scale

### DIFF
--- a/apps/ui/CONTRIBUTING.md
+++ b/apps/ui/CONTRIBUTING.md
@@ -95,6 +95,25 @@ budget — keep new dependencies/imports lean.
     raw `z-[1]`/`z-[2]` for micro-stacking inside the table's own local
     stacking context — not a global layer, so it doesn't belong on this scale.
 
+  - Border radius: use one of the 5 approved steps, never `rounded-sm`/`rounded-lg`/
+    `rounded-3xl` or an arbitrary `rounded-[…]` value:
+
+    | Token          | Use for                                                                                                                                                             |
+    | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | `rounded-full` | Pills, badges, dots, avatars, circular icon buttons                                                                                                                 |
+    | `rounded`      | Inputs, buttons, chips, kbd, small controls, table-corner clips                                                                                                     |
+    | `rounded-md`   | Cards/panels not using `<Panel>`, popover/menu surfaces                                                                                                             |
+    | `rounded-xl`   | Drawers, modals, sheets, command palette, `<PageSection>`'s content shells                                                                                          |
+    | `rounded-2xl`  | Homepage hero/marketing tiles, and detail-page KPI panels using the documented `.mg-card-glow`/`.mg-card-glow-accent` soft-elevation variant (#6398) — nowhere else |
+
+    Two standing exceptions: dense visualization grids (heatmaps, the status
+    mosaic, the endpoint-uptime bar) use a sub-token `rounded-[1px]`/
+    `rounded-[2px]` micro-radius on their per-cell fills — every named step
+    above is visually much larger and would materially change these grids, so
+    this is a documented residual, not drift (still flagged as a warning to
+    stay visible). `rounded-sm`/`rounded-lg` were fully eliminated (snapped to
+    `rounded`/`rounded-md`) in the 2026-07-24 sweep — see #7843.
+
   - See `docs/ssr-safety.md` for the hydration-safety rules (also partly ESLint-enforced).
 
   **Lint ratchet.** `no-restricted-syntax` is warn-tier everywhere by default — a

--- a/apps/ui/eslint.config.ts
+++ b/apps/ui/eslint.config.ts
@@ -140,6 +140,34 @@ const GLASS_SURFACE_RULES = [
   },
 ];
 
+// #7843: `rounded-sm`/`rounded-lg` were eliminated (snapped to `rounded` /
+// `rounded-md`) and `rounded-3xl` was never used -- the approved 5-step scale
+// is rounded-full / rounded (base) / rounded-md / rounded-xl / rounded-2xl
+// (the last confined to the homepage hero family and the documented
+// .mg-card-glow detail-page panel pattern, #6398 -- see CONTRIBUTING.md's
+// radius table). Arbitrary `rounded-[…]` is flagged too, except the
+// documented dense-grid micro-radius residual (heatmap/mosaic/uptime-bar
+// cells at 1-2px, far below any named step) -- those still warn here rather
+// than getting a file exemption, same residual-worklist convention as the
+// z-index rule's compare-drawer sites.
+const RADIUS_RULES = [
+  {
+    // Message deliberately avoids spelling out the banned classes as
+    // contiguous "rounded-X" tokens -- doing so would self-match this same
+    // selector inside this config file (a real 2026-07-24 false positive).
+    selector: "Literal[value=/\\brounded-(?:sm|lg|3xl)\\b/]",
+    message:
+      "This radius step was eliminated from the approved scale. Use rounded (base), rounded-md, rounded-xl, or rounded-2xl (hero/mg-card-glow only) -- see CONTRIBUTING.md.",
+  },
+  {
+    // Same self-match hazard as above -- the message avoids a literal
+    // bracket-closed "rounded-[...]" example.
+    selector: "Literal[value=/\\brounded-\\[[^\\]]+\\]/]",
+    message:
+      "Arbitrary bracketed radius value outside the approved scale. Use rounded-full, rounded, rounded-md, rounded-xl, or rounded-2xl -- see CONTRIBUTING.md.",
+  },
+];
+
 // The full Bone & Ink rule set applied to src/**/*.{ts,tsx} (the "warn" block
 // below) -- named so the #7851 ratchet block can apply the identical set at
 // "error" without duplicating the array.
@@ -151,6 +179,7 @@ const FULL_DESIGN_RULES = [
   ...ELEVATION_RULES,
   ...Z_INDEX_RULES,
   ...GLASS_SURFACE_RULES,
+  ...RADIUS_RULES,
 ];
 
 // #7851: one-way lint ratchet. A directory enters this list only once it's

--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -256,7 +256,7 @@ function Legend({ cell, count }: { cell: Cell; count: number }) {
   return (
     <span className="inline-flex items-center gap-1">
       <span
-        className={classNames("inline-block size-2 rounded-sm", tone.bg.split(" ")[0])}
+        className={classNames("inline-block size-2 rounded", tone.bg.split(" ")[0])}
         aria-hidden
       />
       <span>{tone.label.toLowerCase()}</span>

--- a/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
@@ -203,7 +203,7 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                   <div className="flex items-center gap-2">
                     <span
                       className={classNames(
-                        "inline-block size-2 rounded-sm",
+                        "inline-block size-2 rounded",
                         SEVERITY_TINT[r.worst] ?? SEVERITY_TINT.unknown,
                       )}
                       aria-hidden
@@ -289,7 +289,7 @@ function TimelineTrack({
           <span
             key={i.id}
             className={classNames(
-              "absolute top-1 bottom-1 rounded-sm transition-all",
+              "absolute top-1 bottom-1 rounded transition-all",
               tone,
               ongoing && "ring-1 ring-paper/40",
             )}

--- a/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/network-pulse-band.tsx
@@ -203,7 +203,7 @@ export function NetworkPulseBand({ className }: { className?: string }) {
 function Legend({ swatch, label }: { swatch: string; label: string }) {
   return (
     <span className="inline-flex items-center gap-1 mg-type-data-sm text-ink-muted">
-      <span className={classNames("inline-block size-2 rounded-sm", swatch)} aria-hidden />
+      <span className={classNames("inline-block size-2 rounded", swatch)} aria-hidden />
       {label}
     </span>
   );

--- a/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/registry-depth.tsx
@@ -194,7 +194,7 @@ export function DimensionCoverageHeatmap({ className }: { className?: string }) 
 function Swatch({ color, label }: { color: string; label: string }) {
   return (
     <span className="inline-flex items-center gap-1">
-      <span className="inline-block size-2 rounded-sm" style={{ background: color }} aria-hidden />
+      <span className="inline-block size-2 rounded" style={{ background: color }} aria-hidden />
       {label}
     </span>
   );

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -321,7 +321,7 @@ function KindLegend({ kind }: { kind: DriftKind }) {
   const t = KIND_TONE[kind];
   return (
     <span className="inline-flex items-center gap-1">
-      <span className={classNames("inline-block size-2 rounded-sm", t.dot)} aria-hidden />
+      <span className={classNames("inline-block size-2 rounded", t.dot)} aria-hidden />
       {t.label.toLowerCase()}
     </span>
   );

--- a/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
@@ -75,7 +75,7 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
                 >
                   {k !== "all" ? (
                     <span
-                      className={classNames("inline-block size-1.5 rounded-sm", TONE[k])}
+                      className={classNames("inline-block size-1.5 rounded", TONE[k])}
                       aria-hidden
                     />
                   ) : null}

--- a/apps/ui/src/components/metagraphed/analytics/time-range-scrub.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/time-range-scrub.tsx
@@ -43,7 +43,7 @@ export function TimeRangeScrub({
             aria-checked={on}
             onClick={() => set(o.value)}
             className={classNames(
-              "px-2 py-0.5 mg-type-micro rounded-sm transition-colors",
+              "px-2 py-0.5 mg-type-micro rounded transition-colors",
               on ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",
             )}
           >

--- a/apps/ui/src/components/metagraphed/ask-box.tsx
+++ b/apps/ui/src/components/metagraphed/ask-box.tsx
@@ -50,7 +50,7 @@ export function sourceCountLabel(contextCount: number, model: string): string {
 
 function AskResult({ result }: { result: AskAnswerData }) {
   return (
-    <div className="mt-4 space-y-3 rounded-lg border border-accent/30 bg-accent-surface p-4">
+    <div className="mt-4 space-y-3 rounded-md border border-accent/30 bg-accent-surface p-4">
       <p className="mg-type-caption-lg leading-relaxed text-ink-strong">{result.answer}</p>
       {result.citations.length > 0 ? (
         <ul className="divide-y divide-border rounded border border-border bg-card">
@@ -90,14 +90,14 @@ export function AskBox() {
             placeholder="Which subnet does image generation?"
             value={question}
             onChange={(e) => setQuestion(e.target.value)}
-            className="w-full resize-none rounded-lg border border-border bg-card px-3 py-2 mg-type-caption-lg text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
+            className="w-full resize-none rounded-md border border-border bg-card px-3 py-2 mg-type-caption-lg text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
           />
         </label>
         <button
           type="submit"
           disabled={mutation.isPending || !question.trim()}
           className={classNames(
-            "shrink-0 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15",
+            "shrink-0 rounded-md border border-accent/40 bg-accent/10 px-4 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15",
             "disabled:cursor-not-allowed disabled:opacity-50",
           )}
         >

--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -99,7 +99,7 @@ export function LiveBlockRail() {
                 params={{ ref: String(b.block_number) }}
                 title={`#${formatNumber(b.block_number)} · ${formatNumber(ext)} ext`}
                 className={classNames(
-                  "block w-[6px] min-w-[6px] rounded-sm transition-colors",
+                  "block w-[6px] min-w-[6px] rounded transition-colors",
                   isLatest ? "bg-accent" : "bg-ink-strong/25 hover:bg-ink-strong/50",
                 )}
                 style={{ height: `${h}%` }}

--- a/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
+++ b/apps/ui/src/components/metagraphed/charts/economics-mini.tsx
@@ -225,7 +225,7 @@ function EconomicsDrilldown({
 function DeltaTile({ label, value, tip }: { label: string; value: string; tip?: string }) {
   return (
     <div
-      className="rounded-lg border border-border bg-paper/50 p-3"
+      className="rounded-md border border-border bg-paper/50 p-3"
       title={tip}
       aria-label={tip ? `${label}: ${value}. ${tip}` : `${label}: ${value}`}
     >

--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -287,12 +287,12 @@ function Cell({ cell }: { cell: Cell }) {
           {cell.downCount > 0 || cell.warnCount > 0 ? (
             <span className="absolute top-0.5 right-0.5 flex items-center gap-0.5" aria-hidden>
               {cell.downCount > 0 ? (
-                <span className="inline-flex h-3 min-w-[12px] items-center justify-center rounded-sm bg-health-down/95 px-0.5 text-[9px] font-mono leading-none text-paper">
+                <span className="inline-flex h-3 min-w-[12px] items-center justify-center rounded bg-health-down/95 px-0.5 text-[9px] font-mono leading-none text-paper">
                   {cell.downCount}
                 </span>
               ) : null}
               {cell.warnCount > 0 ? (
-                <span className="inline-flex h-3 min-w-[12px] items-center justify-center rounded-sm bg-health-warn/95 px-0.5 text-[9px] font-mono leading-none text-paper">
+                <span className="inline-flex h-3 min-w-[12px] items-center justify-center rounded bg-health-warn/95 px-0.5 text-[9px] font-mono leading-none text-paper">
                   {cell.warnCount}
                 </span>
               ) : null}
@@ -430,7 +430,7 @@ function LegendBucket({ cls, label, hint }: { cls: string; label: string; hint: 
           tabIndex={0}
           role="listitem"
         >
-          <span className={`size-2 rounded-sm ${cls}`} aria-hidden />
+          <span className={`size-2 rounded ${cls}`} aria-hidden />
           {label}
         </span>
       </TooltipTrigger>

--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -57,9 +57,9 @@ export function ValidatorSubnetHeatmap() {
         <div className="flex flex-wrap items-center gap-2.5 font-mono text-[9.5px] text-ink-muted">
           <span>top {rows.length} validators · top 10 subnets each (server-capped)</span>
           <span className="inline-flex items-center gap-1">
-            <span className="inline-block h-2.5 w-2.5 rounded-sm bg-accent/20" />
-            <span className="inline-block h-2.5 w-2.5 rounded-sm bg-accent/50" />
-            <span className="inline-block h-2.5 w-2.5 rounded-sm bg-accent/80" />
+            <span className="inline-block h-2.5 w-2.5 rounded bg-accent/20" />
+            <span className="inline-block h-2.5 w-2.5 rounded bg-accent/50" />
+            <span className="inline-block h-2.5 w-2.5 rounded bg-accent/80" />
             more stake
           </span>
         </div>
@@ -112,7 +112,7 @@ export function ValidatorSubnetHeatmap() {
                                 role="img"
                                 aria-label={summary}
                                 className={classNames(
-                                  "block h-6 rounded-sm cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+                                  "block h-6 rounded cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
                                   stakeTone(ratio),
                                 )}
                               />

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -681,7 +681,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                   <button
                     type="button"
                     onClick={filterSubnetsByQuery}
-                    className="flex w-full items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-left text-sm text-ink-strong hover:border-accent/40 hover:bg-surface transition-colors"
+                    className="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-sm text-ink-strong hover:border-accent/40 hover:bg-surface transition-colors"
                   >
                     <Search className="size-4 shrink-0 text-ink-muted" />
                     <span>Filter /subnets by "{debounced}"</span>
@@ -691,7 +691,7 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
                   <button
                     type="button"
                     onClick={filterEndpointsByQuery}
-                    className="flex w-full items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-left text-sm text-ink-strong hover:border-accent/40 hover:bg-surface transition-colors"
+                    className="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-sm text-ink-strong hover:border-accent/40 hover:bg-surface transition-colors"
                   >
                     <Wifi className="size-4 shrink-0 text-ink-muted" />
                     <span>Filter /endpoints by "{debounced}"</span>

--- a/apps/ui/src/components/metagraphed/continue-exploring.tsx
+++ b/apps/ui/src/components/metagraphed/continue-exploring.tsx
@@ -98,7 +98,7 @@ export function ContinueExploring() {
               <Link
                 key={`${v.kind}-${v.id}`}
                 to={v.href}
-                className="mg-recent-card group flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5 hover:border-accent/40 transition-colors min-w-0"
+                className="mg-recent-card group flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2.5 hover:border-accent/40 transition-colors min-w-0"
               >
                 {v.kind === "subnet" ? (
                   <BrandIcon

--- a/apps/ui/src/components/metagraphed/delegate-cta.tsx
+++ b/apps/ui/src/components/metagraphed/delegate-cta.tsx
@@ -42,7 +42,7 @@ export function DelegateCTA({ netuid, variant = "inline", className }: Props) {
         >
           <span
             aria-hidden
-            className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg border border-border bg-paper text-ink-strong"
+            className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-md border border-border bg-paper text-ink-strong"
           >
             <Coins className="size-4" />
           </span>
@@ -88,7 +88,7 @@ export function DelegateCTA({ netuid, variant = "inline", className }: Props) {
       >
         <span
           aria-hidden
-          className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg border border-accent/60 bg-paper text-accent"
+          className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-md border border-accent/60 bg-paper text-accent"
         >
           <Sparkles className="size-4" />
         </span>

--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -49,7 +49,7 @@ export function EndpointKindTabs({ value, counts, onChange }: Props) {
             {count != null ? (
               <span
                 className={classNames(
-                  "rounded-sm px-1 tabular-nums text-[10px]",
+                  "rounded px-1 tabular-nums text-[10px]",
                   active ? "bg-paper/40 text-ink-strong" : "bg-surface/60 text-ink-muted",
                 )}
               >

--- a/apps/ui/src/components/metagraphed/endpoint-list.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-list.tsx
@@ -311,7 +311,7 @@ function MobileCard({
   const { copied, copy } = useCopy({ label: "endpoint url" });
   const safeUrl = safeExternalUrl(e.url ?? undefined);
   return (
-    <li className="rounded-lg border border-border bg-card p-3">
+    <li className="rounded-md border border-border bg-card p-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 mb-1">

--- a/apps/ui/src/components/metagraphed/graphiql-explorer-body.tsx
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer-body.tsx
@@ -91,7 +91,7 @@ export function GraphiqlExplorerBody({
   return (
     <div
       className={classNames(
-        "mg-graphiql-frame overflow-hidden rounded-lg border border-border",
+        "mg-graphiql-frame overflow-hidden rounded-md border border-border",
         heightClassName,
       )}
     >

--- a/apps/ui/src/components/metagraphed/hero-feature-row.tsx
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.tsx
@@ -83,7 +83,7 @@ function ChainThroughputCard() {
             className="w-full"
           />
         ) : (
-          <div className="h-[180px] w-full animate-pulse rounded-lg bg-surface-2" />
+          <div className="h-[180px] w-full animate-pulse rounded-md bg-surface-2" />
         )}
       </div>
 

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -407,7 +407,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                       key={r.to}
                       to={r.to}
                       onClick={() => setOpen(false)}
-                      className="group/jump flex items-center gap-2.5 rounded-lg border border-border bg-card px-3 py-2.5 hover:border-accent/40 hover:bg-surface transition-colors"
+                      className="group/jump flex items-center gap-2.5 rounded-md border border-border bg-card px-3 py-2.5 hover:border-accent/40 hover:bg-surface transition-colors"
                     >
                       <r.Icon className="size-3.5 shrink-0 text-ink-muted group-hover/jump:text-accent transition-colors" />
                       <span className="min-w-0">
@@ -421,7 +421,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                 </div>
               </div>
 
-              <div className="mx-3 mb-2 rounded-lg border border-border/60 mg-glass-soft px-3 py-2">
+              <div className="mx-3 mb-2 rounded-md border border-border/60 mg-glass-soft px-3 py-2">
                 <p className="text-[11px] text-ink-muted leading-relaxed">
                   <span className="font-medium text-ink">Paste anything:</span> wallet address
                   (ss58), block number, transaction hash (0x…) or block hash to jump directly.
@@ -490,7 +490,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                         onMouseEnter={() => setActive(i)}
                         onClick={() => commit(n)}
                         className={classNames(
-                          "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-colors",
+                          "w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-left transition-colors",
                           isActive ? "bg-surface" : "hover:bg-surface/60",
                         )}
                       >
@@ -544,7 +544,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                               onMouseEnter={() => setActive(idx)}
                               onClick={() => commit({ kind: "hit", hit: h })}
                               className={classNames(
-                                "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors",
+                                "w-full flex items-center gap-3 px-3 py-2 rounded-md text-left transition-colors",
                                 isActive ? "bg-surface" : "hover:bg-surface/60",
                               )}
                             >
@@ -579,7 +579,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
                     onMouseEnter={() => setActive(flat.length - 1)}
                     onClick={() => commit({ kind: "action" })}
                     className={classNames(
-                      "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors",
+                      "w-full flex items-center gap-3 px-3 py-2 rounded-md text-left transition-colors",
                       active === flat.length - 1 ? "bg-surface" : "hover:bg-surface/60",
                     )}
                   >

--- a/apps/ui/src/components/metagraphed/network-mood-gauge.tsx
+++ b/apps/ui/src/components/metagraphed/network-mood-gauge.tsx
@@ -43,7 +43,7 @@ export function NetworkMoodGauge() {
     <Link
       id="network-mood-gauge"
       to="/subnets"
-      className="mg-fade-in mg-fade-in-delay-3 mt-3 flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 hover:border-ink/30 transition-colors"
+      className="mg-fade-in mg-fade-in-delay-3 mt-3 flex items-center gap-3 rounded-md border border-border bg-card px-4 py-2.5 hover:border-ink/30 transition-colors"
       title={`Network mood: ${meta.label} (ratio ${sentiment_ratio.toFixed(2)}) -- net/gross 24h alpha buy vs sell volume across ${formatNumber(subnet_count)} subnets.`}
     >
       <Icon aria-hidden className="size-4 shrink-0" style={{ color: meta.color }} />

--- a/apps/ui/src/components/metagraphed/operational-panel.tsx
+++ b/apps/ui/src/components/metagraphed/operational-panel.tsx
@@ -283,7 +283,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                   context="recent incidents"
                 />
               ) : incidents.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-border bg-paper/40 px-3 py-6 text-center">
+                <div className="rounded-md border border-dashed border-border bg-paper/40 px-3 py-6 text-center">
                   <div className="mg-type-micro text-ink-muted">Clean history</div>
                   <div className="mt-1 text-[11px] text-ink-muted">
                     No incidents recorded for this subnet.
@@ -296,7 +296,7 @@ export function OperationalPanel({ netuid }: { netuid: number }) {
                     return (
                       <li
                         key={`${inc.surface_id}-${inc.started_at ?? i}`}
-                        className="flex items-start gap-2 rounded-lg border border-border bg-surface/30 px-2.5 py-2"
+                        className="flex items-start gap-2 rounded-md border border-border bg-surface/30 px-2.5 py-2"
                       >
                         <span className="shrink-0 mt-0.5">{sevIcon(inc.severity)}</span>
                         <div className="min-w-0 flex-1">

--- a/apps/ui/src/components/metagraphed/quick-actions-row.tsx
+++ b/apps/ui/src/components/metagraphed/quick-actions-row.tsx
@@ -76,7 +76,7 @@ export function QuickActionsRow() {
               <div className="flex items-start justify-between">
                 <span
                   aria-hidden
-                  className="mg-quick-icon inline-flex size-9 items-center justify-center rounded-lg border border-border bg-surface/60 text-ink-strong"
+                  className="mg-quick-icon inline-flex size-9 items-center justify-center rounded-md border border-border bg-surface/60 text-ink-strong"
                 >
                   <Icon className="size-4" />
                 </span>

--- a/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
+++ b/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
@@ -73,7 +73,7 @@ export function ReadinessScorecard({ profile }: { profile?: SubnetProfile }) {
           // (shrink-to-fit) anchor never triggers the inner `truncate`, so the
           // CTA overflowed the card (#6903). `w-full` constrains it to the card
           // width, engaging the existing truncate chain.
-          className="mt-3 w-full items-center gap-2 rounded-lg border border-accent/30 bg-accent-surface px-3 py-2 text-sm"
+          className="mt-3 w-full items-center gap-2 rounded-md border border-accent/30 bg-accent-surface px-3 py-2 text-sm"
         >
           <ArrowRight className="size-4 shrink-0 text-accent" />
           <span className="min-w-0 flex-1 truncate">

--- a/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
+++ b/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
@@ -47,7 +47,7 @@ export function RecentIdentityChanges() {
   }
 
   return (
-    <ul className="divide-y divide-border rounded-lg border border-border bg-card">
+    <ul className="divide-y divide-border rounded-md border border-border bg-card">
       {changes.map((c) => (
         <li key={`${c.netuid}-${c.identity_hash}`} className="flex items-center gap-3 px-4 py-3">
           <Link

--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -64,7 +64,7 @@ export function ProxyHero() {
   const proxyUrl = `${API_BASE}/rpc/v1/${chain}`;
   const curlExample = curlFor(proxyUrl);
   return (
-    <div className="rounded-lg border border-accent/30 bg-accent-surface p-4">
+    <div className="rounded-md border border-accent/30 bg-accent-surface p-4">
       <div className="flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center gap-1.5 rounded border border-health-ok/40 bg-health-ok/10 px-1.5 py-0.5 mg-type-micro text-health-ok">
           <span className="size-1.5 rounded-full bg-health-ok" />

--- a/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
@@ -180,7 +180,7 @@ function EvidenceSection({
   if (links.length === 0) return null;
 
   return (
-    <div className="rounded-lg border border-border mg-glass-soft p-3">
+    <div className="rounded-md border border-border mg-glass-soft p-3">
       <div className="mb-2 flex items-center gap-2 mg-type-micro text-ink-muted">
         evidence &amp; sources
         <InfoTooltip label="Where the snapshot diff was derived from. Open or copy these to verify the change against the source." />

--- a/apps/ui/src/components/metagraphed/schema-snapshot-summary.tsx
+++ b/apps/ui/src/components/metagraphed/schema-snapshot-summary.tsx
@@ -104,7 +104,7 @@ export function SchemaSnapshotSummary({ schema }: { schema: SchemaInfo }) {
       </div>
 
       {/* Hash transition (the registry's canonical drift signal). */}
-      <div className="rounded-lg border border-border bg-paper p-3 mg-type-data">
+      <div className="rounded-md border border-border bg-paper p-3 mg-type-data">
         {hashChanged ? (
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-ink-muted">{schema.previous_hash!.slice(0, 12)}</span>

--- a/apps/ui/src/components/metagraphed/search-box.tsx
+++ b/apps/ui/src/components/metagraphed/search-box.tsx
@@ -83,7 +83,7 @@ function SearchResults({ results }: { results: SemanticSearchResult[] }) {
     );
   }
   return (
-    <ul className="mt-4 divide-y divide-border rounded-lg border border-border bg-card">
+    <ul className="mt-4 divide-y divide-border rounded-md border border-border bg-card">
       {results.map((r, i) => (
         // Results have no stable id in the schema; index is safe since this list
         // is fully replaced (not reordered/filtered in place) on every new query.
@@ -119,14 +119,14 @@ export function SearchBox() {
             placeholder="video generation"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="w-full rounded-lg border border-border bg-card px-3 py-2 mg-type-caption-lg text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
+            className="w-full rounded-md border border-border bg-card px-3 py-2 mg-type-caption-lg text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
           />
         </label>
         <button
           type="submit"
           disabled={isFetching || !query.trim()}
           className={classNames(
-            "shrink-0 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15",
+            "shrink-0 rounded-md border border-accent/40 bg-accent/10 px-4 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15",
             "disabled:cursor-not-allowed disabled:opacity-50",
           )}
         >

--- a/apps/ui/src/components/metagraphed/settings-popover.tsx
+++ b/apps/ui/src/components/metagraphed/settings-popover.tsx
@@ -157,7 +157,7 @@ function SegmentBtn({
       aria-label={label}
       title={title ?? label}
       className={classNames(
-        "flex-1 inline-flex items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-[11px] font-medium transition-colors min-h-8",
+        "flex-1 inline-flex items-center justify-center gap-1.5 rounded px-2 py-1.5 text-[11px] font-medium transition-colors min-h-8",
         active ? "bg-card text-ink-strong shadow-sm" : "text-ink-muted hover:text-ink-strong",
       )}
     >

--- a/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
@@ -42,7 +42,7 @@ export function SubnetHealthMatrix() {
     return (
       <div className="grid grid-cols-[repeat(auto-fill,minmax(28px,1fr))] gap-1.5">
         {Array.from({ length: 128 }).map((_, i) => (
-          <div key={i} className="aspect-square rounded-sm bg-surface-2/60 animate-pulse" />
+          <div key={i} className="aspect-square rounded bg-surface-2/60 animate-pulse" />
         ))}
       </div>
     );
@@ -61,7 +61,7 @@ export function SubnetHealthMatrix() {
                     to="/subnets/$netuid"
                     params={{ netuid: s.netuid }}
                     className={classNames(
-                      "group flex aspect-square items-center justify-center rounded-sm transition-all duration-150 ring-0 hover:ring-2 hover:ring-accent/40 hover:scale-110",
+                      "group flex aspect-square items-center justify-center rounded transition-all duration-150 ring-0 hover:ring-2 hover:ring-accent/40 hover:scale-110",
                       tone,
                       TONE_TEXT[s.health ?? "unknown"],
                     )}
@@ -100,7 +100,7 @@ function Legend() {
     <div className="flex flex-wrap items-center gap-3 mg-type-micro text-ink-muted">
       {items.map((i) => (
         <span key={i.state} className="inline-flex items-center gap-1.5">
-          <span className={classNames("size-2 rounded-sm", TONE[i.state])} aria-hidden />
+          <span className={classNames("size-2 rounded", TONE[i.state])} aria-hidden />
           {i.label}
         </span>
       ))}

--- a/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-lease-panel.tsx
@@ -225,7 +225,7 @@ function LeaseHistorySection({
           {events.map((ev, i) => (
             <li
               key={`${ev.block_number ?? i}-${ev.event_kind ?? i}-${ev.observed_at ?? i}`}
-              className="rounded-lg border border-border bg-card p-3"
+              className="rounded-md border border-border bg-card p-3"
             >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="flex min-w-0 flex-wrap items-center gap-2">

--- a/apps/ui/src/components/metagraphed/subnet-ownership-history.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ownership-history.tsx
@@ -50,7 +50,7 @@ export function SubnetOwnershipHistory({ netuid }: { netuid: number }) {
       {changes.map((change, i) => (
         <li
           key={`${change.block_number ?? i}-${change.new_coldkey ?? i}`}
-          className="rounded-lg border border-border bg-card p-3"
+          className="rounded-md border border-border bg-card p-3"
         >
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex min-w-0 flex-wrap items-center gap-1.5">

--- a/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-priority-highlights.tsx
@@ -45,7 +45,7 @@ function Tile({
     <a
       href={href}
       className={classNames(
-        "group flex items-start gap-3 rounded-lg border p-3 transition-colors hover:border-ink/30 mg-focus-ring",
+        "group flex items-start gap-3 rounded-md border p-3 transition-colors hover:border-ink/30 mg-focus-ring",
         TONE[tone],
       )}
     >

--- a/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
@@ -269,7 +269,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                       <div className="flex items-center gap-1.5">
                         <span
                           aria-hidden
-                          className="inline-block size-2 rounded-sm"
+                          className="inline-block size-2 rounded"
                           style={{ background: "var(--accent)" }}
                         />
                         <span className="text-ink">In</span>
@@ -280,7 +280,7 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
                       <div className="flex items-center gap-1.5">
                         <span
                           aria-hidden
-                          className="inline-block size-2 rounded-sm"
+                          className="inline-block size-2 rounded"
                           style={{ background: "var(--health-warn)" }}
                         />
                         <span className="text-ink">Out</span>

--- a/apps/ui/src/components/metagraphed/subnets-highlights.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-highlights.tsx
@@ -59,7 +59,7 @@ function Card({
     <Link
       to={href}
       className={classNames(
-        "group flex items-start gap-3 rounded-lg border p-3 transition-colors hover:border-ink/30",
+        "group flex items-start gap-3 rounded-md border p-3 transition-colors hover:border-ink/30",
         TONE[tone],
       )}
     >

--- a/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
@@ -123,7 +123,7 @@ export function SubnetsSavedViews() {
                 onClick={() => apply(p.patch)}
                 className={classNames(
                   "relative inline-flex shrink-0 items-center px-3 py-2 mg-type-caption-lg transition-colors",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded",
                   active ? "text-ink-strong" : "text-ink-muted hover:text-ink-strong",
                 )}
               >

--- a/apps/ui/src/components/metagraphed/top-active-account-row.tsx
+++ b/apps/ui/src/components/metagraphed/top-active-account-row.tsx
@@ -29,7 +29,7 @@ export function TopActiveAccountRowLink({ row }: TopActiveAccountRowLinkProps) {
           to="/accounts/$ss58"
           params={{ ss58: row.ss58 }}
           title={row.ss58}
-          className="min-w-0 truncate rounded-sm hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 group-hover:text-accent"
+          className="min-w-0 truncate rounded hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 group-hover:text-accent"
           preload="intent"
         >
           {label}

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -65,7 +65,7 @@ export function ValidatorGuide() {
   const [open, setOpen] = useState(false);
 
   return (
-    <aside aria-label={HEADING} className="mb-6 rounded-lg border border-border mg-glass-soft">
+    <aside aria-label={HEADING} className="mb-6 rounded-md border border-border mg-glass-soft">
       {/* Desktop / tablet: collapsible callout with the full grid. */}
       <div className="hidden sm:block">
         <button

--- a/apps/ui/src/routes/-about-page.tsx
+++ b/apps/ui/src/routes/-about-page.tsx
@@ -234,7 +234,7 @@ function AtAGlance() {
           <li key={label}>
             <Link
               to={to}
-              className="group flex items-center gap-3 rounded-lg border border-transparent hover:border-border hover:bg-surface/40 px-2 py-1.5 -mx-2 transition-colors"
+              className="group flex items-center gap-3 rounded-md border border-transparent hover:border-border hover:bg-surface/40 px-2 py-1.5 -mx-2 transition-colors"
             >
               <span className="inline-flex size-7 items-center justify-center rounded-md bg-surface/70 text-ink shrink-0">
                 <Icon className="size-3.5" />

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -2436,7 +2436,7 @@ function AccountFootprintSection({
 
       <ul className="space-y-2 md:hidden">
         {rows.map((r) => (
-          <li key={`${r.netuid}-${r.uid}`} className="rounded-lg border border-border bg-card p-3">
+          <li key={`${r.netuid}-${r.uid}`} className="rounded-md border border-border bg-card p-3">
             <div className="flex items-center justify-between gap-3">
               <div className="flex min-w-0 items-center gap-2">
                 {r.netuid != null ? (

--- a/apps/ui/src/routes/-agents-page.tsx
+++ b/apps/ui/src/routes/-agents-page.tsx
@@ -113,7 +113,7 @@ function AgentsBody() {
           title="Connect over MCP"
           intro={`One command in Claude Code, Cursor, or any MCP client. ${mcp.tools.length} tools over ${mcp.transport} — search the registry, find a subnet for a task, get a callable RPC endpoint, ask a grounded question.`}
         />
-        <div className="flex items-center gap-3 rounded-lg border border-accent/30 bg-accent-surface px-4 py-3.5">
+        <div className="flex items-center gap-3 rounded-md border border-accent/30 bg-accent-surface px-4 py-3.5">
           <Terminal className="size-4 shrink-0 text-accent" aria-hidden />
           <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono mg-type-caption-lg text-ink-strong">
             {mcp.install}
@@ -183,7 +183,7 @@ function AgentsBody() {
               href={CLAUDE_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-accent/40 bg-accent/10 px-3.5 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15"
+              className="inline-flex items-center gap-1.5 rounded-md border border-accent/40 bg-accent/10 px-3.5 py-2 mg-type-caption-lg font-medium text-accent hover:bg-accent/15"
             >
               Open in Claude <ArrowUpRight className="size-3.5" />
             </a>
@@ -191,7 +191,7 @@ function AgentsBody() {
               href={CHATGPT_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3.5 py-2 mg-type-caption-lg font-medium text-ink-strong hover:border-ink/30"
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3.5 py-2 mg-type-caption-lg font-medium text-ink-strong hover:border-ink/30"
             >
               Open in ChatGPT <ArrowUpRight className="size-3.5" />
             </a>
@@ -212,7 +212,7 @@ function AgentsBody() {
           title="Everything else, fetchable directly"
           intro={`A paste-ready agent prompt, a Bittensor skill, llms.txt, the OpenAPI contract, grounded Q&A, semantic search, and bulk data — ${res.summary.callable_service_count} callable services across ${res.summary.subnet_count} subnets, all indexed at /api/v1/agent-resources.`}
         />
-        <div className="divide-y divide-border overflow-hidden rounded-lg border border-border">
+        <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
           {res.resources.map((r) => {
             const meta = kindMeta(r.kind);
             const Icon = meta.icon;

--- a/apps/ui/src/routes/-delegate-page.tsx
+++ b/apps/ui/src/routes/-delegate-page.tsx
@@ -100,7 +100,7 @@ export function DelegatePage() {
 
 function TrustCell({ icon, title, body }: { icon: React.ReactNode; title: string; body: string }) {
   return (
-    <div className="rounded-lg border border-border mg-glass-soft px-4 py-3">
+    <div className="rounded-md border border-border mg-glass-soft px-4 py-3">
       <div className="flex items-center gap-2 text-ink-strong">
         <span className="text-accent" aria-hidden>
           {icon}

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -236,7 +236,7 @@ function CallMixSection({ calls }: { calls: ChainCalls }) {
                     >
                       <span
                         aria-hidden
-                        className="inline-block size-2 shrink-0 rounded-sm"
+                        className="inline-block size-2 shrink-0 rounded"
                         style={{ background: CALL_MIX_PALETTE[i % CALL_MIX_PALETTE.length] }}
                       />
                       <span

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -564,7 +564,7 @@ function OpenGapsSection() {
       </div>
 
       {missingSet.size > 0 ? (
-        <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-accent/30 bg-primary-soft/40 px-3 py-2 mg-type-data text-ink-strong">
+        <div className="mt-3 flex flex-wrap items-center gap-2 rounded-md border border-accent/30 bg-primary-soft/40 px-3 py-2 mg-type-data text-ink-strong">
           <span className="mg-type-micro text-ink-muted">filtered by missing kind:</span>
           {Array.from(missingSet).map((k) => (
             <span
@@ -852,7 +852,7 @@ function CompletenessList() {
       {rows.slice(0, 24).map((r) => (
         <li
           key={r.netuid}
-          className="flex items-center gap-4 rounded-lg border border-border bg-card px-4 py-2.5"
+          className="flex items-center gap-4 rounded-md border border-border bg-card px-4 py-2.5"
         >
           <Link
             to="/subnets/$netuid"
@@ -895,7 +895,7 @@ function AdapterCandidates() {
       {rows.map((r, i) => (
         <li
           key={`${r.netuid}-${i}`}
-          className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5"
+          className="flex items-center gap-3 rounded-md border border-border bg-card px-4 py-2.5"
         >
           {r.netuid != null ? (
             <Link
@@ -1126,7 +1126,7 @@ function GapPriorityList() {
       {rows.map((r, i) => (
         <li
           key={`${r.netuid}-${i}`}
-          className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5"
+          className="flex items-center gap-3 rounded-md border border-border bg-card px-4 py-2.5"
         >
           {r.netuid != null ? (
             <Link

--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -71,7 +71,7 @@ export function HealthPage() {
   const activeSectionId =
     VIEW_SECTION_ID[search.view as HealthView] ?? (search.status !== "all" ? "incidents" : null);
   const sectionRing = (id: string) =>
-    activeSectionId === id ? "ring-1 ring-accent/40 rounded-2xl" : undefined;
+    activeSectionId === id ? "ring-1 ring-accent/40 rounded-xl" : undefined;
 
   useEffect(() => {
     if (!activeSectionId) return;
@@ -476,7 +476,7 @@ function Cell({
   format?: (n: number) => string;
 }) {
   return (
-    <div className="rounded-lg border border-border/60 bg-paper/40 px-3 py-2.5">
+    <div className="rounded-md border border-border/60 bg-paper/40 px-3 py-2.5">
       <div className="mg-type-micro text-[10px] text-ink-muted">{label}</div>
       <div
         className={`mt-1 font-display text-lg font-semibold tabular-nums leading-none ${accent ?? "text-ink-strong"}`}

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -548,7 +548,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                   to="/providers/$slug"
                   params={{ slug: p.slug }}
                   className={classNames(
-                    "group block rounded-lg border border-border bg-card p-4 transition-colors",
+                    "group block rounded-md border border-border bg-card p-4 transition-colors",
                     "hover:border-accent/60 hover:shadow-[var(--mg-shadow-ring-accent)]",
                   )}
                 >

--- a/apps/ui/src/routes/-providers-slug-page.tsx
+++ b/apps/ui/src/routes/-providers-slug-page.tsx
@@ -327,7 +327,7 @@ function SubnetsServedGrid({ slug, compact }: { slug: string; compact?: boolean 
               <Link
                 to="/subnets/$netuid"
                 params={{ netuid: netuid }}
-                className="flex items-center gap-2.5 rounded-lg border border-border bg-card p-3 hover:border-ink/30 mg-row-hover"
+                className="flex items-center gap-2.5 rounded-md border border-border bg-card p-3 hover:border-ink/30 mg-row-hover"
               >
                 <BrandIcon
                   url={sn?.website}

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -1501,7 +1501,7 @@ function SubnetMatrix({ rows }: { rows: Subnet[] }) {
               aria-label={`Subnet ${s.netuid}${s.name ? ` — ${s.name}` : ""}`}
               title={`#${s.netuid}${s.name ? ` · ${s.name}` : ""} · ${s.health ?? "unknown"}`}
               className={classNames(
-                "mg-pulse-cell flex aspect-square items-center justify-center rounded-sm mg-type-data-sm font-medium transition-transform",
+                "mg-pulse-cell flex aspect-square items-center justify-center rounded mg-type-data-sm font-medium transition-transform",
                 HEALTH_BG[s.health ?? "unknown"] ?? HEALTH_BG.unknown,
                 HEALTH_TEXT[s.health ?? "unknown"] ?? HEALTH_TEXT.unknown,
               )}
@@ -1518,7 +1518,7 @@ function SubnetMatrix({ rows }: { rows: Subnet[] }) {
 function Legend({ color, label }: { color: string; label: string }) {
   return (
     <span className="inline-flex items-center gap-1">
-      <span className={classNames("size-2 rounded-sm", color)} />
+      <span className={classNames("size-2 rounded", color)} />
       {label}
     </span>
   );

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -733,7 +733,7 @@ function IdentityHistoryList({ netuid }: { netuid: number }) {
       {entries.map((entry, i) => (
         <li
           key={`${entry.identity_hash}-${i}`}
-          className="rounded-lg border border-border bg-card p-3"
+          className="rounded-md border border-border bg-card p-3"
         >
           <div className="flex flex-wrap items-baseline justify-between gap-2">
             <span className="font-display text-sm font-semibold text-ink-strong">
@@ -1401,7 +1401,7 @@ function AgentReadinessCard({
 function ServiceCard({ service }: { service: AgentCatalogService }) {
   const callable = service.eligibility?.callable;
   return (
-    <li className="rounded-lg border border-border bg-card p-4">
+    <li className="rounded-md border border-border bg-card p-4">
       <div className="flex flex-wrap items-center gap-2">
         <span className="mg-type-micro inline-flex items-center rounded border border-accent/40 bg-primary-soft px-1.5 py-0.5 text-[10px] text-accent-text">
           {service.kind ?? "service"}
@@ -2160,7 +2160,7 @@ function HyperparamsHistoryList({ netuid }: { netuid: number }) {
       {entries.map((entry) => {
         const expanded = expandedHash === entry.hyperparams_hash;
         return (
-          <li key={entry.hyperparams_hash} className="rounded-lg border border-border bg-card p-3">
+          <li key={entry.hyperparams_hash} className="rounded-md border border-border bg-card p-3">
             <button
               type="button"
               onClick={() => setExpandedHash(expanded ? null : entry.hyperparams_hash)}
@@ -2235,7 +2235,7 @@ function SurfacesList({ netuid }: { netuid: number }) {
           </div>
           <ul className="space-y-2">
             {items.map((s) => (
-              <li key={s.id} className="rounded-lg border border-border bg-card p-3 mg-row-hover">
+              <li key={s.id} className="rounded-md border border-border bg-card p-3 mg-row-hover">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
@@ -2299,7 +2299,7 @@ function CandidatesList({ netuid }: { netuid: number }) {
   return (
     <ul className="space-y-2">
       {rows.map((c) => (
-        <li key={c.id} className="rounded-lg border border-dashed border-ink-subtle bg-paper p-3">
+        <li key={c.id} className="rounded-md border border-dashed border-ink-subtle bg-paper p-3">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">

--- a/apps/ui/src/routes/-tools-ss58-page.tsx
+++ b/apps/ui/src/routes/-tools-ss58-page.tsx
@@ -46,7 +46,7 @@ export function Ss58ToolPage() {
             placeholder="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
             spellCheck={false}
             autoComplete="off"
-            className="w-full rounded-lg border border-border bg-card px-4 py-3 font-mono text-sm text-ink-strong placeholder:text-ink-muted/50 focus:border-accent/50 focus:outline-none"
+            className="w-full rounded-md border border-border bg-card px-4 py-3 font-mono text-sm text-ink-strong placeholder:text-ink-muted/50 focus:border-accent/50 focus:outline-none"
           />
         </div>
 
@@ -161,7 +161,7 @@ function ResultCard({
   return (
     <div
       className={classNames(
-        "rounded-lg border p-4",
+        "rounded-md border p-4",
         tone === "ok" && "border-health-ok/30 bg-health-ok/5",
         tone === "warn" && "border-health-warn/30 bg-health-warn/5",
         tone === "error" && "border-health-down/30 bg-health-down/5",

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -80,7 +80,7 @@ function SubnetPerformanceTable({
   }
   const sorted = [...subnets].sort((a, b) => (b.stake_tao ?? 0) - (a.stake_tao ?? 0));
   return (
-    <div className="overflow-x-auto rounded-lg border border-border">
+    <div className="overflow-x-auto rounded-md border border-border">
       <table className="w-full text-left text-sm">
         <thead className="bg-surface/50">
           <tr>

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -153,7 +153,7 @@ function ValidatorsTable({
       </div>
 
       {validators.length > 0 ? (
-        <div className="hidden md:block overflow-x-auto rounded-lg border border-border">
+        <div className="hidden md:block overflow-x-auto rounded-md border border-border">
           <table
             className={classNames(
               "w-full text-left text-sm",

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -169,13 +169,13 @@ var DialogContent = React3__namespace.forwardRef(({ className, children, ...prop
     {
       ref,
       className: cn(
-        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-md",
         className
       ),
       ...props,
       children: [
         children,
-        /* @__PURE__ */ jsxRuntime.jsxs(DialogPrimitive__namespace.Close, { className: "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", children: [
+        /* @__PURE__ */ jsxRuntime.jsxs(DialogPrimitive__namespace.Close, { className: "absolute right-4 top-4 rounded opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", children: [
           /* @__PURE__ */ jsxRuntime.jsx(lucideReact.X, { className: "h-4 w-4" }),
           /* @__PURE__ */ jsxRuntime.jsx("span", { className: "sr-only", children: "Close" })
         ] })
@@ -307,7 +307,7 @@ var CommandItem = React3__namespace.forwardRef(({ className, ...props }, ref) =>
   {
     ref,
     className: cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className
     ),
     ...props
@@ -404,7 +404,7 @@ var SheetContent = React3__namespace.forwardRef(({ side = "right", className, ch
       className: cn(sheetVariants({ side }), className),
       ...props,
       children: [
-        /* @__PURE__ */ jsxRuntime.jsxs(DialogPrimitive__namespace.Close, { className: "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary", children: [
+        /* @__PURE__ */ jsxRuntime.jsxs(DialogPrimitive__namespace.Close, { className: "absolute right-4 top-4 rounded opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary", children: [
           /* @__PURE__ */ jsxRuntime.jsx(lucideReact.X, { className: "h-4 w-4" }),
           /* @__PURE__ */ jsxRuntime.jsx("span", { className: "sr-only", children: "Close" })
         ] }),
@@ -2228,7 +2228,7 @@ function PageSection({
       "data-section-anchor": id ? "" : void 0,
       className: classNames(
         "mg-section",
-        tone === "muted" && "rounded-2xl bg-surface-2/40 px-5 md:px-8 py-8 md:py-10",
+        tone === "muted" && "rounded-xl bg-surface-2/40 px-5 md:px-8 py-8 md:py-10",
         className
       ),
       children: [
@@ -2954,7 +2954,7 @@ function MethodologyCallout({
     "aside",
     {
       "aria-label": "Data freshness and methodology",
-      className: "mb-6 rounded-lg border border-border mg-glass-soft",
+      className: "mb-6 rounded-md border border-border mg-glass-soft",
       children: [
         /* @__PURE__ */ jsxRuntime.jsxs(
           "button",
@@ -3365,7 +3365,7 @@ function DonutLegend({ segments }) {
           "span",
           {
             "aria-hidden": true,
-            className: "inline-block size-2 rounded-sm",
+            className: "inline-block size-2 rounded",
             style: { background: s.color }
           }
         ),
@@ -3969,7 +3969,7 @@ function NoDataSpark({
           tabIndex: 0,
           role: "img",
           "aria-label": `${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`,
-          className: "flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          className: "flex w-full items-center gap-1.5 rounded border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           style: { height },
           children: [
             /* @__PURE__ */ jsxRuntime.jsx(
@@ -4094,7 +4094,7 @@ function TreemapMini({
           children: /* @__PURE__ */ jsxRuntime.jsx(
             "div",
             {
-              className: "flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5",
+              className: "flex h-full w-full flex-col justify-between rounded border border-background/40 p-1.5",
               style: { background: t.color ?? "var(--accent)" },
               children: t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
                 /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate mg-type-data-sm font-medium leading-none text-accent-foreground", children: t.label }),
@@ -5479,7 +5479,7 @@ function QueryBarRoot({
       className: classNames(
         "mg-query-shell",
         "flex w-full items-center gap-1 min-w-0",
-        "h-10 rounded-lg border border-border mg-glass-soft",
+        "h-10 rounded-md border border-border mg-glass-soft",
         "px-1 transition-colors",
         "focus-within:border-[color-mix(in_oklab,var(--accent)_45%,var(--border))]",
         "focus-within:ring-2 focus-within:ring-ring/60",
@@ -5842,7 +5842,7 @@ function ChartSkeleton({
         variant === "bars" ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "absolute inset-2 flex items-end gap-[3px]", "aria-hidden": true, children: Array.from({ length: 16 }).map((_, i) => /* @__PURE__ */ jsxRuntime.jsx(
           "div",
           {
-            className: "flex-1 rounded-sm bg-ink-strong/10 animate-pulse",
+            className: "flex-1 rounded bg-ink-strong/10 animate-pulse",
             style: { height: `${20 + i * 17 % 70}%` }
           },
           i

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -140,13 +140,13 @@ var DialogContent = React3.forwardRef(({ className, children, ...props }, ref) =
     {
       ref,
       className: cn(
-        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-md",
         className
       ),
       ...props,
       children: [
         children,
-        /* @__PURE__ */ jsxs(DialogPrimitive.Close, { className: "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", children: [
+        /* @__PURE__ */ jsxs(DialogPrimitive.Close, { className: "absolute right-4 top-4 rounded opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", children: [
           /* @__PURE__ */ jsx(X, { className: "h-4 w-4" }),
           /* @__PURE__ */ jsx("span", { className: "sr-only", children: "Close" })
         ] })
@@ -278,7 +278,7 @@ var CommandItem = React3.forwardRef(({ className, ...props }, ref) => /* @__PURE
   {
     ref,
     className: cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className
     ),
     ...props
@@ -375,7 +375,7 @@ var SheetContent = React3.forwardRef(({ side = "right", className, children, ...
       className: cn(sheetVariants({ side }), className),
       ...props,
       children: [
-        /* @__PURE__ */ jsxs(DialogPrimitive.Close, { className: "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary", children: [
+        /* @__PURE__ */ jsxs(DialogPrimitive.Close, { className: "absolute right-4 top-4 rounded opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary", children: [
           /* @__PURE__ */ jsx(X, { className: "h-4 w-4" }),
           /* @__PURE__ */ jsx("span", { className: "sr-only", children: "Close" })
         ] }),
@@ -2199,7 +2199,7 @@ function PageSection({
       "data-section-anchor": id ? "" : void 0,
       className: classNames(
         "mg-section",
-        tone === "muted" && "rounded-2xl bg-surface-2/40 px-5 md:px-8 py-8 md:py-10",
+        tone === "muted" && "rounded-xl bg-surface-2/40 px-5 md:px-8 py-8 md:py-10",
         className
       ),
       children: [
@@ -2925,7 +2925,7 @@ function MethodologyCallout({
     "aside",
     {
       "aria-label": "Data freshness and methodology",
-      className: "mb-6 rounded-lg border border-border mg-glass-soft",
+      className: "mb-6 rounded-md border border-border mg-glass-soft",
       children: [
         /* @__PURE__ */ jsxs(
           "button",
@@ -3336,7 +3336,7 @@ function DonutLegend({ segments }) {
           "span",
           {
             "aria-hidden": true,
-            className: "inline-block size-2 rounded-sm",
+            className: "inline-block size-2 rounded",
             style: { background: s.color }
           }
         ),
@@ -3940,7 +3940,7 @@ function NoDataSpark({
           tabIndex: 0,
           role: "img",
           "aria-label": `${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`,
-          className: "flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          className: "flex w-full items-center gap-1.5 rounded border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           style: { height },
           children: [
             /* @__PURE__ */ jsx(
@@ -4065,7 +4065,7 @@ function TreemapMini({
           children: /* @__PURE__ */ jsx(
             "div",
             {
-              className: "flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5",
+              className: "flex h-full w-full flex-col justify-between rounded border border-background/40 p-1.5",
               style: { background: t.color ?? "var(--accent)" },
               children: t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? /* @__PURE__ */ jsxs(Fragment, { children: [
                 /* @__PURE__ */ jsx("span", { className: "truncate mg-type-data-sm font-medium leading-none text-accent-foreground", children: t.label }),
@@ -5450,7 +5450,7 @@ function QueryBarRoot({
       className: classNames(
         "mg-query-shell",
         "flex w-full items-center gap-1 min-w-0",
-        "h-10 rounded-lg border border-border mg-glass-soft",
+        "h-10 rounded-md border border-border mg-glass-soft",
         "px-1 transition-colors",
         "focus-within:border-[color-mix(in_oklab,var(--accent)_45%,var(--border))]",
         "focus-within:ring-2 focus-within:ring-ring/60",
@@ -5813,7 +5813,7 @@ function ChartSkeleton({
         variant === "bars" ? /* @__PURE__ */ jsx("div", { className: "absolute inset-2 flex items-end gap-[3px]", "aria-hidden": true, children: Array.from({ length: 16 }).map((_, i) => /* @__PURE__ */ jsx(
           "div",
           {
-            className: "flex-1 rounded-sm bg-ink-strong/10 animate-pulse",
+            className: "flex-1 rounded bg-ink-strong/10 animate-pulse",
             style: { height: `${20 + i * 17 % 70}%` }
           },
           i

--- a/packages/ui-kit/eslint.config.ts
+++ b/packages/ui-kit/eslint.config.ts
@@ -90,6 +90,28 @@ const DESIGN_RULES = [
     message:
       "Raw bg-card opacity. Use .mg-glass or .mg-glass-soft (see styles.css).",
   },
+  {
+    // #7843: rounded-sm/rounded-lg were eliminated (snapped to rounded /
+    // rounded-md) and rounded-3xl was never used -- see
+    // apps/ui/CONTRIBUTING.md's radius table for the approved 5-step scale.
+    // Message deliberately avoids spelling out the banned classes as
+    // contiguous "rounded-X" tokens -- doing so would self-match this same
+    // selector inside this config file (a real 2026-07-24 false positive).
+    selector: "Literal[value=/\\brounded-(?:sm|lg|3xl)\\b/]",
+    message:
+      "This radius step was eliminated from the approved scale. Use rounded (base), rounded-md, rounded-xl, or rounded-2xl (hero/mg-card-glow only) -- see apps/ui/CONTRIBUTING.md.",
+  },
+  {
+    // Arbitrary bracketed radius outside the scale. The dense-grid
+    // micro-radius sites (heatmap/mosaic/uptime-bar cells at 1-2px) still
+    // warn here rather than getting a file exemption -- same
+    // residual-worklist convention the z-index rule's compare-drawer sites
+    // already use. Message avoids a literal bracket-closed example (same
+    // self-match hazard as above).
+    selector: "Literal[value=/\\brounded-\\[[^\\]]+\\]/]",
+    message:
+      "Arbitrary bracketed radius value outside the approved scale. Use rounded-full, rounded, rounded-md, rounded-xl, or rounded-2xl -- see apps/ui/CONTRIBUTING.md.",
+  },
 ];
 
 // SSR footguns -- see apps/ui/docs/ssr-safety.md. ui-kit's own components

--- a/packages/ui-kit/src/components/metagraphed/chart-skeleton.tsx
+++ b/packages/ui-kit/src/components/metagraphed/chart-skeleton.tsx
@@ -41,7 +41,7 @@ export function ChartSkeleton({
           {Array.from({ length: 16 }).map((_, i) => (
             <div
               key={i}
-              className="flex-1 rounded-sm bg-ink-strong/10 animate-pulse"
+              className="flex-1 rounded bg-ink-strong/10 animate-pulse"
               style={{ height: `${20 + ((i * 17) % 70)}%` }}
             />
           ))}

--- a/packages/ui-kit/src/components/metagraphed/charts/donut.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/donut.tsx
@@ -122,7 +122,7 @@ export function DonutLegend({ segments }: { segments: DonutSegment[] }) {
         >
           <span
             aria-hidden
-            className="inline-block size-2 rounded-sm"
+            className="inline-block size-2 rounded"
             style={{ background: s.color }}
           />
           <span className="text-ink">{s.label}</span>

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-with-spark.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-with-spark.tsx
@@ -261,7 +261,7 @@ export function NoDataSpark({
             tabIndex={0}
             role="img"
             aria-label={`${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`}
-            className="flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            className="flex w-full items-center gap-1.5 rounded border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             style={{ height }}
           >
             <span

--- a/packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/treemap-mini.tsx
@@ -168,7 +168,7 @@ export function TreemapMini({
           }}
         >
           <div
-            className="flex h-full w-full flex-col justify-between rounded-sm border border-background/40 p-1.5"
+            className="flex h-full w-full flex-col justify-between rounded border border-background/40 p-1.5"
             style={{ background: t.color ?? "var(--accent)" }}
           >
             {t.w > MIN_TILE_W_FOR_LABEL && t.h > MIN_TILE_H_FOR_LABEL ? (

--- a/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
+++ b/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
@@ -29,7 +29,7 @@ export function MethodologyCallout({
   return (
     <aside
       aria-label="Data freshness and methodology"
-      className="mb-6 rounded-lg border border-border mg-glass-soft"
+      className="mb-6 rounded-md border border-border mg-glass-soft"
     >
       <button
         type="button"

--- a/packages/ui-kit/src/components/metagraphed/page-section.tsx
+++ b/packages/ui-kit/src/components/metagraphed/page-section.tsx
@@ -44,7 +44,7 @@ export function PageSection({
       className={classNames(
         "mg-section",
         tone === "muted" &&
-          "rounded-2xl bg-surface-2/40 px-5 md:px-8 py-8 md:py-10",
+          "rounded-xl bg-surface-2/40 px-5 md:px-8 py-8 md:py-10",
         className,
       )}
     >

--- a/packages/ui-kit/src/components/metagraphed/query-bar.tsx
+++ b/packages/ui-kit/src/components/metagraphed/query-bar.tsx
@@ -65,7 +65,7 @@ function QueryBarRoot({
       className={classNames(
         "mg-query-shell",
         "flex w-full items-center gap-1 min-w-0",
-        "h-10 rounded-lg border border-border mg-glass-soft",
+        "h-10 rounded-md border border-border mg-glass-soft",
         "px-1 transition-colors",
         "focus-within:border-[color-mix(in_oklab,var(--accent)_45%,var(--border))]",
         "focus-within:ring-2 focus-within:ring-ring/60",

--- a/packages/ui-kit/src/components/ui/command.tsx
+++ b/packages/ui-kit/src/components/ui/command.tsx
@@ -115,7 +115,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className,
     )}
     {...props}

--- a/packages/ui-kit/src/components/ui/dialog.tsx
+++ b/packages/ui-kit/src/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[var(--mg-z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-md",
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/ui-kit/src/components/ui/sheet.tsx
+++ b/packages/ui-kit/src/components/ui/sheet.tsx
@@ -65,7 +65,7 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>


### PR DESCRIPTION
## Summary

Phase 1 audit + proposed table posted as a comment on #7843 (occurrence census across both packages, archetype→radius mapping with two justified adjustments and one documented exception carve-out). Phase 2 (this PR) executes the approved sweep:

- `rounded-sm` → `rounded` (35 sites), `rounded-lg` → `rounded-md` (60 sites) — mechanical, exact-token renames via `perl -pi`, verified with an occurrence-count check (0 remaining of either class) and a duplicate-collision check (no `rounded rounded`/`rounded-md rounded-md` artifacts).
- `packages/ui-kit/src/components/metagraphed/page-section.tsx`'s muted-tone `rounded-2xl` → `rounded-xl` — `<PageSection>` is a general page-content wrapper (used in `gaps.tsx`, `schemas.tsx`, the health dashboard), not hero-specific, so it belongs in the "large surface" tier next to drawers/modals. `-health-page.tsx`'s `sectionRing()` active-state ring (which outlines whichever `<PageSection>` a deep-link scrolled to) moves to `rounded-xl` in lockstep so the ring stays visually paired with its section.
- Confirmed `rounded-2xl` is otherwise confined to the homepage hero family (`hero-feature-row.tsx`, `-index-page.tsx`) and the documented `.mg-card-glow`/`.mg-card-glow-accent` detail-page KPI-panel pattern (#6398 — already an explicit ESLint exemption elsewhere in the same config, not new drift).
- Left the 10 dense-grid `rounded-[1px]`/`rounded-[2px]` micro-radius sites (heatmaps, status mosaic, endpoint-uptime bar) as a documented residual rather than force-fitting them into the scale — every named step is visually far larger and would materially change these per-cell fills. Matches the existing residual-worklist convention the z-index rule already uses for the compare-drawers' `z-[1]`/`z-[2]` sites.
- Adds a warn-tier `no-restricted-syntax` rule to both `eslint.config.ts` files flagging `rounded-(sm|lg|3xl)` and arbitrary `rounded-[…]`. Caught and fixed a real self-match false positive during development: the rule's own message text initially spelled out `rounded-sm`/`rounded-[…]` as literal examples, which matched the very selector it was documenting inside the config file itself — same root-cause class as the existing hex-color rule's GitHub-issue-reference false positive. Rewrote both messages to describe the violation without a literal contiguous match.
- Documents the approved 5-step radius table in `apps/ui/CONTRIBUTING.md` (`rounded-full` / `rounded` / `rounded-md` / `rounded-xl` / `rounded-2xl`, with the two exceptions above called out).

## Test plan
- [x] `tsc --noEmit` clean in both packages
- [x] `eslint .` in both packages: 0 errors (388 warnings in apps/ui, 43 in ui-kit — 9 are the documented dense-grid residual, the rest pre-existing and unrelated)
- [x] `prettier --check` clean on all touched files
- [x] `vitest run`: 1464/1464 passing in apps/ui, 98/98 passing in ui-kit
- [x] Live-browser check: `/subnets` renders correctly with no console errors attributable to this change (one pre-existing, unrelated hydration warning about `FinancialTrendCell`'s dynamic `text-[10px]` USD/pct timing, not touched here); confirmed `rounded-md` computes to a real `10px` border-radius across 218 live elements on the page, proving the class swap compiles and applies correctly, not just present as dead text.

Closes #7843.