### PR TITLE
feat(mcp): types-epic E — Zod schemas for 15 account-activity MCP tools (#8070)

### DIFF
--- a/schemas-src/mcp-tools/account-extrinsics.ts
+++ b/schemas-src/mcp-tools/account-extrinsics.ts
@@ -1,0 +1,59 @@
+// MCP tool `get_account_extrinsics` (types-epic E batch 7, #8070). Mirrors
+// GET /api/v1/accounts/{ss58}/extrinsics, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. The extrinsics item shape mirrors src/mcp-server.ts's shared
+// EXTRINSIC_ITEM object literal (also used by list_extrinsics/get_extrinsic/
+// get_block_extrinsics, none of which are in this batch) -- modeled fresh
+// here rather than importing a shared schema, since those other tools stay
+// hand-written JSON Schema for now and EXTRINSIC_ITEM itself has no Zod
+// equivalent yet.
+import { z } from "zod";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountExtrinsicsInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    block_start: z.int().min(0).optional(),
+    block_end: z.int().min(0).optional(),
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetAccountExtrinsicsInput = z.infer<
+  typeof GetAccountExtrinsicsInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const ExtrinsicItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    extrinsic_index: z.int().nullable().optional(),
+    extrinsic_hash: z.string().nullable().optional(),
+    signer: z.string().nullable().optional(),
+    call_module: z.string().nullable().optional(),
+    call_function: z.string().nullable().optional(),
+    call_args: z.unknown().optional(),
+    success: z.boolean().nullable().optional(),
+    fee_tao: z.unknown().optional(),
+    tip_tao: z.unknown().optional(),
+    observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetAccountExtrinsicsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    extrinsic_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    extrinsics: z.array(ExtrinsicItemSchema),
+  })
+  .passthrough();
+export type GetAccountExtrinsicsOutput = z.infer<
+  typeof GetAccountExtrinsicsOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-footprints.ts
+++ b/schemas-src/mcp-tools/account-footprints.ts
@@ -1,0 +1,270 @@
+// MCP tools `get_account_stake_moves`, `get_account_axon_removals`,
+// `get_account_prometheus`, `get_account_registrations`,
+// `get_account_weight_setters`, `get_account_serving`,
+// `get_account_deregistrations` (types-epic E batch 7, #8070). Each mirrors
+// a GET /api/v1/accounts/{ss58}/* footprint route that is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. All seven share one shape (address/window/total_X/subnet_count/
+// concentration/dominant_netuid/subnets), but with genuinely different
+// per-tool field names (movements vs removals vs announcements, etc.), so
+// each is modeled explicitly rather than through a shared factory. Unlike
+// the objectItems()-built item shapes elsewhere in this epic, these
+// `subnets` items are hand-written as STRICT objects (additionalProperties:
+// false) with every field in their own `required` array -- modeled here
+// with the SAME strictness, not the usual item-level looseness.
+import { z } from "zod";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+// Symbolic in each hand-written original (src/account-*.ts's own
+// *_WINDOWS/DEFAULT_*_WINDOW constants), cross-checked against the actual
+// runtime source at the time of writing. Six of the seven tools share the
+// same 3-way set; get_account_weight_setters uses a 2-way set.
+const FOOTPRINT_WINDOWS_3 = ["7d", "30d", "90d"] as const;
+const WEIGHT_SETTERS_WINDOWS_2 = ["7d", "30d"] as const;
+
+export const GetAccountStakeMovesInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+  })
+  .strict();
+export type GetAccountStakeMovesInput = z.infer<
+  typeof GetAccountStakeMovesInputSchema
+>;
+
+const StakeMovesSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    movements: z.int(),
+    first_moved_at: z.string().nullable(),
+    last_moved_at: z.string().nullable(),
+    price_tao_at_last_move: z.number().nullable(),
+  })
+  .strict();
+
+export const GetAccountStakeMovesOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    address: z.string(),
+    window: z.string().nullable(),
+    total_movements: z.int(),
+    subnet_count: z.int(),
+    concentration: z.number().nullable().optional(),
+    dominant_netuid: z.int().nullable().optional(),
+    subnets: z.array(StakeMovesSubnetSchema),
+  })
+  .passthrough();
+export type GetAccountStakeMovesOutput = z.infer<
+  typeof GetAccountStakeMovesOutputSchema
+>;
+
+export const GetAccountAxonRemovalsInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+  })
+  .strict();
+export type GetAccountAxonRemovalsInput = z.infer<
+  typeof GetAccountAxonRemovalsInputSchema
+>;
+
+const AxonRemovalsSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    removals: z.int(),
+    first_removed_at: z.string().nullable(),
+    last_removed_at: z.string().nullable(),
+  })
+  .strict();
+
+export const GetAccountAxonRemovalsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    address: z.string(),
+    window: z.string().nullable(),
+    total_removals: z.int(),
+    subnet_count: z.int(),
+    concentration: z.number().nullable().optional(),
+    dominant_netuid: z.int().nullable().optional(),
+    subnets: z.array(AxonRemovalsSubnetSchema),
+  })
+  .passthrough();
+export type GetAccountAxonRemovalsOutput = z.infer<
+  typeof GetAccountAxonRemovalsOutputSchema
+>;
+
+export const GetAccountPrometheusInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+  })
+  .strict();
+export type GetAccountPrometheusInput = z.infer<
+  typeof GetAccountPrometheusInputSchema
+>;
+
+const PrometheusSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    announcements: z.int(),
+    first_announced_at: z.string().nullable(),
+    last_announced_at: z.string().nullable(),
+  })
+  .strict();
+
+export const GetAccountPrometheusOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    address: z.string(),
+    window: z.string().nullable(),
+    total_announcements: z.int(),
+    subnet_count: z.int(),
+    concentration: z.number().nullable().optional(),
+    dominant_netuid: z.int().nullable().optional(),
+    subnets: z.array(PrometheusSubnetSchema),
+  })
+  .passthrough();
+export type GetAccountPrometheusOutput = z.infer<
+  typeof GetAccountPrometheusOutputSchema
+>;
+
+export const GetAccountRegistrationsInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+  })
+  .strict();
+export type GetAccountRegistrationsInput = z.infer<
+  typeof GetAccountRegistrationsInputSchema
+>;
+
+const RegistrationsSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    registrations: z.int(),
+    first_registered_at: z.string().nullable(),
+    last_registered_at: z.string().nullable(),
+  })
+  .strict();
+
+export const GetAccountRegistrationsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    address: z.string(),
+    window: z.string().nullable(),
+    total_registrations: z.int(),
+    subnet_count: z.int(),
+    concentration: z.number().nullable().optional(),
+    dominant_netuid: z.int().nullable().optional(),
+    subnets: z.array(RegistrationsSubnetSchema),
+  })
+  .passthrough();
+export type GetAccountRegistrationsOutput = z.infer<
+  typeof GetAccountRegistrationsOutputSchema
+>;
+
+export const GetAccountWeightSettersInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    window: z.enum(WEIGHT_SETTERS_WINDOWS_2).optional(),
+  })
+  .strict();
+export type GetAccountWeightSettersInput = z.infer<
+  typeof GetAccountWeightSettersInputSchema
+>;
+
+const WeightSettersSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    weight_sets: z.int(),
+    first_set_at: z.string().nullable(),
+    last_set_at: z.string().nullable(),
+  })
+  .strict();
+
+export const GetAccountWeightSettersOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    address: z.string(),
+    window: z.string().nullable(),
+    total_weight_sets: z.int(),
+    subnet_count: z.int(),
+    concentration: z.number().nullable().optional(),
+    dominant_netuid: z.int().nullable().optional(),
+    subnets: z.array(WeightSettersSubnetSchema),
+  })
+  .passthrough();
+export type GetAccountWeightSettersOutput = z.infer<
+  typeof GetAccountWeightSettersOutputSchema
+>;
+
+export const GetAccountServingInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+  })
+  .strict();
+export type GetAccountServingInput = z.infer<
+  typeof GetAccountServingInputSchema
+>;
+
+const ServingSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    announcements: z.int(),
+    first_served_at: z.string().nullable(),
+    last_served_at: z.string().nullable(),
+  })
+  .strict();
+
+export const GetAccountServingOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    address: z.string(),
+    window: z.string().nullable(),
+    total_announcements: z.int(),
+    subnet_count: z.int(),
+    concentration: z.number().nullable().optional(),
+    dominant_netuid: z.int().nullable().optional(),
+    subnets: z.array(ServingSubnetSchema),
+  })
+  .passthrough();
+export type GetAccountServingOutput = z.infer<
+  typeof GetAccountServingOutputSchema
+>;
+
+export const GetAccountDeregistrationsInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    window: z.enum(FOOTPRINT_WINDOWS_3).optional(),
+  })
+  .strict();
+export type GetAccountDeregistrationsInput = z.infer<
+  typeof GetAccountDeregistrationsInputSchema
+>;
+
+const DeregistrationsSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    deregistrations: z.int(),
+    first_deregistered_at: z.string().nullable(),
+    last_deregistered_at: z.string().nullable(),
+  })
+  .strict();
+
+export const GetAccountDeregistrationsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    address: z.string(),
+    window: z.string().nullable(),
+    total_deregistrations: z.int(),
+    subnet_count: z.int(),
+    concentration: z.number().nullable().optional(),
+    dominant_netuid: z.int().nullable().optional(),
+    subnets: z.array(DeregistrationsSubnetSchema),
+  })
+  .passthrough();
+export type GetAccountDeregistrationsOutput = z.infer<
+  typeof GetAccountDeregistrationsOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-history.ts
+++ b/schemas-src/mcp-tools/account-history.ts
@@ -1,0 +1,50 @@
+// MCP tool `get_account_history` (types-epic E batch 7, #8070). Mirrors
+// GET /api/v1/accounts/{ss58}/history, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, matching the hand-written literal it replaces
+// field-for-field.
+import { z } from "zod";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountHistoryInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    netuid: z.int().min(0).optional(),
+    from: z.string().optional(),
+    to: z.string().optional(),
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetAccountHistoryInput = z.infer<
+  typeof GetAccountHistoryInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const AccountHistoryDaySchema = z
+  .object({
+    day: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    event_count: z.int().nullable().optional(),
+    event_kinds: z.array(z.string()).optional(),
+    first_block: z.int().nullable().optional(),
+    last_block: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetAccountHistoryOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    day_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    days: z.array(AccountHistoryDaySchema),
+  })
+  .passthrough();
+export type GetAccountHistoryOutput = z.infer<
+  typeof GetAccountHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/account-transfers.ts
+++ b/schemas-src/mcp-tools/account-transfers.ts
@@ -1,0 +1,95 @@
+// MCP tools `get_account_transfers`, `get_account_counterparties`
+// (types-epic E batch 7, #8070). Each mirrors a GET /api/v1/accounts/{ss58}/
+// {transfers,counterparties} route that is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// matching each hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const GetAccountTransfersInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    direction: z.enum(["sent", "received"]).optional(),
+    block_start: z.int().min(0).optional(),
+    block_end: z.int().min(0).optional(),
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetAccountTransfersInput = z.infer<
+  typeof GetAccountTransfersInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const AccountTransferItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    event_index: z.int().nullable().optional(),
+    from: z.string().nullable().optional(),
+    to: z.string().nullable().optional(),
+    amount_tao: z.unknown().optional(),
+    direction: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetAccountTransfersOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    transfer_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    transfers: z.array(AccountTransferItemSchema),
+  })
+  .passthrough();
+export type GetAccountTransfersOutput = z.infer<
+  typeof GetAccountTransfersOutputSchema
+>;
+
+export const GetAccountCounterpartiesInputSchema = z
+  .object({
+    ss58: Ss58Schema,
+    counterparty: Ss58Schema.optional(),
+    limit: z.int().min(1).max(100).optional(),
+  })
+  .strict();
+export type GetAccountCounterpartiesInput = z.infer<
+  typeof GetAccountCounterpartiesInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level.
+const CounterpartyItemSchema = z
+  .object({
+    address: z.string().nullable().optional(),
+    sent_tao: z.unknown().optional(),
+    received_tao: z.unknown().optional(),
+    net_tao: z.unknown().optional(),
+    transfer_count: z.int().nullable().optional(),
+    last_block: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetAccountCounterpartiesOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ss58: z.string(),
+    counterparty_count: z.int(),
+    transfers_scanned: z.int().nullable().optional(),
+    scan_capped: z.boolean().optional(),
+    total_sent_tao: z.unknown().optional(),
+    total_received_tao: z.unknown().optional(),
+    counterparties: z.array(CounterpartyItemSchema),
+    // Present only in counterparty='<ss58>' drilldown mode (the per-pair
+    // detail) -- bare open object, matching the hand-written original.
+    relationship: OpenObjectSchema.optional(),
+  })
+  .passthrough();
+export type GetAccountCounterpartiesOutput = z.infer<
+  typeof GetAccountCounterpartiesOutputSchema
+>;

--- a/schemas-src/mcp-tools/accounts-leaderboards.ts
+++ b/schemas-src/mcp-tools/accounts-leaderboards.ts
@@ -1,0 +1,103 @@
+// MCP tools `list_accounts`, `get_top_holders` (types-epic E batch 7,
+// #8070). Each mirrors a GET /api/v1/accounts* leaderboard route that is
+// not one of schemas-src/routes/'s covered pilot routes -- no existing Zod
+// schema to reuse. Modeled fresh, matching each hand-written literal
+// field-for-field.
+import { z } from "zod";
+import { OpenObjectArraySchema } from "./shared.ts";
+
+// Symbolic in the hand-written originals (src/accounts-list.ts's
+// ACCOUNTS_LIST_SORTS/*_LIMIT_*, src/top-holders.ts's TOP_HOLDERS_SORTS/
+// *_LIMIT_*), cross-checked against the actual runtime source at the time
+// of writing.
+const ACCOUNTS_LIST_SORTS = [
+  "total_stake",
+  "total_emission",
+  "subnet_count",
+  "uid_count",
+  "validator_count",
+  "stake_dominance",
+  "last_active",
+] as const;
+const TOP_HOLDERS_SORTS = [
+  "total_tao",
+  "free_tao",
+  "delegated_tao",
+  "net_flow_7d",
+  "net_flow_30d",
+  "net_flow_90d",
+] as const;
+
+export const ListAccountsInputSchema = z
+  .object({
+    sort: z.enum(ACCOUNTS_LIST_SORTS).optional(),
+    limit: z.int().min(1).max(100).optional(),
+  })
+  .strict();
+export type ListAccountsInput = z.infer<typeof ListAccountsInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const AccountsListItemSchema = z
+  .object({
+    hotkey: z.string().optional(),
+    coldkey: z.string().nullable().optional(),
+    coldkey_count: z.int().optional(),
+    subnet_count: z.int().optional(),
+    uid_count: z.int().optional(),
+    validator_count: z.int().optional(),
+    miner_count: z.int().optional(),
+    total_stake_tao: z.unknown().optional(),
+    total_emission_tao: z.unknown().optional(),
+    latest_captured_at: z.string().nullable().optional(),
+    latest_block_number: z.int().nullable().optional(),
+    subnets: OpenObjectArraySchema.optional(),
+  })
+  .passthrough();
+
+export const ListAccountsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    sort: z.enum(ACCOUNTS_LIST_SORTS),
+    limit: z.int(),
+    captured_at: z.string().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    account_count: z.int(),
+    accounts: z.array(AccountsListItemSchema),
+  })
+  .passthrough();
+export type ListAccountsOutput = z.infer<typeof ListAccountsOutputSchema>;
+
+export const GetTopHoldersInputSchema = z
+  .object({
+    sort: z.enum(TOP_HOLDERS_SORTS).optional(),
+    limit: z.int().min(1).max(100).optional(),
+  })
+  .strict();
+export type GetTopHoldersInput = z.infer<typeof GetTopHoldersInputSchema>;
+
+// objectItems(...) properties, none required at the item level.
+const TopHolderItemSchema = z
+  .object({
+    ss58: z.string().optional(),
+    free_tao: z.unknown().optional(),
+    delegated_tao: z.unknown().optional(),
+    total_tao: z.unknown().optional(),
+    net_flow_7d: z.unknown().optional(),
+    net_flow_30d: z.unknown().optional(),
+    net_flow_90d: z.unknown().optional(),
+    last_updated: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetTopHoldersOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    sort: z.enum(TOP_HOLDERS_SORTS),
+    limit: z.int(),
+    captured_at: z.string().nullable().optional(),
+    account_count: z.int(),
+    accounts: z.array(TopHolderItemSchema),
+  })
+  .passthrough();
+export type GetTopHoldersOutput = z.infer<typeof GetTopHoldersOutputSchema>;

--- a/schemas-src/mcp-tools/evm.ts
+++ b/schemas-src/mcp-tools/evm.ts
@@ -1,0 +1,54 @@
+// MCP tools `decode_evm_call`, `get_evm_address_mapping` (types-epic E
+// batch 7, #8070). decode_evm_call is pure/local (src/evm-precompiles.ts,
+// no REST mirror); get_evm_address_mapping mirrors GET /api/v1/evm/address/
+// {h160}. Neither is one of schemas-src/routes/'s covered pilot routes --
+// no existing Zod schema to reuse. Both hand-written originals declare
+// their outputSchema INLINE on the tool definition (not via the shared
+// TOOL_OUTPUT_SCHEMAS map every other tool in this epic uses) and are
+// additionalProperties:false (strict) at the top level, unlike the
+// additionalProperties:true posture everywhere else in this epic -- modeled
+// here with the SAME strictness, not loosened to match the majority
+// convention.
+import { z } from "zod";
+
+const H160Schema = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
+
+export const DecodeEvmCallInputSchema = z
+  .object({
+    to: H160Schema,
+    input: z.string().regex(/^0x[0-9a-fA-F]*$/),
+  })
+  .strict();
+export type DecodeEvmCallInput = z.infer<typeof DecodeEvmCallInputSchema>;
+
+export const DecodeEvmCallOutputSchema = z
+  .object({
+    precompile: z.string().nullable(),
+    address: z.string().nullable(),
+    function: z.string().nullable(),
+    signature: z.string().optional(),
+    args: z.object({}).passthrough().optional(),
+  })
+  .strict();
+export type DecodeEvmCallOutput = z.infer<typeof DecodeEvmCallOutputSchema>;
+
+export const GetEvmAddressMappingInputSchema = z
+  .object({
+    h160: H160Schema,
+  })
+  .strict();
+export type GetEvmAddressMappingInput = z.infer<
+  typeof GetEvmAddressMappingInputSchema
+>;
+
+export const GetEvmAddressMappingOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    h160: z.string(),
+    ss58: z.string().nullable(),
+    queried_at: z.string().nullable(),
+  })
+  .strict();
+export type GetEvmAddressMappingOutput = z.infer<
+  typeof GetEvmAddressMappingOutputSchema
+>;

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -318,6 +318,48 @@ import {
   GetAccountStakeFlowInputSchema,
   GetAccountStakeFlowOutputSchema,
 } from "../schemas-src/mcp-tools/account-stake-flow.ts";
+import {
+  GetAccountStakeMovesInputSchema,
+  GetAccountStakeMovesOutputSchema,
+  GetAccountAxonRemovalsInputSchema,
+  GetAccountAxonRemovalsOutputSchema,
+  GetAccountPrometheusInputSchema,
+  GetAccountPrometheusOutputSchema,
+  GetAccountRegistrationsInputSchema,
+  GetAccountRegistrationsOutputSchema,
+  GetAccountWeightSettersInputSchema,
+  GetAccountWeightSettersOutputSchema,
+  GetAccountServingInputSchema,
+  GetAccountServingOutputSchema,
+  GetAccountDeregistrationsInputSchema,
+  GetAccountDeregistrationsOutputSchema,
+} from "../schemas-src/mcp-tools/account-footprints.ts";
+import {
+  GetAccountHistoryInputSchema,
+  GetAccountHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/account-history.ts";
+import {
+  GetAccountExtrinsicsInputSchema,
+  GetAccountExtrinsicsOutputSchema,
+} from "../schemas-src/mcp-tools/account-extrinsics.ts";
+import {
+  GetAccountTransfersInputSchema,
+  GetAccountTransfersOutputSchema,
+  GetAccountCounterpartiesInputSchema,
+  GetAccountCounterpartiesOutputSchema,
+} from "../schemas-src/mcp-tools/account-transfers.ts";
+import {
+  ListAccountsInputSchema,
+  ListAccountsOutputSchema,
+  GetTopHoldersInputSchema,
+  GetTopHoldersOutputSchema,
+} from "../schemas-src/mcp-tools/accounts-leaderboards.ts";
+import {
+  DecodeEvmCallInputSchema,
+  DecodeEvmCallOutputSchema,
+  GetEvmAddressMappingInputSchema,
+  GetEvmAddressMappingOutputSchema,
+} from "../schemas-src/mcp-tools/evm.ts";
 
 type Row = Record<string, unknown>;
 
@@ -532,6 +574,33 @@ const NOMINATOR_SORTS = ["net_staked", "gross_staked", "last_activity"];
 // SS58_PATTERN_SOURCE), cross-checked against the actual runtime value at the
 // time of writing.
 const SS58_PATTERN = "^[1-9A-HJ-NP-Za-km-z]{47,48}$";
+
+// Batch 6 (#8070) resolved enum values, same treatment as above -- symbolic
+// in the hand-written originals (each account-footprint tool's own
+// src/account-*.ts *_WINDOWS constant, src/accounts-list.ts's
+// ACCOUNTS_LIST_SORTS, src/top-holders.ts's TOP_HOLDERS_SORTS), cross-checked
+// against the actual runtime source at the time of writing. Mirrors
+// src/mcp-server.ts's H160_PATTERN.source for the two EVM tools.
+const ACCOUNT_FOOTPRINT_WINDOWS_3 = ["7d", "30d", "90d"];
+const ACCOUNT_WEIGHT_SETTERS_WINDOWS_2 = ["7d", "30d"];
+const ACCOUNTS_LIST_SORTS = [
+  "total_stake",
+  "total_emission",
+  "subnet_count",
+  "uid_count",
+  "validator_count",
+  "stake_dominance",
+  "last_active",
+];
+const TOP_HOLDERS_SORTS = [
+  "total_tao",
+  "free_tao",
+  "delegated_tao",
+  "net_flow_7d",
+  "net_flow_30d",
+  "net_flow_90d",
+];
+const H160_PATTERN = "^0x[0-9a-fA-F]{40}$";
 
 const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
   search_subnets: {
@@ -3379,6 +3448,616 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  get_account_stake_moves: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: ACCOUNT_FOOTPRINT_WINDOWS_3 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "address",
+        "window",
+        "total_movements",
+        "subnet_count",
+        "subnets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        address: { type: "string" },
+        window: NULLABLE_STRING,
+        total_movements: { type: "integer" },
+        subnet_count: { type: "integer" },
+        concentration: { type: ["number", "null"] },
+        dominant_netuid: NULLABLE_INT,
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "movements",
+              "first_moved_at",
+              "last_moved_at",
+              "price_tao_at_last_move",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              movements: { type: "integer" },
+              first_moved_at: NULLABLE_STRING,
+              last_moved_at: NULLABLE_STRING,
+              price_tao_at_last_move: { type: ["number", "null"] },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_account_axon_removals: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: ACCOUNT_FOOTPRINT_WINDOWS_3 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "address",
+        "window",
+        "total_removals",
+        "subnet_count",
+        "subnets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        address: { type: "string" },
+        window: NULLABLE_STRING,
+        total_removals: { type: "integer" },
+        subnet_count: { type: "integer" },
+        concentration: { type: ["number", "null"] },
+        dominant_netuid: NULLABLE_INT,
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "removals",
+              "first_removed_at",
+              "last_removed_at",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              removals: { type: "integer" },
+              first_removed_at: NULLABLE_STRING,
+              last_removed_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_account_prometheus: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: ACCOUNT_FOOTPRINT_WINDOWS_3 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "address",
+        "window",
+        "total_announcements",
+        "subnet_count",
+        "subnets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        address: { type: "string" },
+        window: NULLABLE_STRING,
+        total_announcements: { type: "integer" },
+        subnet_count: { type: "integer" },
+        concentration: { type: ["number", "null"] },
+        dominant_netuid: NULLABLE_INT,
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "announcements",
+              "first_announced_at",
+              "last_announced_at",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              announcements: { type: "integer" },
+              first_announced_at: NULLABLE_STRING,
+              last_announced_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_account_registrations: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: ACCOUNT_FOOTPRINT_WINDOWS_3 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "address",
+        "window",
+        "total_registrations",
+        "subnet_count",
+        "subnets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        address: { type: "string" },
+        window: NULLABLE_STRING,
+        total_registrations: { type: "integer" },
+        subnet_count: { type: "integer" },
+        concentration: { type: ["number", "null"] },
+        dominant_netuid: NULLABLE_INT,
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "registrations",
+              "first_registered_at",
+              "last_registered_at",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              registrations: { type: "integer" },
+              first_registered_at: NULLABLE_STRING,
+              last_registered_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_account_weight_setters: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: ACCOUNT_WEIGHT_SETTERS_WINDOWS_2 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "address",
+        "window",
+        "total_weight_sets",
+        "subnet_count",
+        "subnets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        address: { type: "string" },
+        window: NULLABLE_STRING,
+        total_weight_sets: { type: "integer" },
+        subnet_count: { type: "integer" },
+        concentration: { type: ["number", "null"] },
+        dominant_netuid: NULLABLE_INT,
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["netuid", "weight_sets", "first_set_at", "last_set_at"],
+            properties: {
+              netuid: { type: "integer" },
+              weight_sets: { type: "integer" },
+              first_set_at: NULLABLE_STRING,
+              last_set_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_account_serving: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: ACCOUNT_FOOTPRINT_WINDOWS_3 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "address",
+        "window",
+        "total_announcements",
+        "subnet_count",
+        "subnets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        address: { type: "string" },
+        window: NULLABLE_STRING,
+        total_announcements: { type: "integer" },
+        subnet_count: { type: "integer" },
+        concentration: { type: ["number", "null"] },
+        dominant_netuid: NULLABLE_INT,
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "announcements",
+              "first_served_at",
+              "last_served_at",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              announcements: { type: "integer" },
+              first_served_at: NULLABLE_STRING,
+              last_served_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_account_deregistrations: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        window: { type: "string", enum: ACCOUNT_FOOTPRINT_WINDOWS_3 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "address",
+        "window",
+        "total_deregistrations",
+        "subnet_count",
+        "subnets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        address: { type: "string" },
+        window: NULLABLE_STRING,
+        total_deregistrations: { type: "integer" },
+        subnet_count: { type: "integer" },
+        concentration: { type: ["number", "null"] },
+        dominant_netuid: NULLABLE_INT,
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "deregistrations",
+              "first_deregistered_at",
+              "last_deregistered_at",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              deregistrations: { type: "integer" },
+              first_deregistered_at: NULLABLE_STRING,
+              last_deregistered_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_account_history: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        netuid: { type: "integer", minimum: 0 },
+        from: { type: "string" },
+        to: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "day_count", "days"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        day_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        days: objectItems({
+          day: NULLABLE_STRING,
+          netuid: NULLABLE_INT,
+          event_count: NULLABLE_INT,
+          event_kinds: { type: "array", items: { type: "string" } },
+          first_block: NULLABLE_INT,
+          last_block: NULLABLE_INT,
+        }),
+      },
+    },
+  },
+  get_account_extrinsics: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        block_start: { type: "integer", minimum: 0 },
+        block_end: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "extrinsic_count", "extrinsics"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        extrinsic_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        extrinsics: objectItems({
+          block_number: NULLABLE_INT,
+          extrinsic_index: NULLABLE_INT,
+          extrinsic_hash: NULLABLE_STRING,
+          signer: NULLABLE_STRING,
+          call_module: NULLABLE_STRING,
+          call_function: NULLABLE_STRING,
+          call_args: ANY,
+          success: { type: ["boolean", "null"] },
+          fee_tao: ANY,
+          tip_tao: ANY,
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_account_transfers: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        direction: { type: "string", enum: ["sent", "received"] },
+        block_start: { type: "integer", minimum: 0 },
+        block_end: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "transfer_count", "transfers"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        transfer_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        transfers: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          from: NULLABLE_STRING,
+          to: NULLABLE_STRING,
+          amount_tao: ANY,
+          direction: NULLABLE_STRING,
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_account_counterparties: {
+    input: {
+      type: "object",
+      properties: {
+        ss58: { type: "string", pattern: SS58_PATTERN },
+        counterparty: { type: "string", pattern: SS58_PATTERN },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ss58", "counterparty_count", "counterparties"],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string" },
+        counterparty_count: { type: "integer" },
+        transfers_scanned: NULLABLE_INT,
+        scan_capped: { type: "boolean" },
+        total_sent_tao: ANY,
+        total_received_tao: ANY,
+        counterparties: objectItems({
+          address: NULLABLE_STRING,
+          sent_tao: ANY,
+          received_tao: ANY,
+          net_tao: ANY,
+          transfer_count: NULLABLE_INT,
+          last_block: NULLABLE_INT,
+        }),
+        relationship: { type: "object", additionalProperties: true },
+      },
+    },
+  },
+  list_accounts: {
+    input: {
+      type: "object",
+      properties: {
+        sort: { type: "string", enum: ACCOUNTS_LIST_SORTS },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["sort", "limit", "account_count", "accounts"],
+      properties: {
+        schema_version: { type: "integer" },
+        sort: { type: "string", enum: ACCOUNTS_LIST_SORTS },
+        limit: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        block_number: NULLABLE_INT,
+        account_count: { type: "integer" },
+        accounts: objectItems({
+          hotkey: { type: "string" },
+          coldkey: NULLABLE_STRING,
+          coldkey_count: { type: "integer" },
+          subnet_count: { type: "integer" },
+          uid_count: { type: "integer" },
+          validator_count: { type: "integer" },
+          miner_count: { type: "integer" },
+          total_stake_tao: ANY,
+          total_emission_tao: ANY,
+          latest_captured_at: NULLABLE_STRING,
+          latest_block_number: NULLABLE_INT,
+          subnets: { type: "array", items: { type: "object" } },
+        }),
+      },
+    },
+  },
+  get_top_holders: {
+    input: {
+      type: "object",
+      properties: {
+        sort: { type: "string", enum: TOP_HOLDERS_SORTS },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["sort", "limit", "account_count", "accounts"],
+      properties: {
+        schema_version: { type: "integer" },
+        sort: { type: "string", enum: TOP_HOLDERS_SORTS },
+        limit: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        account_count: { type: "integer" },
+        accounts: objectItems({
+          ss58: { type: "string" },
+          free_tao: ANY,
+          delegated_tao: ANY,
+          total_tao: ANY,
+          net_flow_7d: ANY,
+          net_flow_30d: ANY,
+          net_flow_90d: ANY,
+          last_updated: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  decode_evm_call: {
+    input: {
+      type: "object",
+      required: ["to", "input"],
+      properties: {
+        to: { type: "string", pattern: H160_PATTERN },
+        input: { type: "string", pattern: "^0x[0-9a-fA-F]*$" },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: false,
+      required: ["precompile", "address", "function"],
+      properties: {
+        precompile: { type: ["string", "null"] },
+        address: { type: ["string", "null"] },
+        function: { type: ["string", "null"] },
+        signature: { type: "string" },
+        args: { type: "object" },
+      },
+    },
+  },
+  get_evm_address_mapping: {
+    input: {
+      type: "object",
+      required: ["h160"],
+      properties: {
+        h160: { type: "string", pattern: H160_PATTERN },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: false,
+      required: ["schema_version", "h160", "ss58", "queried_at"],
+      properties: {
+        schema_version: { type: "integer" },
+        h160: { type: "string" },
+        ss58: { type: ["string", "null"] },
+        queried_at: { type: ["string", "null"] },
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -3722,6 +4401,66 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
   get_account_stake_flow: {
     input: GetAccountStakeFlowInputSchema,
     output: GetAccountStakeFlowOutputSchema,
+  },
+  get_account_stake_moves: {
+    input: GetAccountStakeMovesInputSchema,
+    output: GetAccountStakeMovesOutputSchema,
+  },
+  get_account_axon_removals: {
+    input: GetAccountAxonRemovalsInputSchema,
+    output: GetAccountAxonRemovalsOutputSchema,
+  },
+  get_account_prometheus: {
+    input: GetAccountPrometheusInputSchema,
+    output: GetAccountPrometheusOutputSchema,
+  },
+  get_account_registrations: {
+    input: GetAccountRegistrationsInputSchema,
+    output: GetAccountRegistrationsOutputSchema,
+  },
+  get_account_weight_setters: {
+    input: GetAccountWeightSettersInputSchema,
+    output: GetAccountWeightSettersOutputSchema,
+  },
+  get_account_serving: {
+    input: GetAccountServingInputSchema,
+    output: GetAccountServingOutputSchema,
+  },
+  get_account_deregistrations: {
+    input: GetAccountDeregistrationsInputSchema,
+    output: GetAccountDeregistrationsOutputSchema,
+  },
+  get_account_history: {
+    input: GetAccountHistoryInputSchema,
+    output: GetAccountHistoryOutputSchema,
+  },
+  get_account_extrinsics: {
+    input: GetAccountExtrinsicsInputSchema,
+    output: GetAccountExtrinsicsOutputSchema,
+  },
+  get_account_transfers: {
+    input: GetAccountTransfersInputSchema,
+    output: GetAccountTransfersOutputSchema,
+  },
+  get_account_counterparties: {
+    input: GetAccountCounterpartiesInputSchema,
+    output: GetAccountCounterpartiesOutputSchema,
+  },
+  list_accounts: {
+    input: ListAccountsInputSchema,
+    output: ListAccountsOutputSchema,
+  },
+  get_top_holders: {
+    input: GetTopHoldersInputSchema,
+    output: GetTopHoldersOutputSchema,
+  },
+  decode_evm_call: {
+    input: DecodeEvmCallInputSchema,
+    output: DecodeEvmCallOutputSchema,
+  },
+  get_evm_address_mapping: {
+    input: GetEvmAddressMappingInputSchema,
+    output: GetEvmAddressMappingOutputSchema,
   },
 };
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -590,6 +590,48 @@ import {
   GetAccountStakeFlowOutputSchema,
 } from "../schemas-src/mcp-tools/account-stake-flow.ts";
 import {
+  GetAccountStakeMovesInputSchema,
+  GetAccountStakeMovesOutputSchema,
+  GetAccountAxonRemovalsInputSchema,
+  GetAccountAxonRemovalsOutputSchema,
+  GetAccountPrometheusInputSchema,
+  GetAccountPrometheusOutputSchema,
+  GetAccountRegistrationsInputSchema,
+  GetAccountRegistrationsOutputSchema,
+  GetAccountWeightSettersInputSchema,
+  GetAccountWeightSettersOutputSchema,
+  GetAccountServingInputSchema,
+  GetAccountServingOutputSchema,
+  GetAccountDeregistrationsInputSchema,
+  GetAccountDeregistrationsOutputSchema,
+} from "../schemas-src/mcp-tools/account-footprints.ts";
+import {
+  GetAccountHistoryInputSchema,
+  GetAccountHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/account-history.ts";
+import {
+  GetAccountExtrinsicsInputSchema,
+  GetAccountExtrinsicsOutputSchema,
+} from "../schemas-src/mcp-tools/account-extrinsics.ts";
+import {
+  GetAccountTransfersInputSchema,
+  GetAccountTransfersOutputSchema,
+  GetAccountCounterpartiesInputSchema,
+  GetAccountCounterpartiesOutputSchema,
+} from "../schemas-src/mcp-tools/account-transfers.ts";
+import {
+  ListAccountsInputSchema,
+  ListAccountsOutputSchema,
+  GetTopHoldersInputSchema,
+  GetTopHoldersOutputSchema,
+} from "../schemas-src/mcp-tools/accounts-leaderboards.ts";
+import {
+  DecodeEvmCallInputSchema,
+  DecodeEvmCallOutputSchema,
+  GetEvmAddressMappingInputSchema,
+  GetEvmAddressMappingOutputSchema,
+} from "../schemas-src/mcp-tools/evm.ts";
+import {
   buildChainConcentration,
   buildConcentration,
   buildConcentrationHistory,
@@ -6685,25 +6727,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "operational re-delegation churn, not net capital flow (see get_account_stake_flow). " +
       "The account-level companion to get_chain_stake_moves and get_subnet_stake_moves. " +
       "Mirrors GET /api/v1/accounts/{ss58}/stake-moves.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 coldkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_STAKE_MOVES_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountStakeMovesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountStakeMovesInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW;
@@ -6738,25 +6768,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "removed — the teardown-side complement to get_account_serving (axon announcements) " +
       "and the account-level companion to get_chain_axon_removals and " +
       "get_subnet_axon_removals. Mirrors GET /api/v1/accounts/{ss58}/axon-removals.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_AXON_REMOVALS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_AXON_REMOVAL_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountAxonRemovalsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountAxonRemovalsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_AXON_REMOVAL_WINDOW;
@@ -6792,25 +6810,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "companion to get_account_serving (axon announcements) and the account-level " +
       "companion to get_chain_prometheus and get_subnet_prometheus. Mirrors GET " +
       "/api/v1/accounts/{ss58}/prometheus.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_PROMETHEUS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_PROMETHEUS_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountPrometheusInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountPrometheusInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_PROMETHEUS_WINDOW;
@@ -6845,25 +6851,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "re-registrations after a deregistration — distinct from get_account_subnets " +
       "(current registration state). The account-level companion to get_chain_registrations " +
       "and get_subnet_registrations. Mirrors GET /api/v1/accounts/{ss58}/registrations.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_REGISTRATIONS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_REGISTRATION_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountRegistrationsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountRegistrationsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_REGISTRATION_WINDOW;
@@ -6897,25 +6891,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "and the dominant subnet. WeightsSet is a validator submitting its weight vector " +
       "for a subnet's consensus. The account-level companion to get_chain_weight_setters " +
       "and get_subnet_weight_setters. Mirrors GET /api/v1/accounts/{ss58}/weight-setters.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_WEIGHT_SETTERS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountWeightSettersInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountWeightSettersInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW;
@@ -6951,25 +6933,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(registration events). The axon-endpoint companion to get_account_prometheus " +
       "(Prometheus telemetry) and the account-level companion to get_chain_serving and " +
       "get_subnet_serving. Mirrors GET /api/v1/accounts/{ss58}/serving.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_SERVING_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_SERVING_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountServingInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountServingInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const window = optionalString(args, "window") ?? DEFAULT_SERVING_WINDOW;
       if (!Object.hasOwn(SERVING_WINDOWS, window)) {
@@ -7004,25 +6974,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "distinct from get_account_subnets (current registration state). The " +
       "account-level companion to get_chain_deregistrations and " +
       "get_subnet_deregistrations. Mirrors GET /api/v1/accounts/{ss58}/deregistrations.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        window: {
-          type: "string",
-          enum: ACCOUNT_DEREGISTRATIONS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_ACCOUNT_DEREGISTRATION_WINDOW}).`,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountDeregistrationsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountDeregistrationsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const window =
         optionalString(args, "window") ?? DEFAULT_ACCOUNT_DEREGISTRATION_WINDOW;
@@ -7057,53 +7015,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "offset. Newest day first. Useful for understanding how active a wallet has been " +
       "over time. Note: the rollup is hotkey-attributed only — a delegate-only SS58 " +
       "address returns zero days even if it has events in get_account_events.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 hotkey address, base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        netuid: {
-          type: "integer",
-          description: "Optional subnet filter. Omit for all subnets.",
-          minimum: 0,
-        },
-        from: {
-          type: "string",
-          description:
-            "Optional start date inclusive, YYYY-MM-DD. Omit for no lower bound.",
-        },
-        to: {
-          type: "string",
-          description:
-            "Optional end date inclusive, YYYY-MM-DD. Omit for no upper bound.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max days to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description:
-            "Pagination offset. Default 0. Ignored when cursor is set.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor. " +
-            "Takes precedence over offset for stable head-growing pages.",
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const netuid = optionalNonNegativeInt(args, "netuid") ?? undefined;
       const from = optionalDayArg(args, "from");
@@ -7140,49 +7058,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "block_start/block_end (inclusive). Page with limit (1-1000, default 100) / " +
       "offset, or follow next_cursor for stable keyset pagination. Mirrors " +
       "GET /api/v1/accounts/{ss58}/extrinsics.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (the extrinsic signer), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        block_start: {
-          type: "integer",
-          description:
-            "Optional inclusive lower block bound; omit for no lower limit.",
-          minimum: 0,
-        },
-        block_end: {
-          type: "integer",
-          description:
-            "Optional inclusive upper block bound; omit for no upper limit.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Max extrinsics to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset. Default 0.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor; takes " +
-            "precedence over offset for stable deep pagination.",
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountExtrinsicsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountExtrinsicsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       // block_start/block_end/cursor are validated for REST-parity and forwarded
       // to the Postgres tier below; the D1 fallback (buildAccountExtrinsics([]))
@@ -7192,7 +7074,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const cursor = optionalString(args, "cursor");
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = Number.isFinite(args?.offset)
-        ? Math.max(0, Math.floor(args.offset))
+        ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       return (
         (await tryPostgresTier(
@@ -7225,56 +7107,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(inclusive). Page with limit (1-1000, default 100) / offset, or follow " +
       "next_cursor for stable keyset pagination. Mirrors " +
       "GET /api/v1/accounts/{ss58}/transfers.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (sender or recipient), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        direction: {
-          type: "string",
-          description:
-            "Filter by side: 'sent' (this account is sender), 'received' (recipient), " +
-            "or omit for both. Any other value is treated as both-sides.",
-          enum: ["sent", "received"],
-        },
-        block_start: {
-          type: "integer",
-          description:
-            "Optional inclusive lower block bound; omit for no lower limit.",
-          minimum: 0,
-        },
-        block_end: {
-          type: "integer",
-          description:
-            "Optional inclusive upper block bound; omit for no upper limit.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Max transfers to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset. Default 0.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor; takes " +
-            "precedence over offset for stable deep pagination.",
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountTransfersInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountTransfersInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const direction = optionalString(args, "direction");
       // block_start/block_end/cursor are validated for REST-parity and forwarded to
@@ -7287,7 +7126,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const cursor = optionalString(args, "cursor");
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = Number.isFinite(args?.offset)
-        ? Math.max(0, Math.floor(args.offset))
+        ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       return (
         (await tryPostgresTier(
@@ -7323,36 +7162,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "counterparties (1-100, default 20); the relationship drilldown returns up to " +
       "`limit` transfers (default 50). Native-TAO transfers only, NOT stake or other " +
       "events (those are in get_account_events).",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ss58: {
-          type: "string",
-          description:
-            "The account's SS58 address (sender or recipient), base58, 47-48 chars.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        counterparty: {
-          type: "string",
-          description:
-            "Optional second SS58 address: drill into this account's relationship " +
-            "with it (fund-flow totals + transfer evidence) instead of the ranked " +
-            "list. Must differ from ss58.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        limit: {
-          type: "integer",
-          description:
-            "Max counterparties (list mode, default 20) or transfers (relationship " +
-            "mode, default 50) to return; 1-100.",
-          minimum: 1,
-          maximum: 100,
-        },
-      },
-      required: ["ss58"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAccountCounterpartiesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAccountCounterpartiesInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ss58 = requireSs58(args);
       const counterparty = optionalString(args, "counterparty");
       if (counterparty != null) {
@@ -8106,24 +7922,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "total_stake (default), total_emission, subnet_count, uid_count, " +
       "validator_count, stake_dominance, or last_active. The all-accounts " +
       "generalization of list_global_validators. Mirrors GET /api/v1/accounts.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        sort: {
-          type: "string",
-          enum: ACCOUNTS_LIST_SORTS,
-          description: "Ranking key (default total_stake).",
-        },
-        limit: {
-          type: "integer",
-          description: "Max accounts to return (1-100, default 20).",
-          minimum: 1,
-          maximum: ACCOUNTS_LIST_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListAccountsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof ListAccountsInputSchema>, ctx: McpCtx) {
       const sort =
         optionalEnum(args, "sort", ACCOUNTS_LIST_SORTS) ??
         DEFAULT_ACCOUNTS_LIST_SORT;
@@ -8153,24 +7955,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "net_flow_90d -- StakeAdded minus StakeRemoved, #6886/#6887). The " +
       "coldkey/balance-centric counterpart to list_accounts. Mirrors GET " +
       "/api/v1/accounts/top-holders.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        sort: {
-          type: "string",
-          enum: TOP_HOLDERS_SORTS,
-          description: "Ranking key (default total_tao).",
-        },
-        limit: {
-          type: "integer",
-          description: "Max accounts to return (1-100, default 20).",
-          minimum: 1,
-          maximum: TOP_HOLDERS_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetTopHoldersInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetTopHoldersInputSchema>, ctx: McpCtx) {
       const sort =
         optionalEnum(args, "sort", TOP_HOLDERS_SORTS) ??
         DEFAULT_TOP_HOLDERS_SORT;
@@ -11024,38 +10812,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "precompile but the calldata's 4-byte selector doesn't match any of " +
       "its declared functions, function is null but precompile/address are " +
       "still populated.",
-    inputSchema: {
-      type: "object",
-      required: ["to", "input"],
-      properties: {
-        to: {
-          type: "string",
-          pattern: "^0x[0-9a-fA-F]{40}$",
-          description:
-            "The transaction's target H160 address (20 bytes, 0x-prefixed hex).",
-        },
-        input: {
-          type: "string",
-          pattern: "^0x[0-9a-fA-F]*$",
-          description:
-            "The transaction's raw calldata: a 4-byte selector plus ABI-encoded args, 0x-prefixed hex.",
-        },
-      },
-      additionalProperties: false,
-    },
-    outputSchema: {
-      type: "object",
-      additionalProperties: false,
-      required: ["precompile", "address", "function"],
-      properties: {
-        precompile: { type: ["string", "null"] },
-        address: { type: ["string", "null"] },
-        function: { type: ["string", "null"] },
-        signature: { type: "string" },
-        args: { type: "object" },
-      },
-    },
-    async handler(args: Row) {
+    inputSchema: z.toJSONSchema(DecodeEvmCallInputSchema, {
+      target: "draft-2020-12",
+    }),
+    outputSchema: z.toJSONSchema(DecodeEvmCallOutputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof DecodeEvmCallInputSchema>) {
       if (
         typeof args?.to !== "string" ||
         !/^0x[0-9a-fA-F]{40}$/.test(args.to)
@@ -11092,30 +10855,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(#6725/#6728) -- a deterministic function of the runtime's configured " +
       "mapping algorithm, queried live rather than replicated client-side. " +
       "Mirrors GET /api/v1/evm/address/{h160}. ss58 is null on RPC failure.",
-    inputSchema: {
-      type: "object",
-      required: ["h160"],
-      properties: {
-        h160: {
-          type: "string",
-          pattern: "^0x[0-9a-fA-F]{40}$",
-          description: "The EVM address (20 bytes, 0x-prefixed hex).",
-        },
-      },
-      additionalProperties: false,
-    },
-    outputSchema: {
-      type: "object",
-      additionalProperties: false,
-      required: ["schema_version", "h160", "ss58", "queried_at"],
-      properties: {
-        schema_version: { type: "integer" },
-        h160: { type: "string" },
-        ss58: { type: ["string", "null"] },
-        queried_at: { type: ["string", "null"] },
-      },
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetEvmAddressMappingInputSchema, {
+      target: "draft-2020-12",
+    }),
+    outputSchema: z.toJSONSchema(GetEvmAddressMappingOutputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetEvmAddressMappingInputSchema>,
+      ctx: McpCtx,
+    ) {
       if (typeof args?.h160 !== "string" || !H160_PATTERN.test(args.h160)) {
         throw toolError(
           "invalid_params",
@@ -12399,371 +12148,54 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_account_stake_flow: z.toJSONSchema(GetAccountStakeFlowOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_account_stake_moves: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_movements",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_movements: { type: "integer" },
-      subnet_count: { type: "integer" },
-      // Herfindahl-Hirschman index of StakeMoved events across subnets: 1 means
-      // all movements on one subnet; null when the account has no movements.
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "movements",
-            "first_moved_at",
-            "last_moved_at",
-            "price_tao_at_last_move",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            movements: { type: "integer" },
-            first_moved_at: NULLABLE_STRING,
-            last_moved_at: NULLABLE_STRING,
-            // Alpha price on the day of the most recent move (#4332/6.3),
-            // from the daily subnet_snapshots rollup; null when that day has
-            // no snapshot yet or there was no move to date from.
-            price_tao_at_last_move: { type: ["number", "null"] },
-          },
-        },
-      },
+  get_account_stake_moves: z.toJSONSchema(GetAccountStakeMovesOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_axon_removals: z.toJSONSchema(
+    GetAccountAxonRemovalsOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_account_axon_removals: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_removals",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_removals: { type: "integer" },
-      subnet_count: { type: "integer" },
-      // Herfindahl-Hirschman index of AxonInfoRemoved events across subnets: 1
-      // means all removals on one subnet; null when the account has no removals.
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "removals",
-            "first_removed_at",
-            "last_removed_at",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            removals: { type: "integer" },
-            first_removed_at: NULLABLE_STRING,
-            last_removed_at: NULLABLE_STRING,
-          },
-        },
-      },
+  ),
+  get_account_prometheus: z.toJSONSchema(GetAccountPrometheusOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_registrations: z.toJSONSchema(
+    GetAccountRegistrationsOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_account_prometheus: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_announcements",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_announcements: { type: "integer" },
-      subnet_count: { type: "integer" },
-      // Herfindahl-Hirschman index of PrometheusServed events across subnets: 1
-      // means all announcements on one subnet; null when the account has none.
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "announcements",
-            "first_announced_at",
-            "last_announced_at",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            announcements: { type: "integer" },
-            first_announced_at: NULLABLE_STRING,
-            last_announced_at: NULLABLE_STRING,
-          },
-        },
-      },
+  ),
+  get_account_weight_setters: z.toJSONSchema(
+    GetAccountWeightSettersOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_account_registrations: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_registrations",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_registrations: { type: "integer" },
-      subnet_count: { type: "integer" },
-      // Herfindahl-Hirschman index of NeuronRegistered events across subnets: 1
-      // means all registrations on one subnet; null when the account has none.
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "registrations",
-            "first_registered_at",
-            "last_registered_at",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            registrations: { type: "integer" },
-            first_registered_at: NULLABLE_STRING,
-            last_registered_at: NULLABLE_STRING,
-          },
-        },
-      },
+  ),
+  get_account_serving: z.toJSONSchema(GetAccountServingOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_deregistrations: z.toJSONSchema(
+    GetAccountDeregistrationsOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_account_weight_setters: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_weight_sets",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_weight_sets: { type: "integer" },
-      subnet_count: { type: "integer" },
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: ["netuid", "weight_sets", "first_set_at", "last_set_at"],
-          properties: {
-            netuid: { type: "integer" },
-            weight_sets: { type: "integer" },
-            first_set_at: NULLABLE_STRING,
-            last_set_at: NULLABLE_STRING,
-          },
-        },
-      },
+  ),
+  get_account_history: z.toJSONSchema(GetAccountHistoryOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_extrinsics: z.toJSONSchema(GetAccountExtrinsicsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_transfers: z.toJSONSchema(GetAccountTransfersOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_account_counterparties: z.toJSONSchema(
+    GetAccountCounterpartiesOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_account_serving: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_announcements",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_announcements: { type: "integer" },
-      subnet_count: { type: "integer" },
-      // Herfindahl-Hirschman index of AxonServed events across subnets: 1 means all
-      // announcements on one subnet; null when the account has none.
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "announcements",
-            "first_served_at",
-            "last_served_at",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            announcements: { type: "integer" },
-            first_served_at: NULLABLE_STRING,
-            last_served_at: NULLABLE_STRING,
-          },
-        },
-      },
-    },
-  },
-  get_account_deregistrations: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "address",
-      "window",
-      "total_deregistrations",
-      "subnet_count",
-      "subnets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      address: { type: "string" },
-      window: NULLABLE_STRING,
-      total_deregistrations: { type: "integer" },
-      subnet_count: { type: "integer" },
-      // Herfindahl-Hirschman index of NeuronDeregistered events across subnets: 1
-      // means all deregistrations on one subnet; null when the account has none.
-      concentration: { type: ["number", "null"] },
-      dominant_netuid: NULLABLE_INT,
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "deregistrations",
-            "first_deregistered_at",
-            "last_deregistered_at",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            deregistrations: { type: "integer" },
-            first_deregistered_at: NULLABLE_STRING,
-            last_deregistered_at: NULLABLE_STRING,
-          },
-        },
-      },
-    },
-  },
-  get_account_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "day_count", "days"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      day_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      days: objectItems({
-        day: NULLABLE_STRING,
-        netuid: NULLABLE_INT,
-        event_count: NULLABLE_INT,
-        event_kinds: { type: "array", items: { type: "string" } },
-        first_block: NULLABLE_INT,
-        last_block: NULLABLE_INT,
-      }),
-    },
-  },
-  get_account_extrinsics: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "extrinsic_count", "extrinsics"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      extrinsic_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      extrinsics: objectItems(EXTRINSIC_ITEM),
-    },
-  },
-  get_account_transfers: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "transfer_count", "transfers"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      transfer_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      transfers: objectItems({
-        block_number: NULLABLE_INT,
-        event_index: NULLABLE_INT,
-        from: NULLABLE_STRING,
-        to: NULLABLE_STRING,
-        amount_tao: ANY,
-        direction: NULLABLE_STRING,
-        observed_at: NULLABLE_STRING,
-      }),
-    },
-  },
-  get_account_counterparties: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ss58", "counterparty_count", "counterparties"],
-    properties: {
-      schema_version: { type: "integer" },
-      ss58: { type: "string" },
-      counterparty_count: { type: "integer" },
-      transfers_scanned: NULLABLE_INT,
-      scan_capped: { type: "boolean" },
-      total_sent_tao: ANY,
-      total_received_tao: ANY,
-      counterparties: objectItems({
-        address: NULLABLE_STRING,
-        sent_tao: ANY,
-        received_tao: ANY,
-        net_tao: ANY,
-        transfer_count: NULLABLE_INT,
-        last_block: NULLABLE_INT,
-      }),
-      // Present only in counterparty='<ss58>' drilldown mode (the per-pair detail).
-      relationship: { type: "object", additionalProperties: true },
-    },
-  },
+  ),
   list_blocks: {
     type: "object",
     additionalProperties: true,
@@ -12928,55 +12360,12 @@ const TOOL_OUTPUT_SCHEMAS = {
       }),
     },
   },
-  list_accounts: {
-    type: "object",
-    additionalProperties: true,
-    required: ["sort", "limit", "account_count", "accounts"],
-    properties: {
-      schema_version: { type: "integer" },
-      sort: { type: "string", enum: ACCOUNTS_LIST_SORTS },
-      limit: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      block_number: NULLABLE_INT,
-      account_count: { type: "integer" },
-      accounts: objectItems({
-        hotkey: { type: "string" },
-        coldkey: NULLABLE_STRING,
-        coldkey_count: { type: "integer" },
-        subnet_count: { type: "integer" },
-        uid_count: { type: "integer" },
-        validator_count: { type: "integer" },
-        miner_count: { type: "integer" },
-        total_stake_tao: ANY,
-        total_emission_tao: ANY,
-        latest_captured_at: NULLABLE_STRING,
-        latest_block_number: NULLABLE_INT,
-        subnets: { type: "array", items: { type: "object" } },
-      }),
-    },
-  },
-  get_top_holders: {
-    type: "object",
-    additionalProperties: true,
-    required: ["sort", "limit", "account_count", "accounts"],
-    properties: {
-      schema_version: { type: "integer" },
-      sort: { type: "string", enum: TOP_HOLDERS_SORTS },
-      limit: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      account_count: { type: "integer" },
-      accounts: objectItems({
-        ss58: { type: "string" },
-        free_tao: ANY,
-        delegated_tao: ANY,
-        total_tao: ANY,
-        net_flow_7d: ANY,
-        net_flow_30d: ANY,
-        net_flow_90d: ANY,
-        last_updated: NULLABLE_STRING,
-      }),
-    },
-  },
+  list_accounts: z.toJSONSchema(ListAccountsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_top_holders: z.toJSONSchema(GetTopHoldersOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_block_chain_events: {
     type: "object",
     additionalProperties: true,


### PR DESCRIPTION
## Summary

Batch 6 of types-epic E (#7863, tracked as #8070): converts 15 more MCP tool input/output schemas from hand-written JSON Schema literals to Zod-generated (`z.toJSONSchema(...)`), covering the account-activity surface: `get_account_stake_moves`, `get_account_axon_removals`, `get_account_prometheus`, `get_account_registrations`, `get_account_weight_setters`, `get_account_serving`, `get_account_deregistrations`, `get_account_history`, `get_account_extrinsics`, `get_account_transfers`, `get_account_counterparties`, `list_accounts`, `get_top_holders`, `decode_evm_call`, `get_evm_address_mapping`.

Closes #8070.

## Diff-audit results (`scripts/diff-mcp-tool-schemas.ts`)

200/202 schema checks PASS (pilot + all prior batches + this batch combined). 2 DIFFs, both pre-existing and unrelated to this batch:

- `get_subnet_identity_history.output` — pre-existing, already-documented finding from #8067.
- `get_account_identity_history.output` — pre-existing, already-documented finding from #8069.

Zero new findings from this batch's 15 tools (30/30 input+output checks PASS).

## Reuse note

None of this batch's 15 tools reuse an existing `schemas-src/routes/` REST schema — no REST route in the accounts or evm domains has been Zod-converted yet under types-epic B. All 15 are modeled fresh, matching each hand-written literal field-for-field (verified against the pre-conversion source via `git show`, not transcribed from memory).

Two conventions worth flagging:

- The 7 "footprint" account-activity tools (`get_account_stake_moves`, `axon_removals`, `prometheus`, `registrations`, `weight_setters`, `serving`, `deregistrations`) do **not** use the shared `objectItems()` item-level looseness convention used everywhere else in this epic — their `subnets` array items are hand-written as STRICT objects (`additionalProperties: false`, every field required). Modeled with the same strictness (`.strict()`, no `.optional()` on item fields), not loosened to match the majority convention.
- `decode_evm_call` and `get_evm_address_mapping` declare `outputSchema` INLINE on the tool object (not via the shared `TOOL_OUTPUT_SCHEMAS` map every other tool in this epic uses) and are `additionalProperties: false` (strict) at the top level, unlike the `additionalProperties: true` posture everywhere else in this epic. Modeled with the same strictness.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` / `npx prettier --check` (touched files) — clean
- `npx tsx scripts/diff-mcp-tool-schemas.ts` — 200/202 PASS, 0 new findings (2 pre-existing, documented above)
- `npx tsx scripts/validate-mcp.ts` — 204 tools, full lifecycle/subscribe round trips pass
- Full test suite: 490/490 files, 11853/11853 tests passing
- Zero JSON Schema object literals remain for these 15 tools (grep-verified)

## Test plan

- [x] tsc clean
- [x] eslint/prettier clean
- [x] Diff-audit run, 0 new findings
- [x] `validate-mcp.ts` passes
- [x] Full test suite green
