### PR TITLE
feat(observability): real per-caller PostHog identity for MCP + fullnode RPC

### DIFF
--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -539,6 +539,13 @@ interface AskDeps {
     input: { subnets: unknown[] },
     liveHealth: unknown,
   ) => { subnets?: unknown[] } | null | undefined;
+  // metagraphed#7153: threaded from the MCP ask tool's McpCtx.distinctId
+  // (resolved from a validated GitHub OAuth identity when present) so an
+  // authenticated caller's $ai_generation events attribute to them instead
+  // of the shared anonymous fallback. undefined for the REST /api/v1/ask
+  // route (no caller identity concept there) and every unauthenticated MCP
+  // call -- recordAiGenerationEvent's own anonymous fallback handles both.
+  distinctId?: string;
 }
 
 // Builds a netuid → {callable_count, base_url, health} lookup from the
@@ -652,35 +659,43 @@ export async function askQuestion(
     messages,
     max_tokens: ASK_MAX_TOKENS,
   }).catch(async (error) => {
-    await recordAiGenerationEvent(env, {
-      provider: ASK_PROVIDER,
-      model: ASK_MODEL,
-      traceName: ASK_TRACE_NAME,
-      latencyMs: Date.now() - generationStart,
-      isError: true,
-      error,
-      modelParameters,
-      input: messages,
-    });
+    await recordAiGenerationEvent(
+      env,
+      {
+        provider: ASK_PROVIDER,
+        model: ASK_MODEL,
+        traceName: ASK_TRACE_NAME,
+        latencyMs: Date.now() - generationStart,
+        isError: true,
+        error,
+        modelParameters,
+        input: messages,
+      },
+      { distinctId: deps.distinctId },
+    );
     throw error;
   });
   const inputTokens = completion?.usage?.prompt_tokens;
   const outputTokens = completion?.usage?.completion_tokens;
   const answer = (completion?.response || "").trim();
-  await recordAiGenerationEvent(env, {
-    provider: ASK_PROVIDER,
-    model: ASK_MODEL,
-    traceName: ASK_TRACE_NAME,
-    latencyMs: Date.now() - generationStart,
-    isError: false,
-    inputTokens,
-    outputTokens,
-    inputCostUsd: costUsd(inputTokens, ASK_MODEL_INPUT_USD_PER_MILLION),
-    outputCostUsd: costUsd(outputTokens, ASK_MODEL_OUTPUT_USD_PER_MILLION),
-    modelParameters,
-    input: messages,
-    outputChoices: [{ role: "assistant", content: answer }],
-  });
+  await recordAiGenerationEvent(
+    env,
+    {
+      provider: ASK_PROVIDER,
+      model: ASK_MODEL,
+      traceName: ASK_TRACE_NAME,
+      latencyMs: Date.now() - generationStart,
+      isError: false,
+      inputTokens,
+      outputTokens,
+      inputCostUsd: costUsd(inputTokens, ASK_MODEL_INPUT_USD_PER_MILLION),
+      outputCostUsd: costUsd(outputTokens, ASK_MODEL_OUTPUT_USD_PER_MILLION),
+      modelParameters,
+      input: messages,
+      outputChoices: [{ role: "assistant", content: answer }],
+    },
+    { distinctId: deps.distinctId },
+  );
   return {
     question: q,
     answer,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1107,7 +1107,25 @@ interface McpCtx {
   clientIp?: string | null;
   readArtifact?: AnyFn;
   readHealthKv?: AnyFn;
-  executionCtx?: { waitUntil?: (p: Promise<unknown>) => void };
+  // props: set by @cloudflare/workers-oauth-provider on the ExecutionContext
+  // it hands to apiHandler once it has already validated a Bearer token
+  // (src/github-oauth.ts's buildOAuthProviderOptions/completeAuthorization) --
+  // absent on every anonymous /mcp request (the common case) and on every
+  // direct-call test, hence optional throughout.
+  executionCtx?: {
+    waitUntil?: (p: Promise<unknown>) => void;
+    props?: {
+      githubUserId?: unknown;
+      githubLogin?: unknown;
+      accountId?: unknown;
+    };
+  };
+  // Resolved once in buildContext from executionCtx.props.githubLogin, namespaced
+  // ("github:<login>") so it can never collide with a distinct_id minted by a
+  // different identity system (e.g. Unkey's rpc_accounts-derived one). undefined
+  // for every anonymous call -- recordX's own `deps.distinctId ?? <anonymous
+  // fallback>` handles that case, this module never invents a fallback itself.
+  distinctId?: string;
   recordUsageEvent?: AnyFn;
   chainSignersCache?: Map<string, unknown>;
   recordMcpToolCallEvent?: AnyFn;
@@ -9789,7 +9807,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
           ctx.env,
           question,
           { type: args?.type },
-          { readArtifact: ctx.readArtifact },
+          { readArtifact: ctx.readArtifact, distinctId: ctx.distinctId },
         ),
       );
     },
@@ -13278,7 +13296,9 @@ function scheduleToolUsageEvent(ctx: McpCtx, event: Row) {
   try {
     if (!isUsageTelemetryConfigured(ctx?.env)) return;
     const record = ctx?.recordUsageEvent ?? recordUsageEvent;
-    const pending = Promise.resolve(record(ctx.env, event)).catch(() => false);
+    const pending = Promise.resolve(
+      record(ctx.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
     ctx?.executionCtx?.waitUntil?.(pending);
   } catch {
     // Telemetry must never surface into the tool path.
@@ -13288,7 +13308,9 @@ function scheduleToolUsageEvent(ctx: McpCtx, event: Row) {
 function scheduleMcpToolCallEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordMcpToolCallEvent ?? recordMcpToolCallEvent;
-    const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
     ctx?.executionCtx?.waitUntil?.(pending);
   } catch {
     // Telemetry must never surface into the tool path.
@@ -13298,7 +13320,9 @@ function scheduleMcpToolCallEvent(ctx: McpCtx, event: Row) {
 function scheduleMcpInitializeEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordMcpInitializeEvent ?? recordMcpInitializeEvent;
-    const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
     ctx?.executionCtx?.waitUntil?.(pending);
   } catch {
     // Telemetry must never surface into the tool path.
@@ -13311,7 +13335,9 @@ function scheduleMcpInitializeEvent(ctx: McpCtx, event: Row) {
 function scheduleExceptionEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordExceptionEvent ?? recordExceptionEvent;
-    const pending = Promise.resolve(record(ctx?.env, event)).catch(() => false);
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
     ctx?.executionCtx?.waitUntil?.(pending);
   } catch {
     // Telemetry must never surface into the tool path.
@@ -13523,6 +13549,18 @@ function buildContext(request: Request, env: Env, deps: Row) {
   // presence) is already enforced by handleMcpRequest before this is called,
   // so a malformed header never reaches here as a truthy value.
   const rawSessionId = request.headers.get("mcp-session-id");
+  // metagraphed#7153: a validated GitHub identity (present only when the
+  // request carried a Bearer token @cloudflare/workers-oauth-provider itself
+  // already accepted -- see executionCtx's own type comment) becomes the
+  // caller's PostHog distinct_id. Anonymous requests (no props, or a
+  // malformed/non-string login) resolve to undefined here on purpose --
+  // recordX's own anonymous-fallback constant is the single place that
+  // decision lives, not duplicated here.
+  const githubLogin = deps.executionCtx?.props?.githubLogin;
+  const distinctId =
+    typeof githubLogin === "string" && githubLogin
+      ? `github:${githubLogin}`
+      : undefined;
   return {
     env,
     domain,
@@ -13534,7 +13572,17 @@ function buildContext(request: Request, env: Env, deps: Row) {
     // real fetch entry does, so it stays optional and every direct-call test
     // keeps working. Used solely to drain usage telemetry (#6031).
     executionCtx: deps.executionCtx,
+    distinctId,
     recordUsageEvent: deps.recordUsageEvent,
+    // Pre-existing gap fixed alongside #7153: these three were declared on
+    // McpCtx and read by their own schedulers (scheduleMcpToolCallEvent/
+    // scheduleMcpInitializeEvent/scheduleExceptionEvent) but never actually
+    // copied from deps here, so a test-injected override always silently
+    // fell through to the real recorder instead of the double the test meant
+    // to exercise. Same test-injection convention as recordUsageEvent above.
+    recordMcpToolCallEvent: deps.recordMcpToolCallEvent,
+    recordMcpInitializeEvent: deps.recordMcpInitializeEvent,
+    recordExceptionEvent: deps.recordExceptionEvent,
   };
 }
 

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -20,7 +20,10 @@ import {
 import { handleRequest, handleScheduled } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { overlayCatalogIndex } from "../src/health-serving.ts";
-import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+import {
+  POSTHOG_PROJECT_TOKEN_ENV,
+  USAGE_EVENT_DISTINCT_ID,
+} from "../src/usage-telemetry.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
 
@@ -1034,6 +1037,75 @@ describe("askQuestion AI observability ($ai_generation, #7763)", () => {
       await askQuestion(mockEnv(env), "Which subnet does images?");
     });
     assert.equal(calls.length, 0);
+  });
+
+  // metagraphed#7153: an authenticated MCP caller's real identity (threaded
+  // from McpCtx.distinctId, resolved from a validated GitHub OAuth login)
+  // attributes the $ai_generation event to them instead of the shared
+  // anonymous fallback -- same deps.distinctId passthrough on both the
+  // success and error paths.
+  test("attributes a successful $ai_generation event to the passed-in distinctId", async () => {
+    const calls: Row[] = [];
+    await withGlobalFetch(fetchSpy(calls), async () => {
+      const env = {
+        AI: stubAi(),
+        VECTORIZE: stubVectorize(),
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test",
+      };
+      await askQuestion(
+        mockEnv(env),
+        "Which subnet does images?",
+        {},
+        { distinctId: "github:octocat" },
+      );
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].distinct_id, "github:octocat");
+  });
+
+  test("attributes a failed $ai_generation event to the passed-in distinctId", async () => {
+    const calls: Row[] = [];
+    const failingAi = {
+      run(model: string, input: Row) {
+        if (model === EMBED_MODEL) {
+          const n = Array.isArray(input.text) ? input.text.length : 1;
+          return Promise.resolve({
+            data: Array.from({ length: n }, () => new Array(1024).fill(0.02)),
+          });
+        }
+        return Promise.reject(new Error("Workers AI unavailable"));
+      },
+    };
+    await withGlobalFetch(fetchSpy(calls), async () => {
+      const env = {
+        AI: failingAi,
+        VECTORIZE: stubVectorize(),
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test",
+      };
+      await assert.rejects(() =>
+        askQuestion(
+          mockEnv(env),
+          "Which subnet does images?",
+          {},
+          { distinctId: "github:octocat" },
+        ),
+      );
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].distinct_id, "github:octocat");
+  });
+
+  test("falls back to the shared anonymous distinct_id when no distinctId is passed", async () => {
+    const calls: Row[] = [];
+    await withGlobalFetch(fetchSpy(calls), async () => {
+      const env = {
+        AI: stubAi(),
+        VECTORIZE: stubVectorize(),
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test",
+      };
+      await askQuestion(mockEnv(env), "Which subnet does images?");
+    });
+    assert.equal(calls[0].distinct_id, USAGE_EVENT_DISTINCT_ID);
   });
 });
 

--- a/tests/fullnode-rpc-proxy.test.ts
+++ b/tests/fullnode-rpc-proxy.test.ts
@@ -11,8 +11,12 @@
 // {valid, code, tier, accountId} shape each test needs, exactly the
 // contract workers/data-api.mjs's handleApiKeyVerify actually returns.
 import assert from "node:assert/strict";
-import { afterEach, beforeEach, test } from "vitest";
+import { afterEach, beforeEach, describe, test } from "vitest";
 import { handleFullnodeRpcProxyRequest } from "../workers/request-handlers/fullnode-rpc-proxy.ts";
+import {
+  POSTHOG_CAPTURE_PATH,
+  USAGE_EVENT_NAME,
+} from "../src/usage-telemetry.ts";
 import type { Row } from "./row-type.ts";
 
 function createFakeKv() {
@@ -547,4 +551,149 @@ test("fails over to a second configured origin when one is unreachable", async (
   const body = (await res.json()) as Row;
   assert.equal(body.result, "ok");
   assert.ok(calls >= 1);
+});
+
+// PostHog usage telemetry (metagraphed#7153): fullnode-rpc-proxy.ts is the one
+// route with genuine per-caller identity already available pre-request (the
+// resolved Unkey accountId), so it records its own event directly rather than
+// going through the generic withUsageTelemetry chokepoint (which explicitly
+// excludes "the RPC proxy" — workers/api.ts's usageRouteLabel). The capture
+// POST and the proxied RPC call both go through the same monkey-patched
+// globalThis.fetch, matching this file's own established convention, so these
+// tests distinguish them by URL.
+describe("PostHog usage telemetry", () => {
+  function captureCalls(
+    rpcResult: unknown = { jsonrpc: "2.0", id: 1, result: "ok" },
+  ) {
+    const captures: Row[] = [];
+    globalThis.fetch = (async (url: unknown, init?: Row) => {
+      if (String(url).includes(POSTHOG_CAPTURE_PATH)) {
+        captures.push(JSON.parse(init!.body));
+        return new Response(null, { status: 200 });
+      }
+      return new Response(JSON.stringify(rpcResult), { status: 200 });
+    }) as unknown as typeof fetch;
+    return captures;
+  }
+
+  function fakeCtx() {
+    const pending: Promise<unknown>[] = [];
+    return {
+      ctx: { waitUntil: (p: Promise<unknown>) => pending.push(p) },
+      flush: () => Promise.all(pending),
+    };
+  }
+
+  test("records a usage_event scoped to the caller's account on success", async () => {
+    const { env, key } = makeValidatedKeyEnv({
+      POSTHOG_PROJECT_TOKEN: "phc_test_token",
+    });
+    const captures = captureCalls();
+    const { ctx, flush } = fakeCtx();
+    const request = req(`/rpc/v1/fullnode?authorization=${key}`, {
+      body: { jsonrpc: "2.0", id: 1, method: "system_health" },
+    });
+    const res = await handleFullnodeRpcProxyRequest(
+      request,
+      env,
+      new URL(request.url),
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    await flush();
+    assert.equal(captures.length, 1);
+    assert.equal(captures[0]!.distinct_id, "account:1");
+    assert.equal(captures[0]!.event, USAGE_EVENT_NAME);
+    assert.equal(captures[0]!.properties.route, "fullnode_rpc");
+    assert.equal(captures[0]!.properties.ok, true);
+    assert.equal(captures[0]!.properties.error_code, undefined);
+  });
+
+  test("records the route error_code on a rejected (but non-5xx) call", async () => {
+    const { env, key } = makeValidatedKeyEnv({
+      POSTHOG_PROJECT_TOKEN: "phc_test_token",
+      FULLNODE_RPC_RATE_LIMITER: { limit: async () => ({ success: false }) },
+    });
+    const captures = captureCalls();
+    const { ctx, flush } = fakeCtx();
+    const request = req(`/rpc/v1/fullnode?authorization=${key}`, {
+      body: { jsonrpc: "2.0", id: 1, method: "system_health" },
+    });
+    const res = await handleFullnodeRpcProxyRequest(
+      request,
+      env,
+      new URL(request.url),
+      ctx,
+    );
+    assert.equal(res.status, 429);
+    await flush();
+    assert.equal(captures.length, 1);
+    // 429 is a route correctly rejecting an over-quota caller, not a broken
+    // route -- same status<500 "ok" convention withUsageTelemetry uses.
+    assert.equal(captures[0]!.properties.ok, true);
+    assert.equal(
+      captures[0]!.properties.error_code,
+      "fullnode_rpc_rate_limited",
+    );
+  });
+
+  test("does not record telemetry for an unauthenticated request", async () => {
+    const { env } = makeValidatedKeyEnv({
+      POSTHOG_PROJECT_TOKEN: "phc_test_token",
+    });
+    const captures = captureCalls();
+    const { ctx, flush } = fakeCtx();
+    const request = req("/rpc/v1/fullnode", {
+      body: { jsonrpc: "2.0", id: 1, method: "system_health" },
+    });
+    const res = await handleFullnodeRpcProxyRequest(
+      request,
+      env,
+      new URL(request.url),
+      ctx,
+    );
+    assert.equal(res.status, 401);
+    await flush();
+    assert.equal(captures.length, 0);
+  });
+
+  test("a telemetry capture failure never surfaces into the proxied response", async () => {
+    const { env, key } = makeValidatedKeyEnv({
+      POSTHOG_PROJECT_TOKEN: "phc_test_token",
+    });
+    globalThis.fetch = (async (url: unknown) => {
+      if (String(url).includes(POSTHOG_CAPTURE_PATH)) {
+        throw new Error("posthog unreachable");
+      }
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    const { ctx, flush } = fakeCtx();
+    const request = req(`/rpc/v1/fullnode?authorization=${key}`, {
+      body: { jsonrpc: "2.0", id: 1, method: "system_health" },
+    });
+    const res = await handleFullnodeRpcProxyRequest(
+      request,
+      env,
+      new URL(request.url),
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    await assert.doesNotReject(flush());
+  });
+
+  test("works with no ctx provided at all (direct call, no waitUntil available)", async () => {
+    const { env, key } = makeValidatedKeyEnv({
+      POSTHOG_PROJECT_TOKEN: "phc_test_token",
+    });
+    captureCalls();
+    const res = await call(
+      `/rpc/v1/fullnode?authorization=${key}`,
+      { body: { jsonrpc: "2.0", id: 1, method: "system_health" } },
+      env,
+    );
+    assert.equal(res.status, 200);
+  });
 });

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+import {
+  POSTHOG_PROJECT_TOKEN_ENV,
+  USAGE_EVENT_DISTINCT_ID,
+} from "../src/usage-telemetry.ts";
 import { handleMcpRequest } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
@@ -433,6 +436,147 @@ describe("MCP tool-dispatch usage telemetry", () => {
   });
 });
 
+// metagraphed#7153: real per-caller identity. @cloudflare/workers-oauth-provider
+// stamps `ctx.props` on the ExecutionContext once it has validated the
+// caller's Bearer token (src/github-oauth.ts) -- buildContext resolves that
+// into a namespaced PostHog distinct_id, threaded through every telemetry
+// event this dispatch path emits.
+describe("MCP telemetry distinct_id resolution (#7153)", () => {
+  function fakeExecutionCtxWithProps(props?: Row) {
+    const scheduled: Promise<unknown>[] = [];
+    return {
+      scheduled,
+      waitUntil: (promise: Promise<unknown>) => scheduled.push(promise),
+      ...(props !== undefined ? { props } : {}),
+    };
+  }
+
+  test("an authenticated caller's events carry distinct_id github:<login>", async () => {
+    const original = globalThis.fetch;
+    const posted: Row[] = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      posted.push({ url, body: JSON.parse(init!.body as string) });
+      return { ok: true };
+    }) as typeof fetch;
+    try {
+      const executionCtx = fakeExecutionCtxWithProps({
+        githubUserId: 12345,
+        githubLogin: "octocat",
+      });
+      const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, {
+        executionCtx,
+      });
+      await Promise.all(executionCtx.scheduled);
+
+      assert.equal(payload.result.isError, false);
+      assert.equal(posted.length, 2);
+      for (const post of posted) {
+        assert.equal(post.body.distinct_id, "github:octocat");
+      }
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("an anonymous caller (no executionCtx.props) still falls back to the shared distinct_id", async () => {
+    const original = globalThis.fetch;
+    const posted: Row[] = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      posted.push({ url, body: JSON.parse(init!.body as string) });
+      return { ok: true };
+    }) as typeof fetch;
+    try {
+      const executionCtx = fakeExecutionCtxWithProps();
+      const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, {
+        executionCtx,
+      });
+      await Promise.all(executionCtx.scheduled);
+
+      assert.equal(payload.result.isError, false);
+      assert.equal(posted.length, 2);
+      for (const post of posted) {
+        assert.equal(post.body.distinct_id, USAGE_EVENT_DISTINCT_ID);
+      }
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("a malformed (non-string) githubLogin is treated as anonymous, not a crash", async () => {
+    const original = globalThis.fetch;
+    const posted: Row[] = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      posted.push({ url, body: JSON.parse(init!.body as string) });
+      return { ok: true };
+    }) as typeof fetch;
+    try {
+      const executionCtx = fakeExecutionCtxWithProps({ githubLogin: 12345 });
+      const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, {
+        executionCtx,
+      });
+      await Promise.all(executionCtx.scheduled);
+
+      assert.equal(payload.result.isError, false);
+      const usagePost = posted.find((p) => p.body.event === "usage_event");
+      assert.ok(usagePost);
+      assert.equal(usagePost.body.distinct_id, USAGE_EVENT_DISTINCT_ID);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  // Proves the full chain end-to-end: executionCtx.props -> buildContext's
+  // McpCtx.distinctId -> the ask tool handler -> askQuestion's AskDeps ->
+  // recordAiGenerationEvent -- not just the usage_event/$mcp_tool_call
+  // schedulers covered above, which don't exercise the ask tool's own
+  // separate distinctId passthrough (src/mcp-server.ts's ask handler,
+  // src/ai-search.ts's askQuestion).
+  test("the ask tool attributes its $ai_generation event to the same resolved identity", async () => {
+    const original = globalThis.fetch;
+    const posted: Row[] = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      posted.push({ url, body: JSON.parse(init!.body as string) });
+      return { ok: true };
+    }) as typeof fetch;
+    try {
+      const executionCtx = fakeExecutionCtxWithProps({
+        githubLogin: "octocat",
+      });
+      const env = {
+        ...CONFIGURED_ENV,
+        METAGRAPH_ENABLE_AI: "true",
+        AI: {
+          run(_model: unknown, input: Row) {
+            if (input?.text) {
+              const n = Array.isArray(input.text) ? input.text.length : 1;
+              return Promise.resolve({
+                data: Array.from({ length: n }, () =>
+                  new Array(1024).fill(0.02),
+                ),
+              });
+            }
+            return Promise.resolve({ response: "answer." });
+          },
+        },
+        VECTORIZE: { query: () => Promise.resolve({ matches: [] }) },
+      };
+      const payload = await callMcp(
+        toolCall("ask", { question: "which subnet does images?" }),
+        env,
+        { executionCtx },
+      );
+      await Promise.all(executionCtx.scheduled);
+
+      assert.equal(payload.result.isError, false);
+      const aiPost = posted.find((p) => p.body.event === "$ai_generation");
+      assert.ok(aiPost, "$ai_generation should be posted");
+      assert.equal(aiPost.body.distinct_id, "github:octocat");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
 // metagraphed#7758: dispatchTool's PostHog $exception capture, parallel-run
 // alongside the existing Sentry.captureException at the same site. Uses the
 // same real internal-error trigger as
@@ -523,6 +667,48 @@ describe("MCP dispatchTool exception capture ($exception)", () => {
       );
     } finally {
       globalThis.fetch = original;
+    }
+  });
+
+  // Mirrors the usage_event/$mcp_tool_call/$mcp_initialize failure-mode tests
+  // above -- scheduleExceptionEvent's own .catch(() => false), now actually
+  // reachable via injection since buildContext threads recordExceptionEvent
+  // through (fixed alongside #7153; it previously only copied
+  // recordUsageEvent onto ctx, so this exact injection silently no-opped).
+  test("an $exception telemetry failure changes nothing about the tool result", async () => {
+    const baseline = await callMcp(
+      toolCall("semantic_search", { query: "images" }),
+      aiEnv(),
+    );
+    assert.equal(baseline.result.isError, true);
+
+    const failureModes: Record<string, Row> = {
+      "recorder rejects": {
+        recordExceptionEvent: () => Promise.reject(new Error("posthog down")),
+        executionCtx: fakeExecutionCtx(),
+      },
+      "recorder throws synchronously": {
+        recordExceptionEvent: () => {
+          throw new Error("recorder exploded");
+        },
+        executionCtx: fakeExecutionCtx(),
+      },
+    };
+
+    for (const [mode, deps] of Object.entries(failureModes)) {
+      const payload = await callMcp(
+        toolCall("semantic_search", { query: "images" }),
+        aiEnv(),
+        deps,
+      );
+      if (Array.isArray(deps.executionCtx?.scheduled)) {
+        await Promise.allSettled(deps.executionCtx.scheduled);
+      }
+      assert.deepEqual(
+        payload,
+        baseline,
+        `telemetry mode changed the result: ${mode}`,
+      );
     }
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1568,7 +1568,7 @@ export async function handleRequest(
   // which would otherwise just 404 as rpc_network_unsupported instead of
   // reaching this dedicated, differently-authed handler).
   if (url.pathname === "/rpc/v1/fullnode") {
-    return handleFullnodeRpcProxyRequest(request, env, url);
+    return handleFullnodeRpcProxyRequest(request, env, url, ctx);
   }
 
   if (url.pathname.startsWith("/rpc/v1/")) {

--- a/workers/request-handlers/fullnode-rpc-proxy.ts
+++ b/workers/request-handlers/fullnode-rpc-proxy.ts
@@ -36,12 +36,57 @@ import {
   type RpcEndpoint,
   type RpcHealthMap,
 } from "./rpc-proxy.ts";
+import type { EdgeCacheCtx } from "./analytics.ts";
 import {
   DENIED_RPC_PREFIXES,
   MAX_RPC_BODY_BYTES,
   resolveClientIp,
   SAFE_RPC_METHODS,
 } from "../config.ts";
+import { recordUsageEvent } from "../../src/usage-telemetry.ts";
+
+// PostHog usage telemetry for this gate (metagraphed#7153): excluded from the
+// generic withUsageTelemetry chokepoint (workers/api.ts's usageRouteLabel
+// explicitly treats "the RPC proxy" as not API usage -- it has its own
+// Postgres-backed rpc_proxy_events analytics instead, see rpc-proxy.ts's
+// recordRpcUsage), so this route records its own event directly. Unlike the
+// public pool, every caller here already authenticates with a real mg_...
+// key (validateApiKey), so distinct_id is the actual rpc_accounts.id rather
+// than the shared USAGE_EVENT_DISTINCT_ID fallback every anonymous surface
+// is stuck with -- this is real per-caller identity, not proxy volume/
+// failover analytics, so it's a deliberate second, PostHog-side event
+// alongside (not a replacement for) recordRpcUsage.
+function recordFullnodeRpcUsage(
+  env: Env,
+  ctx: EdgeCacheCtx | undefined,
+  event: {
+    ok: boolean;
+    durationMs: number;
+    errorCode?: string;
+    accountId: string;
+  },
+) {
+  try {
+    // recordUsageEvent never throws/rejects (its own header comment) -- no
+    // .catch() needed here, unlike workers/api.ts's scheduleUsageEvent, which
+    // wraps an INJECTABLE recorder a caller/test could swap for one that does.
+    const pending = recordUsageEvent(
+      env,
+      {
+        route: "fullnode_rpc",
+        ok: event.ok,
+        durationMs: event.durationMs,
+        ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+      },
+      { distinctId: `account:${event.accountId}` },
+    );
+    if (typeof ctx?.waitUntil === "function") {
+      ctx.waitUntil(pending);
+    }
+  } catch {
+    // Telemetry must never surface into the request path.
+  }
+}
 
 const FULLNODE_EXTRA_SAFE_METHODS = new Set(["author_submitExtrinsic"]);
 
@@ -148,6 +193,7 @@ export async function handleFullnodeRpcProxyRequest(
   request: Request,
   env: Env,
   url: URL,
+  ctx?: EdgeCacheCtx,
 ): Promise<Response> {
   if (request.method !== "POST") {
     return errorResponse(
@@ -181,6 +227,9 @@ export async function handleFullnodeRpcProxyRequest(
   const rawKey = url.searchParams.get("authorization") || "";
   const auth = await validateApiKey(env, rawKey);
   if (!auth.ok) {
+    // No accountId to attribute an event to yet -- an unauthenticated guess
+    // is exactly what FULLNODE_RPC_GUESS_RATE_LIMITER above already bounds
+    // the cost of, not a real caller worth recording.
     return errorResponse(
       "fullnode_rpc_unauthorized",
       auth.code === "key_revoked"
@@ -190,6 +239,22 @@ export async function handleFullnodeRpcProxyRequest(
     );
   }
 
+  const startedAt = Date.now();
+  const response = await runAuthenticatedFullnodeRpc(request, env, auth);
+  recordFullnodeRpcUsage(env, ctx, {
+    ok: response.status < 500,
+    durationMs: Date.now() - startedAt,
+    errorCode: response.headers.get("x-metagraph-error-code") ?? undefined,
+    accountId: String(auth.accountId),
+  });
+  return response;
+}
+
+async function runAuthenticatedFullnodeRpc(
+  request: Request,
+  env: Env,
+  auth: { ok: true; tier: unknown; accountId: unknown },
+): Promise<Response> {
   // auth.tier is `unknown` (validateApiKey's success-shape tier comes straight
   // from Unkey's own untyped JSON response) -- rateLimitPolicyForTier's own
   // `|| FULLNODE_RPC_TIER_RATE_LIMITS.free` fallback already handles a


### PR DESCRIPTION
## Summary

Closes #7153.

Every PostHog telemetry event has shipped with the same shared, hardcoded `distinct_id` since day one -- #7153 claimed a real per-caller identity strategy was implemented, but no call site anywhere in the codebase ever overrode it. This wires up the two places where real caller identity is actually already resolved but wasn't being used:

- **MCP**: GitHub OAuth (`@cloudflare/workers-oauth-provider`) already puts `{githubLogin, ...}` on `ctx.props` once it validates a caller's Bearer token -- architecturally live since the OAuth work landed, just never read. `McpCtx.distinctId` now resolves to `github:<login>` and threads through all 4 telemetry schedulers (`usage_event`, `$mcp_tool_call`, `$mcp_initialize`, `$exception`) plus the `ask` tool's `$ai_generation` event.
- **Fullnode RPC gate** (`/rpc/v1/fullnode`): every caller already authenticates with a real Unkey-backed `mg_...` key and resolves an `accountId`, but the route emitted zero PostHog telemetry (it's explicitly excluded from the generic `withUsageTelemetry` chokepoint, which treats "the RPC proxy" as not API usage -- it has its own separate Postgres-backed volume/failover analytics). Added a dedicated `usage_event` capture keyed by `account:<id>`.

**Bug found and fixed along the way**: `buildContext` only ever copied `recordUsageEvent` from `deps` onto `ctx` -- `recordMcpToolCallEvent`/`recordMcpInitializeEvent`/`recordExceptionEvent` were declared on `McpCtx` and read by their own schedulers, but never actually wired through. This meant the existing "a rejecting recorder doesn't break the tool result" safety tests for those three events passed vacuously (the injected override never reached the scheduler, so the real recorder ran instead and just... didn't reject). Fixed the wiring and added a test that actually exercises the reject path for `recordExceptionEvent`.

Anonymous callers are unaffected -- `distinct_id` falls back to the existing shared constant exactly as before.

## Test plan
- [x] `npm run typecheck` / `npm run lint` / `npx prettier --check` clean
- [x] Full suite (`npx vitest run`): 11898/11898 passing
- [x] New/updated tests: distinct_id resolution in `buildContext` (valid login, absent, malformed non-string), all 4 schedulers, the `ask` tool's end-to-end passthrough, `askQuestion()`'s success/error/fallback paths, fullnode RPC gate's usage_event (success, rejected-but-non-5xx, unauthenticated no-op, capture-failure isolation, no-ctx call)
- [x] 100% line/branch coverage on every line touched (`workers/request-handlers/fullnode-rpc-proxy.ts` fully covered; the only pre-existing gaps remaining in `src/mcp-server.ts` predate this diff)