### PR TITLE
feat(mcp): types-epic E — Zod schemas for 15 account-core MCP tools (#8069)

### DIFF
--- a/schemas-src/mcp-tools/account-balance.ts
+++ b/schemas-src/mcp-tools/account-balance.ts
@@ -1,0 +1,29 @@
+// MCP tool `get_account_balance` (types-epic E batch 6, #8069). Mirrors
+// GET /api/v1/accounts/{ss58}/balance, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, matching the hand-written literal it replaces
+// field-for-field.
+import { z } from "zod";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountBalanceInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountBalanceInput = z.infer<
+  typeof GetAccountBalanceInputSchema
+>;
+
+export const GetAccountBalanceOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    balance_tao: z.number().nullable(),
+    queried_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GetAccountBalanceOutput = z.infer<
+  typeof GetAccountBalanceOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-delegation.ts
+++ b/schemas-src/mcp-tools/account-delegation.ts
@@ -1,0 +1,82 @@
+// MCP tools `get_account_children`, `get_account_parents` (types-epic E
+// batch 6, #8069). Each mirrors a GET /api/v1/accounts/{ss58}/{children,
+// parents} route that is not one of schemas-src/routes/'s covered pilot
+// routes -- no existing Zod schema to reuse. Modeled fresh, matching each
+// hand-written literal field-for-field, including its own item-level
+// looseness (neither the hand-written subnets items nor their nested
+// entries items declare a `required` array).
+import { z } from "zod";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountChildrenInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountChildrenInput = z.infer<
+  typeof GetAccountChildrenInputSchema
+>;
+
+const ChildEntrySchema = z
+  .object({
+    child: z.string().nullable().optional(),
+    proportion: z.string().optional(),
+    proportion_fraction: z.number().optional(),
+  })
+  .strict();
+
+const ChildSubnetSchema = z
+  .object({
+    netuid: z.int().optional(),
+    entries: z.array(ChildEntrySchema).optional(),
+  })
+  .strict();
+
+export const GetAccountChildrenOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    account: z.string(),
+    subnets: z.array(ChildSubnetSchema).nullable().optional(),
+    queried_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetAccountChildrenOutput = z.infer<
+  typeof GetAccountChildrenOutputSchema
+>;
+
+export const GetAccountParentsInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountParentsInput = z.infer<
+  typeof GetAccountParentsInputSchema
+>;
+
+const ParentEntrySchema = z
+  .object({
+    parent: z.string().nullable().optional(),
+    proportion: z.string().optional(),
+    proportion_fraction: z.number().optional(),
+  })
+  .strict();
+
+const ParentSubnetSchema = z
+  .object({
+    netuid: z.int().optional(),
+    entries: z.array(ParentEntrySchema).optional(),
+  })
+  .strict();
+
+export const GetAccountParentsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    account: z.string(),
+    subnets: z.array(ParentSubnetSchema).nullable().optional(),
+    queried_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetAccountParentsOutput = z.infer<
+  typeof GetAccountParentsOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-identity.ts
+++ b/schemas-src/mcp-tools/account-identity.ts
@@ -1,0 +1,86 @@
+// MCP tools `get_account_identity`, `get_account_identity_history`
+// (types-epic E batch 6, #8069). Each mirrors a GET /api/v1/accounts/{ss58}/
+// identity* route that is not one of schemas-src/routes/'s covered pilot
+// routes -- no existing Zod schema to reuse. Modeled fresh, matching each
+// hand-written literal field-for-field.
+import { z } from "zod";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountIdentityInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountIdentityInput = z.infer<
+  typeof GetAccountIdentityInputSchema
+>;
+
+export const GetAccountIdentityOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    account: z.string(),
+    has_identity: z.boolean(),
+    name: z.string().nullable().optional(),
+    url: z.string().nullable().optional(),
+    github: z.string().nullable().optional(),
+    image: z.string().nullable().optional(),
+    discord: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    additional: z.string().nullable().optional(),
+    captured_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetAccountIdentityOutput = z.infer<
+  typeof GetAccountIdentityOutputSchema
+>;
+
+export const GetAccountIdentityHistoryInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetAccountIdentityHistoryInput = z.infer<
+  typeof GetAccountIdentityHistoryInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch) -- except
+// identity_hash, which is a real finding (bucket b), same root cause
+// #8055/#8067 already found and fixed for the subnet-scoped identity
+// history: formatAccountIdentityHistoryEntry() (src/account-identity-
+// history.ts) unconditionally sets `entry.identity_hash = row.identity_hash
+// ?? null`, so the key itself is always present even though the hand-
+// written original never required it. Modeled here as nullable (still
+// required), matching real behavior.
+const AccountIdentityHistoryEntrySchema = z
+  .object({
+    observed_at: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    url: z.string().nullable().optional(),
+    github: z.string().nullable().optional(),
+    image: z.string().nullable().optional(),
+    discord: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    additional: z.string().nullable().optional(),
+    identity_hash: z.string().nullable(),
+  })
+  .passthrough();
+
+export const GetAccountIdentityHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    account: z.string(),
+    entry_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    entries: z.array(AccountIdentityHistoryEntrySchema),
+  })
+  .passthrough();
+export type GetAccountIdentityHistoryOutput = z.infer<
+  typeof GetAccountIdentityHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-portfolio.ts
+++ b/schemas-src/mcp-tools/account-portfolio.ts
@@ -1,0 +1,91 @@
+// MCP tools `get_account_portfolio`, `get_account_positions`,
+// `get_account_snapshot` (types-epic E batch 6, #8069). Each mirrors a
+// GET /api/v1/accounts/{ss58}/{portfolio,positions} route (get_account_snapshot
+// has no REST equivalent -- it fans out to five other tools' own live loaders
+// in one call), none of which are covered by schemas-src/routes/ -- no
+// existing Zod schema to reuse. get_account_snapshot's balance/portfolio/
+// subnets/positions/recent_events fields are deliberately bare open objects,
+// NOT the sibling tools' own precise output schemas from this same batch --
+// the hand-written original never nested their real shapes either (bare
+// {type:"object"}), so reusing them here would be a real tightening the
+// issue's wire-compatibility constraint doesn't require.
+import { z } from "zod";
+import { OpenObjectArraySchema, OpenObjectSchema } from "./shared.ts";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountPortfolioInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountPortfolioInput = z.infer<
+  typeof GetAccountPortfolioInputSchema
+>;
+
+export const GetAccountPortfolioOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    captured_at: z.string().nullable().optional(),
+    subnet_count: z.int().optional(),
+    position_count: z.int(),
+    validator_count: z.int().optional(),
+    miner_count: z.int().optional(),
+    total_stake_tao: z.number().optional(),
+    total_emission_tao: z.number().optional(),
+    overall_yield: z.number().nullable().optional(),
+    stake_concentration: OpenObjectSchema.nullable().optional(),
+    positions: OpenObjectArraySchema,
+  })
+  .passthrough();
+export type GetAccountPortfolioOutput = z.infer<
+  typeof GetAccountPortfolioOutputSchema
+>;
+
+export const GetAccountPositionsInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountPositionsInput = z.infer<
+  typeof GetAccountPositionsInputSchema
+>;
+
+export const GetAccountPositionsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    captured_at: z.string().nullable().optional(),
+    position_count: z.int(),
+    total_stake_tao: z.number(),
+    positions: OpenObjectArraySchema,
+  })
+  .passthrough();
+export type GetAccountPositionsOutput = z.infer<
+  typeof GetAccountPositionsOutputSchema
+>;
+
+export const GetAccountSnapshotInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    recent_events_limit: z.int().min(1).max(1000).optional(),
+  })
+  .strict();
+export type GetAccountSnapshotInput = z.infer<
+  typeof GetAccountSnapshotInputSchema
+>;
+
+export const GetAccountSnapshotOutputSchema = z
+  .object({
+    ss58: z.string(),
+    balance: OpenObjectSchema,
+    portfolio: OpenObjectSchema,
+    subnets: OpenObjectSchema,
+    positions: OpenObjectSchema,
+    recent_events: OpenObjectSchema,
+  })
+  .passthrough();
+export type GetAccountSnapshotOutput = z.infer<
+  typeof GetAccountSnapshotOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-position-history.ts
+++ b/schemas-src/mcp-tools/account-position-history.ts
@@ -1,0 +1,34 @@
+// MCP tool `get_account_position_history` (types-epic E batch 6, #8069).
+// Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history, which is
+// not one of schemas-src/routes/'s covered pilot routes -- no existing Zod
+// schema to reuse. Modeled fresh, matching the hand-written literal it
+// replaces field-for-field.
+import { z } from "zod";
+import { OpenObjectArraySchema } from "./shared.ts";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountPositionHistoryInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    netuid: z.int().min(0),
+    window: z.enum(["7d", "30d", "90d", "1y", "all"]).optional(),
+  })
+  .strict();
+export type GetAccountPositionHistoryInput = z.infer<
+  typeof GetAccountPositionHistoryInputSchema
+>;
+
+export const GetAccountPositionHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    netuid: z.int(),
+    window: z.string().nullable().optional(),
+    point_count: z.int(),
+    points: OpenObjectArraySchema,
+  })
+  .passthrough();
+export type GetAccountPositionHistoryOutput = z.infer<
+  typeof GetAccountPositionHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-root-claim.ts
+++ b/schemas-src/mcp-tools/account-root-claim.ts
@@ -1,0 +1,53 @@
+// MCP tool `get_account_root_claim` (types-epic E batch 6, #8069). Mirrors
+// GET /api/v1/accounts/{ss58}/root-claim, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, matching the hand-written literal it replaces
+// field-for-field.
+import { z } from "zod";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountRootClaimInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountRootClaimInput = z.infer<
+  typeof GetAccountRootClaimInputSchema
+>;
+
+const RootClaimTypeSchema = z
+  .object({
+    kind: z.string(),
+    subnets: z.array(z.int()).optional(),
+  })
+  .strict();
+
+const RootClaimEntrySchema = z
+  .object({
+    netuid: z.int(),
+    claimable_rate: z.number(),
+    claimed: z.string(),
+    threshold: z.number(),
+  })
+  .strict();
+
+const RootClaimHotkeySchema = z
+  .object({
+    hotkey: z.string(),
+    entries: z.array(RootClaimEntrySchema),
+  })
+  .strict();
+
+export const GetAccountRootClaimOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    claim_type: RootClaimTypeSchema.nullable().optional(),
+    hotkeys: z.array(RootClaimHotkeySchema).nullable().optional(),
+    queried_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GetAccountRootClaimOutput = z.infer<
+  typeof GetAccountRootClaimOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-stake-flow.ts
+++ b/schemas-src/mcp-tools/account-stake-flow.ts
@@ -1,0 +1,69 @@
+// MCP tool `get_account_stake_flow` (types-epic E batch 6, #8069). Mirrors
+// GET /api/v1/accounts/{ss58}/stake-flow, backed by the SAME
+// src/stake-flow.ts STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS constants the
+// REST subnet-scoped stake-flow route (schemas-src/routes/
+// subnet-stake-flow.ts, types-epic B batch 2 #8056) uses -- NOT reused as a
+// schema import: that's a per-SUBNET artifact shape (SubnetStakeFlowArtifact,
+// strict/flat), while this tool is per-ACCOUNT with a materially different
+// shape (address-keyed, additionalProperties:true, a nested per-subnet
+// breakdown array) -- the two were never the same contract. Modeled fresh,
+// matching the hand-written literal it replaces field-for-field.
+import { z } from "zod";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+// Symbolic in the hand-written original (src/stake-flow.ts's
+// STAKE_FLOW_WINDOWS/STAKE_FLOW_DIRECTIONS), cross-checked against the
+// actual runtime source at the time of writing.
+const ACCOUNT_STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
+const ACCOUNT_STAKE_FLOW_DIRECTIONS = ["all", "in", "out"] as const;
+
+export const GetAccountStakeFlowInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    window: z.enum(ACCOUNT_STAKE_FLOW_WINDOWS).optional(),
+    direction: z.enum(ACCOUNT_STAKE_FLOW_DIRECTIONS).optional(),
+  })
+  .strict();
+export type GetAccountStakeFlowInput = z.infer<
+  typeof GetAccountStakeFlowInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const AccountStakeFlowSubnetSchema = z
+  .object({
+    netuid: z.int().optional(),
+    staked_tao: z.unknown().optional(),
+    unstaked_tao: z.unknown().optional(),
+    net_flow_tao: z.unknown().optional(),
+    gross_flow_tao: z.unknown().optional(),
+    flow_ratio: z.number().nullable().optional(),
+    direction: z.string().nullable().optional(),
+    stake_events: z.int().optional(),
+    unstake_events: z.int().optional(),
+  })
+  .passthrough();
+
+export const GetAccountStakeFlowOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    address: z.string(),
+    window: z.string().nullable(),
+    total_staked_tao: z.unknown(),
+    total_unstaked_tao: z.unknown(),
+    net_flow_tao: z.unknown(),
+    gross_flow_tao: z.unknown(),
+    flow_ratio: z.number().nullable().optional(),
+    direction: z.string().nullable(),
+    stake_events: z.int(),
+    unstake_events: z.int(),
+    subnet_count: z.int(),
+    concentration: z.number().nullable().optional(),
+    dominant_netuid: z.int().nullable().optional(),
+    subnets: z.array(AccountStakeFlowSubnetSchema),
+  })
+  .passthrough();
+export type GetAccountStakeFlowOutput = z.infer<
+  typeof GetAccountStakeFlowOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-summary.ts
+++ b/schemas-src/mcp-tools/account-summary.ts
@@ -1,0 +1,164 @@
+// MCP tools `get_account`, `get_account_entities`, `get_account_events`,
+// `get_account_subnets` (types-epic E batch 6, #8069). Each mirrors a
+// GET /api/v1/accounts/{ss58}* route that is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. AccountEventItem/
+// AccountRegistrationItem are deliberately NOT the same as any REST
+// schemas-src/routes/ AccountEvent-style schema (none exist yet for this
+// domain): modeled fresh, matching each hand-written literal (and the
+// shared ACCOUNT_EVENT_ITEM/ACCOUNT_REGISTRATION_ITEM object literals
+// src/mcp-server.ts's objectItems() wraps) field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const AccountEventItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    event_index: z.int().nullable().optional(),
+    event_kind: z.string().nullable().optional(),
+    hotkey: z.string().nullable().optional(),
+    coldkey: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    uid: z.int().nullable().optional(),
+    amount_tao: z.unknown().optional(),
+    alpha_amount: z.unknown().optional(),
+    observed_at: z.string().nullable().optional(),
+    extrinsic_index: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+const AccountRegistrationItemSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    uid: z.int().nullable().optional(),
+    stake_tao: z.unknown().optional(),
+    validator_permit: z.boolean().optional(),
+    active: z.boolean().optional(),
+  })
+  .passthrough();
+
+const AccountLabelItemSchema = z
+  .object({
+    name: z.string().nullable().optional(),
+    category: z.string().nullable().optional(),
+    notes: z.string().nullable().optional(),
+    source_urls: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+export const GetAccountInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountInput = z.infer<typeof GetAccountInputSchema>;
+
+export const GetAccountOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    event_count: z.int(),
+    subnet_count: z.int(),
+    first_block: z.int().nullable().optional(),
+    last_block: z.int().nullable().optional(),
+    first_seen_at: z.string().nullable().optional(),
+    last_seen_at: z.string().nullable().optional(),
+    event_kinds: z.array(
+      z
+        .object({
+          kind: z.string().optional(),
+          count: z.int().optional(),
+        })
+        .passthrough(),
+    ),
+    registrations: z.array(AccountRegistrationItemSchema),
+    recent_events: z.array(AccountEventItemSchema),
+    activity: OpenObjectSchema.optional(),
+    labels: z.array(AccountLabelItemSchema).optional(),
+  })
+  .passthrough();
+export type GetAccountOutput = z.infer<typeof GetAccountOutputSchema>;
+
+export const GetAccountEntitiesInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountEntitiesInput = z.infer<
+  typeof GetAccountEntitiesInputSchema
+>;
+
+export const GetAccountEntitiesOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    labels: z.array(AccountLabelItemSchema),
+    ownership_tie_count: z.int(),
+    ownership_ties: z.array(
+      z
+        .object({
+          netuid: z.int().nullable().optional(),
+          role: z.string().optional(),
+          block_number: z.int().nullable().optional(),
+          observed_at: z.string().nullable().optional(),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+export type GetAccountEntitiesOutput = z.infer<
+  typeof GetAccountEntitiesOutputSchema
+>;
+
+export const GetAccountEventsInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    kind: z.string().optional(),
+    netuid: z.int().min(0).optional(),
+    block_start: z.int().min(0).optional(),
+    block_end: z.int().min(0).optional(),
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetAccountEventsInput = z.infer<typeof GetAccountEventsInputSchema>;
+
+export const GetAccountEventsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    event_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    events: z.array(AccountEventItemSchema),
+  })
+  .passthrough();
+export type GetAccountEventsOutput = z.infer<
+  typeof GetAccountEventsOutputSchema
+>;
+
+export const GetAccountSubnetsInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+  })
+  .strict();
+export type GetAccountSubnetsInput = z.infer<
+  typeof GetAccountSubnetsInputSchema
+>;
+
+export const GetAccountSubnetsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    subnet_count: z.int(),
+    subnets: z.array(AccountRegistrationItemSchema),
+  })
+  .passthrough();
+export type GetAccountSubnetsOutput = z.infer<
+  typeof GetAccountSubnetsOutputSchema
+>;

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -272,6 +272,52 @@ import {
   GetNeuronHistoryInputSchema,
   GetNeuronHistoryOutputSchema,
 } from "../schemas-src/mcp-tools/neurons.ts";
+import {
+  GetAccountInputSchema,
+  GetAccountOutputSchema,
+  GetAccountEntitiesInputSchema,
+  GetAccountEntitiesOutputSchema,
+  GetAccountEventsInputSchema,
+  GetAccountEventsOutputSchema,
+  GetAccountSubnetsInputSchema,
+  GetAccountSubnetsOutputSchema,
+} from "../schemas-src/mcp-tools/account-summary.ts";
+import {
+  GetAccountBalanceInputSchema,
+  GetAccountBalanceOutputSchema,
+} from "../schemas-src/mcp-tools/account-balance.ts";
+import {
+  GetAccountRootClaimInputSchema,
+  GetAccountRootClaimOutputSchema,
+} from "../schemas-src/mcp-tools/account-root-claim.ts";
+import {
+  GetAccountChildrenInputSchema,
+  GetAccountChildrenOutputSchema,
+  GetAccountParentsInputSchema,
+  GetAccountParentsOutputSchema,
+} from "../schemas-src/mcp-tools/account-delegation.ts";
+import {
+  GetAccountPortfolioInputSchema,
+  GetAccountPortfolioOutputSchema,
+  GetAccountPositionsInputSchema,
+  GetAccountPositionsOutputSchema,
+  GetAccountSnapshotInputSchema,
+  GetAccountSnapshotOutputSchema,
+} from "../schemas-src/mcp-tools/account-portfolio.ts";
+import {
+  GetAccountIdentityInputSchema,
+  GetAccountIdentityOutputSchema,
+  GetAccountIdentityHistoryInputSchema,
+  GetAccountIdentityHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/account-identity.ts";
+import {
+  GetAccountPositionHistoryInputSchema,
+  GetAccountPositionHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/account-position-history.ts";
+import {
+  GetAccountStakeFlowInputSchema,
+  GetAccountStakeFlowOutputSchema,
+} from "../schemas-src/mcp-tools/account-stake-flow.ts";
 
 type Row = Record<string, unknown>;
 
@@ -2767,6 +2813,572 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  get_account: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "ss58",
+        "event_count",
+        "subnet_count",
+        "event_kinds",
+        "registrations",
+        "recent_events",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        event_count: { type: "integer" },
+        subnet_count: { type: "integer" },
+        first_block: NULLABLE_INT,
+        last_block: NULLABLE_INT,
+        first_seen_at: NULLABLE_STRING,
+        last_seen_at: NULLABLE_STRING,
+        event_kinds: objectItems({
+          kind: { type: "string" },
+          count: { type: "integer" },
+        }),
+        registrations: objectItems({
+          netuid: NULLABLE_INT,
+          uid: NULLABLE_INT,
+          stake_tao: ANY,
+          validator_permit: { type: "boolean" },
+          active: { type: "boolean" },
+        }),
+        recent_events: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          event_kind: NULLABLE_STRING,
+          hotkey: NULLABLE_STRING,
+          coldkey: NULLABLE_STRING,
+          netuid: NULLABLE_INT,
+          uid: NULLABLE_INT,
+          amount_tao: ANY,
+          alpha_amount: ANY,
+          observed_at: NULLABLE_STRING,
+          extrinsic_index: NULLABLE_INT,
+        }),
+        activity: { type: "object", additionalProperties: true },
+        labels: objectItems({
+          name: NULLABLE_STRING,
+          category: NULLABLE_STRING,
+          notes: NULLABLE_STRING,
+          source_urls: { type: "array", items: { type: "string" } },
+        }),
+      },
+    },
+  },
+  get_account_entities: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "labels", "ownership_tie_count", "ownership_ties"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        labels: objectItems({
+          name: NULLABLE_STRING,
+          category: NULLABLE_STRING,
+          notes: NULLABLE_STRING,
+          source_urls: { type: "array", items: { type: "string" } },
+        }),
+        ownership_tie_count: { type: "integer" },
+        ownership_ties: objectItems({
+          netuid: NULLABLE_INT,
+          role: { type: "string" },
+          block_number: NULLABLE_INT,
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_account_balance: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "balance_tao", "queried_at"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        balance_tao: { type: ["number", "null"] },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_account_root_claim: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "queried_at"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        claim_type: {
+          anyOf: [
+            {
+              type: "object",
+              additionalProperties: false,
+              required: ["kind"],
+              properties: {
+                kind: { type: "string" },
+                subnets: {
+                  type: "array",
+                  items: { type: "integer" },
+                },
+              },
+            },
+            { type: "null" },
+          ],
+        },
+        hotkeys: {
+          type: ["array", "null"],
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["hotkey", "entries"],
+            properties: {
+              hotkey: { type: "string" },
+              entries: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: [
+                    "netuid",
+                    "claimable_rate",
+                    "claimed",
+                    "threshold",
+                  ],
+                  properties: {
+                    netuid: { type: "integer" },
+                    claimable_rate: { type: "number" },
+                    claimed: { type: "string" },
+                    threshold: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_account_children: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["account"],
+      properties: {
+        schema_version: { type: "integer" },
+        account: { type: "string" },
+        subnets: {
+          type: ["array", "null"],
+          items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              netuid: { type: "integer" },
+              entries: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  properties: {
+                    child: { type: ["string", "null"] },
+                    proportion: { type: "string" },
+                    proportion_fraction: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_account_parents: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["account"],
+      properties: {
+        schema_version: { type: "integer" },
+        account: { type: "string" },
+        subnets: {
+          type: ["array", "null"],
+          items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              netuid: { type: "integer" },
+              entries: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  properties: {
+                    parent: { type: ["string", "null"] },
+                    proportion: { type: "string" },
+                    proportion_fraction: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_account_events: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        kind: { type: "string" },
+        netuid: { type: "integer", minimum: 0 },
+        block_start: { type: "integer", minimum: 0 },
+        block_end: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "event_count", "events"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        event_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        events: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          event_kind: NULLABLE_STRING,
+          hotkey: NULLABLE_STRING,
+          coldkey: NULLABLE_STRING,
+          netuid: NULLABLE_INT,
+          uid: NULLABLE_INT,
+          amount_tao: ANY,
+          alpha_amount: ANY,
+          observed_at: NULLABLE_STRING,
+          extrinsic_index: NULLABLE_INT,
+        }),
+      },
+    },
+  },
+  get_account_subnets: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "subnet_count", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        subnet_count: { type: "integer" },
+        subnets: objectItems({
+          netuid: NULLABLE_INT,
+          uid: NULLABLE_INT,
+          stake_tao: ANY,
+          validator_permit: { type: "boolean" },
+          active: { type: "boolean" },
+        }),
+      },
+    },
+  },
+  get_account_portfolio: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "position_count", "positions"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        captured_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        position_count: { type: "integer" },
+        validator_count: { type: "integer" },
+        miner_count: { type: "integer" },
+        total_stake_tao: { type: "number" },
+        total_emission_tao: { type: "number" },
+        overall_yield: { type: ["number", "null"] },
+        stake_concentration: { type: ["object", "null"] },
+        positions: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  get_account_positions: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "position_count", "total_stake_tao", "positions"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        captured_at: NULLABLE_STRING,
+        position_count: { type: "integer" },
+        total_stake_tao: { type: "number" },
+        positions: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  get_account_snapshot: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        recent_events_limit: { type: "integer", minimum: 1, maximum: 1000 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "ss58",
+        "balance",
+        "portfolio",
+        "subnets",
+        "positions",
+        "recent_events",
+      ],
+      properties: {
+        ss58: { type: "string" },
+        balance: { type: "object" },
+        portfolio: { type: "object" },
+        subnets: { type: "object" },
+        positions: { type: "object" },
+        recent_events: { type: "object" },
+      },
+    },
+  },
+  get_account_identity: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["account", "has_identity"],
+      properties: {
+        schema_version: { type: "integer" },
+        account: { type: "string" },
+        has_identity: { type: "boolean" },
+        name: NULLABLE_STRING,
+        url: NULLABLE_STRING,
+        github: NULLABLE_STRING,
+        image: NULLABLE_STRING,
+        discord: NULLABLE_STRING,
+        description: NULLABLE_STRING,
+        additional: NULLABLE_STRING,
+        captured_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_account_identity_history: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["account", "entry_count", "entries"],
+      properties: {
+        schema_version: { type: "integer" },
+        account: { type: "string" },
+        entry_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        entries: objectItems({
+          observed_at: NULLABLE_STRING,
+          name: NULLABLE_STRING,
+          url: NULLABLE_STRING,
+          github: NULLABLE_STRING,
+          image: NULLABLE_STRING,
+          discord: NULLABLE_STRING,
+          description: NULLABLE_STRING,
+          additional: NULLABLE_STRING,
+          identity_hash: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_account_position_history: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        netuid: { type: "integer", minimum: 0 },
+        window: { type: "string", enum: HISTORY_WINDOWS_5 },
+      },
+      required: ["ss58", "netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "netuid", "point_count", "points"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        netuid: { type: "integer" },
+        window: NULLABLE_STRING,
+        point_count: { type: "integer" },
+        points: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  get_account_stake_flow: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: ["7d", "30d", "90d"] },
+        direction: { type: "string", enum: ["all", "in", "out"] },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "address",
+        "window",
+        "total_staked_tao",
+        "total_unstaked_tao",
+        "net_flow_tao",
+        "gross_flow_tao",
+        "direction",
+        "stake_events",
+        "unstake_events",
+        "subnet_count",
+        "subnets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        address: { type: "string" },
+        window: NULLABLE_STRING,
+        total_staked_tao: ANY,
+        total_unstaked_tao: ANY,
+        net_flow_tao: ANY,
+        gross_flow_tao: ANY,
+        flow_ratio: { type: ["number", "null"] },
+        direction: NULLABLE_STRING,
+        stake_events: { type: "integer" },
+        unstake_events: { type: "integer" },
+        subnet_count: { type: "integer" },
+        concentration: { type: ["number", "null"] },
+        dominant_netuid: NULLABLE_INT,
+        subnets: objectItems({
+          netuid: { type: "integer" },
+          staked_tao: ANY,
+          unstaked_tao: ANY,
+          net_flow_tao: ANY,
+          gross_flow_tao: ANY,
+          flow_ratio: { type: ["number", "null"] },
+          direction: NULLABLE_STRING,
+          stake_events: { type: "integer" },
+          unstake_events: { type: "integer" },
+        }),
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -3050,6 +3662,66 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
   get_neuron_history: {
     input: GetNeuronHistoryInputSchema,
     output: GetNeuronHistoryOutputSchema,
+  },
+  get_account: {
+    input: GetAccountInputSchema,
+    output: GetAccountOutputSchema,
+  },
+  get_account_entities: {
+    input: GetAccountEntitiesInputSchema,
+    output: GetAccountEntitiesOutputSchema,
+  },
+  get_account_balance: {
+    input: GetAccountBalanceInputSchema,
+    output: GetAccountBalanceOutputSchema,
+  },
+  get_account_root_claim: {
+    input: GetAccountRootClaimInputSchema,
+    output: GetAccountRootClaimOutputSchema,
+  },
+  get_account_children: {
+    input: GetAccountChildrenInputSchema,
+    output: GetAccountChildrenOutputSchema,
+  },
+  get_account_parents: {
+    input: GetAccountParentsInputSchema,
+    output: GetAccountParentsOutputSchema,
+  },
+  get_account_events: {
+    input: GetAccountEventsInputSchema,
+    output: GetAccountEventsOutputSchema,
+  },
+  get_account_subnets: {
+    input: GetAccountSubnetsInputSchema,
+    output: GetAccountSubnetsOutputSchema,
+  },
+  get_account_portfolio: {
+    input: GetAccountPortfolioInputSchema,
+    output: GetAccountPortfolioOutputSchema,
+  },
+  get_account_positions: {
+    input: GetAccountPositionsInputSchema,
+    output: GetAccountPositionsOutputSchema,
+  },
+  get_account_snapshot: {
+    input: GetAccountSnapshotInputSchema,
+    output: GetAccountSnapshotOutputSchema,
+  },
+  get_account_identity: {
+    input: GetAccountIdentityInputSchema,
+    output: GetAccountIdentityOutputSchema,
+  },
+  get_account_identity_history: {
+    input: GetAccountIdentityHistoryInputSchema,
+    output: GetAccountIdentityHistoryOutputSchema,
+  },
+  get_account_position_history: {
+    input: GetAccountPositionHistoryInputSchema,
+    output: GetAccountPositionHistoryOutputSchema,
+  },
+  get_account_stake_flow: {
+    input: GetAccountStakeFlowInputSchema,
+    output: GetAccountStakeFlowOutputSchema,
   },
 };
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -544,6 +544,52 @@ import {
   GetNeuronHistoryOutputSchema,
 } from "../schemas-src/mcp-tools/neurons.ts";
 import {
+  GetAccountInputSchema,
+  GetAccountOutputSchema,
+  GetAccountEntitiesInputSchema,
+  GetAccountEntitiesOutputSchema,
+  GetAccountEventsInputSchema,
+  GetAccountEventsOutputSchema,
+  GetAccountSubnetsInputSchema,
+  GetAccountSubnetsOutputSchema,
+} from "../schemas-src/mcp-tools/account-summary.ts";
+import {
+  GetAccountBalanceInputSchema,
+  GetAccountBalanceOutputSchema,
+} from "../schemas-src/mcp-tools/account-balance.ts";
+import {
+  GetAccountRootClaimInputSchema,
+  GetAccountRootClaimOutputSchema,
+} from "../schemas-src/mcp-tools/account-root-claim.ts";
+import {
+  GetAccountChildrenInputSchema,
+  GetAccountChildrenOutputSchema,
+  GetAccountParentsInputSchema,
+  GetAccountParentsOutputSchema,
+} from "../schemas-src/mcp-tools/account-delegation.ts";
+import {
+  GetAccountPortfolioInputSchema,
+  GetAccountPortfolioOutputSchema,
+  GetAccountPositionsInputSchema,
+  GetAccountPositionsOutputSchema,
+  GetAccountSnapshotInputSchema,
+  GetAccountSnapshotOutputSchema,
+} from "../schemas-src/mcp-tools/account-portfolio.ts";
+import {
+  GetAccountIdentityInputSchema,
+  GetAccountIdentityOutputSchema,
+  GetAccountIdentityHistoryInputSchema,
+  GetAccountIdentityHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/account-identity.ts";
+import {
+  GetAccountPositionHistoryInputSchema,
+  GetAccountPositionHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/account-position-history.ts";
+import {
+  GetAccountStakeFlowInputSchema,
+  GetAccountStakeFlowOutputSchema,
+} from "../schemas-src/mcp-tools/account-stake-flow.ts";
+import {
   buildChainConcentration,
   buildConcentration,
   buildConcentrationHistory,
@@ -6027,20 +6073,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "is this wallet doing across the network'. Computed live from the " +
       "account_events + neurons + extrinsics tiers; a never-seen address returns a " +
       "schema-stable zero summary, not an error.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (hotkey or coldkey), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetAccountInputSchema>, ctx: McpCtx) {
       const ss58 = requireSs58(args);
       const data =
         (await tryPostgresTier(
@@ -6074,19 +6110,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "genesis ownership -- a coldkey that has held a subnet since " +
       "registration and never lost it will not appear in ownership_ties. " +
       "Mirrors GET /api/v1/accounts/{ss58}/entities.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description: "The coldkey's SS58 address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountEntitiesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountEntitiesInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const [entitiesArtifact, ownershipData] = await Promise.all([
         ctx.readArtifact!(ctx.env, ENTITY_LABELS_ARTIFACT),
@@ -6116,20 +6146,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "cache. balance_tao is null on RPC failure (schema-stable, not an error). Use " +
       "it alongside get_account when an agent needs the wallet's current holdings. " +
       "Mirrors GET /api/v1/accounts/{ss58}/balance.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (finney network), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountBalanceInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountBalanceInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       if (!isFinneySs58Address(ss58)) {
         throw toolError(
@@ -6162,20 +6185,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "hotkeys are null on RPC failure (schema-stable, not an error). Read-only " +
       "display only — never submits claim_root or any other extrinsic. Mirrors " +
       "GET /api/v1/accounts/{ss58}/root-claim.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (finney network), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountRootClaimInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountRootClaimInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       if (!isFinneySs58Address(ss58)) {
         throw toolError(
@@ -6209,20 +6225,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "is who it delegates to). subnets is null on an RPC failure, distinct " +
       "from a confirmed empty graph (the common case for most accounts). " +
       "Mirrors GET /api/v1/accounts/{ss58}/children.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (finney network), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountChildrenInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountChildrenInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       if (!isFinneySs58Address(ss58)) {
         throw toolError(
@@ -6254,20 +6263,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "to get_account_children. subnets is null on an RPC failure, distinct " +
       "from a confirmed empty graph. Mirrors GET " +
       "/api/v1/accounts/{ss58}/parents.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (finney network), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountParentsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountParentsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       if (!isFinneySs58Address(ss58)) {
         throw toolError(
@@ -6301,62 +6303,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "block_start/block_end (inclusive). Page with limit (1-1000, default 100) / " +
       "offset, or follow next_cursor for stable keyset pagination. Mirrors " +
       "GET /api/v1/accounts/{ss58}/events.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (hotkey or coldkey), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        kind: {
-          type: "string",
-          description:
-            "Optional event-kind filter, e.g. 'StakeAdded' or 'NeuronRegistered'. " +
-            "Omit for all kinds; unsupported kinds are rejected.",
-        },
-        netuid: {
-          type: "integer",
-          description:
-            "Optional subnet scope: only events tied to this netuid. Omit for " +
-            "events across every subnet.",
-          minimum: 0,
-        },
-        block_start: {
-          type: "integer",
-          description:
-            "Optional inclusive lower block bound; omit for no lower limit.",
-          minimum: 0,
-        },
-        block_end: {
-          type: "integer",
-          description:
-            "Optional inclusive upper block bound; omit for no upper limit.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Max events to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset into the history. Default 0.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor; takes " +
-            "precedence over offset for stable deep pagination.",
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountEventsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountEventsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const kind = optionalString(args, "kind");
       requireKnownEventKind(kind);
@@ -6370,7 +6323,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const cursor = optionalString(args, "cursor");
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = Number.isFinite(args?.offset)
-        ? Math.max(0, Math.floor(args.offset))
+        ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       return (
         (await tryPostgresTier(
@@ -6403,20 +6356,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "subnet — the live cross-subnet footprint of where a wallet mines and " +
       "validates right now. Computed live from the neurons tier; an unregistered or " +
       "never-seen address returns an empty footprint, not an error.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's hotkey SS58 address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountSubnetsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountSubnetsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       return (
         (await tryPostgresTier(
@@ -6437,20 +6383,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "overall return, and how concentrated the wallet's stake is across subnets). " +
       "Richer than get_account_subnets; computed live from the neurons tier. An " +
       "unregistered address returns an empty portfolio, not an error.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's hotkey SS58 address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountPortfolioInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountPortfolioInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       return (
         (await tryPostgresTier(
@@ -6474,20 +6413,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(netuid 0) stake is not covered — root has no alpha pool. An address with " +
       "no delegated positions returns an empty card, not an error. Mirrors " +
       "GET /api/v1/accounts/{ss58}/positions.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's coldkey SS58 address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountPositionsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountPositionsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       return (
         (await tryPostgresTier(
@@ -6513,27 +6445,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "+ get_account_subnets + get_account_positions + get_account_events " +
       "separately -- use this instead when an agent needs a broad picture of one " +
       "wallet rather than drilling into just one facet.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address, base58, 47-48 chars. Hotkey or " +
-            "coldkey -- see the role note above.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        recent_events_limit: {
-          type: "integer",
-          description: "Max events in the recent-events slice. Default 10.",
-          minimum: 1,
-          maximum: 1000,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountSnapshotInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountSnapshotInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const recentEventsLimit = clampLimit(args?.recent_events_limit, 10, 1000);
       // balance is a live RPC call (its own rate limiter + address-network
@@ -6612,19 +6530,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "fields set via set_identity). has_identity is false for the common case " +
       "— most accounts never call set_identity. Mirrors " +
       "GET /api/v1/accounts/{ss58}/identity.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description: "The account's SS58 address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountIdentityInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountIdentityInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       return (
         (await tryPostgresTier(
@@ -6642,35 +6554,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Fetch the append-only diff-tracking timeline for one account's on-chain " +
       "identity, newest first. Page with limit (1-1000, default 100) / offset, " +
       "or follow next_cursor. Mirrors GET /api/v1/accounts/{ss58}/identity-history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description: "The account's SS58 address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        limit: {
-          type: "integer",
-          description: "Max entries to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description: "Deprecated offset fallback when cursor is omitted.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a prior response's next_cursor.",
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountIdentityHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountIdentityHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = optionalNonNegativeInt(args, "offset") ?? 0;
@@ -6697,25 +6587,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "emission, rank, trust, incentive, dividends per snapshot_date, newest " +
       "first. Choose the window (7d, 30d, 90d, 1y, all; default 30d). Mirrors " +
       "GET /api/v1/accounts/{ss58}/subnets/{netuid}/history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description: "The account's SS58 address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        window: {
-          type: "string",
-          enum: ["7d", "30d", "90d", "1y", "all"],
-          description: "History window (default 30d).",
-        },
-      },
-      required: ["ss58", "netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountPositionHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountPositionHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const netuid = requireNetuid(args);
       const { label } = requireHistoryWindow(args);
@@ -6754,30 +6632,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "its flow is focused, and the dominant subnet. ?direction narrows to inflow " +
       "(in) or outflow (out) only; all (default) reports both sides. Mirrors " +
       "GET /api/v1/accounts/{ss58}/stake-flow.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: STAKE_FLOW_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_STAKE_FLOW_WINDOW}).`,
-        },
-        direction: {
-          type: "string",
-          enum: STAKE_FLOW_DIRECTIONS,
-          description: `Flow side to report: in | out | all (default ${DEFAULT_STAKE_FLOW_DIRECTION}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountStakeFlowInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountStakeFlowInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_STAKE_FLOW_WINDOW;
@@ -11284,15 +11145,8 @@ const objectItems = (properties = {}) => ({
   type: "array",
   items: { type: "object", additionalProperties: true, properties },
 });
-// Shared account item shapes: a registration appears in get_account +
-// get_account_subnets, an event in get_account + get_account_events.
-const ACCOUNT_REGISTRATION_ITEM = {
-  netuid: NULLABLE_INT,
-  uid: NULLABLE_INT,
-  stake_tao: ANY,
-  validator_permit: { type: "boolean" },
-  active: { type: "boolean" },
-};
+// Shared account item shape: an event appears in get_block_events,
+// get_extrinsic, and other block/extrinsic-domain tools.
 const ACCOUNT_EVENT_ITEM = {
   block_number: NULLABLE_INT,
   event_index: NULLABLE_INT,
@@ -12498,366 +12352,53 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_subnet_events: z.toJSONSchema(GetSubnetEventsOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_account: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "ss58",
-      "event_count",
-      "subnet_count",
-      "event_kinds",
-      "registrations",
-      "recent_events",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      event_count: { type: "integer" },
-      subnet_count: { type: "integer" },
-      first_block: NULLABLE_INT,
-      last_block: NULLABLE_INT,
-      first_seen_at: NULLABLE_STRING,
-      last_seen_at: NULLABLE_STRING,
-      event_kinds: objectItems({
-        kind: { type: "string" },
-        count: { type: "integer" },
-      }),
-      registrations: objectItems(ACCOUNT_REGISTRATION_ITEM),
-      recent_events: objectItems(ACCOUNT_EVENT_ITEM),
-      activity: { type: "object", additionalProperties: true },
-      labels: objectItems({
-        name: NULLABLE_STRING,
-        category: NULLABLE_STRING,
-        notes: NULLABLE_STRING,
-        source_urls: { type: "array", items: { type: "string" } },
-      }),
-    },
-  },
-  get_account_entities: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "labels", "ownership_tie_count", "ownership_ties"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      labels: objectItems({
-        name: NULLABLE_STRING,
-        category: NULLABLE_STRING,
-        notes: NULLABLE_STRING,
-        source_urls: { type: "array", items: { type: "string" } },
-      }),
-      ownership_tie_count: { type: "integer" },
-      ownership_ties: objectItems({
-        netuid: NULLABLE_INT,
-        role: { type: "string" },
-        block_number: NULLABLE_INT,
-        observed_at: NULLABLE_STRING,
-      }),
-    },
-  },
-  get_account_balance: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "balance_tao", "queried_at"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      balance_tao: { type: ["number", "null"] },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_account_root_claim: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "queried_at"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      claim_type: {
-        anyOf: [
-          {
-            type: "object",
-            additionalProperties: false,
-            required: ["kind"],
-            properties: {
-              kind: { type: "string" },
-              subnets: {
-                type: "array",
-                items: { type: "integer" },
-              },
-            },
-          },
-          { type: "null" },
-        ],
-      },
-      hotkeys: {
-        type: ["array", "null"],
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: ["hotkey", "entries"],
-          properties: {
-            hotkey: { type: "string" },
-            entries: {
-              type: "array",
-              items: {
-                type: "object",
-                additionalProperties: false,
-                required: ["netuid", "claimable_rate", "claimed", "threshold"],
-                properties: {
-                  netuid: { type: "integer" },
-                  claimable_rate: { type: "number" },
-                  claimed: { type: "string" },
-                  threshold: { type: "number" },
-                },
-              },
-            },
-          },
-        },
-      },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_account_children: {
-    type: "object",
-    additionalProperties: true,
-    required: ["account"],
-    properties: {
-      schema_version: { type: "integer" },
-      account: { type: "string" },
-      subnets: {
-        type: ["array", "null"],
-        items: {
-          type: "object",
-          additionalProperties: false,
-          properties: {
-            netuid: { type: "integer" },
-            entries: {
-              type: "array",
-              items: {
-                type: "object",
-                additionalProperties: false,
-                properties: {
-                  child: { type: ["string", "null"] },
-                  proportion: { type: "string" },
-                  proportion_fraction: { type: "number" },
-                },
-              },
-            },
-          },
-        },
-      },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_account_parents: {
-    type: "object",
-    additionalProperties: true,
-    required: ["account"],
-    properties: {
-      schema_version: { type: "integer" },
-      account: { type: "string" },
-      subnets: {
-        type: ["array", "null"],
-        items: {
-          type: "object",
-          additionalProperties: false,
-          properties: {
-            netuid: { type: "integer" },
-            entries: {
-              type: "array",
-              items: {
-                type: "object",
-                additionalProperties: false,
-                properties: {
-                  parent: { type: ["string", "null"] },
-                  proportion: { type: "string" },
-                  proportion_fraction: { type: "number" },
-                },
-              },
-            },
-          },
-        },
-      },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_account_portfolio: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "position_count", "positions"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      captured_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      position_count: { type: "integer" },
-      validator_count: { type: "integer" },
-      miner_count: { type: "integer" },
-      total_stake_tao: { type: "number" },
-      total_emission_tao: { type: "number" },
-      overall_yield: { type: ["number", "null"] },
-      stake_concentration: { type: ["object", "null"] },
-      positions: { type: "array", items: { type: "object" } },
-    },
-  },
-  get_account_positions: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "position_count", "total_stake_tao", "positions"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      captured_at: NULLABLE_STRING,
-      position_count: { type: "integer" },
-      total_stake_tao: { type: "number" },
-      positions: { type: "array", items: { type: "object" } },
-    },
-  },
-  get_account_snapshot: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "ss58",
-      "balance",
-      "portfolio",
-      "subnets",
-      "positions",
-      "recent_events",
-    ],
-    properties: {
-      ss58: { type: "string" },
-      balance: { type: "object" },
-      portfolio: { type: "object" },
-      subnets: { type: "object" },
-      positions: { type: "object" },
-      recent_events: { type: "object" },
-    },
-  },
-  get_account_identity: {
-    type: "object",
-    additionalProperties: true,
-    required: ["account", "has_identity"],
-    properties: {
-      schema_version: { type: "integer" },
-      account: { type: "string" },
-      has_identity: { type: "boolean" },
-      name: NULLABLE_STRING,
-      url: NULLABLE_STRING,
-      github: NULLABLE_STRING,
-      image: NULLABLE_STRING,
-      discord: NULLABLE_STRING,
-      description: NULLABLE_STRING,
-      additional: NULLABLE_STRING,
-      captured_at: NULLABLE_STRING,
-    },
-  },
-  get_account_identity_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["account", "entry_count", "entries"],
-    properties: {
-      schema_version: { type: "integer" },
-      account: { type: "string" },
-      entry_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      entries: objectItems({
-        observed_at: NULLABLE_STRING,
-        name: NULLABLE_STRING,
-        url: NULLABLE_STRING,
-        github: NULLABLE_STRING,
-        image: NULLABLE_STRING,
-        discord: NULLABLE_STRING,
-        description: NULLABLE_STRING,
-        additional: NULLABLE_STRING,
-        identity_hash: NULLABLE_STRING,
-      }),
-    },
-  },
-  get_account_position_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "netuid", "point_count", "points"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      netuid: { type: "integer" },
-      window: NULLABLE_STRING,
-      point_count: { type: "integer" },
-      points: { type: "array", items: { type: "object" } },
-    },
-  },
-  get_account_events: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "event_count", "events"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      event_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      events: objectItems(ACCOUNT_EVENT_ITEM),
-    },
-  },
-  get_account_subnets: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "subnet_count", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      subnet_count: { type: "integer" },
-      subnets: objectItems(ACCOUNT_REGISTRATION_ITEM),
-    },
-  },
-  get_account_stake_flow: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_staked_tao",
-      "total_unstaked_tao",
-      "net_flow_tao",
-      "gross_flow_tao",
-      "direction",
-      "stake_events",
-      "unstake_events",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_staked_tao: ANY,
-      total_unstaked_tao: ANY,
-      net_flow_tao: ANY,
-      gross_flow_tao: ANY,
-      flow_ratio: { type: ["number", "null"] },
-      direction: NULLABLE_STRING,
-      stake_events: { type: "integer" },
-      unstake_events: { type: "integer" },
-      subnet_count: { type: "integer" },
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: objectItems({
-        netuid: { type: "integer" },
-        staked_tao: ANY,
-        unstaked_tao: ANY,
-        net_flow_tao: ANY,
-        gross_flow_tao: ANY,
-        flow_ratio: { type: ["number", "null"] },
-        direction: NULLABLE_STRING,
-        stake_events: { type: "integer" },
-        unstake_events: { type: "integer" },
-      }),
-    },
-  },
+  get_account: z.toJSONSchema(GetAccountOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_entities: z.toJSONSchema(GetAccountEntitiesOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_balance: z.toJSONSchema(GetAccountBalanceOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_root_claim: z.toJSONSchema(GetAccountRootClaimOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_children: z.toJSONSchema(GetAccountChildrenOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_parents: z.toJSONSchema(GetAccountParentsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_portfolio: z.toJSONSchema(GetAccountPortfolioOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_positions: z.toJSONSchema(GetAccountPositionsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_snapshot: z.toJSONSchema(GetAccountSnapshotOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_identity: z.toJSONSchema(GetAccountIdentityOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_identity_history: z.toJSONSchema(
+    GetAccountIdentityHistoryOutputSchema,
+    { target: "draft-2020-12" },
+  ),
+  get_account_position_history: z.toJSONSchema(
+    GetAccountPositionHistoryOutputSchema,
+    { target: "draft-2020-12" },
+  ),
+  get_account_events: z.toJSONSchema(GetAccountEventsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_subnets: z.toJSONSchema(GetAccountSubnetsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_stake_flow: z.toJSONSchema(GetAccountStakeFlowOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_account_stake_moves: {
     type: "object",
     additionalProperties: true,


### PR DESCRIPTION
## Summary

Batch 6 of types-epic E (#7863, tracked as #8069): converts 15 more MCP tool input/output schemas from hand-written JSON Schema literals to Zod-generated (`z.toJSONSchema(...)`), covering the account-core surface: `get_account`, `get_account_entities`, `get_account_balance`, `get_account_root_claim`, `get_account_children`, `get_account_parents`, `get_account_events`, `get_account_subnets`, `get_account_portfolio`, `get_account_positions`, `get_account_snapshot`, `get_account_identity`, `get_account_identity_history`, `get_account_position_history`, `get_account_stake_flow`.

Closes #8069.

## Diff-audit results (`scripts/diff-mcp-tool-schemas.ts`)

170/172 schema checks PASS (pilot + all prior batches + this batch combined). 2 DIFFs, only 1 belongs to this batch:

- **`get_account_identity_history.output`** (this batch, bucket b) — `identity_hash` is now required (still nullable). `formatAccountIdentityHistoryEntry()` ([src/account-identity-history.ts](src/account-identity-history.ts)) unconditionally sets `entry.identity_hash = row.identity_hash ?? null`, so the key itself is always present even though the hand-written original never required it — the same root cause #8055/#8067 already found and fixed for the subnet-scoped identity history.
- `get_subnet_identity_history.output` — pre-existing, already-documented finding from #8067, unrelated to this batch.

## Reuse note

None of this batch's 15 tools mirror an existing `schemas-src/routes/` REST schema (no account-domain REST route is Zod-converted yet). `get_account_stake_flow` shares the same `src/stake-flow.ts` window/direction constants as the per-subnet REST `stake-flow` route (#8056) but is a materially different, per-account shape — not reused as a schema import (documented in the file header). `get_account_snapshot`'s `balance`/`portfolio`/`subnets`/`positions`/`recent_events` fields stay bare open objects, matching the hand-written original exactly, rather than nesting the sibling tools' own precise schemas from this same batch (the original never did either).

## Cleanup

Removed the now-dead `ACCOUNT_REGISTRATION_ITEM` constant in `src/mcp-server.ts` (only referenced by the hand-written literals this batch replaced). `ACCOUNT_EVENT_ITEM` stays — still used by `get_block_events`/`get_extrinsic`.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` / `npx prettier --check` (touched files) — clean
- `npx tsx scripts/diff-mcp-tool-schemas.ts` — 170/172 PASS, 1 finding for this batch (documented above)
- `npx tsx scripts/validate-mcp.ts` — 204 tools, full lifecycle/subscribe round trips pass
- Full test suite: 490/490 files, 11853/11853 tests passing
- Zero JSON Schema object literals remain for these 15 tools (grep-verified)

## Test plan

- [x] tsc clean
- [x] eslint/prettier clean
- [x] Diff-audit run, 1 finding for this batch documented above
- [x] `validate-mcp.ts` passes
- [x] Full test suite green