### PR TITLE
fix(ui-kit): Donut center label no longer overlaps the ring

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3338,11 +3338,19 @@ function Donut({
           {
             style: {
               position: "absolute",
-              inset: 0,
+              top: "50%",
+              left: "50%",
+              // Constrain to the ring's unstroked hole (not the full size×size
+              // box) so long labels wrap within it instead of rendering on top
+              // of the ring, where they read as illegible against its color
+              // (#8112).
+              width: Math.max(0, size - strokeWidth * 2),
+              transform: "translate(-50%, -50%)",
               display: "flex",
               flexDirection: "column",
               alignItems: "center",
               justifyContent: "center",
+              textAlign: "center",
               pointerEvents: "none"
             },
             children: [

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3309,11 +3309,19 @@ function Donut({
           {
             style: {
               position: "absolute",
-              inset: 0,
+              top: "50%",
+              left: "50%",
+              // Constrain to the ring's unstroked hole (not the full size×size
+              // box) so long labels wrap within it instead of rendering on top
+              // of the ring, where they read as illegible against its color
+              // (#8112).
+              width: Math.max(0, size - strokeWidth * 2),
+              transform: "translate(-50%, -50%)",
               display: "flex",
               flexDirection: "column",
               alignItems: "center",
               justifyContent: "center",
+              textAlign: "center",
               pointerEvents: "none"
             },
             children: [

--- a/packages/ui-kit/src/components/metagraphed/charts/donut.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/donut.tsx
@@ -88,11 +88,19 @@ export function Donut({
         <div
           style={{
             position: "absolute",
-            inset: 0,
+            top: "50%",
+            left: "50%",
+            // Constrain to the ring's unstroked hole (not the full size×size
+            // box) so long labels wrap within it instead of rendering on top
+            // of the ring, where they read as illegible against its color
+            // (#8112).
+            width: Math.max(0, size - strokeWidth * 2),
+            transform: "translate(-50%, -50%)",
             display: "flex",
             flexDirection: "column",
             alignItems: "center",
             justifyContent: "center",
+            textAlign: "center",
             pointerEvents: "none",
           }}
         >


### PR DESCRIPTION
## Summary

Fixes #8112 — the status-mix donut's center-sub label read as illegible ("EALTHY NOW" instead of "HEALTHY NOW") because its text overlapped the colored ring.

## Root cause

`packages/ui-kit/src/components/metagraphed/charts/donut.tsx`: the center-label overlay was `position:absolute; inset:0`, centering its content across the **full** `size×size` box — but the ring's actual unstroked hole is only `size - 2*strokeWidth`px in diameter (at the default `size=96, strokeWidth=12`, that's a 72px hole vs. the 96px box). `centerSub`'s rendered text ("healthy now") measured 82px wide — wider than the 72px hole — so its leading/trailing edges rendered on top of the ring stroke, where muted gray text has poor contrast against a saturated status color and reads as illegible.

## Fix

Constrains the overlay's width to the hole diameter (`size - strokeWidth * 2`) instead of the full box, positioned via `top/left: 50%` + `translate(-50%, -50%)`. Long labels now wrap onto additional lines within the hole instead of overlapping the ring.

## Verification (local dev server)

| Where | Before | After |
|---|---|---|
| `/status` status-mix donut, dark theme | "healthy now" renders 82px wide, overlapping the ring; leading "H" illegible | Wraps to "HEALTHY" / "NOW" on 2 lines, 72px wide, fully within the hole, fully legible |
| `/status` status-mix donut, light theme | same issue | same fix |
| `/subnets/:netuid` alpha-pool donut ("56% IN", a short `centerSub` that already fit on one line) | — | No regression — still renders on one line, correctly centered |

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` on the touched file: 0 errors, 0 warnings
- [x] `vitest run`: 98/98 passing in ui-kit
- [x] `packages/ui-kit/dist` rebuilt and committed (drift-check gate)
- [x] Live dev-server check on both `Donut` call sites (`/status`, `/subnets/:netuid`), both themes, 0 console errors

Closes #8112.