### PR TITLE
feat(mcp): types-epic E batch 9 — Zod schemas for 17 registry-discovery MCP tools (#8073)

### DIFF
--- a/schemas-src/mcp-tools/catalog-detail.ts
+++ b/schemas-src/mcp-tools/catalog-detail.ts
@@ -1,0 +1,95 @@
+// MCP tools `list_subnet_apis`, `get_api_schema`, `get_fixture`,
+// `get_provider_detail` (types-epic E batch 9, #8073). Each is defined
+// inline in src/mcp-server.ts's MCP_TOOLS array (unlike this batch's other
+// 13 tools, which live in separate src/*-mcp.ts files). None mirror an
+// existing schemas-src/routes/ REST schema -- modeled fresh, matching each
+// hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenArraySchema, OpenObjectSchema } from "./shared.ts";
+
+export const ListSubnetApisInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type ListSubnetApisInput = z.infer<typeof ListSubnetApisInputSchema>;
+
+export const ListSubnetApisOutputSchema = z
+  .object({
+    netuid: z.int(),
+    service_count: z.int(),
+    services: z.array(OpenObjectSchema),
+    operational_observed_at: z.string().nullable().optional(),
+    health_source: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSubnetApisOutput = z.infer<typeof ListSubnetApisOutputSchema>;
+
+export const GetApiSchemaInputSchema = z
+  .object({
+    surface_id: z.string(),
+  })
+  .strict();
+export type GetApiSchemaInput = z.infer<typeof GetApiSchemaInputSchema>;
+
+export const GetApiSchemaOutputSchema = z
+  .object({
+    surface_id: z.string(),
+    kind: z.string().nullable().optional(),
+    base_url: z.string().nullable().optional(),
+    auth_required: z.boolean().nullable().optional(),
+    auth_schemes: OpenArraySchema.optional(),
+    drift_status: z.string().nullable().optional(),
+    document: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetApiSchemaOutput = z.infer<typeof GetApiSchemaOutputSchema>;
+
+export const GetFixtureInputSchema = z
+  .object({
+    surface_id: z.string(),
+  })
+  .strict();
+export type GetFixtureInput = z.infer<typeof GetFixtureInputSchema>;
+
+// The hand-written original declares only surface_id -- the actual fixture
+// payload has many more fields, deliberately left undeclared (loose
+// additionalProperties:true), not "improved" with a guessed shape here.
+export const GetFixtureOutputSchema = z
+  .object({
+    surface_id: z.string(),
+  })
+  .passthrough();
+export type GetFixtureOutput = z.infer<typeof GetFixtureOutputSchema>;
+
+export const GetProviderDetailInputSchema = z
+  .object({
+    slug: z.string(),
+    include_endpoints: z.boolean().optional(),
+  })
+  .strict();
+export type GetProviderDetailInput = z.infer<
+  typeof GetProviderDetailInputSchema
+>;
+
+// Two shapes: the bare provider detail (default) or {provider, endpoints}
+// when include_endpoints is set. Both are operator-controlled artifact
+// payloads, so nothing is required in the hand-written original; the keys
+// below describe each shape when present.
+export const GetProviderDetailOutputSchema = z
+  .object({
+    id: z.string().nullable().optional(),
+    slug: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    authority: z.string().nullable().optional(),
+    kind: z.string().nullable().optional(),
+    provider: OpenObjectSchema.nullable().optional(),
+    endpoints: z
+      .union([OpenObjectSchema, OpenArraySchema])
+      .nullable()
+      .optional(),
+  })
+  .passthrough();
+export type GetProviderDetailOutput = z.infer<
+  typeof GetProviderDetailOutputSchema
+>;

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -1,0 +1,111 @@
+// MCP tools `list_endpoints`, `get_subnet_endpoints` (types-epic E batch 9,
+// #8073). Both are defined inline in src/mcp-server.ts's MCP_TOOLS array
+// (unlike this batch's 11 other list_* tools, which live in separate
+// src/*-mcp.ts files). Neither mirrors an existing schemas-src/routes/ REST
+// schema -- modeled fresh, matching each hand-written literal
+// field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+const ENDPOINT_LAYERS = [
+  "bittensor-base",
+  "data-provider",
+  "docs-provider",
+  "subnet-app",
+] as const;
+const ENDPOINT_PUBLICATION_STATES = [
+  "candidate",
+  "verified",
+  "monitored",
+  "pool-eligible",
+  "disabled",
+  "rejected",
+] as const;
+const HEALTH_STATUSES = ["ok", "degraded", "failed", "unknown"] as const;
+const ENDPOINT_SORT_FIELDS = [
+  "kind",
+  "last_checked",
+  "latency_ms",
+  "layer",
+  "netuid",
+  "pool_eligible",
+  "provider",
+  "publication_state",
+  "score",
+  "status",
+] as const;
+
+export const ListEndpointsInputSchema = z
+  .object({
+    kind: z.enum(SURFACE_KINDS).optional(),
+    layer: z.enum(ENDPOINT_LAYERS).optional(),
+    netuid: z.int().min(0).optional(),
+    provider: z.string().optional(),
+    publication_state: z.enum(ENDPOINT_PUBLICATION_STATES).optional(),
+    status: z.enum(HEALTH_STATUSES).optional(),
+    pool_eligible: z.boolean().optional(),
+    min_latency_ms: z.number().optional(),
+    max_latency_ms: z.number().optional(),
+    min_score: z.number().optional(),
+    max_score: z.number().optional(),
+    sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListEndpointsInput = z.infer<typeof ListEndpointsInputSchema>;
+
+export const ListEndpointsOutputSchema = z
+  .object({
+    endpoints: z.array(OpenObjectSchema).optional(),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    cursor: z.int().optional(),
+    limit: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+  })
+  .passthrough();
+export type ListEndpointsOutput = z.infer<typeof ListEndpointsOutputSchema>;
+
+export const GetSubnetEndpointsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetEndpointsInput = z.infer<
+  typeof GetSubnetEndpointsInputSchema
+>;
+
+export const GetSubnetEndpointsOutputSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    endpoints: z.array(OpenObjectSchema).optional(),
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetEndpointsOutput = z.infer<
+  typeof GetSubnetEndpointsOutputSchema
+>;

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -1,0 +1,171 @@
+// MCP tools `list_providers`, `list_surfaces`, `list_candidates` (types-epic
+// E batch 9, #8073). Unlike every other tool converted so far in this
+// epic, these three are NOT defined inline in src/mcp-server.ts -- their
+// `LIST_X_MCP_TOOL`/`LIST_X_OUTPUT_SCHEMA` hand-written literals live in
+// src/providers-mcp.ts, src/surfaces-mcp.ts, and src/candidates-mcp.ts
+// respectively, imported into mcp-server.ts's MCP_TOOLS array via object
+// spread (`{ ...LIST_PROVIDERS_MCP_TOOL, async handler(...) {...} }`). The
+// z.toJSONSchema(...) wiring for these three happens in THEIR OWN files, not
+// mcp-server.ts. None mirror an existing schemas-src/routes/ REST schema --
+// modeled fresh, matching each hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+// Symbolic in each hand-written original (src/contracts.ts's QUERY_ENUMS /
+// API_QUERY_COLLECTIONS.*.sort_fields), cross-checked against the actual
+// runtime source at the time of writing.
+const PROVIDER_KINDS = [
+  "data-provider",
+  "docs-provider",
+  "infrastructure-provider",
+  "registry",
+  "subnet-team",
+] as const;
+const PROVIDER_AUTHORITIES = [
+  "community",
+  "official",
+  "provider-claimed",
+  "registry-observed",
+] as const;
+const PROVIDER_SORT_FIELDS = ["authority", "id", "kind", "name"] as const;
+
+export const ListProvidersInputSchema = z
+  .object({
+    id: z.string().optional(),
+    kind: z.enum(PROVIDER_KINDS).optional(),
+    authority: z.enum(PROVIDER_AUTHORITIES).optional(),
+    sort: z.enum(PROVIDER_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListProvidersInput = z.infer<typeof ListProvidersInputSchema>;
+
+export const ListProvidersOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+    providers: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListProvidersOutput = z.infer<typeof ListProvidersOutputSchema>;
+
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+const SURFACE_SORT_FIELDS = [
+  "id",
+  "kind",
+  "name",
+  "netuid",
+  "provider",
+] as const;
+
+export const ListSurfacesInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    provider: z.string().optional(),
+    id: z.string().optional(),
+    sort: z.enum(SURFACE_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSurfacesInput = z.infer<typeof ListSurfacesInputSchema>;
+
+export const ListSurfacesOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+    surfaces: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSurfacesOutput = z.infer<typeof ListSurfacesOutputSchema>;
+
+const CANDIDATE_STATES = [
+  "schema-invalid",
+  "schema-valid",
+  "maintainer-review",
+  "verified",
+  "stale",
+  "rejected",
+] as const;
+const CONFIDENCE_LEVELS = ["low", "medium", "high"] as const;
+const CANDIDATES_SORT_FIELDS = [
+  "confidence",
+  "id",
+  "kind",
+  "name",
+  "netuid",
+  "provider",
+  "state",
+] as const;
+
+export const ListCandidatesInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    provider: z.string().optional(),
+    state: z.enum(CANDIDATE_STATES).optional(),
+    id: z.string().optional(),
+    confidence: z.enum(CONFIDENCE_LEVELS).optional(),
+    sort: z.enum(CANDIDATES_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(1000).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListCandidatesInput = z.infer<typeof ListCandidatesInputSchema>;
+
+export const ListCandidatesOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: z
+      .union([z.array(z.string()), z.string()])
+      .nullable()
+      .optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+    candidates: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListCandidatesOutput = z.infer<typeof ListCandidatesOutputSchema>;

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -1,0 +1,300 @@
+// MCP tools `list_evidence`, `list_rpc_endpoints`, `list_rpc_pools`,
+// `list_source_snapshots`, `list_profile_completeness` (types-epic E batch
+// 9, #8073). Like registry-catalogs-1.ts's three tools, these five are NOT
+// defined inline in src/mcp-server.ts -- their `LIST_X_MCP_TOOL`/
+// `LIST_X_OUTPUT_SCHEMA` hand-written literals live in src/evidence-mcp.ts,
+// src/rpc-endpoints-mcp.ts, src/rpc-pools-mcp.ts, src/source-snapshots-mcp.ts,
+// and src/profile-completeness-mcp.ts respectively, imported into
+// mcp-server.ts's MCP_TOOLS array via object spread. The z.toJSONSchema(...)
+// wiring for these five happens in THEIR OWN files, not mcp-server.ts. None
+// mirror an existing schemas-src/routes/ REST schema -- modeled fresh,
+// matching each hand-written literal field-for-field. Genuine per-tool
+// variation worth flagging: list_rpc_pools and list_profile_completeness
+// have NO schema_version output field at all (their siblings all do);
+// list_rpc_endpoints' schema_version is a plain nullable integer (not the
+// string|integer|null union every other tool in this batch uses); and
+// list_rpc_endpoints' `fields`/`cursor` inputs are `oneOf` unions (string-or-
+// array, integer-or-string) unlike every other tool's single-type fields.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const CLAIM_SORT_FIELDS = [
+  "claim",
+  "source_url",
+  "subject",
+  "verified_at",
+] as const;
+
+export const ListEvidenceInputSchema = z
+  .object({
+    q: z.string().optional(),
+    sort: z.enum(CLAIM_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListEvidenceInput = z.infer<typeof ListEvidenceInputSchema>;
+
+export const ListEvidenceOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+    summary: OpenObjectSchema.nullable().optional(),
+    claims: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListEvidenceOutput = z.infer<typeof ListEvidenceOutputSchema>;
+
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+const ENDPOINT_LAYERS = [
+  "bittensor-base",
+  "data-provider",
+  "docs-provider",
+  "subnet-app",
+] as const;
+const HEALTH_STATUSES = ["ok", "degraded", "failed", "unknown"] as const;
+const ENDPOINT_PUBLICATION_STATES = [
+  "candidate",
+  "verified",
+  "monitored",
+  "pool-eligible",
+  "disabled",
+  "rejected",
+] as const;
+const ENDPOINT_SORT_FIELDS = [
+  "kind",
+  "last_checked",
+  "latency_ms",
+  "layer",
+  "netuid",
+  "pool_eligible",
+  "provider",
+  "publication_state",
+  "score",
+  "status",
+] as const;
+
+export const ListRpcEndpointsInputSchema = z
+  .object({
+    kind: z.enum(SURFACE_KINDS).optional(),
+    layer: z.enum(ENDPOINT_LAYERS).optional(),
+    netuid: z.int().min(0).optional(),
+    provider: z.string().optional(),
+    publication_state: z.enum(ENDPOINT_PUBLICATION_STATES).optional(),
+    status: z.enum(HEALTH_STATUSES).optional(),
+    pool_eligible: z.boolean().optional(),
+    min_latency_ms: z.number().optional(),
+    max_latency_ms: z.number().optional(),
+    min_score: z.number().optional(),
+    max_score: z.number().optional(),
+    sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.union([z.string(), z.array(z.string())]).optional(),
+    limit: z.int().min(1).optional(),
+    cursor: z.union([z.int().min(0), z.string()]).optional(),
+  })
+  .strict();
+export type ListRpcEndpointsInput = z.infer<typeof ListRpcEndpointsInputSchema>;
+
+export const ListRpcEndpointsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: z
+      .union([z.array(z.string()), z.string()])
+      .nullable()
+      .optional(),
+    schema_version: z.int().nullable().optional(),
+    summary: OpenObjectSchema.nullable().optional(),
+    source: z.string().nullable().optional(),
+    operational_observed_at: z.string().nullable().optional(),
+    endpoints: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListRpcEndpointsOutput = z.infer<
+  typeof ListRpcEndpointsOutputSchema
+>;
+
+const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"] as const;
+const POOL_SORT_FIELDS = [
+  "eligible_count",
+  "endpoint_count",
+  "id",
+  "kind",
+] as const;
+
+export const ListRpcPoolsInputSchema = z
+  .object({
+    id: z.string().optional(),
+    kind: z.enum(POOL_KINDS).optional(),
+    min_eligible_count: z.number().optional(),
+    max_eligible_count: z.number().optional(),
+    min_endpoint_count: z.number().optional(),
+    max_endpoint_count: z.number().optional(),
+    sort: z.enum(POOL_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListRpcPoolsInput = z.infer<typeof ListRpcPoolsInputSchema>;
+
+// No schema_version field in the hand-written original, unlike every other
+// tool in this batch.
+export const ListRpcPoolsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: z
+      .union([z.array(z.string()), z.string()])
+      .nullable()
+      .optional(),
+    source: z.string().nullable().optional(),
+    operational_observed_at: z.string().nullable().optional(),
+    pools: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListRpcPoolsOutput = z.infer<typeof ListRpcPoolsOutputSchema>;
+
+const SOURCE_SORT_FIELDS = ["id", "kind", "path", "record_count"] as const;
+
+export const ListSourceSnapshotsInputSchema = z
+  .object({
+    q: z.string().optional(),
+    sort: z.enum(SOURCE_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSourceSnapshotsInput = z.infer<
+  typeof ListSourceSnapshotsInputSchema
+>;
+
+export const ListSourceSnapshotsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+    summary: OpenObjectSchema.nullable().optional(),
+    sources: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSourceSnapshotsOutput = z.infer<
+  typeof ListSourceSnapshotsOutputSchema
+>;
+
+const PROFILE_LEVELS = [
+  "directory-only",
+  "identity-partial",
+  "identity-complete",
+  "operational",
+  "adapter-backed",
+] as const;
+const CONFIDENCE_LEVELS = ["low", "medium", "high"] as const;
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"] as const;
+const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"] as const;
+const PROFILE_SORT_FIELDS = [
+  "candidate_count",
+  "completeness_score",
+  "identity_level",
+  "identity_promotion_kind_count",
+  "identity_surface_count",
+  "live_identity_candidate_kind_count",
+  "missing_critical_count",
+  "name",
+  "native_identity_signal_count",
+  "native_name_quality",
+  "netuid",
+  "priority_score",
+  "profile_level",
+  "stale_identity_candidate_kind_count",
+] as const;
+
+export const ListProfileCompletenessInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    profile_level: z.enum(PROFILE_LEVELS).optional(),
+    confidence: z.enum(CONFIDENCE_LEVELS).optional(),
+    identity_level: z.enum(IDENTITY_LEVELS).optional(),
+    identity_promotion_kinds: z.enum(SURFACE_KINDS).optional(),
+    native_name_quality: z.enum(NATIVE_NAME_QUALITIES).optional(),
+    sort: z.enum(PROFILE_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListProfileCompletenessInput = z.infer<
+  typeof ListProfileCompletenessInputSchema
+>;
+
+// No schema_version field in the hand-written original. summary declares
+// additionalProperties:true explicitly, unlike list_evidence's bare
+// nullable-object summary.
+export const ListProfileCompletenessOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: z
+      .union([z.array(z.string()), z.string()])
+      .nullable()
+      .optional(),
+    summary: z.object({}).passthrough().nullable().optional(),
+    profiles: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListProfileCompletenessOutput = z.infer<
+  typeof ListProfileCompletenessOutputSchema
+>;

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -1,0 +1,208 @@
+// MCP tools `list_subnet_endpoints`, `list_subnet_surfaces`,
+// `list_subnet_health` (types-epic E batch 9, #8073). Like
+// registry-catalogs-{1,2}.ts's tools, these three are NOT defined inline in
+// src/mcp-server.ts -- their `LIST_X_MCP_TOOL`/`LIST_X_OUTPUT_SCHEMA`
+// hand-written literals live in src/subnet-endpoints-mcp.ts,
+// src/subnet-surfaces-mcp.ts, and src/subnet-health-mcp.ts respectively,
+// imported into mcp-server.ts's MCP_TOOLS array via object spread. The
+// z.toJSONSchema(...) wiring for these three happens in THEIR OWN files, not
+// mcp-server.ts. None mirror an existing schemas-src/routes/ REST schema --
+// modeled fresh, matching each hand-written literal field-for-field. Unlike
+// the network-wide list_* tools in registry-catalogs-{1,2}.ts, `netuid` is
+// REQUIRED here (a path parameter, not a filter), and none of the three
+// output shapes carry schema_version/notes/summary. list_subnet_endpoints'
+// `pool_eligible` is a STRING enum (["true","false"]), unlike
+// list_rpc_endpoints' plain boolean for the same filter name.
+// list_subnet_surfaces/list_subnet_health have no `fields` projection param
+// at all, unlike every other list_* tool in this epic.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+const ENDPOINT_LAYERS = [
+  "bittensor-base",
+  "data-provider",
+  "docs-provider",
+  "subnet-app",
+] as const;
+const ENDPOINT_PUBLICATION_STATES = [
+  "candidate",
+  "verified",
+  "monitored",
+  "pool-eligible",
+  "disabled",
+  "rejected",
+] as const;
+const HEALTH_STATUSES = ["ok", "degraded", "failed", "unknown"] as const;
+const BOOLEAN_STRINGS = ["true", "false"] as const;
+const ENDPOINT_SORT_FIELDS = [
+  "kind",
+  "last_checked",
+  "latency_ms",
+  "layer",
+  "netuid",
+  "pool_eligible",
+  "provider",
+  "publication_state",
+  "score",
+  "status",
+] as const;
+
+export const ListSubnetEndpointsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    layer: z.enum(ENDPOINT_LAYERS).optional(),
+    provider: z.string().optional(),
+    publication_state: z.enum(ENDPOINT_PUBLICATION_STATES).optional(),
+    status: z.enum(HEALTH_STATUSES).optional(),
+    pool_eligible: z.enum(BOOLEAN_STRINGS).optional(),
+    min_latency_ms: z.number().optional(),
+    max_latency_ms: z.number().optional(),
+    min_score: z.number().optional(),
+    max_score: z.number().optional(),
+    sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSubnetEndpointsInput = z.infer<
+  typeof ListSubnetEndpointsInputSchema
+>;
+
+export const ListSubnetEndpointsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    endpoints: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSubnetEndpointsOutput = z.infer<
+  typeof ListSubnetEndpointsOutputSchema
+>;
+
+const SURFACE_SORT_FIELDS = [
+  "id",
+  "kind",
+  "name",
+  "netuid",
+  "provider",
+] as const;
+
+export const ListSubnetSurfacesInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    provider: z.string().optional(),
+    id: z.string().optional(),
+    sort: z.enum(SURFACE_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSubnetSurfacesInput = z.infer<
+  typeof ListSubnetSurfacesInputSchema
+>;
+
+export const ListSubnetSurfacesOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    surfaces: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSubnetSurfacesOutput = z.infer<
+  typeof ListSubnetSurfacesOutputSchema
+>;
+
+const HEALTH_CLASSIFICATIONS = [
+  "auth-required",
+  "content-mismatch",
+  "dead",
+  "live",
+  "rate-limited",
+  "redirected",
+  "timeout",
+  "transient",
+  "unsupported",
+  "unsafe",
+  "wrong-chain",
+] as const;
+const HEALTH_SORT_FIELDS = [
+  "classification",
+  "kind",
+  "last_checked",
+  "last_ok",
+  "latency_ms",
+  "netuid",
+  "provider",
+  "status",
+  "status_code",
+  "surface_id",
+  "verified_at",
+] as const;
+
+export const ListSubnetHealthInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    provider: z.string().optional(),
+    status: z.enum(HEALTH_STATUSES).optional(),
+    classification: z.enum(HEALTH_CLASSIFICATIONS).optional(),
+    sort: z.enum(HEALTH_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSubnetHealthInput = z.infer<typeof ListSubnetHealthInputSchema>;
+
+export const ListSubnetHealthOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    surfaces: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSubnetHealthOutput = z.infer<
+  typeof ListSubnetHealthOutputSchema
+>;

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -464,6 +464,50 @@ import {
   GetChainTransferPairsInputSchema,
   GetChainTransferPairsOutputSchema,
 } from "../schemas-src/mcp-tools/chain-transfers.ts";
+import {
+  ListSubnetApisInputSchema,
+  ListSubnetApisOutputSchema,
+  GetApiSchemaInputSchema,
+  GetApiSchemaOutputSchema,
+  GetFixtureInputSchema,
+  GetFixtureOutputSchema,
+  GetProviderDetailInputSchema,
+  GetProviderDetailOutputSchema,
+} from "../schemas-src/mcp-tools/catalog-detail.ts";
+import {
+  ListEndpointsInputSchema,
+  ListEndpointsOutputSchema,
+  GetSubnetEndpointsInputSchema,
+  GetSubnetEndpointsOutputSchema,
+} from "../schemas-src/mcp-tools/endpoints-catalog.ts";
+import {
+  ListProvidersInputSchema,
+  ListProvidersOutputSchema,
+  ListSurfacesInputSchema,
+  ListSurfacesOutputSchema,
+  ListCandidatesInputSchema,
+  ListCandidatesOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-1.ts";
+import {
+  ListEvidenceInputSchema,
+  ListEvidenceOutputSchema,
+  ListRpcEndpointsInputSchema,
+  ListRpcEndpointsOutputSchema,
+  ListRpcPoolsInputSchema,
+  ListRpcPoolsOutputSchema,
+  ListSourceSnapshotsInputSchema,
+  ListSourceSnapshotsOutputSchema,
+  ListProfileCompletenessInputSchema,
+  ListProfileCompletenessOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
+import {
+  ListSubnetEndpointsInputSchema,
+  ListSubnetEndpointsOutputSchema,
+  ListSubnetSurfacesInputSchema,
+  ListSubnetSurfacesOutputSchema,
+  ListSubnetHealthInputSchema,
+  ListSubnetHealthOutputSchema,
+} from "../schemas-src/mcp-tools/subnet-scoped-lists.ts";
 
 type Row = Record<string, unknown>;
 
@@ -734,6 +778,99 @@ const DISTRIBUTION_STATS = {
     max: { type: "number" },
   },
 };
+
+// Batch 9 (#8073) resolved enum values, same treatment as above -- symbolic
+// in the hand-written originals (src/contracts.ts's QUERY_ENUMS.* and
+// API_QUERY_COLLECTIONS.{providers,curated-surfaces,candidates,claims,
+// rpc-pools,sources,profile-completeness}.sort_fields), cross-checked
+// against the actual runtime source at the time of writing. Reuses
+// SURFACE_KIND/HEALTH_STATUS/HEALTH_CLASSIFICATION/HEALTH_SURFACE_SORT_FIELDS/
+// PROFILE_LEVEL already defined above (batches 2-4) -- confirmed identical to
+// this batch's own QUERY_ENUMS.surfaceKind/healthStatus/healthClassification/
+// API_QUERY_COLLECTIONS["health-surfaces"].sort_fields/QUERY_ENUMS.profileLevel
+// values, not just reused by name.
+const PROVIDER_KINDS = [
+  "data-provider",
+  "docs-provider",
+  "infrastructure-provider",
+  "registry",
+  "subnet-team",
+];
+const PROVIDER_AUTHORITIES = [
+  "community",
+  "official",
+  "provider-claimed",
+  "registry-observed",
+];
+const PROVIDER_SORT_FIELDS = ["authority", "id", "kind", "name"];
+const SURFACE_SORT_FIELDS = ["id", "kind", "name", "netuid", "provider"];
+const CANDIDATE_STATES = [
+  "schema-invalid",
+  "schema-valid",
+  "maintainer-review",
+  "verified",
+  "stale",
+  "rejected",
+];
+const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+const CANDIDATES_SORT_FIELDS = [
+  "confidence",
+  "id",
+  "kind",
+  "name",
+  "netuid",
+  "provider",
+  "state",
+];
+const CLAIM_SORT_FIELDS = ["claim", "source_url", "subject", "verified_at"];
+const ENDPOINT_LAYERS = [
+  "bittensor-base",
+  "data-provider",
+  "docs-provider",
+  "subnet-app",
+];
+const ENDPOINT_PUBLICATION_STATES = [
+  "candidate",
+  "verified",
+  "monitored",
+  "pool-eligible",
+  "disabled",
+  "rejected",
+];
+const ENDPOINT_SORT_FIELDS = [
+  "kind",
+  "last_checked",
+  "latency_ms",
+  "layer",
+  "netuid",
+  "pool_eligible",
+  "provider",
+  "publication_state",
+  "score",
+  "status",
+];
+const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"];
+const POOL_SORT_FIELDS = ["eligible_count", "endpoint_count", "id", "kind"];
+const SOURCE_SORT_FIELDS = ["id", "kind", "path", "record_count"];
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
+const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"];
+const PROFILE_SORT_FIELDS = [
+  "candidate_count",
+  "completeness_score",
+  "identity_level",
+  "identity_promotion_kind_count",
+  "identity_surface_count",
+  "live_identity_candidate_kind_count",
+  "missing_critical_count",
+  "name",
+  "native_identity_signal_count",
+  "native_name_quality",
+  "netuid",
+  "priority_score",
+  "profile_level",
+  "stale_identity_candidate_kind_count",
+];
+const BOOLEAN_STRINGS = ["true", "false"];
 
 const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
   search_subnets: {
@@ -5805,6 +5942,582 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  list_subnet_apis: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "service_count", "services"],
+      properties: {
+        netuid: { type: "integer" },
+        service_count: { type: "integer" },
+        services: { type: "array", items: { type: "object" } },
+        operational_observed_at: NULLABLE_STRING,
+        health_source: NULLABLE_STRING,
+      },
+    },
+  },
+  get_api_schema: {
+    input: {
+      type: "object",
+      properties: {
+        surface_id: { type: "string" },
+      },
+      required: ["surface_id"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["surface_id"],
+      properties: {
+        surface_id: { type: "string" },
+        kind: NULLABLE_STRING,
+        base_url: NULLABLE_STRING,
+        auth_required: { type: ["boolean", "null"] },
+        auth_schemes: { type: "array" },
+        drift_status: NULLABLE_STRING,
+        document: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_fixture: {
+    input: {
+      type: "object",
+      properties: {
+        surface_id: { type: "string" },
+      },
+      required: ["surface_id"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["surface_id"],
+      properties: { surface_id: { type: "string" } },
+    },
+  },
+  get_provider_detail: {
+    input: {
+      type: "object",
+      properties: {
+        slug: { type: "string" },
+        include_endpoints: { type: "boolean" },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        id: NULLABLE_STRING,
+        slug: NULLABLE_STRING,
+        name: NULLABLE_STRING,
+        authority: NULLABLE_STRING,
+        kind: NULLABLE_STRING,
+        provider: { type: ["object", "null"] },
+        endpoints: { type: ["object", "array", "null"] },
+      },
+    },
+  },
+  list_providers: {
+    input: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        kind: { type: "string", enum: PROVIDER_KINDS },
+        authority: { type: "string", enum: PROVIDER_AUTHORITIES },
+        sort: { type: "string", enum: PROVIDER_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["providers"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+        providers: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_surfaces: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string", enum: SURFACE_KIND },
+        provider: { type: "string" },
+        id: { type: "string" },
+        sort: { type: "string", enum: SURFACE_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["surfaces"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+        surfaces: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_candidates: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string", enum: SURFACE_KIND },
+        provider: { type: "string" },
+        state: { type: "string", enum: CANDIDATE_STATES },
+        id: { type: "string" },
+        confidence: { type: "string", enum: CONFIDENCE_LEVELS },
+        sort: { type: "string", enum: CANDIDATES_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 1000 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["candidates"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        schema_version: { type: ["string", "integer", "null"] },
+        candidates: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_endpoints: {
+    input: {
+      type: "object",
+      properties: {
+        kind: { type: "string", enum: SURFACE_KIND },
+        layer: { type: "string", enum: ENDPOINT_LAYERS },
+        netuid: { type: "integer", minimum: 0 },
+        provider: { type: "string" },
+        publication_state: {
+          type: "string",
+          enum: ENDPOINT_PUBLICATION_STATES,
+        },
+        status: { type: "string", enum: HEALTH_STATUS },
+        pool_eligible: { type: "boolean" },
+        min_latency_ms: { type: "number" },
+        max_latency_ms: { type: "number" },
+        min_score: { type: "number" },
+        max_score: { type: "number" },
+        sort: { type: "string", enum: ENDPOINT_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        endpoints: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        cursor: { type: "integer" },
+        limit: { type: "integer" },
+        next_cursor: { type: ["integer", "null"] },
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+      },
+    },
+  },
+  list_evidence: {
+    input: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+        sort: { type: "string", enum: CLAIM_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["claims"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+        summary: { type: ["object", "null"] },
+        claims: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_rpc_endpoints: {
+    input: {
+      type: "object",
+      properties: {
+        kind: { type: "string", enum: SURFACE_KIND },
+        layer: { type: "string", enum: ENDPOINT_LAYERS },
+        netuid: { type: "integer", minimum: 0 },
+        provider: { type: "string" },
+        publication_state: {
+          type: "string",
+          enum: ENDPOINT_PUBLICATION_STATES,
+        },
+        status: { type: "string", enum: HEALTH_STATUS },
+        pool_eligible: { type: "boolean" },
+        min_latency_ms: { type: "number" },
+        max_latency_ms: { type: "number" },
+        min_score: { type: "number" },
+        max_score: { type: "number" },
+        sort: { type: "string", enum: ENDPOINT_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: {
+          oneOf: [
+            { type: "string" },
+            { type: "array", items: { type: "string" } },
+          ],
+        },
+        limit: { type: "integer", minimum: 1 },
+        cursor: {
+          oneOf: [{ type: "integer", minimum: 0 }, { type: "string" }],
+        },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["endpoints"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        schema_version: NULLABLE_INT,
+        summary: { type: ["object", "null"] },
+        source: NULLABLE_STRING,
+        operational_observed_at: NULLABLE_STRING,
+        endpoints: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_source_snapshots: {
+    input: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+        sort: { type: "string", enum: SOURCE_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["sources"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+        summary: { type: ["object", "null"] },
+        sources: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_profile_completeness: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        profile_level: { type: "string", enum: PROFILE_LEVEL },
+        confidence: { type: "string", enum: CONFIDENCE_LEVELS },
+        identity_level: { type: "string", enum: IDENTITY_LEVELS },
+        identity_promotion_kinds: { type: "string", enum: SURFACE_KIND },
+        native_name_quality: { type: "string", enum: NATIVE_NAME_QUALITIES },
+        sort: { type: "string", enum: PROFILE_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["profiles"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        summary: { type: ["object", "null"], additionalProperties: true },
+        profiles: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_rpc_pools: {
+    input: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        kind: { type: "string", enum: POOL_KINDS },
+        min_eligible_count: { type: "number" },
+        max_eligible_count: { type: "number" },
+        min_endpoint_count: { type: "number" },
+        max_endpoint_count: { type: "number" },
+        sort: { type: "string", enum: POOL_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["pools"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        source: NULLABLE_STRING,
+        operational_observed_at: NULLABLE_STRING,
+        pools: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  get_subnet_endpoints: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        netuid: { type: ["integer", "null"] },
+        endpoints: { type: "array", items: { type: "object" } },
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+      },
+    },
+  },
+  list_subnet_endpoints: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string", enum: SURFACE_KIND },
+        layer: { type: "string", enum: ENDPOINT_LAYERS },
+        provider: { type: "string" },
+        publication_state: {
+          type: "string",
+          enum: ENDPOINT_PUBLICATION_STATES,
+        },
+        status: { type: "string", enum: HEALTH_STATUS },
+        pool_eligible: { type: "string", enum: BOOLEAN_STRINGS },
+        min_latency_ms: { type: "number" },
+        max_latency_ms: { type: "number" },
+        min_score: { type: "number" },
+        max_score: { type: "number" },
+        sort: { type: "string", enum: ENDPOINT_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["endpoints"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        netuid: NULLABLE_INT,
+        endpoints: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_subnet_surfaces: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string", enum: SURFACE_KIND },
+        provider: { type: "string" },
+        id: { type: "string" },
+        sort: { type: "string", enum: SURFACE_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["surfaces"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        netuid: NULLABLE_INT,
+        surfaces: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_subnet_health: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string", enum: SURFACE_KIND },
+        provider: { type: "string" },
+        status: { type: "string", enum: HEALTH_STATUS },
+        classification: { type: "string", enum: HEALTH_CLASSIFICATION },
+        sort: { type: "string", enum: HEALTH_SURFACE_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["surfaces"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        netuid: NULLABLE_INT,
+        surfaces: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -6365,6 +7078,74 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
     input: GetNetworkActivityInputSchema,
     output: GetNetworkActivityOutputSchema,
   },
+  list_subnet_apis: {
+    input: ListSubnetApisInputSchema,
+    output: ListSubnetApisOutputSchema,
+  },
+  get_api_schema: {
+    input: GetApiSchemaInputSchema,
+    output: GetApiSchemaOutputSchema,
+  },
+  get_fixture: {
+    input: GetFixtureInputSchema,
+    output: GetFixtureOutputSchema,
+  },
+  get_provider_detail: {
+    input: GetProviderDetailInputSchema,
+    output: GetProviderDetailOutputSchema,
+  },
+  list_providers: {
+    input: ListProvidersInputSchema,
+    output: ListProvidersOutputSchema,
+  },
+  list_surfaces: {
+    input: ListSurfacesInputSchema,
+    output: ListSurfacesOutputSchema,
+  },
+  list_candidates: {
+    input: ListCandidatesInputSchema,
+    output: ListCandidatesOutputSchema,
+  },
+  list_endpoints: {
+    input: ListEndpointsInputSchema,
+    output: ListEndpointsOutputSchema,
+  },
+  list_evidence: {
+    input: ListEvidenceInputSchema,
+    output: ListEvidenceOutputSchema,
+  },
+  list_rpc_endpoints: {
+    input: ListRpcEndpointsInputSchema,
+    output: ListRpcEndpointsOutputSchema,
+  },
+  list_source_snapshots: {
+    input: ListSourceSnapshotsInputSchema,
+    output: ListSourceSnapshotsOutputSchema,
+  },
+  list_profile_completeness: {
+    input: ListProfileCompletenessInputSchema,
+    output: ListProfileCompletenessOutputSchema,
+  },
+  list_rpc_pools: {
+    input: ListRpcPoolsInputSchema,
+    output: ListRpcPoolsOutputSchema,
+  },
+  get_subnet_endpoints: {
+    input: GetSubnetEndpointsInputSchema,
+    output: GetSubnetEndpointsOutputSchema,
+  },
+  list_subnet_endpoints: {
+    input: ListSubnetEndpointsInputSchema,
+    output: ListSubnetEndpointsOutputSchema,
+  },
+  list_subnet_surfaces: {
+    input: ListSubnetSurfacesInputSchema,
+    output: ListSubnetSurfacesOutputSchema,
+  },
+  list_subnet_health: {
+    input: ListSubnetHealthInputSchema,
+    output: ListSubnetHealthOutputSchema,
+  },
 };
 
 const MAX_SAFE_INT = Number.MAX_SAFE_INTEGER;
@@ -6436,6 +7217,17 @@ function normalize(node: unknown, path: string): unknown {
     if (key === "$schema" || key === "$id") continue;
     if (key === "description") continue; // issue-sanctioned cosmetic (#7863's own wording)
 
+    // `oneOf` (hand-written, e.g. batch 9's list_rpc_endpoints fields/cursor
+    // params: string-or-array, integer-or-string) vs Zod's `anyOf` for the
+    // equivalent z.union([...]). For branches of distinct JSON Schema
+    // `type`s, the two keywords accept exactly the same values here -- a
+    // value can never simultaneously match two different-`type` branches --
+    // so treat the keyword itself as cosmetic rather than a real difference.
+    if (key === "oneOf") {
+      out.anyOf = normalize(value, `${path}.anyOf`);
+      continue;
+    }
+
     if (
       ACCEPTED_TIGHTENINGS.has(path) &&
       (key === "exclusiveMinimum" || key === "minimum")
@@ -6502,9 +7294,33 @@ function normalize(node: unknown, path: string): unknown {
     out[key] = normalize(value, key === "properties" ? path : `${path}.${key}`);
   }
 
-  if (Array.isArray(out.anyOf) && out.anyOf.length === 1) {
-    Object.assign(out, out.anyOf[0]);
-    delete out.anyOf;
+  if (Array.isArray(out.anyOf)) {
+    // Flatten a nested `anyOf: [{anyOf: [...]}, ...]` -- Zod's
+    // `z.union([A, B, ...]).nullable()` always produces this nested shape
+    // (the union's own anyOf, wrapped in an outer anyOf with the null
+    // branch), where the hand-written original instead declares one flat
+    // N-way `type: [...]` array (already rewritten to a single flat anyOf by
+    // the type-split rule above, e.g. batch 9's schema_version:
+    // {type:["string","integer","null"]} vs
+    // z.union([z.string(), z.int()]).nullable()). OR distributes over OR, so
+    // a nested and a flattened anyOf accept exactly the same values --
+    // splice a branch's own sub-list into the parent when that branch is
+    // NOTHING but an anyOf (no other sibling keys that would make inlining
+    // lossy), batch 9, #8073.
+    const flattened = (out.anyOf as unknown[]).flatMap((branch) =>
+      branch &&
+      typeof branch === "object" &&
+      !Array.isArray(branch) &&
+      Object.keys(branch as Row).length === 1 &&
+      Array.isArray((branch as Row).anyOf)
+        ? ((branch as Row).anyOf as unknown[])
+        : [branch],
+    );
+    out.anyOf = flattened;
+    if (flattened.length === 1) {
+      Object.assign(out, flattened[0]);
+      delete out.anyOf;
+    }
   }
 
   return sortKeys(out);

--- a/src/candidates-mcp.ts
+++ b/src/candidates-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/candidates.json artifact (mirrors gaps-mcp.ts for GET /api/v1/gaps).
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListCandidatesInputSchema,
+  ListCandidatesOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-1.ts";
 
 export const CANDIDATES_ARTIFACT = "/metagraph/candidates.json";
 
@@ -210,92 +215,14 @@ export const LIST_CANDIDATES_MCP_TOOL = {
     "Filter by netuid/kind/provider/state/id/confidence, sort with sort + order, " +
     "and page with limit (1-1000) / cursor — the full catalog can be large. " +
     "Mirrors GET /api/v1/candidates.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Subnet netuid.",
-        minimum: 0,
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
-      },
-      provider: {
-        type: "string",
-        description: "Provider slug, e.g. 'datura'.",
-      },
-      state: {
-        type: "string",
-        enum: CANDIDATE_STATES,
-        description: "Review state, e.g. 'schema-valid' or 'verified'.",
-      },
-      id: {
-        type: "string",
-        description:
-          "Exact candidate surface id match (case-insensitive), e.g. 'sn-7-openapi'.",
-      },
-      confidence: {
-        type: "string",
-        enum: CONFIDENCE_LEVELS,
-        description: "Confidence level: low, medium, or high.",
-      },
-      sort: {
-        type: "string",
-        enum: CANDIDATES_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of candidate row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description:
-          "Max candidates to return (1-1000). Omit for the full filtered list.",
-        minimum: 1,
-        maximum: 1000,
-      },
-      cursor: {
-        type: "integer",
-        description:
-          "Pagination cursor from a prior response's next_cursor. Default 0.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListCandidatesInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_CANDIDATES_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["candidates"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    schema_version: { type: ["string", "integer", "null"] },
-    candidates: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_CANDIDATES_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListCandidatesOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/evidence-mcp.ts
+++ b/src/evidence-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/evidence-ledger.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
+import {
+  ListEvidenceInputSchema,
+  ListEvidenceOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
 
 export const EVIDENCE_LEDGER_ARTIFACT = "/metagraph/evidence-ledger.json";
 
@@ -189,63 +194,14 @@ export const LIST_EVIDENCE_MCP_TOOL = {
     "source_url, and support_summary; sort with sort + order; project with " +
     "fields; and page with limit (1-100) / cursor. Distinct from " +
     "list_subnet_evidence (one subnet's claims). Mirrors GET /api/v1/evidence.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      q: {
-        type: "string",
-        description:
-          "Keyword search across subject, claim, source_url, and support_summary.",
-      },
-      sort: {
-        type: "string",
-        enum: CLAIM_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of claim row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListEvidenceInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_EVIDENCE_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["claims"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    schema_version: { type: ["string", "integer", "null"] },
-    summary: { type: ["object", "null"] },
-    claims: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_EVIDENCE_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListEvidenceOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -672,6 +672,39 @@ import {
   GetExtrinsicChainEventsOutputSchema,
 } from "../schemas-src/mcp-tools/chain-events.ts";
 import {
+  ListSubnetApisInputSchema,
+  ListSubnetApisOutputSchema,
+  GetApiSchemaInputSchema,
+  GetApiSchemaOutputSchema,
+  GetFixtureInputSchema,
+  GetFixtureOutputSchema,
+  GetProviderDetailInputSchema,
+  GetProviderDetailOutputSchema,
+} from "../schemas-src/mcp-tools/catalog-detail.ts";
+import {
+  ListEndpointsInputSchema,
+  ListEndpointsOutputSchema,
+  GetSubnetEndpointsInputSchema,
+  GetSubnetEndpointsOutputSchema,
+} from "../schemas-src/mcp-tools/endpoints-catalog.ts";
+import {
+  ListProvidersInputSchema,
+  ListSurfacesInputSchema,
+  ListCandidatesInputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-1.ts";
+import {
+  ListEvidenceInputSchema,
+  ListRpcEndpointsInputSchema,
+  ListRpcPoolsInputSchema,
+  ListSourceSnapshotsInputSchema,
+  ListProfileCompletenessInputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
+import {
+  ListSubnetEndpointsInputSchema,
+  ListSubnetSurfacesInputSchema,
+  ListSubnetHealthInputSchema,
+} from "../schemas-src/mcp-tools/subnet-scoped-lists.ts";
+import {
   GetChainConcentrationInputSchema,
   GetChainConcentrationOutputSchema,
   GetChainPerformanceInputSchema,
@@ -8154,15 +8187,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "List the callable services (subnet-api, openapi, sse) one subnet " +
       "exposes, each with base URL, auth requirement, machine-readable schema " +
       "URL, current health, and call eligibility. The agent integration path.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListSubnetApisInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof ListSubnetApisInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const staticDetail = await loadArtifactData(
         ctx,
@@ -8191,19 +8222,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "metadata (auth_required, auth_schemes, drift_status). Use it to " +
       "generate a typed client or understand endpoints; prefer the curated " +
       "surface base_url over any upstream server/callback hints.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        surface_id: {
-          type: "string",
-          description:
-            "Surface id (slug-style), e.g. 'allways-docs' or 'sn-64-chutes-openapi'.",
-        },
-      },
-      required: ["surface_id"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetApiSchemaInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetApiSchemaInputSchema>, ctx: McpCtx) {
       const surfaceId = requireString(args, "surface_id");
       // surface_id is part of an R2 key path; reject anything that could escape
       // the schemas/ namespace.
@@ -8227,19 +8249,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "returns — the real shape, not just what its schema claims — so you can " +
       "code against it. Credentials/secrets are redacted and large values " +
       "truncated; treat field values as untrusted data.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        surface_id: {
-          type: "string",
-          description:
-            "Surface id (slug-style), e.g. 'allways-docs' or 'sn-64-chutes-openapi'.",
-        },
-      },
-      required: ["surface_id"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetFixtureInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetFixtureInputSchema>, ctx: McpCtx) {
       // #7867: shared loadFixture — same surface_id charset gate, deprecated-id
       // alias resolve, and artifact read GraphQL fixture(surface_id) uses.
       return loadFixture(asMcpLoaderCtx(ctx), args);
@@ -8257,25 +8270,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "MCP detail serves the catalogued endpoints). Mirrors " +
       "GET /api/v1/providers/{slug} (+ /endpoints). Discover slugs via the " +
       "providers list at /metagraph/providers.json.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        slug: {
-          type: "string",
-          description:
-            "Provider slug (slug-style), e.g. 'datura' or 'rayonlabs'.",
-        },
-        include_endpoints: {
-          type: "boolean",
-          description:
-            "When true, also attach the provider's catalogued endpoints under " +
-            "`endpoints` (the detail moves under `provider`). Default false.",
-        },
-      },
-      required: ["slug"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetProviderDetailInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetProviderDetailInputSchema>,
+      ctx: McpCtx,
+    ) {
       const slug = requireString(args, "slug");
       // slug is part of an R2 key path; reject anything that could escape the
       // providers/ namespace.
@@ -8291,19 +8292,22 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...LIST_PROVIDERS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListProvidersInputSchema>, ctx: McpCtx) {
       return loadProvidersList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_SURFACES_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListSurfacesInputSchema>, ctx: McpCtx) {
       return loadSurfacesList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_CANDIDATES_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListCandidatesInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadCandidatesList(asMcpLoaderCtx(ctx), args);
     },
   },
@@ -8320,85 +8324,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "and min_/max_score, sort with sort + order, project a subset of fields " +
       "with fields, and page with limit/cursor — the full catalog can be " +
       "large. Mirrors GET /api/v1/endpoints.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        kind: {
-          type: "string",
-          enum: QUERY_ENUMS.surfaceKind,
-          description: "Surface kind, e.g. 'subnet-api' or 'openapi'.",
-        },
-        layer: {
-          type: "string",
-          enum: QUERY_ENUMS.endpointLayer,
-          description: "Endpoint layer, e.g. 'subnet-app' or 'bittensor-base'.",
-        },
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-        provider: {
-          type: "string",
-          description: "Provider slug, e.g. 'datura'.",
-        },
-        publication_state: {
-          type: "string",
-          enum: QUERY_ENUMS.endpointPublicationState,
-          description:
-            "Publication state, e.g. 'monitored' or 'pool-eligible'.",
-        },
-        status: {
-          type: "string",
-          enum: QUERY_ENUMS.healthStatus,
-          description: "Probe-derived health status, e.g. 'ok' or 'degraded'.",
-        },
-        pool_eligible: {
-          type: "boolean",
-          description: "Only endpoints eligible (or not) for RPC pooling.",
-        },
-        min_latency_ms: {
-          type: "number",
-          description: "Only endpoints with probe-derived latency_ms >= this.",
-        },
-        max_latency_ms: {
-          type: "number",
-          description: "Only endpoints with probe-derived latency_ms <= this.",
-        },
-        min_score: {
-          type: "number",
-          description: "Only endpoints with probe-derived score >= this.",
-        },
-        max_score: {
-          type: "number",
-          description: "Only endpoints with probe-derived score <= this.",
-        },
-        sort: {
-          type: "string",
-          enum: ENDPOINT_SORT_FIELDS,
-          description: "Field to sort by before paging.",
-        },
-        order: {
-          type: "string",
-          enum: ["asc", "desc"],
-          description: "Sort direction for sort (default asc).",
-        },
-        fields: {
-          type: "string",
-          description:
-            "Comma-separated projection of endpoint row fields to return.",
-        },
-        limit: {
-          type: "integer",
-          description: "Max endpoints to return. Omit for the full list.",
-          minimum: 1,
-        },
-        cursor: {
-          type: "integer",
-          description:
-            "Pagination cursor from a prior response's next_cursor. Default 0.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListEndpointsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof ListEndpointsInputSchema>, ctx: McpCtx) {
       const kind = optionalEnum(args, "kind", QUERY_ENUMS.surfaceKind);
       const layer = optionalEnum(args, "layer", QUERY_ENUMS.endpointLayer);
       const netuid = optionalNonNegativeInt(args, "netuid");
@@ -8419,7 +8348,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         "max_latency_ms",
         "min_score",
         "max_score",
-      ].filter((arg) => Number.isFinite(args?.[arg]));
+      ].filter((arg) =>
+        Number.isFinite((args as Record<string, unknown>)?.[arg]),
+      );
       const sort = optionalEnum(args, "sort", ENDPOINT_SORT_FIELDS);
       const order = optionalEnum(args, "order", ["asc", "desc"]);
       const fields = optionalString(args, "fields");
@@ -8466,7 +8397,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         queryUrl.searchParams.set("pool_eligible", String(poolEligible));
       }
       for (const arg of rangeArgs) {
-        queryUrl.searchParams.set(arg, String(args[arg]));
+        queryUrl.searchParams.set(
+          arg,
+          String((args as Record<string, unknown>)[arg]),
+        );
       }
       if (sort) queryUrl.searchParams.set("sort", sort);
       if (order) queryUrl.searchParams.set("order", order);
@@ -8501,31 +8435,40 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...LIST_EVIDENCE_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListEvidenceInputSchema>, ctx: McpCtx) {
       return loadEvidenceList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_RPC_ENDPOINTS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListRpcEndpointsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadRpcEndpointsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_SOURCE_SNAPSHOTS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListSourceSnapshotsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadSourceSnapshotsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_PROFILE_COMPLETENESS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListProfileCompletenessInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadProfileCompletenessList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_RPC_POOLS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListRpcPoolsInputSchema>, ctx: McpCtx) {
       return loadRpcPoolsList(asMcpLoaderCtx(ctx), args);
     },
   },
@@ -8538,15 +8481,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "probe-derived status/latency/score. The per-subnet view of " +
       "list_endpoints (the network-wide catalog). Mirrors " +
       "GET /api/v1/subnets/{netuid}/endpoints.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetEndpointsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetEndpointsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       const data = await loadArtifactData(
         ctx,
@@ -8568,19 +8509,28 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...LIST_SUBNET_ENDPOINTS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListSubnetEndpointsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadSubnetEndpointsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_SUBNET_SURFACES_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListSubnetSurfacesInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadSubnetSurfacesList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_SUBNET_HEALTH_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListSubnetHealthInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadSubnetHealthList(asMcpLoaderCtx(ctx), args);
     },
   },
@@ -10928,76 +10878,24 @@ const TOOL_OUTPUT_SCHEMAS = {
       buckets: RPC_USAGE_BUCKETS,
     },
   },
-  list_subnet_apis: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "service_count", "services"],
-    properties: {
-      netuid: { type: "integer" },
-      service_count: { type: "integer" },
-      services: { type: "array", items: { type: "object" } },
-      operational_observed_at: NULLABLE_STRING,
-      health_source: NULLABLE_STRING,
-    },
-  },
-  get_api_schema: {
-    type: "object",
-    additionalProperties: true,
-    required: ["surface_id"],
-    properties: {
-      surface_id: { type: "string" },
-      kind: NULLABLE_STRING,
-      base_url: NULLABLE_STRING,
-      auth_required: { type: ["boolean", "null"] },
-      auth_schemes: { type: "array" },
-      drift_status: NULLABLE_STRING,
-      document: { type: ["object", "null"] },
-    },
-  },
-  get_fixture: {
-    type: "object",
-    additionalProperties: true,
-    required: ["surface_id"],
-    properties: { surface_id: { type: "string" } },
-  },
-  get_provider_detail: {
-    // Two shapes: the bare provider detail (default) or {provider, endpoints}
-    // when include_endpoints is set. Both are operator-controlled artifact
-    // payloads, so nothing is required; the keys below describe each shape when
-    // present.
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      id: NULLABLE_STRING,
-      slug: NULLABLE_STRING,
-      name: NULLABLE_STRING,
-      authority: NULLABLE_STRING,
-      kind: NULLABLE_STRING,
-      provider: { type: ["object", "null"] },
-      endpoints: { type: ["object", "array", "null"] },
-    },
-  },
+  list_subnet_apis: z.toJSONSchema(ListSubnetApisOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_api_schema: z.toJSONSchema(GetApiSchemaOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_fixture: z.toJSONSchema(GetFixtureOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_provider_detail: z.toJSONSchema(GetProviderDetailOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_providers: LIST_PROVIDERS_OUTPUT_SCHEMA,
   list_surfaces: LIST_SURFACES_OUTPUT_SCHEMA,
   list_candidates: LIST_CANDIDATES_OUTPUT_SCHEMA,
-  list_endpoints: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      endpoints: { type: "array", items: { type: "object" } },
-      total: { type: "integer" },
-      returned: { type: "integer" },
-      cursor: { type: "integer" },
-      limit: { type: "integer" },
-      next_cursor: { type: ["integer", "null"] },
-      sort: NULLABLE_STRING,
-      order: NULLABLE_STRING,
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_endpoints: z.toJSONSchema(ListEndpointsOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_subnet_surfaces: {
     type: "object",
     additionalProperties: true,
@@ -11033,17 +10931,9 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   list_subnet_candidates: LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA,
-  get_subnet_endpoints: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      netuid: { type: ["integer", "null"] },
-      endpoints: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  get_subnet_endpoints: z.toJSONSchema(GetSubnetEndpointsOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_subnet_endpoints: LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
   list_subnet_surfaces: LIST_SUBNET_SURFACES_OUTPUT_SCHEMA,
   list_subnet_health: LIST_SUBNET_HEALTH_OUTPUT_SCHEMA,

--- a/src/profile-completeness-mcp.ts
+++ b/src/profile-completeness-mcp.ts
@@ -3,9 +3,14 @@
 // transforms as the REST route over the baked
 // /metagraph/review/profile-completeness.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListProfileCompletenessInputSchema,
+  ListProfileCompletenessOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
 
 export const PROFILE_COMPLETENESS_ARTIFACT =
   "/metagraph/review/profile-completeness.json";
@@ -226,92 +231,14 @@ export const LIST_PROFILE_COMPLETENESS_MCP_TOOL = {
     "identity_promotion_kinds, or native_name_quality; sort with sort + order; " +
     "and page with limit (1-100) / cursor. Use it to find high-value profile " +
     "contributions. Mirrors GET /api/v1/review/profile-completeness.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      profile_level: {
-        type: "string",
-        enum: PROFILE_LEVELS,
-        description: "Filter by profile completeness level.",
-      },
-      confidence: {
-        type: "string",
-        enum: CONFIDENCE_LEVELS,
-        description: "Filter by confidence level.",
-      },
-      identity_level: {
-        type: "string",
-        enum: IDENTITY_LEVELS,
-        description: "Filter by subnet identity completeness.",
-      },
-      identity_promotion_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description:
-          "Filter rows whose identity promotion kinds include this surface kind.",
-      },
-      native_name_quality: {
-        type: "string",
-        enum: NATIVE_NAME_QUALITIES,
-        description: "Filter by native name quality.",
-      },
-      sort: {
-        type: "string",
-        enum: PROFILE_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of profile row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListProfileCompletenessInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["profiles"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    summary: { type: ["object", "null"], additionalProperties: true },
-    profiles: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_PROFILE_COMPLETENESS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListProfileCompletenessOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/providers-mcp.ts
+++ b/src/providers-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/providers.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListProvidersInputSchema,
+  ListProvidersOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-1.ts";
 
 export const PROVIDERS_ARTIFACT = "/metagraph/providers.json";
 
@@ -187,70 +192,14 @@ export const LIST_PROVIDERS_MCP_TOOL = {
     "project with fields; and page with limit (1-100) / cursor. This is the list " +
     "counterpart to get_provider_detail (one provider by slug). Mirrors " +
     "GET /api/v1/providers.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      id: {
-        type: "string",
-        description: "Provider slug, e.g. 'datura'.",
-      },
-      kind: {
-        type: "string",
-        enum: PROVIDER_KINDS,
-        description: "Provider kind, e.g. 'data-provider' or 'registry'.",
-      },
-      authority: {
-        type: "string",
-        enum: PROVIDER_AUTHORITIES,
-        description: "Trust authority, e.g. 'official' or 'community'.",
-      },
-      sort: {
-        type: "string",
-        enum: PROVIDER_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description: "Comma-separated projection of provider fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListProvidersInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_PROVIDERS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["providers"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    schema_version: { type: ["string", "integer", "null"] },
-    providers: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_PROVIDERS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListProvidersOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -8,11 +8,16 @@
 // mirrors provider-endpoints-mcp.ts (endpoints collection filters) and
 // rpc-pools-mcp.ts (live overlay before filter).
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
 import { mergeRpcEndpoints } from "./health-serving.ts";
+import {
+  ListRpcEndpointsInputSchema,
+  ListRpcEndpointsOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
 
 export const RPC_ENDPOINTS_ARTIFACT = "/metagraph/rpc-endpoints.json";
 
@@ -309,126 +314,14 @@ export const LIST_RPC_ENDPOINTS_MCP_TOOL = {
     "with limit / cursor. This is the full-catalog view; use " +
     "get_best_rpc_endpoint instead to pick one live-healthy endpoint. " +
     "Mirrors GET /api/v1/rpc/endpoints.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Surface kind, e.g. 'subtensor-rpc' or 'subtensor-wss'.",
-      },
-      layer: {
-        type: "string",
-        enum: ENDPOINT_LAYERS,
-        description: "Endpoint layer, e.g. 'bittensor-base'.",
-      },
-      netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      provider: {
-        type: "string",
-        description: "Provider slug, e.g. 'opentensor'.",
-      },
-      publication_state: {
-        type: "string",
-        enum: PUBLICATION_STATES,
-        description: "Filter by publication state.",
-      },
-      status: {
-        type: "string",
-        enum: HEALTH_STATUSES,
-        description: "Filter by probe-derived health status.",
-      },
-      pool_eligible: {
-        type: "boolean",
-        description: "Only endpoints eligible (or not) for RPC pooling.",
-      },
-      min_latency_ms: {
-        type: "number",
-        description: "Keep endpoints with latency_ms >= this bound.",
-      },
-      max_latency_ms: {
-        type: "number",
-        description: "Keep endpoints with latency_ms <= this bound.",
-      },
-      min_score: {
-        type: "number",
-        description: "Keep endpoints with score >= this bound.",
-      },
-      max_score: {
-        type: "number",
-        description: "Keep endpoints with score <= this bound.",
-      },
-      sort: {
-        type: "string",
-        enum: ENDPOINT_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        oneOf: [
-          {
-            type: "string",
-            description:
-              "Comma-separated projection of endpoint row fields to return.",
-          },
-          {
-            type: "array",
-            items: { type: "string" },
-            description: "Field names to return.",
-          },
-        ],
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (clamped to REST parity).",
-        minimum: 1,
-      },
-      cursor: {
-        oneOf: [
-          {
-            type: "integer",
-            description:
-              "Pagination cursor from a prior response's next_cursor.",
-            minimum: 0,
-          },
-          {
-            type: "string",
-            description: "String-form pagination cursor.",
-          },
-        ],
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListRpcEndpointsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["endpoints"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    schema_version: NULLABLE_INT,
-    summary: { type: ["object", "null"] },
-    source: NULLABLE_STRING,
-    operational_observed_at: NULLABLE_STRING,
-    endpoints: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListRpcEndpointsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/rpc-pools-mcp.ts
+++ b/src/rpc-pools-mcp.ts
@@ -7,11 +7,16 @@
 // endpoint-pools-mcp.ts (the generalized sibling collection), which has no
 // live-overlay step of its own.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
 import { overlayRpcPoolEligibility } from "./health-serving.ts";
+import {
+  ListRpcPoolsInputSchema,
+  ListRpcPoolsOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
 
 export const RPC_POOLS_ARTIFACT = "/metagraph/rpc/pools.json";
 
@@ -248,86 +253,14 @@ export const LIST_RPC_POOLS_MCP_TOOL = {
     "list_rpc_endpoints (the individual endpoints), get_best_rpc_endpoint (the " +
     "pick-one shortcut), and list_endpoint_pools (the generalized sibling). " +
     "Mirrors GET /api/v1/rpc/pools.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      id: {
-        type: "string",
-        description: "Filter to one pool id, e.g. 'finney-rpc'.",
-      },
-      kind: {
-        type: "string",
-        enum: POOL_KINDS,
-        description: "Filter by pool kind.",
-      },
-      min_eligible_count: {
-        type: "number",
-        description: "Keep pools with eligible_count >= this bound.",
-      },
-      max_eligible_count: {
-        type: "number",
-        description: "Keep pools with eligible_count <= this bound.",
-      },
-      min_endpoint_count: {
-        type: "number",
-        description: "Keep pools with endpoint_count >= this bound.",
-      },
-      max_endpoint_count: {
-        type: "number",
-        description: "Keep pools with endpoint_count <= this bound.",
-      },
-      sort: {
-        type: "string",
-        enum: POOL_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description: "Comma-separated projection of pool row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListRpcPoolsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_RPC_POOLS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["pools"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    source: NULLABLE_STRING,
-    operational_observed_at: NULLABLE_STRING,
-    pools: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_RPC_POOLS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListRpcPoolsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/source-snapshots-mcp.ts
+++ b/src/source-snapshots-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/source-snapshots.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
+import {
+  ListSourceSnapshotsInputSchema,
+  ListSourceSnapshotsOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
 
 export const SOURCE_SNAPSHOTS_ARTIFACT = "/metagraph/source-snapshots.json";
 
@@ -189,61 +194,14 @@ export const LIST_SOURCE_SNAPSHOTS_MCP_TOOL = {
     "(1-100) / cursor. Use it to detect when a source's underlying data " +
     "changed (hash drift) or to see how many records each source contributed. " +
     "Mirrors GET /api/v1/source-snapshots.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      q: {
-        type: "string",
-        description: "Keyword search across source id, kind, and path.",
-      },
-      sort: {
-        type: "string",
-        enum: SOURCE_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description: "Comma-separated projection of source fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSourceSnapshotsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["sources"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    schema_version: { type: ["string", "integer", "null"] },
-    summary: { type: ["object", "null"] },
-    sources: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSourceSnapshotsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/subnet-endpoints-mcp.ts
+++ b/src/subnet-endpoints-mcp.ts
@@ -3,9 +3,14 @@
 // transforms as the REST route over the baked
 // /metagraph/endpoints/{netuid}.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListSubnetEndpointsInputSchema,
+  ListSubnetEndpointsOutputSchema,
+} from "../schemas-src/mcp-tools/subnet-scoped-lists.ts";
 
 const ENDPOINT_SORT_FIELDS = API_QUERY_COLLECTIONS.endpoints.sort_fields;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
@@ -258,108 +263,14 @@ export const LIST_SUBNET_ENDPOINTS_MCP_TOOL = {
     "sort with sort + order; and page with limit (1-100) / cursor. Distinct from " +
     "get_subnet_endpoints (raw artifact dump) and list_endpoints (network-wide " +
     "catalog). Mirrors GET /api/v1/subnets/{netuid}/endpoints.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Subnet netuid.",
-        minimum: 0,
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter by surface kind, e.g. 'subnet-api'.",
-      },
-      layer: {
-        type: "string",
-        enum: ENDPOINT_LAYERS,
-        description: "Filter by endpoint layer.",
-      },
-      provider: {
-        type: "string",
-        description: "Filter by provider slug.",
-      },
-      publication_state: {
-        type: "string",
-        enum: PUBLICATION_STATES,
-        description: "Filter by publication state.",
-      },
-      status: {
-        type: "string",
-        enum: HEALTH_STATUSES,
-        description: "Filter by probe-derived health status.",
-      },
-      pool_eligible: {
-        type: "string",
-        enum: BOOLEAN_STRINGS,
-        description: "Filter by whether the endpoint is pool-eligible.",
-      },
-      min_latency_ms: {
-        type: "number",
-        description: "Inclusive minimum probe latency in milliseconds.",
-      },
-      max_latency_ms: {
-        type: "number",
-        description: "Inclusive maximum probe latency in milliseconds.",
-      },
-      min_score: {
-        type: "number",
-        description: "Inclusive minimum probe score.",
-      },
-      max_score: {
-        type: "number",
-        description: "Inclusive maximum probe score.",
-      },
-      sort: {
-        type: "string",
-        enum: ENDPOINT_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of endpoint row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    required: ["netuid"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSubnetEndpointsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["endpoints"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    netuid: NULLABLE_INT,
-    endpoints: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSubnetEndpointsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/subnet-health-mcp.ts
+++ b/src/subnet-health-mcp.ts
@@ -3,9 +3,14 @@
 // transforms as the REST route over the baked
 // /metagraph/health/subnets/{netuid}.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListSubnetHealthInputSchema,
+  ListSubnetHealthOutputSchema,
+} from "../schemas-src/mcp-tools/subnet-scoped-lists.ts";
 
 const HEALTH_SORT_FIELDS = API_QUERY_COLLECTIONS["health-surfaces"].sort_fields;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
@@ -218,77 +223,14 @@ export const LIST_SUBNET_HEALTH_MCP_TOOL = {
     "or classification; sort with sort + order; and page with limit (1-100) / " +
     "cursor. The filtered sibling of get_subnet_health (raw artifact dump). " +
     "Mirrors GET /api/v1/subnets/{netuid}/health.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Subnet netuid.",
-        minimum: 0,
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter by surface kind, e.g. 'subnet-api'.",
-      },
-      provider: {
-        type: "string",
-        description: "Filter by provider slug.",
-      },
-      status: {
-        type: "string",
-        enum: HEALTH_STATUSES,
-        description: "Filter by probe-derived health status.",
-      },
-      classification: {
-        type: "string",
-        enum: HEALTH_CLASSIFICATIONS,
-        description: "Filter by probe-derived reachability classification.",
-      },
-      sort: {
-        type: "string",
-        enum: HEALTH_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    required: ["netuid"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSubnetHealthInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SUBNET_HEALTH_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["surfaces"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    netuid: NULLABLE_INT,
-    surfaces: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SUBNET_HEALTH_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSubnetHealthOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/subnet-surfaces-mcp.ts
+++ b/src/subnet-surfaces-mcp.ts
@@ -3,9 +3,14 @@
 // transforms as the REST route over the baked
 // /metagraph/surfaces/{netuid}.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListSubnetSurfacesInputSchema,
+  ListSubnetSurfacesOutputSchema,
+} from "../schemas-src/mcp-tools/subnet-scoped-lists.ts";
 
 const SURFACE_SORT_FIELDS =
   API_QUERY_COLLECTIONS["curated-surfaces"].sort_fields;
@@ -205,71 +210,14 @@ export const LIST_SUBNET_SURFACES_MCP_TOOL = {
     "Filter by kind, provider, or id; sort with sort + order; and page with " +
     "limit (1-100) / cursor. The filtered sibling of get_subnet_surfaces (raw " +
     "artifact dump). Mirrors GET /api/v1/subnets/{netuid}/surfaces.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Subnet netuid.",
-        minimum: 0,
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter by surface kind, e.g. 'subnet-api'.",
-      },
-      provider: {
-        type: "string",
-        description: "Filter by provider slug.",
-      },
-      id: {
-        type: "string",
-        description: "Filter to a single surface id.",
-      },
-      sort: {
-        type: "string",
-        enum: SURFACE_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    required: ["netuid"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSubnetSurfacesInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SUBNET_SURFACES_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["surfaces"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    netuid: NULLABLE_INT,
-    surfaces: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SUBNET_SURFACES_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSubnetSurfacesOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/surfaces-mcp.ts
+++ b/src/surfaces-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/surfaces.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListSurfacesInputSchema,
+  ListSurfacesOutputSchema,
+} from "../schemas-src/mcp-tools/registry-catalogs-1.ts";
 
 export const SURFACES_ARTIFACT = "/metagraph/surfaces.json";
 
@@ -198,74 +203,14 @@ export const LIST_SURFACES_MCP_TOOL = {
     "fields; and page with limit (1-100) / cursor. Distinct from " +
     "get_subnet_surfaces (one subnet's raw artifact dump). Mirrors " +
     "GET /api/v1/surfaces.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Filter by subnet netuid.",
-        minimum: 0,
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Surface kind, e.g. 'openapi' or 'subnet-api'.",
-      },
-      provider: {
-        type: "string",
-        description: "Provider slug, e.g. 'datura'.",
-      },
-      id: {
-        type: "string",
-        description: "Exact surface id, to narrow to a single surface.",
-      },
-      sort: {
-        type: "string",
-        enum: SURFACE_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description: "Comma-separated projection of surface fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSurfacesInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SURFACES_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["surfaces"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    schema_version: { type: ["string", "integer", "null"] },
-    surfaces: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SURFACES_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSurfacesOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/tests/candidates-mcp.test.ts
+++ b/tests/candidates-mcp.test.ts
@@ -400,9 +400,13 @@ describe("candidates-mcp (#7889)", () => {
     assert.ok(tool);
     assert.equal(tool.name, LIST_CANDIDATES_MCP_TOOL.name);
     assert.equal(tool.title, "List unpromoted candidate surfaces");
-    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties.id);
-    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties.confidence);
-    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties.sort);
-    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties.order);
+    // inputSchema is now z.toJSONSchema(...) output (types-epic E, #8073):
+    // `properties` is structurally optional on the generic JSON Schema type,
+    // even though it's always present in practice for this tool -- optional
+    // chaining satisfies tsc without changing what's actually asserted.
+    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties?.id);
+    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties?.confidence);
+    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties?.sort);
+    assert.ok(LIST_CANDIDATES_MCP_TOOL.inputSchema.properties?.order);
   });
 });


### PR DESCRIPTION
## Summary
Converts 17 MCP tools' hand-written JSON Schema `inputSchema`/output-schema literals to Zod-generated (`z.toJSONSchema(...)`), continuing types-epic E (#7863): `list_subnet_apis`, `get_api_schema`, `get_fixture`, `get_provider_detail`, `list_providers`, `list_surfaces`, `list_candidates`, `list_endpoints`, `list_evidence`, `list_rpc_endpoints`, `list_source_snapshots`, `list_profile_completeness`, `list_rpc_pools`, `get_subnet_endpoints`, `list_subnet_endpoints`, `list_subnet_surfaces`, `list_subnet_health`.

New pattern in this batch: 11 of the 17 tools aren't defined inline in `src/mcp-server.ts` — each has its own `src/<name>-mcp.ts` file exporting a `LIST_X_MCP_TOOL`/`LIST_X_OUTPUT_SCHEMA` pair, spread into `mcp-server.ts`'s `MCP_TOOLS` array. The `z.toJSONSchema(...)` wiring lives in each of those 11 files; `mcp-server.ts` only needed its wrapper handlers' `args` retyped to `z.infer<typeof <Tool>InputSchema>`.

## Diff-audit results
`npx tsx scripts/diff-mcp-tool-schemas.ts`: **312/314 PASS**. 0 new findings for this batch — all 34 input+output checks for the 17 tools above PASS. The 2 remaining DIFFs are pre-existing, already-documented findings from #8067 (`get_subnet_identity_history`) and #8069 (`get_account_identity_history`), unrelated to this batch.

Extended the audit script's `normalize()` with two new equivalence rules, both provable JSON-Schema-semantic equivalences rather than special-cased silencing:
- **`oneOf` vs `anyOf`**: `list_rpc_endpoints`' hand-written `fields`/`cursor` params use `oneOf` (string-or-array, integer-or-string); Zod's `z.union([...])` emits `anyOf`. For branches of distinct JSON Schema `type`s, a value can never match two different-`type` branches simultaneously, so the keyword itself is cosmetic.
- **Nested `anyOf` flattening**: Zod's `z.union([A, B]).nullable()` always emits a *nested* `anyOf: [{anyOf: [A, B]}, {type: "null"}]`, where a hand-written `type: ["A", "B", "null"]` normalizes (via the existing type-split rule) to one *flat* 3-way `anyOf`. OR distributes over OR, so the two are semantically identical — this recurred across ~9 of this batch's tools (`schema_version: string|integer|null`, `notes: array|string|null`, `endpoints: object|array|null`), so it's a systemic rule, not a one-off.

## Bug caught and fixed before merge
`list_subnet_apis`' `services` field used the fully-open `OpenArraySchema` (`z.array(z.unknown())`, any item type) where the hand-written original constrained items to objects (`items: {type: "object"}`). Narrowed to `z.array(OpenObjectSchema)` to match — the diff-audit caught this as a real DIFF, not a false positive.

## Reuse / genuine-variance notes
- `list_rpc_endpoints`/`list_endpoints`'s `pool_eligible` is a plain boolean; `list_subnet_endpoints`'s is a string enum `["true","false"]` for the same filter name — a pre-existing inconsistency, preserved as-is rather than "fixed" to match.
- `list_rpc_pools` and `list_profile_completeness` have no `schema_version` output field at all, unlike every sibling in this batch.
- `list_rpc_endpoints`'s `schema_version` is a plain nullable integer, unlike every sibling's `string|integer|null` union.
- None of this batch's 17 tools mirror an existing `schemas-src/routes/` REST schema — all modeled fresh, matching each hand-written literal field-for-field.

## Cleanup
Removed the now-dead local `NULLABLE_STRING`/`NULLABLE_INT` constants from each of the 11 individually-edited `src/*-mcp.ts` files (their only use was the literal being replaced).

## Verification
- `npx tsc --noEmit -p .` — clean.
- `npx eslint` across all 19 touched/created files — clean.
- `npx prettier --check` — clean.
- `npx tsx scripts/diff-mcp-tool-schemas.ts` — 312/314 PASS (see above).
- `npx tsx scripts/validate-mcp.ts` — 204 tools, all MCP lifecycle/dispatch checks pass.
- Zero JSON Schema object literals remain for these 17 tools (grep-verified).

## Test plan
- [x] `npx vitest run tests/mcp-server.test.ts tests/zod-schemas.test.ts tests/candidates-mcp.test.ts` + the other 9 directly-affected `*-mcp.test.ts` files — 1588/1588 pass. `tests/mcp-server.test.ts` itself is UNCHANGED (its Ajv output-schema validation is the independent referee, per #8073's acceptance criterion 1).
- [x] `tests/candidates-mcp.test.ts` needed 4 `?.` optional-chaining fixes (`inputSchema.properties?.field`) since `z.toJSONSchema()`'s return type declares `properties` as structurally optional — same precedent as an earlier REST batch's `subnet-yield.test.ts` fix.
- [x] Full suite: `npx vitest run` — 490/490 files, 11898/11898 tests pass.

Closes #8073.