### PR TITLE
feat(mcp): types-epic E — Zod schemas for 25 chain network-stats MCP tools (#8072)

### DIFF
--- a/schemas-src/mcp-tools/chain-calls-fees.ts
+++ b/schemas-src/mcp-tools/chain-calls-fees.ts
@@ -1,0 +1,122 @@
+// MCP tools `get_chain_calls`, `get_chain_signers`, `get_chain_fees`
+// (types-epic E batch 9, #8072). Each mirrors a GET /api/v1/chain/
+// {calls,signers,fees} route that is not one of schemas-src/routes/'s
+// covered pilot routes -- no existing Zod schema to reuse. Modeled fresh,
+// matching each hand-written literal field-for-field. `window` is a LITERAL
+// inline `["7d","30d"]` enum in all three hand-written originals (no
+// symbolic *_WINDOWS import), backed by the shared parseAnalyticsWindow()
+// runtime helper -- modeled the same way here, no shared constant.
+import { z } from "zod";
+
+const WINDOWS_2 = ["7d", "30d"] as const;
+
+export const GetChainCallsInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    group_by: z.enum(["module", "module_function"]).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    call_module: z.string().optional(),
+  })
+  .strict();
+export type GetChainCallsInput = z.infer<typeof GetChainCallsInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const ChainCallGroupSchema = z
+  .object({
+    call_module: z.string().nullable().optional(),
+    call_function: z.string().nullable().optional(),
+    count: z.int().nullable().optional(),
+    share: z.unknown().optional(),
+  })
+  .passthrough();
+
+export const GetChainCallsOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    window: z.string(),
+    group_by: z.string(),
+    observed_at: z.string().nullable().optional(),
+    total_extrinsics: z.int(),
+    call_count: z.int(),
+    calls: z.array(ChainCallGroupSchema),
+  })
+  .passthrough();
+export type GetChainCallsOutput = z.infer<typeof GetChainCallsOutputSchema>;
+
+export const GetChainSignersInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    sort: z.enum(["tx_count", "total_fee_tao"]).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    call_module: z.string().optional(),
+  })
+  .strict();
+export type GetChainSignersInput = z.infer<typeof GetChainSignersInputSchema>;
+
+// objectItems(...) properties, none required at the item level.
+const ChainSignerSchema = z
+  .object({
+    signer: z.string().nullable().optional(),
+    tx_count: z.int().nullable().optional(),
+    total_fee_tao: z.number().nullable().optional(),
+    total_tip_tao: z.number().nullable().optional(),
+    last_tx_block: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetChainSignersOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string(),
+    sort: z.enum(["tx_count", "total_fee_tao"]),
+    observed_at: z.string().nullable().optional(),
+    signer_count: z.int(),
+    signers: z.array(ChainSignerSchema),
+  })
+  .passthrough();
+export type GetChainSignersOutput = z.infer<typeof GetChainSignersOutputSchema>;
+
+export const GetChainFeesInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    call_module: z.string().optional(),
+  })
+  .strict();
+export type GetChainFeesInput = z.infer<typeof GetChainFeesInputSchema>;
+
+// objectItems(...) properties, none required at the item level.
+const ChainFeesDaySchema = z
+  .object({
+    day: z.string().nullable().optional(),
+    extrinsic_count: z.int().nullable().optional(),
+    total_fee_tao: z.number().nullable().optional(),
+    avg_fee_tao: z.number().nullable().optional(),
+    median_fee_tao: z.number().nullable().optional(),
+    total_tip_tao: z.number().nullable().optional(),
+    avg_tip_tao: z.number().nullable().optional(),
+    median_tip_tao: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+const ChainTopFeePayerSchema = z
+  .object({
+    signer: z.string().nullable().optional(),
+    total_fee_tao: z.number().nullable().optional(),
+    total_tip_tao: z.number().nullable().optional(),
+    extrinsic_count: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetChainFeesOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string(),
+    observed_at: z.string().nullable().optional(),
+    day_count: z.int(),
+    daily: z.array(ChainFeesDaySchema),
+    top_fee_payers: z.array(ChainTopFeePayerSchema),
+  })
+  .passthrough();
+export type GetChainFeesOutput = z.infer<typeof GetChainFeesOutputSchema>;

--- a/schemas-src/mcp-tools/chain-events-activity.ts
+++ b/schemas-src/mcp-tools/chain-events-activity.ts
@@ -1,0 +1,116 @@
+// MCP tools `get_chain_activity`, `list_chain_events`, `get_network_activity`
+// (types-epic E batch 9, #8072). Each mirrors a GET /api/v1/chain{-events,
+// /activity} route that is not one of schemas-src/routes/'s covered pilot
+// routes -- no existing Zod schema to reuse. Modeled fresh, matching each
+// hand-written literal field-for-field. `window` on all three tools using it
+// is a LITERAL inline `["7d","30d"]` enum in the hand-written original (no
+// symbolic *_WINDOWS import, unlike chain-leaderboards.ts's tools), backed by
+// the shared parseAnalyticsWindow() runtime helper rather than an
+// Object.hasOwn() check -- modeled the same way here, no shared constant.
+import { z } from "zod";
+
+const WINDOWS_2 = ["7d", "30d"] as const;
+
+export const GetChainActivityInputSchema = z
+  .object({
+    blocks: z.int().min(1).max(5000).optional(),
+  })
+  .strict();
+export type GetChainActivityInput = z.infer<typeof GetChainActivityInputSchema>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const ChainActivityGroupSchema = z
+  .object({
+    pallet: z.string().nullable().optional(),
+    method: z.string().nullable().optional(),
+    count: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetChainActivityOutputSchema = z
+  .object({
+    window_blocks: z.int(),
+    groups: z.int(),
+    activity: z.array(ChainActivityGroupSchema),
+  })
+  .passthrough();
+export type GetChainActivityOutput = z.infer<
+  typeof GetChainActivityOutputSchema
+>;
+
+export const ListChainEventsInputSchema = z
+  .object({
+    pallet: z.string().optional(),
+    method: z.string().optional(),
+    block: z.int().min(0).optional(),
+    extrinsic: z.int().min(0).optional(),
+    cursor: z.string().optional(),
+    before: z.int().min(0).optional(),
+    limit: z.int().min(1).max(200).optional(),
+  })
+  .strict();
+export type ListChainEventsInput = z.infer<typeof ListChainEventsInputSchema>;
+
+// objectItems(...) properties, none required at the item level. observed_at
+// is a fully untyped ANY here in the hand-written original -- NOT the
+// nullable-integer CHAIN_EVENT_ITEM convention batch 8's
+// get_block_chain_events/get_extrinsic_chain_events use for the same field
+// name; this tool inlines its own item shape rather than sharing that one.
+const ChainEventFeedItemSchema = z
+  .object({
+    block_number: z.int().nullable().optional(),
+    event_index: z.int().nullable().optional(),
+    pallet: z.string().nullable().optional(),
+    method: z.string().nullable().optional(),
+    args: z.unknown().optional(),
+    phase: z.unknown().optional(),
+    extrinsic_index: z.int().nullable().optional(),
+    observed_at: z.unknown().optional(),
+  })
+  .passthrough();
+
+export const ListChainEventsOutputSchema = z
+  .object({
+    count: z.int(),
+    next_before: z.int().nullable().optional(),
+    next_cursor: z.string().nullable().optional(),
+    events: z.array(ChainEventFeedItemSchema),
+  })
+  .passthrough();
+export type ListChainEventsOutput = z.infer<typeof ListChainEventsOutputSchema>;
+
+export const GetNetworkActivityInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+  })
+  .strict();
+export type GetNetworkActivityInput = z.infer<
+  typeof GetNetworkActivityInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level.
+const NetworkActivityDaySchema = z
+  .object({
+    day: z.string().nullable().optional(),
+    block_count: z.int().nullable().optional(),
+    extrinsic_count: z.int().nullable().optional(),
+    event_count: z.int().nullable().optional(),
+    successful_extrinsics: z.int().nullable().optional(),
+    success_rate: z.number().nullable().optional(),
+    unique_signers: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetNetworkActivityOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string(),
+    observed_at: z.string().nullable().optional(),
+    day_count: z.int(),
+    days: z.array(NetworkActivityDaySchema),
+  })
+  .passthrough();
+export type GetNetworkActivityOutput = z.infer<
+  typeof GetNetworkActivityOutputSchema
+>;

--- a/schemas-src/mcp-tools/chain-identity-history.ts
+++ b/schemas-src/mcp-tools/chain-identity-history.ts
@@ -1,0 +1,47 @@
+// MCP tool `get_chain_identity_history` (types-epic E batch 9, #8072).
+// Mirrors GET /api/v1/chain/identity-history, which is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. Modeled fresh, matching the hand-written literal it replaces
+// field-for-field.
+import { z } from "zod";
+
+const CHAIN_IDENTITY_HISTORY_LIMIT_MAX = 200;
+
+export const GetChainIdentityHistoryInputSchema = z
+  .object({
+    limit: z.int().min(1).max(CHAIN_IDENTITY_HISTORY_LIMIT_MAX).optional(),
+  })
+  .strict();
+export type GetChainIdentityHistoryInput = z.infer<
+  typeof GetChainIdentityHistoryInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const ChainIdentityChangeSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    block_number: z.int().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_name: z.string().nullable().optional(),
+    symbol: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    github_repo: z.string().nullable().optional(),
+    subnet_url: z.string().nullable().optional(),
+    discord: z.string().nullable().optional(),
+    logo_url: z.string().nullable().optional(),
+    identity_hash: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetChainIdentityHistoryOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    count: z.int(),
+    subnet_count: z.int(),
+    changes: z.array(ChainIdentityChangeSchema),
+  })
+  .passthrough();
+export type GetChainIdentityHistoryOutput = z.infer<
+  typeof GetChainIdentityHistoryOutputSchema
+>;

--- a/schemas-src/mcp-tools/chain-leaderboards.ts
+++ b/schemas-src/mcp-tools/chain-leaderboards.ts
@@ -1,0 +1,469 @@
+// MCP tools `get_chain_turnover`, `get_chain_stake_flow`,
+// `get_chain_alpha_volume`, `get_chain_weights`, `get_chain_weight_setters`,
+// `get_chain_stake_moves`, `get_chain_stake_transfers`,
+// `get_chain_axon_removals`, `get_chain_serving`, `get_chain_prometheus`
+// (types-epic E batch 9, #8072). Each mirrors a GET /api/v1/chain/* route
+// that is not one of schemas-src/routes/'s covered pilot routes -- no
+// existing Zod schema to reuse. Modeled fresh, matching each hand-written
+// literal field-for-field. Nine of the ten share one shape (subnet_count +
+// a STRICT `network` rollup object + a nullable `*_distribution` stats
+// object [DistributionStatsSchema, shared.ts] + a `subnets` leaderboard
+// array of STRICT items -- additionalProperties:false, every item field
+// required, unlike the objectItems() looseness convention used elsewhere
+// in this epic), but with genuinely different per-tool field names
+// (movers vs senders vs removers, etc.), so each is modeled explicitly
+// rather than through a shared factory. get_chain_weight_setters is the
+// exception: a flat setters leaderboard with no network/distribution
+// rollup, using the usual objectItems() item-level looseness instead.
+import { z } from "zod";
+import { DistributionStatsSchema } from "./shared.ts";
+
+const WINDOWS_2 = ["7d", "30d"] as const;
+const WINDOWS_3 = ["7d", "30d", "90d"] as const;
+const LIMIT_MAX_100 = 100;
+
+export const GetChainTurnoverInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_3).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainTurnoverInput = z.infer<typeof GetChainTurnoverInputSchema>;
+
+const ChainTurnoverNetworkSchema = z
+  .object({
+    validators_start: z.int(),
+    validators_end: z.int(),
+    validators_entered: z.int(),
+    validators_exited: z.int(),
+    validator_retention: z.number().nullable(),
+    stability_score: z.int().nullable(),
+  })
+  .strict();
+
+const ChainTurnoverSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    validators_start: z.int(),
+    validators_end: z.int(),
+    validators_entered: z.int(),
+    validators_exited: z.int(),
+    validator_retention: z.number(),
+    stability_score: z.int(),
+  })
+  .strict();
+
+export const GetChainTurnoverOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    start_date: z.string().nullable().optional(),
+    end_date: z.string().nullable().optional(),
+    comparable: z.boolean(),
+    subnet_count: z.int(),
+    network: ChainTurnoverNetworkSchema,
+    stability_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainTurnoverSubnetSchema),
+  })
+  .passthrough();
+export type GetChainTurnoverOutput = z.infer<
+  typeof GetChainTurnoverOutputSchema
+>;
+
+export const GetChainStakeFlowInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainStakeFlowInput = z.infer<
+  typeof GetChainStakeFlowInputSchema
+>;
+
+const ChainStakeFlowNetworkSchema = z
+  .object({
+    total_staked_tao: z.number(),
+    total_unstaked_tao: z.number(),
+    net_flow_tao: z.number(),
+    gross_flow_tao: z.number(),
+    stake_events: z.int(),
+    unstake_events: z.int(),
+    gaining: z.int(),
+    losing: z.int(),
+    flat: z.int(),
+  })
+  .strict();
+
+const ChainStakeFlowSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    total_staked_tao: z.number(),
+    total_unstaked_tao: z.number(),
+    net_flow_tao: z.number(),
+    gross_flow_tao: z.number(),
+    stake_events: z.int(),
+    unstake_events: z.int(),
+    direction: z.string(),
+  })
+  .strict();
+
+export const GetChainStakeFlowOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainStakeFlowNetworkSchema,
+    net_flow_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainStakeFlowSubnetSchema),
+  })
+  .passthrough();
+export type GetChainStakeFlowOutput = z.infer<
+  typeof GetChainStakeFlowOutputSchema
+>;
+
+export const GetChainAlphaVolumeInputSchema = z
+  .object({
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainAlphaVolumeInput = z.infer<
+  typeof GetChainAlphaVolumeInputSchema
+>;
+
+const ChainAlphaVolumeNetworkSchema = z
+  .object({
+    buy_volume_alpha: z.unknown(),
+    sell_volume_alpha: z.unknown(),
+    total_volume_alpha: z.unknown(),
+    buy_volume_tao: z.unknown(),
+    sell_volume_tao: z.unknown(),
+    total_volume_tao: z.unknown(),
+    buy_count: z.int(),
+    sell_count: z.int(),
+    net_volume_alpha: z.unknown(),
+    sentiment_ratio: z.number().nullable(),
+    sentiment: z.string(),
+  })
+  .strict();
+
+// Each subnet entry is a full get_subnet_volume-shaped scorecard -- loose
+// (additionalProperties:true), only netuid/window required, matching the
+// hand-written original exactly rather than nesting get_subnet_volume's own
+// (not-yet-converted) precise schema.
+const ChainAlphaVolumeSubnetSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    netuid: z.int(),
+    window: z.string(),
+    buy_volume_alpha: z.unknown().optional(),
+    sell_volume_alpha: z.unknown().optional(),
+    total_volume_alpha: z.unknown().optional(),
+    buy_volume_tao: z.unknown().optional(),
+    sell_volume_tao: z.unknown().optional(),
+    total_volume_tao: z.unknown().optional(),
+    buy_count: z.int().optional(),
+    sell_count: z.int().optional(),
+    net_volume_alpha: z.unknown().optional(),
+    sentiment_ratio: z.number().nullable().optional(),
+    sentiment: z.string().nullable().optional(),
+    vol_mcap_ratio: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetChainAlphaVolumeOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainAlphaVolumeNetworkSchema,
+    volume_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainAlphaVolumeSubnetSchema),
+  })
+  .passthrough();
+export type GetChainAlphaVolumeOutput = z.infer<
+  typeof GetChainAlphaVolumeOutputSchema
+>;
+
+export const GetChainWeightsInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainWeightsInput = z.infer<typeof GetChainWeightsInputSchema>;
+
+const ChainWeightsNetworkSchema = z
+  .object({
+    distinct_setters: z.int(),
+    weight_sets: z.int(),
+    sets_per_setter: z.number().nullable(),
+  })
+  .strict();
+
+const ChainWeightsSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    distinct_setters: z.int(),
+    weight_sets: z.int(),
+    sets_per_setter: z.number(),
+  })
+  .strict();
+
+export const GetChainWeightsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainWeightsNetworkSchema,
+    intensity_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainWeightsSubnetSchema),
+  })
+  .passthrough();
+export type GetChainWeightsOutput = z.infer<typeof GetChainWeightsOutputSchema>;
+
+export const GetChainWeightSettersInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainWeightSettersInput = z.infer<
+  typeof GetChainWeightSettersInputSchema
+>;
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch).
+const ChainWeightSetterSchema = z
+  .object({
+    hotkey: z.string().nullable().optional(),
+    uid: z.int().nullable().optional(),
+    weight_sets: z.int().optional(),
+    share: z.unknown().optional(),
+    first_set_at: z.string().nullable().optional(),
+    last_set_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetChainWeightSettersOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable(),
+    observed_at: z.string().nullable().optional(),
+    distinct_setters: z.int(),
+    weight_sets: z.int(),
+    setter_count: z.int(),
+    setters: z.array(ChainWeightSetterSchema),
+  })
+  .passthrough();
+export type GetChainWeightSettersOutput = z.infer<
+  typeof GetChainWeightSettersOutputSchema
+>;
+
+export const GetChainStakeMovesInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainStakeMovesInput = z.infer<
+  typeof GetChainStakeMovesInputSchema
+>;
+
+const ChainStakeMovesNetworkSchema = z
+  .object({
+    distinct_movers: z.int(),
+    movements: z.int(),
+    movements_per_mover: z.number().nullable(),
+  })
+  .strict();
+
+const ChainStakeMovesSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    distinct_movers: z.int(),
+    movements: z.int(),
+    movements_per_mover: z.number(),
+  })
+  .strict();
+
+export const GetChainStakeMovesOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainStakeMovesNetworkSchema,
+    intensity_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainStakeMovesSubnetSchema),
+  })
+  .passthrough();
+export type GetChainStakeMovesOutput = z.infer<
+  typeof GetChainStakeMovesOutputSchema
+>;
+
+export const GetChainStakeTransfersInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainStakeTransfersInput = z.infer<
+  typeof GetChainStakeTransfersInputSchema
+>;
+
+const ChainStakeTransfersNetworkSchema = z
+  .object({
+    distinct_senders: z.int(),
+    transfers: z.int(),
+    transfers_per_sender: z.number().nullable(),
+  })
+  .strict();
+
+const ChainStakeTransfersSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    distinct_senders: z.int(),
+    transfers: z.int(),
+    transfers_per_sender: z.number(),
+  })
+  .strict();
+
+export const GetChainStakeTransfersOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainStakeTransfersNetworkSchema,
+    intensity_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainStakeTransfersSubnetSchema),
+  })
+  .passthrough();
+export type GetChainStakeTransfersOutput = z.infer<
+  typeof GetChainStakeTransfersOutputSchema
+>;
+
+export const GetChainAxonRemovalsInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainAxonRemovalsInput = z.infer<
+  typeof GetChainAxonRemovalsInputSchema
+>;
+
+const ChainAxonRemovalsNetworkSchema = z
+  .object({
+    distinct_removers: z.int(),
+    removals: z.int(),
+    removals_per_remover: z.number().nullable(),
+  })
+  .strict();
+
+const ChainAxonRemovalsSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    distinct_removers: z.int(),
+    removals: z.int(),
+    removals_per_remover: z.number(),
+  })
+  .strict();
+
+export const GetChainAxonRemovalsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainAxonRemovalsNetworkSchema,
+    intensity_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainAxonRemovalsSubnetSchema),
+  })
+  .passthrough();
+export type GetChainAxonRemovalsOutput = z.infer<
+  typeof GetChainAxonRemovalsOutputSchema
+>;
+
+export const GetChainServingInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainServingInput = z.infer<typeof GetChainServingInputSchema>;
+
+const ChainServingNetworkSchema = z
+  .object({
+    distinct_servers: z.int(),
+    announcements: z.int(),
+    announcements_per_server: z.number().nullable(),
+  })
+  .strict();
+
+const ChainServingSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    distinct_servers: z.int(),
+    announcements: z.int(),
+    announcements_per_server: z.number(),
+  })
+  .strict();
+
+export const GetChainServingOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainServingNetworkSchema,
+    intensity_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainServingSubnetSchema),
+  })
+  .passthrough();
+export type GetChainServingOutput = z.infer<typeof GetChainServingOutputSchema>;
+
+export const GetChainPrometheusInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainPrometheusInput = z.infer<
+  typeof GetChainPrometheusInputSchema
+>;
+
+const ChainPrometheusNetworkSchema = z
+  .object({
+    distinct_exporters: z.int(),
+    announcements: z.int(),
+    announcements_per_exporter: z.number().nullable(),
+  })
+  .strict();
+
+const ChainPrometheusSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    distinct_exporters: z.int(),
+    announcements: z.int(),
+    announcements_per_exporter: z.number(),
+  })
+  .strict();
+
+export const GetChainPrometheusOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainPrometheusNetworkSchema,
+    intensity_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainPrometheusSubnetSchema),
+  })
+  .passthrough();
+export type GetChainPrometheusOutput = z.infer<
+  typeof GetChainPrometheusOutputSchema
+>;

--- a/schemas-src/mcp-tools/chain-registrations.ts
+++ b/schemas-src/mcp-tools/chain-registrations.ts
@@ -1,0 +1,114 @@
+// MCP tools `get_chain_registrations`, `get_chain_deregistrations`
+// (types-epic E batch 9, #8072). Each mirrors a GET /api/v1/chain/
+// {de,}registrations route that is not one of schemas-src/routes/'s covered
+// pilot routes -- no existing Zod schema to reuse. Modeled fresh, matching
+// each hand-written literal field-for-field.
+//
+// The two are NOT siblings despite the name: get_chain_deregistrations
+// follows the same STRICT network/intensity_distribution/subnets[] shape as
+// chain-leaderboards.ts's nine tools (additionalProperties:false + full
+// required arrays), but get_chain_registrations's hand-written original is
+// genuinely looser -- its `network` sub-object has no additionalProperties/
+// required declared (structurally open, JSON Schema's own default),
+// `intensity_distribution` is a completely untyped `{type:["object","null"]}`
+// (no properties at all, unlike its sibling's typed DistributionStatsSchema),
+// and `subnets` uses the usual objectItems() item-level looseness instead of
+// strict items. Modeled as-is, not "fixed" to match its sibling -- the epic's
+// wire-compatibility mandate preserves what shipped, not what's consistent.
+import { z } from "zod";
+import { DistributionStatsSchema, OpenObjectSchema } from "./shared.ts";
+
+const WINDOWS_2 = ["7d", "30d"] as const;
+const LIMIT_MAX_100 = 100;
+
+export const GetChainRegistrationsInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainRegistrationsInput = z.infer<
+  typeof GetChainRegistrationsInputSchema
+>;
+
+// Genuinely open (no additionalProperties:false, no required array in the
+// hand-written original) -- see file header.
+const ChainRegistrationsNetworkSchema = z
+  .object({
+    distinct_registrants: z.int().nullable().optional(),
+    registrations: z.int().nullable().optional(),
+    registrations_per_registrant: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+// objectItems(...) properties, none required at the item level (see
+// search-subnets.ts's same note from the pilot batch) -- unlike
+// get_chain_deregistrations's strict items below.
+const ChainRegistrationsSubnetSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    distinct_registrants: z.int().nullable().optional(),
+    registrations: z.int().nullable().optional(),
+    registrations_per_registrant: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetChainRegistrationsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainRegistrationsNetworkSchema,
+    // Untyped in the hand-written original (bare `{type:["object","null"]}`,
+    // no properties) -- NOT DistributionStatsSchema despite the field name
+    // matching its sibling tools' typed *_distribution fields.
+    intensity_distribution: OpenObjectSchema.nullable().optional(),
+    subnets: z.array(ChainRegistrationsSubnetSchema),
+  })
+  .passthrough();
+export type GetChainRegistrationsOutput = z.infer<
+  typeof GetChainRegistrationsOutputSchema
+>;
+
+export const GetChainDeregistrationsInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(LIMIT_MAX_100).optional(),
+  })
+  .strict();
+export type GetChainDeregistrationsInput = z.infer<
+  typeof GetChainDeregistrationsInputSchema
+>;
+
+const ChainDeregistrationsNetworkSchema = z
+  .object({
+    distinct_deregistered_hotkeys: z.int(),
+    deregistrations: z.int(),
+    deregistrations_per_hotkey: z.number().nullable(),
+  })
+  .strict();
+
+const ChainDeregistrationsSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    distinct_deregistered_hotkeys: z.int(),
+    deregistrations: z.int(),
+    deregistrations_per_hotkey: z.number(),
+  })
+  .strict();
+
+export const GetChainDeregistrationsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    window: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    network: ChainDeregistrationsNetworkSchema,
+    intensity_distribution: DistributionStatsSchema.nullable().optional(),
+    subnets: z.array(ChainDeregistrationsSubnetSchema),
+  })
+  .passthrough();
+export type GetChainDeregistrationsOutput = z.infer<
+  typeof GetChainDeregistrationsOutputSchema
+>;

--- a/schemas-src/mcp-tools/chain-scorecards.ts
+++ b/schemas-src/mcp-tools/chain-scorecards.ts
@@ -1,0 +1,106 @@
+// MCP tools `get_chain_concentration`, `get_chain_performance`,
+// `get_chain_idle_stake`, `get_chain_yield` (types-epic E batch 9, #8072).
+// Each mirrors a GET /api/v1/chain/* route that is not one of
+// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
+// reuse. All four take no input (bare `{}`). Modeled fresh, matching each
+// hand-written literal field-for-field -- including several bare nullable
+// `{type:["object","null"]}` fields with no declared shape, which stay
+// untyped open objects here too (not "improved" with a guessed shape).
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetChainConcentrationInputSchema = z.object({}).strict();
+export type GetChainConcentrationInput = z.infer<
+  typeof GetChainConcentrationInputSchema
+>;
+
+export const GetChainConcentrationOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    subnet_count: z.int(),
+    neuron_count: z.int(),
+    entity_count: z.int().optional(),
+    uids_per_entity: z.number().nullable().optional(),
+    captured_at: z.string().nullable().optional(),
+    stake: OpenObjectSchema.nullable().optional(),
+    emission: OpenObjectSchema.nullable().optional(),
+    entity_stake: OpenObjectSchema.nullable().optional(),
+    entity_emission: OpenObjectSchema.nullable().optional(),
+    validator_stake: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetChainConcentrationOutput = z.infer<
+  typeof GetChainConcentrationOutputSchema
+>;
+
+export const GetChainPerformanceInputSchema = z.object({}).strict();
+export type GetChainPerformanceInput = z.infer<
+  typeof GetChainPerformanceInputSchema
+>;
+
+export const GetChainPerformanceOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    subnet_count: z.int(),
+    neuron_count: z.int(),
+    validator_count: z.int().optional(),
+    active_count: z.int().optional(),
+    captured_at: z.string().nullable().optional(),
+    incentive: OpenObjectSchema.nullable().optional(),
+    dividends: OpenObjectSchema.nullable().optional(),
+    trust: OpenObjectSchema.nullable().optional(),
+    consensus: OpenObjectSchema.nullable().optional(),
+    validator_trust: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetChainPerformanceOutput = z.infer<
+  typeof GetChainPerformanceOutputSchema
+>;
+
+export const GetChainIdleStakeInputSchema = z.object({}).strict();
+export type GetChainIdleStakeInput = z.infer<
+  typeof GetChainIdleStakeInputSchema
+>;
+
+const ChainIdleStakeSubnetSchema = z
+  .object({
+    netuid: z.int(),
+    neuron_count: z.int(),
+    idle_neuron_count: z.int(),
+    idle_stake_tao: z.number(),
+  })
+  .passthrough();
+
+export const GetChainIdleStakeOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    captured_at: z.string().nullable().optional(),
+    subnet_count: z.int(),
+    total_idle_stake_tao: z.number(),
+    subnets: z.array(ChainIdleStakeSubnetSchema),
+  })
+  .passthrough();
+export type GetChainIdleStakeOutput = z.infer<
+  typeof GetChainIdleStakeOutputSchema
+>;
+
+export const GetChainYieldInputSchema = z.object({}).strict();
+export type GetChainYieldInput = z.infer<typeof GetChainYieldInputSchema>;
+
+export const GetChainYieldOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    subnet_count: z.int(),
+    neuron_count: z.int(),
+    validator_count: z.int().optional(),
+    miner_count: z.int().optional(),
+    captured_at: z.string().nullable().optional(),
+    total_stake_tao: z.number().optional(),
+    total_emission_tao: z.number().optional(),
+    network_yield: z.number().nullable().optional(),
+    validator_yield: z.number().nullable().optional(),
+    miner_yield: z.number().nullable().optional(),
+    distribution: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetChainYieldOutput = z.infer<typeof GetChainYieldOutputSchema>;

--- a/schemas-src/mcp-tools/chain-transfers.ts
+++ b/schemas-src/mcp-tools/chain-transfers.ts
@@ -1,0 +1,91 @@
+// MCP tools `get_chain_transfers`, `get_chain_transfer_pairs` (types-epic E
+// batch 9, #8072). Each mirrors a GET /api/v1/chain/transfer{s,-pairs} route
+// that is not one of schemas-src/routes/'s covered pilot routes -- no
+// existing Zod schema to reuse. Both hand-written originals are
+// additionalProperties:false (strict) at the top level, unlike the
+// additionalProperties:true posture most tools in this epic use -- modeled
+// here with the same strictness. Their `window` fields are a REQUIRED but
+// NULLABLE enum (`type:["string","null"], enum:[...windows, null]`) --
+// `z.enum(...).nullable()`, not `.optional()`.
+import { z } from "zod";
+
+const WINDOWS_2 = ["7d", "30d"] as const;
+
+// Mirrors mcp-server.ts's shared CHAIN_TRANSFER_PARTY_ITEM object literal
+// (this batch's last consumer -- get_chain_transfer_pairs.pairs items have
+// their own distinct shape, not this one).
+const ChainTransferPartySchema = z
+  .object({
+    address: z.string(),
+    volume_tao: z.number(),
+    transfer_count: z.int().min(0),
+  })
+  .strict();
+
+export const GetChainTransfersInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    limit: z.int().min(1).max(100).optional(),
+  })
+  .strict();
+export type GetChainTransfersInput = z.infer<
+  typeof GetChainTransfersInputSchema
+>;
+
+export const GetChainTransfersOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    window: z.enum(WINDOWS_2).nullable(),
+    observed_at: z.string().nullable(),
+    total_volume_tao: z.number(),
+    transfer_count: z.int().min(0),
+    unique_senders: z.int().min(0),
+    unique_receivers: z.int().min(0),
+    top_sender_share: z.number().nullable(),
+    top_senders: z.array(ChainTransferPartySchema),
+    top_receivers: z.array(ChainTransferPartySchema),
+  })
+  .strict();
+export type GetChainTransfersOutput = z.infer<
+  typeof GetChainTransfersOutputSchema
+>;
+
+export const GetChainTransferPairsInputSchema = z
+  .object({
+    window: z.enum(WINDOWS_2).optional(),
+    sort: z.enum(["volume", "count"]).optional(),
+    limit: z.int().min(1).max(100).optional(),
+  })
+  .strict();
+export type GetChainTransferPairsInput = z.infer<
+  typeof GetChainTransferPairsInputSchema
+>;
+
+const ChainTransferPairSchema = z
+  .object({
+    from: z.string(),
+    to: z.string(),
+    volume_tao: z.number(),
+    transfer_count: z.int().min(0),
+    last_block: z.int().nullable(),
+    last_observed_at: z.string().nullable(),
+  })
+  .strict();
+
+export const GetChainTransferPairsOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    window: z.enum(WINDOWS_2).nullable(),
+    sort: z.enum(["volume", "count"]),
+    observed_at: z.string().nullable(),
+    total_volume_tao: z.number(),
+    transfer_count: z.int().min(0),
+    unique_pairs: z.int().min(0),
+    pair_count: z.int().min(0),
+    top_pair_share: z.number().nullable(),
+    pairs: z.array(ChainTransferPairSchema),
+  })
+  .strict();
+export type GetChainTransferPairsOutput = z.infer<
+  typeof GetChainTransferPairsOutputSchema
+>;

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -59,3 +59,25 @@ export const AccountEventItemSchema = z
     extrinsic_index: z.int().nullable().optional(),
   })
   .passthrough();
+
+// The 8-field distribution-stats shape (count/mean/min/p25/median/p75/p90/
+// max) 10 of types-epic E batch 9's (#8072) "chain leaderboard" tools use
+// identically for their `*_distribution` field (get_chain_turnover's
+// stability_distribution, get_chain_stake_flow's net_flow_distribution,
+// get_chain_alpha_volume's volume_distribution, and the intensity_distribution
+// on get_chain_weights/stake_moves/stake_transfers/axon_removals/serving/
+// prometheus/deregistrations) -- hoisted here rather than defined 10 times,
+// unlike every other nested shape in this epic which stayed tool-local
+// (those never repeated verbatim across more than 2 tools).
+export const DistributionStatsSchema = z
+  .object({
+    count: z.int(),
+    mean: z.number(),
+    min: z.number(),
+    p25: z.number(),
+    median: z.number(),
+    p75: z.number(),
+    p90: z.number(),
+    max: z.number(),
+  })
+  .strict();

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -400,6 +400,70 @@ import {
   GetExtrinsicChainEventsInputSchema,
   GetExtrinsicChainEventsOutputSchema,
 } from "../schemas-src/mcp-tools/chain-events.ts";
+import {
+  GetChainConcentrationInputSchema,
+  GetChainConcentrationOutputSchema,
+  GetChainPerformanceInputSchema,
+  GetChainPerformanceOutputSchema,
+  GetChainIdleStakeInputSchema,
+  GetChainIdleStakeOutputSchema,
+  GetChainYieldInputSchema,
+  GetChainYieldOutputSchema,
+} from "../schemas-src/mcp-tools/chain-scorecards.ts";
+import {
+  GetChainIdentityHistoryInputSchema,
+  GetChainIdentityHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/chain-identity-history.ts";
+import {
+  GetChainTurnoverInputSchema,
+  GetChainTurnoverOutputSchema,
+  GetChainStakeFlowInputSchema,
+  GetChainStakeFlowOutputSchema,
+  GetChainAlphaVolumeInputSchema,
+  GetChainAlphaVolumeOutputSchema,
+  GetChainWeightsInputSchema,
+  GetChainWeightsOutputSchema,
+  GetChainWeightSettersInputSchema,
+  GetChainWeightSettersOutputSchema,
+  GetChainStakeMovesInputSchema,
+  GetChainStakeMovesOutputSchema,
+  GetChainStakeTransfersInputSchema,
+  GetChainStakeTransfersOutputSchema,
+  GetChainAxonRemovalsInputSchema,
+  GetChainAxonRemovalsOutputSchema,
+  GetChainServingInputSchema,
+  GetChainServingOutputSchema,
+  GetChainPrometheusInputSchema,
+  GetChainPrometheusOutputSchema,
+} from "../schemas-src/mcp-tools/chain-leaderboards.ts";
+import {
+  GetChainRegistrationsInputSchema,
+  GetChainRegistrationsOutputSchema,
+  GetChainDeregistrationsInputSchema,
+  GetChainDeregistrationsOutputSchema,
+} from "../schemas-src/mcp-tools/chain-registrations.ts";
+import {
+  GetChainActivityInputSchema,
+  GetChainActivityOutputSchema,
+  ListChainEventsInputSchema,
+  ListChainEventsOutputSchema,
+  GetNetworkActivityInputSchema,
+  GetNetworkActivityOutputSchema,
+} from "../schemas-src/mcp-tools/chain-events-activity.ts";
+import {
+  GetChainCallsInputSchema,
+  GetChainCallsOutputSchema,
+  GetChainSignersInputSchema,
+  GetChainSignersOutputSchema,
+  GetChainFeesInputSchema,
+  GetChainFeesOutputSchema,
+} from "../schemas-src/mcp-tools/chain-calls-fees.ts";
+import {
+  GetChainTransfersInputSchema,
+  GetChainTransfersOutputSchema,
+  GetChainTransferPairsInputSchema,
+  GetChainTransferPairsOutputSchema,
+} from "../schemas-src/mcp-tools/chain-transfers.ts";
 
 type Row = Record<string, unknown>;
 
@@ -641,6 +705,35 @@ const TOP_HOLDERS_SORTS = [
   "net_flow_90d",
 ];
 const H160_PATTERN = "^0x[0-9a-fA-F]{40}$";
+
+// Batch 9 (#8072) resolved enum values, same treatment as above -- symbolic
+// in the hand-written originals (each chain-* leaderboard tool's own
+// src/chain-*.ts *_WINDOWS/*_LIMIT_MAX/*_LIMIT_DEFAULT constants, cross-
+// checked against the actual runtime source at the time of writing).
+// get_chain_calls/signers/fees/registrations/network_activity/list_chain_events
+// use a LITERAL inline ["7d","30d"] enum in their own hand-written originals
+// (no symbolic *_WINDOWS import there either) -- CHAIN_ANALYTICS_WINDOWS_2
+// covers both cases since the values are identical.
+const CHAIN_ANALYTICS_WINDOWS_2 = ["7d", "30d"];
+// The 8-field distribution-stats shape (count/mean/min/p25/median/p75/p90/
+// max) 9 of this batch's "chain leaderboard" tools use identically for their
+// `*_distribution` field -- mirrors schemas-src/mcp-tools/shared.ts's
+// DistributionStatsSchema.
+const DISTRIBUTION_STATS = {
+  type: "object",
+  additionalProperties: false,
+  required: ["count", "mean", "min", "p25", "median", "p75", "p90", "max"],
+  properties: {
+    count: { type: "integer" },
+    mean: { type: "number" },
+    min: { type: "number" },
+    p25: { type: "number" },
+    median: { type: "number" },
+    p75: { type: "number" },
+    p90: { type: "number" },
+    max: { type: "number" },
+  },
+};
 
 const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
   search_subnets: {
@@ -4565,6 +4658,1153 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  get_chain_concentration: {
+    input: { type: "object", properties: {}, additionalProperties: false },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "neuron_count"],
+      properties: {
+        schema_version: { type: "integer" },
+        subnet_count: { type: "integer" },
+        neuron_count: { type: "integer" },
+        entity_count: { type: "integer" },
+        uids_per_entity: { type: ["number", "null"] },
+        captured_at: NULLABLE_STRING,
+        stake: { type: ["object", "null"] },
+        emission: { type: ["object", "null"] },
+        entity_stake: { type: ["object", "null"] },
+        entity_emission: { type: ["object", "null"] },
+        validator_stake: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_chain_performance: {
+    input: { type: "object", properties: {}, additionalProperties: false },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "neuron_count"],
+      properties: {
+        schema_version: { type: "integer" },
+        subnet_count: { type: "integer" },
+        neuron_count: { type: "integer" },
+        validator_count: { type: "integer" },
+        active_count: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        incentive: { type: ["object", "null"] },
+        dividends: { type: ["object", "null"] },
+        trust: { type: ["object", "null"] },
+        consensus: { type: ["object", "null"] },
+        validator_trust: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_chain_idle_stake: {
+    input: { type: "object", properties: {}, additionalProperties: false },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "total_idle_stake_tao", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        total_idle_stake_tao: { type: "number" },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            required: [
+              "netuid",
+              "neuron_count",
+              "idle_neuron_count",
+              "idle_stake_tao",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              neuron_count: { type: "integer" },
+              idle_neuron_count: { type: "integer" },
+              idle_stake_tao: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_identity_history: {
+    input: {
+      type: "object",
+      properties: {
+        limit: { type: "integer", minimum: 1, maximum: 200 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["schema_version", "count", "subnet_count", "changes"],
+      properties: {
+        schema_version: { type: "integer" },
+        count: { type: "integer" },
+        subnet_count: { type: "integer" },
+        changes: objectItems({
+          netuid: NULLABLE_INT,
+          block_number: NULLABLE_INT,
+          observed_at: NULLABLE_STRING,
+          subnet_name: NULLABLE_STRING,
+          symbol: NULLABLE_STRING,
+          description: NULLABLE_STRING,
+          github_repo: NULLABLE_STRING,
+          subnet_url: NULLABLE_STRING,
+          discord: NULLABLE_STRING,
+          logo_url: NULLABLE_STRING,
+          identity_hash: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_chain_yield: {
+    input: { type: "object", properties: {}, additionalProperties: false },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "neuron_count"],
+      properties: {
+        schema_version: { type: "integer" },
+        subnet_count: { type: "integer" },
+        neuron_count: { type: "integer" },
+        validator_count: { type: "integer" },
+        miner_count: { type: "integer" },
+        captured_at: NULLABLE_STRING,
+        total_stake_tao: { type: "number" },
+        total_emission_tao: { type: "number" },
+        network_yield: { type: ["number", "null"] },
+        validator_yield: { type: ["number", "null"] },
+        miner_yield: { type: ["number", "null"] },
+        distribution: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_chain_turnover: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: ["7d", "30d", "90d"] },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["comparable", "subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        start_date: NULLABLE_STRING,
+        end_date: NULLABLE_STRING,
+        comparable: { type: "boolean" },
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "validators_start",
+            "validators_end",
+            "validators_entered",
+            "validators_exited",
+            "validator_retention",
+            "stability_score",
+          ],
+          properties: {
+            validators_start: { type: "integer" },
+            validators_end: { type: "integer" },
+            validators_entered: { type: "integer" },
+            validators_exited: { type: "integer" },
+            validator_retention: { type: ["number", "null"] },
+            stability_score: { type: ["integer", "null"] },
+          },
+        },
+        stability_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "validators_start",
+              "validators_end",
+              "validators_entered",
+              "validators_exited",
+              "validator_retention",
+              "stability_score",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              validators_start: { type: "integer" },
+              validators_end: { type: "integer" },
+              validators_entered: { type: "integer" },
+              validators_exited: { type: "integer" },
+              validator_retention: { type: "number" },
+              stability_score: { type: "integer" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_stake_flow: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "total_staked_tao",
+            "total_unstaked_tao",
+            "net_flow_tao",
+            "gross_flow_tao",
+            "stake_events",
+            "unstake_events",
+            "gaining",
+            "losing",
+            "flat",
+          ],
+          properties: {
+            total_staked_tao: { type: "number" },
+            total_unstaked_tao: { type: "number" },
+            net_flow_tao: { type: "number" },
+            gross_flow_tao: { type: "number" },
+            stake_events: { type: "integer" },
+            unstake_events: { type: "integer" },
+            gaining: { type: "integer" },
+            losing: { type: "integer" },
+            flat: { type: "integer" },
+          },
+        },
+        net_flow_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "total_staked_tao",
+              "total_unstaked_tao",
+              "net_flow_tao",
+              "gross_flow_tao",
+              "stake_events",
+              "unstake_events",
+              "direction",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              total_staked_tao: { type: "number" },
+              total_unstaked_tao: { type: "number" },
+              net_flow_tao: { type: "number" },
+              gross_flow_tao: { type: "number" },
+              stake_events: { type: "integer" },
+              unstake_events: { type: "integer" },
+              direction: { type: "string" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_alpha_volume: {
+    input: {
+      type: "object",
+      properties: {
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: { type: "string" },
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "buy_volume_alpha",
+            "sell_volume_alpha",
+            "total_volume_alpha",
+            "buy_volume_tao",
+            "sell_volume_tao",
+            "total_volume_tao",
+            "buy_count",
+            "sell_count",
+            "net_volume_alpha",
+            "sentiment_ratio",
+            "sentiment",
+          ],
+          properties: {
+            buy_volume_alpha: ANY,
+            sell_volume_alpha: ANY,
+            total_volume_alpha: ANY,
+            buy_volume_tao: ANY,
+            sell_volume_tao: ANY,
+            total_volume_tao: ANY,
+            buy_count: { type: "integer" },
+            sell_count: { type: "integer" },
+            net_volume_alpha: ANY,
+            sentiment_ratio: { type: ["number", "null"] },
+            sentiment: { type: "string" },
+          },
+        },
+        volume_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            required: ["netuid", "window"],
+            properties: {
+              schema_version: { type: "integer" },
+              netuid: { type: "integer" },
+              window: { type: "string" },
+              buy_volume_alpha: ANY,
+              sell_volume_alpha: ANY,
+              total_volume_alpha: ANY,
+              buy_volume_tao: ANY,
+              sell_volume_tao: ANY,
+              total_volume_tao: ANY,
+              buy_count: { type: "integer" },
+              sell_count: { type: "integer" },
+              net_volume_alpha: ANY,
+              sentiment_ratio: { type: ["number", "null"] },
+              sentiment: NULLABLE_STRING,
+              vol_mcap_ratio: { type: ["number", "null"] },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_weights: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: ["distinct_setters", "weight_sets", "sets_per_setter"],
+          properties: {
+            distinct_setters: { type: "integer" },
+            weight_sets: { type: "integer" },
+            sets_per_setter: { type: ["number", "null"] },
+          },
+        },
+        intensity_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "distinct_setters",
+              "weight_sets",
+              "sets_per_setter",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              distinct_setters: { type: "integer" },
+              weight_sets: { type: "integer" },
+              sets_per_setter: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_weight_setters: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "window",
+        "distinct_setters",
+        "weight_sets",
+        "setter_count",
+        "setters",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        distinct_setters: { type: "integer" },
+        weight_sets: { type: "integer" },
+        setter_count: { type: "integer" },
+        setters: objectItems({
+          hotkey: NULLABLE_STRING,
+          uid: NULLABLE_INT,
+          weight_sets: { type: "integer" },
+          share: ANY,
+          first_set_at: NULLABLE_STRING,
+          last_set_at: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  get_chain_stake_moves: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: ["distinct_movers", "movements", "movements_per_mover"],
+          properties: {
+            distinct_movers: { type: "integer" },
+            movements: { type: "integer" },
+            movements_per_mover: { type: ["number", "null"] },
+          },
+        },
+        intensity_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "distinct_movers",
+              "movements",
+              "movements_per_mover",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              distinct_movers: { type: "integer" },
+              movements: { type: "integer" },
+              movements_per_mover: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_stake_transfers: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: ["distinct_senders", "transfers", "transfers_per_sender"],
+          properties: {
+            distinct_senders: { type: "integer" },
+            transfers: { type: "integer" },
+            transfers_per_sender: { type: ["number", "null"] },
+          },
+        },
+        intensity_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "distinct_senders",
+              "transfers",
+              "transfers_per_sender",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              distinct_senders: { type: "integer" },
+              transfers: { type: "integer" },
+              transfers_per_sender: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_axon_removals: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: ["distinct_removers", "removals", "removals_per_remover"],
+          properties: {
+            distinct_removers: { type: "integer" },
+            removals: { type: "integer" },
+            removals_per_remover: { type: ["number", "null"] },
+          },
+        },
+        intensity_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "distinct_removers",
+              "removals",
+              "removals_per_remover",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              distinct_removers: { type: "integer" },
+              removals: { type: "integer" },
+              removals_per_remover: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_serving: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "distinct_servers",
+            "announcements",
+            "announcements_per_server",
+          ],
+          properties: {
+            distinct_servers: { type: "integer" },
+            announcements: { type: "integer" },
+            announcements_per_server: { type: ["number", "null"] },
+          },
+        },
+        intensity_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "distinct_servers",
+              "announcements",
+              "announcements_per_server",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              distinct_servers: { type: "integer" },
+              announcements: { type: "integer" },
+              announcements_per_server: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_prometheus: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "distinct_exporters",
+            "announcements",
+            "announcements_per_exporter",
+          ],
+          properties: {
+            distinct_exporters: { type: "integer" },
+            announcements: { type: "integer" },
+            announcements_per_exporter: { type: ["number", "null"] },
+          },
+        },
+        intensity_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "distinct_exporters",
+              "announcements",
+              "announcements_per_exporter",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              distinct_exporters: { type: "integer" },
+              announcements: { type: "integer" },
+              announcements_per_exporter: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_activity: {
+    input: {
+      type: "object",
+      properties: {
+        blocks: { type: "integer", minimum: 1, maximum: 5000 },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["window_blocks", "groups", "activity"],
+      properties: {
+        window_blocks: { type: "integer" },
+        groups: { type: "integer" },
+        activity: objectItems({
+          pallet: NULLABLE_STRING,
+          method: NULLABLE_STRING,
+          count: NULLABLE_INT,
+        }),
+      },
+    },
+  },
+  list_chain_events: {
+    input: {
+      type: "object",
+      properties: {
+        pallet: { type: "string" },
+        method: { type: "string" },
+        block: { type: "integer", minimum: 0 },
+        extrinsic: { type: "integer", minimum: 0 },
+        cursor: { type: "string" },
+        before: { type: "integer", minimum: 0 },
+        limit: { type: "integer", minimum: 1, maximum: 200 },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["count", "events"],
+      properties: {
+        count: { type: "integer" },
+        next_before: NULLABLE_INT,
+        next_cursor: NULLABLE_STRING,
+        events: objectItems({
+          block_number: NULLABLE_INT,
+          event_index: NULLABLE_INT,
+          pallet: NULLABLE_STRING,
+          method: NULLABLE_STRING,
+          args: ANY,
+          phase: ANY,
+          extrinsic_index: NULLABLE_INT,
+          observed_at: ANY,
+        }),
+      },
+    },
+  },
+  get_chain_calls: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        group_by: { type: "string", enum: ["module", "module_function"] },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        call_module: { type: "string" },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "schema_version",
+        "window",
+        "group_by",
+        "total_extrinsics",
+        "call_count",
+        "calls",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        window: { type: "string" },
+        group_by: { type: "string" },
+        observed_at: NULLABLE_STRING,
+        total_extrinsics: { type: "integer" },
+        call_count: { type: "integer" },
+        calls: objectItems({
+          call_module: NULLABLE_STRING,
+          call_function: NULLABLE_STRING,
+          count: NULLABLE_INT,
+          share: ANY,
+        }),
+      },
+    },
+  },
+  get_chain_signers: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        sort: { type: "string", enum: ["tx_count", "total_fee_tao"] },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        call_module: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["window", "sort", "signer_count", "signers"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: { type: "string" },
+        sort: { type: "string", enum: ["tx_count", "total_fee_tao"] },
+        observed_at: NULLABLE_STRING,
+        signer_count: { type: "integer" },
+        signers: objectItems({
+          signer: NULLABLE_STRING,
+          tx_count: NULLABLE_INT,
+          total_fee_tao: { type: ["number", "null"] },
+          total_tip_tao: { type: ["number", "null"] },
+          last_tx_block: NULLABLE_INT,
+        }),
+      },
+    },
+  },
+  get_chain_fees: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        call_module: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["window", "day_count", "daily", "top_fee_payers"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: { type: "string" },
+        observed_at: NULLABLE_STRING,
+        day_count: { type: "integer" },
+        daily: objectItems({
+          day: NULLABLE_STRING,
+          extrinsic_count: NULLABLE_INT,
+          total_fee_tao: { type: ["number", "null"] },
+          avg_fee_tao: { type: ["number", "null"] },
+          median_fee_tao: { type: ["number", "null"] },
+          total_tip_tao: { type: ["number", "null"] },
+          avg_tip_tao: { type: ["number", "null"] },
+          median_tip_tao: { type: ["number", "null"] },
+        }),
+        top_fee_payers: objectItems({
+          signer: NULLABLE_STRING,
+          total_fee_tao: { type: ["number", "null"] },
+          total_tip_tao: { type: ["number", "null"] },
+          extrinsic_count: NULLABLE_INT,
+        }),
+      },
+    },
+  },
+  get_chain_registrations: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["window", "subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          properties: {
+            distinct_registrants: NULLABLE_INT,
+            registrations: NULLABLE_INT,
+            registrations_per_registrant: { type: ["number", "null"] },
+          },
+        },
+        intensity_distribution: { type: ["object", "null"] },
+        subnets: objectItems({
+          netuid: NULLABLE_INT,
+          distinct_registrants: NULLABLE_INT,
+          registrations: NULLABLE_INT,
+          registrations_per_registrant: { type: ["number", "null"] },
+        }),
+      },
+    },
+  },
+  get_chain_deregistrations: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "network", "subnets"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        subnet_count: { type: "integer" },
+        network: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "distinct_deregistered_hotkeys",
+            "deregistrations",
+            "deregistrations_per_hotkey",
+          ],
+          properties: {
+            distinct_deregistered_hotkeys: { type: "integer" },
+            deregistrations: { type: "integer" },
+            deregistrations_per_hotkey: { type: ["number", "null"] },
+          },
+        },
+        intensity_distribution: {
+          ...DISTRIBUTION_STATS,
+          type: ["object", "null"],
+        },
+        subnets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "netuid",
+              "distinct_deregistered_hotkeys",
+              "deregistrations",
+              "deregistrations_per_hotkey",
+            ],
+            properties: {
+              netuid: { type: "integer" },
+              distinct_deregistered_hotkeys: { type: "integer" },
+              deregistrations: { type: "integer" },
+              deregistrations_per_hotkey: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_transfers: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "schema_version",
+        "window",
+        "observed_at",
+        "total_volume_tao",
+        "transfer_count",
+        "unique_senders",
+        "unique_receivers",
+        "top_sender_share",
+        "top_senders",
+        "top_receivers",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        window: {
+          type: ["string", "null"],
+          enum: [...CHAIN_ANALYTICS_WINDOWS_2, null],
+        },
+        observed_at: NULLABLE_STRING,
+        total_volume_tao: { type: "number" },
+        transfer_count: { type: "integer", minimum: 0 },
+        unique_senders: { type: "integer", minimum: 0 },
+        unique_receivers: { type: "integer", minimum: 0 },
+        top_sender_share: { type: ["number", "null"] },
+        top_senders: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["address", "volume_tao", "transfer_count"],
+            properties: {
+              address: { type: "string" },
+              volume_tao: { type: "number" },
+              transfer_count: { type: "integer", minimum: 0 },
+            },
+          },
+        },
+        top_receivers: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["address", "volume_tao", "transfer_count"],
+            properties: {
+              address: { type: "string" },
+              volume_tao: { type: "number" },
+              transfer_count: { type: "integer", minimum: 0 },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_chain_transfer_pairs: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+        sort: { type: "string", enum: ["volume", "count"] },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "schema_version",
+        "window",
+        "sort",
+        "observed_at",
+        "total_volume_tao",
+        "transfer_count",
+        "unique_pairs",
+        "pair_count",
+        "top_pair_share",
+        "pairs",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        window: {
+          type: ["string", "null"],
+          enum: [...CHAIN_ANALYTICS_WINDOWS_2, null],
+        },
+        sort: { type: "string", enum: ["volume", "count"] },
+        observed_at: NULLABLE_STRING,
+        total_volume_tao: { type: "number" },
+        transfer_count: { type: "integer", minimum: 0 },
+        unique_pairs: { type: "integer", minimum: 0 },
+        pair_count: { type: "integer", minimum: 0 },
+        top_pair_share: { type: ["number", "null"] },
+        pairs: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "from",
+              "to",
+              "volume_tao",
+              "transfer_count",
+              "last_block",
+              "last_observed_at",
+            ],
+            properties: {
+              from: { type: "string" },
+              to: { type: "string" },
+              volume_tao: { type: "number" },
+              transfer_count: { type: "integer", minimum: 0 },
+              last_block: { type: ["integer", "null"] },
+              last_observed_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_network_activity: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: CHAIN_ANALYTICS_WINDOWS_2 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["window", "day_count", "days"],
+      properties: {
+        schema_version: { type: "integer" },
+        window: { type: "string" },
+        observed_at: NULLABLE_STRING,
+        day_count: { type: "integer" },
+        days: objectItems({
+          day: NULLABLE_STRING,
+          block_count: NULLABLE_INT,
+          extrinsic_count: NULLABLE_INT,
+          event_count: NULLABLE_INT,
+          successful_extrinsics: NULLABLE_INT,
+          success_rate: { type: ["number", "null"] },
+          unique_signers: NULLABLE_INT,
+        }),
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -5025,6 +6265,106 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
     input: GetExtrinsicChainEventsInputSchema,
     output: GetExtrinsicChainEventsOutputSchema,
   },
+  get_chain_concentration: {
+    input: GetChainConcentrationInputSchema,
+    output: GetChainConcentrationOutputSchema,
+  },
+  get_chain_performance: {
+    input: GetChainPerformanceInputSchema,
+    output: GetChainPerformanceOutputSchema,
+  },
+  get_chain_idle_stake: {
+    input: GetChainIdleStakeInputSchema,
+    output: GetChainIdleStakeOutputSchema,
+  },
+  get_chain_identity_history: {
+    input: GetChainIdentityHistoryInputSchema,
+    output: GetChainIdentityHistoryOutputSchema,
+  },
+  get_chain_yield: {
+    input: GetChainYieldInputSchema,
+    output: GetChainYieldOutputSchema,
+  },
+  get_chain_turnover: {
+    input: GetChainTurnoverInputSchema,
+    output: GetChainTurnoverOutputSchema,
+  },
+  get_chain_stake_flow: {
+    input: GetChainStakeFlowInputSchema,
+    output: GetChainStakeFlowOutputSchema,
+  },
+  get_chain_alpha_volume: {
+    input: GetChainAlphaVolumeInputSchema,
+    output: GetChainAlphaVolumeOutputSchema,
+  },
+  get_chain_weights: {
+    input: GetChainWeightsInputSchema,
+    output: GetChainWeightsOutputSchema,
+  },
+  get_chain_weight_setters: {
+    input: GetChainWeightSettersInputSchema,
+    output: GetChainWeightSettersOutputSchema,
+  },
+  get_chain_stake_moves: {
+    input: GetChainStakeMovesInputSchema,
+    output: GetChainStakeMovesOutputSchema,
+  },
+  get_chain_stake_transfers: {
+    input: GetChainStakeTransfersInputSchema,
+    output: GetChainStakeTransfersOutputSchema,
+  },
+  get_chain_axon_removals: {
+    input: GetChainAxonRemovalsInputSchema,
+    output: GetChainAxonRemovalsOutputSchema,
+  },
+  get_chain_serving: {
+    input: GetChainServingInputSchema,
+    output: GetChainServingOutputSchema,
+  },
+  get_chain_prometheus: {
+    input: GetChainPrometheusInputSchema,
+    output: GetChainPrometheusOutputSchema,
+  },
+  get_chain_activity: {
+    input: GetChainActivityInputSchema,
+    output: GetChainActivityOutputSchema,
+  },
+  list_chain_events: {
+    input: ListChainEventsInputSchema,
+    output: ListChainEventsOutputSchema,
+  },
+  get_chain_calls: {
+    input: GetChainCallsInputSchema,
+    output: GetChainCallsOutputSchema,
+  },
+  get_chain_signers: {
+    input: GetChainSignersInputSchema,
+    output: GetChainSignersOutputSchema,
+  },
+  get_chain_fees: {
+    input: GetChainFeesInputSchema,
+    output: GetChainFeesOutputSchema,
+  },
+  get_chain_registrations: {
+    input: GetChainRegistrationsInputSchema,
+    output: GetChainRegistrationsOutputSchema,
+  },
+  get_chain_deregistrations: {
+    input: GetChainDeregistrationsInputSchema,
+    output: GetChainDeregistrationsOutputSchema,
+  },
+  get_chain_transfers: {
+    input: GetChainTransfersInputSchema,
+    output: GetChainTransfersOutputSchema,
+  },
+  get_chain_transfer_pairs: {
+    input: GetChainTransferPairsInputSchema,
+    output: GetChainTransferPairsOutputSchema,
+  },
+  get_network_activity: {
+    input: GetNetworkActivityInputSchema,
+    output: GetNetworkActivityOutputSchema,
+  },
 };
 
 const MAX_SAFE_INT = Number.MAX_SAFE_INTEGER;
@@ -5071,6 +6411,16 @@ function normalize(node: unknown, path: string): unknown {
   // scripts/diff-openapi-zod-components.ts's equivalent rule.
   if (Array.isArray(obj.type) && obj.type.length > 1) {
     const { type: _t, ...siblings } = obj;
+    // A hand-written `enum:[...values, null]` sibling on a `type:[X,"null"]`
+    // node (e.g. batch 9's get_chain_transfers.window: `{type:["string",
+    // "null"], enum:[...CHAIN_TRANSFER_WINDOW_KEYS, null]}`) carries a
+    // redundant literal `null` into the non-null branch once split -- the
+    // null case is already the separate `{type:"null"}` branch below, and
+    // Zod's own `z.enum(...).nullable()` output never repeats it there.
+    // Strip it so both sides produce the same anyOf shape.
+    if (Array.isArray(siblings.enum) && obj.type.includes("null")) {
+      siblings.enum = siblings.enum.filter((v: unknown) => v !== null);
+    }
     return normalize(
       {
         anyOf: obj.type.map((t, i) =>

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -672,6 +672,70 @@ import {
   GetExtrinsicChainEventsOutputSchema,
 } from "../schemas-src/mcp-tools/chain-events.ts";
 import {
+  GetChainConcentrationInputSchema,
+  GetChainConcentrationOutputSchema,
+  GetChainPerformanceInputSchema,
+  GetChainPerformanceOutputSchema,
+  GetChainIdleStakeInputSchema,
+  GetChainIdleStakeOutputSchema,
+  GetChainYieldInputSchema,
+  GetChainYieldOutputSchema,
+} from "../schemas-src/mcp-tools/chain-scorecards.ts";
+import {
+  GetChainIdentityHistoryInputSchema,
+  GetChainIdentityHistoryOutputSchema,
+} from "../schemas-src/mcp-tools/chain-identity-history.ts";
+import {
+  GetChainTurnoverInputSchema,
+  GetChainTurnoverOutputSchema,
+  GetChainStakeFlowInputSchema,
+  GetChainStakeFlowOutputSchema,
+  GetChainAlphaVolumeInputSchema,
+  GetChainAlphaVolumeOutputSchema,
+  GetChainWeightsInputSchema,
+  GetChainWeightsOutputSchema,
+  GetChainWeightSettersInputSchema,
+  GetChainWeightSettersOutputSchema,
+  GetChainStakeMovesInputSchema,
+  GetChainStakeMovesOutputSchema,
+  GetChainStakeTransfersInputSchema,
+  GetChainStakeTransfersOutputSchema,
+  GetChainAxonRemovalsInputSchema,
+  GetChainAxonRemovalsOutputSchema,
+  GetChainServingInputSchema,
+  GetChainServingOutputSchema,
+  GetChainPrometheusInputSchema,
+  GetChainPrometheusOutputSchema,
+} from "../schemas-src/mcp-tools/chain-leaderboards.ts";
+import {
+  GetChainRegistrationsInputSchema,
+  GetChainRegistrationsOutputSchema,
+  GetChainDeregistrationsInputSchema,
+  GetChainDeregistrationsOutputSchema,
+} from "../schemas-src/mcp-tools/chain-registrations.ts";
+import {
+  GetChainActivityInputSchema,
+  GetChainActivityOutputSchema,
+  ListChainEventsInputSchema,
+  ListChainEventsOutputSchema,
+  GetNetworkActivityInputSchema,
+  GetNetworkActivityOutputSchema,
+} from "../schemas-src/mcp-tools/chain-events-activity.ts";
+import {
+  GetChainCallsInputSchema,
+  GetChainCallsOutputSchema,
+  GetChainSignersInputSchema,
+  GetChainSignersOutputSchema,
+  GetChainFeesInputSchema,
+  GetChainFeesOutputSchema,
+} from "../schemas-src/mcp-tools/chain-calls-fees.ts";
+import {
+  GetChainTransfersInputSchema,
+  GetChainTransfersOutputSchema,
+  GetChainTransferPairsInputSchema,
+  GetChainTransferPairsOutputSchema,
+} from "../schemas-src/mcp-tools/chain-transfers.ts";
+import {
   buildChainConcentration,
   buildConcentration,
   buildConcentrationHistory,
@@ -3608,11 +3672,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "subnets counts once), and validator-only distributions, plus the " +
       "subnet_count the snapshot spans. The network-level companion of " +
       "get_subnet_concentration. Mirrors GET /api/v1/chain/concentration.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetChainConcentrationInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
@@ -3635,11 +3697,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "the snapshot spans. The network-level companion of get_subnet_performance " +
       "and the reward-flow companion of get_chain_concentration. Mirrors GET " +
       "/api/v1/chain/performance.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetChainPerformanceInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
@@ -3659,11 +3719,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "idle_stake_tao descending, plus the network total. The network-level " +
       "companion of get_subnet_idle_stake and the idle-delegation companion of " +
       "get_chain_performance. Mirrors GET /api/v1/chain/idle-stake.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetChainIdleStakeInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
@@ -3687,19 +3745,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       ") and reporting the distinct subnet_count the feed spans. The network-level " +
       "companion of get_subnet_identity_history. Mirrors GET " +
       "/api/v1/chain/identity-history.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        limit: {
-          type: "integer",
-          description: `Max changes to return (1-${CHAIN_IDENTITY_HISTORY_LIMIT_MAX}, default ${CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainIdentityHistoryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainIdentityHistoryInputSchema>,
+      ctx: McpCtx,
+    ) {
       // Mirrors REST's handleChainIdentityHistory: same tryPostgresTier
       // contract, same METAGRAPH_SUBNET_IDENTITY_SOURCE flag as the REST
       // route (#4832), so this tool and GET /api/v1/chain/identity-history
@@ -3726,11 +3778,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "and the subnet_count the snapshot spans. The network-level companion of " +
       "get_subnet_yield and the return-rate companion of get_chain_performance. " +
       "Mirrors GET /api/v1/chain/yield.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetChainYieldInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return (
         (await tryPostgresTier(
@@ -3754,24 +3804,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "The network-level companion of get_subnet_turnover, mirroring how " +
       "get_chain_concentration companions get_subnet_concentration. Mirrors " +
       "GET /api/v1/chain/turnover.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_TURNOVER_WINDOW_KEYS,
-          description: `Comparison window (default ${DEFAULT_CHAIN_TURNOVER_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the turnover leaderboard (1-${CHAIN_TURNOVER_LIMIT_MAX}, default ${CHAIN_TURNOVER_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_TURNOVER_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainTurnoverInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainTurnoverInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_TURNOVER_WINDOW;
       if (!Object.hasOwn(CHAIN_TURNOVER_WINDOWS, window)) {
@@ -3813,24 +3852,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "summed live from the account_events stream. The network-level companion " +
       "of get_subnet_stake_flow, mirroring how get_chain_concentration " +
       "companions get_subnet_concentration. Mirrors GET /api/v1/chain/stake-flow.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_STAKE_FLOW_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_STAKE_FLOW_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the stake-flow leaderboard (1-${CHAIN_STAKE_FLOW_LIMIT_MAX}, default ${CHAIN_STAKE_FLOW_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_STAKE_FLOW_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainStakeFlowInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainStakeFlowInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_FLOW_WINDOW;
       if (!Object.hasOwn(CHAIN_STAKE_FLOW_WINDOWS, window)) {
@@ -3874,19 +3902,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "companion of get_subnet_volume, mirroring how get_chain_stake_flow companions " +
       "get_subnet_stake_flow. Fixed 24h window, no window parameter. Mirrors GET " +
       "/api/v1/chain/alpha-volume.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        limit: {
-          type: "integer",
-          description: `Max subnets in the alpha-volume leaderboard (1-${CHAIN_ALPHA_VOLUME_LIMIT_MAX}, default ${CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_ALPHA_VOLUME_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainAlphaVolumeInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainAlphaVolumeInputSchema>,
+      ctx: McpCtx,
+    ) {
       const limit = clampLimit(
         args?.limit,
         CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
@@ -3914,24 +3936,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "consensus-maintenance companion to get_chain_stake_flow (capital) and " +
       "get_chain_turnover (validator churn). Use get_chain_weight_setters for the " +
       "setter-level leaderboard drill-in. Mirrors GET /api/v1/chain/weights.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_WEIGHTS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_WEIGHTS_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the weight-setting leaderboard (1-${CHAIN_WEIGHTS_LIMIT_MAX}, default ${CHAIN_WEIGHTS_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_WEIGHTS_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainWeightsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainWeightsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_WEIGHTS_WINDOW;
       if (!Object.hasOwn(CHAIN_WEIGHTS_WINDOWS, window)) {
@@ -3974,24 +3985,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "The network-wide drill-in behind get_chain_weights — use " +
       "get_subnet_weight_setters for one subnet's setter leaderboard. Mirrors GET " +
       "/api/v1/chain/weights/setters.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_WEIGHT_SETTERS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max setters in the leaderboard (1-${CHAIN_WEIGHT_SETTERS_LIMIT_MAX}, default ${CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainWeightSettersInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainWeightSettersInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW;
       if (!Object.hasOwn(CHAIN_WEIGHT_SETTERS_WINDOWS, window)) {
@@ -4034,24 +4034,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "hotkeys/subnets without unstaking — it measures re-delegation churn, not " +
       "net capital flow (that is get_chain_stake_flow). Mirrors GET " +
       "/api/v1/chain/stake-moves.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_STAKE_MOVES_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_STAKE_MOVES_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the stake-movement leaderboard (1-${CHAIN_STAKE_MOVES_LIMIT_MAX}, default ${CHAIN_STAKE_MOVES_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_STAKE_MOVES_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainStakeMovesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainStakeMovesInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_MOVES_WINDOW;
       if (!Object.hasOwn(CHAIN_STAKE_MOVES_WINDOWS, window)) {
@@ -4094,24 +4083,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "coldkey to another on the same hotkey — it relocates ownership, not net " +
       "capital (get_chain_stake_flow) or re-delegation churn (get_chain_stake_moves). " +
       "Mirrors GET /api/v1/chain/stake-transfers.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_STAKE_TRANSFERS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the stake-transfer leaderboard (1-${CHAIN_STAKE_TRANSFERS_LIMIT_MAX}, default ${CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainStakeTransfersInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainStakeTransfersInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW;
       if (!Object.hasOwn(CHAIN_STAKE_TRANSFERS_WINDOWS, window)) {
@@ -4154,24 +4132,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "removed — the teardown-side companion to get_chain_serving (axon " +
       "announcements) and get_subnet_axon_removals (one subnet). Mirrors GET " +
       "/api/v1/chain/axon-removals.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_AXON_REMOVALS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_AXON_REMOVALS_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the axon-removal leaderboard (1-${CHAIN_AXON_REMOVALS_LIMIT_MAX}, default ${CHAIN_AXON_REMOVALS_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_AXON_REMOVALS_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainAxonRemovalsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainAxonRemovalsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
       if (!Object.hasOwn(CHAIN_AXON_REMOVALS_WINDOWS, window)) {
@@ -4215,24 +4182,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "get_chain_prometheus (Prometheus telemetry announcements) and " +
       "get_chain_axon_removals (AxonInfoRemoved teardown). Mirrors GET " +
       "/api/v1/chain/serving.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_SERVING_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_SERVING_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the axon serving leaderboard (1-${CHAIN_SERVING_LIMIT_MAX}, default ${CHAIN_SERVING_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_SERVING_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainServingInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainServingInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_SERVING_WINDOW;
       if (!Object.hasOwn(CHAIN_SERVING_WINDOWS, window)) {
@@ -4276,24 +4232,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "telemetry-endpoint companion to get_chain_serving (axon announcements) " +
       "and get_subnet_prometheus (one subnet). Mirrors GET " +
       "/api/v1/chain/prometheus.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_PROMETHEUS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_PROMETHEUS_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the Prometheus serving leaderboard (1-${CHAIN_PROMETHEUS_LIMIT_MAX}, default ${CHAIN_PROMETHEUS_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_PROMETHEUS_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainPrometheusInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainPrometheusInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_PROMETHEUS_WINDOW;
       if (!Object.hasOwn(CHAIN_PROMETHEUS_WINDOWS, window)) {
@@ -7763,22 +7708,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "been doing lately — which pallets and calls dominate recent traffic — " +
       "before drilling into specific blocks (get_block) or extrinsics " +
       "(list_extrinsics). Mirrors GET /api/v1/chain-events/stats.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        blocks: {
-          type: "integer",
-          description:
-            "How many of the most recent blocks to aggregate over (1-5000, " +
-            "default 1000).",
-          minimum: 1,
-          maximum: 5000,
-        },
-      },
-      required: [],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainActivityInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainActivityInputSchema>,
+      ctx: McpCtx,
+    ) {
       const blocks = optionalBlocksWindow(args);
       return loadChainActivity(ctx, blocks);
     },
@@ -7795,58 +7731,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "keyset cursor, or the legacy before=block_number cursor. The event-level " +
       "companion to list_extrinsics and get_chain_activity (the pallet.method " +
       "distribution). Mirrors GET /api/v1/chain-events.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        pallet: {
-          type: "string",
-          description:
-            "Filter to one pallet (e.g. 'SubtensorModule'); 1-64 letters, digits, " +
-            "or underscores, starting with a letter.",
-        },
-        method: {
-          type: "string",
-          description:
-            "Filter to one event method (e.g. 'WeightsSet'); requires pallet unless " +
-            "block is set.",
-        },
-        block: {
-          type: "integer",
-          description: "Scope to one block_number.",
-          minimum: 0,
-        },
-        extrinsic: {
-          type: "integer",
-          description:
-            "Scope to the events emitted by one extrinsic (its extrinsic_index); " +
-            "requires block.",
-          minimum: 0,
-        },
-        cursor: {
-          type: "string",
-          description:
-            "Opaque keyset cursor from a previous response's next_cursor, for stable " +
-            "deep pagination over (block_number, event_index). Preferred over before " +
-            "when both are set.",
-        },
-        before: {
-          type: "integer",
-          description:
-            "Legacy block_number-only cursor: return events strictly before this " +
-            "block. Prefer cursor for deep pagination; ignored when cursor is set.",
-          minimum: 0,
-        },
-        limit: {
-          type: "integer",
-          description: "Max events to return (1-200, default 50).",
-          minimum: 1,
-          maximum: 200,
-        },
-      },
-      required: [],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListChainEventsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof ListChainEventsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadChainEventsFeed(ctx, {
         pallet: optionalString(args, "pallet"),
         method: optionalString(args, "method"),
@@ -7868,36 +7759,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "call_module. Use it to see which pallets and calls dominate on-chain traffic " +
       "before drilling into specific blocks (get_block) or extrinsics " +
       "(list_extrinsics). Mirrors GET /api/v1/chain/calls.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Aggregation window (default 7d).",
-        },
-        group_by: {
-          type: "string",
-          enum: ["module", "module_function"],
-          description:
-            "Group by call_module only (default) or by call_module + call_function.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max call groups returned (1-100, default 50).",
-          minimum: 1,
-          maximum: 100,
-        },
-        call_module: {
-          type: "string",
-          description:
-            "Optional pallet filter (e.g. Balances); omit for all modules.",
-        },
-      },
-      required: [],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainCallsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetChainCallsInputSchema>, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
@@ -7943,35 +7808,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "extrinsic count (default) or total fees over the requested window " +
       "(7d or 30d), with total fees, tips, and last signed block. Optionally " +
       "scope to one pallet via call_module. Mirrors GET /api/v1/chain/signers.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Lookback window (default 7d).",
-        },
-        sort: {
-          type: "string",
-          enum: ["tx_count", "total_fee_tao"],
-          description:
-            "Rank signers by extrinsic count (default) or total fees paid.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max signers to return (1-100, default 50).",
-          minimum: 1,
-          maximum: 100,
-        },
-        call_module: {
-          type: "string",
-          description:
-            "Optional pallet filter (e.g. Balances); omit for all modules.",
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainSignersInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainSignersInputSchema>,
+      ctx: McpCtx,
+    ) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
@@ -8017,29 +7860,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "per-UTC-day fee series (totals + averages) plus a top-fee-payer list. " +
       "Optionally scope to one pallet via call_module. Mirrors " +
       "GET /api/v1/chain/fees.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Lookback window (default 7d).",
-        },
-        limit: {
-          type: "integer",
-          description: "Max top fee payers to return (1-100, default 25).",
-          minimum: 1,
-          maximum: 100,
-        },
-        call_module: {
-          type: "string",
-          description:
-            "Optional pallet filter (e.g. Balances); omit for all modules.",
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainFeesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetChainFeesInputSchema>, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
@@ -8082,24 +7906,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "NeuronRegistered count) plus the network rollup, computed live from the " +
       "account_events NeuronRegistered stream. limit caps the leaderboard " +
       "(1-100, default 20). Mirrors GET /api/v1/chain/registrations.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Lookback window (default 7d).",
-        },
-        limit: {
-          type: "integer",
-          description: "Max leaderboard subnets to return (1-100, default 20).",
-          minimum: 1,
-          maximum: 100,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainRegistrationsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainRegistrationsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
@@ -8139,24 +7952,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "activity — the exit-side companion to get_chain_registrations " +
       "(NeuronRegistered demand) and get_subnet_deregistrations (one subnet). " +
       "Mirrors GET /api/v1/chain/deregistrations.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_DEREGISTRATIONS_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max subnets in the deregistration leaderboard (1-${CHAIN_DEREGISTRATIONS_LIMIT_MAX}, default ${CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_DEREGISTRATIONS_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainDeregistrationsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainDeregistrationsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW;
       if (!Object.hasOwn(CHAIN_DEREGISTRATIONS_WINDOWS, window)) {
@@ -8195,24 +7997,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "of total volume (a concentration signal). The network-level companion of " +
       "get_account_transfers and get_account_counterparties. Mirrors " +
       "GET /api/v1/chain/transfers.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_TRANSFER_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_TRANSFER_WINDOW}).`,
-        },
-        limit: {
-          type: "integer",
-          description: `Max top senders/receivers to return (1-${CHAIN_TRANSFER_LIMIT_MAX}, default ${CHAIN_TRANSFER_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_TRANSFER_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainTransfersInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainTransfersInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_TRANSFER_WINDOW;
       if (!Object.hasOwn(CHAIN_TRANSFER_WINDOWS, window)) {
@@ -8259,30 +8050,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "get_chain_transfers (top individual senders/receivers) and " +
       "get_account_counterparties (one account's relationships). Mirrors GET " +
       "/api/v1/chain/transfer-pairs.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: CHAIN_TRANSFER_PAIR_WINDOW_KEYS,
-          description: `Lookback window (default ${DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW}).`,
-        },
-        sort: {
-          type: "string",
-          enum: CHAIN_TRANSFER_PAIR_SORTS,
-          description:
-            "Rank corridors by total TAO volume (default) or transfer count.",
-        },
-        limit: {
-          type: "integer",
-          description: `Max corridors to return (1-${CHAIN_TRANSFER_PAIR_LIMIT_MAX}, default ${CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT}).`,
-          minimum: 1,
-          maximum: CHAIN_TRANSFER_PAIR_LIMIT_MAX,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetChainTransferPairsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetChainTransferPairsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW;
       if (!Object.hasOwn(CHAIN_TRANSFER_PAIR_WINDOWS, window)) {
@@ -8327,18 +8101,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "unique signers, newest day first. Use it for a network-at-a-glance view " +
       "before drilling into call-mix (get_chain_calls) or fee markets " +
       "(get_chain_fees). Mirrors GET /api/v1/chain/activity.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Lookback window (default 7d).",
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetNetworkActivityInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetNetworkActivityInputSchema>,
+      ctx: McpCtx,
+    ) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
@@ -10599,16 +10368,6 @@ const objectItems = (properties = {}) => ({
   type: "array",
   items: { type: "object", additionalProperties: true, properties },
 });
-const CHAIN_TRANSFER_PARTY_ITEM = {
-  type: "object",
-  additionalProperties: false,
-  required: ["address", "volume_tao", "transfer_count"],
-  properties: {
-    address: { type: "string" },
-    volume_tao: { type: "number" },
-    transfer_count: { type: "integer", minimum: 0 },
-  },
-};
 // RpcUsageArtifact item shapes — shared by get_rpc_usage outputSchema (mirrors
 // schemas/api-components.schema.json#/components/schemas/RpcUsageArtifact).
 const RPC_USAGE_LATENCY_MS = {
@@ -10745,866 +10504,57 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_subnet_idle_stake: z.toJSONSchema(GetSubnetIdleStakeOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_chain_concentration: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "neuron_count"],
-    properties: {
-      schema_version: { type: "integer" },
-      subnet_count: { type: "integer" },
-      neuron_count: { type: "integer" },
-      entity_count: { type: "integer" },
-      uids_per_entity: { type: ["number", "null"] },
-      captured_at: NULLABLE_STRING,
-      stake: { type: ["object", "null"] },
-      emission: { type: ["object", "null"] },
-      entity_stake: { type: ["object", "null"] },
-      entity_emission: { type: ["object", "null"] },
-      validator_stake: { type: ["object", "null"] },
+  get_chain_concentration: z.toJSONSchema(GetChainConcentrationOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_performance: z.toJSONSchema(GetChainPerformanceOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_idle_stake: z.toJSONSchema(GetChainIdleStakeOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_identity_history: z.toJSONSchema(
+    GetChainIdentityHistoryOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_chain_performance: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "neuron_count"],
-    properties: {
-      schema_version: { type: "integer" },
-      subnet_count: { type: "integer" },
-      neuron_count: { type: "integer" },
-      validator_count: { type: "integer" },
-      active_count: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      incentive: { type: ["object", "null"] },
-      dividends: { type: ["object", "null"] },
-      trust: { type: ["object", "null"] },
-      consensus: { type: ["object", "null"] },
-      validator_trust: { type: ["object", "null"] },
+  ),
+  get_chain_yield: z.toJSONSchema(GetChainYieldOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_turnover: z.toJSONSchema(GetChainTurnoverOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_stake_flow: z.toJSONSchema(GetChainStakeFlowOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_alpha_volume: z.toJSONSchema(GetChainAlphaVolumeOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_weights: z.toJSONSchema(GetChainWeightsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_weight_setters: z.toJSONSchema(GetChainWeightSettersOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_stake_moves: z.toJSONSchema(GetChainStakeMovesOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_stake_transfers: z.toJSONSchema(
+    GetChainStakeTransfersOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  get_chain_idle_stake: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "total_idle_stake_tao", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      total_idle_stake_tao: { type: "number" },
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: true,
-          required: [
-            "netuid",
-            "neuron_count",
-            "idle_neuron_count",
-            "idle_stake_tao",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            neuron_count: { type: "integer" },
-            idle_neuron_count: { type: "integer" },
-            idle_stake_tao: { type: "number" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_identity_history: {
-    type: "object",
-    additionalProperties: true,
-    required: ["schema_version", "count", "subnet_count", "changes"],
-    properties: {
-      schema_version: { type: "integer" },
-      count: { type: "integer" },
-      subnet_count: { type: "integer" },
-      changes: objectItems({
-        netuid: NULLABLE_INT,
-        block_number: NULLABLE_INT,
-        observed_at: NULLABLE_STRING,
-        subnet_name: NULLABLE_STRING,
-        symbol: NULLABLE_STRING,
-        description: NULLABLE_STRING,
-        github_repo: NULLABLE_STRING,
-        subnet_url: NULLABLE_STRING,
-        discord: NULLABLE_STRING,
-        logo_url: NULLABLE_STRING,
-        identity_hash: NULLABLE_STRING,
-      }),
-    },
-  },
-  get_chain_yield: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "neuron_count"],
-    properties: {
-      schema_version: { type: "integer" },
-      subnet_count: { type: "integer" },
-      neuron_count: { type: "integer" },
-      validator_count: { type: "integer" },
-      miner_count: { type: "integer" },
-      captured_at: NULLABLE_STRING,
-      total_stake_tao: { type: "number" },
-      total_emission_tao: { type: "number" },
-      network_yield: { type: ["number", "null"] },
-      validator_yield: { type: ["number", "null"] },
-      miner_yield: { type: ["number", "null"] },
-      distribution: { type: ["object", "null"] },
-    },
-  },
-  get_chain_turnover: {
-    type: "object",
-    additionalProperties: true,
-    required: ["comparable", "subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      start_date: NULLABLE_STRING,
-      end_date: NULLABLE_STRING,
-      comparable: { type: "boolean" },
-      subnet_count: { type: "integer" },
-      // Network rollup over the union validator set. retention/stability are
-      // null only on the cold/single-snapshot empty block.
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: [
-          "validators_start",
-          "validators_end",
-          "validators_entered",
-          "validators_exited",
-          "validator_retention",
-          "stability_score",
-        ],
-        properties: {
-          validators_start: { type: "integer" },
-          validators_end: { type: "integer" },
-          validators_entered: { type: "integer" },
-          validators_exited: { type: "integer" },
-          validator_retention: { type: ["number", "null"] },
-          stability_score: { type: ["integer", "null"] },
-        },
-      },
-      // Spread of per-subnet stability over EVERY comparable subnet; null when
-      // nothing is comparable.
-      stability_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "integer" },
-          p25: { type: "integer" },
-          median: { type: "integer" },
-          p75: { type: "integer" },
-          p90: { type: "integer" },
-          max: { type: "integer" },
-        },
-      },
-      // Per-subnet turnover leaderboard, most volatile first.
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "validators_start",
-            "validators_end",
-            "validators_entered",
-            "validators_exited",
-            "validator_retention",
-            "stability_score",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            validators_start: { type: "integer" },
-            validators_end: { type: "integer" },
-            validators_entered: { type: "integer" },
-            validators_exited: { type: "integer" },
-            validator_retention: { type: "number" },
-            stability_score: { type: "integer" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_stake_flow: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that moved stake in the window, plus
-      // gaining/losing/flat subnet counts from each subnet's direction label.
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: [
-          "total_staked_tao",
-          "total_unstaked_tao",
-          "net_flow_tao",
-          "gross_flow_tao",
-          "stake_events",
-          "unstake_events",
-          "gaining",
-          "losing",
-          "flat",
-        ],
-        properties: {
-          total_staked_tao: { type: "number" },
-          total_unstaked_tao: { type: "number" },
-          net_flow_tao: { type: "number" },
-          gross_flow_tao: { type: "number" },
-          stake_events: { type: "integer" },
-          unstake_events: { type: "integer" },
-          gaining: { type: "integer" },
-          losing: { type: "integer" },
-          flat: { type: "integer" },
-        },
-      },
-      // Spread of per-subnet net flow (TAO) over EVERY active subnet; null when
-      // no subnet moved stake in the window.
-      net_flow_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet capital-flow leaderboard, biggest net inflow first.
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "total_staked_tao",
-            "total_unstaked_tao",
-            "net_flow_tao",
-            "gross_flow_tao",
-            "stake_events",
-            "unstake_events",
-            "direction",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            total_staked_tao: { type: "number" },
-            total_unstaked_tao: { type: "number" },
-            net_flow_tao: { type: "number" },
-            gross_flow_tao: { type: "number" },
-            stake_events: { type: "integer" },
-            unstake_events: { type: "integer" },
-            direction: { type: "string" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_alpha_volume: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: { type: "string" },
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that had volume in the window, plus a network-wide
-      // net/gross sentiment reading derived from the same totals.
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: [
-          "buy_volume_alpha",
-          "sell_volume_alpha",
-          "total_volume_alpha",
-          "buy_volume_tao",
-          "sell_volume_tao",
-          "total_volume_tao",
-          "buy_count",
-          "sell_count",
-          "net_volume_alpha",
-          "sentiment_ratio",
-          "sentiment",
-        ],
-        properties: {
-          buy_volume_alpha: ANY,
-          sell_volume_alpha: ANY,
-          total_volume_alpha: ANY,
-          buy_volume_tao: ANY,
-          sell_volume_tao: ANY,
-          total_volume_tao: ANY,
-          buy_count: { type: "integer" },
-          sell_count: { type: "integer" },
-          net_volume_alpha: ANY,
-          sentiment_ratio: { type: ["number", "null"] },
-          sentiment: { type: "string" },
-        },
-      },
-      // Spread of per-subnet total_volume_tao over EVERY subnet with volume; null when no
-      // subnet had volume in the window.
-      volume_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet alpha-volume leaderboard, biggest total volume first -- each entry is a
-      // full get_subnet_volume-shaped scorecard.
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: true,
-          required: ["netuid", "window"],
-          properties: {
-            schema_version: { type: "integer" },
-            netuid: { type: "integer" },
-            window: { type: "string" },
-            buy_volume_alpha: ANY,
-            sell_volume_alpha: ANY,
-            total_volume_alpha: ANY,
-            buy_volume_tao: ANY,
-            sell_volume_tao: ANY,
-            total_volume_tao: ANY,
-            buy_count: { type: "integer" },
-            sell_count: { type: "integer" },
-            net_volume_alpha: ANY,
-            sentiment_ratio: { type: ["number", "null"] },
-            sentiment: NULLABLE_STRING,
-            vol_mcap_ratio: { type: ["number", "null"] },
-          },
-        },
-      },
-    },
-  },
-  get_chain_weights: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that set weights in the window.
-      // sets_per_setter is null when the network-wide distinct-setter count is
-      // unavailable/zero (no divide-by-zero).
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: ["distinct_setters", "weight_sets", "sets_per_setter"],
-        properties: {
-          distinct_setters: { type: "integer" },
-          weight_sets: { type: "integer" },
-          sets_per_setter: { type: ["number", "null"] },
-        },
-      },
-      // Spread of per-subnet update intensity (WeightsSet events per setter) over
-      // EVERY subnet that set weights; null when no subnet set weights in the window.
-      intensity_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet weight-setting leaderboard, most WeightsSet events first. Each
-      // listed subnet has at least one distinct setter, so sets_per_setter is
-      // always a finite number here (never divide-by-zero).
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "distinct_setters",
-            "weight_sets",
-            "sets_per_setter",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            distinct_setters: { type: "integer" },
-            weight_sets: { type: "integer" },
-            sets_per_setter: { type: "number" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_weight_setters: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "window",
-      "distinct_setters",
-      "weight_sets",
-      "setter_count",
-      "setters",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      distinct_setters: { type: "integer" },
-      weight_sets: { type: "integer" },
-      setter_count: { type: "integer" },
-      setters: objectItems({
-        hotkey: NULLABLE_STRING,
-        uid: NULLABLE_INT,
-        weight_sets: { type: "integer" },
-        share: ANY,
-        first_set_at: NULLABLE_STRING,
-        last_set_at: NULLABLE_STRING,
-      }),
-    },
-  },
-  get_chain_stake_moves: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that saw a StakeMoved event. A coldkey
-      // moving stake out of several subnets counts once in distinct_movers.
-      // movements_per_mover is null when the network-wide distinct-mover count
-      // is unavailable/zero (no divide-by-zero).
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: ["distinct_movers", "movements", "movements_per_mover"],
-        properties: {
-          distinct_movers: { type: "integer" },
-          movements: { type: "integer" },
-          movements_per_mover: { type: ["number", "null"] },
-        },
-      },
-      // Spread of per-subnet re-move intensity (StakeMoved events per mover) over
-      // EVERY subnet that saw a move; null when no subnet saw a move in the window.
-      intensity_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet stake-movement leaderboard, most StakeMoved events first. Each
-      // listed subnet has at least one distinct mover, so movements_per_mover is
-      // always a finite number here (never divide-by-zero).
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "distinct_movers",
-            "movements",
-            "movements_per_mover",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            distinct_movers: { type: "integer" },
-            movements: { type: "integer" },
-            movements_per_mover: { type: "number" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_stake_transfers: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that saw a StakeTransferred event. A
-      // coldkey transferring stake out of several subnets counts once in
-      // distinct_senders. transfers_per_sender is null when the network-wide
-      // distinct-sender count is unavailable/zero (no divide-by-zero).
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: ["distinct_senders", "transfers", "transfers_per_sender"],
-        properties: {
-          distinct_senders: { type: "integer" },
-          transfers: { type: "integer" },
-          transfers_per_sender: { type: ["number", "null"] },
-        },
-      },
-      // Spread of per-subnet transfer intensity (StakeTransferred events per
-      // sender) over EVERY subnet that saw a transfer; null when no subnet saw
-      // a transfer in the window.
-      intensity_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet stake-transfer leaderboard, most StakeTransferred events
-      // first. Each listed subnet has at least one distinct sender, so
-      // transfers_per_sender is always a finite number here (never divide-by-zero).
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "distinct_senders",
-            "transfers",
-            "transfers_per_sender",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            distinct_senders: { type: "integer" },
-            transfers: { type: "integer" },
-            transfers_per_sender: { type: "number" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_axon_removals: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that saw an AxonInfoRemoved event. A
-      // hotkey removing an axon on several subnets counts once in distinct_removers.
-      // removals_per_remover is null when the network-wide distinct-remover count
-      // is unavailable/zero (no divide-by-zero).
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: ["distinct_removers", "removals", "removals_per_remover"],
-        properties: {
-          distinct_removers: { type: "integer" },
-          removals: { type: "integer" },
-          removals_per_remover: { type: ["number", "null"] },
-        },
-      },
-      // Spread of per-subnet re-teardown intensity (AxonInfoRemoved events per
-      // remover) over EVERY subnet that saw a removal; null when no subnet saw
-      // a removal in the window.
-      intensity_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet axon-removal leaderboard, most AxonInfoRemoved events first.
-      // Each listed subnet has at least one distinct remover, so removals_per_remover
-      // is always a finite number here (never divide-by-zero).
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "distinct_removers",
-            "removals",
-            "removals_per_remover",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            distinct_removers: { type: "integer" },
-            removals: { type: "integer" },
-            removals_per_remover: { type: "number" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_serving: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that saw an AxonServed event. A hotkey
-      // announcing on several subnets counts once in distinct_servers.
-      // announcements_per_server is null when the network-wide distinct-server
-      // count is unavailable/zero (no divide-by-zero).
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: [
-          "distinct_servers",
-          "announcements",
-          "announcements_per_server",
-        ],
-        properties: {
-          distinct_servers: { type: "integer" },
-          announcements: { type: "integer" },
-          announcements_per_server: { type: ["number", "null"] },
-        },
-      },
-      // Spread of per-subnet re-announcement intensity (AxonServed events per
-      // server) over EVERY subnet that saw an announcement; null when no subnet
-      // saw serving activity in the window.
-      intensity_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet axon serving leaderboard, most AxonServed events first. Each
-      // listed subnet has at least one distinct server, so announcements_per_server
-      // is always a finite number here.
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "distinct_servers",
-            "announcements",
-            "announcements_per_server",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            distinct_servers: { type: "integer" },
-            announcements: { type: "integer" },
-            announcements_per_server: { type: "number" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_prometheus: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that saw a PrometheusServed event. A
-      // hotkey announcing on several subnets counts once in distinct_exporters.
-      // announcements_per_exporter is null when the network-wide distinct-exporter
-      // count is unavailable/zero (no divide-by-zero).
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: [
-          "distinct_exporters",
-          "announcements",
-          "announcements_per_exporter",
-        ],
-        properties: {
-          distinct_exporters: { type: "integer" },
-          announcements: { type: "integer" },
-          announcements_per_exporter: { type: ["number", "null"] },
-        },
-      },
-      // Spread of per-subnet re-announcement intensity (PrometheusServed events
-      // per exporter) over EVERY subnet that saw an announcement; null when no
-      // subnet saw Prometheus activity in the window.
-      intensity_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet Prometheus serving leaderboard, most PrometheusServed events
-      // first. Each listed subnet has at least one distinct exporter, so
-      // announcements_per_exporter is always a finite number here.
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "distinct_exporters",
-            "announcements",
-            "announcements_per_exporter",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            distinct_exporters: { type: "integer" },
-            announcements: { type: "integer" },
-            announcements_per_exporter: { type: "number" },
-          },
-        },
-      },
-    },
-  },
+  ),
+  get_chain_axon_removals: z.toJSONSchema(GetChainAxonRemovalsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_serving: z.toJSONSchema(GetChainServingOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_prometheus: z.toJSONSchema(GetChainPrometheusOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_blocks_summary: z.toJSONSchema(GetBlocksSummaryOutputSchema, {
     target: "draft-2020-12",
   }),
@@ -11904,329 +10854,39 @@ const TOOL_OUTPUT_SCHEMAS = {
       target: "draft-2020-12",
     },
   ),
-  get_chain_activity: {
-    type: "object",
-    additionalProperties: true,
-    required: ["window_blocks", "groups", "activity"],
-    properties: {
-      window_blocks: { type: "integer" },
-      groups: { type: "integer" },
-      activity: objectItems({
-        pallet: NULLABLE_STRING,
-        method: NULLABLE_STRING,
-        count: NULLABLE_INT,
-      }),
+  get_chain_activity: z.toJSONSchema(GetChainActivityOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  list_chain_events: z.toJSONSchema(ListChainEventsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_calls: z.toJSONSchema(GetChainCallsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_signers: z.toJSONSchema(GetChainSignersOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_fees: z.toJSONSchema(GetChainFeesOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_registrations: z.toJSONSchema(GetChainRegistrationsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_deregistrations: z.toJSONSchema(
+    GetChainDeregistrationsOutputSchema,
+    {
+      target: "draft-2020-12",
     },
-  },
-  list_chain_events: {
-    type: "object",
-    additionalProperties: true,
-    required: ["count", "events"],
-    properties: {
-      count: { type: "integer" },
-      next_before: NULLABLE_INT,
-      next_cursor: NULLABLE_STRING,
-      events: objectItems({
-        block_number: NULLABLE_INT,
-        event_index: NULLABLE_INT,
-        pallet: NULLABLE_STRING,
-        method: NULLABLE_STRING,
-        args: ANY,
-        phase: ANY,
-        extrinsic_index: NULLABLE_INT,
-        observed_at: ANY,
-      }),
-    },
-  },
-  get_chain_calls: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "schema_version",
-      "window",
-      "group_by",
-      "total_extrinsics",
-      "call_count",
-      "calls",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      window: { type: "string" },
-      group_by: { type: "string" },
-      observed_at: NULLABLE_STRING,
-      total_extrinsics: { type: "integer" },
-      call_count: { type: "integer" },
-      calls: objectItems({
-        call_module: NULLABLE_STRING,
-        call_function: NULLABLE_STRING,
-        count: NULLABLE_INT,
-        share: ANY,
-      }),
-    },
-  },
-  get_chain_signers: {
-    type: "object",
-    additionalProperties: true,
-    required: ["window", "sort", "signer_count", "signers"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: { type: "string" },
-      sort: { type: "string", enum: ["tx_count", "total_fee_tao"] },
-      observed_at: NULLABLE_STRING,
-      signer_count: { type: "integer" },
-      signers: objectItems({
-        signer: NULLABLE_STRING,
-        tx_count: NULLABLE_INT,
-        total_fee_tao: { type: ["number", "null"] },
-        total_tip_tao: { type: ["number", "null"] },
-        last_tx_block: NULLABLE_INT,
-      }),
-    },
-  },
-  get_chain_fees: {
-    type: "object",
-    additionalProperties: true,
-    required: ["window", "day_count", "daily", "top_fee_payers"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: { type: "string" },
-      observed_at: NULLABLE_STRING,
-      day_count: { type: "integer" },
-      daily: objectItems({
-        day: NULLABLE_STRING,
-        extrinsic_count: NULLABLE_INT,
-        total_fee_tao: { type: ["number", "null"] },
-        avg_fee_tao: { type: ["number", "null"] },
-        median_fee_tao: { type: ["number", "null"] },
-        total_tip_tao: { type: ["number", "null"] },
-        avg_tip_tao: { type: ["number", "null"] },
-        median_tip_tao: { type: ["number", "null"] },
-      }),
-      top_fee_payers: objectItems({
-        signer: NULLABLE_STRING,
-        total_fee_tao: { type: ["number", "null"] },
-        total_tip_tao: { type: ["number", "null"] },
-        extrinsic_count: NULLABLE_INT,
-      }),
-    },
-  },
-  get_chain_registrations: {
-    type: "object",
-    additionalProperties: true,
-    required: ["window", "subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      network: {
-        type: "object",
-        properties: {
-          distinct_registrants: NULLABLE_INT,
-          registrations: NULLABLE_INT,
-          registrations_per_registrant: { type: ["number", "null"] },
-        },
-      },
-      intensity_distribution: { type: ["object", "null"] },
-      subnets: objectItems({
-        netuid: NULLABLE_INT,
-        distinct_registrants: NULLABLE_INT,
-        registrations: NULLABLE_INT,
-        registrations_per_registrant: { type: ["number", "null"] },
-      }),
-    },
-  },
-  get_chain_deregistrations: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "network", "subnets"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      subnet_count: { type: "integer" },
-      // Network rollup over every subnet that saw a NeuronDeregistered event. A
-      // hotkey deregistered on several subnets counts once in
-      // distinct_deregistered_hotkeys. deregistrations_per_hotkey is null when
-      // the network-wide distinct-hotkey count is unavailable/zero (no divide-by-zero).
-      network: {
-        type: "object",
-        additionalProperties: false,
-        required: [
-          "distinct_deregistered_hotkeys",
-          "deregistrations",
-          "deregistrations_per_hotkey",
-        ],
-        properties: {
-          distinct_deregistered_hotkeys: { type: "integer" },
-          deregistrations: { type: "integer" },
-          deregistrations_per_hotkey: { type: ["number", "null"] },
-        },
-      },
-      // Spread of per-subnet re-deregistration intensity (NeuronDeregistered
-      // events per hotkey) over EVERY subnet that saw a deregistration; null when
-      // no subnet saw a deregistration in the window.
-      intensity_distribution: {
-        type: ["object", "null"],
-        additionalProperties: false,
-        required: [
-          "count",
-          "mean",
-          "min",
-          "p25",
-          "median",
-          "p75",
-          "p90",
-          "max",
-        ],
-        properties: {
-          count: { type: "integer" },
-          mean: { type: "number" },
-          min: { type: "number" },
-          p25: { type: "number" },
-          median: { type: "number" },
-          p75: { type: "number" },
-          p90: { type: "number" },
-          max: { type: "number" },
-        },
-      },
-      // Per-subnet deregistration leaderboard, most NeuronDeregistered events
-      // first. Each listed subnet has at least one distinct deregistered hotkey,
-      // so deregistrations_per_hotkey is always a finite number here.
-      subnets: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "netuid",
-            "distinct_deregistered_hotkeys",
-            "deregistrations",
-            "deregistrations_per_hotkey",
-          ],
-          properties: {
-            netuid: { type: "integer" },
-            distinct_deregistered_hotkeys: { type: "integer" },
-            deregistrations: { type: "integer" },
-            deregistrations_per_hotkey: { type: "number" },
-          },
-        },
-      },
-    },
-  },
-  get_chain_transfers: {
-    type: "object",
-    additionalProperties: false,
-    required: [
-      "schema_version",
-      "window",
-      "observed_at",
-      "total_volume_tao",
-      "transfer_count",
-      "unique_senders",
-      "unique_receivers",
-      "top_sender_share",
-      "top_senders",
-      "top_receivers",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      window: {
-        type: ["string", "null"],
-        enum: [...CHAIN_TRANSFER_WINDOW_KEYS, null],
-      },
-      observed_at: NULLABLE_STRING,
-      total_volume_tao: { type: "number" },
-      transfer_count: { type: "integer", minimum: 0 },
-      unique_senders: { type: "integer", minimum: 0 },
-      unique_receivers: { type: "integer", minimum: 0 },
-      top_sender_share: { type: ["number", "null"] },
-      top_senders: {
-        type: "array",
-        items: CHAIN_TRANSFER_PARTY_ITEM,
-      },
-      top_receivers: {
-        type: "array",
-        items: CHAIN_TRANSFER_PARTY_ITEM,
-      },
-    },
-  },
-  get_chain_transfer_pairs: {
-    type: "object",
-    additionalProperties: false,
-    required: [
-      "schema_version",
-      "window",
-      "sort",
-      "observed_at",
-      "total_volume_tao",
-      "transfer_count",
-      "unique_pairs",
-      "pair_count",
-      "top_pair_share",
-      "pairs",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      window: {
-        type: ["string", "null"],
-        enum: [...CHAIN_TRANSFER_PAIR_WINDOW_KEYS, null],
-      },
-      sort: { type: "string", enum: CHAIN_TRANSFER_PAIR_SORTS },
-      observed_at: NULLABLE_STRING,
-      total_volume_tao: { type: "number" },
-      transfer_count: { type: "integer", minimum: 0 },
-      unique_pairs: { type: "integer", minimum: 0 },
-      pair_count: { type: "integer", minimum: 0 },
-      // Top corridor's share of total volume (0..1), clamped below a flat 1 for a
-      // near-monopoly; null when there is no volume in the window.
-      top_pair_share: { type: ["number", "null"] },
-      // Directed sender->receiver corridors, ranked by the requested sort.
-      pairs: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: [
-            "from",
-            "to",
-            "volume_tao",
-            "transfer_count",
-            "last_block",
-            "last_observed_at",
-          ],
-          properties: {
-            from: { type: "string" },
-            to: { type: "string" },
-            volume_tao: { type: "number" },
-            transfer_count: { type: "integer", minimum: 0 },
-            last_block: { type: ["integer", "null"] },
-            last_observed_at: NULLABLE_STRING,
-          },
-        },
-      },
-    },
-  },
-  get_network_activity: {
-    type: "object",
-    additionalProperties: true,
-    required: ["window", "day_count", "days"],
-    properties: {
-      schema_version: { type: "integer" },
-      window: { type: "string" },
-      observed_at: NULLABLE_STRING,
-      day_count: { type: "integer" },
-      days: objectItems({
-        day: NULLABLE_STRING,
-        block_count: NULLABLE_INT,
-        extrinsic_count: NULLABLE_INT,
-        event_count: NULLABLE_INT,
-        successful_extrinsics: NULLABLE_INT,
-        success_rate: { type: ["number", "null"] },
-        unique_signers: NULLABLE_INT,
-      }),
-    },
-  },
+  ),
+  get_chain_transfers: z.toJSONSchema(GetChainTransfersOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_chain_transfer_pairs: z.toJSONSchema(GetChainTransferPairsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_network_activity: z.toJSONSchema(GetNetworkActivityOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_rpc_usage: {
     type: "object",
     additionalProperties: true,


### PR DESCRIPTION
## Summary

Batch 9 of types-epic E (#7863, tracked as #8072): converts 25 more MCP tool input/output schemas from hand-written JSON Schema literals to Zod-generated (`z.toJSONSchema(...)`), covering the chain network-stats surface: `get_chain_concentration`, `get_chain_performance`, `get_chain_idle_stake`, `get_chain_identity_history`, `get_chain_yield`, `get_chain_turnover`, `get_chain_stake_flow`, `get_chain_alpha_volume`, `get_chain_weights`, `get_chain_weight_setters`, `get_chain_stake_moves`, `get_chain_stake_transfers`, `get_chain_axon_removals`, `get_chain_serving`, `get_chain_prometheus`, `get_chain_activity`, `list_chain_events`, `get_chain_calls`, `get_chain_signers`, `get_chain_fees`, `get_chain_registrations`, `get_chain_deregistrations`, `get_chain_transfers`, `get_chain_transfer_pairs`, `get_network_activity`. This is the largest single batch of the epic so far.

Closes #8072.

## Diff-audit results (`scripts/diff-mcp-tool-schemas.ts`)

278/280 schema checks PASS (pilot + all prior batches + this batch combined). 2 DIFFs, both pre-existing and unrelated to this batch:

- `get_subnet_identity_history.output` — pre-existing, already-documented finding from #8067.
- `get_account_identity_history.output` — pre-existing, already-documented finding from #8069.

Zero new findings from this batch's 25 tools (50/50 input+output checks PASS) — after fixing two genuine gaps in the diff-audit script itself (not the schemas):

1. **`required: []` vs. an omitted `required` key.** `get_chain_activity`/`list_chain_events`/`get_chain_calls`'s hand-written originals declare `required: []` explicitly; Zod's `z.toJSONSchema()` omits the key entirely when nothing is required. Both mean "nothing required" — extended `normalize()` to drop an empty `required` array the same way it already drops `additionalProperties:true`/`items:{}`. (First hit for this class of gap was `list_blocks`/`list_extrinsics` in #8071, which carries the identical fix once rebased in.)
2. **Redundant `null` inside a split enum branch.** `get_chain_transfers`/`get_chain_transfer_pairs`'s `window` field is a required-but-nullable enum: `{type:["string","null"], enum:[...WINDOW_KEYS, null]}`. The script's existing `type:[X,Y]→anyOf` rewrite (established in batch 4 for `get_subnet_lease`) was carrying that literal `null` into the non-null branch's `enum` array verbatim, e.g. `anyOf:[{type:"string", enum:["7d","30d",null]}, {type:"null"}]` — redundant since the null case is already the separate `{type:"null"}` branch, and Zod's own `z.enum(...).nullable()` output never repeats it there. Fixed by stripping `null` from the enum array during that same rewrite.

## Reuse note

None of this batch's 25 tools reuse an existing `schemas-src/routes/` REST schema — no REST route in the chain-network-stats domain has been Zod-converted yet under types-epic B. All 25 are modeled fresh, matching each hand-written literal field-for-field (verified against the pre-conversion source directly in the working tree, not transcribed from memory).

Conventions worth flagging:

- **Shared `DistributionStatsSchema`.** 10 of this batch's tools use an identical 8-field distribution-stats shape (`count`/`mean`/`min`/`p25`/`median`/`p75`/`p90`/`max`, all required, `additionalProperties:false`) for their `*_distribution` field. Hoisted into `schemas-src/mcp-tools/shared.ts` rather than defined 10 times — unlike every other nested shape in this epic, which stayed tool-local (none repeated verbatim across more than 2 tools before).
- **`get_chain_registrations` is a genuine outlier, not a sibling of `get_chain_deregistrations`.** Despite the near-identical name and description shape, `get_chain_registrations`'s hand-written `network` sub-object has no `additionalProperties`/`required` declared (structurally open), its `intensity_distribution` is a completely untyped `{type:["object","null"]}` (no properties at all — NOT `DistributionStatsSchema`), and its `subnets` uses the usual `objectItems()` looseness instead of strict items. `get_chain_deregistrations` follows the strict pattern every other leaderboard tool in this batch uses. Modeled as-is — the epic's wire-compatibility mandate preserves what shipped, not what's consistent between siblings.
- **`get_chain_calls`/`get_chain_signers`/`get_chain_fees`/`get_chain_registrations`/`get_network_activity`/`get_chain_activity`/`list_chain_events`** use a LITERAL inline `["7d","30d"]` window enum (backed by the shared `parseAnalyticsWindow()` runtime helper), unlike the other 12 window-taking tools in this batch which import a symbolic `CHAIN_*_WINDOWS`/`CHAIN_*_WINDOW_KEYS` pair and use `Object.hasOwn()` for runtime validation. Modeled the same way per tool — no shared constant invented where the original didn't have one.
- **`list_chain_events`'s `observed_at`** on its event items is a fully untyped `ANY`, distinct from batch 8's `get_block_chain_events`/`get_extrinsic_chain_events` which use a nullable *integer* for the same field name on their own separate item shape (`CHAIN_EVENT_ITEM`). Not reused — `list_chain_events` inlines its own item shape in the hand-written original.

## Cleanup

Removed the now-dead `CHAIN_TRANSFER_PARTY_ITEM` constant in `src/mcp-server.ts` (only remaining consumer, `get_chain_transfers`, converted in this batch).

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` / `npx prettier --check` (touched files) — clean
- `npx tsx scripts/diff-mcp-tool-schemas.ts` — 278/280 PASS, 0 new findings (2 pre-existing, documented above)
- `npx tsx scripts/validate-mcp.ts` — 204 tools, full lifecycle/subscribe round trips pass
- Full test suite: 490/490 files, 11885/11885 tests passing
- Zero JSON Schema object literals remain for these 25 tools (grep-verified)

## Test plan

- [x] tsc clean
- [x] eslint/prettier clean
- [x] Diff-audit run, 0 new findings (2 genuine script-normalization gaps fixed along the way)
- [x] `validate-mcp.ts` passes
- [x] Full test suite green
