### PR TITLE
fix(ui): homepage chain-throughput card CTA no longer wraps at mobile

### DIFF
--- a/apps/ui/src/components/metagraphed/hero-feature-row.tsx
+++ b/apps/ui/src/components/metagraphed/hero-feature-row.tsx
@@ -87,7 +87,7 @@ function ChainThroughputCard() {
         )}
       </div>
 
-      <div className="mt-1 flex items-center justify-between border-t border-border px-4 py-3">
+      <div className="mt-1 flex flex-col items-start gap-1.5 border-t border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <span className="mg-type-micro text-ink-muted">/api/v1/chain/activity</span>
         <Link
           to="/blocks"


### PR DESCRIPTION
## Summary

Fixes #8108 — the homepage's chain-throughput card footer wrapped its "Open the block explorer" CTA onto two ugly lines at mobile.

## Root cause

`apps/ui/src/components/metagraphed/hero-feature-row.tsx`: the footer row `<div className="mt-1 flex items-center justify-between border-t border-border px-4 py-3">` held the `/api/v1/chain/activity` label and the CTA link side by side with `justify-between` and no responsive handling. At 375px viewport the card's content width (~319px after padding) wasn't enough to fit both on one line, so the uppercase, letter-spaced CTA wrapped to two lines ("OPEN THE" / "BLOCK EXPLORER") flush against the still-single-line label. Confirmed via DOM measurement: link `getBoundingClientRect()` was 41px tall (2 lines) at 375px.

## Fix

Stacks the row vertically below `sm:` (label on top, CTA below, both left-aligned single-line) and reverts to the existing side-by-side layout at `sm:`+ (tablet/desktop), where it already rendered correctly.

## Verification (local dev server)

| Viewport | Before | After |
|---|---|---|
| 375px | CTA link 41px tall (wrapped 2 lines) | CTA link 14px tall (single line), stacked below the label |
| 768px | 14px (single line, side-by-side) | 14px (unchanged, side-by-side) |
| 1280px | 14px (single line, side-by-side) | 14px (unchanged, side-by-side) |

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` on the touched file: 0 errors, 0 warnings
- [x] `vitest run`: 1464/1464 passing
- [x] Live dev-server check at 375px/768px/1280px, 0 console errors

Closes #8108.