### PR TITLE
feat(mcp): types-epic E — Zod schemas for 11 validator/neuron MCP tools (#8068)

### DIFF
--- a/schemas-src/mcp-tools/get-alert-trigger.ts
+++ b/schemas-src/mcp-tools/get-alert-trigger.ts
@@ -1,0 +1,33 @@
+// MCP tool `get_alert_trigger` (types-epic E batch 4, #8068). Mirrors
+// GET /api/v1/alerts/triggers/{id}, which is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// matching the hand-written literal it replaces field-for-field.
+import { z } from "zod";
+
+export const GetAlertTriggerInputSchema = z
+  .object({
+    id: z.string(),
+    owner_token: z.string(),
+  })
+  .strict();
+export type GetAlertTriggerInput = z.infer<typeof GetAlertTriggerInputSchema>;
+
+export const GetAlertTriggerOutputSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().nullable().optional(),
+    table_filter: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    event_kind: z.string().nullable().optional(),
+    account: z.string().nullable().optional(),
+    min_amount_tao: z.number().nullable().optional(),
+    channel: z.string().optional(),
+    destination: z.string().optional(),
+    active: z.boolean(),
+    created_at: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
+    last_matched_at: z.string().nullable().optional(),
+    match_count: z.int().optional(),
+  })
+  .passthrough();
+export type GetAlertTriggerOutput = z.infer<typeof GetAlertTriggerOutputSchema>;

--- a/schemas-src/mcp-tools/get-global-incidents.ts
+++ b/schemas-src/mcp-tools/get-global-incidents.ts
@@ -1,0 +1,51 @@
+// MCP tool `get_global_incidents` (types-epic E batch 4, #8068). Mirrors
+// GET /api/v1/incidents, which is not one of schemas-src/routes/'s covered
+// pilot routes -- no existing Zod schema to reuse. Modeled fresh, shallow,
+// from the hand-written literal it replaces.
+import { z } from "zod";
+import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+
+// Symbolic in the hand-written original (src/contracts.ts's
+// API_QUERY_COLLECTIONS.incidents.sort_fields), cross-checked against the
+// actual runtime array at the time of writing.
+const GLOBAL_INCIDENTS_SORT_FIELDS = [
+  "downtime_ms",
+  "incident_count",
+  "netuid",
+  "surface_id",
+] as const;
+
+export const GetGlobalIncidentsInputSchema = z
+  .object({
+    window: z.enum(["7d", "30d"]).optional(),
+    netuid: z.int().min(0).optional(),
+    sort: z.enum(GLOBAL_INCIDENTS_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type GetGlobalIncidentsInput = z.infer<
+  typeof GetGlobalIncidentsInputSchema
+>;
+
+export const GetGlobalIncidentsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    source: z.string().nullable().optional(),
+    summary: OpenObjectSchema,
+    surfaces: OpenObjectArraySchema,
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetGlobalIncidentsOutput = z.infer<
+  typeof GetGlobalIncidentsOutputSchema
+>;

--- a/schemas-src/mcp-tools/get-webhook-subscription.ts
+++ b/schemas-src/mcp-tools/get-webhook-subscription.ts
@@ -1,0 +1,51 @@
+// MCP tool `get_webhook_subscription` (types-epic E batch 4, #8068). Mirrors
+// GET /api/v1/webhooks/subscriptions/{id}, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, matching the hand-written literal it replaces
+// field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetWebhookSubscriptionInputSchema = z
+  .object({
+    id: z.string(),
+  })
+  .strict();
+export type GetWebhookSubscriptionInput = z.infer<
+  typeof GetWebhookSubscriptionInputSchema
+>;
+
+const WebhookDeliveryFailureSchema = z
+  .object({
+    event_id: z.string().optional(),
+    attempts: z.int().optional(),
+    reason: z.string().nullable().optional(),
+    status_code: z.int().nullable().optional(),
+    state: z.string().optional(),
+    last_attempt_at: z.string().nullable().optional(),
+    next_attempt_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const WebhookDeliveryStatusSchema = z
+  .object({
+    status: z.enum(["ok", "retrying", "dead_letter"]),
+    pending: z.int(),
+    dead_letter: z.int(),
+    last_failure: WebhookDeliveryFailureSchema.nullable().optional(),
+  })
+  .passthrough();
+
+export const GetWebhookSubscriptionOutputSchema = z
+  .object({
+    id: z.string(),
+    url: z.string(),
+    filters: OpenObjectSchema.optional(),
+    created_at: z.string().nullable().optional(),
+    active: z.boolean(),
+    delivery: WebhookDeliveryStatusSchema.optional(),
+  })
+  .passthrough();
+export type GetWebhookSubscriptionOutput = z.infer<
+  typeof GetWebhookSubscriptionOutputSchema
+>;

--- a/schemas-src/mcp-tools/neurons.ts
+++ b/schemas-src/mcp-tools/neurons.ts
@@ -1,0 +1,49 @@
+// MCP tools `get_neuron`, `get_neuron_history` (types-epic E batch 4,
+// #8068). Each mirrors a GET /api/v1/subnets/{netuid}/neurons* route that is
+// not one of schemas-src/routes/'s covered pilot routes -- no existing Zod
+// schema to reuse. Modeled fresh, matching each hand-written literal
+// field-for-field.
+import { z } from "zod";
+import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+
+export const GetNeuronInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    uid: z.int().min(0),
+  })
+  .strict();
+export type GetNeuronInput = z.infer<typeof GetNeuronInputSchema>;
+
+export const GetNeuronOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    captured_at: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    neuron: OpenObjectSchema.nullable(),
+  })
+  .passthrough();
+export type GetNeuronOutput = z.infer<typeof GetNeuronOutputSchema>;
+
+export const GetNeuronHistoryInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    uid: z.int().min(0),
+    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+  })
+  .strict();
+export type GetNeuronHistoryInput = z.infer<typeof GetNeuronHistoryInputSchema>;
+
+export const GetNeuronHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    uid: z.int(),
+    window: z.string().nullable().optional(),
+    point_count: z.int(),
+    points: OpenObjectArraySchema,
+  })
+  .passthrough();
+export type GetNeuronHistoryOutput = z.infer<
+  typeof GetNeuronHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -1,0 +1,250 @@
+// MCP tools `list_subnet_validators`, `list_global_validators`,
+// `get_validator_detail`, `compare_validators`, `get_validator_nominators`,
+// `get_validator_history` (types-epic E batch 4, #8068). Each mirrors a
+// GET /api/v1/validators* route that is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// matching each hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectArraySchema } from "./shared.ts";
+
+// Mirrors workers/config.ts's SS58_ADDRESS_PATTERN (inlined rather than
+// cross-imported from workers/, matching this directory's existing
+// convention of inlining its own regex constants, e.g. subnets.ts's
+// HttpUrlSchema).
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const ListSubnetValidatorsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    limit: z.int().min(1).optional(),
+    min_stake_tao: z.number().min(0).optional(),
+  })
+  .strict();
+export type ListSubnetValidatorsInput = z.infer<
+  typeof ListSubnetValidatorsInputSchema
+>;
+
+export const ListSubnetValidatorsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    validator_count: z.int(),
+    captured_at: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    validators: OpenObjectArraySchema,
+  })
+  .passthrough();
+export type ListSubnetValidatorsOutput = z.infer<
+  typeof ListSubnetValidatorsOutputSchema
+>;
+
+// Symbolic in the hand-written original (src/metagraph-neurons.ts's
+// GLOBAL_VALIDATOR_SORTS/DEFAULT_GLOBAL_VALIDATOR_SORT/*_LIMIT_*), cross-
+// checked against the actual runtime source at the time of writing.
+const GLOBAL_VALIDATOR_SORTS = [
+  "avg_validator_trust",
+  "max_validator_trust",
+  "stake_dominance",
+  "subnet_count",
+  "total_emission",
+  "total_stake",
+  "uid_count",
+] as const;
+
+export const ListGlobalValidatorsInputSchema = z
+  .object({
+    sort: z.enum(GLOBAL_VALIDATOR_SORTS).optional(),
+    limit: z.int().min(1).max(100).optional(),
+  })
+  .strict();
+export type ListGlobalValidatorsInput = z.infer<
+  typeof ListGlobalValidatorsInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const GlobalValidatorSubnetItemSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    uid: z.int().nullable().optional(),
+    stake_tao: z.unknown().optional(),
+    emission_tao: z.unknown().optional(),
+    validator_trust: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+const GlobalValidatorItemSchema = z
+  .object({
+    hotkey: z.string().nullable().optional(),
+    coldkey: z.string().nullable().optional(),
+    coldkey_count: z.int().optional(),
+    subnet_count: z.int().optional(),
+    uid_count: z.int().optional(),
+    total_stake_tao: z.unknown().optional(),
+    total_emission_tao: z.unknown().optional(),
+    avg_validator_trust: z.number().nullable().optional(),
+    max_validator_trust: z.number().nullable().optional(),
+    latest_captured_at: z.string().nullable().optional(),
+    latest_block_number: z.int().nullable().optional(),
+    stake_dominance: z.number().nullable().optional(),
+    subnets: z.array(GlobalValidatorSubnetItemSchema).optional(),
+  })
+  .passthrough();
+
+export const ListGlobalValidatorsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    sort: z.enum(GLOBAL_VALIDATOR_SORTS),
+    limit: z.int(),
+    captured_at: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    validator_count: z.int(),
+    validators: z.array(GlobalValidatorItemSchema),
+  })
+  .passthrough();
+export type ListGlobalValidatorsOutput = z.infer<
+  typeof ListGlobalValidatorsOutputSchema
+>;
+
+export const GetValidatorDetailInputSchema = z
+  .object({
+    hotkey: Ss58Schema,
+  })
+  .strict();
+export type GetValidatorDetailInput = z.infer<
+  typeof GetValidatorDetailInputSchema
+>;
+
+export const GetValidatorDetailOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    hotkey: z.string(),
+    coldkey: z.string().nullable().optional(),
+    coldkey_count: z.int().optional(),
+    subnet_count: z.int(),
+    take: z.number().nullable().optional(),
+    total_stake_tao: z.unknown().optional(),
+    total_emission_tao: z.unknown().optional(),
+    avg_validator_trust: z.number().nullable().optional(),
+    max_validator_trust: z.number().nullable().optional(),
+    captured_at: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    subnets: OpenObjectArraySchema,
+  })
+  .passthrough();
+export type GetValidatorDetailOutput = z.infer<
+  typeof GetValidatorDetailOutputSchema
+>;
+
+// src/analytics-live.ts's COMPARE_VALIDATORS_MAX, cross-checked against the
+// actual runtime value at the time of writing.
+const COMPARE_VALIDATORS_MAX = 16;
+
+export const CompareValidatorsInputSchema = z
+  .object({
+    hotkeys: z.array(Ss58Schema).min(1).max(COMPARE_VALIDATORS_MAX),
+    netuid: z.int().min(0).optional(),
+  })
+  .strict();
+export type CompareValidatorsInput = z.infer<
+  typeof CompareValidatorsInputSchema
+>;
+
+export const CompareValidatorsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int().nullable().optional(),
+    validator_count: z.int(),
+    validators: OpenObjectArraySchema,
+  })
+  .passthrough();
+export type CompareValidatorsOutput = z.infer<
+  typeof CompareValidatorsOutputSchema
+>;
+
+// Symbolic in the hand-written original (src/validator-nominators.ts's
+// NOMINATOR_WINDOWS/NOMINATOR_SORTS/*_LIMIT_*), cross-checked against the
+// actual runtime source at the time of writing.
+const NOMINATOR_WINDOWS = ["7d", "30d", "90d"] as const;
+const NOMINATOR_SORTS = [
+  "net_staked",
+  "gross_staked",
+  "last_activity",
+] as const;
+
+export const GetValidatorNominatorsInputSchema = z
+  .object({
+    hotkey: Ss58Schema,
+    window: z.enum(NOMINATOR_WINDOWS).optional(),
+    sort: z.enum(NOMINATOR_SORTS).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    offset: z.int().min(0).optional(),
+    coldkey: Ss58Schema.optional(),
+  })
+  .strict();
+export type GetValidatorNominatorsInput = z.infer<
+  typeof GetValidatorNominatorsInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level.
+const NominatorItemSchema = z
+  .object({
+    coldkey: z.string().optional(),
+    staked_tao: z.unknown().optional(),
+    unstaked_tao: z.unknown().optional(),
+    net_staked_tao: z.unknown().optional(),
+    gross_staked_tao: z.unknown().optional(),
+    event_count: z.int().optional(),
+    last_observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetValidatorNominatorsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    hotkey: z.string(),
+    window: z.string().nullable().optional(),
+    sort: z.enum(NOMINATOR_SORTS).optional(),
+    limit: z.int().optional(),
+    offset: z.int().optional(),
+    nominator_count: z.int(),
+    nominators: z.array(NominatorItemSchema),
+  })
+  .passthrough();
+export type GetValidatorNominatorsOutput = z.infer<
+  typeof GetValidatorNominatorsOutputSchema
+>;
+
+export const GetValidatorHistoryInputSchema = z
+  .object({
+    hotkey: Ss58Schema,
+    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+  })
+  .strict();
+export type GetValidatorHistoryInput = z.infer<
+  typeof GetValidatorHistoryInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level.
+const ValidatorHistoryPointSchema = z
+  .object({
+    snapshot_date: z.string().nullable().optional(),
+    subnet_count: z.int().nullable().optional(),
+    total_stake_tao: z.unknown().optional(),
+    total_emission_tao: z.unknown().optional(),
+    rewards_per_1000_tao: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetValidatorHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    hotkey: z.string(),
+    window: z.string().nullable().optional(),
+    point_count: z.int(),
+    points: z.array(ValidatorHistoryPointSchema),
+  })
+  .passthrough();
+export type GetValidatorHistoryOutput = z.infer<
+  typeof GetValidatorHistoryOutputSchema
+>;

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -240,6 +240,38 @@ import {
   GetSubnetLeaseHistoryInputSchema,
   GetSubnetLeaseHistoryOutputSchema,
 } from "../schemas-src/mcp-tools/get-subnet-lease.ts";
+import {
+  GetGlobalIncidentsInputSchema,
+  GetGlobalIncidentsOutputSchema,
+} from "../schemas-src/mcp-tools/get-global-incidents.ts";
+import {
+  ListSubnetValidatorsInputSchema,
+  ListSubnetValidatorsOutputSchema,
+  ListGlobalValidatorsInputSchema,
+  ListGlobalValidatorsOutputSchema,
+  GetValidatorDetailInputSchema,
+  GetValidatorDetailOutputSchema,
+  CompareValidatorsInputSchema,
+  CompareValidatorsOutputSchema,
+  GetValidatorNominatorsInputSchema,
+  GetValidatorNominatorsOutputSchema,
+  GetValidatorHistoryInputSchema,
+  GetValidatorHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/validators.ts";
+import {
+  GetWebhookSubscriptionInputSchema,
+  GetWebhookSubscriptionOutputSchema,
+} from "../schemas-src/mcp-tools/get-webhook-subscription.ts";
+import {
+  GetAlertTriggerInputSchema,
+  GetAlertTriggerOutputSchema,
+} from "../schemas-src/mcp-tools/get-alert-trigger.ts";
+import {
+  GetNeuronInputSchema,
+  GetNeuronOutputSchema,
+  GetNeuronHistoryInputSchema,
+  GetNeuronHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/neurons.ts";
 
 type Row = Record<string, unknown>;
 
@@ -425,6 +457,35 @@ const PROFILES_SORT_FIELDS_4 = [
 const COMPARE_DIMENSIONS = ["structure", "economics", "health"];
 const HISTORY_WINDOWS_4 = ["7d", "30d", "90d", "1y", "all"];
 const OHLC_INTERVALS_4 = ["1h", "1d"];
+
+// Batch 5 (#8068) resolved enum values, same treatment as above -- symbolic
+// in the hand-written originals (src/contracts.ts's
+// API_QUERY_COLLECTIONS.incidents.sort_fields, src/metagraph-neurons.ts's
+// GLOBAL_VALIDATOR_SORTS, src/validator-nominators.ts's NOMINATOR_SORTS;
+// NOMINATOR_WINDOWS' keys and get_validator_history/get_neuron_history's
+// window sets reuse HISTORY_WINDOWS_3/HISTORY_WINDOWS_5 above -- same literal
+// value sets), cross-checked against the actual runtime source at the time
+// of writing.
+const GLOBAL_INCIDENTS_SORT_FIELDS = [
+  "downtime_ms",
+  "incident_count",
+  "netuid",
+  "surface_id",
+];
+const GLOBAL_VALIDATOR_SORTS = [
+  "avg_validator_trust",
+  "max_validator_trust",
+  "stake_dominance",
+  "subnet_count",
+  "total_emission",
+  "total_stake",
+  "uid_count",
+];
+const NOMINATOR_SORTS = ["net_staked", "gross_staked", "last_activity"];
+// Mirrors workers/config.ts's SS58_ADDRESS_PATTERN.source (src/mcp-server.ts's
+// SS58_PATTERN_SOURCE), cross-checked against the actual runtime value at the
+// time of writing.
+const SS58_PATTERN = "^[1-9A-HJ-NP-Za-km-z]{47,48}$";
 
 const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
   search_subnets: {
@@ -2356,6 +2417,356 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  get_global_incidents: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: ["7d", "30d"] },
+        netuid: { type: "integer", minimum: 0 },
+        sort: { type: "string", enum: GLOBAL_INCIDENTS_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["summary", "surfaces"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        source: NULLABLE_STRING,
+        summary: { type: "object" },
+        surfaces: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_subnet_validators: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1 },
+        min_stake_tao: { type: "number", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "validator_count", "validators"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        validator_count: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        block_number: NULLABLE_INT,
+        validators: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  list_global_validators: {
+    input: {
+      type: "object",
+      properties: {
+        sort: { type: "string", enum: GLOBAL_VALIDATOR_SORTS },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["sort", "limit", "validator_count", "validators"],
+      properties: {
+        schema_version: { type: "integer" },
+        sort: { type: "string", enum: GLOBAL_VALIDATOR_SORTS },
+        limit: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        block_number: NULLABLE_INT,
+        validator_count: { type: "integer" },
+        validators: objectItems({
+          hotkey: NULLABLE_STRING,
+          coldkey: NULLABLE_STRING,
+          coldkey_count: { type: "integer" },
+          subnet_count: { type: "integer" },
+          uid_count: { type: "integer" },
+          total_stake_tao: ANY,
+          total_emission_tao: ANY,
+          avg_validator_trust: { type: ["number", "null"] },
+          max_validator_trust: { type: ["number", "null"] },
+          latest_captured_at: NULLABLE_STRING,
+          latest_block_number: NULLABLE_INT,
+          stake_dominance: { type: ["number", "null"] },
+          subnets: objectItems({
+            netuid: NULLABLE_INT,
+            uid: NULLABLE_INT,
+            stake_tao: ANY,
+            emission_tao: ANY,
+            validator_trust: { type: ["number", "null"] },
+          }),
+        }),
+      },
+    },
+  },
+  get_validator_detail: {
+    input: {
+      type: "object",
+      properties: {
+        hotkey: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["hotkey"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["hotkey", "subnet_count", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        hotkey: { type: "string" },
+        coldkey: NULLABLE_STRING,
+        coldkey_count: { type: "integer" },
+        subnet_count: { type: "integer" },
+        take: { type: ["number", "null"] },
+        total_stake_tao: ANY,
+        total_emission_tao: ANY,
+        avg_validator_trust: { type: ["number", "null"] },
+        max_validator_trust: { type: ["number", "null"] },
+        captured_at: NULLABLE_STRING,
+        block_number: NULLABLE_INT,
+        subnets: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  compare_validators: {
+    input: {
+      type: "object",
+      properties: {
+        hotkeys: {
+          type: "array",
+          items: { type: "string", pattern: SS58_PATTERN },
+          minItems: 1,
+          maxItems: 16,
+        },
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["hotkeys"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["validator_count", "validators"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: NULLABLE_INT,
+        validator_count: { type: "integer" },
+        validators: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  get_webhook_subscription: {
+    input: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["id", "url", "active"],
+      properties: {
+        id: { type: "string" },
+        url: { type: "string" },
+        filters: { type: "object" },
+        created_at: NULLABLE_STRING,
+        active: { type: "boolean" },
+        delivery: {
+          type: "object",
+          required: ["status", "pending", "dead_letter"],
+          properties: {
+            status: { type: "string", enum: ["ok", "retrying", "dead_letter"] },
+            pending: { type: "integer" },
+            dead_letter: { type: "integer" },
+            last_failure: {
+              type: ["object", "null"],
+              properties: {
+                event_id: { type: "string" },
+                attempts: { type: "integer" },
+                reason: NULLABLE_STRING,
+                status_code: NULLABLE_INT,
+                state: { type: "string" },
+                last_attempt_at: NULLABLE_STRING,
+                next_attempt_at: NULLABLE_STRING,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_alert_trigger: {
+    input: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        owner_token: { type: "string" },
+      },
+      required: ["id", "owner_token"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["id", "active"],
+      properties: {
+        id: { type: "string" },
+        name: NULLABLE_STRING,
+        table_filter: NULLABLE_STRING,
+        netuid: NULLABLE_INT,
+        event_kind: NULLABLE_STRING,
+        account: NULLABLE_STRING,
+        min_amount_tao: { type: ["number", "null"] },
+        channel: { type: "string" },
+        destination: { type: "string" },
+        active: { type: "boolean" },
+        created_at: NULLABLE_STRING,
+        updated_at: NULLABLE_STRING,
+        last_matched_at: NULLABLE_STRING,
+        match_count: { type: "integer" },
+      },
+    },
+  },
+  get_validator_nominators: {
+    input: {
+      type: "object",
+      properties: {
+        hotkey: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: HISTORY_WINDOWS_3 },
+        sort: { type: "string", enum: NOMINATOR_SORTS },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        offset: { type: "integer", minimum: 0 },
+        coldkey: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["hotkey"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["hotkey", "nominator_count", "nominators"],
+      properties: {
+        schema_version: { type: "integer" },
+        hotkey: { type: "string" },
+        window: NULLABLE_STRING,
+        sort: { type: "string", enum: NOMINATOR_SORTS },
+        limit: { type: "integer" },
+        offset: { type: "integer" },
+        nominator_count: { type: "integer" },
+        nominators: objectItems({
+          coldkey: { type: "string" },
+          staked_tao: ANY,
+          unstaked_tao: ANY,
+          net_staked_tao: ANY,
+          gross_staked_tao: ANY,
+          event_count: { type: "integer" },
+          last_observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_validator_history: {
+    input: {
+      type: "object",
+      properties: {
+        hotkey: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: HISTORY_WINDOWS_5 },
+      },
+      required: ["hotkey"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["hotkey", "point_count", "points"],
+      properties: {
+        schema_version: { type: "integer" },
+        hotkey: { type: "string" },
+        window: NULLABLE_STRING,
+        point_count: { type: "integer" },
+        points: objectItems({
+          snapshot_date: NULLABLE_STRING,
+          subnet_count: NULLABLE_INT,
+          total_stake_tao: ANY,
+          total_emission_tao: ANY,
+          rewards_per_1000_tao: { type: ["number", "null"] },
+        }),
+      },
+    },
+  },
+  get_neuron: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        uid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid", "uid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "neuron"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        block_number: NULLABLE_INT,
+        neuron: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_neuron_history: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        uid: { type: "integer", minimum: 0 },
+        window: { type: "string", enum: HISTORY_WINDOWS_5 },
+      },
+      required: ["netuid", "uid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "uid", "point_count", "points"],
+      properties: {
+        schema_version: { type: "integer" },
+        netuid: { type: "integer" },
+        uid: { type: "integer" },
+        window: NULLABLE_STRING,
+        point_count: { type: "integer" },
+        points: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -2595,6 +3006,50 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
   get_subnet_lease_history: {
     input: GetSubnetLeaseHistoryInputSchema,
     output: GetSubnetLeaseHistoryOutputSchema,
+  },
+  get_global_incidents: {
+    input: GetGlobalIncidentsInputSchema,
+    output: GetGlobalIncidentsOutputSchema,
+  },
+  list_subnet_validators: {
+    input: ListSubnetValidatorsInputSchema,
+    output: ListSubnetValidatorsOutputSchema,
+  },
+  list_global_validators: {
+    input: ListGlobalValidatorsInputSchema,
+    output: ListGlobalValidatorsOutputSchema,
+  },
+  get_validator_detail: {
+    input: GetValidatorDetailInputSchema,
+    output: GetValidatorDetailOutputSchema,
+  },
+  compare_validators: {
+    input: CompareValidatorsInputSchema,
+    output: CompareValidatorsOutputSchema,
+  },
+  get_webhook_subscription: {
+    input: GetWebhookSubscriptionInputSchema,
+    output: GetWebhookSubscriptionOutputSchema,
+  },
+  get_alert_trigger: {
+    input: GetAlertTriggerInputSchema,
+    output: GetAlertTriggerOutputSchema,
+  },
+  get_validator_nominators: {
+    input: GetValidatorNominatorsInputSchema,
+    output: GetValidatorNominatorsOutputSchema,
+  },
+  get_validator_history: {
+    input: GetValidatorHistoryInputSchema,
+    output: GetValidatorHistoryOutputSchema,
+  },
+  get_neuron: {
+    input: GetNeuronInputSchema,
+    output: GetNeuronOutputSchema,
+  },
+  get_neuron_history: {
+    input: GetNeuronHistoryInputSchema,
+    output: GetNeuronHistoryOutputSchema,
   },
 };
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -369,10 +369,7 @@ import {
   LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
   loadEndpointIncidentsList,
 } from "./endpoint-incidents-mcp.ts";
-import {
-  applyGlobalIncidentsListQuery,
-  GLOBAL_INCIDENTS_SORT_FIELDS,
-} from "./global-incidents-mcp.ts";
+import { applyGlobalIncidentsListQuery } from "./global-incidents-mcp.ts";
 import {
   LIST_PROVIDER_ENDPOINTS_INSTRUCTIONS,
   LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
@@ -514,6 +511,38 @@ import {
   GetSubnetLeaseHistoryInputSchema,
   GetSubnetLeaseHistoryOutputSchema,
 } from "../schemas-src/mcp-tools/get-subnet-lease.ts";
+import {
+  GetGlobalIncidentsInputSchema,
+  GetGlobalIncidentsOutputSchema,
+} from "../schemas-src/mcp-tools/get-global-incidents.ts";
+import {
+  ListSubnetValidatorsInputSchema,
+  ListSubnetValidatorsOutputSchema,
+  ListGlobalValidatorsInputSchema,
+  ListGlobalValidatorsOutputSchema,
+  GetValidatorDetailInputSchema,
+  GetValidatorDetailOutputSchema,
+  CompareValidatorsInputSchema,
+  CompareValidatorsOutputSchema,
+  GetValidatorNominatorsInputSchema,
+  GetValidatorNominatorsOutputSchema,
+  GetValidatorHistoryInputSchema,
+  GetValidatorHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/validators.ts";
+import {
+  GetWebhookSubscriptionInputSchema,
+  GetWebhookSubscriptionOutputSchema,
+} from "../schemas-src/mcp-tools/get-webhook-subscription.ts";
+import {
+  GetAlertTriggerInputSchema,
+  GetAlertTriggerOutputSchema,
+} from "../schemas-src/mcp-tools/get-alert-trigger.ts";
+import {
+  GetNeuronInputSchema,
+  GetNeuronOutputSchema,
+  GetNeuronHistoryInputSchema,
+  GetNeuronHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/neurons.ts";
 import {
   buildChainConcentration,
   buildConcentration,
@@ -5090,44 +5119,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "probe failures grouped into downtime incidents over the requested window " +
       "(7d or 30d). Filter by netuid, sort with sort + order, and page with " +
       "limit (1-100) / cursor. Mirrors GET /api/v1/incidents.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Incident lookback window (default 7d).",
-        },
-        netuid: {
-          type: "integer",
-          description: "Filter to one subnet netuid.",
-          minimum: 0,
-        },
-        sort: {
-          type: "string",
-          enum: GLOBAL_INCIDENTS_SORT_FIELDS,
-          description: "Field to sort by before paging.",
-        },
-        order: {
-          type: "string",
-          enum: ["asc", "desc"],
-          description: "Sort direction for sort (default asc).",
-        },
-        limit: {
-          type: "integer",
-          description: "Max rows to return (1-100). Enables pagination.",
-          minimum: 1,
-          maximum: 100,
-        },
-        cursor: {
-          type: "integer",
-          description: "Pagination cursor from a prior response's next_cursor.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetGlobalIncidentsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetGlobalIncidentsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
@@ -5201,28 +5199,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "target, delegate to, or weight against. Optionally cap the list with " +
       "limit (keeps the highest-stake rows, since the list is already " +
       "stake-ranked) or drop small-stake rows with min_stake_tao.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        limit: {
-          type: "integer",
-          description:
-            "Max validators to return, keeping the highest-stake rows. Omit " +
-            "for the full list.",
-          minimum: 1,
-        },
-        min_stake_tao: {
-          type: "number",
-          description:
-            "Only validators whose stake is >= this many TAO. Omit for no floor.",
-          minimum: 0,
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListSubnetValidatorsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof ListSubnetValidatorsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const limit = optionalPositiveInt(args, "limit");
       const minStakeTao = optionalNonNegativeNumber(args, "min_stake_tao");
@@ -5266,25 +5249,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "or stake_dominance; limit caps the list (default 20, max 100). Use it to " +
       "find operators spanning many subnets or dominating network stake. Mirrors " +
       "GET /api/v1/validators.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        sort: {
-          type: "string",
-          enum: GLOBAL_VALIDATOR_SORTS,
-          description:
-            "Ranking key (default subnet_count). See tool description for options.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max validators to return (1-100, default 20).",
-          minimum: 1,
-          maximum: GLOBAL_VALIDATOR_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListGlobalValidatorsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof ListGlobalValidatorsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const sort =
         optionalEnum(args, "sort", GLOBAL_VALIDATOR_SORTS) ??
         DEFAULT_GLOBAL_VALIDATOR_SORT;
@@ -5312,19 +5283,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "The single-entity drill-in of list_global_validators. Returns a zeroed " +
       "aggregate with an empty subnets list for a cold/absent hotkey, never an " +
       "error. Mirrors GET /api/v1/validators/{hotkey}.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        hotkey: {
-          type: "string",
-          description: "Validator hotkey (SS58 address).",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["hotkey"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetValidatorDetailInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetValidatorDetailInputSchema>,
+      ctx: McpCtx,
+    ) {
       const hotkey = requireHotkey(args);
       return (
         (await tryPostgresTier(
@@ -5351,30 +5316,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Strictly READ-ONLY and decision-support only: it builds no transaction, " +
       "produces no signable/extrinsic artifact, and never touches a wallet or " +
       "key -- the validator equivalent of compare_subnets.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        hotkeys: {
-          type: "array",
-          items: { type: "string", pattern: SS58_PATTERN_SOURCE },
-          minItems: 1,
-          maxItems: COMPARE_VALIDATORS_MAX,
-          description:
-            "Validator hotkeys (SS58 addresses) to compare, in display order.",
-        },
-        netuid: {
-          type: "integer",
-          minimum: 0,
-          description:
-            "Optional subnet context -- when set, each validator also carries " +
-            "its membership row in that subnet (subnet_context), or null when " +
-            "it holds no validator permit there.",
-        },
-      },
-      required: ["hotkeys"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(CompareValidatorsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof CompareValidatorsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const hotkeys = parseCompareHotkeyList(args?.hotkeys);
       if (!hotkeys) {
         throw toolError(
@@ -5413,19 +5361,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "enumerate subscriptions, only look one up by an id you already hold " +
       "(the same id returned when it was created). Mirrors GET " +
       "/api/v1/webhooks/subscriptions/{id}.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-          description:
-            "Subscription id (UUID v4), returned when the subscription was created.",
-        },
-      },
-      required: ["id"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetWebhookSubscriptionInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetWebhookSubscriptionInputSchema>,
+      ctx: McpCtx,
+    ) {
       const id = requireString(args, "id");
       if (!isValidSubscriptionId(id)) {
         throw toolError(
@@ -5467,20 +5409,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "/api/v1/alerts/triggers/{id}'s own auth requirement exactly (the " +
       "same 404 is returned for both a wrong token and a nonexistent id, " +
       "so this can't be used to enumerate other callers' triggers).",
-    inputSchema: {
-      type: "object",
-      properties: {
-        id: { type: "string", description: "Alert trigger id." },
-        owner_token: {
-          type: "string",
-          description:
-            "The owner token returned when this trigger was created.",
-        },
-      },
-      required: ["id", "owner_token"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAlertTriggerInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAlertTriggerInputSchema>,
+      ctx: McpCtx,
+    ) {
       const id = requireString(args, "id");
       const ownerToken = requireString(args, "owner_token");
       if (!ctx.env.DATA_API) {
@@ -5523,45 +5458,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "operates in, over a window (7d, 30d, default 90d), ranked by net_staked " +
       "(default), gross_staked, or last_activity. Optional coldkey narrows to " +
       "one nominator's own flow. Mirrors GET /api/v1/validators/{hotkey}/nominators.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        hotkey: {
-          type: "string",
-          description: "Validator hotkey (SS58 address).",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: Object.keys(NOMINATOR_WINDOWS),
-          description: "History window (default 90d).",
-        },
-        sort: {
-          type: "string",
-          enum: NOMINATOR_SORTS,
-          description: "Ranking key (default net_staked).",
-        },
-        limit: {
-          type: "integer",
-          description: "Max nominators to return (1-100, default 20).",
-          minimum: 1,
-          maximum: NOMINATOR_LIMIT_MAX,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset (default 0).",
-          minimum: 0,
-        },
-        coldkey: {
-          type: "string",
-          description: "Narrow to one nominator's own flow (SS58 address).",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["hotkey"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetValidatorNominatorsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetValidatorNominatorsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const hotkey = requireHotkey(args);
       const window =
         optionalEnum(args, "window", Object.keys(NOMINATOR_WINDOWS)) ??
@@ -5610,24 +5513,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "per day, summed across every subnet it validates in, plus a rewards-per-" +
       "1000-TAO rate. Choose the window (7d, 30d, 90d, 1y, all; default 30d). " +
       "Mirrors GET /api/v1/validators/{hotkey}/history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        hotkey: {
-          type: "string",
-          description: "Validator hotkey (SS58 address).",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ["7d", "30d", "90d", "1y", "all"],
-          description: "History window (default 30d).",
-        },
-      },
-      required: ["hotkey"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetValidatorHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetValidatorHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const hotkey = requireHotkey(args);
       const { label } = requireHistoryWindow(args);
       return (
@@ -5649,20 +5541,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "rank, trust, consensus, incentive, dividends, emission, validator " +
       "permit, immunity, and axon. Returns neuron: null when that UID is not " +
       "in the latest snapshot.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        uid: {
-          type: "integer",
-          description: "The neuron UID within the subnet.",
-          minimum: 0,
-        },
-      },
-      required: ["netuid", "uid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetNeuronInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetNeuronInputSchema>, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       // uid is validated for REST-parity but, like the D1 filter it used to
       // bound, has nothing left to look up now that neurons is retired
@@ -5734,25 +5616,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "first. Choose the window (7d, 30d, 90d, 1y, all; default 30d). Use it to " +
       "track how one miner or validator has performed over time. Mirrors " +
       "GET /api/v1/subnets/{netuid}/neurons/{uid}/history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        uid: {
-          type: "integer",
-          description: "The neuron UID within the subnet.",
-          minimum: 0,
-        },
-        window: {
-          type: "string",
-          enum: ["7d", "30d", "90d", "1y", "all"],
-          description: "History window (default 30d).",
-        },
-      },
-      required: ["netuid", "uid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetNeuronHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetNeuronHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const uid = requireNonNegativeInt(args, "uid");
       return loadNeuronHistory(ctx, netuid, uid, requireHistoryWindow(args));
@@ -11436,28 +11306,6 @@ const ACCOUNT_EVENT_ITEM = {
   observed_at: NULLABLE_STRING,
   extrinsic_index: NULLABLE_INT,
 };
-const GLOBAL_VALIDATOR_SUBNET_ITEM = {
-  netuid: NULLABLE_INT,
-  uid: NULLABLE_INT,
-  stake_tao: ANY,
-  emission_tao: ANY,
-  validator_trust: { type: ["number", "null"] },
-};
-const GLOBAL_VALIDATOR_ITEM = {
-  hotkey: NULLABLE_STRING,
-  coldkey: NULLABLE_STRING,
-  coldkey_count: { type: "integer" },
-  subnet_count: { type: "integer" },
-  uid_count: { type: "integer" },
-  total_stake_tao: ANY,
-  total_emission_tao: ANY,
-  avg_validator_trust: { type: ["number", "null"] },
-  max_validator_trust: { type: ["number", "null"] },
-  latest_captured_at: NULLABLE_STRING,
-  latest_block_number: NULLABLE_INT,
-  stake_dominance: { type: ["number", "null"] },
-  subnets: objectItems(GLOBAL_VALIDATOR_SUBNET_ITEM),
-};
 const CHAIN_TRANSFER_PARTY_ITEM = {
   type: "object",
   additionalProperties: false,
@@ -12572,194 +12420,39 @@ const TOOL_OUTPUT_SCHEMAS = {
   compare_subnets: z.toJSONSchema(CompareSubnetsOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_global_incidents: {
-    type: "object",
-    additionalProperties: true,
-    required: ["summary", "surfaces"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      source: NULLABLE_STRING,
-      summary: { type: "object" },
-      surfaces: { type: "array", items: { type: "object" } },
-      total: { type: "integer" },
-      returned: { type: "integer" },
-      limit: { type: "integer" },
-      cursor: { type: "integer" },
-      next_cursor: NULLABLE_INT,
-      sort: NULLABLE_STRING,
-      order: NULLABLE_STRING,
-    },
-  },
+  get_global_incidents: z.toJSONSchema(GetGlobalIncidentsOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_subnet_metagraph: z.toJSONSchema(GetSubnetMetagraphOutputSchema, {
     target: "draft-2020-12",
   }),
-  list_subnet_validators: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "validator_count", "validators"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      validator_count: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      block_number: NULLABLE_INT,
-      validators: { type: "array", items: { type: "object" } },
-    },
-  },
-  list_global_validators: {
-    type: "object",
-    additionalProperties: true,
-    required: ["sort", "limit", "validator_count", "validators"],
-    properties: {
-      schema_version: { type: "integer" },
-      sort: { type: "string", enum: GLOBAL_VALIDATOR_SORTS },
-      limit: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      block_number: NULLABLE_INT,
-      validator_count: { type: "integer" },
-      validators: objectItems(GLOBAL_VALIDATOR_ITEM),
-    },
-  },
-  get_validator_detail: {
-    type: "object",
-    additionalProperties: true,
-    required: ["hotkey", "subnet_count", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      hotkey: { type: "string" },
-      coldkey: NULLABLE_STRING,
-      coldkey_count: { type: "integer" },
-      subnet_count: { type: "integer" },
-      take: { type: ["number", "null"] },
-      total_stake_tao: ANY,
-      total_emission_tao: ANY,
-      avg_validator_trust: { type: ["number", "null"] },
-      max_validator_trust: { type: ["number", "null"] },
-      captured_at: NULLABLE_STRING,
-      block_number: NULLABLE_INT,
-      subnets: { type: "array", items: { type: "object" } },
-    },
-  },
-  compare_validators: {
-    type: "object",
-    additionalProperties: true,
-    required: ["validator_count", "validators"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: NULLABLE_INT,
-      validator_count: { type: "integer" },
-      validators: { type: "array", items: { type: "object" } },
-    },
-  },
-  get_webhook_subscription: {
-    type: "object",
-    additionalProperties: true,
-    required: ["id", "url", "active"],
-    properties: {
-      id: { type: "string" },
-      url: { type: "string" },
-      filters: { type: "object" },
-      created_at: NULLABLE_STRING,
-      active: { type: "boolean" },
-      delivery: {
-        type: "object",
-        required: ["status", "pending", "dead_letter"],
-        properties: {
-          status: { type: "string", enum: ["ok", "retrying", "dead_letter"] },
-          pending: { type: "integer" },
-          dead_letter: { type: "integer" },
-          last_failure: {
-            type: ["object", "null"],
-            properties: {
-              event_id: { type: "string" },
-              attempts: { type: "integer" },
-              reason: NULLABLE_STRING,
-              status_code: NULLABLE_INT,
-              state: { type: "string" },
-              last_attempt_at: NULLABLE_STRING,
-              next_attempt_at: NULLABLE_STRING,
-            },
-          },
-        },
-      },
-    },
-  },
-  get_alert_trigger: {
-    type: "object",
-    additionalProperties: true,
-    required: ["id", "active"],
-    properties: {
-      id: { type: "string" },
-      name: NULLABLE_STRING,
-      table_filter: NULLABLE_STRING,
-      netuid: NULLABLE_INT,
-      event_kind: NULLABLE_STRING,
-      account: NULLABLE_STRING,
-      min_amount_tao: { type: ["number", "null"] },
-      channel: { type: "string" },
-      destination: { type: "string" },
-      active: { type: "boolean" },
-      created_at: NULLABLE_STRING,
-      updated_at: NULLABLE_STRING,
-      last_matched_at: NULLABLE_STRING,
-      match_count: { type: "integer" },
-    },
-  },
-  get_validator_nominators: {
-    type: "object",
-    additionalProperties: true,
-    required: ["hotkey", "nominator_count", "nominators"],
-    properties: {
-      schema_version: { type: "integer" },
-      hotkey: { type: "string" },
-      window: NULLABLE_STRING,
-      sort: { type: "string", enum: NOMINATOR_SORTS },
-      limit: { type: "integer" },
-      offset: { type: "integer" },
-      nominator_count: { type: "integer" },
-      nominators: objectItems({
-        coldkey: { type: "string" },
-        staked_tao: ANY,
-        unstaked_tao: ANY,
-        net_staked_tao: ANY,
-        gross_staked_tao: ANY,
-        event_count: { type: "integer" },
-        last_observed_at: NULLABLE_STRING,
-      }),
-    },
-  },
-  get_validator_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["hotkey", "point_count", "points"],
-    properties: {
-      schema_version: { type: "integer" },
-      hotkey: { type: "string" },
-      window: NULLABLE_STRING,
-      point_count: { type: "integer" },
-      points: objectItems({
-        snapshot_date: NULLABLE_STRING,
-        subnet_count: NULLABLE_INT,
-        total_stake_tao: ANY,
-        total_emission_tao: ANY,
-        rewards_per_1000_tao: { type: ["number", "null"] },
-      }),
-    },
-  },
-  get_neuron: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "neuron"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      block_number: NULLABLE_INT,
-      neuron: { type: ["object", "null"] },
-    },
-  },
+  list_subnet_validators: z.toJSONSchema(ListSubnetValidatorsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  list_global_validators: z.toJSONSchema(ListGlobalValidatorsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_validator_detail: z.toJSONSchema(GetValidatorDetailOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  compare_validators: z.toJSONSchema(CompareValidatorsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_webhook_subscription: z.toJSONSchema(GetWebhookSubscriptionOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_alert_trigger: z.toJSONSchema(GetAlertTriggerOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_validator_nominators: z.toJSONSchema(GetValidatorNominatorsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_validator_history: z.toJSONSchema(GetValidatorHistoryOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_neuron: z.toJSONSchema(GetNeuronOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_subnet_history: z.toJSONSchema(GetSubnetHistoryOutputSchema, {
     target: "draft-2020-12",
   }),
@@ -12799,19 +12492,9 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_subnet_lease_history: z.toJSONSchema(GetSubnetLeaseHistoryOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_neuron_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "uid", "point_count", "points"],
-    properties: {
-      schema_version: { type: "integer" },
-      netuid: { type: "integer" },
-      uid: { type: "integer" },
-      window: NULLABLE_STRING,
-      point_count: { type: "integer" },
-      points: { type: "array", items: { type: "object" } },
-    },
-  },
+  get_neuron_history: z.toJSONSchema(GetNeuronHistoryOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_subnet_events: z.toJSONSchema(GetSubnetEventsOutputSchema, {
     target: "draft-2020-12",
   }),


### PR DESCRIPTION
## Summary

Batch 4 of types-epic E (#7863, tracked as #8068): converts 11 more MCP tool input/output schemas from hand-written JSON Schema literals to Zod-generated (`z.toJSONSchema(...)`), covering the validator/neuron/incidents/webhooks/alerts surface: `get_global_incidents`, `list_subnet_validators`, `list_global_validators`, `get_validator_detail`, `compare_validators`, `get_webhook_subscription`, `get_alert_trigger`, `get_validator_nominators`, `get_validator_history`, `get_neuron`, `get_neuron_history`.

Closes #8068.

## Diff-audit results (`scripts/diff-mcp-tool-schemas.ts`)

22/22 schema checks PASS for this batch (0 findings). Combined with all prior batches: 141/142 PASS; the 1 remaining DIFF (`get_subnet_identity_history.output`) is the pre-existing, already-documented finding from #8067 — unrelated to this batch.

None of this batch's 11 tools mirror an existing `schemas-src/routes/` REST schema (validators/neurons/incidents/webhooks/alerts aren't covered by any REST batch yet), so all were modeled fresh, matching each hand-written literal field-for-field.

## Verification

- `npx tsc --noEmit -p .` — clean
- `npx eslint` (touched files) — clean
- `npx prettier --check` (touched files) — clean
- `npx tsx scripts/diff-mcp-tool-schemas.ts` — 141/142 PASS, 1 pre-existing documented DIFF (unrelated to this batch)
- `npx tsx scripts/validate-mcp.ts` — 204 tools, full lifecycle/subscribe round trips pass
- Full test suite: 490/490 files, 11853/11853 tests passing

## Test plan

- [x] tsc clean
- [x] eslint/prettier clean
- [x] Diff-audit run, 0 findings for this batch's 11 tools
- [x] `validate-mcp.ts` passes
- [x] Full test suite green