### PR TITLE
fix(ui): PageMasthead title no longer collapses vs busy actions row

### DIFF
--- a/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/page-masthead.tsx
@@ -92,7 +92,7 @@ export function PageMasthead({
       ) : null}
 
       <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
-        <div className="min-w-0 flex-1">
+        <div className="min-w-[120px] flex-1">
           <div className="flex items-center gap-2 flex-wrap">
             {live ? <span className="mg-live-dot shrink-0" aria-hidden /> : null}
             <h1 className="font-display text-2xl md:text-3xl font-semibold leading-[1.15] tracking-[-0.015em] text-ink-strong min-w-0 truncate">
@@ -119,7 +119,7 @@ export function PageMasthead({
           ) : null}
         </div>
         {actions ? (
-          <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>
+          <div className="flex min-w-0 max-w-full flex-wrap items-center gap-2">{actions}</div>
         ) : null}
         {aside ? <div className="hidden md:block shrink-0">{aside}</div> : null}
       </div>


### PR DESCRIPTION
## Summary

Fixes #8109 — `PageMasthead`'s title collapsing to near-zero width (or the page gaining real horizontal scroll) whenever the `actions` slot content is wide, at mobile/tablet widths. Confirmed on 5 routes during the #7855 visual QA sweep.

Root cause: the title column was `min-w-0 flex-1` (no floor) and the actions wrapper was `shrink-0` (never shrinks). CSS flexbox resolves a too-narrow row by shrinking flexible items before wrapping — since the title had no minimum, it got crushed toward zero instead of the row ever wrapping actions onto their own line.

Fix (`apps/ui/src/components/metagraphed/primitives/page-masthead.tsx`):
- Title column: `min-w-0` → `min-w-[120px]` — a hard CSS `min-width` floor (unaffected by flex-shrink math), so the title can never be crushed below a legible width.
- Actions wrapper: `shrink-0` → `min-w-0 max-w-full` — lets it actually participate in the shrink/wrap calculation instead of holding its full natural width. Once the row can't fit both the title-at-floor and actions-at-natural-width, the parent's existing `flex-wrap` puts actions on its own line; if actions is still too wide for that line, its own `flex-wrap` now (because it's no longer `shrink-0`, so it isn't forced to its content width) wraps its own children across sub-lines instead of overflowing.

Two lines changed, one file.

## Before / after (375px viewport, `/subnets`)

**Before:** H1 renders at 23px wide, truncated to "S…"; description truncated to "Evel…" / "ac…". Actions row (Table/Grid/Matrix toggle, density toggle, Download CSV, Share view) crowds the title down to nothing.

**After:** H1 renders at 94px, fully legible ("Subnets"); description reads in full. Actions wrap cleanly onto their own row below the title, matching the existing desktop visual language just stacked instead of side-by-side.

(Screenshots captured locally via toggling the fix on/off with `git stash` against the live dev server — not embedded here since this environment has no image host, but the DOM measurements below are from the same sessions the screenshots were taken in.)

## Verified across all 5 repro routes (local dev server, both before and after)

| Route | Before (375px) | After (375px) |
|---|---|---|
| `/subnets` | H1 23px ("S…") | H1 94px ("Subnets") |
| `/subnets` (768px) | H1 45px ("S…") | H1 118px ("Subnets") |
| `/accounts/:ss58` | "API Endpoints" pill clipped off-screen | All 3 action pills visible, wrapped onto own line |
| `/health` | `body.scrollWidth` 437px vs 375px viewport (real page scroll) | `body.scrollWidth` 375px === 375px (no scroll) |
| `/explorer` | H1 52px ("Ch…") | H1 162px ("Chain explorer", full) |
| `/schemas` | `body.scrollWidth` 738px vs 375px viewport (363px overflow) | Masthead actions bounded to 343px, wraps into multiple lines; H1 full width (238px) |

No regression at 1280px desktop on any of the above, or on previously-clean routes (`/providers`, `/extrinsics`, `/blocks/:ref` spot-checked).

Note: `/schemas` still has a small (41px) unrelated horizontal overflow further down the page from a separate `contracts`/`providers` card grid that doesn't wrap at mobile — pre-existing, untouched by this diff, out of scope here (not part of #8109's root cause, which is exclusively the masthead).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` on the touched file: 0 errors, 0 warnings
- [x] `vitest run`: 1464/1464 passing
- [x] Live dev-server check at 375px/768px/1280px on all 5 repro routes plus 3 previously-clean routes, 0 console errors, DOM measurements confirmed above

Closes #8109.