### PR TITLE
feat(mcp): types-epic E — Zod schemas for 14 blocks/extrinsics/chain-tx MCP tools (#8071)

### DIFF
--- a/schemas-src/mcp-tools/blocks.ts
+++ b/schemas-src/mcp-tools/blocks.ts
@@ -1,0 +1,123 @@
+// MCP tools `list_blocks`, `get_block`, `list_block_extrinsics`,
+// `get_block_events` (types-epic E batch 8, #8071). Each mirrors a
+// GET /api/v1/blocks* route that is not one of schemas-src/routes/'s covered
+// pilot routes -- no existing Zod schema to reuse. Modeled fresh, matching
+// each hand-written literal field-for-field.
+import { z } from "zod";
+import {
+  AccountEventItemSchema,
+  ExtrinsicItemSchema,
+  OpenObjectSchema,
+} from "./shared.ts";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const ListBlocksInputSchema = z
+  .object({
+    author: Ss58Schema.optional(),
+    spec_version: z.int().min(0).optional(),
+    block_start: z.int().min(0).optional(),
+    block_end: z.int().min(0).optional(),
+    from: z.int().min(0).optional(),
+    to: z.int().min(0).optional(),
+    min_extrinsics: z.int().min(0).optional(),
+    min_events: z.int().min(0).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type ListBlocksInput = z.infer<typeof ListBlocksInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const BlockItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    block_hash: z.string().nullable().optional(),
+    parent_hash: z.string().nullable().optional(),
+    author: z.string().nullable().optional(),
+    extrinsic_count: z.int().nullable().optional(),
+    event_count: z.int().nullable().optional(),
+    spec_version: z.int().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const ListBlocksOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    block_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    blocks: z.array(BlockItemSchema),
+  })
+  .passthrough();
+export type ListBlocksOutput = z.infer<typeof ListBlocksOutputSchema>;
+
+export const GetBlockInputSchema = z
+  .object({
+    ref: z.string(),
+  })
+  .strict();
+export type GetBlockInput = z.infer<typeof GetBlockInputSchema>;
+
+export const GetBlockOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ref: z.unknown(),
+    block: OpenObjectSchema.nullable().optional(),
+    prev_block_number: z.int().nullable().optional(),
+    next_block_number: z.int().nullable().optional(),
+  })
+  .passthrough();
+export type GetBlockOutput = z.infer<typeof GetBlockOutputSchema>;
+
+export const ListBlockExtrinsicsInputSchema = z
+  .object({
+    ref: z.string(),
+    limit: z.int().min(1).max(100).optional(),
+    offset: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListBlockExtrinsicsInput = z.infer<
+  typeof ListBlockExtrinsicsInputSchema
+>;
+
+export const ListBlockExtrinsicsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ref: z.unknown(),
+    block_number: z.int().nullable().optional(),
+    extrinsic_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    extrinsics: z.array(ExtrinsicItemSchema),
+  })
+  .passthrough();
+export type ListBlockExtrinsicsOutput = z.infer<
+  typeof ListBlockExtrinsicsOutputSchema
+>;
+
+export const GetBlockEventsInputSchema = z
+  .object({
+    ref: z.string(),
+    limit: z.int().min(1).max(1000).optional(),
+    offset: z.int().min(0).optional(),
+  })
+  .strict();
+export type GetBlockEventsInput = z.infer<typeof GetBlockEventsInputSchema>;
+
+export const GetBlockEventsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ref: z.unknown(),
+    block_number: z.int().nullable().optional(),
+    event_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    events: z.array(AccountEventItemSchema),
+  })
+  .passthrough();
+export type GetBlockEventsOutput = z.infer<typeof GetBlockEventsOutputSchema>;

--- a/schemas-src/mcp-tools/chain-events.ts
+++ b/schemas-src/mcp-tools/chain-events.ts
@@ -1,0 +1,73 @@
+// MCP tools `get_block_chain_events`, `get_extrinsic_chain_events`
+// (types-epic E batch 8, #8071). Each mirrors a GET /api/v1/{blocks/*/chain-
+// events,chain-events} route that is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// matching each hand-written literal field-for-field.
+import { z } from "zod";
+
+export const GetBlockChainEventsInputSchema = z
+  .object({
+    block_number: z.int().min(0),
+  })
+  .strict();
+export type GetBlockChainEventsInput = z.infer<
+  typeof GetBlockChainEventsInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch). observed_at here is
+// a plain nullable INTEGER (epoch ms), unlike the nullable STRING timestamp
+// convention every other item shape in this epic uses -- the hand-written
+// original's CHAIN_EVENT_ITEM literally wraps it in NULLABLE_INT, not
+// NULLABLE_STRING.
+const ChainEventItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    event_index: z.int().nullable().optional(),
+    pallet: z.string().nullable().optional(),
+    method: z.string().nullable().optional(),
+    args: z.unknown().optional(),
+    phase: z.unknown().optional(),
+    extrinsic_index: z.int().nullable().optional(),
+    observed_at: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetBlockChainEventsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    block_number: z.int().nullable(),
+    event_count: z.int(),
+    events: z.array(ChainEventItemSchema),
+  })
+  .passthrough();
+export type GetBlockChainEventsOutput = z.infer<
+  typeof GetBlockChainEventsOutputSchema
+>;
+
+export const GetExtrinsicChainEventsInputSchema = z
+  .object({
+    ref: z.string(),
+    limit: z.int().min(1).max(200).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetExtrinsicChainEventsInput = z.infer<
+  typeof GetExtrinsicChainEventsInputSchema
+>;
+
+export const GetExtrinsicChainEventsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ref: z.unknown(),
+    block_number: z.int().nullable(),
+    extrinsic_index: z.int().nullable(),
+    limit: z.int().nullable().optional(),
+    event_count: z.int(),
+    next_cursor: z.string().nullable().optional(),
+    events: z.array(ChainEventItemSchema),
+  })
+  .passthrough();
+export type GetExtrinsicChainEventsOutput = z.infer<
+  typeof GetExtrinsicChainEventsOutputSchema
+>;

--- a/schemas-src/mcp-tools/extrinsics.ts
+++ b/schemas-src/mcp-tools/extrinsics.ts
@@ -1,0 +1,60 @@
+// MCP tools `list_extrinsics`, `get_extrinsic` (types-epic E batch 8,
+// #8071). Each mirrors a GET /api/v1/extrinsics* route that is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, matching each hand-written literal field-for-field.
+import { z } from "zod";
+import {
+  AccountEventItemSchema,
+  ExtrinsicItemSchema,
+  OpenObjectSchema,
+} from "./shared.ts";
+
+const Ss58Schema = z.string().regex(/^[1-9A-HJ-NP-Za-km-z]{47,48}$/);
+
+export const ListExtrinsicsInputSchema = z
+  .object({
+    block: z.int().min(0).optional(),
+    signer: Ss58Schema.optional(),
+    call_module: z.string().optional(),
+    call_function: z.string().optional(),
+    call_hash: z.string().optional(),
+    success: z.boolean().optional(),
+    block_start: z.int().min(0).optional(),
+    block_end: z.int().min(0).optional(),
+    from: z.int().min(0).optional(),
+    to: z.int().min(0).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type ListExtrinsicsInput = z.infer<typeof ListExtrinsicsInputSchema>;
+
+export const ListExtrinsicsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    extrinsic_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    extrinsics: z.array(ExtrinsicItemSchema),
+  })
+  .passthrough();
+export type ListExtrinsicsOutput = z.infer<typeof ListExtrinsicsOutputSchema>;
+
+export const GetExtrinsicInputSchema = z
+  .object({
+    ref: z.string(),
+  })
+  .strict();
+export type GetExtrinsicInput = z.infer<typeof GetExtrinsicInputSchema>;
+
+export const GetExtrinsicOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    ref: z.unknown(),
+    extrinsic: OpenObjectSchema.nullable().optional(),
+    events: z.array(AccountEventItemSchema).optional(),
+  })
+  .passthrough();
+export type GetExtrinsicOutput = z.infer<typeof GetExtrinsicOutputSchema>;

--- a/schemas-src/mcp-tools/governance-feeds.ts
+++ b/schemas-src/mcp-tools/governance-feeds.ts
@@ -1,0 +1,83 @@
+// MCP tools `get_sudo`, `get_sudo_key`, `get_governance_config_changes`
+// (types-epic E batch 8, #8071). Each mirrors a GET /api/v1/{sudo,governance}*
+// route that is not one of schemas-src/routes/'s covered pilot routes -- no
+// existing Zod schema to reuse. Modeled fresh, matching each hand-written
+// literal field-for-field. get_sudo/get_governance_config_changes's input
+// omits `required` entirely in the hand-written original (every field
+// optional) rather than declaring `required: []` -- both are semantically
+// identical JSON Schema and the diff-audit script already treats them as
+// equal (see list_accounts/get_top_holders in #8070).
+import { z } from "zod";
+import { ExtrinsicItemSchema } from "./shared.ts";
+
+export const GetSudoInputSchema = z
+  .object({
+    block: z.int().min(0).optional(),
+    call_function: z.string().optional(),
+    success: z.boolean().optional(),
+    block_start: z.int().min(0).optional(),
+    block_end: z.int().min(0).optional(),
+    from: z.int().min(0).optional(),
+    to: z.int().min(0).optional(),
+    limit: z.int().min(1).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetSudoInput = z.infer<typeof GetSudoInputSchema>;
+
+export const GetSudoOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    extrinsic_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    extrinsics: z.array(ExtrinsicItemSchema),
+  })
+  .passthrough();
+export type GetSudoOutput = z.infer<typeof GetSudoOutputSchema>;
+
+export const GetSudoKeyInputSchema = z.object({}).strict();
+export type GetSudoKeyInput = z.infer<typeof GetSudoKeyInputSchema>;
+
+export const GetSudoKeyOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    hotkey: z.string().nullable(),
+    queried_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GetSudoKeyOutput = z.infer<typeof GetSudoKeyOutputSchema>;
+
+export const GetGovernanceConfigChangesInputSchema = z
+  .object({
+    block: z.int().min(0).optional(),
+    call_function: z.string().optional(),
+    success: z.boolean().optional(),
+    block_start: z.int().min(0).optional(),
+    block_end: z.int().min(0).optional(),
+    from: z.int().min(0).optional(),
+    to: z.int().min(0).optional(),
+    limit: z.int().min(1).optional(),
+    offset: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+  })
+  .strict();
+export type GetGovernanceConfigChangesInput = z.infer<
+  typeof GetGovernanceConfigChangesInputSchema
+>;
+
+export const GetGovernanceConfigChangesOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    extrinsic_count: z.int(),
+    limit: z.int().nullable().optional(),
+    offset: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    extrinsics: z.array(ExtrinsicItemSchema),
+  })
+  .passthrough();
+export type GetGovernanceConfigChangesOutput = z.infer<
+  typeof GetGovernanceConfigChangesOutputSchema
+>;

--- a/schemas-src/mcp-tools/network-live.ts
+++ b/schemas-src/mcp-tools/network-live.ts
@@ -1,0 +1,44 @@
+// MCP tools `get_network_parameters`, `get_randomness_status` (types-epic E
+// batch 8, #8071). Each mirrors a GET /api/v1/network/* route that is not
+// one of schemas-src/routes/'s covered pilot routes -- no existing Zod
+// schema to reuse. Both take no input (bare `{}`) and every output field is
+// required-but-independently-nullable (each queried live from a separate RPC
+// call that can fail on its own) -- modeled fresh, matching each hand-written
+// literal field-for-field.
+import { z } from "zod";
+
+export const GetNetworkParametersInputSchema = z.object({}).strict();
+export type GetNetworkParametersInput = z.infer<
+  typeof GetNetworkParametersInputSchema
+>;
+
+export const GetNetworkParametersOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    tao_weight: z.number().nullable(),
+    stake_threshold_tao: z.number().nullable(),
+    pending_childkey_cooldown_blocks: z.int().nullable(),
+    queried_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GetNetworkParametersOutput = z.infer<
+  typeof GetNetworkParametersOutputSchema
+>;
+
+export const GetRandomnessStatusInputSchema = z.object({}).strict();
+export type GetRandomnessStatusInput = z.infer<
+  typeof GetRandomnessStatusInputSchema
+>;
+
+export const GetRandomnessStatusOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    last_stored_round: z.int().nullable(),
+    oldest_stored_round: z.int().nullable(),
+    stored_round_span: z.int().nullable(),
+    queried_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GetRandomnessStatusOutput = z.infer<
+  typeof GetRandomnessStatusOutputSchema
+>;

--- a/schemas-src/mcp-tools/runtime.ts
+++ b/schemas-src/mcp-tools/runtime.ts
@@ -1,0 +1,33 @@
+// MCP tool `get_runtime` (types-epic E batch 8, #8071). Mirrors
+// GET /api/v1/runtime, which is not one of schemas-src/routes/'s covered
+// pilot routes -- no existing Zod schema to reuse. Modeled fresh, matching
+// the hand-written literal it replaces field-for-field.
+import { z } from "zod";
+
+export const GetRuntimeInputSchema = z.object({}).strict();
+export type GetRuntimeInput = z.infer<typeof GetRuntimeInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch) -- but unlike most
+// other item shapes in this epic, spec_version/block_number are plain
+// (non-nullable) integers when present: the hand-written original wraps
+// them in bare `{type:"integer"}`, not NULLABLE_INT.
+const RuntimeTransitionSchema = z
+  .object({
+    spec_version: z.int().optional(),
+    block_number: z.int().optional(),
+    observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetRuntimeOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    transition_count: z.int(),
+    current_spec_version: z.int().nullable().optional(),
+    coverage_from_block: z.int().nullable().optional(),
+    coverage_from_at: z.string().nullable().optional(),
+    transitions: z.array(RuntimeTransitionSchema),
+  })
+  .passthrough();
+export type GetRuntimeOutput = z.infer<typeof GetRuntimeOutputSchema>;

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -19,3 +19,43 @@ export const OpenObjectSchema = z.object({}).passthrough();
 // items-shape constraint beyond "each item is some object", or none at all).
 export const OpenArraySchema = z.array(z.unknown());
 export const OpenObjectArraySchema = z.array(OpenObjectSchema);
+
+// Mirrors mcp-server.ts's shared EXTRINSIC_ITEM / ACCOUNT_EVENT_ITEM object
+// literals (types-epic E batch 8, #8071): each used across 3+ tools spanning
+// multiple schemas-src/mcp-tools/*.ts files in that batch (list_extrinsics,
+// list_block_extrinsics, get_sudo, get_governance_config_changes for the
+// former; get_block_events, get_extrinsic for the latter), unlike every
+// other item shape converted so far which stayed tool-local -- hoisted here
+// rather than tripled. objectItems(...) properties, none required at the
+// item level (see search-subnets.ts's same note from the pilot batch).
+export const ExtrinsicItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    extrinsic_index: z.int().nullable().optional(),
+    extrinsic_hash: z.string().nullable().optional(),
+    signer: z.string().nullable().optional(),
+    call_module: z.string().nullable().optional(),
+    call_function: z.string().nullable().optional(),
+    call_args: z.unknown().optional(),
+    success: z.boolean().nullable().optional(),
+    fee_tao: z.unknown().optional(),
+    tip_tao: z.unknown().optional(),
+    observed_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const AccountEventItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    event_index: z.int().nullable().optional(),
+    event_kind: z.string().nullable().optional(),
+    hotkey: z.string().nullable().optional(),
+    coldkey: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    uid: z.int().nullable().optional(),
+    amount_tao: z.unknown().optional(),
+    alpha_amount: z.unknown().optional(),
+    observed_at: z.string().nullable().optional(),
+    extrinsic_index: z.int().nullable().optional(),
+  })
+  .passthrough();

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -360,6 +360,46 @@ import {
   GetEvmAddressMappingInputSchema,
   GetEvmAddressMappingOutputSchema,
 } from "../schemas-src/mcp-tools/evm.ts";
+import {
+  ListBlocksInputSchema,
+  ListBlocksOutputSchema,
+  GetBlockInputSchema,
+  GetBlockOutputSchema,
+  ListBlockExtrinsicsInputSchema,
+  ListBlockExtrinsicsOutputSchema,
+  GetBlockEventsInputSchema,
+  GetBlockEventsOutputSchema,
+} from "../schemas-src/mcp-tools/blocks.ts";
+import {
+  ListExtrinsicsInputSchema,
+  ListExtrinsicsOutputSchema,
+  GetExtrinsicInputSchema,
+  GetExtrinsicOutputSchema,
+} from "../schemas-src/mcp-tools/extrinsics.ts";
+import {
+  GetSudoInputSchema,
+  GetSudoOutputSchema,
+  GetSudoKeyInputSchema,
+  GetSudoKeyOutputSchema,
+  GetGovernanceConfigChangesInputSchema,
+  GetGovernanceConfigChangesOutputSchema,
+} from "../schemas-src/mcp-tools/governance-feeds.ts";
+import {
+  GetNetworkParametersInputSchema,
+  GetNetworkParametersOutputSchema,
+  GetRandomnessStatusInputSchema,
+  GetRandomnessStatusOutputSchema,
+} from "../schemas-src/mcp-tools/network-live.ts";
+import {
+  GetRuntimeInputSchema,
+  GetRuntimeOutputSchema,
+} from "../schemas-src/mcp-tools/runtime.ts";
+import {
+  GetBlockChainEventsInputSchema,
+  GetBlockChainEventsOutputSchema,
+  GetExtrinsicChainEventsInputSchema,
+  GetExtrinsicChainEventsOutputSchema,
+} from "../schemas-src/mcp-tools/chain-events.ts";
 
 type Row = Record<string, unknown>;
 
@@ -4058,6 +4098,473 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  list_blocks: {
+    input: {
+      type: "object",
+      properties: {
+        author: { type: "string", pattern: SS58_PATTERN },
+        spec_version: { type: "integer", minimum: 0 },
+        block_start: { type: "integer", minimum: 0 },
+        block_end: { type: "integer", minimum: 0 },
+        from: { type: "integer", minimum: 0 },
+        to: { type: "integer", minimum: 0 },
+        min_extrinsics: { type: "integer", minimum: 0 },
+        min_events: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["block_count", "blocks"],
+      properties: {
+        schema_version: { type: "integer" },
+        block_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        blocks: objectItems({
+          block_number: NULLABLE_INT,
+          block_hash: NULLABLE_STRING,
+          parent_hash: NULLABLE_STRING,
+          author: NULLABLE_STRING,
+          extrinsic_count: NULLABLE_INT,
+          event_count: NULLABLE_INT,
+          spec_version: NULLABLE_INT,
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_block: {
+    input: {
+      type: "object",
+      properties: {
+        ref: { type: "string" },
+      },
+      required: ["ref"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ref"],
+      properties: {
+        schema_version: { type: "integer" },
+        ref: ANY,
+        block: { type: ["object", "null"], additionalProperties: true },
+        prev_block_number: NULLABLE_INT,
+        next_block_number: NULLABLE_INT,
+      },
+    },
+  },
+  list_block_extrinsics: {
+    input: {
+      type: "object",
+      properties: {
+        ref: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        offset: { type: "integer", minimum: 0 },
+      },
+      required: ["ref"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ref", "extrinsic_count", "extrinsics"],
+      properties: {
+        schema_version: { type: "integer" },
+        ref: ANY,
+        block_number: NULLABLE_INT,
+        extrinsic_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        extrinsics: objectItems({
+          block_number: NULLABLE_INT,
+          extrinsic_index: NULLABLE_INT,
+          extrinsic_hash: NULLABLE_STRING,
+          signer: NULLABLE_STRING,
+          call_module: NULLABLE_STRING,
+          call_function: NULLABLE_STRING,
+          call_args: ANY,
+          success: { type: ["boolean", "null"] },
+          fee_tao: ANY,
+          tip_tao: ANY,
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_block_events: {
+    input: {
+      type: "object",
+      properties: {
+        ref: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        offset: { type: "integer", minimum: 0 },
+      },
+      required: ["ref"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ref", "event_count", "events"],
+      properties: {
+        schema_version: { type: "integer" },
+        ref: ANY,
+        block_number: NULLABLE_INT,
+        event_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        events: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          event_kind: NULLABLE_STRING,
+          hotkey: NULLABLE_STRING,
+          coldkey: NULLABLE_STRING,
+          netuid: NULLABLE_INT,
+          uid: NULLABLE_INT,
+          amount_tao: ANY,
+          alpha_amount: ANY,
+          observed_at: NULLABLE_STRING,
+          extrinsic_index: NULLABLE_INT,
+        }),
+      },
+    },
+  },
+  list_extrinsics: {
+    input: {
+      type: "object",
+      properties: {
+        block: { type: "integer", minimum: 0 },
+        signer: { type: "string", pattern: SS58_PATTERN },
+        call_module: { type: "string" },
+        call_function: { type: "string" },
+        call_hash: { type: "string" },
+        success: { type: "boolean" },
+        block_start: { type: "integer", minimum: 0 },
+        block_end: { type: "integer", minimum: 0 },
+        from: { type: "integer", minimum: 0 },
+        to: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["extrinsic_count", "extrinsics"],
+      properties: {
+        schema_version: { type: "integer" },
+        extrinsic_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        extrinsics: objectItems({
+          block_number: NULLABLE_INT,
+          extrinsic_index: NULLABLE_INT,
+          extrinsic_hash: NULLABLE_STRING,
+          signer: NULLABLE_STRING,
+          call_module: NULLABLE_STRING,
+          call_function: NULLABLE_STRING,
+          call_args: ANY,
+          success: { type: ["boolean", "null"] },
+          fee_tao: ANY,
+          tip_tao: ANY,
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_extrinsic: {
+    input: {
+      type: "object",
+      properties: {
+        ref: { type: "string" },
+      },
+      required: ["ref"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["ref"],
+      properties: {
+        schema_version: { type: "integer" },
+        ref: ANY,
+        extrinsic: { type: ["object", "null"], additionalProperties: true },
+        events: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          event_kind: NULLABLE_STRING,
+          hotkey: NULLABLE_STRING,
+          coldkey: NULLABLE_STRING,
+          netuid: NULLABLE_INT,
+          uid: NULLABLE_INT,
+          amount_tao: ANY,
+          alpha_amount: ANY,
+          observed_at: NULLABLE_STRING,
+          extrinsic_index: NULLABLE_INT,
+        }),
+      },
+    },
+  },
+  get_sudo: {
+    input: {
+      type: "object",
+      properties: {
+        block: { type: "integer", minimum: 0 },
+        call_function: { type: "string" },
+        success: { type: "boolean" },
+        block_start: { type: "integer", minimum: 0 },
+        block_end: { type: "integer", minimum: 0 },
+        from: { type: "integer", minimum: 0 },
+        to: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["extrinsic_count", "extrinsics"],
+      properties: {
+        schema_version: { type: "integer" },
+        extrinsic_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        extrinsics: objectItems({
+          block_number: NULLABLE_INT,
+          extrinsic_index: NULLABLE_INT,
+          extrinsic_hash: NULLABLE_STRING,
+          signer: NULLABLE_STRING,
+          call_module: NULLABLE_STRING,
+          call_function: NULLABLE_STRING,
+          call_args: ANY,
+          success: { type: ["boolean", "null"] },
+          fee_tao: ANY,
+          tip_tao: ANY,
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_sudo_key: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["hotkey", "queried_at"],
+      properties: {
+        schema_version: { type: "integer" },
+        hotkey: NULLABLE_STRING,
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_network_parameters: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "tao_weight",
+        "stake_threshold_tao",
+        "pending_childkey_cooldown_blocks",
+        "queried_at",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        tao_weight: { type: ["number", "null"] },
+        stake_threshold_tao: { type: ["number", "null"] },
+        pending_childkey_cooldown_blocks: { type: ["integer", "null"] },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_randomness_status: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "last_stored_round",
+        "oldest_stored_round",
+        "stored_round_span",
+        "queried_at",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        last_stored_round: { type: ["integer", "null"] },
+        oldest_stored_round: { type: ["integer", "null"] },
+        stored_round_span: { type: ["integer", "null"] },
+        queried_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_governance_config_changes: {
+    input: {
+      type: "object",
+      properties: {
+        block: { type: "integer", minimum: 0 },
+        call_function: { type: "string" },
+        success: { type: "boolean" },
+        block_start: { type: "integer", minimum: 0 },
+        block_end: { type: "integer", minimum: 0 },
+        from: { type: "integer", minimum: 0 },
+        to: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1 },
+        offset: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["extrinsic_count", "extrinsics"],
+      properties: {
+        schema_version: { type: "integer" },
+        extrinsic_count: { type: "integer" },
+        limit: NULLABLE_INT,
+        offset: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        extrinsics: objectItems({
+          block_number: NULLABLE_INT,
+          extrinsic_index: NULLABLE_INT,
+          extrinsic_hash: NULLABLE_STRING,
+          signer: NULLABLE_STRING,
+          call_module: NULLABLE_STRING,
+          call_function: NULLABLE_STRING,
+          call_args: ANY,
+          success: { type: ["boolean", "null"] },
+          fee_tao: ANY,
+          tip_tao: ANY,
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_runtime: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["transition_count", "transitions"],
+      properties: {
+        schema_version: { type: "integer" },
+        transition_count: { type: "integer" },
+        current_spec_version: NULLABLE_INT,
+        coverage_from_block: NULLABLE_INT,
+        coverage_from_at: NULLABLE_STRING,
+        transitions: objectItems({
+          spec_version: { type: "integer" },
+          block_number: { type: "integer" },
+          observed_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_block_chain_events: {
+    input: {
+      type: "object",
+      properties: {
+        block_number: { type: "integer", minimum: 0 },
+      },
+      required: ["block_number"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["block_number", "event_count", "events"],
+      properties: {
+        schema_version: { type: "integer" },
+        block_number: NULLABLE_INT,
+        event_count: { type: "integer" },
+        events: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          pallet: NULLABLE_STRING,
+          method: NULLABLE_STRING,
+          args: ANY,
+          phase: ANY,
+          extrinsic_index: NULLABLE_INT,
+          observed_at: { type: ["integer", "null"] },
+        }),
+      },
+    },
+  },
+  get_extrinsic_chain_events: {
+    input: {
+      type: "object",
+      properties: {
+        ref: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 200 },
+        cursor: { type: "string" },
+      },
+      required: ["ref"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "ref",
+        "block_number",
+        "extrinsic_index",
+        "event_count",
+        "events",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        ref: ANY,
+        block_number: NULLABLE_INT,
+        extrinsic_index: NULLABLE_INT,
+        limit: NULLABLE_INT,
+        event_count: { type: "integer" },
+        next_cursor: NULLABLE_STRING,
+        events: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          pallet: NULLABLE_STRING,
+          method: NULLABLE_STRING,
+          args: ANY,
+          phase: ANY,
+          extrinsic_index: NULLABLE_INT,
+          observed_at: { type: ["integer", "null"] },
+        }),
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -4462,6 +4969,62 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
     input: GetEvmAddressMappingInputSchema,
     output: GetEvmAddressMappingOutputSchema,
   },
+  list_blocks: {
+    input: ListBlocksInputSchema,
+    output: ListBlocksOutputSchema,
+  },
+  get_block: {
+    input: GetBlockInputSchema,
+    output: GetBlockOutputSchema,
+  },
+  list_block_extrinsics: {
+    input: ListBlockExtrinsicsInputSchema,
+    output: ListBlockExtrinsicsOutputSchema,
+  },
+  get_block_events: {
+    input: GetBlockEventsInputSchema,
+    output: GetBlockEventsOutputSchema,
+  },
+  list_extrinsics: {
+    input: ListExtrinsicsInputSchema,
+    output: ListExtrinsicsOutputSchema,
+  },
+  get_extrinsic: {
+    input: GetExtrinsicInputSchema,
+    output: GetExtrinsicOutputSchema,
+  },
+  get_sudo: {
+    input: GetSudoInputSchema,
+    output: GetSudoOutputSchema,
+  },
+  get_sudo_key: {
+    input: GetSudoKeyInputSchema,
+    output: GetSudoKeyOutputSchema,
+  },
+  get_network_parameters: {
+    input: GetNetworkParametersInputSchema,
+    output: GetNetworkParametersOutputSchema,
+  },
+  get_randomness_status: {
+    input: GetRandomnessStatusInputSchema,
+    output: GetRandomnessStatusOutputSchema,
+  },
+  get_governance_config_changes: {
+    input: GetGovernanceConfigChangesInputSchema,
+    output: GetGovernanceConfigChangesOutputSchema,
+  },
+  get_runtime: {
+    input: GetRuntimeInputSchema,
+    output: GetRuntimeOutputSchema,
+  },
+  get_block_chain_events: {
+    input: GetBlockChainEventsInputSchema,
+    output: GetBlockChainEventsOutputSchema,
+  },
+  get_extrinsic_chain_events: {
+    input: GetExtrinsicChainEventsInputSchema,
+    output: GetExtrinsicChainEventsOutputSchema,
+  },
 };
 
 const MAX_SAFE_INT = Number.MAX_SAFE_INTEGER;
@@ -4530,7 +5093,15 @@ function normalize(node: unknown, path: string): unknown {
       continue;
     }
 
+    // `required: []` (hand-written, e.g. list_blocks/list_extrinsics's
+    // explicit empty array) and omitting `required` entirely (Zod's
+    // z.toJSONSchema output when nothing is required, e.g. get_sudo/
+    // list_accounts's hand-written originals which never declared the key
+    // either) both mean "nothing required" -- the SAME as the
+    // additionalProperties/items normalizations above. Drop the key outright
+    // rather than keeping an empty array on one side only (batch 8, #8071).
     if (key === "required" && Array.isArray(value)) {
+      if (value.length === 0) continue;
       out[key] = [...(value as string[])].sort();
       continue;
     }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -632,6 +632,46 @@ import {
   GetEvmAddressMappingOutputSchema,
 } from "../schemas-src/mcp-tools/evm.ts";
 import {
+  ListBlocksInputSchema,
+  ListBlocksOutputSchema,
+  GetBlockInputSchema,
+  GetBlockOutputSchema,
+  ListBlockExtrinsicsInputSchema,
+  ListBlockExtrinsicsOutputSchema,
+  GetBlockEventsInputSchema,
+  GetBlockEventsOutputSchema,
+} from "../schemas-src/mcp-tools/blocks.ts";
+import {
+  ListExtrinsicsInputSchema,
+  ListExtrinsicsOutputSchema,
+  GetExtrinsicInputSchema,
+  GetExtrinsicOutputSchema,
+} from "../schemas-src/mcp-tools/extrinsics.ts";
+import {
+  GetSudoInputSchema,
+  GetSudoOutputSchema,
+  GetSudoKeyInputSchema,
+  GetSudoKeyOutputSchema,
+  GetGovernanceConfigChangesInputSchema,
+  GetGovernanceConfigChangesOutputSchema,
+} from "../schemas-src/mcp-tools/governance-feeds.ts";
+import {
+  GetNetworkParametersInputSchema,
+  GetNetworkParametersOutputSchema,
+  GetRandomnessStatusInputSchema,
+  GetRandomnessStatusOutputSchema,
+} from "../schemas-src/mcp-tools/network-live.ts";
+import {
+  GetRuntimeInputSchema,
+  GetRuntimeOutputSchema,
+} from "../schemas-src/mcp-tools/runtime.ts";
+import {
+  GetBlockChainEventsInputSchema,
+  GetBlockChainEventsOutputSchema,
+  GetExtrinsicChainEventsInputSchema,
+  GetExtrinsicChainEventsOutputSchema,
+} from "../schemas-src/mcp-tools/chain-events.ts";
+import {
   buildChainConcentration,
   buildConcentration,
   buildConcentrationHistory,
@@ -2360,10 +2400,6 @@ function requireSs58(args: Row) {
   }
   return value;
 }
-
-// The ss58 inputSchema `pattern` (advisory; runtime validation is requireSs58),
-// derived from the single pattern source so it can't drift.
-const SS58_PATTERN_SOURCE = SS58_ADDRESS_PATTERN.source;
 
 // A validator identity is the same SS58 shape as an account, just a different
 // argument name (a hotkey the caller already knows, not one they're looking
@@ -7236,78 +7272,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "block_end (inclusive height range), from/to (observed_at epoch-ms range), " +
       "min_extrinsics, or min_events. Page with limit (1-100, default 50) / offset, " +
       "or follow next_cursor for stable keyset pagination. Mirrors GET /api/v1/blocks.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        author: {
-          type: "string",
-          description:
-            "Optional block author SS58 address filter. Omit for all authors.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        spec_version: {
-          type: "integer",
-          description: "Optional runtime spec_version filter. Omit for all.",
-          minimum: 0,
-        },
-        block_start: {
-          type: "integer",
-          description:
-            "Optional inclusive lower block bound; omit for no lower limit.",
-          minimum: 0,
-        },
-        block_end: {
-          type: "integer",
-          description:
-            "Optional inclusive upper block bound; omit for no upper limit.",
-          minimum: 0,
-        },
-        from: {
-          type: "integer",
-          description:
-            "Optional observed_at lower bound (epoch ms). Omit for no lower limit.",
-          minimum: 0,
-        },
-        to: {
-          type: "integer",
-          description:
-            "Optional observed_at upper bound (epoch ms). Omit for no upper limit.",
-          minimum: 0,
-        },
-        min_extrinsics: {
-          type: "integer",
-          description:
-            "Optional minimum extrinsic_count per block. Omit for no floor.",
-          minimum: 0,
-        },
-        min_events: {
-          type: "integer",
-          description:
-            "Optional minimum event_count per block. Omit for no floor.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Max blocks to return (1-100, default 50).",
-          minimum: 1,
-          maximum: 100,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset. Default 0.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor; takes " +
-            "precedence over offset for stable deep pagination.",
-        },
-      },
-      required: [],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListBlocksInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof ListBlocksInputSchema>, ctx: McpCtx) {
       // Every filter below is validated for REST-parity and, now that the
       // Postgres tier can be flipped on, forwarded to it below -- only the
       // buildBlockFeed([]) D1 fallback ignores them (nothing left to filter
@@ -7323,7 +7291,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const minEvents = optionalNonNegativeInt(args, "min_events");
       const limit = clampLimit(args?.limit, 50, 100);
       const offset = Number.isFinite(args?.offset)
-        ? Math.max(0, Math.floor(args.offset))
+        ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       // Mirrors REST's handleBlocks: try Postgres first, fall back to the
       // schema-stable empty feed now that blocks' D1 write path is retired
@@ -7362,20 +7330,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(64-char hex). Returns the block header plus the nearest stored prev/next block " +
       "numbers for chain-walk navigation. Returns block:null when the ref is unknown or " +
       "the store is cold — never errors. Use list_blocks to find block refs.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ref: {
-          type: "string",
-          description:
-            "Block reference: a numeric block number as a string (e.g. '4200000') " +
-            "or a 0x block hash (e.g. '0xabc...64hex').",
-        },
-      },
-      required: ["ref"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetBlockInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetBlockInputSchema>, ctx: McpCtx) {
       const ref = requireString(args, "ref");
       // Mirrors REST's handleBlock: try Postgres first, fall back to the
       // schema-stable block:null shape now that blocks' D1 write path is
@@ -7398,35 +7356,17 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(1-100, default 50) / offset. Returns block_number:null + extrinsics:[] when " +
       "the ref is unknown or the store is cold — never errors. Use get_block to " +
       "resolve a block header first. Mirrors GET /api/v1/blocks/{ref}/extrinsics.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ref: {
-          type: "string",
-          description:
-            "Block reference: a numeric block number as a string (e.g. '4200000') " +
-            "or a 0x block hash (e.g. '0xabc...64hex').",
-        },
-        limit: {
-          type: "integer",
-          description: "Max extrinsics to return (1-100, default 50).",
-          minimum: 1,
-          maximum: 100,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset. Default 0.",
-          minimum: 0,
-        },
-      },
-      required: ["ref"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListBlockExtrinsicsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof ListBlockExtrinsicsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ref = requireString(args, "ref");
       const limit = clampLimit(args?.limit, 50, 100);
       const offset = Number.isFinite(args?.offset)
-        ? Math.max(0, Math.floor(args.offset))
+        ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       // Mirrors REST's handleBlockExtrinsics, which destructures `{ data }` from
       // tryPostgresTier's result -- workers/data-api.mjs's /blocks/:ref/extrinsics
@@ -7455,35 +7395,17 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(1-1000, default 100) / offset. Returns block_number:null + events:[] when " +
       "the ref is unknown or the store is cold — never errors. Use get_block to " +
       "resolve a block header first. Mirrors GET /api/v1/blocks/{ref}/events.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ref: {
-          type: "string",
-          description:
-            "Block reference: a numeric block number as a string (e.g. '4200000') " +
-            "or a 0x block hash (e.g. '0xabc...64hex').",
-        },
-        limit: {
-          type: "integer",
-          description: "Max events to return (1-1000, default 100).",
-          minimum: 1,
-          maximum: 1000,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset. Default 0.",
-          minimum: 0,
-        },
-      },
-      required: ["ref"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetBlockEventsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetBlockEventsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ref = requireString(args, "ref");
       const limit = clampLimit(args?.limit, 100, 1000);
       const offset = Number.isFinite(args?.offset)
-        ? Math.max(0, Math.floor(args.offset))
+        ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       // Mirrors REST's handleBlockEvents, which destructures `{ data }` from
       // tryPostgresTier's result -- workers/data-api.mjs's /blocks/:ref/events
@@ -7516,90 +7438,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "height range), and from/to (observed_at epoch-ms range). Page with limit " +
       "(1-100, default 50) / offset, or follow next_cursor for stable keyset " +
       "pagination. Mirrors GET /api/v1/extrinsics.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        block: {
-          type: "integer",
-          description:
-            "Optional exact block_number filter. Omit for all blocks.",
-          minimum: 0,
-        },
-        signer: {
-          type: "string",
-          description:
-            "Optional signer SS58 address to filter by. Omit for all signers.",
-          pattern: SS58_PATTERN_SOURCE,
-        },
-        call_module: {
-          type: "string",
-          description:
-            "Optional call module filter, e.g. 'SubtensorModule'. Omit for all.",
-        },
-        call_function: {
-          type: "string",
-          description:
-            "Optional call function filter, e.g. 'set_weights'. Omit for all.",
-        },
-        call_hash: {
-          type: "string",
-          description:
-            "Optional 0x call hash to match inside call_args, e.g. to link a " +
-            "Multisig approve_as_multi/cancel_as_multi/as_multi approval chain. " +
-            "Pair with call_module for a narrow scan. Omit for all.",
-        },
-        success: {
-          type: "boolean",
-          description:
-            "Optional success filter: true for succeeded extrinsics only, false " +
-            "for failed only. Omit for all.",
-        },
-        block_start: {
-          type: "integer",
-          description:
-            "Optional inclusive lower block bound; omit for no lower limit.",
-          minimum: 0,
-        },
-        block_end: {
-          type: "integer",
-          description:
-            "Optional inclusive upper block bound; omit for no upper limit.",
-          minimum: 0,
-        },
-        from: {
-          type: "integer",
-          description:
-            "Optional observed_at lower bound (epoch ms). Omit for no lower limit.",
-          minimum: 0,
-        },
-        to: {
-          type: "integer",
-          description:
-            "Optional observed_at upper bound (epoch ms). Omit for no upper limit.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Max extrinsics to return (1-100, default 50).",
-          minimum: 1,
-          maximum: 100,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset. Default 0.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor; takes " +
-            "precedence over offset for stable deep pagination.",
-        },
-      },
-      required: [],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListExtrinsicsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof ListExtrinsicsInputSchema>,
+      ctx: McpCtx,
+    ) {
       // Validated for REST-parity but, like the D1 filters they used to bound, have
       // nothing left to filter now that extrinsics is retired (#4772) --
       // buildExtrinsicFeed([]) below never sees them.
@@ -7628,7 +7473,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         buildExtrinsicFeed([], {
           limit: clampLimit(args?.limit, 50, 100),
           offset: Number.isFinite(args?.offset)
-            ? Math.max(0, Math.floor(args.offset))
+            ? Math.max(0, Math.floor(args.offset as number))
             : 0,
           nextCursor: null,
         })
@@ -7646,20 +7491,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "errors. Use list_extrinsics to find extrinsic refs. For every raw pallet.method " +
       "event an extrinsic emitted, use get_extrinsic_chain_events. Mirrors " +
       "GET /api/v1/extrinsics/{ref}.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ref: {
-          type: "string",
-          description:
-            "Extrinsic reference: a 0x hash (e.g. '0xabc...64hex') or the composite " +
-            "id 'block_number-extrinsic_index' (e.g. '4200000-3').",
-        },
-      },
-      required: ["ref"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetExtrinsicInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetExtrinsicInputSchema>, ctx: McpCtx) {
       const ref = requireString(args, "ref");
       // Mirrors REST's handleExtrinsic: try Postgres first (#4694), fall back to
       // the schema-stable empty detail now that extrinsics' D1 write path is
@@ -7682,61 +7517,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "filters as list_extrinsics minus signer/call_module (call_module is " +
       "fixed to Sudo). Use get_sudo_key for the current Sudo::Key holder. " +
       "Mirrors GET /api/v1/sudo.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        block: {
-          type: "integer",
-          description: "Exact block number.",
-          minimum: 0,
-        },
-        call_function: {
-          type: "string",
-          description: "Exact call_function to match.",
-        },
-        success: {
-          type: "boolean",
-          description: "Filter to successful (true) or failed (false) calls.",
-        },
-        block_start: {
-          type: "integer",
-          description: "Inclusive block-height range start.",
-          minimum: 0,
-        },
-        block_end: {
-          type: "integer",
-          description: "Inclusive block-height range end.",
-          minimum: 0,
-        },
-        from: {
-          type: "integer",
-          description: "Alias for block_start.",
-          minimum: 0,
-        },
-        to: {
-          type: "integer",
-          description: "Alias for block_end.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Pagination limit.",
-          minimum: 1,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor.",
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSudoInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetSudoInputSchema>, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -7758,11 +7542,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Fetch the current Sudo::Key holder, queried live from finney RPC at " +
       "request time (1h KV cache). hotkey is null on an RPC failure or an " +
       "unset sudo key. Mirrors GET /api/v1/sudo/key.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetSudoKeyInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadSudoKey(ctx.env);
     },
@@ -7776,11 +7558,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "from finney RPC at request time (300s KV cache). Each field is " +
       "independently null on its own RPC failure. Mirrors GET " +
       "/api/v1/network/parameters.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetNetworkParametersInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadNetworkParameters(ctx.env);
     },
@@ -7796,11 +7576,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "weight-setter checking whether a given round has landed. Each field " +
       "is independently null on its own RPC failure. Mirrors GET " +
       "/api/v1/network/randomness.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetRandomnessStatusInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadRandomnessStatus(ctx.env);
     },
@@ -7814,61 +7592,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "(re-scoped from a Council/Senate framing subtensor doesn't have). Same " +
       "filters as list_extrinsics minus signer/call_module (call_module is " +
       "fixed to AdminUtils). Mirrors GET /api/v1/governance/config-changes.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        block: {
-          type: "integer",
-          description: "Exact block number.",
-          minimum: 0,
-        },
-        call_function: {
-          type: "string",
-          description: "Exact call_function to match.",
-        },
-        success: {
-          type: "boolean",
-          description: "Filter to successful (true) or failed (false) calls.",
-        },
-        block_start: {
-          type: "integer",
-          description: "Inclusive block-height range start.",
-          minimum: 0,
-        },
-        block_end: {
-          type: "integer",
-          description: "Inclusive block-height range end.",
-          minimum: 0,
-        },
-        from: {
-          type: "integer",
-          description: "Alias for block_start.",
-          minimum: 0,
-        },
-        to: {
-          type: "integer",
-          description: "Alias for block_end.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Pagination limit.",
-          minimum: 1,
-        },
-        offset: {
-          type: "integer",
-          description: "Pagination offset.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor.",
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetGovernanceConfigChangesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetGovernanceConfigChangesInputSchema>,
+      ctx: McpCtx,
+    ) {
       return (
         (await tryPostgresTier(
           ctx.env,
@@ -7896,11 +7626,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "filter or paginate. spec_version wasn't tracked before 2026-06-25 and " +
       "can't be back-filled for rows written before then. Mirrors " +
       "GET /api/v1/runtime.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetRuntimeInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
       // table is dropped in production, so a D1 query here would always miss.
@@ -7989,19 +7717,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Returns event_count:0 + events:[] when the tier is empty for that block. " +
       "Requires the all-events data Worker (tier_unavailable in preview deploys). " +
       "Mirrors GET /api/v1/blocks/{block_number}/chain-events.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        block_number: {
-          type: "integer",
-          description: "Numeric block height.",
-          minimum: 0,
-        },
-      },
-      required: ["block_number"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetBlockChainEventsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetBlockChainEventsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const blockNumber = requireNonNegativeInt(args, "block_number");
       return loadBlockChainEvents(ctx, blockNumber);
     },
@@ -8016,30 +7738,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "default 50) or follow next_cursor for deeper pages. Distinct from the curated " +
       "account_events embedded in get_extrinsic. Requires the all-events data Worker " +
       "(tier_unavailable in preview deploys). Mirrors GET /api/v1/chain-events?block=&extrinsic=.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        ref: {
-          type: "string",
-          description:
-            "Composite extrinsic id 'block_number-extrinsic_index' (e.g. '4200000-3').",
-        },
-        limit: {
-          type: "integer",
-          description: "Max events to return (1-200, default 50).",
-          minimum: 1,
-          maximum: 200,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor for the next page.",
-        },
-      },
-      required: ["ref"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetExtrinsicChainEventsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetExtrinsicChainEventsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const ref = requireString(args, "ref");
       const cursor = optionalString(args, "cursor");
       return loadExtrinsicChainEvents(ctx, ref, {
@@ -10894,21 +10599,6 @@ const objectItems = (properties = {}) => ({
   type: "array",
   items: { type: "object", additionalProperties: true, properties },
 });
-// Shared account item shape: an event appears in get_block_events,
-// get_extrinsic, and other block/extrinsic-domain tools.
-const ACCOUNT_EVENT_ITEM = {
-  block_number: NULLABLE_INT,
-  event_index: NULLABLE_INT,
-  event_kind: NULLABLE_STRING,
-  hotkey: NULLABLE_STRING,
-  coldkey: NULLABLE_STRING,
-  netuid: NULLABLE_INT,
-  uid: NULLABLE_INT,
-  amount_tao: ANY,
-  alpha_amount: ANY,
-  observed_at: NULLABLE_STRING,
-  extrinsic_index: NULLABLE_INT,
-};
 const CHAIN_TRANSFER_PARTY_ITEM = {
   type: "object",
   additionalProperties: false,
@@ -10918,42 +10608,6 @@ const CHAIN_TRANSFER_PARTY_ITEM = {
     volume_tao: { type: "number" },
     transfer_count: { type: "integer", minimum: 0 },
   },
-};
-// Shared block item shape for list_blocks (each block in the feed).
-const BLOCK_ITEM = {
-  block_number: NULLABLE_INT,
-  block_hash: NULLABLE_STRING,
-  parent_hash: NULLABLE_STRING,
-  author: NULLABLE_STRING,
-  extrinsic_count: NULLABLE_INT,
-  event_count: NULLABLE_INT,
-  spec_version: NULLABLE_INT,
-  observed_at: NULLABLE_STRING,
-};
-// Shared extrinsic item shape for list_extrinsics + get_account_extrinsics.
-const EXTRINSIC_ITEM = {
-  block_number: NULLABLE_INT,
-  extrinsic_index: NULLABLE_INT,
-  extrinsic_hash: NULLABLE_STRING,
-  signer: NULLABLE_STRING,
-  call_module: NULLABLE_STRING,
-  call_function: NULLABLE_STRING,
-  call_args: ANY,
-  success: { type: ["boolean", "null"] },
-  fee_tao: ANY,
-  tip_tao: ANY,
-  observed_at: NULLABLE_STRING,
-};
-// Raw all-events tier item (pallet.method events from Postgres chain_events).
-const CHAIN_EVENT_ITEM = {
-  block_number: NULLABLE_INT,
-  event_index: NULLABLE_INT,
-  pallet: NULLABLE_STRING,
-  method: NULLABLE_STRING,
-  args: ANY,
-  phase: ANY,
-  extrinsic_index: NULLABLE_INT,
-  observed_at: NULLABLE_INT,
 };
 // RpcUsageArtifact item shapes — shared by get_rpc_usage outputSchema (mirrors
 // schemas/api-components.schema.json#/components/schemas/RpcUsageArtifact).
@@ -12196,208 +11850,60 @@ const TOOL_OUTPUT_SCHEMAS = {
       target: "draft-2020-12",
     },
   ),
-  list_blocks: {
-    type: "object",
-    additionalProperties: true,
-    required: ["block_count", "blocks"],
-    properties: {
-      schema_version: { type: "integer" },
-      block_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      blocks: objectItems(BLOCK_ITEM),
+  list_blocks: z.toJSONSchema(ListBlocksOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_block: z.toJSONSchema(GetBlockOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  list_block_extrinsics: z.toJSONSchema(ListBlockExtrinsicsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_block_events: z.toJSONSchema(GetBlockEventsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  list_extrinsics: z.toJSONSchema(ListExtrinsicsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_extrinsic: z.toJSONSchema(GetExtrinsicOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_sudo: z.toJSONSchema(GetSudoOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_sudo_key: z.toJSONSchema(GetSudoKeyOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_network_parameters: z.toJSONSchema(GetNetworkParametersOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_randomness_status: z.toJSONSchema(GetRandomnessStatusOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_governance_config_changes: z.toJSONSchema(
+    GetGovernanceConfigChangesOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_block: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ref"],
-    properties: {
-      schema_version: { type: "integer" },
-      ref: ANY,
-      block: { type: ["object", "null"], additionalProperties: true },
-      prev_block_number: NULLABLE_INT,
-      next_block_number: NULLABLE_INT,
-    },
-  },
-  list_block_extrinsics: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ref", "extrinsic_count", "extrinsics"],
-    properties: {
-      schema_version: { type: "integer" },
-      ref: ANY,
-      block_number: NULLABLE_INT,
-      extrinsic_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      extrinsics: objectItems(EXTRINSIC_ITEM),
-    },
-  },
-  get_block_events: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ref", "event_count", "events"],
-    properties: {
-      schema_version: { type: "integer" },
-      ref: ANY,
-      block_number: NULLABLE_INT,
-      event_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      events: objectItems(ACCOUNT_EVENT_ITEM),
-    },
-  },
-  list_extrinsics: {
-    type: "object",
-    additionalProperties: true,
-    required: ["extrinsic_count", "extrinsics"],
-    properties: {
-      schema_version: { type: "integer" },
-      extrinsic_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      extrinsics: objectItems(EXTRINSIC_ITEM),
-    },
-  },
-  get_extrinsic: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ref"],
-    properties: {
-      schema_version: { type: "integer" },
-      ref: ANY,
-      extrinsic: { type: ["object", "null"], additionalProperties: true },
-      events: objectItems(ACCOUNT_EVENT_ITEM),
-    },
-  },
-  get_sudo: {
-    type: "object",
-    additionalProperties: true,
-    required: ["extrinsic_count", "extrinsics"],
-    properties: {
-      schema_version: { type: "integer" },
-      extrinsic_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      extrinsics: objectItems(EXTRINSIC_ITEM),
-    },
-  },
-  get_sudo_key: {
-    type: "object",
-    additionalProperties: true,
-    required: ["hotkey", "queried_at"],
-    properties: {
-      schema_version: { type: "integer" },
-      hotkey: NULLABLE_STRING,
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_network_parameters: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "tao_weight",
-      "stake_threshold_tao",
-      "pending_childkey_cooldown_blocks",
-      "queried_at",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      tao_weight: { type: ["number", "null"] },
-      stake_threshold_tao: { type: ["number", "null"] },
-      pending_childkey_cooldown_blocks: { type: ["integer", "null"] },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_randomness_status: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "last_stored_round",
-      "oldest_stored_round",
-      "stored_round_span",
-      "queried_at",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      last_stored_round: { type: ["integer", "null"] },
-      oldest_stored_round: { type: ["integer", "null"] },
-      stored_round_span: { type: ["integer", "null"] },
-      queried_at: NULLABLE_STRING,
-    },
-  },
-  get_governance_config_changes: {
-    type: "object",
-    additionalProperties: true,
-    required: ["extrinsic_count", "extrinsics"],
-    properties: {
-      schema_version: { type: "integer" },
-      extrinsic_count: { type: "integer" },
-      limit: NULLABLE_INT,
-      offset: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      extrinsics: objectItems(EXTRINSIC_ITEM),
-    },
-  },
-  get_runtime: {
-    type: "object",
-    additionalProperties: true,
-    required: ["transition_count", "transitions"],
-    properties: {
-      schema_version: { type: "integer" },
-      transition_count: { type: "integer" },
-      current_spec_version: NULLABLE_INT,
-      coverage_from_block: NULLABLE_INT,
-      coverage_from_at: NULLABLE_STRING,
-      transitions: objectItems({
-        spec_version: { type: "integer" },
-        block_number: { type: "integer" },
-        observed_at: NULLABLE_STRING,
-      }),
-    },
-  },
+  ),
+  get_runtime: z.toJSONSchema(GetRuntimeOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_accounts: z.toJSONSchema(ListAccountsOutputSchema, {
     target: "draft-2020-12",
   }),
   get_top_holders: z.toJSONSchema(GetTopHoldersOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_block_chain_events: {
-    type: "object",
-    additionalProperties: true,
-    required: ["block_number", "event_count", "events"],
-    properties: {
-      schema_version: { type: "integer" },
-      block_number: NULLABLE_INT,
-      event_count: { type: "integer" },
-      events: objectItems(CHAIN_EVENT_ITEM),
+  get_block_chain_events: z.toJSONSchema(GetBlockChainEventsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_extrinsic_chain_events: z.toJSONSchema(
+    GetExtrinsicChainEventsOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_extrinsic_chain_events: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "ref",
-      "block_number",
-      "extrinsic_index",
-      "event_count",
-      "events",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      ref: ANY,
-      block_number: NULLABLE_INT,
-      extrinsic_index: NULLABLE_INT,
-      limit: NULLABLE_INT,
-      event_count: { type: "integer" },
-      next_cursor: NULLABLE_STRING,
-      events: objectItems(CHAIN_EVENT_ITEM),
-    },
-  },
+  ),
   get_chain_activity: {
     type: "object",
     additionalProperties: true,


### PR DESCRIPTION
## Summary

Batch 7 of types-epic E (#7863, tracked as #8071): converts 14 more MCP tool input/output schemas from hand-written JSON Schema literals to Zod-generated (`z.toJSONSchema(...)`), covering the blocks/extrinsics/chain-tx surface: `list_blocks`, `get_block`, `list_block_extrinsics`, `get_block_events`, `list_extrinsics`, `get_extrinsic`, `get_sudo`, `get_sudo_key`, `get_network_parameters`, `get_randomness_status`, `get_governance_config_changes`, `get_runtime`, `get_block_chain_events`, `get_extrinsic_chain_events`.

Closes #8071.

## Diff-audit results (`scripts/diff-mcp-tool-schemas.ts`)

198/200 schema checks PASS (pilot + all prior batches + this batch combined). 2 DIFFs, both pre-existing and unrelated to this batch:

- `get_subnet_identity_history.output` — pre-existing, already-documented finding from #8067.
- `get_account_identity_history.output` — pre-existing, already-documented finding from #8069.

Zero new findings from this batch's 14 tools (28/28 input+output checks PASS).

One normalize()-script finding worth flagging (bucket a, fixed in the script itself rather than documented as a live DIFF): `list_blocks`/`list_extrinsics`'s hand-written input schemas declare `required: []` explicitly, while Zod's `z.toJSONSchema()` omits the `required` key entirely when nothing is required — both are semantically identical JSON Schema ("nothing required"), the same class of cosmetic difference the script already normalizes for `additionalProperties`/`items`. Extended `normalize()` to drop an empty `required` array the same way, rather than documenting a false-positive DIFF per tool. Re-verified this doesn't mask any prior batch's real findings — 198/200 unchanged except the 2 now-resolved false positives.

## Reuse note

None of this batch's 14 tools reuse an existing `schemas-src/routes/` REST schema — no REST route in the blocks/extrinsics/chain-events/runtime/governance domains has been Zod-converted yet under types-epic B. All 14 are modeled fresh, matching each hand-written literal field-for-field (verified against the pre-conversion source directly in the working tree, not transcribed from memory).

`EXTRINSIC_ITEM`/`ACCOUNT_EVENT_ITEM` (the two JS object-literal item shapes `list_block_extrinsics`/`list_extrinsics`/`get_sudo`/`get_governance_config_changes` and `get_block_events`/`get_extrinsic` shared, respectively) are each used across 3+ tools spanning multiple `schemas-src/mcp-tools/*.ts` files in this batch — hoisted their Zod equivalents into `shared.ts` as `ExtrinsicItemSchema`/`AccountEventItemSchema` rather than tripling the definition, unlike every other item shape converted so far (which stayed tool-local since they were only ever used by 1 tool/file).

`get_runtime`'s `transitions` items and `get_block_chain_events`/`get_extrinsic_chain_events`'s `events` items each preserve a genuine quirk in the hand-written original: `RuntimeTransitionSchema.spec_version`/`block_number` are optional-but-non-nullable (bare `{type:"integer"}`, not `NULLABLE_INT`), and `ChainEventItemSchema.observed_at` is a nullable **integer** (epoch ms), not the nullable-string convention every other item's `observed_at` uses.

## Cleanup

Removed the now-dead `ACCOUNT_EVENT_ITEM`, `BLOCK_ITEM`, and `CHAIN_EVENT_ITEM` constants in `src/mcp-server.ts` (each had zero remaining consumers after this batch's conversions). `EXTRINSIC_ITEM` stays for now — `get_account_extrinsics` (#8070) was still hand-written when this branch forked; it will go dead too once this branch picks up #8070's merge.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` / `npx prettier --check` (touched files) — clean
- `npx tsx scripts/diff-mcp-tool-schemas.ts` — 198/200 PASS, 0 new findings (2 pre-existing, documented above)
- `npx tsx scripts/validate-mcp.ts` — 204 tools, full lifecycle/subscribe round trips pass
- Full test suite: 490/490 files, 11885/11885 tests passing
- Zero JSON Schema object literals remain for these 14 tools (grep-verified)

## Test plan

- [x] tsc clean
- [x] eslint/prettier clean
- [x] Diff-audit run, 0 new findings
- [x] `validate-mcp.ts` passes
- [x] Full test suite green
