### PR TITLE
feat(observability): capture 2 remaining console-only fault sites

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -13522,6 +13522,16 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
       return rpcError(id, RPC_INVALID_PARAMS, error.message);
     }
     // Don't echo raw internals to the public client; log server-side instead.
+    // Same discipline as callTool's sibling catch above: a handled toolError
+    // is an expected outcome and returns before this point, uncaptured --
+    // only a genuinely unexpected fault (malformed/unroutable JSON-RPC) gets
+    // captured (metagraphed#8081).
+    Sentry.captureException(error, { tags: { mcp_method: method } });
+    scheduleExceptionEvent(ctx, {
+      error,
+      route: `mcp-dispatch:${method}`,
+      errorCode: "internal_error",
+    });
     console.error("MCP dispatch failed:", error);
     return rpcError(id, RPC_INTERNAL_ERROR, "Internal error.");
   }

--- a/src/subnet-identity-history.ts
+++ b/src/subnet-identity-history.ts
@@ -7,6 +7,7 @@
 // recordSubnetIdentityChanges' own header comment). Pure + injectable for
 // tests.
 
+import * as Sentry from "@sentry/cloudflare";
 import { encodeCursor, decodeCursor } from "./cursor.ts";
 import {
   sanitizeIdentityHistoryFields,
@@ -18,6 +19,7 @@ import {
   FEED_PAGINATION,
 } from "../workers/request-params.ts";
 import { tryPostgresTier } from "../workers/postgres-tier.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
 
 type Row = Record<string, unknown>;
 type D1Runner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -294,6 +296,18 @@ export async function recordSubnetIdentityChanges(
     // #4832 gap-closure follow-up: a swallowed read error here dark-served
     // the identity-history diff for an unknown stretch before anyone
     // noticed -- same failure class d1All was originally hardened against.
+    // metagraphed#8081: capture it instead of only logging, matching
+    // src/graphql.ts's handleGraphQLRequest -- no ExecutionContext reaches
+    // this cron-tick call path (writeSubnetSnapshot -> here), so this is
+    // awaited inline rather than fire-and-forget via waitUntil.
+    Sentry.captureException(error, {
+      tags: { route: "subnet-identity-history-diff" },
+    });
+    await recordExceptionEvent(env, {
+      error,
+      route: "subnet-identity-history-diff",
+      errorCode: "read_failed",
+    });
     console.error(
       "[recordSubnetIdentityChanges]",
       String((error as Error)?.message ?? error),

--- a/tests/mcp-server-dispatch-error-capture.test.ts
+++ b/tests/mcp-server-dispatch-error-capture.test.ts
@@ -1,0 +1,132 @@
+// metagraphed#8081: dispatchMessage's catch (src/mcp-server.ts, the
+// resources/read | resources/subscribe | prompts/get | etc. dispatch layer,
+// one level above callTool's own catch) only ever logged a genuinely
+// unexpected fault to console -- unlike its sibling in callTool, it never
+// reached Sentry or PostHog. A separate small file rather than folded into
+// tests/mcp-server-sentry-args-safety.test.ts: vi.mock is file-scoped and
+// hoisted, and that file's other tests already exercise the real (unmocked)
+// Sentry.captureException through a different call path -- mocking it there
+// risks disturbing tests this issue doesn't own. Mirrors that file's and
+// tests/graphql-sentry-and-error-code.test.ts's own identical rationale.
+import assert from "node:assert/strict";
+import { afterEach, test, vi } from "vitest";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+import type { Row } from "./row-type.ts";
+
+const captureException = vi.hoisted(() => vi.fn());
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException,
+}));
+
+const { handleMcpRequest } = await import("../src/mcp-server.ts");
+
+afterEach(() => {
+  captureException.mockClear();
+});
+
+// resources/read for a valid subnet URI routes through loadArtifactData,
+// which calls ctx.readArtifact -- a rejection there is exactly the
+// "readArtifact rejection" case dispatchMessage's own comment names as a
+// genuine (non-toolError) fault, propagating uncaught to dispatchMessage's
+// catch. deps.executionCtx.waitUntil is captured so the fire-and-forget
+// PostHog scheduling (never awaited by the main response path, by design --
+// it must not delay the client) can be awaited explicitly before asserting.
+async function readResourceExpectingDispatchFault(env: Row = {}) {
+  const waited: Promise<unknown>[] = [];
+  const response = await handleMcpRequest(
+    new Request("https://metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/read",
+        params: { uri: "metagraph://subnet/5" },
+      }),
+    }),
+    env as unknown as Env,
+    {
+      readArtifact: async () => {
+        throw new Error("R2 get failed");
+      },
+      executionCtx: { waitUntil: (p: Promise<unknown>) => waited.push(p) },
+    },
+  );
+  await Promise.all(waited);
+  return { body: (await response.json()) as Row };
+}
+
+test("a genuine dispatch-level fault reaches Sentry, tagged with the JSON-RPC method", async () => {
+  const { body } = await readResourceExpectingDispatchFault();
+
+  assert.equal(body.error?.message, "Internal error.");
+  assert.equal(captureException.mock.calls.length, 1);
+  const [capturedError, context] = captureException.mock.calls[0];
+  assert.equal(capturedError.message, "R2 get failed");
+  assert.deepEqual(context, { tags: { mcp_method: "resources/read" } });
+});
+
+test("the same fault also reaches PostHog as $exception, tagged mcp-dispatch:resources/read", async () => {
+  const original = globalThis.fetch;
+  const posted: Row[] = [];
+  globalThis.fetch = (async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return { ok: true };
+  }) as unknown as typeof fetch;
+  try {
+    await readResourceExpectingDispatchFault({
+      [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+    });
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].body.event, "$exception");
+    assert.equal(
+      posted[0].body.properties.route,
+      "mcp-dispatch:resources/read",
+    );
+    assert.equal(posted[0].body.properties.error_code, "internal_error");
+    assert.equal(
+      posted[0].body.properties.$exception_list[0].value,
+      "R2 get failed",
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("a handled toolError (e.g. an unknown resource URI) never reaches Sentry or PostHog", async () => {
+  const original = globalThis.fetch;
+  const posted: Row[] = [];
+  globalThis.fetch = (async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return { ok: true };
+  }) as unknown as typeof fetch;
+  try {
+    const response = await handleMcpRequest(
+      new Request("https://metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "resources/read",
+          params: { uri: "not-a-metagraph-uri" },
+        }),
+      }),
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" } as unknown as Env,
+      {},
+    );
+    const body = (await response.json()) as Row;
+    assert.equal(body.error?.code, -32602);
+    assert.equal(captureException.mock.calls.length, 0);
+    assert.equal(posted.length, 0);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/tests/subnet-identity-history-sentry.test.ts
+++ b/tests/subnet-identity-history-sentry.test.ts
@@ -1,0 +1,117 @@
+// metagraphed#8081: recordSubnetIdentityChanges's read-failure catch
+// (src/subnet-identity-history.ts) only ever logged to console -- per its
+// own #4832 gap-closure comment, a swallowed read error here "dark-served
+// the identity-history diff for an unknown stretch before anyone noticed."
+// A separate small file rather than folded into
+// tests/subnet-identity-history.test.ts (946 lines): vi.mock is file-scoped
+// and hoisted, and that file's other tests already exercise the real
+// (unmocked) Sentry no-op through the same function -- mocking it there
+// risks disturbing tests this issue doesn't own. Mirrors
+// tests/graphql-sentry-and-error-code.test.ts's own identical rationale.
+import assert from "node:assert/strict";
+import { afterEach, test, vi } from "vitest";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+import type { Row } from "./row-type.ts";
+
+const captureException = vi.hoisted(() => vi.fn());
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException,
+}));
+
+const { recordSubnetIdentityChanges } =
+  await import("../src/subnet-identity-history.ts");
+
+afterEach(() => {
+  captureException.mockClear();
+});
+
+// latestIdentityHashes only throws when Postgres hands back a truthy but
+// non-iterable `hashes` payload (tryPostgresTier itself never throws) --
+// see the sibling "returns read_failed" test in
+// tests/subnet-identity-history.test.ts for the same trigger.
+function pgEnvWithBadPayload(extra: Row = {}): Env {
+  return {
+    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        new Response(JSON.stringify({ hashes: { not: "an array" } }), {
+          status: 200,
+        }),
+    },
+    ...extra,
+  } as unknown as Env;
+}
+
+const profiles = [{ netuid: 7, native_identity: { subnet_name: "X" } }];
+
+test("a genuine read failure reaches Sentry, tagged subnet-identity-history-diff", async () => {
+  const result = await recordSubnetIdentityChanges(pgEnvWithBadPayload(), {
+    profiles,
+  });
+  assert.deepEqual(result, { recorded: false, reason: "read_failed" });
+
+  assert.equal(captureException.mock.calls.length, 1);
+  const [, context] = captureException.mock.calls[0];
+  assert.deepEqual(context, {
+    tags: { route: "subnet-identity-history-diff" },
+  });
+});
+
+test("the same failure also reaches PostHog as $exception, tagged error_code read_failed", async () => {
+  const original = globalThis.fetch;
+  const posted: Row[] = [];
+  const env = pgEnvWithBadPayload({
+    [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+  });
+  // env.DATA_API.fetch above only intercepts the internal latest-hashes
+  // lookup; globalThis.fetch is what recordExceptionEvent posts $exception
+  // through, so both must be stubbed independently.
+  globalThis.fetch = (async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return { ok: true };
+  }) as unknown as typeof fetch;
+  try {
+    await recordSubnetIdentityChanges(env, { profiles });
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].body.event, "$exception");
+    assert.equal(
+      posted[0].body.properties.route,
+      "subnet-identity-history-diff",
+    );
+    assert.equal(posted[0].body.properties.error_code, "read_failed");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("an unchanged-identity run (no read failure) never reaches Sentry or PostHog", async () => {
+  const original = globalThis.fetch;
+  const posted: Row[] = [];
+  globalThis.fetch = (async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    posted.push({ url, body: JSON.parse(init!.body as string) });
+    return { ok: true };
+  }) as unknown as typeof fetch;
+  try {
+    const env = {
+      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          new Response(JSON.stringify({ hashes: [] }), { status: 200 }),
+      },
+      [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+    } as unknown as Env;
+    const result = await recordSubnetIdentityChanges(env, { profiles });
+    assert.equal(result.recorded, true);
+    assert.equal(captureException.mock.calls.length, 0);
+    assert.equal(posted.length, 0);
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #8081 — wires the two console-only fault sites the #7764 audit found that still lack Sentry/PostHog capture.

**Note on scope:** the issue named 3 sites. `workers/registry-sync-api.ts:377`'s write-failure path was already fixed by #8094, merged after #8081 was filed — `captureRegistrySyncError` already runs there (verified: both `console.error` and the capture call are present at that site today). This PR wires the remaining 2:

### `src/mcp-server.ts` — `dispatchMessage`'s catch ("MCP dispatch failed")

The protocol-level JSON-RPC dispatch layer, one level above `callTool`'s own catch (which already captures via `scheduleExceptionEvent` — that's the compliant sibling site the original audit found). Malformed/unroutable JSON-RPC requests (bad `resources/read` params, etc.) were invisible outside Cloudflare's own tail.

Tags `Sentry.captureException` with `mcp_method` (the JSON-RPC method string — there's no single tool `name` in scope at this dispatch level) and schedules a PostHog `$exception` via the existing `scheduleExceptionEvent` fire-and-forget helper, matching `callTool`'s own sibling exactly (this path has no `ExecutionContext` guarantee on every caller either). A handled `toolError` still returns before this point, uncaptured — same expected-vs-genuine-fault discriminator the sibling already uses, preserved verbatim.

### `src/subnet-identity-history.ts` — `recordSubnetIdentityChanges`'s read catch

Explicitly flagged in its own `#4832` comment as a repeat of a past incident: a swallowed read error here "dark-served the identity-history diff for an unknown stretch before anyone noticed." Matches `src/graphql.ts`'s `handleGraphQLRequest` exactly — no `ExecutionContext` reaches this cron-tick call path (`writeSubnetSnapshot` → here), so it's `await`ed inline rather than fire-and-forget.

Both follow the exact existing `Sentry.captureException` + `recordExceptionEvent(env, {...})` pattern already used at every other fault site in these files (`workers/data-api.ts`'s `captureDataApiError`, `workers/api.ts`'s `captureAiRouteError`, `src/graphql.ts`'s inline capture).

## Regression tests

Two new small test files (mirroring the existing convention in `tests/graphql-sentry-and-error-code.test.ts` / `tests/mcp-server-sentry-args-safety.test.ts` — `vi.mock` is file-scoped and hoisted, and each function's other tests already exercise the real unmocked Sentry no-op, so a separate file avoids disturbing tests this issue doesn't own):

- `tests/mcp-server-dispatch-error-capture.test.ts` — a genuine `readArtifact` rejection during `resources/read` reaches both Sentry (tagged `mcp_method`) and PostHog `$exception` (tagged `route: mcp-dispatch:resources/read`); a handled `toolError` (unknown resource URI) reaches neither.
- `tests/subnet-identity-history-sentry.test.ts` — a genuine read failure (non-iterable Postgres payload) reaches both Sentry and PostHog, tagged `route: subnet-identity-history-diff` / `error_code: read_failed`; a clean run reaches neither.

## Test plan
- [x] `tsc --noEmit`: no new errors (2 pre-existing, unrelated `scripts/` errors — missing `kanel` type declarations — confirmed present with these changes stashed out too)
- [x] `eslint` on all 4 touched/added files: 0 errors, 0 warnings
- [x] `prettier --check` clean on all 4 files
- [x] New tests: 6/6 passing (both new files, run standalone and together)
- [x] Confirmed no regression to the sibling `callTool` capture path or `recordSubnetIdentityChanges`'s existing D1-retirement canary tests (`tests/mcp-server.test.ts`'s `resources/read` suite, `tests/subnet-identity-history.test.ts`'s `recordSubnetIdentityChanges` suite — both fully green)

Closes #8081.