### PR TITLE
feat(mcp): types-epic E — Zod schemas for 19 subnet metagraph-identity MCP tools (#8067)

### DIFF
--- a/schemas-src/mcp-tools/compare-subnets.ts
+++ b/schemas-src/mcp-tools/compare-subnets.ts
@@ -1,0 +1,27 @@
+// MCP tool `compare_subnets` (types-epic E batch 4, #8067). Mirrors GET
+// /api/v1/compare, which is not one of schemas-src/routes/'s covered pilot
+// routes -- no existing Zod schema to reuse. Modeled fresh, shallow, from
+// the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectArraySchema } from "./shared.ts";
+
+const COMPARE_DIMENSIONS = ["structure", "economics", "health"] as const;
+
+export const CompareSubnetsInputSchema = z
+  .object({
+    netuids: z.array(z.int().min(0)).min(1).max(128),
+    dimensions: z.array(z.enum(COMPARE_DIMENSIONS)).optional(),
+  })
+  .strict();
+export type CompareSubnetsInput = z.infer<typeof CompareSubnetsInputSchema>;
+
+export const CompareSubnetsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    requested_netuids: z.array(z.int()),
+    dimensions: z.array(z.string()),
+    subnets: OpenObjectArraySchema,
+    observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type CompareSubnetsOutput = z.infer<typeof CompareSubnetsOutputSchema>;

--- a/schemas-src/mcp-tools/get-domain-summary.ts
+++ b/schemas-src/mcp-tools/get-domain-summary.ts
@@ -1,0 +1,54 @@
+// MCP tool `get_domain_summary` (types-epic E batch 4, #8067). Composite
+// tool mirroring EITHER GET /api/v1/domains/{tag}/summary (DomainSummaryArtifact
+// shape) OR GET /api/v1/domains (DomainsArtifact shape), chosen by whether
+// `domain` was passed -- schemas-src/routes/domains.ts (#8055) models each
+// REST shape separately and strictly; this tool's single return value can be
+// either one, so (matching the hand-written literal's own documented
+// rationale) the output stays deliberately loose rather than reusing either
+// REST schema or forcing a discriminated union that doesn't reflect how the
+// original was ever validated. Modeled fresh, shallow, from the hand-written
+// literal it replaces. Domain enum hardcoded from src/domain-tags.ts's
+// DOMAIN_TAGS at the time of writing.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const DOMAIN_TAGS = [
+  "agents",
+  "compute",
+  "data",
+  "finance",
+  "inference",
+  "media",
+  "prediction",
+  "privacy",
+  "robotics",
+  "science",
+  "search",
+  "security",
+  "storage",
+  "training",
+] as const;
+
+export const GetDomainSummaryInputSchema = z
+  .object({
+    domain: z.enum(DOMAIN_TAGS).optional(),
+  })
+  .strict();
+export type GetDomainSummaryInput = z.infer<typeof GetDomainSummaryInputSchema>;
+
+export const GetDomainSummaryOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    domain: z.string().nullable().optional(),
+    subnet_count: z.int().optional(),
+    netuids: z.array(z.int()).optional(),
+    total_stake_tao: z.number().nullable().optional(),
+    total_emission_share: z.number().nullable().optional(),
+    emission_concentration: OpenObjectSchema.nullable().optional(),
+    domain_count: z.int().optional(),
+    domains: z.array(OpenObjectSchema).optional(),
+  })
+  .passthrough();
+export type GetDomainSummaryOutput = z.infer<
+  typeof GetDomainSummaryOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-registry-leaderboards.ts
+++ b/schemas-src/mcp-tools/get-registry-leaderboards.ts
@@ -1,0 +1,45 @@
+// MCP tool `get_registry_leaderboards` (types-epic E batch 4, #8067). Mirrors
+// GET /api/v1/registry/leaderboards, which is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// shallow, from the hand-written literal it replaces. Board enum hardcoded
+// from src/health-serving.ts's LEADERBOARD_BOARDS (base 6 boards +
+// ECONOMIC_BOARD_SPECS's 6 keys) at the time of writing.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const LEADERBOARD_BOARDS = [
+  "healthiest",
+  "fastest-rpc",
+  "most-complete",
+  "most-enriched",
+  "fastest-growing",
+  "most-reliable",
+  "open-slots",
+  "cheapest-registration",
+  "highest-emission",
+  "validator-headroom",
+  "biggest-alpha-gain-1d",
+  "biggest-alpha-gain-7d",
+] as const;
+
+export const GetRegistryLeaderboardsInputSchema = z
+  .object({
+    board: z.enum(LEADERBOARD_BOARDS).optional(),
+    limit: z.int().min(1).max(100).optional(),
+  })
+  .strict();
+export type GetRegistryLeaderboardsInput = z.infer<
+  typeof GetRegistryLeaderboardsInputSchema
+>;
+
+export const GetRegistryLeaderboardsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    board: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    boards: OpenObjectSchema,
+  })
+  .passthrough();
+export type GetRegistryLeaderboardsOutput = z.infer<
+  typeof GetRegistryLeaderboardsOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-events.ts
+++ b/schemas-src/mcp-tools/get-subnet-events.ts
@@ -1,0 +1,53 @@
+// MCP tool `get_subnet_events` (types-epic E batch 4, #8067). Mirrors GET
+// /api/v1/subnets/{netuid}/events, covered by schemas-src/routes/
+// subnet-events.ts (#8055) -- NOT reused: that REST schema's AccountEvent
+// item requires block_number+event_kind and the artifact requires
+// schema_version; this tool's own hand-written ACCOUNT_EVENT_ITEM leaves
+// every item field optional (via the shared objectItems() shape) and
+// schema_version optional too. Modeled fresh instead, matching the
+// hand-written literal it replaces field-for-field.
+import { z } from "zod";
+
+export const GetSubnetEventsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    kind: z.string().optional(),
+    block_start: z.int().min(0).optional(),
+    block_end: z.int().min(0).optional(),
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetSubnetEventsInput = z.infer<typeof GetSubnetEventsInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const AccountEventItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    event_index: z.int().nullable().optional(),
+    event_kind: z.string().nullable().optional(),
+    hotkey: z.string().nullable().optional(),
+    coldkey: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    uid: z.int().nullable().optional(),
+    amount_tao: z.unknown().optional(),
+    alpha_amount: z.unknown().optional(),
+    observed_at: z.string().nullable().optional(),
+    extrinsic_index: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetEventsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    event_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    events: z.array(AccountEventItemSchema),
+  })
+  .passthrough();
+export type GetSubnetEventsOutput = z.infer<typeof GetSubnetEventsOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-history.ts
@@ -1,0 +1,44 @@
+// MCP tool `get_subnet_history` (types-epic E batch 4, #8067). Mirrors GET
+// /api/v1/subnets/{netuid}/history, covered by schemas-src/routes/
+// subnet-history.ts (#8055) -- NOT reused: that REST schema's `window`
+// field is required (bare nullable string, no enum); this tool's own
+// hand-written original leaves `window` optional and constrains it to a
+// 5-value enum. Reusing would both loosen (drop the enum) and tighten
+// (require the key) the existing contract in different ways -- modeled
+// fresh instead, matching the original exactly.
+import { z } from "zod";
+
+const HISTORY_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
+
+export const GetSubnetHistoryInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    window: z.enum(HISTORY_WINDOWS).optional(),
+  })
+  .strict();
+export type GetSubnetHistoryInput = z.infer<typeof GetSubnetHistoryInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const SubnetHistoryPointSchema = z
+  .object({
+    snapshot_date: z.string().nullable().optional(),
+    neuron_count: z.int().nullable().optional(),
+    validator_count: z.int().nullable().optional(),
+    total_stake_tao: z.unknown().optional(),
+    total_emission_tao: z.unknown().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    window: z.string().nullable().optional(),
+    point_count: z.int(),
+    points: z.array(SubnetHistoryPointSchema),
+  })
+  .passthrough();
+export type GetSubnetHistoryOutput = z.infer<
+  typeof GetSubnetHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-hyperparams.ts
+++ b/schemas-src/mcp-tools/get-subnet-hyperparams.ts
@@ -1,0 +1,67 @@
+// MCP tools `get_subnet_hyperparams`, `get_subnet_hyperparams_history`
+// (types-epic E batch 4, #8067). Mirror GET /api/v1/subnets/{netuid}/
+// hyperparameters(/history), neither of which is one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// shallow, from the hand-written literals they replace.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetSubnetHyperparamsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetHyperparamsInput = z.infer<
+  typeof GetSubnetHyperparamsInputSchema
+>;
+
+export const GetSubnetHyperparamsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    captured_at: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    hyperparameters: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetHyperparamsOutput = z.infer<
+  typeof GetSubnetHyperparamsOutputSchema
+>;
+
+export const GetSubnetHyperparamsHistoryInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetSubnetHyperparamsHistoryInput = z.infer<
+  typeof GetSubnetHyperparamsHistoryInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const HyperparamsHistoryEntrySchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    hyperparameters: OpenObjectSchema.nullable().optional(),
+    hyperparams_hash: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetHyperparamsHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    entry_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    entries: z.array(HyperparamsHistoryEntrySchema),
+  })
+  .passthrough();
+export type GetSubnetHyperparamsHistoryOutput = z.infer<
+  typeof GetSubnetHyperparamsHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-identity-history.ts
+++ b/schemas-src/mcp-tools/get-subnet-identity-history.ts
@@ -1,0 +1,64 @@
+// MCP tool `get_subnet_identity_history` (types-epic E batch 4, #8067).
+// Mirrors GET /api/v1/subnets/{netuid}/identity-history, backed by the SAME
+// src/subnet-identity-history.ts buildSubnetIdentityHistory()/
+// formatIdentityHistoryEntry() the REST route (schemas-src/routes/
+// subnet-identity-history.ts, #8055) uses -- NOT reused as a schema import:
+// this tool's own required set (schema_version IS required here, unlike
+// REST's envelope-relative posture) and additionalProperties posture
+// differ enough that a blind reuse would change what this tool's own
+// contract accepts. Modeled fresh instead, matching the hand-written
+// literal it replaces field-for-field.
+//
+// Real finding (bucket b), same root cause #8055 already found and fixed
+// on the REST side: the hand-written entry schema required identity_hash
+// as a non-nullable string, but formatIdentityHistoryEntry() builds it as
+// `record.identity_hash ?? null` -- a row with no computed hash yields
+// identity_hash: null, which the old schema would have rejected. Modeled
+// here as nullable (still required -- the key itself is always present),
+// matching real behavior.
+import { z } from "zod";
+
+export const GetSubnetIdentityHistoryInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetSubnetIdentityHistoryInput = z.infer<
+  typeof GetSubnetIdentityHistoryInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch) -- except
+// identity_hash, which the original also required (see header).
+const SubnetIdentityHistoryEntrySchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_name: z.string().nullable().optional(),
+    symbol: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    github_repo: z.string().nullable().optional(),
+    subnet_url: z.string().nullable().optional(),
+    discord: z.string().nullable().optional(),
+    logo_url: z.string().nullable().optional(),
+    identity_hash: z.string().nullable(),
+  })
+  .passthrough();
+
+export const GetSubnetIdentityHistoryOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    netuid: z.int(),
+    entry_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    entries: z.array(SubnetIdentityHistoryEntrySchema),
+  })
+  .passthrough();
+export type GetSubnetIdentityHistoryOutput = z.infer<
+  typeof GetSubnetIdentityHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-lease.ts
+++ b/schemas-src/mcp-tools/get-subnet-lease.ts
@@ -1,0 +1,68 @@
+// MCP tools `get_subnet_lease`, `get_subnet_lease_history` (types-epic E
+// batch 4, #8067). Mirror GET /api/v1/subnets/{netuid}/lease(/history),
+// neither of which is one of schemas-src/routes/'s covered pilot routes --
+// no existing Zod schema to reuse. Modeled fresh, shallow, from the
+// hand-written literals they replace.
+import { z } from "zod";
+
+export const GetSubnetLeaseInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetLeaseInput = z.infer<typeof GetSubnetLeaseInputSchema>;
+
+const LeaseDetailSchema = z
+  .object({
+    lease_id: z.int().optional(),
+    beneficiary: z.string().optional(),
+    coldkey: z.string().optional(),
+    hotkey: z.string().optional(),
+    emissions_share_percent: z.int().optional(),
+    end_block: z.int().nullable().optional(),
+    netuid: z.int().optional(),
+    cost_tao: z.number().optional(),
+    accumulated_dividends_alpha: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetLeaseOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    leased: z.boolean().nullable(),
+    lease: LeaseDetailSchema.nullable().optional(),
+    queried_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetLeaseOutput = z.infer<typeof GetSubnetLeaseOutputSchema>;
+
+export const GetSubnetLeaseHistoryInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetLeaseHistoryInput = z.infer<
+  typeof GetSubnetLeaseHistoryInputSchema
+>;
+
+const LeaseEventSchema = z
+  .object({
+    event_kind: z.string().optional(),
+    beneficiary: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetLeaseHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    count: z.int(),
+    lease_events: z.array(LeaseEventSchema),
+  })
+  .passthrough();
+export type GetSubnetLeaseHistoryOutput = z.infer<
+  typeof GetSubnetLeaseHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-metagraph.ts
+++ b/schemas-src/mcp-tools/get-subnet-metagraph.ts
@@ -1,0 +1,30 @@
+// MCP tool `get_subnet_metagraph` (types-epic E batch 4, #8067). Mirrors
+// GET /api/v1/subnets/{netuid}/metagraph, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectArraySchema } from "./shared.ts";
+
+export const GetSubnetMetagraphInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    validator_permit: z.boolean().optional(),
+  })
+  .strict();
+export type GetSubnetMetagraphInput = z.infer<
+  typeof GetSubnetMetagraphInputSchema
+>;
+
+export const GetSubnetMetagraphOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    neuron_count: z.int(),
+    captured_at: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    neurons: OpenObjectArraySchema,
+  })
+  .passthrough();
+export type GetSubnetMetagraphOutput = z.infer<
+  typeof GetSubnetMetagraphOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-ownership-conviction.ts
+++ b/schemas-src/mcp-tools/get-subnet-ownership-conviction.ts
@@ -1,0 +1,72 @@
+// MCP tools `get_subnet_ownership_history`, `get_subnet_conviction`
+// (types-epic E batch 4, #8067). Mirror GET /api/v1/subnets/{netuid}/
+// ownership-history and GET /api/v1/subnets/{netuid}/conviction, neither of
+// which is one of schemas-src/routes/'s covered pilot routes -- no existing
+// Zod schema to reuse. Modeled fresh, shallow, from the hand-written
+// literals they replace.
+import { z } from "zod";
+
+export const GetSubnetOwnershipHistoryInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetOwnershipHistoryInput = z.infer<
+  typeof GetSubnetOwnershipHistoryInputSchema
+>;
+
+const OwnershipChangeSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    old_coldkey: z.string().nullable().optional(),
+    new_coldkey: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetOwnershipHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    count: z.int(),
+    ownership_changes: z.array(OwnershipChangeSchema),
+  })
+  .passthrough();
+export type GetSubnetOwnershipHistoryOutput = z.infer<
+  typeof GetSubnetOwnershipHistoryOutputSchema
+>;
+
+export const GetSubnetConvictionInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetConvictionInput = z.infer<
+  typeof GetSubnetConvictionInputSchema
+>;
+
+const ConvictionLeaderboardEntrySchema = z
+  .object({
+    hotkey: z.string().optional(),
+    is_owner: z.boolean().optional(),
+    locked_mass: z.number().optional(),
+    conviction: z.number().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetConvictionOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    queried_at_block: z.int().nullable().optional(),
+    unlock_rate: z.int().nullable().optional(),
+    maturity_rate: z.int().nullable().optional(),
+    king: z.string().nullable().optional(),
+    count: z.int(),
+    leaderboard: z.array(ConvictionLeaderboardEntrySchema),
+  })
+  .passthrough();
+export type GetSubnetConvictionOutput = z.infer<
+  typeof GetSubnetConvictionOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
+++ b/schemas-src/mcp-tools/get-subnet-recycled-burn.ts
@@ -1,0 +1,49 @@
+// MCP tools `get_subnet_recycled`, `get_subnet_burn` (types-epic E batch 4,
+// #8067). Backed by the SAME src/subnet-recycled.ts loadSubnetRecycled() /
+// src/subnet-burn.ts loadSubnetBurn() the REST routes (schemas-src/routes/
+// subnet-registration-cost.ts, #8055) use -- NOT reused as schema imports:
+// that REST schema leaves recycled_tao/burn_tao/queried_at all optional
+// (`.passthrough()`, matching the KV-cache-hit code path that may return a
+// smaller cached shape), but these MCP tools' own hand-written originals
+// require queried_at (nullable, but always present). Reusing would loosen
+// this tool's existing required set. Modeled fresh instead, matching each
+// hand-written literal exactly.
+import { z } from "zod";
+
+export const GetSubnetRecycledInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetRecycledInput = z.infer<
+  typeof GetSubnetRecycledInputSchema
+>;
+
+export const GetSubnetRecycledOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    recycled_tao: z.number().nullable().optional(),
+    queried_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GetSubnetRecycledOutput = z.infer<
+  typeof GetSubnetRecycledOutputSchema
+>;
+
+export const GetSubnetBurnInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetBurnInput = z.infer<typeof GetSubnetBurnInputSchema>;
+
+export const GetSubnetBurnOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    burn_tao: z.number().nullable().optional(),
+    queried_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GetSubnetBurnOutput = z.infer<typeof GetSubnetBurnOutputSchema>;

--- a/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
+++ b/schemas-src/mcp-tools/get-subnet-volume-ohlc.ts
@@ -1,0 +1,78 @@
+// MCP tools `get_subnet_volume`, `get_subnet_ohlc` (types-epic E batch 4,
+// #8067). get_subnet_volume mirrors GET /api/v1/subnets/{netuid}/volume,
+// covered by schemas-src/routes/subnet-alpha-volume.ts (#8055) -- NOT
+// reused: that REST schema is `.strict()` with all 15 fields required; this
+// tool's own hand-written original requires only netuid+window, leaving
+// every numeric field optional. Reusing would substantially tighten this
+// tool's existing contract. get_subnet_ohlc mirrors GET /api/v1/subnets/
+// {netuid}/ohlc, which is not one of schemas-src/routes/'s covered pilot
+// routes -- no existing Zod schema to reuse either. Both modeled fresh,
+// shallow, from the hand-written literals they replace.
+import { z } from "zod";
+
+export const GetSubnetVolumeInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetVolumeInput = z.infer<typeof GetSubnetVolumeInputSchema>;
+
+export const GetSubnetVolumeOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    window: z.string(),
+    buy_volume_alpha: z.unknown().optional(),
+    sell_volume_alpha: z.unknown().optional(),
+    total_volume_alpha: z.unknown().optional(),
+    buy_volume_tao: z.unknown().optional(),
+    sell_volume_tao: z.unknown().optional(),
+    total_volume_tao: z.unknown().optional(),
+    buy_count: z.int().optional(),
+    sell_count: z.int().optional(),
+    net_volume_alpha: z.unknown().optional(),
+    sentiment_ratio: z.number().nullable().optional(),
+    sentiment: z.string().nullable().optional(),
+    vol_mcap_ratio: z.number().nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetVolumeOutput = z.infer<typeof GetSubnetVolumeOutputSchema>;
+
+const OHLC_INTERVALS = ["1h", "1d"] as const;
+const MAX_OHLC_WINDOW_DAYS = 365;
+
+export const GetSubnetOhlcInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    interval: z.enum(OHLC_INTERVALS).optional(),
+    days: z.int().min(1).max(MAX_OHLC_WINDOW_DAYS).optional(),
+  })
+  .strict();
+export type GetSubnetOhlcInput = z.infer<typeof GetSubnetOhlcInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const OhlcCandleSchema = z
+  .object({
+    bucket_start: z.int().optional(),
+    bucket_start_iso: z.string().optional(),
+    open: z.unknown().optional(),
+    high: z.unknown().optional(),
+    low: z.unknown().optional(),
+    close: z.unknown().optional(),
+    volume_alpha: z.unknown().optional(),
+    volume_tao: z.unknown().optional(),
+    event_count: z.int().optional(),
+  })
+  .passthrough();
+
+export const GetSubnetOhlcOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    interval: z.string(),
+    candles: z.array(OhlcCandleSchema),
+    root_excluded: z.boolean(),
+  })
+  .passthrough();
+export type GetSubnetOhlcOutput = z.infer<typeof GetSubnetOhlcOutputSchema>;

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -1,0 +1,101 @@
+// MCP tools `list_profiles`, `get_subnet_profile` (types-epic E batch 4,
+// #8067). Mirror GET /api/v1/profiles and GET /api/v1/subnets/{netuid}/profile,
+// neither of which is one of schemas-src/routes/'s covered pilot routes --
+// no existing Zod schema to reuse (SubnetProfile from schemas-src/routes/
+// subnet-profile.ts, #8055, is NOT reused: the hand-written LIST_PROFILES_
+// OUTPUT_SCHEMA/GET_SUBNET_PROFILE_OUTPUT_SCHEMA this replaces already left
+// `profiles`/`subnet`/`profile` as bare objects, not SubnetProfile-shaped --
+// reusing the deep schema now would tighten what these two tools' own
+// existing contract accepts, the same "look-but-don't-reuse" finding
+// pilot batch's get-network-health.ts/get-economics.ts documented). Modeled
+// fresh, shallow, from the hand-written literals src/profiles-mcp.ts
+// replaces. Enum values hardcoded from src/contracts.ts's QUERY_ENUMS.{
+// subnetType,curationLevel,profileLevel} and the "profiles" query
+// collection's sort_fields at the time of writing.
+import { z } from "zod";
+import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+
+const SUBNET_TYPE = ["root", "application"] as const;
+const CURATION_LEVEL = [
+  "native",
+  "candidate-discovered",
+  "community-seeded",
+  "machine-verified",
+  "maintainer-reviewed",
+  "adapter-backed",
+] as const;
+const PROFILE_LEVEL = [
+  "directory-only",
+  "identity-partial",
+  "identity-complete",
+  "operational",
+  "adapter-backed",
+] as const;
+const PROFILES_SORT_FIELDS = [
+  "candidate_count",
+  "completeness_score",
+  "curation_level",
+  "interface_count",
+  "missing_critical_count",
+  "name",
+  "netuid",
+  "operational_interface_count",
+  "profile_level",
+  "review_state",
+] as const;
+
+export const ListProfilesInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    subnet_type: z.enum(SUBNET_TYPE).optional(),
+    curation_level: z.enum(CURATION_LEVEL).optional(),
+    review_state: z.string().optional(),
+    confidence: z.enum(["low", "medium", "high"]).optional(),
+    profile_level: z.enum(PROFILE_LEVEL).optional(),
+    q: z.string().optional(),
+    sort: z.enum(PROFILES_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(1000).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListProfilesInput = z.infer<typeof ListProfilesInputSchema>;
+
+export const GetSubnetProfileInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetProfileInput = z.infer<typeof GetSubnetProfileInputSchema>;
+
+export const ListProfilesOutputSchema = z
+  .object({
+    captured_at: z.string().nullable().optional(),
+    profiles: OpenObjectArraySchema,
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListProfilesOutput = z.infer<typeof ListProfilesOutputSchema>;
+
+export const GetSubnetProfileOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    contract_version: z.string().nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+    subnet: OpenObjectSchema.nullable().optional(),
+    profile: OpenObjectSchema.nullable().optional(),
+    surfaces: OpenObjectArraySchema.optional(),
+    endpoints: OpenObjectArraySchema.optional(),
+    gaps: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetProfileOutput = z.infer<
+  typeof GetSubnetProfileOutputSchema
+>;

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -176,6 +176,70 @@ import {
   GetEconomicsTrendsInputSchema,
   GetEconomicsTrendsOutputSchema,
 } from "../schemas-src/mcp-tools/get-economics-trends.ts";
+import {
+  GetRegistryLeaderboardsInputSchema,
+  GetRegistryLeaderboardsOutputSchema,
+} from "../schemas-src/mcp-tools/get-registry-leaderboards.ts";
+import {
+  GetDomainSummaryInputSchema,
+  GetDomainSummaryOutputSchema,
+} from "../schemas-src/mcp-tools/get-domain-summary.ts";
+import {
+  ListProfilesInputSchema,
+  ListProfilesOutputSchema,
+  GetSubnetProfileInputSchema,
+  GetSubnetProfileOutputSchema,
+} from "../schemas-src/mcp-tools/profiles.ts";
+import {
+  CompareSubnetsInputSchema,
+  CompareSubnetsOutputSchema,
+} from "../schemas-src/mcp-tools/compare-subnets.ts";
+import {
+  GetSubnetMetagraphInputSchema,
+  GetSubnetMetagraphOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-metagraph.ts";
+import {
+  GetSubnetHistoryInputSchema,
+  GetSubnetHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-history.ts";
+import {
+  GetSubnetIdentityHistoryInputSchema,
+  GetSubnetIdentityHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-identity-history.ts";
+import {
+  GetSubnetEventsInputSchema,
+  GetSubnetEventsOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-events.ts";
+import {
+  GetSubnetHyperparamsInputSchema,
+  GetSubnetHyperparamsOutputSchema,
+  GetSubnetHyperparamsHistoryInputSchema,
+  GetSubnetHyperparamsHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-hyperparams.ts";
+import {
+  GetSubnetVolumeInputSchema,
+  GetSubnetVolumeOutputSchema,
+  GetSubnetOhlcInputSchema,
+  GetSubnetOhlcOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-volume-ohlc.ts";
+import {
+  GetSubnetOwnershipHistoryInputSchema,
+  GetSubnetOwnershipHistoryOutputSchema,
+  GetSubnetConvictionInputSchema,
+  GetSubnetConvictionOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-ownership-conviction.ts";
+import {
+  GetSubnetRecycledInputSchema,
+  GetSubnetRecycledOutputSchema,
+  GetSubnetBurnInputSchema,
+  GetSubnetBurnOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-recycled-burn.ts";
+import {
+  GetSubnetLeaseInputSchema,
+  GetSubnetLeaseOutputSchema,
+  GetSubnetLeaseHistoryInputSchema,
+  GetSubnetLeaseHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-lease.ts";
 
 type Row = Record<string, unknown>;
 
@@ -294,6 +358,73 @@ const HISTORY_WINDOWS_3 = ["7d", "30d", "90d"];
 const HISTORY_WINDOWS_5 = ["7d", "30d", "90d", "1y", "all"];
 const STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"];
 const STAKE_FLOW_DIRECTIONS = ["all", "in", "out"];
+// Batch 4 (#8067) resolved enum values, same treatment as above -- symbolic
+// in the hand-written originals (src/health-serving.ts's LEADERBOARD_BOARDS,
+// src/domain-tags.ts's DOMAIN_TAGS, src/contracts.ts's QUERY_ENUMS + the
+// "profiles" query collection's sort_fields, src/subnet-ohlc.ts's
+// OHLC_INTERVALS, src/neuron-history.ts's HISTORY_WINDOWS), cross-checked
+// against the actual runtime source at the time of writing.
+const LEADERBOARD_BOARDS = [
+  "healthiest",
+  "fastest-rpc",
+  "most-complete",
+  "most-enriched",
+  "fastest-growing",
+  "most-reliable",
+  "open-slots",
+  "cheapest-registration",
+  "highest-emission",
+  "validator-headroom",
+  "biggest-alpha-gain-1d",
+  "biggest-alpha-gain-7d",
+];
+const DOMAIN_TAGS = [
+  "agents",
+  "compute",
+  "data",
+  "finance",
+  "inference",
+  "media",
+  "prediction",
+  "privacy",
+  "robotics",
+  "science",
+  "search",
+  "security",
+  "storage",
+  "training",
+];
+const PROFILE_SUBNET_TYPE = ["root", "application"];
+const PROFILE_CURATION_LEVEL = [
+  "native",
+  "candidate-discovered",
+  "community-seeded",
+  "machine-verified",
+  "maintainer-reviewed",
+  "adapter-backed",
+];
+const PROFILE_LEVEL = [
+  "directory-only",
+  "identity-partial",
+  "identity-complete",
+  "operational",
+  "adapter-backed",
+];
+const PROFILES_SORT_FIELDS_4 = [
+  "candidate_count",
+  "completeness_score",
+  "curation_level",
+  "interface_count",
+  "missing_critical_count",
+  "name",
+  "netuid",
+  "operational_interface_count",
+  "profile_level",
+  "review_state",
+];
+const COMPARE_DIMENSIONS = ["structure", "economics", "health"];
+const HISTORY_WINDOWS_4 = ["7d", "30d", "90d", "1y", "all"];
+const OHLC_INTERVALS_4 = ["1h", "1d"];
 
 const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
   search_subnets: {
@@ -1640,6 +1771,591 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  get_registry_leaderboards: {
+    input: {
+      type: "object",
+      properties: {
+        board: { type: "string", enum: LEADERBOARD_BOARDS },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["boards"],
+      properties: {
+        schema_version: { type: "integer" },
+        board: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        boards: { type: "object" },
+      },
+    },
+  },
+  get_domain_summary: {
+    input: {
+      type: "object",
+      properties: {
+        domain: { type: "string", enum: DOMAIN_TAGS },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["schema_version"],
+      properties: {
+        schema_version: { type: "integer" },
+        domain: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        netuids: { type: "array", items: { type: "integer" } },
+        total_stake_tao: { type: ["number", "null"] },
+        total_emission_share: { type: ["number", "null"] },
+        emission_concentration: { type: ["object", "null"] },
+        domain_count: { type: "integer" },
+        domains: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  list_profiles: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        subnet_type: { type: "string", enum: PROFILE_SUBNET_TYPE },
+        curation_level: { type: "string", enum: PROFILE_CURATION_LEVEL },
+        review_state: { type: "string" },
+        confidence: { type: "string", enum: ["low", "medium", "high"] },
+        profile_level: { type: "string", enum: PROFILE_LEVEL },
+        q: { type: "string" },
+        sort: { type: "string", enum: PROFILES_SORT_FIELDS_4 },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["profiles"],
+      properties: {
+        captured_at: NULLABLE_STRING,
+        profiles: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  get_subnet_profile: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      properties: {
+        schema_version: { type: "integer" },
+        contract_version: NULLABLE_STRING,
+        generated_at: NULLABLE_STRING,
+        subnet: { type: ["object", "null"] },
+        profile: { type: ["object", "null"] },
+        surfaces: { type: "array", items: { type: "object" } },
+        endpoints: { type: "array", items: { type: "object" } },
+        gaps: { type: ["object", "null"] },
+      },
+    },
+  },
+  compare_subnets: {
+    input: {
+      type: "object",
+      properties: {
+        netuids: {
+          type: "array",
+          items: { type: "integer", minimum: 0 },
+          minItems: 1,
+          maxItems: 128,
+        },
+        dimensions: {
+          type: "array",
+          items: { type: "string", enum: COMPARE_DIMENSIONS },
+        },
+      },
+      required: ["netuids"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["requested_netuids", "subnets", "dimensions"],
+      properties: {
+        schema_version: { type: "integer" },
+        requested_netuids: { type: "array", items: { type: "integer" } },
+        dimensions: { type: "array", items: { type: "string" } },
+        subnets: { type: "array", items: { type: "object" } },
+        observed_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_subnet_metagraph: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        validator_permit: { type: "boolean" },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "neuron_count", "neurons"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        neuron_count: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        block_number: NULLABLE_INT,
+        neurons: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  get_subnet_history: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        window: { type: "string", enum: HISTORY_WINDOWS_4 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "point_count", "points"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        window: NULLABLE_STRING,
+        point_count: { type: "integer" },
+        points: objectItems({
+          snapshot_date: NULLABLE_STRING,
+          neuron_count: NULLABLE_INT,
+          validator_count: NULLABLE_INT,
+          total_stake_tao: ANY,
+          total_emission_tao: ANY,
+        }),
+      },
+    },
+  },
+  get_subnet_identity_history: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["schema_version", "netuid", "entry_count", "entries"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        entry_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        entries: objectItems({
+          block_number: NULLABLE_INT,
+          observed_at: NULLABLE_STRING,
+          subnet_name: NULLABLE_STRING,
+          symbol: NULLABLE_STRING,
+          description: NULLABLE_STRING,
+          github_repo: NULLABLE_STRING,
+          subnet_url: NULLABLE_STRING,
+          discord: NULLABLE_STRING,
+          logo_url: NULLABLE_STRING,
+          identity_hash: { type: "string" },
+        }),
+      },
+    },
+  },
+  get_subnet_events: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string" },
+        block_start: { type: "integer", minimum: 0 },
+        block_end: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "event_count", "events"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        event_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        events: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          event_kind: NULLABLE_STRING,
+          hotkey: NULLABLE_STRING,
+          coldkey: NULLABLE_STRING,
+          netuid: NULLABLE_INT,
+          uid: NULLABLE_INT,
+          amount_tao: ANY,
+          alpha_amount: ANY,
+          observed_at: NULLABLE_STRING,
+          extrinsic_index: NULLABLE_INT,
+        }),
+      },
+    },
+  },
+  get_subnet_hyperparams: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        block_number: NULLABLE_INT,
+        hyperparameters: {
+          type: ["object", "null"],
+          additionalProperties: true,
+        },
+      },
+    },
+  },
+  get_subnet_hyperparams_history: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "entry_count", "entries"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        entry_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        entries: objectItems({
+          block_number: NULLABLE_INT,
+          observed_at: NULLABLE_STRING,
+          hyperparameters: {
+            type: ["object", "null"],
+            additionalProperties: true,
+          },
+          hyperparams_hash: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_subnet_volume: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "window"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        window: { type: "string" },
+        buy_volume_alpha: ANY,
+        sell_volume_alpha: ANY,
+        total_volume_alpha: ANY,
+        buy_volume_tao: ANY,
+        sell_volume_tao: ANY,
+        total_volume_tao: ANY,
+        buy_count: { type: "integer" },
+        sell_count: { type: "integer" },
+        net_volume_alpha: ANY,
+        sentiment_ratio: { type: ["number", "null"] },
+        sentiment: NULLABLE_STRING,
+        vol_mcap_ratio: { type: ["number", "null"] },
+      },
+    },
+  },
+  get_subnet_ohlc: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        interval: { type: "string", enum: OHLC_INTERVALS_4 },
+        days: { type: "integer", minimum: 1, maximum: 365 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "interval", "candles", "root_excluded"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        interval: { type: "string" },
+        candles: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            properties: {
+              bucket_start: { type: "integer" },
+              bucket_start_iso: { type: "string" },
+              open: ANY,
+              high: ANY,
+              low: ANY,
+              close: ANY,
+              volume_alpha: ANY,
+              volume_tao: ANY,
+              event_count: { type: "integer" },
+            },
+          },
+        },
+        root_excluded: { type: "boolean" },
+      },
+    },
+  },
+  get_subnet_ownership_history: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "count", "ownership_changes"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        count: { type: "integer" },
+        ownership_changes: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            properties: {
+              netuid: { type: ["integer", "null"] },
+              old_coldkey: { type: ["string", "null"] },
+              new_coldkey: { type: ["string", "null"] },
+              block_number: { type: ["integer", "null"] },
+              observed_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_subnet_conviction: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "count", "leaderboard"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        queried_at_block: { type: ["integer", "null"] },
+        unlock_rate: { type: ["integer", "null"] },
+        maturity_rate: { type: ["integer", "null"] },
+        king: { type: ["string", "null"] },
+        count: { type: "integer" },
+        leaderboard: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            properties: {
+              hotkey: { type: "string" },
+              is_owner: { type: "boolean" },
+              locked_mass: { type: "number" },
+              conviction: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_subnet_recycled: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "queried_at"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        recycled_tao: { type: ["number", "null"] },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_subnet_burn: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "queried_at"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        burn_tao: { type: ["number", "null"] },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_subnet_lease: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "leased"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        leased: { type: ["boolean", "null"] },
+        lease: {
+          type: ["object", "null"],
+          additionalProperties: true,
+          properties: {
+            lease_id: { type: "integer" },
+            beneficiary: { type: "string" },
+            coldkey: { type: "string" },
+            hotkey: { type: "string" },
+            emissions_share_percent: { type: "integer" },
+            end_block: { type: ["integer", "null"] },
+            netuid: { type: "integer" },
+            cost_tao: { type: "number" },
+            accumulated_dividends_alpha: { type: ["number", "null"] },
+          },
+        },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_subnet_lease_history: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "count", "lease_events"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        count: { type: "integer" },
+        lease_events: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            properties: {
+              event_kind: { type: "string" },
+              beneficiary: { type: ["string", "null"] },
+              block_number: { type: ["integer", "null"] },
+              observed_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -1804,6 +2520,82 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
     input: GetEconomicsTrendsInputSchema,
     output: GetEconomicsTrendsOutputSchema,
   },
+  get_registry_leaderboards: {
+    input: GetRegistryLeaderboardsInputSchema,
+    output: GetRegistryLeaderboardsOutputSchema,
+  },
+  get_domain_summary: {
+    input: GetDomainSummaryInputSchema,
+    output: GetDomainSummaryOutputSchema,
+  },
+  list_profiles: {
+    input: ListProfilesInputSchema,
+    output: ListProfilesOutputSchema,
+  },
+  get_subnet_profile: {
+    input: GetSubnetProfileInputSchema,
+    output: GetSubnetProfileOutputSchema,
+  },
+  compare_subnets: {
+    input: CompareSubnetsInputSchema,
+    output: CompareSubnetsOutputSchema,
+  },
+  get_subnet_metagraph: {
+    input: GetSubnetMetagraphInputSchema,
+    output: GetSubnetMetagraphOutputSchema,
+  },
+  get_subnet_history: {
+    input: GetSubnetHistoryInputSchema,
+    output: GetSubnetHistoryOutputSchema,
+  },
+  get_subnet_identity_history: {
+    input: GetSubnetIdentityHistoryInputSchema,
+    output: GetSubnetIdentityHistoryOutputSchema,
+  },
+  get_subnet_events: {
+    input: GetSubnetEventsInputSchema,
+    output: GetSubnetEventsOutputSchema,
+  },
+  get_subnet_hyperparams: {
+    input: GetSubnetHyperparamsInputSchema,
+    output: GetSubnetHyperparamsOutputSchema,
+  },
+  get_subnet_hyperparams_history: {
+    input: GetSubnetHyperparamsHistoryInputSchema,
+    output: GetSubnetHyperparamsHistoryOutputSchema,
+  },
+  get_subnet_volume: {
+    input: GetSubnetVolumeInputSchema,
+    output: GetSubnetVolumeOutputSchema,
+  },
+  get_subnet_ohlc: {
+    input: GetSubnetOhlcInputSchema,
+    output: GetSubnetOhlcOutputSchema,
+  },
+  get_subnet_ownership_history: {
+    input: GetSubnetOwnershipHistoryInputSchema,
+    output: GetSubnetOwnershipHistoryOutputSchema,
+  },
+  get_subnet_conviction: {
+    input: GetSubnetConvictionInputSchema,
+    output: GetSubnetConvictionOutputSchema,
+  },
+  get_subnet_recycled: {
+    input: GetSubnetRecycledInputSchema,
+    output: GetSubnetRecycledOutputSchema,
+  },
+  get_subnet_burn: {
+    input: GetSubnetBurnInputSchema,
+    output: GetSubnetBurnOutputSchema,
+  },
+  get_subnet_lease: {
+    input: GetSubnetLeaseInputSchema,
+    output: GetSubnetLeaseOutputSchema,
+  },
+  get_subnet_lease_history: {
+    input: GetSubnetLeaseHistoryInputSchema,
+    output: GetSubnetLeaseHistoryOutputSchema,
+  },
 };
 
 const MAX_SAFE_INT = Number.MAX_SAFE_INTEGER;
@@ -1840,13 +2632,24 @@ function normalize(node: unknown, path: string): unknown {
   const obj = node as Row;
 
   // `type: [X, Y, ...]` (hand-written, one schema node, N-way union of bare
-  // types) vs Zod's `anyOf: [{type:X}, {type:Y}, ...]` (a flat union of
-  // single-type schemas -- verified this batch never nests further, see
-  // get-network-health.ts's contract_version comment on avoiding the nested
-  // anyOf-of-anyOf z.union([...]).nullable() would otherwise produce).
-  // Rewrite the hand-written side into the same flat anyOf shape.
+  // types), possibly with sibling constraint keys that apply ONLY to the
+  // non-null branch (e.g. batch 4's get_subnet_lease.lease:
+  // {type:["object","null"], properties:{...9 fields...}}) vs Zod's
+  // `anyOf: [{type:X, ...siblings}, {type:Y}, ...]`. Earlier batches never
+  // exercised the sibling case (their type:[X,Y] nodes were always bare,
+  // e.g. NULLABLE_STRING) so this rewrite used to drop siblings outright;
+  // batch 4 needs them carried into the first (non-null) branch, mirroring
+  // scripts/diff-openapi-zod-components.ts's equivalent rule.
   if (Array.isArray(obj.type) && obj.type.length > 1) {
-    return normalize({ anyOf: obj.type.map((t) => ({ type: t })) }, path);
+    const { type: _t, ...siblings } = obj;
+    return normalize(
+      {
+        anyOf: obj.type.map((t, i) =>
+          i === 0 ? { type: t, ...siblings } : { type: t },
+        ),
+      },
+      path,
+    );
   }
 
   const out: Row = {};

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -453,6 +453,68 @@ import {
 } from "./health-history-mcp.ts";
 import { GetHealthHistoryInputSchema } from "../schemas-src/mcp-tools/get-health-history.ts";
 import {
+  GetRegistryLeaderboardsInputSchema,
+  GetRegistryLeaderboardsOutputSchema,
+} from "../schemas-src/mcp-tools/get-registry-leaderboards.ts";
+import {
+  GetDomainSummaryInputSchema,
+  GetDomainSummaryOutputSchema,
+} from "../schemas-src/mcp-tools/get-domain-summary.ts";
+import {
+  ListProfilesInputSchema,
+  GetSubnetProfileInputSchema,
+} from "../schemas-src/mcp-tools/profiles.ts";
+import {
+  CompareSubnetsInputSchema,
+  CompareSubnetsOutputSchema,
+} from "../schemas-src/mcp-tools/compare-subnets.ts";
+import {
+  GetSubnetMetagraphInputSchema,
+  GetSubnetMetagraphOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-metagraph.ts";
+import {
+  GetSubnetHistoryInputSchema,
+  GetSubnetHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-history.ts";
+import {
+  GetSubnetIdentityHistoryInputSchema,
+  GetSubnetIdentityHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-identity-history.ts";
+import {
+  GetSubnetEventsInputSchema,
+  GetSubnetEventsOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-events.ts";
+import {
+  GetSubnetHyperparamsInputSchema,
+  GetSubnetHyperparamsOutputSchema,
+  GetSubnetHyperparamsHistoryInputSchema,
+  GetSubnetHyperparamsHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-hyperparams.ts";
+import {
+  GetSubnetVolumeInputSchema,
+  GetSubnetVolumeOutputSchema,
+  GetSubnetOhlcInputSchema,
+  GetSubnetOhlcOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-volume-ohlc.ts";
+import {
+  GetSubnetOwnershipHistoryInputSchema,
+  GetSubnetOwnershipHistoryOutputSchema,
+  GetSubnetConvictionInputSchema,
+  GetSubnetConvictionOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-ownership-conviction.ts";
+import {
+  GetSubnetRecycledInputSchema,
+  GetSubnetRecycledOutputSchema,
+  GetSubnetBurnInputSchema,
+  GetSubnetBurnOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-recycled-burn.ts";
+import {
+  GetSubnetLeaseInputSchema,
+  GetSubnetLeaseOutputSchema,
+  GetSubnetLeaseHistoryInputSchema,
+  GetSubnetLeaseHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-lease.ts";
+import {
   buildChainConcentration,
   buildConcentration,
   buildConcentrationHistory,
@@ -4861,24 +4923,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "opportunity boards (open-slots, cheapest-registration, highest-emission, " +
       "validator-headroom, biggest-alpha-gain-1d, biggest-alpha-gain-7d). Omit " +
       "board for all boards. Mirrors GET /api/v1/registry/leaderboards.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        board: {
-          type: "string",
-          enum: [...LEADERBOARD_BOARDS],
-          description: "Optional single board. Omit to return all boards.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max subnets per board (1-100, default 20).",
-          minimum: 1,
-          maximum: 100,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetRegistryLeaderboardsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetRegistryLeaderboardsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const board = optionalEnum(args, "board", LEADERBOARD_BOARDS);
       const limit = clampLimit(args?.limit, 20, 100);
       const profiles =
@@ -4903,19 +4954,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "and within-domain emission concentration, per domain tag. Pass `domain` " +
       "for one tag's own rollup (mirrors GET /api/v1/domains/{tag}/summary); " +
       "omit it for every tag's rollup in one call (mirrors GET /api/v1/domains).",
-    inputSchema: {
-      type: "object",
-      properties: {
-        domain: {
-          type: "string",
-          enum: DOMAIN_TAGS,
-          description:
-            "Optional single domain tag. Omit to return every tag's rollup.",
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetDomainSummaryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetDomainSummaryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const domain = optionalEnum(args, "domain", DOMAIN_TAGS);
       // A cold/missing subnets index degrades to an empty rollup (like
       // loadEconomicsSubnetRows' own graceful fallback below), not a thrown
@@ -4932,7 +4977,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...LIST_PROFILES_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListProfilesInputSchema>, ctx: McpCtx) {
       try {
         return await loadProfilesList(asMcpLoaderCtx(ctx), args, {
           readOptionalArtifact: loadOptionalArtifact,
@@ -4948,7 +4993,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...GET_SUBNET_PROFILE_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof GetSubnetProfileInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       try {
         return await loadSubnetProfile(asMcpLoaderCtx(ctx), netuid, {
@@ -4970,29 +5018,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Place several subnets side by side across registry structure, economics, " +
       "and live probe health in one call. Choose dimensions to limit the payload " +
       "(structure, economics, health — default all). Mirrors GET /api/v1/compare.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuids: {
-          type: "array",
-          items: { type: "integer", minimum: 0 },
-          minItems: 1,
-          maxItems: 128,
-          description: "Subnet netuids to compare, in display order.",
-        },
-        dimensions: {
-          type: "array",
-          items: {
-            type: "string",
-            enum: ["structure", "economics", "health"],
-          },
-          description: "Optional subset of compare dimensions (default all).",
-        },
-      },
-      required: ["netuids"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(CompareSubnetsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof CompareSubnetsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuids = parseCompareNetuidList(args?.netuids);
       if (!netuids) {
         throw toolError(
@@ -5133,20 +5165,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "emission, validator permit, immunity, and axon, ordered by UID. Set " +
       "validator_permit to true to return only permit-holding validators. " +
       "Captured from the chain on a schedule; empty when no snapshot exists yet.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        validator_permit: {
-          type: "boolean",
-          description:
-            "When true, return only neurons that hold a validator permit.",
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetMetagraphInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetMetagraphInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       // validator_permit is validated for REST-parity but, like the D1 filter it
       // used to bound, has nothing left to filter now that neurons is retired
@@ -5663,20 +5688,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "snapshot_date, newest first. Choose the window (7d, 30d, 90d, 1y, all; " +
       "default 30d). Use it to chart how a subnet's size, stake, and emission " +
       "have moved over time. Mirrors GET /api/v1/subnets/{netuid}/history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        window: {
-          type: "string",
-          enum: ["7d", "30d", "90d", "1y", "all"],
-          description: "History window (default 30d).",
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadSubnetHistory(ctx, netuid, requireHistoryWindow(args));
     },
@@ -5691,31 +5709,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Newest first. Page with limit (1-1000, default 100) / offset, or follow " +
       "next_cursor for stable keyset pagination. Mirrors " +
       "GET /api/v1/subnets/{netuid}/identity-history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        limit: {
-          type: "integer",
-          description: "Max entries to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description: "Deprecated offset fallback when cursor is omitted.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a prior response's next_cursor.",
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetIdentityHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetIdentityHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadSubnetIdentityHistoryTool(ctx, netuid, {
         limit: args?.limit,
@@ -5770,50 +5770,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Optionally constrain block height with block_start/block_end (inclusive). " +
       "Use it to watch what is happening on one subnet right now. Events are " +
       "decoded directly from the chain. Mirrors GET /api/v1/subnets/{netuid}/events.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        kind: {
-          type: "string",
-          description:
-            "Optional event-kind filter, e.g. 'StakeAdded' or 'WeightsSet'. " +
-            "Omit for all kinds; unsupported kinds are rejected.",
-        },
-        block_start: {
-          type: "integer",
-          description:
-            "Optional inclusive lower block bound; omit for no lower limit.",
-          minimum: 0,
-        },
-        block_end: {
-          type: "integer",
-          description:
-            "Optional inclusive upper block bound; omit for no upper limit.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Max events to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset into the stream. Default 0.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor; takes " +
-            "precedence over offset for stable deep pagination.",
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetEventsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetEventsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const kind = optionalString(args, "kind");
       requireKnownEventKind(kind);
@@ -5825,7 +5788,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const cursor = optionalString(args, "cursor");
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = Number.isFinite(args?.offset)
-        ? Math.max(0, Math.floor(args.offset))
+        ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       return (
         (await tryPostgresTier(
@@ -5857,15 +5820,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "rest of the SubtensorModule hyperparameter set). hyperparameters:null " +
       "when the subnet has never been captured. Mirrors " +
       "GET /api/v1/subnets/{netuid}/hyperparameters.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetHyperparamsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetHyperparamsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return (
         (await tryPostgresTier(
@@ -5885,31 +5846,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "exist from when diff-on-change tracking started. Page with limit " +
       "(1-1000, default 100) / offset, or follow next_cursor. Mirrors " +
       "GET /api/v1/subnets/{netuid}/hyperparameters/history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        limit: {
-          type: "integer",
-          description: "Max entries to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description: "Deprecated offset fallback when cursor is omitted.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a prior response's next_cursor.",
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetHyperparamsHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetHyperparamsHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = optionalNonNegativeInt(args, "offset") ?? 0;
@@ -5942,15 +5885,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "alpha volume, unsigned (buy + sell, never netted) — a canonical market-" +
       "depth figure, not a windowed analytics view. Mirrors " +
       "GET /api/v1/subnets/{netuid}/volume.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetVolumeInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetVolumeInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const netEconomics = await loadSubnetEconomics(ctx, netuid);
       const marketCapTao =
@@ -5982,26 +5923,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Root (netuid 0) has no AMM pool (1:1 TAO, no price impact) and " +
       "returns an empty, root_excluded series rather than a meaningless " +
       "flat line. Mirrors GET /api/v1/subnets/{netuid}/ohlc.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        interval: {
-          type: "string",
-          enum: Object.keys(OHLC_INTERVALS),
-          description: `Candle width (default ${OHLC_INTERVAL_DEFAULT}).`,
-        },
-        days: {
-          type: "integer",
-          description: `Lookback window in days (default ${DEFAULT_OHLC_WINDOW_DAYS}).`,
-          minimum: 1,
-          maximum: MAX_OHLC_WINDOW_DAYS,
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetOhlcInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetSubnetOhlcInputSchema>, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const interval =
         optionalString(args, "interval") ?? OHLC_INTERVAL_DEFAULT;
@@ -6047,15 +5972,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "owner cooperation required). A subnet that has never changed hands " +
       "returns an empty list, not an error. Mirrors GET " +
       "/api/v1/subnets/{netuid}/ownership-history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetOwnershipHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetOwnershipHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadSubnetOwnershipHistory(ctx, netuid);
     },
@@ -6075,15 +5998,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "governance-adjustable. A subnet with no active challengers/owner " +
       "lock returns an empty leaderboard, not an error. Mirrors GET " +
       "/api/v1/subnets/{netuid}/conviction.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetConvictionInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetConvictionInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadSubnetConviction(ctx, netuid);
     },
@@ -6096,15 +6017,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "queried directly from the chain's RAORecycledForRegistration storage at " +
       "request time (not a rollup). recycled_tao is null on an RPC failure. " +
       "Mirrors GET /api/v1/subnets/{netuid}/recycled.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetRecycledInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetRecycledInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       if (!isU16Netuid(netuid)) {
         throw toolError(
@@ -6135,15 +6054,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "queried directly from the chain's Burn storage at request time (not a " +
       "rollup). burn_tao is null on an RPC failure. Mirrors GET " +
       "/api/v1/subnets/{netuid}/burn.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetBurnInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetSubnetBurnInputSchema>, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       if (!isU16Netuid(netuid)) {
         throw toolError(
@@ -6179,15 +6093,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "request time (not a rollup). leased is null (not false) on an RPC " +
       "failure, distinct from a confirmed no-lease (leased:false). Mirrors " +
       "GET /api/v1/subnets/{netuid}/lease.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetLeaseInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetLeaseInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       if (!isU16Netuid(netuid)) {
         throw toolError(
@@ -6222,15 +6134,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "account_events row. A subnet that has never been leased returns an " +
       "empty list, not an error. Mirrors GET " +
       "/api/v1/subnets/{netuid}/lease/history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetLeaseHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetLeaseHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadSubnetLeaseHistory(ctx, netuid);
     },
@@ -12652,51 +12562,16 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_subnet_uptime: z.toJSONSchema(GetSubnetUptimeOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_registry_leaderboards: {
-    type: "object",
-    additionalProperties: true,
-    required: ["boards"],
-    properties: {
-      schema_version: { type: "integer" },
-      board: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      boards: { type: "object" },
-    },
-  },
-  get_domain_summary: {
-    type: "object",
-    additionalProperties: true,
-    // Two possible shapes depending on whether `domain` was passed -- a single
-    // DomainSummaryArtifact (domain/subnet_count/netuids/...) or the
-    // DomainsArtifact overview (domain_count/domains). Only schema_version is
-    // common to both, so this schema stays loose rather than forcing one
-    // shape's required fields onto the other (the established convention for
-    // composite/nested sections, per get_subnet_snapshot's own precedent).
-    required: ["schema_version"],
-    properties: {
-      schema_version: { type: "integer" },
-      domain: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      netuids: { type: "array", items: { type: "integer" } },
-      total_stake_tao: { type: ["number", "null"] },
-      total_emission_share: { type: ["number", "null"] },
-      emission_concentration: { type: ["object", "null"] },
-      domain_count: { type: "integer" },
-      domains: { type: "array", items: { type: "object" } },
-    },
-  },
-  compare_subnets: {
-    type: "object",
-    additionalProperties: true,
-    required: ["requested_netuids", "subnets", "dimensions"],
-    properties: {
-      schema_version: { type: "integer" },
-      requested_netuids: { type: "array", items: { type: "integer" } },
-      dimensions: { type: "array", items: { type: "string" } },
-      subnets: { type: "array", items: { type: "object" } },
-      observed_at: NULLABLE_STRING,
-    },
-  },
+  get_registry_leaderboards: z.toJSONSchema(
+    GetRegistryLeaderboardsOutputSchema,
+    { target: "draft-2020-12" },
+  ),
+  get_domain_summary: z.toJSONSchema(GetDomainSummaryOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  compare_subnets: z.toJSONSchema(CompareSubnetsOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_global_incidents: {
     type: "object",
     additionalProperties: true,
@@ -12717,19 +12592,9 @@ const TOOL_OUTPUT_SCHEMAS = {
       order: NULLABLE_STRING,
     },
   },
-  get_subnet_metagraph: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "neuron_count", "neurons"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      neuron_count: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      block_number: NULLABLE_INT,
-      neurons: { type: "array", items: { type: "object" } },
-    },
-  },
+  get_subnet_metagraph: z.toJSONSchema(GetSubnetMetagraphOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_subnet_validators: {
     type: "object",
     additionalProperties: true,
@@ -12895,256 +12760,45 @@ const TOOL_OUTPUT_SCHEMAS = {
       neuron: { type: ["object", "null"] },
     },
   },
-  get_subnet_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "point_count", "points"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      window: NULLABLE_STRING,
-      point_count: { type: "integer" },
-      points: objectItems({
-        snapshot_date: NULLABLE_STRING,
-        neuron_count: NULLABLE_INT,
-        validator_count: NULLABLE_INT,
-        total_stake_tao: ANY,
-        total_emission_tao: ANY,
-      }),
-    },
-  },
-  get_subnet_identity_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["schema_version", "netuid", "entry_count", "entries"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      entry_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      entries: objectItems({
-        block_number: NULLABLE_INT,
-        observed_at: NULLABLE_STRING,
-        subnet_name: NULLABLE_STRING,
-        symbol: NULLABLE_STRING,
-        description: NULLABLE_STRING,
-        github_repo: NULLABLE_STRING,
-        subnet_url: NULLABLE_STRING,
-        discord: NULLABLE_STRING,
-        logo_url: NULLABLE_STRING,
-        identity_hash: { type: "string" },
-      }),
-    },
-  },
-  get_subnet_hyperparams: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      block_number: NULLABLE_INT,
-      hyperparameters: { type: ["object", "null"], additionalProperties: true },
-    },
-  },
-  get_subnet_hyperparams_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "entry_count", "entries"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      entry_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      entries: objectItems({
-        block_number: NULLABLE_INT,
-        observed_at: NULLABLE_STRING,
-        hyperparameters: {
-          type: ["object", "null"],
-          additionalProperties: true,
-        },
-        hyperparams_hash: NULLABLE_STRING,
-      }),
-    },
-  },
-  get_subnet_volume: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "window"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      window: { type: "string" },
-      buy_volume_alpha: ANY,
-      sell_volume_alpha: ANY,
-      total_volume_alpha: ANY,
-      buy_volume_tao: ANY,
-      sell_volume_tao: ANY,
-      total_volume_tao: ANY,
-      buy_count: { type: "integer" },
-      sell_count: { type: "integer" },
-      net_volume_alpha: ANY,
-      sentiment_ratio: { type: ["number", "null"] },
-      sentiment: NULLABLE_STRING,
-      vol_mcap_ratio: { type: ["number", "null"] },
-    },
-  },
-  get_subnet_ohlc: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "interval", "candles", "root_excluded"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      interval: { type: "string" },
-      candles: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: true,
-          properties: {
-            bucket_start: { type: "integer" },
-            bucket_start_iso: { type: "string" },
-            open: ANY,
-            high: ANY,
-            low: ANY,
-            close: ANY,
-            volume_alpha: ANY,
-            volume_tao: ANY,
-            event_count: { type: "integer" },
-          },
-        },
-      },
-      root_excluded: { type: "boolean" },
-    },
-  },
-  get_subnet_ownership_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "count", "ownership_changes"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      count: { type: "integer" },
-      ownership_changes: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: true,
-          properties: {
-            netuid: { type: ["integer", "null"] },
-            old_coldkey: { type: ["string", "null"] },
-            new_coldkey: { type: ["string", "null"] },
-            block_number: { type: ["integer", "null"] },
-            observed_at: NULLABLE_STRING,
-          },
-        },
-      },
-    },
-  },
-  get_subnet_conviction: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "count", "leaderboard"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      queried_at_block: { type: ["integer", "null"] },
-      unlock_rate: { type: ["integer", "null"] },
-      maturity_rate: { type: ["integer", "null"] },
-      king: { type: ["string", "null"] },
-      count: { type: "integer" },
-      leaderboard: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: true,
-          properties: {
-            hotkey: { type: "string" },
-            is_owner: { type: "boolean" },
-            locked_mass: { type: "number" },
-            conviction: { type: "number" },
-          },
-        },
-      },
-    },
-  },
-  get_subnet_recycled: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "queried_at"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      recycled_tao: { type: ["number", "null"] },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_subnet_burn: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "queried_at"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      burn_tao: { type: ["number", "null"] },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_subnet_lease: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "leased"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      leased: { type: ["boolean", "null"] },
-      lease: {
-        type: ["object", "null"],
-        additionalProperties: true,
-        properties: {
-          lease_id: { type: "integer" },
-          beneficiary: { type: "string" },
-          coldkey: { type: "string" },
-          hotkey: { type: "string" },
-          emissions_share_percent: { type: "integer" },
-          end_block: { type: ["integer", "null"] },
-          netuid: { type: "integer" },
-          cost_tao: { type: "number" },
-          accumulated_dividends_alpha: { type: ["number", "null"] },
-        },
-      },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_subnet_lease_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "count", "lease_events"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      count: { type: "integer" },
-      lease_events: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: true,
-          properties: {
-            event_kind: { type: "string" },
-            beneficiary: { type: ["string", "null"] },
-            block_number: { type: ["integer", "null"] },
-            observed_at: NULLABLE_STRING,
-          },
-        },
-      },
-    },
-  },
+  get_subnet_history: z.toJSONSchema(GetSubnetHistoryOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_identity_history: z.toJSONSchema(
+    GetSubnetIdentityHistoryOutputSchema,
+    { target: "draft-2020-12" },
+  ),
+  get_subnet_hyperparams: z.toJSONSchema(GetSubnetHyperparamsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_hyperparams_history: z.toJSONSchema(
+    GetSubnetHyperparamsHistoryOutputSchema,
+    { target: "draft-2020-12" },
+  ),
+  get_subnet_volume: z.toJSONSchema(GetSubnetVolumeOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_ohlc: z.toJSONSchema(GetSubnetOhlcOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_ownership_history: z.toJSONSchema(
+    GetSubnetOwnershipHistoryOutputSchema,
+    { target: "draft-2020-12" },
+  ),
+  get_subnet_conviction: z.toJSONSchema(GetSubnetConvictionOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_recycled: z.toJSONSchema(GetSubnetRecycledOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_burn: z.toJSONSchema(GetSubnetBurnOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_lease: z.toJSONSchema(GetSubnetLeaseOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_lease_history: z.toJSONSchema(GetSubnetLeaseHistoryOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_neuron_history: {
     type: "object",
     additionalProperties: true,
@@ -13158,20 +12812,9 @@ const TOOL_OUTPUT_SCHEMAS = {
       points: { type: "array", items: { type: "object" } },
     },
   },
-  get_subnet_events: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "event_count", "events"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      event_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      events: objectItems(ACCOUNT_EVENT_ITEM),
-    },
-  },
+  get_subnet_events: z.toJSONSchema(GetSubnetEventsOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_account: {
     type: "object",
     additionalProperties: true,

--- a/src/profiles-mcp.ts
+++ b/src/profiles-mcp.ts
@@ -2,13 +2,18 @@
 // GET /api/v1/subnets/{netuid}/profile. Artifact-backed list-query over
 // profiles.json and per-netuid profile detail snapshots.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListProfilesInputSchema,
+  ListProfilesOutputSchema,
+  GetSubnetProfileInputSchema,
+  GetSubnetProfileOutputSchema,
+} from "../schemas-src/mcp-tools/profiles.ts";
 
 const PROFILES_SORT_FIELDS = API_QUERY_COLLECTIONS.profiles.sort_fields;
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
 
 export interface ProfilesMcpError extends Error {
   profilesMcp: true;
@@ -211,73 +216,9 @@ export const LIST_PROFILES_MCP_TOOL = {
     "review_state, confidence, or profile_level; search by name/slug/project " +
     "(q); sort with sort + order; page with limit (1-1000) / cursor. Mirrors " +
     "GET /api/v1/profiles.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      subnet_type: {
-        type: "string",
-        enum: QUERY_ENUMS.subnetType,
-        description: "Filter by subnet type.",
-      },
-      curation_level: {
-        type: "string",
-        enum: QUERY_ENUMS.curationLevel,
-        description: "Filter by curation level.",
-      },
-      review_state: {
-        type: "string",
-        description: "Filter by review state.",
-      },
-      confidence: {
-        type: "string",
-        enum: ["low", "medium", "high"],
-        description: "Filter by profile confidence.",
-      },
-      profile_level: {
-        type: "string",
-        enum: QUERY_ENUMS.profileLevel,
-        description: "Filter by profile completeness level.",
-      },
-      q: {
-        type: "string",
-        description:
-          "Search subnet name, slug, project name, team, or categories.",
-      },
-      sort: {
-        type: "string",
-        enum: PROFILES_SORT_FIELDS,
-        description:
-          "Field to sort by (bare name only). Pair with order for direction.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of profile row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max profile rows to return (1-1000). Enables pagination.",
-        minimum: 1,
-        maximum: 1000,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListProfilesInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
 export const GET_SUBNET_PROFILE_MCP_TOOL = {
@@ -288,48 +229,17 @@ export const GET_SUBNET_PROFILE_MCP_TOOL = {
     "score, curation and review metadata, native identity signals, surface " +
     "counts, and contributor-facing enrichment context. Mirrors " +
     "GET /api/v1/subnets/{netuid}/profile.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Subnet netuid.",
-        minimum: 0,
-      },
-    },
-    required: ["netuid"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetSubnetProfileInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-export const LIST_PROFILES_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["profiles"],
-  properties: {
-    captured_at: NULLABLE_STRING,
-    profiles: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
-  },
-};
+export const LIST_PROFILES_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListProfilesOutputSchema,
+  { target: "draft-2020-12" },
+);
 
-export const GET_SUBNET_PROFILE_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  properties: {
-    schema_version: { type: "integer" },
-    contract_version: NULLABLE_STRING,
-    generated_at: NULLABLE_STRING,
-    subnet: { type: ["object", "null"] },
-    profile: { type: ["object", "null"] },
-    surfaces: { type: "array", items: { type: "object" } },
-    endpoints: { type: "array", items: { type: "object" } },
-    gaps: { type: ["object", "null"] },
-  },
-};
+export const GET_SUBNET_PROFILE_OUTPUT_SCHEMA = z.toJSONSchema(
+  GetSubnetProfileOutputSchema,
+  { target: "draft-2020-12" },
+);


### PR DESCRIPTION
## Summary

Batch 4 of types-epic E (#7863): converts 19 more MCP tool input/output schemas from hand-written JSON Schema literals to Zod-generated (`z.toJSONSchema(...)`), covering the subnet metagraph/identity/lease surface: `get_registry_leaderboards`, `get_domain_summary`, `list_profiles`, `get_subnet_profile`, `compare_subnets`, `get_subnet_metagraph`, `get_subnet_history`, `get_subnet_identity_history`, `get_subnet_events`, `get_subnet_hyperparams`(+`_history`), `get_subnet_volume`, `get_subnet_ohlc`, `get_subnet_ownership_history`, `get_subnet_conviction`, `get_subnet_recycled`, `get_subnet_burn`, `get_subnet_lease`(+`_history`).

Closes #8067.

## Diff-audit results (`scripts/diff-mcp-tool-schemas.ts`)

119/120 schema checks PASS (pilot batch 1 + batches 2/3/4 combined: 60 tools × input/output). One documented, expected DIFF:

- **`get_subnet_identity_history.output`** — real finding, same root cause #8055 already found and fixed on the REST side (`schemas-src/routes/subnet-identity-history.ts`). The hand-written entry schema required `identity_hash` as a non-nullable string, but `formatIdentityHistoryEntry()` builds it as `record.identity_hash ?? null` — a row with no computed hash yields `identity_hash: null`, which the old schema would have rejected. Modeled here as nullable (still required — the key itself is always present), matching real behavior.

## Reuse-declined rationale

Several tools in this batch share a data-loading function with a REST route from #8055 but were deliberately **not** wired to reuse that REST Zod schema, since each tool's own hand-written contract had a different required-set/`additionalProperties` posture than its REST counterpart — reusing would have silently tightened or loosened the tool's existing contract:

- `get_subnet_volume` / REST's alpha-volume route
- `get_subnet_recycled`, `get_subnet_burn` / REST's registration-cost route
- `get_subnet_events` / REST's subnet-events route
- `get_subnet_history` / REST's subnet-history route
- `get_subnet_identity_history` / REST's subnet-identity-history route

Each is documented with a header comment in its `schemas-src/mcp-tools/*.ts` file explaining the specific posture difference. `list_profiles`/`get_subnet_profile` are likewise kept deliberately shallow rather than reusing the deeper `SubnetProfileSchema` from #8055, since the original MCP contract was already shallow.

## Bug fix: `normalize()` sibling-dropping

While modeling `get_subnet_lease.lease` (a nullable object with 9 typed properties), found and fixed a real bug in the diff-audit's own `normalize()` helper: the `type:["object","null"]`-to-`anyOf` rewrite was discarding all sibling constraint keys (`properties`, `additionalProperties`) whenever a node had extra keys alongside `type`. Earlier batches never exercised this (their nullable-union nodes were always bare, e.g. `NULLABLE_STRING`). Fixed to carry siblings into the non-null branch, mirroring `scripts/diff-openapi-zod-components.ts`'s already-correct version.

## Verification

- `npx tsc --noEmit -p .` — clean
- `npx eslint` (touched files) — clean
- `npx prettier --check` (touched files) — clean
- `npx tsx scripts/diff-mcp-tool-schemas.ts` — 119/120 PASS, 1 documented DIFF (above)
- `npx tsx scripts/validate-mcp.ts` — 204 tools, full lifecycle/subscribe round trips pass
- Full test suite: 490/490 files, 11853/11853 tests passing

## Test plan

- [x] tsc clean
- [x] eslint/prettier clean
- [x] Diff-audit run, 1 expected finding documented above
- [x] `validate-mcp.ts` passes
- [x] Full test suite green