### PR TITLE
feat(observability): drop Sentry entirely from the Worker deploy script

### DIFF
--- a/.github/workflows/check-worker-deploy-drift.yml
+++ b/.github/workflows/check-worker-deploy-drift.yml
@@ -12,15 +12,6 @@ name: Check Worker Deploy Drift
 # prior scheduled run (see scripts/check-worker-deploy-drift.ts for the exact
 # grace-window rule -- this only needs to catch a genuinely stuck build, not race a
 # normal in-flight deploy).
-#
-# SENTRY_AUTH_TOKEN (same repo secret ui-sentry-release.yml already uses) is a
-# fallback: if the active deployment's workers/message annotation (set by
-# scripts/deploy-worker-with-sourcemaps.sh's --message, #7224) is ever absent
-# -- e.g. a deployment predating that fix -- the script falls back to the
-# deployed commit SHA that @sentry/cloudflare's withSentry() already tags
-# every production error event with (workers/api.sentry.mjs), independent of
-# Cloudflare's own deployment bookkeeping. Optional: omitting the secret just
-# removes the fallback, not the primary check.
 on:
   schedule:
     - cron: "53 8 * * *"
@@ -69,6 +60,3 @@ jobs:
           MAIN_HEAD_SHA: ${{ steps.main-head.outputs.sha }}
           MAIN_HEAD_COMMITTED_AT: ${{ steps.main-head.outputs.committed_at }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: jsonbored
-          SENTRY_PROJECT: metagraphed

--- a/scripts/check-worker-deploy-drift.ts
+++ b/scripts/check-worker-deploy-drift.ts
@@ -8,10 +8,8 @@
 // compares the live deployment's commit -- read from the workers/message
 // annotation that scripts/deploy-worker-with-sourcemaps.sh's `--message
 // "$(git rev-parse HEAD)"` sets on every deploy -- against origin/main HEAD,
-// falling back to Sentry's release tracking if that annotation is ever
-// absent (e.g. a deployment predating the #7224 fix), and fails the
-// scheduled job once the drift has persisted across a prior scheduled run
-// (see evaluateDeployDrift below for the grace-window rule).
+// and fails the scheduled job once the drift has persisted across a prior
+// scheduled run (see evaluateDeployDrift below for the grace-window rule).
 //
 // #7224: this previously read a `workers/commit_hash` annotation that never
 // existed for Cloudflare Workers deployments (confirmed against wrangler's
@@ -25,15 +23,8 @@ type Row = Record<string, unknown>;
 
 const DEPLOYMENTS_PATH_TEMPLATE =
   "https://api.cloudflare.com/client/v4/accounts/{accountId}/workers/scripts/{scriptName}/deployments";
-const SENTRY_RELEASES_PATH_TEMPLATE =
-  "https://sentry.io/api/0/projects/{org}/{project}/releases/";
-// A bare 40-hex-char git SHA is what both a real deployment's workers/message
-// annotation (deploy-worker-with-sourcemaps.sh's --message) and a real
-// production Sentry release's version (workers/api.sentry.ts's
-// `release: env.SENTRY_RELEASE || ...`) should contain. PR-preview deploys
-// (apps/ui/.github/workflows/ui-preview-deploy.yml) tag Sentry releases
-// "<sha>-preview" -- excluded so a preview build is never mistaken for what's
-// actually live in production.
+// A bare 40-hex-char git SHA is what a real deployment's workers/message
+// annotation (deploy-worker-with-sourcemaps.sh's --message) should contain.
 const PRODUCTION_RELEASE_VERSION_PATTERN = /^[0-9a-f]{40}$/i;
 
 export function extractDeployedCommitSha(deploymentsJson: Row): string {
@@ -54,59 +45,6 @@ export function extractDeployedCommitSha(deploymentsJson: Row): string {
     );
   }
   return message;
-}
-
-// Fallback for a deployment whose workers/message annotation is absent or
-// not SHA-shaped (e.g. one predating the #7224 --message fix): @sentry/
-// cloudflare's withSentry() (workers/api.sentry.ts) already tags every
-// production error event with the real deployed commit SHA as its Sentry
-// release, independent of Cloudflare's own deployment bookkeeping. Sorts by
-// dateCreated rather than trusting response order, since that isn't
-// documented/guaranteed.
-export function selectLatestProductionRelease(
-  releases: Row[] | null | undefined,
-): Row | null {
-  if (!Array.isArray(releases)) {
-    return null;
-  }
-  const candidates = releases.filter(
-    (release) =>
-      typeof release?.version === "string" &&
-      PRODUCTION_RELEASE_VERSION_PATTERN.test(release.version as string),
-  );
-  if (candidates.length === 0) {
-    return null;
-  }
-  return candidates.sort(
-    (a, b) =>
-      new Date(b.dateCreated as string).getTime() -
-      new Date(a.dateCreated as string).getTime(),
-  )[0];
-}
-
-export async function findLatestProductionReleaseCommit({
-  sentryAuthToken,
-  sentryOrg,
-  sentryProject,
-}: {
-  sentryAuthToken: string;
-  sentryOrg: string;
-  sentryProject: string;
-}): Promise<string | null> {
-  const releasesUrl = SENTRY_RELEASES_PATH_TEMPLATE.replace(
-    "{org}",
-    sentryOrg,
-  ).replace("{project}", sentryProject);
-  const res = await fetch(releasesUrl, {
-    headers: { Authorization: `Bearer ${sentryAuthToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(
-      `Sentry releases API returned HTTP ${res.status}: ${await res.text()}`,
-    );
-  }
-  const latest = selectLatestProductionRelease((await res.json()) as Row[]);
-  return (latest?.version as string | undefined) ?? null;
 }
 
 export function findPreviousScheduledRunAt(
@@ -233,39 +171,8 @@ async function main(): Promise<number> {
       (await deploymentsRes.json()) as Row,
     );
   } catch (cfError) {
-    // Fall back to Sentry's release tracking (see findLatestProductionReleaseCommit
-    // above) rather than failing outright -- this is what actually let a maintainer
-    // confirm live code was current while this annotation gap was unresolved.
-    const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
-    if (!sentryAuthToken) {
-      console.error(`::error::${(cfError as Error).message}`);
-      return 1;
-    }
-    console.error(
-      `::warning::${(cfError as Error).message} -- falling back to Sentry's latest release commit.`,
-    );
-    let fallbackSha: string | null;
-    try {
-      fallbackSha = await findLatestProductionReleaseCommit({
-        sentryAuthToken,
-        sentryOrg: process.env.SENTRY_ORG || "jsonbored",
-        sentryProject: process.env.SENTRY_PROJECT || "metagraphed",
-      });
-    } catch (sentryError) {
-      console.error(`::error::${(cfError as Error).message}`);
-      console.error(
-        `::error::Sentry fallback also failed: ${(sentryError as Error).message}`,
-      );
-      return 1;
-    }
-    if (!fallbackSha) {
-      console.error(`::error::${(cfError as Error).message}`);
-      console.error(
-        "::error::Sentry fallback found no production release either.",
-      );
-      return 1;
-    }
-    deployedCommitSha = fallbackSha;
+    console.error(`::error::${(cfError as Error).message}`);
+    return 1;
   }
 
   let previousScheduledRunAt: string | null = null;

--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -1,79 +1,61 @@
 #!/usr/bin/env bash
 # Builds/publishes one of the 3 core Cloudflare Workers and uploads its
-# source maps to the consolidated `metagraphed` Sentry project, so a captured
-# error's minified stack trace (workers/*.sentry.mjs bundle, e.g.
-# "api.sentry.js:18:8835") resolves to real source. wrangler.*.jsonc's own
-# upload_source_maps only makes wrangler PRODUCE source maps as build
-# output -- it does not push them into Sentry; that needs this explicit
-# sentry-cli step reading the same output directory.
-#
-# The release value is generated once here (sentry-cli releases propose-
-# version, git-derived) and passed to the build itself via --var, so the
-# Worker's OWN release tag at runtime (env.SENTRY_RELEASE, read by workers/
-# *.sentry.mjs's withSentry() options callback -- see that file's own header)
-# is the exact same value the source maps get uploaded under. Previously the
-# runtime release fell back to CF_VERSION_METADATA's UUID, which has no
-# relationship to a git commit -- this also makes Sentry's suspect-commit
-# detection actually work against the linked JSONbored/metagraphed repo.
+# source maps to PostHog Error Tracking, so a captured error's minified
+# stack trace resolves to real source. wrangler.*.jsonc's own
+# upload_source_maps is Cloudflare's own separate Sourcemap Uploads
+# product (its own dashboard/logs symbolication) -- it does not push
+# anything to PostHog; that needs the posthog-cli steps below.
 #
 # Two modes, matching the two Cloudflare Workers Builds command slots each of
 # the 3 Worker projects has (Settings -> Build):
 #   Deploy command:                      scripts/deploy-worker-with-sourcemaps.sh <config.jsonc>
 #   Non-production branch deploy command: scripts/deploy-worker-with-sourcemaps.sh <config.jsonc> --preview
 # --preview uses `wrangler versions upload` (a non-promoting version, not
-# live traffic -- confirmed supported: --outdir/--upload-source-maps/--var
-# all work identically on this subcommand, `wrangler versions upload --help`)
-# instead of `wrangler deploy`, and tags the release/environment as preview
-# so these don't get filed as production events or dilute suspect-commit
-# data for a real release -- none of the 3 wrangler configs define a
-# separate non-prod environment (wrangler.data.jsonc/wrangler.registry.jsonc
-# even say so explicitly, "preview_urls: false"), so this is the one thing
-# that keeps a branch build's errors distinguishable from production's
-# despite sharing the exact same bindings/database.
+# live traffic) instead of `wrangler deploy`, and tags the release as
+# preview so these don't dilute production release data -- none of the 3
+# wrangler configs define a separate non-prod environment
+# (wrangler.data.jsonc/wrangler.registry.jsonc even say so explicitly,
+# "preview_urls: false"), so this is the one thing that keeps a branch
+# build's errors distinguishable from production's despite sharing the
+# exact same bindings/database.
 #
-# Needs SENTRY_AUTH_TOKEN set as a Workers BUILD secret (not a runtime
-# Variable/Secret -- sentry-cli only runs during the build, never reaches the
-# deployed Worker) on each of the 3 Worker projects.
+# Needs POSTHOG_CLI_API_KEY/POSTHOG_CLI_PROJECT_ID set as Workers BUILD
+# secrets/vars (not a runtime Variable/Secret -- posthog-cli only runs
+# during the build, never reaches the deployed Worker) on each of the 3
+# Worker projects. Fully inert -- a plain build+deploy, no sourcemap
+# upload attempted -- when either is unset.
 #
-# PostHog sourcemap upload (metagraphed#8128) is a SEPARATE, additive step,
-# gated on POSTHOG_CLI_API_KEY/POSTHOG_CLI_PROJECT_ID being set the same way
-# (Workers BUILD secrets/vars) -- completely inert, original single-command
-# build+deploy flow unchanged, until both are configured. Unlike Sentry's
-# release-based association, `posthog-cli` embeds a `//# chunkId=...` marker
-# directly into the shipped JS: that marker MUST be present in the EXACT
-# bytes Cloudflare actually serves, or PostHog can never match a captured
-# stack trace back to the uploaded map (confirmed against PostHog's own
-# docs -- "If you serve a copy of the bundled assets as they were prior to
-# running posthog-cli sourcemap inject, we won't be able to use the
-# uploaded sourcemap"). A single `wrangler deploy --outdir` builds AND ships
-# atomically, so injecting into $OUTDIR afterward would modify a local copy
-# that was never actually deployed. When PostHog is configured, this script
-# instead: (1) `wrangler deploy --dry-run` builds WITHOUT deploying
-# (Cloudflare's own documented use for exactly this purpose -- "gives
-# developers a chance to upload our generated sourcemap to a service...
-# before the service goes live"), (2) `posthog-cli sourcemap inject` embeds
-# the marker into that build output, (3) `wrangler deploy --no-bundle` ships
-# THAT EXACT injected file, skipping wrangler's own esbuild step (which
-# would otherwise silently rebuild from source and discard the marker just
-# injected). Verified locally: the dry-run build + inject steps (single
-# flat `<entry>.js`/`.js.map` per Worker, no code-splitting -- confirmed via
-# `wrangler deploy --dry-run --outdir` against wrangler.jsonc). The
-# `--no-bundle` deploy step (3) could not be safely tested against a live
-# Worker from a dev sandbox -- watch the first real deploy after this lands
-# closely, and consider setting the two POSTHOG_CLI_* vars on a Worker
-# project's non-production branch deploy command slot first (--preview mode
-# below uses `wrangler versions upload`, which never serves live traffic).
+# `posthog-cli` embeds a `//# chunkId=...` marker directly into the shipped
+# JS: that marker MUST be present in the EXACT bytes Cloudflare actually
+# serves, or PostHog can never match a captured stack trace back to the
+# uploaded map (confirmed against PostHog's own docs -- "If you serve a
+# copy of the bundled assets as they were prior to running posthog-cli
+# sourcemap inject, we won't be able to use the uploaded sourcemap"). A
+# single `wrangler deploy --outdir` builds AND ships atomically, so
+# injecting into $OUTDIR afterward would modify a local copy that was
+# never actually deployed. Instead: (1) `wrangler deploy --dry-run` builds
+# WITHOUT deploying (Cloudflare's own documented use for exactly this
+# purpose -- "gives developers a chance to upload our generated
+# sourcemap to a service... before the service goes live"), (2)
+# `posthog-cli sourcemap inject` embeds the marker into that build output,
+# (3) `wrangler deploy --no-bundle` ships THAT EXACT injected file,
+# skipping wrangler's own esbuild step (which would otherwise silently
+# rebuild from source and discard the marker just injected). Verified
+# locally: the dry-run build + inject steps (single flat `<entry>.js`/
+# `.js.map` per Worker, no code-splitting -- confirmed via `wrangler
+# deploy --dry-run --outdir` against wrangler.jsonc). The `--no-bundle`
+# deploy step (3) could not be safely tested against a live Worker from a
+# dev sandbox -- watch the first real deploy after this lands closely.
 #
-# --message also passed on the wrangler call itself (metagraphed#7224): the
+# --message passed on the wrangler call itself (metagraphed#7224): the
 # deployed commit SHA needs to land in the deployment's own real
 # `workers/message` annotation (confirmed against Cloudflare's List
 # Deployments API reference + wrangler's own CLI source -- `workers/message`/
 # `workers/tag`/`workers/triggered_by` are the only Workers deployment
-# annotations that actually exist; `workers/commit_hash` scripts/check-worker-
-# deploy-drift.mjs previously checked was never a real one, that key only
-# exists on Cloudflare Pages' unrelated deploy command) so that scheduled
-# drift check can read the live commit directly instead of relying solely on
-# its Sentry-release fallback.
+# annotations that actually exist; `workers/commit_hash`
+# scripts/check-worker-deploy-drift.ts previously checked was never a real
+# one, that key only exists on Cloudflare Pages' unrelated deploy command)
+# so that scheduled drift check can read the live commit directly.
 #
 # Usage: scripts/deploy-worker-with-sourcemaps.sh <wrangler-config.jsonc> [--preview]
 set -euo pipefail
@@ -92,14 +74,11 @@ if [[ "$PREVIEW" == "--preview" ]]; then
   OUTDIR="dist/worker-$BASENAME-preview"
 fi
 
-export SENTRY_ORG="jsonbored"
-export SENTRY_PROJECT="metagraphed"
-
-RELEASE=$(npx sentry-cli releases propose-version)
-if [[ "$ENVIRONMENT" == "preview" ]]; then
-  RELEASE="$RELEASE-preview"
-fi
 COMMIT_SHA=$(git rev-parse HEAD)
+RELEASE_VERSION="$COMMIT_SHA"
+if [[ "$ENVIRONMENT" == "preview" ]]; then
+  RELEASE_VERSION="$COMMIT_SHA-preview"
+fi
 
 POSTHOG_ENABLED=false
 if [[ -n "${POSTHOG_CLI_API_KEY:-}" && -n "${POSTHOG_CLI_PROJECT_ID:-}" ]]; then
@@ -114,8 +93,6 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
     --config "$CONFIG" \
     --outdir "$OUTDIR" \
     --upload-source-maps \
-    --var "SENTRY_RELEASE:$RELEASE" \
-    --var "SENTRY_ENVIRONMENT:$ENVIRONMENT" \
     --message "$COMMIT_SHA" \
     --dry-run
 
@@ -135,35 +112,18 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
     "$ENTRY_JS" \
     --config "$CONFIG" \
     --no-bundle \
-    --var "SENTRY_RELEASE:$RELEASE" \
-    --var "SENTRY_ENVIRONMENT:$ENVIRONMENT" \
     --message "$COMMIT_SHA"
+
+  # Phase 4: upload, now safe -- $OUTDIR's injected bundle IS what phase 3
+  # actually deployed, so this correctly resolves real production traces.
+  npx @posthog/cli sourcemap upload \
+    --directory "$OUTDIR" \
+    --release-name "metagraphed-$BASENAME" \
+    --release-version "$RELEASE_VERSION"
 else
   npx wrangler "${WRANGLER_SUBCOMMAND[@]}" \
     --config "$CONFIG" \
     --outdir "$OUTDIR" \
     --upload-source-maps \
-    --var "SENTRY_RELEASE:$RELEASE" \
-    --var "SENTRY_ENVIRONMENT:$ENVIRONMENT" \
     --message "$COMMIT_SHA"
-fi
-
-npx sentry-cli releases new "$RELEASE"
-# --auto reads the linked GitHub repo's commit range since the last release
-# (Sentry's GitHub integration, connected separately in the dashboard) --
-# powers suspect-commit detection on issues from this release.
-npx sentry-cli releases set-commits "$RELEASE" --auto
-npx sentry-cli sourcemaps upload \
-  --release="$RELEASE" \
-  --strip-prefix "$OUTDIR/.." \
-  "$OUTDIR"
-npx sentry-cli releases finalize "$RELEASE"
-
-if [[ "$POSTHOG_ENABLED" == "true" ]]; then
-  # Safe now: $OUTDIR's injected bundle IS what phase 3 above actually
-  # deployed, so this upload correctly resolves real production traces.
-  npx @posthog/cli sourcemap upload \
-    --directory "$OUTDIR" \
-    --release-name "metagraphed-$BASENAME" \
-    --release-version "$RELEASE"
 fi

--- a/tests/check-worker-deploy-drift.test.ts
+++ b/tests/check-worker-deploy-drift.test.ts
@@ -4,7 +4,6 @@ import {
   evaluateDeployDrift,
   extractDeployedCommitSha,
   findPreviousScheduledRunAt,
-  selectLatestProductionRelease,
 } from "../scripts/check-worker-deploy-drift.ts";
 
 describe("extractDeployedCommitSha", () => {
@@ -58,54 +57,6 @@ describe("extractDeployedCommitSha", () => {
         }),
       /no workers\/message annotation containing a git commit SHA/,
     );
-  });
-});
-
-describe("selectLatestProductionRelease", () => {
-  const shaA = "a".repeat(40);
-  const shaB = "b".repeat(40);
-
-  test("picks the most recently created bare-SHA release", () => {
-    const release = selectLatestProductionRelease([
-      { version: shaA, dateCreated: "2026-07-19T00:00:00Z" },
-      { version: shaB, dateCreated: "2026-07-20T00:00:00Z" },
-    ]);
-    assert.equal(release!.version, shaB);
-  });
-
-  test("excludes PR-preview releases even if more recent", () => {
-    // apps/ui's ui-preview-deploy.yml tags preview deploys "<sha>-preview" --
-    // a preview build must never be mistaken for what's live in production.
-    const release = selectLatestProductionRelease([
-      { version: shaA, dateCreated: "2026-07-19T00:00:00Z" },
-      { version: `${shaB}-preview`, dateCreated: "2026-07-20T00:00:00Z" },
-    ]);
-    assert.equal(release!.version, shaA);
-  });
-
-  test("excludes non-SHA-shaped versions (e.g. a Cloudflare version UUID)", () => {
-    const release = selectLatestProductionRelease([
-      {
-        version: "c40c4e0e-5143-4207-ac02-7b94edebb4d2",
-        dateCreated: "2026-07-20T00:00:00Z",
-      },
-      { version: shaA, dateCreated: "2026-07-19T00:00:00Z" },
-    ]);
-    assert.equal(release!.version, shaA);
-  });
-
-  test("returns null when no release is a bare production SHA", () => {
-    assert.equal(
-      selectLatestProductionRelease([
-        { version: `${shaA}-preview`, dateCreated: "2026-07-20T00:00:00Z" },
-      ]),
-      null,
-    );
-  });
-
-  test("tolerates a non-array input", () => {
-    assert.equal(selectLatestProductionRelease(undefined), null);
-    assert.equal(selectLatestProductionRelease(null), null);
   });
 });
 


### PR DESCRIPTION
## Summary

Fast-follow to #8131. That PR still sequenced PostHog's sourcemap upload *after* an unconditional block of `sentry-cli` calls, with no gate around them -- if `SENTRY_AUTH_TOKEN` were ever removed, those calls would fail and (`set -euo pipefail`) abort the script before ever reaching the PostHog upload step. That's backwards: PostHog's own upload shouldn't depend on Sentry succeeding, or existing, at all.

- `scripts/deploy-worker-with-sourcemaps.sh`: removed every `sentry-cli` call, `SENTRY_ORG`/`SENTRY_PROJECT`, and the `--var SENTRY_RELEASE`/`--var SENTRY_ENVIRONMENT` flags entirely. The PostHog dry-run/inject/no-bundle-deploy/upload flow (from #8131) is now the only sourcemap-related logic in this script, still fully gated on `POSTHOG_CLI_API_KEY`/`POSTHOG_CLI_PROJECT_ID` -- an unconfigured Worker falls back to a plain build+deploy, same as before.
- `scripts/check-worker-deploy-drift.ts`: removed the Sentry-release fallback path (`selectLatestProductionRelease`/`findLatestProductionReleaseCommit`) and its `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` wiring in `check-worker-deploy-drift.yml`. This fallback only ever mattered when the `workers/message` deployment annotation was absent (a gap already closed by #7224), and this change means no future deploy will ever populate a git-SHA-shaped Sentry release again anyway -- the fallback was already permanently dead code as a direct consequence of the change above.

Runtime Sentry release tagging (`workers/*.sentry.ts`'s `withSentry()`) already has a documented fallback to `CF_VERSION_METADATA`'s own UUID when `env.SENTRY_RELEASE` is unset, so this degrades gracefully rather than breaking anything.

## Test plan
- [x] `npm run typecheck` / `npm run lint`: clean
- [x] `shellcheck` + `bash -n` on the deploy script: clean
- [x] `npx vitest run tests/check-worker-deploy-drift.test.ts`: 11/11 passing (removed the now-obsolete `selectLatestProductionRelease` test block along with the function)