### PR TITLE
feat(mcp): types-epic E batch 10 — Zod schemas for 19 registry-discovery MCP tools (#8074)

### DIFF
--- a/schemas-src/mcp-tools/catalog-indexes.ts
+++ b/schemas-src/mcp-tools/catalog-indexes.ts
@@ -1,0 +1,36 @@
+// MCP tools `list_fixtures`, `list_schemas` (types-epic E batch 11, #8074).
+// Both are defined inline in src/mcp-server.ts's MCP_TOOLS array, take no
+// input, and mirror GET /api/v1/fixtures and GET /api/v1/schemas
+// respectively. Neither mirrors an existing schemas-src/routes/ REST schema
+// -- modeled fresh, matching each hand-written literal field-for-field.
+// `list_schemas`' `notes` is a PLAIN nullable string, unlike the
+// array-or-string-or-null `notes` shape most of this batch's other list_*
+// tools use (see shared.ts's NotesFieldSchema) -- a genuine, deliberate
+// difference, not something to "fix" to match its siblings.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const ListFixturesInputSchema = z.object({}).strict();
+export type ListFixturesInput = z.infer<typeof ListFixturesInputSchema>;
+
+export const ListFixturesOutputSchema = z
+  .object({
+    candidate_count: z.int().optional(),
+    coverage: z.array(OpenObjectSchema).optional(),
+    generated_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListFixturesOutput = z.infer<typeof ListFixturesOutputSchema>;
+
+export const ListSchemasInputSchema = z.object({}).strict();
+export type ListSchemasInput = z.infer<typeof ListSchemasInputSchema>;
+
+export const ListSchemasOutputSchema = z
+  .object({
+    schemas: z.array(OpenObjectSchema).optional(),
+    observed_at: z.string().nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSchemasOutput = z.infer<typeof ListSchemasOutputSchema>;

--- a/schemas-src/mcp-tools/curation-and-gaps.ts
+++ b/schemas-src/mcp-tools/curation-and-gaps.ts
@@ -1,0 +1,97 @@
+// MCP tools `list_curation`, `list_gaps` (types-epic E batch 11, #8074).
+// Neither is defined inline in src/mcp-server.ts -- their `LIST_X_MCP_TOOL`/
+// `LIST_X_OUTPUT_SCHEMA` hand-written literals live in src/curation-mcp.ts
+// and src/gaps-mcp.ts respectively, imported into mcp-server.ts's MCP_TOOLS
+// array via object spread. The z.toJSONSchema(...) wiring for these two
+// happens in THEIR OWN files, not mcp-server.ts. Neither mirrors an existing
+// schemas-src/routes/ REST schema -- modeled fresh, matching each
+// hand-written literal field-for-field. Both declare `notes` as a PLAIN
+// nullable string (unlike this batch's other list_* tools' array-or-string
+// notes shape, see shared.ts's NotesFieldSchema) -- a genuine difference,
+// preserved as-is.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const COVERAGE_LEVELS = ["native-only", "manifested", "probed"] as const;
+const CURATION_LEVELS = [
+  "native",
+  "candidate-discovered",
+  "community-seeded",
+  "machine-verified",
+  "maintainer-reviewed",
+  "adapter-backed",
+] as const;
+const CURATION_SORT_FIELDS = [
+  "coverage_level",
+  "curation_level",
+  "name",
+  "netuid",
+] as const;
+
+export const ListCurationInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    coverage_level: z.enum(COVERAGE_LEVELS).optional(),
+    curation_level: z.enum(CURATION_LEVELS).optional(),
+    sort: z.enum(CURATION_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListCurationInput = z.infer<typeof ListCurationInputSchema>;
+
+export const ListCurationOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: z.string().nullable().optional(),
+    curation: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListCurationOutput = z.infer<typeof ListCurationOutputSchema>;
+
+const GAPS_SORT_FIELDS = [
+  "coverage_level",
+  "curation_level",
+  "gap_count",
+  "name",
+  "netuid",
+] as const;
+
+export const ListGapsInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    coverage_level: z.enum(COVERAGE_LEVELS).optional(),
+    curation_level: z.enum(CURATION_LEVELS).optional(),
+    sort: z.enum(GAPS_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListGapsInput = z.infer<typeof ListGapsInputSchema>;
+
+export const ListGapsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: z.string().nullable().optional(),
+    gaps: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListGapsOutput = z.infer<typeof ListGapsOutputSchema>;

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -1,0 +1,198 @@
+// MCP tools `list_endpoint_pools`, `list_endpoint_incidents`,
+// `list_provider_endpoints` (types-epic E batch 11, #8074). None are defined
+// inline in src/mcp-server.ts -- their `LIST_X_MCP_TOOL`/
+// `LIST_X_OUTPUT_SCHEMA` hand-written literals live in
+// src/endpoint-pools-mcp.ts, src/endpoint-incidents-mcp.ts, and
+// src/provider-endpoints-mcp.ts respectively, imported into mcp-server.ts's
+// MCP_TOOLS array via object spread. The z.toJSONSchema(...) wiring for
+// these three happens in THEIR OWN files, not mcp-server.ts. None mirror an
+// existing schemas-src/routes/ REST schema -- modeled fresh, matching each
+// hand-written literal field-for-field. `list_provider_endpoints`' `slug` is
+// REQUIRED (a path param, not a filter), unlike every other filter in this
+// file.
+import { z } from "zod";
+import { OpenObjectSchema, NotesFieldSchema } from "./shared.ts";
+
+const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"] as const;
+const POOL_SORT_FIELDS = [
+  "eligible_count",
+  "endpoint_count",
+  "id",
+  "kind",
+] as const;
+
+export const ListEndpointPoolsInputSchema = z
+  .object({
+    id: z.string().optional(),
+    kind: z.enum(POOL_KINDS).optional(),
+    min_eligible_count: z.number().optional(),
+    max_eligible_count: z.number().optional(),
+    min_endpoint_count: z.number().optional(),
+    max_endpoint_count: z.number().optional(),
+    sort: z.enum(POOL_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListEndpointPoolsInput = z.infer<
+  typeof ListEndpointPoolsInputSchema
+>;
+
+export const ListEndpointPoolsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    pools: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListEndpointPoolsOutput = z.infer<
+  typeof ListEndpointPoolsOutputSchema
+>;
+
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+const HEALTH_STATUSES = ["ok", "degraded", "failed", "unknown"] as const;
+const INCIDENT_SEVERITIES = ["critical", "warning", "info"] as const;
+const INCIDENT_STATES = ["active", "resolved"] as const;
+const INCIDENT_SORT_FIELDS = [
+  "detected_at",
+  "endpoint_id",
+  "kind",
+  "last_checked",
+  "netuid",
+  "provider",
+  "severity",
+  "state",
+  "status",
+] as const;
+
+export const ListEndpointIncidentsInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    provider: z.string().optional(),
+    status: z.enum(HEALTH_STATUSES).optional(),
+    severity: z.enum(INCIDENT_SEVERITIES).optional(),
+    state: z.enum(INCIDENT_STATES).optional(),
+    sort: z.enum(INCIDENT_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListEndpointIncidentsInput = z.infer<
+  typeof ListEndpointIncidentsInputSchema
+>;
+
+export const ListEndpointIncidentsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    summary: OpenObjectSchema.nullable().optional(),
+    incidents: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListEndpointIncidentsOutput = z.infer<
+  typeof ListEndpointIncidentsOutputSchema
+>;
+
+const ENDPOINT_LAYERS = [
+  "bittensor-base",
+  "data-provider",
+  "docs-provider",
+  "subnet-app",
+] as const;
+const ENDPOINT_PUBLICATION_STATES = [
+  "candidate",
+  "verified",
+  "monitored",
+  "pool-eligible",
+  "disabled",
+  "rejected",
+] as const;
+const ENDPOINT_SORT_FIELDS = [
+  "kind",
+  "last_checked",
+  "latency_ms",
+  "layer",
+  "netuid",
+  "pool_eligible",
+  "provider",
+  "publication_state",
+  "score",
+  "status",
+] as const;
+
+export const ListProviderEndpointsInputSchema = z
+  .object({
+    slug: z.string().regex(/^[a-z0-9-]+$/),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    layer: z.enum(ENDPOINT_LAYERS).optional(),
+    netuid: z.int().min(0).optional(),
+    publication_state: z.enum(ENDPOINT_PUBLICATION_STATES).optional(),
+    status: z.enum(HEALTH_STATUSES).optional(),
+    pool_eligible: z.boolean().optional(),
+    min_latency_ms: z.number().optional(),
+    max_latency_ms: z.number().optional(),
+    min_score: z.number().optional(),
+    max_score: z.number().optional(),
+    sort: z.enum(ENDPOINT_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListProviderEndpointsInput = z.infer<
+  typeof ListProviderEndpointsInputSchema
+>;
+
+export const ListProviderEndpointsOutputSchema = z
+  .object({
+    slug: z.string(),
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    endpoints: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListProviderEndpointsOutput = z.infer<
+  typeof ListProviderEndpointsOutputSchema
+>;

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -1,0 +1,229 @@
+// MCP tools `list_enrichment_evidence`, `list_review_gaps`,
+// `list_review_enrichment_targets` (types-epic E batch 11, #8074). None are
+// defined inline in src/mcp-server.ts -- their `LIST_X_MCP_TOOL`/
+// `LIST_X_OUTPUT_SCHEMA` hand-written literals live in
+// src/enrichment-evidence-mcp.ts, src/review-gaps-mcp.ts, and
+// src/review-enrichment-targets-mcp.ts respectively, imported into
+// mcp-server.ts's MCP_TOOLS array via object spread. The z.toJSONSchema(...)
+// wiring for these three happens in THEIR OWN files, not mcp-server.ts. None
+// mirror an existing schemas-src/routes/ REST schema -- modeled fresh,
+// matching each hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema, NotesFieldSchema } from "./shared.ts";
+
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+const EVIDENCE_ACTIONS = [
+  "submit-new-evidence",
+  "verify-existing-evidence",
+  "replace-stale-evidence",
+  "review-existing-evidence",
+  "maintainer-review-existing-evidence",
+  "monitor",
+] as const;
+const LANES = [
+  "direct-submission",
+  "maintainer-review",
+  "adapter-candidate",
+  "monitoring-followup",
+  "baseline-monitoring",
+] as const;
+const EVIDENCE_SORT_FIELDS = [
+  "evidence_action",
+  "lane",
+  "name",
+  "netuid",
+  "priority_score",
+] as const;
+
+export const ListEnrichmentEvidenceInputSchema = z
+  .object({
+    q: z.string().optional(),
+    netuid: z.int().min(0).optional(),
+    lane: z.enum(LANES).optional(),
+    evidence_action: z.enum(EVIDENCE_ACTIONS).optional(),
+    direct_submission_kinds: z.enum(SURFACE_KINDS).optional(),
+    missing_kinds: z.enum(SURFACE_KINDS).optional(),
+    sort: z.enum(EVIDENCE_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListEnrichmentEvidenceInput = z.infer<
+  typeof ListEnrichmentEvidenceInputSchema
+>;
+
+export const ListEnrichmentEvidenceOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    entries: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListEnrichmentEvidenceOutput = z.infer<
+  typeof ListEnrichmentEvidenceOutputSchema
+>;
+
+const CURATION_LEVELS = [
+  "native",
+  "candidate-discovered",
+  "community-seeded",
+  "machine-verified",
+  "maintainer-reviewed",
+  "adapter-backed",
+] as const;
+const PRIORITY_SORT_FIELDS = [
+  "candidate_count",
+  "curation_level",
+  "missing_kinds",
+  "name",
+  "netuid",
+  "priority_score",
+  "surface_count",
+  "verified_candidate_count",
+] as const;
+
+export const ListReviewGapsInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    curation_level: z.enum(CURATION_LEVELS).optional(),
+    missing_kinds: z.enum(SURFACE_KINDS).optional(),
+    review_state: z.string().optional(),
+    sort: z.enum(PRIORITY_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListReviewGapsInput = z.infer<typeof ListReviewGapsInputSchema>;
+
+export const ListReviewGapsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    priorities: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListReviewGapsOutput = z.infer<typeof ListReviewGapsOutputSchema>;
+
+const PROFILE_LEVELS = [
+  "directory-only",
+  "identity-partial",
+  "identity-complete",
+  "operational",
+  "adapter-backed",
+] as const;
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"] as const;
+const BOOLEAN_STRINGS = ["true", "false"] as const;
+const SUBMISSION_ROUTES = [
+  "direct-candidate-pr",
+  "adapter-request",
+  "maintainer-review",
+  "status-report",
+] as const;
+const TARGET_ACTIONS = [
+  "submit-new-candidate",
+  "replace-stale-candidate",
+  "verify-existing-candidate",
+  "review-existing-candidate",
+  "adapter-review",
+  "maintainer-review",
+  "monitoring-followup",
+] as const;
+const TARGET_TYPES = [
+  "surface-candidate",
+  "adapter-review",
+  "maintainer-review",
+  "monitoring-followup",
+] as const;
+const TARGET_SORT_FIELDS = [
+  "auto_review_candidate",
+  "evidence_action",
+  "identity_level",
+  "kind",
+  "lane",
+  "manual_review_required",
+  "name",
+  "netuid",
+  "priority_score",
+  "profile_level",
+  "submission_route",
+  "target_action",
+  "target_type",
+] as const;
+
+export const ListReviewEnrichmentTargetsInputSchema = z
+  .object({
+    q: z.string().optional(),
+    netuid: z.int().min(0).optional(),
+    target_type: z.enum(TARGET_TYPES).optional(),
+    target_action: z.enum(TARGET_ACTIONS).optional(),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    lane: z.enum(LANES).optional(),
+    evidence_action: z.enum(EVIDENCE_ACTIONS).optional(),
+    identity_level: z.enum(IDENTITY_LEVELS).optional(),
+    profile_level: z.enum(PROFILE_LEVELS).optional(),
+    submission_route: z.enum(SUBMISSION_ROUTES).optional(),
+    auto_review_candidate: z.enum(BOOLEAN_STRINGS).optional(),
+    manual_review_required: z.enum(BOOLEAN_STRINGS).optional(),
+    missing_kinds: z.enum(SURFACE_KINDS).optional(),
+    reason_codes: z.string().optional(),
+    sort: z.enum(TARGET_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListReviewEnrichmentTargetsInput = z.infer<
+  typeof ListReviewEnrichmentTargetsInputSchema
+>;
+
+export const ListReviewEnrichmentTargetsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    targets: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListReviewEnrichmentTargetsOutput = z.infer<
+  typeof ListReviewEnrichmentTargetsOutputSchema
+>;

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -1,0 +1,178 @@
+// MCP tools `list_enrichment_queue`, `list_adapter_candidates` (types-epic E
+// batch 11, #8074). Neither is defined inline in src/mcp-server.ts -- their
+// `LIST_X_MCP_TOOL`/`LIST_X_OUTPUT_SCHEMA` hand-written literals live in
+// src/enrichment-queue-mcp.ts and src/adapter-candidates-mcp.ts
+// respectively, imported into mcp-server.ts's MCP_TOOLS array via object
+// spread. The z.toJSONSchema(...) wiring for these two happens in THEIR OWN
+// files, not mcp-server.ts. Neither mirrors an existing schemas-src/routes/
+// REST schema -- modeled fresh, matching each hand-written literal
+// field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema, NotesFieldSchema } from "./shared.ts";
+
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+const CURATION_LEVELS = [
+  "native",
+  "candidate-discovered",
+  "community-seeded",
+  "machine-verified",
+  "maintainer-reviewed",
+  "adapter-backed",
+] as const;
+const PROFILE_LEVELS = [
+  "directory-only",
+  "identity-partial",
+  "identity-complete",
+  "operational",
+  "adapter-backed",
+] as const;
+const EVIDENCE_ACTIONS = [
+  "submit-new-evidence",
+  "verify-existing-evidence",
+  "replace-stale-evidence",
+  "review-existing-evidence",
+  "maintainer-review-existing-evidence",
+  "monitor",
+] as const;
+const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"] as const;
+const LANES = [
+  "direct-submission",
+  "maintainer-review",
+  "adapter-candidate",
+  "monitoring-followup",
+  "baseline-monitoring",
+] as const;
+const BOOLEAN_STRINGS = ["true", "false"] as const;
+const QUEUE_SORT_FIELDS = [
+  "adapter_score",
+  "candidate_count",
+  "completeness_score",
+  "curation_level",
+  "endpoint_count",
+  "evidence_action",
+  "identity_level",
+  "identity_surface_count",
+  "lane",
+  "name",
+  "netuid",
+  "operational_interface_count",
+  "priority_score",
+  "profile_level",
+  "review_state",
+  "stale_candidate_count",
+  "surface_count",
+  "verified_candidate_count",
+] as const;
+
+export const ListEnrichmentQueueInputSchema = z
+  .object({
+    q: z.string().optional(),
+    netuid: z.int().min(0).optional(),
+    lane: z.enum(LANES).optional(),
+    evidence_action: z.enum(EVIDENCE_ACTIONS).optional(),
+    identity_level: z.enum(IDENTITY_LEVELS).optional(),
+    curation_level: z.enum(CURATION_LEVELS).optional(),
+    profile_level: z.enum(PROFILE_LEVELS).optional(),
+    direct_submission_kinds: z.enum(SURFACE_KINDS).optional(),
+    missing_kinds: z.enum(SURFACE_KINDS).optional(),
+    manual_review_required: z.enum(BOOLEAN_STRINGS).optional(),
+    reason_codes: z.string().optional(),
+    review_state: z.string().optional(),
+    sort: z.enum(QUEUE_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListEnrichmentQueueInput = z.infer<
+  typeof ListEnrichmentQueueInputSchema
+>;
+
+export const ListEnrichmentQueueOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    queue: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListEnrichmentQueueOutput = z.infer<
+  typeof ListEnrichmentQueueOutputSchema
+>;
+
+const RECOMMENDED_ADAPTER_KINDS = [
+  "custom-adapter",
+  "data-artifact-adapter",
+  "generic-openapi-or-custom",
+  "stream-adapter",
+] as const;
+const ADAPTER_CANDIDATES_SORT_FIELDS = [
+  "candidate_api_count",
+  "candidate_api_kinds",
+  "curation_level",
+  "name",
+  "netuid",
+  "operational_kinds",
+  "operational_surface_count",
+  "priority_score",
+  "recommended_adapter_kind",
+] as const;
+
+export const ListAdapterCandidatesInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+    curation_level: z.enum(CURATION_LEVELS).optional(),
+    candidate_api_kinds: z.enum(SURFACE_KINDS).optional(),
+    operational_kinds: z.enum(SURFACE_KINDS).optional(),
+    recommended_adapter_kind: z.enum(RECOMMENDED_ADAPTER_KINDS).optional(),
+    reason_codes: z.string().optional(),
+    sort: z.enum(ADAPTER_CANDIDATES_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListAdapterCandidatesInput = z.infer<
+  typeof ListAdapterCandidatesInputSchema
+>;
+
+export const ListAdapterCandidatesOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    candidates: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListAdapterCandidatesOutput = z.infer<
+  typeof ListAdapterCandidatesOutputSchema
+>;

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -1,0 +1,77 @@
+// MCP tools `list_search_index`, `list_search` (types-epic E batch 11,
+// #8074). Neither is defined inline in src/mcp-server.ts -- their
+// `LIST_X_MCP_TOOL`/`LIST_X_OUTPUT_SCHEMA` hand-written literals live in
+// src/search-index-mcp.ts and src/search-mcp.ts respectively, imported into
+// mcp-server.ts's MCP_TOOLS array via object spread. The z.toJSONSchema(...)
+// wiring for these two happens in THEIR OWN files, not mcp-server.ts.
+// Identical input/output shape (same filters, same "documents" output key)
+// -- list_search serves the full documents WITH token blobs where
+// list_search_index serves the slim variant without them, a runtime-data
+// difference only, not a schema one. Neither mirrors an existing
+// schemas-src/routes/ REST schema -- modeled fresh, matching each
+// hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema, NotesFieldSchema } from "./shared.ts";
+
+const DOCUMENT_TYPES = ["subnet", "surface", "provider"] as const;
+const DOCUMENT_SORT_FIELDS = ["netuid", "slug", "title", "type"] as const;
+
+export const ListSearchIndexInputSchema = z
+  .object({
+    q: z.string().optional(),
+    type: z.enum(DOCUMENT_TYPES).optional(),
+    netuid: z.int().min(0).optional(),
+    sort: z.enum(DOCUMENT_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSearchIndexInput = z.infer<typeof ListSearchIndexInputSchema>;
+
+export const ListSearchIndexOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    documents: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSearchIndexOutput = z.infer<typeof ListSearchIndexOutputSchema>;
+
+export const ListSearchInputSchema = z
+  .object({
+    q: z.string().optional(),
+    type: z.enum(DOCUMENT_TYPES).optional(),
+    netuid: z.int().min(0).optional(),
+    sort: z.enum(DOCUMENT_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSearchInput = z.infer<typeof ListSearchInputSchema>;
+
+export const ListSearchOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    documents: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSearchOutput = z.infer<typeof ListSearchOutputSchema>;

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -81,3 +81,16 @@ export const DistributionStatsSchema = z
     max: z.number(),
   })
   .strict();
+
+// `notes: {type:["array","string","null"], items:{type:"string"}}` -- 10 of
+// types-epic E batch 10's (#8074) list_* tools declare this exact shape for
+// their output `notes` field (list_search_index, list_search,
+// list_enrichment_queue, list_adapter_candidates, list_enrichment_evidence,
+// list_review_gaps, list_review_enrichment_targets, list_endpoint_pools,
+// list_endpoint_incidents, list_provider_endpoints), well past the
+// established "reused 3+ times within a batch" hoisting threshold this
+// epic's shared item shapes above already follow.
+export const NotesFieldSchema = z
+  .union([z.array(z.string()), z.string()])
+  .nullable()
+  .optional();

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -1,0 +1,188 @@
+// MCP tools `get_subnet_candidates`, `list_subnet_candidates`,
+// `get_subnet_evidence`, `list_subnet_evidence`, `get_subnet_surfaces`
+// (types-epic E batch 11, #8074). The first, third, and fifth are defined
+// inline in src/mcp-server.ts's MCP_TOOLS array; `list_subnet_candidates`/
+// `list_subnet_evidence` live in src/subnet-candidates-mcp.ts and
+// src/subnet-evidence-mcp.ts respectively (their `LIST_X_MCP_TOOL`/
+// `LIST_X_OUTPUT_SCHEMA` spread into mcp-server.ts's MCP_TOOLS array) -- the
+// z.toJSONSchema(...) wiring for those two happens in THEIR OWN files, not
+// mcp-server.ts. None mirror an existing schemas-src/routes/ REST schema --
+// modeled fresh, matching each hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+
+export const GetSubnetCandidatesInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetCandidatesInput = z.infer<
+  typeof GetSubnetCandidatesInputSchema
+>;
+
+export const GetSubnetCandidatesOutputSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    candidates: z.array(OpenObjectSchema).optional(),
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetCandidatesOutput = z.infer<
+  typeof GetSubnetCandidatesOutputSchema
+>;
+
+const CANDIDATE_STATES = [
+  "schema-invalid",
+  "schema-valid",
+  "maintainer-review",
+  "verified",
+  "stale",
+  "rejected",
+] as const;
+const CONFIDENCE_LEVELS = ["low", "medium", "high"] as const;
+const CANDIDATES_SORT_FIELDS = [
+  "confidence",
+  "id",
+  "kind",
+  "name",
+  "netuid",
+  "provider",
+  "state",
+] as const;
+
+export const ListSubnetCandidatesInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    kind: z.enum(SURFACE_KINDS).optional(),
+    provider: z.string().optional(),
+    state: z.enum(CANDIDATE_STATES).optional(),
+    id: z.string().optional(),
+    confidence: z.enum(CONFIDENCE_LEVELS).optional(),
+    sort: z.enum(CANDIDATES_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSubnetCandidatesInput = z.infer<
+  typeof ListSubnetCandidatesInputSchema
+>;
+
+export const ListSubnetCandidatesOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    candidates: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSubnetCandidatesOutput = z.infer<
+  typeof ListSubnetCandidatesOutputSchema
+>;
+
+export const GetSubnetEvidenceInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetEvidenceInput = z.infer<
+  typeof GetSubnetEvidenceInputSchema
+>;
+
+export const GetSubnetEvidenceOutputSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    claims: z.array(OpenObjectSchema).optional(),
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetEvidenceOutput = z.infer<
+  typeof GetSubnetEvidenceOutputSchema
+>;
+
+const CLAIM_SORT_FIELDS = [
+  "claim",
+  "source_url",
+  "subject",
+  "verified_at",
+] as const;
+
+export const ListSubnetEvidenceInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    q: z.string().optional(),
+    sort: z.enum(CLAIM_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSubnetEvidenceInput = z.infer<
+  typeof ListSubnetEvidenceInputSchema
+>;
+
+export const ListSubnetEvidenceOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    claims: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSubnetEvidenceOutput = z.infer<
+  typeof ListSubnetEvidenceOutputSchema
+>;
+
+export const GetSubnetSurfacesInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetSurfacesInput = z.infer<
+  typeof GetSubnetSurfacesInputSchema
+>;
+
+export const GetSubnetSurfacesOutputSchema = z
+  .object({
+    netuid: z.int().nullable().optional(),
+    surfaces: z.array(OpenObjectSchema).optional(),
+    generated_at: z.string().nullable().optional(),
+    schema_version: z.union([z.string(), z.int()]).nullable().optional(),
+  })
+  .passthrough();
+export type GetSubnetSurfacesOutput = z.infer<
+  typeof GetSubnetSurfacesOutputSchema
+>;

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -508,6 +508,58 @@ import {
   ListSubnetHealthInputSchema,
   ListSubnetHealthOutputSchema,
 } from "../schemas-src/mcp-tools/subnet-scoped-lists.ts";
+import {
+  GetSubnetCandidatesInputSchema,
+  GetSubnetCandidatesOutputSchema,
+  ListSubnetCandidatesInputSchema,
+  ListSubnetCandidatesOutputSchema,
+  GetSubnetEvidenceInputSchema,
+  GetSubnetEvidenceOutputSchema,
+  ListSubnetEvidenceInputSchema,
+  ListSubnetEvidenceOutputSchema,
+  GetSubnetSurfacesInputSchema,
+  GetSubnetSurfacesOutputSchema,
+} from "../schemas-src/mcp-tools/subnet-registry-lists.ts";
+import {
+  ListFixturesInputSchema,
+  ListFixturesOutputSchema,
+  ListSchemasInputSchema,
+  ListSchemasOutputSchema,
+} from "../schemas-src/mcp-tools/catalog-indexes.ts";
+import {
+  ListSearchIndexInputSchema,
+  ListSearchIndexOutputSchema,
+  ListSearchInputSchema,
+  ListSearchOutputSchema,
+} from "../schemas-src/mcp-tools/search-documents.ts";
+import {
+  ListCurationInputSchema,
+  ListCurationOutputSchema,
+  ListGapsInputSchema,
+  ListGapsOutputSchema,
+} from "../schemas-src/mcp-tools/curation-and-gaps.ts";
+import {
+  ListEnrichmentQueueInputSchema,
+  ListEnrichmentQueueOutputSchema,
+  ListAdapterCandidatesInputSchema,
+  ListAdapterCandidatesOutputSchema,
+} from "../schemas-src/mcp-tools/enrichment-queue-and-candidates.ts";
+import {
+  ListEnrichmentEvidenceInputSchema,
+  ListEnrichmentEvidenceOutputSchema,
+  ListReviewGapsInputSchema,
+  ListReviewGapsOutputSchema,
+  ListReviewEnrichmentTargetsInputSchema,
+  ListReviewEnrichmentTargetsOutputSchema,
+} from "../schemas-src/mcp-tools/enrichment-evidence-and-targets.ts";
+import {
+  ListEndpointPoolsInputSchema,
+  ListEndpointPoolsOutputSchema,
+  ListEndpointIncidentsInputSchema,
+  ListEndpointIncidentsOutputSchema,
+  ListProviderEndpointsInputSchema,
+  ListProviderEndpointsOutputSchema,
+} from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
 
 type Row = Record<string, unknown>;
 
@@ -871,6 +923,152 @@ const PROFILE_SORT_FIELDS = [
   "stale_identity_candidate_kind_count",
 ];
 const BOOLEAN_STRINGS = ["true", "false"];
+
+// Batch 10 (#8074) resolved enum values, same treatment as above -- symbolic
+// in the hand-written originals (src/contracts.ts's QUERY_ENUMS.* and
+// API_QUERY_COLLECTIONS.{documents,curation,gaps,enrichment-queue,
+// adapter-candidates,enrichment-evidence,review-gap-priorities,
+// enrichment-targets,endpoint-pools,endpoint-incidents,endpoints}.sort_fields),
+// cross-checked against the actual runtime source at the time of writing.
+// Reuses SURFACE_KIND/COVERAGE_LEVEL/CURATION_LEVEL/PROFILE_LEVEL/
+// CANDIDATE_STATES/CONFIDENCE_LEVELS/CANDIDATES_SORT_FIELDS/CLAIM_SORT_FIELDS/
+// ENDPOINT_LAYERS/ENDPOINT_PUBLICATION_STATES/ENDPOINT_SORT_FIELDS/
+// POOL_KINDS/POOL_SORT_FIELDS/IDENTITY_LEVELS/BOOLEAN_STRINGS already
+// defined above (batches 1-9) -- confirmed identical to this batch's own
+// symbolic references, not just reused by name.
+const DOCUMENT_TYPES = ["subnet", "surface", "provider"];
+const DOCUMENT_SORT_FIELDS = ["netuid", "slug", "title", "type"];
+const CURATION_SORT_FIELDS = [
+  "coverage_level",
+  "curation_level",
+  "name",
+  "netuid",
+];
+const GAPS_SORT_FIELDS = [
+  "coverage_level",
+  "curation_level",
+  "gap_count",
+  "name",
+  "netuid",
+];
+const EVIDENCE_ACTIONS = [
+  "submit-new-evidence",
+  "verify-existing-evidence",
+  "replace-stale-evidence",
+  "review-existing-evidence",
+  "maintainer-review-existing-evidence",
+  "monitor",
+];
+const LANES = [
+  "direct-submission",
+  "maintainer-review",
+  "adapter-candidate",
+  "monitoring-followup",
+  "baseline-monitoring",
+];
+const QUEUE_SORT_FIELDS = [
+  "adapter_score",
+  "candidate_count",
+  "completeness_score",
+  "curation_level",
+  "endpoint_count",
+  "evidence_action",
+  "identity_level",
+  "identity_surface_count",
+  "lane",
+  "name",
+  "netuid",
+  "operational_interface_count",
+  "priority_score",
+  "profile_level",
+  "review_state",
+  "stale_candidate_count",
+  "surface_count",
+  "verified_candidate_count",
+];
+const RECOMMENDED_ADAPTER_KINDS = [
+  "custom-adapter",
+  "data-artifact-adapter",
+  "generic-openapi-or-custom",
+  "stream-adapter",
+];
+const ADAPTER_CANDIDATES_SORT_FIELDS = [
+  "candidate_api_count",
+  "candidate_api_kinds",
+  "curation_level",
+  "name",
+  "netuid",
+  "operational_kinds",
+  "operational_surface_count",
+  "priority_score",
+  "recommended_adapter_kind",
+];
+const EVIDENCE_SORT_FIELDS = [
+  "evidence_action",
+  "lane",
+  "name",
+  "netuid",
+  "priority_score",
+];
+const PRIORITY_SORT_FIELDS = [
+  "candidate_count",
+  "curation_level",
+  "missing_kinds",
+  "name",
+  "netuid",
+  "priority_score",
+  "surface_count",
+  "verified_candidate_count",
+];
+const SUBMISSION_ROUTES = [
+  "direct-candidate-pr",
+  "adapter-request",
+  "maintainer-review",
+  "status-report",
+];
+const TARGET_ACTIONS = [
+  "submit-new-candidate",
+  "replace-stale-candidate",
+  "verify-existing-candidate",
+  "review-existing-candidate",
+  "adapter-review",
+  "maintainer-review",
+  "monitoring-followup",
+];
+const TARGET_TYPES = [
+  "surface-candidate",
+  "adapter-review",
+  "maintainer-review",
+  "monitoring-followup",
+];
+const TARGET_SORT_FIELDS = [
+  "auto_review_candidate",
+  "evidence_action",
+  "identity_level",
+  "kind",
+  "lane",
+  "manual_review_required",
+  "name",
+  "netuid",
+  "priority_score",
+  "profile_level",
+  "submission_route",
+  "target_action",
+  "target_type",
+];
+const INCIDENT_SEVERITIES = ["critical", "warning", "info"];
+const INCIDENT_STATES = ["active", "resolved"];
+const INCIDENT_SORT_FIELDS = [
+  "detected_at",
+  "endpoint_id",
+  "kind",
+  "last_checked",
+  "netuid",
+  "provider",
+  "severity",
+  "state",
+  "status",
+];
 
 const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
   search_subnets: {
@@ -6518,6 +6716,650 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  get_subnet_candidates: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        netuid: { type: ["integer", "null"] },
+        candidates: { type: "array", items: { type: "object" } },
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+      },
+    },
+  },
+  list_subnet_candidates: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string", enum: SURFACE_KIND },
+        provider: { type: "string" },
+        state: { type: "string", enum: CANDIDATE_STATES },
+        id: { type: "string" },
+        confidence: { type: "string", enum: CONFIDENCE_LEVELS },
+        sort: { type: "string", enum: CANDIDATES_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["candidates"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        netuid: NULLABLE_INT,
+        candidates: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  get_subnet_evidence: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        netuid: { type: ["integer", "null"] },
+        claims: { type: "array", items: { type: "object" } },
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+      },
+    },
+  },
+  list_subnet_evidence: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        q: { type: "string" },
+        sort: { type: "string", enum: CLAIM_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["claims"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        netuid: NULLABLE_INT,
+        claims: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  get_subnet_surfaces: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        netuid: { type: ["integer", "null"] },
+        surfaces: { type: "array", items: { type: "object" } },
+        generated_at: NULLABLE_STRING,
+        schema_version: { type: ["string", "integer", "null"] },
+      },
+    },
+  },
+  list_fixtures: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        candidate_count: { type: "integer" },
+        coverage: { type: "array", items: { type: "object" } },
+        generated_at: NULLABLE_STRING,
+      },
+    },
+  },
+  list_schemas: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        schemas: { type: "array", items: { type: "object" } },
+        observed_at: NULLABLE_STRING,
+        generated_at: NULLABLE_STRING,
+        notes: NULLABLE_STRING,
+      },
+    },
+  },
+  list_search_index: {
+    input: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+        type: { type: "string", enum: DOCUMENT_TYPES },
+        netuid: { type: "integer", minimum: 0 },
+        sort: { type: "string", enum: DOCUMENT_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["documents"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        documents: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_search: {
+    input: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+        type: { type: "string", enum: DOCUMENT_TYPES },
+        netuid: { type: "integer", minimum: 0 },
+        sort: { type: "string", enum: DOCUMENT_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["documents"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        documents: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_curation: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        coverage_level: { type: "string", enum: COVERAGE_LEVEL },
+        curation_level: { type: "string", enum: CURATION_LEVEL },
+        sort: { type: "string", enum: CURATION_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["curation"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: NULLABLE_STRING,
+        curation: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_gaps: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        coverage_level: { type: "string", enum: COVERAGE_LEVEL },
+        curation_level: { type: "string", enum: CURATION_LEVEL },
+        sort: { type: "string", enum: GAPS_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["gaps"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: NULLABLE_STRING,
+        gaps: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_enrichment_queue: {
+    input: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+        netuid: { type: "integer", minimum: 0 },
+        lane: { type: "string", enum: LANES },
+        evidence_action: { type: "string", enum: EVIDENCE_ACTIONS },
+        identity_level: { type: "string", enum: IDENTITY_LEVELS },
+        curation_level: { type: "string", enum: CURATION_LEVEL },
+        profile_level: { type: "string", enum: PROFILE_LEVEL },
+        direct_submission_kinds: { type: "string", enum: SURFACE_KIND },
+        missing_kinds: { type: "string", enum: SURFACE_KIND },
+        manual_review_required: { type: "string", enum: BOOLEAN_STRINGS },
+        reason_codes: { type: "string" },
+        review_state: { type: "string" },
+        sort: { type: "string", enum: QUEUE_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["queue"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        queue: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_adapter_candidates: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        curation_level: { type: "string", enum: CURATION_LEVEL },
+        candidate_api_kinds: { type: "string", enum: SURFACE_KIND },
+        operational_kinds: { type: "string", enum: SURFACE_KIND },
+        recommended_adapter_kind: {
+          type: "string",
+          enum: RECOMMENDED_ADAPTER_KINDS,
+        },
+        reason_codes: { type: "string" },
+        sort: { type: "string", enum: ADAPTER_CANDIDATES_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["candidates"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        candidates: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_enrichment_evidence: {
+    input: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+        netuid: { type: "integer", minimum: 0 },
+        lane: { type: "string", enum: LANES },
+        evidence_action: { type: "string", enum: EVIDENCE_ACTIONS },
+        direct_submission_kinds: { type: "string", enum: SURFACE_KIND },
+        missing_kinds: { type: "string", enum: SURFACE_KIND },
+        sort: { type: "string", enum: EVIDENCE_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["entries"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        entries: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_review_gaps: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        curation_level: { type: "string", enum: CURATION_LEVEL },
+        missing_kinds: { type: "string", enum: SURFACE_KIND },
+        review_state: { type: "string" },
+        sort: { type: "string", enum: PRIORITY_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["priorities"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        priorities: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_review_enrichment_targets: {
+    input: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+        netuid: { type: "integer", minimum: 0 },
+        target_type: { type: "string", enum: TARGET_TYPES },
+        target_action: { type: "string", enum: TARGET_ACTIONS },
+        kind: { type: "string", enum: SURFACE_KIND },
+        lane: { type: "string", enum: LANES },
+        evidence_action: { type: "string", enum: EVIDENCE_ACTIONS },
+        identity_level: { type: "string", enum: IDENTITY_LEVELS },
+        profile_level: { type: "string", enum: PROFILE_LEVEL },
+        submission_route: { type: "string", enum: SUBMISSION_ROUTES },
+        auto_review_candidate: { type: "string", enum: BOOLEAN_STRINGS },
+        manual_review_required: { type: "string", enum: BOOLEAN_STRINGS },
+        missing_kinds: { type: "string", enum: SURFACE_KIND },
+        reason_codes: { type: "string" },
+        sort: { type: "string", enum: TARGET_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["targets"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        targets: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_endpoint_pools: {
+    input: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        kind: { type: "string", enum: POOL_KINDS },
+        min_eligible_count: { type: "number" },
+        max_eligible_count: { type: "number" },
+        min_endpoint_count: { type: "number" },
+        max_endpoint_count: { type: "number" },
+        sort: { type: "string", enum: POOL_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["pools"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        pools: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_endpoint_incidents: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        kind: { type: "string", enum: SURFACE_KIND },
+        provider: { type: "string" },
+        status: { type: "string", enum: HEALTH_STATUS },
+        severity: { type: "string", enum: INCIDENT_SEVERITIES },
+        state: { type: "string", enum: INCIDENT_STATES },
+        sort: { type: "string", enum: INCIDENT_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["incidents"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        summary: { type: ["object", "null"] },
+        incidents: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  list_provider_endpoints: {
+    input: {
+      type: "object",
+      properties: {
+        slug: { type: "string", pattern: "^[a-z0-9-]+$" },
+        kind: { type: "string", enum: SURFACE_KIND },
+        layer: { type: "string", enum: ENDPOINT_LAYERS },
+        netuid: { type: "integer", minimum: 0 },
+        publication_state: {
+          type: "string",
+          enum: ENDPOINT_PUBLICATION_STATES,
+        },
+        status: { type: "string", enum: HEALTH_STATUS },
+        pool_eligible: { type: "boolean" },
+        min_latency_ms: { type: "number" },
+        max_latency_ms: { type: "number" },
+        min_score: { type: "number" },
+        max_score: { type: "number" },
+        sort: { type: "string", enum: ENDPOINT_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["slug", "endpoints"],
+      properties: {
+        slug: { type: "string" },
+        generated_at: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        endpoints: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -7145,6 +7987,82 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
   list_subnet_health: {
     input: ListSubnetHealthInputSchema,
     output: ListSubnetHealthOutputSchema,
+  },
+  get_subnet_candidates: {
+    input: GetSubnetCandidatesInputSchema,
+    output: GetSubnetCandidatesOutputSchema,
+  },
+  list_subnet_candidates: {
+    input: ListSubnetCandidatesInputSchema,
+    output: ListSubnetCandidatesOutputSchema,
+  },
+  get_subnet_evidence: {
+    input: GetSubnetEvidenceInputSchema,
+    output: GetSubnetEvidenceOutputSchema,
+  },
+  list_subnet_evidence: {
+    input: ListSubnetEvidenceInputSchema,
+    output: ListSubnetEvidenceOutputSchema,
+  },
+  get_subnet_surfaces: {
+    input: GetSubnetSurfacesInputSchema,
+    output: GetSubnetSurfacesOutputSchema,
+  },
+  list_fixtures: {
+    input: ListFixturesInputSchema,
+    output: ListFixturesOutputSchema,
+  },
+  list_schemas: {
+    input: ListSchemasInputSchema,
+    output: ListSchemasOutputSchema,
+  },
+  list_search_index: {
+    input: ListSearchIndexInputSchema,
+    output: ListSearchIndexOutputSchema,
+  },
+  list_search: {
+    input: ListSearchInputSchema,
+    output: ListSearchOutputSchema,
+  },
+  list_curation: {
+    input: ListCurationInputSchema,
+    output: ListCurationOutputSchema,
+  },
+  list_gaps: {
+    input: ListGapsInputSchema,
+    output: ListGapsOutputSchema,
+  },
+  list_enrichment_queue: {
+    input: ListEnrichmentQueueInputSchema,
+    output: ListEnrichmentQueueOutputSchema,
+  },
+  list_adapter_candidates: {
+    input: ListAdapterCandidatesInputSchema,
+    output: ListAdapterCandidatesOutputSchema,
+  },
+  list_enrichment_evidence: {
+    input: ListEnrichmentEvidenceInputSchema,
+    output: ListEnrichmentEvidenceOutputSchema,
+  },
+  list_review_gaps: {
+    input: ListReviewGapsInputSchema,
+    output: ListReviewGapsOutputSchema,
+  },
+  list_review_enrichment_targets: {
+    input: ListReviewEnrichmentTargetsInputSchema,
+    output: ListReviewEnrichmentTargetsOutputSchema,
+  },
+  list_endpoint_pools: {
+    input: ListEndpointPoolsInputSchema,
+    output: ListEndpointPoolsOutputSchema,
+  },
+  list_endpoint_incidents: {
+    input: ListEndpointIncidentsInputSchema,
+    output: ListEndpointIncidentsOutputSchema,
+  },
+  list_provider_endpoints: {
+    input: ListProviderEndpointsInputSchema,
+    output: ListProviderEndpointsOutputSchema,
   },
 };
 

--- a/src/adapter-candidates-mcp.ts
+++ b/src/adapter-candidates-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/review/adapter-candidates.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListAdapterCandidatesInputSchema,
+  ListAdapterCandidatesOutputSchema,
+} from "../schemas-src/mcp-tools/enrichment-queue-and-candidates.ts";
 
 export const ADAPTER_CANDIDATES_ARTIFACT =
   "/metagraph/review/adapter-candidates.json";
@@ -228,91 +233,14 @@ export const LIST_ADAPTER_CANDIDATES_MCP_TOOL = {
     "sort with sort + order; and page with limit (1-100) / cursor. Complements " +
     "get_adapter (one adapter by slug) and list_enrichment_queue (full enrichment lanes). " +
     "Mirrors GET /api/v1/review/adapter-candidates.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      curation_level: {
-        type: "string",
-        enum: CURATION_LEVELS,
-        description: "Filter by curation level.",
-      },
-      candidate_api_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description:
-          "Filter rows whose candidate API kinds include this surface kind.",
-      },
-      operational_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description:
-          "Filter rows whose operational kinds include this surface kind.",
-      },
-      recommended_adapter_kind: {
-        type: "string",
-        enum: RECOMMENDED_ADAPTER_KINDS,
-        description: "Filter by the recommended adapter kind.",
-      },
-      reason_codes: {
-        type: "string",
-        description: "Filter by reason_codes substring match.",
-      },
-      sort: {
-        type: "string",
-        enum: CANDIDATE_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of candidate row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListAdapterCandidatesInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["candidates"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    candidates: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_ADAPTER_CANDIDATES_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListAdapterCandidatesOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/curation-mcp.ts
+++ b/src/curation-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/curation.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListCurationInputSchema,
+  ListCurationOutputSchema,
+} from "../schemas-src/mcp-tools/curation-and-gaps.ts";
 
 export const CURATION_ARTIFACT = "/metagraph/curation.json";
 
@@ -197,73 +202,14 @@ export const LIST_CURATION_MCP_TOOL = {
     "curation_level, source counts, and review posture for every active subnet. " +
     "Filter by netuid, coverage_level, or curation_level, sort with sort + " +
     "order, and page with limit (1-100) / cursor. Mirrors GET /api/v1/curation.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      coverage_level: {
-        type: "string",
-        enum: COVERAGE_LEVELS,
-        description:
-          "Filter by coverage depth: native-only, manifested, or probed.",
-      },
-      curation_level: {
-        type: "string",
-        enum: CURATION_LEVELS,
-        description: "Filter by curation level.",
-      },
-      sort: {
-        type: "string",
-        enum: CURATION_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of curation row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListCurationInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_CURATION_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["curation"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: NULLABLE_STRING,
-    curation: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_CURATION_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListCurationOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/endpoint-incidents-mcp.ts
+++ b/src/endpoint-incidents-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/endpoint-incidents.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListEndpointIncidentsInputSchema,
+  ListEndpointIncidentsOutputSchema,
+} from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
 
 export const ENDPOINT_INCIDENTS_ARTIFACT = "/metagraph/endpoint-incidents.json";
 
@@ -215,90 +220,14 @@ export const LIST_ENDPOINT_INCIDENTS_MCP_TOOL = {
     "with sort + order; and page with limit (1-100) / cursor. Complements " +
     "list_endpoints (the full catalog) and get_global_incidents (registry-wide " +
     "operational incidents). Mirrors GET /api/v1/endpoint-incidents.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter by surface kind, e.g. 'subnet-api'.",
-      },
-      provider: {
-        type: "string",
-        description: "Filter by provider slug.",
-      },
-      status: {
-        type: "string",
-        enum: HEALTH_STATUSES,
-        description: "Filter by probe-derived health status.",
-      },
-      severity: {
-        type: "string",
-        enum: INCIDENT_SEVERITIES,
-        description: "Filter by incident severity.",
-      },
-      state: {
-        type: "string",
-        enum: INCIDENT_STATES,
-        description: "Filter by incident state.",
-      },
-      sort: {
-        type: "string",
-        enum: INCIDENT_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of incident row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListEndpointIncidentsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["incidents"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    summary: { type: ["object", "null"] },
-    incidents: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListEndpointIncidentsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/endpoint-pools-mcp.ts
+++ b/src/endpoint-pools-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/endpoint-pools.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
+import {
+  ListEndpointPoolsInputSchema,
+  ListEndpointPoolsOutputSchema,
+} from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
 
 export const ENDPOINT_POOLS_ARTIFACT = "/metagraph/endpoint-pools.json";
 
@@ -221,84 +226,14 @@ export const LIST_ENDPOINT_POOLS_MCP_TOOL = {
     "min_/max_endpoint_count, sort with sort + order, and page with limit (1-100) / " +
     "cursor. Complements list_endpoints (individual resources) and list_rpc_pools " +
     "(Bittensor RPC proxy pools). Mirrors GET /api/v1/endpoint-pools.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      id: {
-        type: "string",
-        description: "Filter to one pool id, e.g. 'finney-rpc'.",
-      },
-      kind: {
-        type: "string",
-        enum: POOL_KINDS,
-        description: "Filter by pool kind.",
-      },
-      min_eligible_count: {
-        type: "number",
-        description: "Keep pools with eligible_count >= this bound.",
-      },
-      max_eligible_count: {
-        type: "number",
-        description: "Keep pools with eligible_count <= this bound.",
-      },
-      min_endpoint_count: {
-        type: "number",
-        description: "Keep pools with endpoint_count >= this bound.",
-      },
-      max_endpoint_count: {
-        type: "number",
-        description: "Keep pools with endpoint_count <= this bound.",
-      },
-      sort: {
-        type: "string",
-        enum: POOL_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description: "Comma-separated projection of pool row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListEndpointPoolsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["pools"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    pools: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListEndpointPoolsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/enrichment-evidence-mcp.ts
+++ b/src/enrichment-evidence-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/review/enrichment-evidence.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListEnrichmentEvidenceInputSchema,
+  ListEnrichmentEvidenceOutputSchema,
+} from "../schemas-src/mcp-tools/enrichment-evidence-and-targets.ts";
 
 export const ENRICHMENT_EVIDENCE_ARTIFACT =
   "/metagraph/review/enrichment-evidence.json";
@@ -231,91 +236,14 @@ export const LIST_ENRICHMENT_EVIDENCE_MCP_TOOL = {
     "sort with sort + order; and page with limit (1-100) / cursor. Distinct from " +
     "list_enrichment_queue (prioritized queue summary) and get_subnet_evidence " +
     "(one subnet's live evidence). Mirrors GET /api/v1/review/enrichment-evidence.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      q: {
-        type: "string",
-        description: "Keyword search across name, slug, and evidence_action.",
-      },
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      lane: {
-        type: "string",
-        enum: LANES,
-        description:
-          "Filter by enrichment lane (direct-submission, maintainer-review, etc.).",
-      },
-      evidence_action: {
-        type: "string",
-        enum: EVIDENCE_ACTIONS,
-        description: "Filter by the recommended evidence action.",
-      },
-      direct_submission_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description:
-          "Filter rows whose direct_submission_kinds include this kind.",
-      },
-      missing_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter rows whose missing_kinds include this kind.",
-      },
-      sort: {
-        type: "string",
-        enum: EVIDENCE_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of evidence row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListEnrichmentEvidenceInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_ENRICHMENT_EVIDENCE_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["entries"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    entries: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_ENRICHMENT_EVIDENCE_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListEnrichmentEvidenceOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/enrichment-queue-mcp.ts
+++ b/src/enrichment-queue-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/review/enrichment-queue.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListEnrichmentQueueInputSchema,
+  ListEnrichmentQueueOutputSchema,
+} from "../schemas-src/mcp-tools/enrichment-queue-and-candidates.ts";
 
 export const ENRICHMENT_QUEUE_ARTIFACT =
   "/metagraph/review/enrichment-queue.json";
@@ -252,120 +257,14 @@ export const LIST_ENRICHMENT_QUEUE_MCP_TOOL = {
     "with limit (1-100) / cursor. Distinct from list_enrichment_targets (coverage-depth " +
     "scorecard) and get_subnet_gaps (one subnet's gap priorities + queue). Mirrors " +
     "GET /api/v1/review/enrichment-queue.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      q: {
-        type: "string",
-        description:
-          "Keyword search across name, slug, recommended_action, and reason_codes.",
-      },
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      lane: {
-        type: "string",
-        enum: LANES,
-        description:
-          "Filter by enrichment lane (direct-submission, maintainer-review, etc.).",
-      },
-      evidence_action: {
-        type: "string",
-        enum: EVIDENCE_ACTIONS,
-        description: "Filter by the recommended evidence action.",
-      },
-      identity_level: {
-        type: "string",
-        enum: IDENTITY_LEVELS,
-        description: "Filter by subnet identity completeness.",
-      },
-      curation_level: {
-        type: "string",
-        enum: CURATION_LEVELS,
-        description: "Filter by curation level.",
-      },
-      profile_level: {
-        type: "string",
-        enum: PROFILE_LEVELS,
-        description: "Filter by profile completeness.",
-      },
-      direct_submission_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description:
-          "Filter rows whose direct_submission_kinds include this kind.",
-      },
-      missing_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter rows whose missing_kinds include this kind.",
-      },
-      manual_review_required: {
-        type: "string",
-        enum: BOOLEAN_STRINGS,
-        description: "Filter by whether manual review is required.",
-      },
-      reason_codes: {
-        type: "string",
-        description: "Filter by reason_codes substring match.",
-      },
-      review_state: {
-        type: "string",
-        description: "Filter by review_state substring match.",
-      },
-      sort: {
-        type: "string",
-        enum: QUEUE_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of queue row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListEnrichmentQueueInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_ENRICHMENT_QUEUE_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["queue"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    queue: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_ENRICHMENT_QUEUE_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListEnrichmentQueueOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/gaps-mcp.ts
+++ b/src/gaps-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/gaps.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListGapsInputSchema,
+  ListGapsOutputSchema,
+} from "../schemas-src/mcp-tools/curation-and-gaps.ts";
 
 export const GAPS_ARTIFACT = "/metagraph/gaps.json";
 
@@ -193,72 +198,11 @@ export const LIST_GAPS_MCP_TOOL = {
     "or curation_level, sort with sort + order, and page with limit (1-100) / " +
     "cursor. Use get_subnet_gaps for one subnet's contributor enrichment queue. " +
     "Mirrors GET /api/v1/gaps.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      coverage_level: {
-        type: "string",
-        enum: COVERAGE_LEVELS,
-        description:
-          "Filter by coverage depth: native-only, manifested, or probed.",
-      },
-      curation_level: {
-        type: "string",
-        enum: CURATION_LEVELS,
-        description: "Filter by curation level.",
-      },
-      sort: {
-        type: "string",
-        enum: GAPS_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description: "Comma-separated projection of gap row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListGapsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_GAPS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["gaps"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: NULLABLE_STRING,
-    gaps: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
-  },
-};
+export const LIST_GAPS_OUTPUT_SCHEMA = z.toJSONSchema(ListGapsOutputSchema, {
+  target: "draft-2020-12",
+});

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -769,6 +769,44 @@ import {
   GetChainTransferPairsOutputSchema,
 } from "../schemas-src/mcp-tools/chain-transfers.ts";
 import {
+  GetSubnetCandidatesInputSchema,
+  GetSubnetCandidatesOutputSchema,
+  ListSubnetCandidatesInputSchema,
+  GetSubnetEvidenceInputSchema,
+  GetSubnetEvidenceOutputSchema,
+  ListSubnetEvidenceInputSchema,
+  GetSubnetSurfacesInputSchema,
+  GetSubnetSurfacesOutputSchema,
+} from "../schemas-src/mcp-tools/subnet-registry-lists.ts";
+import {
+  ListFixturesInputSchema,
+  ListFixturesOutputSchema,
+  ListSchemasInputSchema,
+  ListSchemasOutputSchema,
+} from "../schemas-src/mcp-tools/catalog-indexes.ts";
+import {
+  ListSearchIndexInputSchema,
+  ListSearchInputSchema,
+} from "../schemas-src/mcp-tools/search-documents.ts";
+import {
+  ListCurationInputSchema,
+  ListGapsInputSchema,
+} from "../schemas-src/mcp-tools/curation-and-gaps.ts";
+import {
+  ListEnrichmentQueueInputSchema,
+  ListAdapterCandidatesInputSchema,
+} from "../schemas-src/mcp-tools/enrichment-queue-and-candidates.ts";
+import {
+  ListEnrichmentEvidenceInputSchema,
+  ListReviewGapsInputSchema,
+  ListReviewEnrichmentTargetsInputSchema,
+} from "../schemas-src/mcp-tools/enrichment-evidence-and-targets.ts";
+import {
+  ListEndpointPoolsInputSchema,
+  ListEndpointIncidentsInputSchema,
+  ListProviderEndpointsInputSchema,
+} from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
+import {
   buildChainConcentration,
   buildConcentration,
   buildConcentrationHistory,
@@ -8543,22 +8581,23 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "curated/promoted, each with its kind, provider, and review state. The " +
       "per-subnet view of list_candidates (the network-wide catalog). Mirrors " +
       "GET /api/v1/subnets/{netuid}/candidates.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetCandidatesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetCandidatesInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadArtifactData(ctx, `/metagraph/candidates/${netuid}.json`);
     },
   },
   {
     ...LIST_SUBNET_CANDIDATES_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListSubnetCandidatesInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadSubnetCandidatesList(asMcpLoaderCtx(ctx), args);
     },
   },
@@ -8570,22 +8609,23 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "provenance and verification evidence recorded for that subnet's surfaces " +
       "(what was checked and the outcome). The per-subnet view of list_evidence " +
       "(the network-wide ledger). Mirrors GET /api/v1/subnets/{netuid}/evidence.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetEvidenceInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetEvidenceInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadArtifactData(ctx, `/metagraph/evidence/${netuid}.json`);
     },
   },
   {
     ...LIST_SUBNET_EVIDENCE_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListSubnetEvidenceInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadSubnetEvidenceList(asMcpLoaderCtx(ctx), args);
     },
   },
@@ -8598,15 +8638,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "The per-subnet view of list_surfaces (the network-wide catalog); pair " +
       "with list_subnet_apis to drill into a subnet's API surfaces. Mirrors " +
       "GET /api/v1/subnets/{netuid}/surfaces.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetSurfacesInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetSubnetSurfacesInputSchema>,
+      ctx: McpCtx,
+    ) {
       const netuid = requireNetuid(args);
       return loadArtifactData(ctx, `/metagraph/surfaces/${netuid}.json`);
     },
@@ -8619,11 +8657,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "surfaces carry a sanitized real sample, with capture status and metadata. " +
       "Use it to discover which surfaces have a fixture, then fetch one with " +
       "get_fixture. Mirrors GET /api/v1/fixtures.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(ListFixturesInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/fixtures.json");
     },
@@ -8637,84 +8673,106 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "drift status (new/unchanged/changed). Use it to discover which surfaces " +
       "have a schema, then fetch one with get_api_schema. Mirrors " +
       "GET /api/v1/schemas.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(ListSchemasInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/schemas/index.json");
     },
   },
   {
     ...LIST_SEARCH_INDEX_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListSearchIndexInputSchema>, ctx: McpCtx) {
       return loadSearchIndexList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_SEARCH_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListSearchInputSchema>, ctx: McpCtx) {
       return loadSearchList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_CURATION_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListCurationInputSchema>, ctx: McpCtx) {
       return loadCurationList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_GAPS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof ListGapsInputSchema>, ctx: McpCtx) {
       return loadGapsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ENRICHMENT_QUEUE_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListEnrichmentQueueInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadEnrichmentQueueList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ADAPTER_CANDIDATES_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListAdapterCandidatesInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadAdapterCandidatesList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ENRICHMENT_EVIDENCE_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListEnrichmentEvidenceInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadEnrichmentEvidenceList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_REVIEW_GAPS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListReviewGapsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadReviewGapsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListReviewEnrichmentTargetsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadReviewEnrichmentTargetsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ENDPOINT_POOLS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListEndpointPoolsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadEndpointPoolsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListEndpointIncidentsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadEndpointIncidentsList(asMcpLoaderCtx(ctx), args);
     },
   },
   {
     ...LIST_PROVIDER_ENDPOINTS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListProviderEndpointsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadProviderEndpointsList(asMcpLoaderCtx(ctx), args);
     },
   },
@@ -10896,40 +10954,16 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_endpoints: z.toJSONSchema(ListEndpointsOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_subnet_surfaces: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      netuid: { type: ["integer", "null"] },
-      surfaces: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
-  get_subnet_evidence: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      netuid: { type: ["integer", "null"] },
-      claims: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  get_subnet_surfaces: z.toJSONSchema(GetSubnetSurfacesOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_evidence: z.toJSONSchema(GetSubnetEvidenceOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_subnet_evidence: LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA,
-  get_subnet_candidates: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      netuid: { type: ["integer", "null"] },
-      candidates: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  get_subnet_candidates: z.toJSONSchema(GetSubnetCandidatesOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_subnet_candidates: LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA,
   get_subnet_endpoints: z.toJSONSchema(GetSubnetEndpointsOutputSchema, {
     target: "draft-2020-12",
@@ -10942,27 +10976,12 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_source_snapshots: LIST_SOURCE_SNAPSHOTS_OUTPUT_SCHEMA,
   list_rpc_endpoints: LIST_RPC_ENDPOINTS_OUTPUT_SCHEMA,
   list_evidence: LIST_EVIDENCE_OUTPUT_SCHEMA,
-  list_fixtures: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      candidate_count: { type: "integer" },
-      coverage: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-    },
-  },
-  list_schemas: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      schemas: { type: "array", items: { type: "object" } },
-      observed_at: NULLABLE_STRING,
-      generated_at: NULLABLE_STRING,
-      notes: NULLABLE_STRING,
-    },
-  },
+  list_fixtures: z.toJSONSchema(ListFixturesOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  list_schemas: z.toJSONSchema(ListSchemasOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_search_index: LIST_SEARCH_INDEX_OUTPUT_SCHEMA,
   list_search: LIST_SEARCH_OUTPUT_SCHEMA,
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -8682,7 +8682,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...LIST_SEARCH_INDEX_MCP_TOOL,
-    async handler(args: z.infer<typeof ListSearchIndexInputSchema>, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListSearchIndexInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadSearchIndexList(asMcpLoaderCtx(ctx), args);
     },
   },

--- a/src/provider-endpoints-mcp.ts
+++ b/src/provider-endpoints-mcp.ts
@@ -3,9 +3,14 @@
 // transforms as the REST route over the baked
 // /metagraph/providers/{slug}/endpoints.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListProviderEndpointsInputSchema,
+  ListProviderEndpointsOutputSchema,
+} from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
 
 export const PROVIDER_SLUG_PATTERN = /^[a-z0-9-]+$/;
 
@@ -277,112 +282,14 @@ export const LIST_PROVIDER_ENDPOINTS_MCP_TOOL = {
     "cursor. The per-provider view of list_endpoints (the network-wide catalog). " +
     "Complements get_provider_detail (identity + optional endpoints attachment). " +
     "Mirrors GET /api/v1/providers/{slug}/endpoints.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      slug: {
-        type: "string",
-        pattern: "^[a-z0-9-]+$",
-        description: "Provider slug, e.g. 'datura' or 'allways'.",
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter by surface kind, e.g. 'subnet-api'.",
-      },
-      layer: {
-        type: "string",
-        enum: ENDPOINT_LAYERS,
-        description: "Filter by endpoint layer.",
-      },
-      netuid: {
-        type: "integer",
-        description: "Filter to endpoints for one subnet netuid.",
-        minimum: 0,
-      },
-      publication_state: {
-        type: "string",
-        enum: PUBLICATION_STATES,
-        description: "Filter by publication state.",
-      },
-      status: {
-        type: "string",
-        enum: HEALTH_STATUSES,
-        description: "Filter by probe-derived health status.",
-      },
-      pool_eligible: {
-        type: "boolean",
-        description: "Only endpoints eligible (or not) for RPC pooling.",
-      },
-      min_latency_ms: {
-        type: "number",
-        description: "Keep endpoints with latency_ms >= this bound.",
-      },
-      max_latency_ms: {
-        type: "number",
-        description: "Keep endpoints with latency_ms <= this bound.",
-      },
-      min_score: {
-        type: "number",
-        description: "Keep endpoints with score >= this bound.",
-      },
-      max_score: {
-        type: "number",
-        description: "Keep endpoints with score <= this bound.",
-      },
-      sort: {
-        type: "string",
-        enum: ENDPOINT_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of endpoint row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    required: ["slug"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListProviderEndpointsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["slug", "endpoints"],
-  properties: {
-    slug: { type: "string" },
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    endpoints: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListProviderEndpointsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/review-enrichment-targets-mcp.ts
+++ b/src/review-enrichment-targets-mcp.ts
@@ -3,9 +3,14 @@
 // transforms as the REST route over the baked
 // /metagraph/review/enrichment-targets.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListReviewEnrichmentTargetsInputSchema,
+  ListReviewEnrichmentTargetsOutputSchema,
+} from "../schemas-src/mcp-tools/enrichment-evidence-and-targets.ts";
 
 export const REVIEW_ENRICHMENT_TARGETS_ARTIFACT =
   "/metagraph/review/enrichment-targets.json";
@@ -286,132 +291,14 @@ export const LIST_REVIEW_ENRICHMENT_TARGETS_MCP_TOOL = {
     "(1-100) / cursor. Distinct from list_enrichment_targets (coverage-depth scorecard) " +
     "and list_enrichment_queue (prioritized queue summary). Mirrors " +
     "GET /api/v1/review/enrichment-targets.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      q: {
-        type: "string",
-        description:
-          "Keyword search across name, slug, contribution_prompt, recommended_action, and reason_codes.",
-      },
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      target_type: {
-        type: "string",
-        enum: TARGET_TYPES,
-        description:
-          "Filter by target type (surface-candidate, adapter-review, etc.).",
-      },
-      target_action: {
-        type: "string",
-        enum: TARGET_ACTIONS,
-        description: "Filter by the recommended target action.",
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter by surface kind.",
-      },
-      lane: {
-        type: "string",
-        enum: LANES,
-        description:
-          "Filter by enrichment lane (direct-submission, maintainer-review, etc.).",
-      },
-      evidence_action: {
-        type: "string",
-        enum: EVIDENCE_ACTIONS,
-        description: "Filter by the recommended evidence action.",
-      },
-      identity_level: {
-        type: "string",
-        enum: IDENTITY_LEVELS,
-        description: "Filter by subnet identity completeness.",
-      },
-      profile_level: {
-        type: "string",
-        enum: PROFILE_LEVELS,
-        description: "Filter by profile completeness.",
-      },
-      submission_route: {
-        type: "string",
-        enum: SUBMISSION_ROUTES,
-        description: "Filter by contributor submission route.",
-      },
-      auto_review_candidate: {
-        type: "string",
-        enum: BOOLEAN_STRINGS,
-        description:
-          "Filter by whether the target is an auto-review candidate.",
-      },
-      manual_review_required: {
-        type: "string",
-        enum: BOOLEAN_STRINGS,
-        description: "Filter by whether manual review is required.",
-      },
-      missing_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter rows whose missing_kinds include this kind.",
-      },
-      reason_codes: {
-        type: "string",
-        description: "Filter by reason_codes substring match.",
-      },
-      sort: {
-        type: "string",
-        enum: TARGET_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of target row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListReviewEnrichmentTargetsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_REVIEW_ENRICHMENT_TARGETS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["targets"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    targets: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_REVIEW_ENRICHMENT_TARGETS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListReviewEnrichmentTargetsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/review-gaps-mcp.ts
+++ b/src/review-gaps-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/review/gap-priorities.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListReviewGapsInputSchema,
+  ListReviewGapsOutputSchema,
+} from "../schemas-src/mcp-tools/enrichment-evidence-and-targets.ts";
 
 export const REVIEW_GAPS_ARTIFACT = "/metagraph/review/gap-priorities.json";
 
@@ -198,80 +203,14 @@ export const LIST_REVIEW_GAPS_MCP_TOOL = {
     "or review_state; sort with sort + order; and page with limit (1-100) / cursor. " +
     "Distinct from list_gaps (interface facet reports at GET /api/v1/gaps) and " +
     "get_subnet_gaps (one subnet's detailed gap artifact). Mirrors GET /api/v1/review/gaps.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Filter to one subnet netuid.",
-        minimum: 0,
-      },
-      curation_level: {
-        type: "string",
-        enum: CURATION_LEVELS,
-        description: "Filter by curation level.",
-      },
-      missing_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description:
-          "Filter rows whose missing_kinds include this surface kind.",
-      },
-      review_state: {
-        type: "string",
-        description: "Filter by review_state substring match.",
-      },
-      sort: {
-        type: "string",
-        enum: PRIORITY_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of priority row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListReviewGapsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_REVIEW_GAPS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["priorities"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    priorities: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_REVIEW_GAPS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListReviewGapsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/search-index-mcp.ts
+++ b/src/search-index-mcp.ts
@@ -2,9 +2,14 @@
 // Applies the same list-query transforms as the REST route over the baked
 // /metagraph/search-index.json artifact (slim documents without token blobs).
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
+import {
+  ListSearchIndexInputSchema,
+  ListSearchIndexOutputSchema,
+} from "../schemas-src/mcp-tools/search-documents.ts";
 
 export const SEARCH_INDEX_ARTIFACT = "/metagraph/search-index.json";
 
@@ -202,73 +207,14 @@ export const LIST_SEARCH_INDEX_MCP_TOOL = {
     "order; project with fields; and page with limit (1-100) / cursor. Use " +
     "semantic_search for meaning-based discovery or search_subnets for keyword " +
     "subnet lookup. Mirrors GET /api/v1/search-index.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      q: {
-        type: "string",
-        description: "Keyword search across title, subtitle, slug, and tokens.",
-      },
-      type: {
-        type: "string",
-        enum: ["subnet", "surface", "provider"],
-        description: "Filter by document type (subnet, surface, or provider).",
-      },
-      netuid: {
-        type: "integer",
-        description: "Filter by subnet netuid.",
-        minimum: 0,
-      },
-      sort: {
-        type: "string",
-        enum: DOCUMENT_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description: "Comma-separated projection of document fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSearchIndexInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SEARCH_INDEX_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["documents"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    documents: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SEARCH_INDEX_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSearchIndexOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/search-mcp.ts
+++ b/src/search-mcp.ts
@@ -4,9 +4,14 @@
 // blobs) — the same subnet/surface/provider corpus search_subnets reads but
 // without its subnet-only filter, and unlike list_search_index it keeps tokens.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
+import {
+  ListSearchInputSchema,
+  ListSearchOutputSchema,
+} from "../schemas-src/mcp-tools/search-documents.ts";
 
 export const SEARCH_ARTIFACT = "/metagraph/search.json";
 
@@ -189,73 +194,14 @@ export const LIST_SEARCH_MCP_TOOL = {
     "providers even when the AI layer semantic_search depends on is not configured. " +
     "Unlike list_search_index, which serves the slim variant without token blobs, " +
     "this keeps the full documents. Use semantic_search for meaning-based discovery.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      q: {
-        type: "string",
-        description: "Keyword search across title, subtitle, slug, and tokens.",
-      },
-      type: {
-        type: "string",
-        enum: ["subnet", "surface", "provider"],
-        description: "Filter by document type (subnet, surface, or provider).",
-      },
-      netuid: {
-        type: "integer",
-        description: "Filter by subnet netuid.",
-        minimum: 0,
-      },
-      sort: {
-        type: "string",
-        enum: DOCUMENT_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description: "Comma-separated projection of document fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSearchInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SEARCH_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["documents"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    documents: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SEARCH_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSearchOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/subnet-candidates-mcp.ts
+++ b/src/subnet-candidates-mcp.ts
@@ -3,9 +3,14 @@
 // transforms as the REST route over the baked
 // /metagraph/candidates/{netuid}.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListSubnetCandidatesInputSchema,
+  ListSubnetCandidatesOutputSchema,
+} from "../schemas-src/mcp-tools/subnet-registry-lists.ts";
 
 const CANDIDATE_SORT_FIELDS = API_QUERY_COLLECTIONS.candidates.sort_fields;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
@@ -221,86 +226,14 @@ export const LIST_SUBNET_CANDIDATES_MCP_TOOL = {
     "with limit (1-100) / cursor. Distinct from get_subnet_candidates (raw " +
     "artifact dump) and list_candidates (network-wide catalog). Mirrors " +
     "GET /api/v1/subnets/{netuid}/candidates.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Subnet netuid.",
-        minimum: 0,
-      },
-      kind: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter by surface kind, e.g. 'subnet-api'.",
-      },
-      provider: {
-        type: "string",
-        description: "Filter by provider slug.",
-      },
-      state: {
-        type: "string",
-        enum: CANDIDATE_STATES,
-        description: "Filter by candidate review state.",
-      },
-      id: {
-        type: "string",
-        description: "Exact-match filter on candidate id.",
-      },
-      confidence: {
-        type: "string",
-        enum: CONFIDENCE_LEVELS,
-        description: "Filter by confidence level.",
-      },
-      sort: {
-        type: "string",
-        enum: CANDIDATE_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of candidate row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    required: ["netuid"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSubnetCandidatesInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["candidates"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    netuid: NULLABLE_INT,
-    candidates: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SUBNET_CANDIDATES_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSubnetCandidatesOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/subnet-evidence-mcp.ts
+++ b/src/subnet-evidence-mcp.ts
@@ -3,9 +3,14 @@
 // transforms as the REST route over the baked
 // /metagraph/evidence/{netuid}.json artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS } from "./contracts.ts";
+import {
+  ListSubnetEvidenceInputSchema,
+  ListSubnetEvidenceOutputSchema,
+} from "../schemas-src/mcp-tools/subnet-registry-lists.ts";
 
 const CLAIM_SORT_FIELDS = API_QUERY_COLLECTIONS.claims.sort_fields;
 
@@ -201,68 +206,14 @@ export const LIST_SUBNET_EVIDENCE_MCP_TOOL = {
     "cursor. Distinct from get_subnet_evidence (raw artifact dump) and " +
     "list_evidence (network-wide ledger). Mirrors " +
     "GET /api/v1/subnets/{netuid}/evidence.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Subnet netuid.",
-        minimum: 0,
-      },
-      q: {
-        type: "string",
-        description:
-          "Keyword search across subject, claim, source_url, and support_summary.",
-      },
-      sort: {
-        type: "string",
-        enum: CLAIM_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of claim row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    required: ["netuid"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSubnetEvidenceInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["claims"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    netuid: NULLABLE_INT,
-    claims: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SUBNET_EVIDENCE_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSubnetEvidenceOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);


### PR DESCRIPTION
## Summary
Converts 19 MCP tools' hand-written JSON Schema `inputSchema`/output-schema literals to Zod-generated (`z.toJSONSchema(...)`), continuing types-epic E (#7863): `get_subnet_candidates`, `list_subnet_candidates`, `get_subnet_evidence`, `list_subnet_evidence`, `get_subnet_surfaces`, `list_fixtures`, `list_schemas`, `list_search_index`, `list_search`, `list_curation`, `list_gaps`, `list_enrichment_queue`, `list_adapter_candidates`, `list_enrichment_evidence`, `list_review_gaps`, `list_review_enrichment_targets`, `list_endpoint_pools`, `list_endpoint_incidents`, `list_provider_endpoints`.

Same architecture as batch 9 (#8073): 14 of these 19 tools aren't defined inline in `src/mcp-server.ts` — each has its own `src/<name>-mcp.ts` file exporting a `LIST_X_MCP_TOOL`/`LIST_X_OUTPUT_SCHEMA` pair, spread into `mcp-server.ts`'s `MCP_TOOLS` array. The `z.toJSONSchema(...)` wiring lives in each of those 14 files; `mcp-server.ts` only needed its wrapper handlers' `args` retyped to `z.infer<typeof <Tool>InputSchema>`.

## Diff-audit results
`npx tsx scripts/diff-mcp-tool-schemas.ts`: **350/352 PASS**. 0 new findings for this batch — all 38 input+output checks for the 19 tools above PASS **on the first run**, with no new `normalize()` gaps needed. That's a useful confirmation: the two equivalence rules added in #8073/#8127 (`oneOf` vs `anyOf`, and flattening the nested `anyOf` Zod's `.union([...]).nullable()` produces) generalize correctly rather than being one-off fixes. The 2 remaining DIFFs are pre-existing, already-documented findings from #8067 (`get_subnet_identity_history`) and #8069 (`get_account_identity_history`), unrelated to this batch.

## Reuse notes
- **Hoisted `NotesFieldSchema` into `shared.ts`**: 10 of this batch's 19 tools declare the identical `notes: array-or-string-or-null` output field (`list_search_index`, `list_search`, `list_enrichment_queue`, `list_adapter_candidates`, `list_enrichment_evidence`, `list_review_gaps`, `list_review_enrichment_targets`, `list_endpoint_pools`, `list_endpoint_incidents`, `list_provider_endpoints`) — well past the epic's established "reused 3+ times within a batch" hoisting threshold.
- `list_curation` and `list_gaps` instead declare `notes` as a **plain nullable string**, unlike their `notes`-bearing siblings above — a genuine, deliberate difference, preserved as-is rather than "fixed" to match.
- `list_search` and `list_search_index` share an **identical** input/output shape (same filters, same `documents` output key) — the only difference is which artifact each reads (full documents with token blobs vs. the slim variant without them), a runtime-data distinction, not a schema one.
- None of this batch's 19 tools mirror an existing `schemas-src/routes/` REST schema — all modeled fresh, matching each hand-written literal field-for-field.

## Cleanup
Removed the now-dead local `NULLABLE_STRING`/`NULLABLE_INT` constants from each of the 14 individually-edited `src/*-mcp.ts` files (their only use was the literal being replaced).

## Verification
- `npx tsc --noEmit -p .` — clean.
- `npx eslint` across all 24 touched/created files — clean.
- `npx prettier --check` — clean.
- `npx tsx scripts/diff-mcp-tool-schemas.ts` — 350/352 PASS (see above).
- `npx tsx scripts/validate-mcp.ts` — 204 tools, all MCP lifecycle/dispatch checks pass.
- Zero JSON Schema object literals remain for these 19 tools (grep-verified).

## Test plan
- [x] `npx vitest run tests/mcp-server.test.ts tests/zod-schemas.test.ts` + the 14 directly-affected `*-mcp.test.ts` files — 1708/1708 pass, no test-file edits needed. `tests/mcp-server.test.ts` itself is UNCHANGED (its Ajv output-schema validation is the independent referee, per #8074's acceptance criterion 1).
- [x] Full suite: `npx vitest run` — 492/492 files, 11905/11905 tests pass.

Closes #8074.