### PR TITLE
fix(ui): /blocks cadence-heatmap legend no longer overflows at mobile

### DIFF
--- a/apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx
@@ -105,9 +105,9 @@ function Legend() {
     { label: ">48s", cls: "bg-health-down/80" },
   ];
   return (
-    <div className="mt-3 flex items-center gap-3 border-t border-border/60 pt-2.5 mg-type-micro text-ink-muted">
+    <div className="mt-3 flex flex-wrap items-center gap-3 border-t border-border/60 pt-2.5 mg-type-micro text-ink-muted">
       <span>faster</span>
-      <div className="flex items-center gap-1">
+      <div className="flex flex-wrap items-center gap-1">
         {items.map((i) => (
           <span key={i.label} className="inline-flex items-center gap-1">
             <span className={classNames("inline-block h-2 w-3 rounded-[2px]", i.cls)} />


### PR DESCRIPTION
## Summary

Fixes #8110 — the block-cadence-heatmap's color legend caused the whole `/blocks` page to become horizontally scrollable by 8px at mobile.

## Root cause

`apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx`'s `Legend`: a single-line `flex items-center gap-3` row ("faster" + 5 swatch/label pairs + "slower") with no `flex-wrap` and no responsive hiding. At 375px viewport its natural content width was 383px — 8px wider than the viewport. Confirmed via DOM measurement: `document.body.scrollWidth` 383px vs `window.innerWidth` 375px.

## Fix

Added `flex-wrap` to both the outer row and the inner swatch group, so the legend wraps onto additional lines instead of overflowing. At 375px it now wraps to two lines (swatches on line 1, "slower" on line 2); still a single line at 768px+.

## Verification (local dev server)

| Viewport | Before | After |
|---|---|---|
| 375px | `body.scrollWidth` 383px vs 375px viewport | `body.scrollWidth` === `innerWidth`; legend wraps to 2 lines |
| 768px | clean | clean, still single line |
| 1280px | clean | clean, still single line |

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` on the touched file: 0 errors (2 pre-existing warnings on unrelated lines — the documented dense-grid `rounded-[…]` residual exception from #7843, unchanged)
- [x] `vitest run`: 1464/1464 passing
- [x] Live dev-server check at 375px/768px/1280px, 0 console errors

Closes #8110.