### PR TITLE
fix(ui-kit): CopyableCode truncate={false} now actually constrains width

### DIFF
--- a/apps/ui/src/routes/-design-primitives-page.tsx
+++ b/apps/ui/src/routes/-design-primitives-page.tsx
@@ -233,7 +233,7 @@ function Show({
   children: ReactNode;
 }) {
   return (
-    <div className="space-y-2 rounded border border-border bg-card p-3">
+    <div className="min-w-0 space-y-2 rounded border border-border bg-card p-3">
       <div className="mg-type-micro text-ink-muted">{name}</div>
       <div>{children}</div>
       <CopyableCode value={`import { ${name} } from "${from}";`} truncate={false} />

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1470,6 +1470,14 @@ function CopyableCode({
         "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
         className: classNames(
           "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left mg-type-data text-ink hover:border-ink/30 transition-colors",
+          // `truncate={false}` means "wrap instead of truncate," which only
+          // makes sense once the box is width-bound -- otherwise `inline-flex`
+          // shrink-to-fit sizing lets it grow to its unwrapped content width
+          // and overflow the parent instead of wrapping (#8113). Every
+          // existing call site already compensated with its own `w-full`/
+          // `max-w-full` className; make that the default instead of
+          // something each caller has to remember.
+          !truncate && "w-full",
           // Matches KeyChip's ring treatment -- this one is a bordered chip like
           // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
           // against the card behind it (#6371).

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1441,6 +1441,14 @@ function CopyableCode({
         "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
         className: classNames(
           "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left mg-type-data text-ink hover:border-ink/30 transition-colors",
+          // `truncate={false}` means "wrap instead of truncate," which only
+          // makes sense once the box is width-bound -- otherwise `inline-flex`
+          // shrink-to-fit sizing lets it grow to its unwrapped content width
+          // and overflow the parent instead of wrapping (#8113). Every
+          // existing call site already compensated with its own `w-full`/
+          // `max-w-full` className; make that the default instead of
+          // something each caller has to remember.
+          !truncate && "w-full",
           // Matches KeyChip's ring treatment -- this one is a bordered chip like
           // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
           // against the card behind it (#6371).

--- a/packages/ui-kit/src/components/metagraphed/copyable-code.tsx
+++ b/packages/ui-kit/src/components/metagraphed/copyable-code.tsx
@@ -27,6 +27,14 @@ export function CopyableCode({
         aria-label={copied ? "Copied" : `Copy ${label ?? "value"}`}
         className={classNames(
           "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left mg-type-data text-ink hover:border-ink/30 transition-colors",
+          // `truncate={false}` means "wrap instead of truncate," which only
+          // makes sense once the box is width-bound -- otherwise `inline-flex`
+          // shrink-to-fit sizing lets it grow to its unwrapped content width
+          // and overflow the parent instead of wrapping (#8113). Every
+          // existing call site already compensated with its own `w-full`/
+          // `max-w-full` className; make that the default instead of
+          // something each caller has to remember.
+          !truncate && "w-full",
           // Matches KeyChip's ring treatment -- this one is a bordered chip like
           // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
           // against the card behind it (#6371).


### PR DESCRIPTION
## Summary

Fixes #8113 — nearly every example card on `/design/primitives` overflowed its container at mobile (436px of real page-wide horizontal scroll), because `CopyableCode`'s `truncate={false}` mode never actually constrained the component's width.

## Root cause

Two separate contributing bugs, both needed for a full fix:

1. **`packages/ui-kit/src/components/metagraphed/copyable-code.tsx`** — the trigger `<button>` is `inline-flex`, which shrink-to-fits its own content regardless of what `truncate`/`min-width` classes are applied to descendants. `truncate={false}` is meant to make the value wrap instead of eliding — but wrapping only makes sense once the box is width-bound, and this one never was. Grepping every existing call site shows every single one that passes `truncate={false}` *also* passes its own `className="w-full"` or `"max-w-full"` as a manual workaround — except `-design-primitives-page.tsx`'s `Show` component, which is exactly the one that broke.
2. **`apps/ui/src/routes/-design-primitives-page.tsx`** — `Show`'s card div is a CSS Grid item inside a `grid md:grid-cols-2` container. Grid items default to `min-width: auto` (their content's min-content size), so even after the button itself became width-bound, `white-space: nowrap` text several DOM levels deep (the unwrapped import-line text) was still forcing the *implicit single mobile grid track* to blow out to fit the longest import line, independent of the button fix.

## Fix

- `CopyableCode`: `truncate={false}` now applies `w-full` internally — a no-op for the default `truncate={true}` path (the majority of call sites), so zero regression risk there by construction.
- `Show`: added `min-w-0` to the card div, the standard fix for CSS Grid/Flexbox item blowout.

## Verification (local dev server, 375px unless noted)

| Route | Before | After |
|---|---|---|
| `/design/primitives` | `body.scrollWidth` 811px vs 375px viewport (436px overflow), 558 elements flagged by an automated overflow scan | `body.scrollWidth` === `innerWidth` (375px), 0 elements flagged |
| `/design/primitives` (768px, 1280px) | — | Clean, no regression |
| `/schemas` (uses `CopyableCode` with default `truncate={true}`) | — | Clean, `body.scrollWidth` matches expected (residual 41px overflow present is a separate, pre-existing, unrelated bug — a `contracts`/`providers` card grid further down the page that doesn't wrap at mobile, not part of #8113 or touched by this diff) |
| `/accounts/:ss58` (`truncate={false} className="max-w-full"`) | — | Clean, no regression |
| `/providers/:slug` (`truncate={false} className="w-full"`) | — | Clean, no regression |

## Test plan
- [x] `tsc --noEmit` clean in both packages
- [x] `eslint` on touched files: 0 errors, 0 warnings
- [x] `vitest run`: 1464/1464 passing in apps/ui, 98/98 passing in ui-kit
- [x] `packages/ui-kit/dist` rebuilt and committed (drift-check gate)
- [x] Live dev-server check at 375px/768px/1280px on `/design/primitives` plus 3 other `CopyableCode` call sites, 0 console errors

Closes #8113.