### PR TITLE
feat(observability): PostHog sourcemap upload for the 3 core Workers

### DIFF
--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -35,6 +35,35 @@
 # Variable/Secret -- sentry-cli only runs during the build, never reaches the
 # deployed Worker) on each of the 3 Worker projects.
 #
+# PostHog sourcemap upload (metagraphed#8128) is a SEPARATE, additive step,
+# gated on POSTHOG_CLI_API_KEY/POSTHOG_CLI_PROJECT_ID being set the same way
+# (Workers BUILD secrets/vars) -- completely inert, original single-command
+# build+deploy flow unchanged, until both are configured. Unlike Sentry's
+# release-based association, `posthog-cli` embeds a `//# chunkId=...` marker
+# directly into the shipped JS: that marker MUST be present in the EXACT
+# bytes Cloudflare actually serves, or PostHog can never match a captured
+# stack trace back to the uploaded map (confirmed against PostHog's own
+# docs -- "If you serve a copy of the bundled assets as they were prior to
+# running posthog-cli sourcemap inject, we won't be able to use the
+# uploaded sourcemap"). A single `wrangler deploy --outdir` builds AND ships
+# atomically, so injecting into $OUTDIR afterward would modify a local copy
+# that was never actually deployed. When PostHog is configured, this script
+# instead: (1) `wrangler deploy --dry-run` builds WITHOUT deploying
+# (Cloudflare's own documented use for exactly this purpose -- "gives
+# developers a chance to upload our generated sourcemap to a service...
+# before the service goes live"), (2) `posthog-cli sourcemap inject` embeds
+# the marker into that build output, (3) `wrangler deploy --no-bundle` ships
+# THAT EXACT injected file, skipping wrangler's own esbuild step (which
+# would otherwise silently rebuild from source and discard the marker just
+# injected). Verified locally: the dry-run build + inject steps (single
+# flat `<entry>.js`/`.js.map` per Worker, no code-splitting -- confirmed via
+# `wrangler deploy --dry-run --outdir` against wrangler.jsonc). The
+# `--no-bundle` deploy step (3) could not be safely tested against a live
+# Worker from a dev sandbox -- watch the first real deploy after this lands
+# closely, and consider setting the two POSTHOG_CLI_* vars on a Worker
+# project's non-production branch deploy command slot first (--preview mode
+# below uses `wrangler versions upload`, which never serves live traffic).
+#
 # --message also passed on the wrangler call itself (metagraphed#7224): the
 # deployed commit SHA needs to land in the deployment's own real
 # `workers/message` annotation (confirmed against Cloudflare's List
@@ -72,13 +101,52 @@ if [[ "$ENVIRONMENT" == "preview" ]]; then
 fi
 COMMIT_SHA=$(git rev-parse HEAD)
 
-npx wrangler "${WRANGLER_SUBCOMMAND[@]}" \
-  --config "$CONFIG" \
-  --outdir "$OUTDIR" \
-  --upload-source-maps \
-  --var "SENTRY_RELEASE:$RELEASE" \
-  --var "SENTRY_ENVIRONMENT:$ENVIRONMENT" \
-  --message "$COMMIT_SHA"
+POSTHOG_ENABLED=false
+if [[ -n "${POSTHOG_CLI_API_KEY:-}" && -n "${POSTHOG_CLI_PROJECT_ID:-}" ]]; then
+  POSTHOG_ENABLED=true
+fi
+
+if [[ "$POSTHOG_ENABLED" == "true" ]]; then
+  # Phase 1: build only -- writes $OUTDIR/<entry>.js(.map) without deploying
+  # (see this file's own header comment for why a single combined build+
+  # deploy command can't be injected into afterward).
+  npx wrangler "${WRANGLER_SUBCOMMAND[@]}" \
+    --config "$CONFIG" \
+    --outdir "$OUTDIR" \
+    --upload-source-maps \
+    --var "SENTRY_RELEASE:$RELEASE" \
+    --var "SENTRY_ENVIRONMENT:$ENVIRONMENT" \
+    --message "$COMMIT_SHA" \
+    --dry-run
+
+  # Phase 2: inject PostHog's chunk-ID marker into the just-built bundle,
+  # BEFORE it ever ships.
+  npx @posthog/cli sourcemap inject --directory "$OUTDIR"
+
+  # Phase 3: ship the EXACT injected file -- --no-bundle skips wrangler's
+  # own esbuild step (which would otherwise rebuild from source and discard
+  # the marker just injected above). ENTRY_JS is the single flat bundle
+  # wrangler's own build produces for these Workers (no code-splitting for
+  # a single-entry Worker, confirmed locally) -- resolved by globbing
+  # rather than hardcoded per-Worker, since each of the 3 configs' `main`
+  # basename differs.
+  ENTRY_JS=$(find "$OUTDIR" -maxdepth 1 -name '*.js')
+  npx wrangler "${WRANGLER_SUBCOMMAND[@]}" \
+    "$ENTRY_JS" \
+    --config "$CONFIG" \
+    --no-bundle \
+    --var "SENTRY_RELEASE:$RELEASE" \
+    --var "SENTRY_ENVIRONMENT:$ENVIRONMENT" \
+    --message "$COMMIT_SHA"
+else
+  npx wrangler "${WRANGLER_SUBCOMMAND[@]}" \
+    --config "$CONFIG" \
+    --outdir "$OUTDIR" \
+    --upload-source-maps \
+    --var "SENTRY_RELEASE:$RELEASE" \
+    --var "SENTRY_ENVIRONMENT:$ENVIRONMENT" \
+    --message "$COMMIT_SHA"
+fi
 
 npx sentry-cli releases new "$RELEASE"
 # --auto reads the linked GitHub repo's commit range since the last release
@@ -90,3 +158,12 @@ npx sentry-cli sourcemaps upload \
   --strip-prefix "$OUTDIR/.." \
   "$OUTDIR"
 npx sentry-cli releases finalize "$RELEASE"
+
+if [[ "$POSTHOG_ENABLED" == "true" ]]; then
+  # Safe now: $OUTDIR's injected bundle IS what phase 3 above actually
+  # deployed, so this upload correctly resolves real production traces.
+  npx @posthog/cli sourcemap upload \
+    --directory "$OUTDIR" \
+    --release-name "metagraphed-$BASENAME" \
+    --release-version "$RELEASE"
+fi


### PR DESCRIPTION
## Summary

Closes #8128.

Adds PostHog sourcemap inject+upload to `scripts/deploy-worker-with-sourcemaps.sh` -- the actual Cloudflare Workers Builds deploy command for all 3 core Workers (api/data-api/registry-sync-api). **Additive and fully gated**: the original single-command build+deploy invocation is byte-identical and completely unaffected unless `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID` are both set as Workers build secrets/vars. Merging this changes nothing about the current live deploy behavior.

**Why this needed a different shape than apps/ui's fix (#8129):** `posthog-cli` embeds a `//# chunkId=...` marker directly into the shipped JS -- that marker must be present in the *exact bytes Cloudflare actually serves*, confirmed against PostHog's own docs. A single `wrangler deploy --outdir` builds and deploys atomically, so injecting into the output directory afterward would only modify a local copy that was never actually shipped. This uses wrangler's own documented flags for this exact scenario:
- `wrangler deploy --dry-run` -- builds without deploying (Cloudflare's docs describe this exact use case: "gives developers a chance to upload our generated sourcemap to a service... before the service goes live")
- `posthog-cli sourcemap inject` -- embeds the marker into that build output
- `wrangler deploy --no-bundle <file>` -- ships that exact injected file, skipping wrangler's own esbuild step (which would otherwise rebuild from source and discard the injected marker)

## What I could and couldn't verify

- ✅ `wrangler deploy --dry-run --outdir` against the real `wrangler.jsonc`: confirmed it produces a single flat `<entry>.js` + `.js.map` per Worker (no code-splitting), never touches production
- ✅ `posthog-cli sourcemap inject --directory` against that output: confirmed the `//# chunkId=...` marker gets embedded correctly
- ⚠️ The `--no-bundle` deploy step (phase 3) -- **could not be safely tested** without actually deploying to a live production Worker from my sandbox, which I won't do unprompted. This is the one piece that needs real-world verification.

## Rollout recommendation

Given the unverified step, I'd suggest setting `POSTHOG_CLI_API_KEY`/`POSTHOG_CLI_PROJECT_ID` on a Worker project's **non-production branch deploy command** slot first (the script's existing `--preview` mode uses `wrangler versions upload`, which never serves live traffic) and confirming a preview deploy succeeds before enabling it on the real production deploy command slot.

## Test plan
- [x] `shellcheck` clean
- [x] `bash -n` syntax check clean
- [x] Diffed the unconfigured (`POSTHOG_ENABLED=false`) code path against the original script -- byte-identical
- [x] Empirically verified phases 1-2 (dry-run build + inject) against the real `wrangler.jsonc`