### PR TITLE
fix(ui): /status incident rows no longer overflow at mobile

### DIFF
--- a/apps/ui/src/routes/-status-page.tsx
+++ b/apps/ui/src/routes/-status-page.tsx
@@ -455,7 +455,7 @@ function SurfaceRow({ surface, ongoing }: { surface: GlobalIncidentSurface; ongo
   const latest = surface.incidents.reduce((max, i) => Math.max(max, i.ended_at || 0), 0);
   const downtime = humaniseSeconds(surface.downtime_ms / 1000);
   return (
-    <li className="flex items-center gap-3 rounded border border-border bg-card px-3 py-2.5">
+    <li className="flex flex-wrap items-center gap-3 rounded border border-border bg-card px-3 py-2.5">
       <span
         className={classNames(
           "inline-flex items-center rounded border px-1.5 py-0.5 mg-type-micro shrink-0",
@@ -468,10 +468,10 @@ function SurfaceRow({ surface, ongoing }: { surface: GlobalIncidentSurface; ongo
         {ongoing ? "Ongoing" : "Resolved"}
       </span>
       <span className="mg-label shrink-0">SN{surface.netuid}</span>
-      <span className="font-mono mg-type-caption text-ink-strong truncate">
+      <span className="min-w-0 font-mono mg-type-caption text-ink-strong truncate">
         {surface.surface_id}
       </span>
-      <span className="ml-auto inline-flex items-center gap-3 mg-label shrink-0">
+      <span className="ml-auto flex min-w-0 max-w-full flex-wrap items-center gap-3 mg-label">
         <span className="text-ink-muted tabular-nums">
           {surface.incident_count} {surface.incident_count === 1 ? "event" : "events"}
         </span>


### PR DESCRIPTION
## Summary

Fixes #8111 — `/status`'s "Recent incidents" rows caused real page-wide horizontal scroll at 375px viewport.

## Root cause

`apps/ui/src/routes/-status-page.tsx`'s `SurfaceRow`: a single-line `flex items-center gap-3` row (no `flex-wrap`) with a status badge and `SN{netuid}` label (both `shrink-0`), a `truncate` surface-id span that was missing `min-w-0` (so it couldn't actually shrink below its content width in the flex layout), and a trailing metadata cluster (event count / downtime / last-seen) that was also `shrink-0`. Once the surface-id ran out of room, the trailing cluster pushed past the viewport edge. Confirmed via DOM measurement: `document.body.scrollWidth` 407px vs `window.innerWidth` 375px.

## Fix

- Row: added `flex-wrap`.
- Surface-id span: added `min-w-0` so `truncate` actually engages.
- Trailing cluster: removed `shrink-0`, added `min-w-0 max-w-full`.

Row now degrades gracefully: surface-id truncates properly, and if a row still doesn't fit, the trailing cluster wraps onto its own line instead of overflowing. In practice every row fits on one line at 375px with room to spare — the `flex-wrap` is a safety net, not something users will normally see trigger.

## Verification (local dev server)

| Viewport | Before | After |
|---|---|---|
| 375px | `body.scrollWidth` 407px vs 375px viewport (real page-wide scroll) | `body.scrollWidth` === `innerWidth`; all incident rows render on one line, no clipping |
| 768px | clean | clean, no regression |
| 1280px | clean | clean, no regression |

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` on the touched file: 0 errors (4 pre-existing warnings on unrelated lines, unchanged)
- [x] `vitest run`: 1464/1464 passing
- [x] Live dev-server check at 375px/768px/1280px, 0 console errors

Closes #8111.