### PR TITLE
feat(mcp): types-epic E batch 11 — Zod schemas for 21 meta/ops/misc MCP tools (#8075)

### DIFF
--- a/schemas-src/mcp-tools/agent-catalog-resources.ts
+++ b/schemas-src/mcp-tools/agent-catalog-resources.ts
@@ -1,0 +1,55 @@
+// MCP tools `get_agent_catalog`, `get_agent_resources` (types-epic E batch
+// 12, #8075). `get_agent_catalog` is defined inline in src/mcp-server.ts's
+// MCP_TOOLS array; `get_agent_resources` lives in its own
+// src/agent-resources-mcp.ts (its `GET_AGENT_RESOURCES_MCP_TOOL`/
+// `GET_AGENT_RESOURCES_OUTPUT_SCHEMA` spread into mcp-server.ts's MCP_TOOLS
+// array). Neither mirrors an existing schemas-src/routes/ REST schema --
+// modeled fresh, matching each hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const GetAgentCatalogInputSchema = z
+  .object({
+    netuid: z.int().min(0).optional(),
+  })
+  .strict();
+export type GetAgentCatalogInput = z.infer<typeof GetAgentCatalogInputSchema>;
+
+// Two shapes: the global index (no netuid) and a single-subnet catalog
+// (with a netuid). They share few keys, so nothing is required in the
+// hand-written original; the fields below describe the global index when
+// present.
+export const GetAgentCatalogOutputSchema = z
+  .object({
+    subnet_count: z.int().optional(),
+    total_subnet_count: z.int().optional(),
+    callable_service_count: z.int().optional(),
+    content_hash: z.string().nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+    published_at: z.string().nullable().optional(),
+    subnets: z.array(OpenObjectSchema).optional(),
+    operational_observed_at: z.string().nullable().optional(),
+    health_source: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetAgentCatalogOutput = z.infer<typeof GetAgentCatalogOutputSchema>;
+
+export const GetAgentResourcesInputSchema = z.object({}).strict();
+export type GetAgentResourcesInput = z.infer<
+  typeof GetAgentResourcesInputSchema
+>;
+
+export const GetAgentResourcesOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    published_at: z.string().nullable().optional(),
+    content_hash: z.string().nullable().optional(),
+    summary: OpenObjectSchema.optional(),
+    copyable_agent: OpenObjectSchema.optional(),
+    mcp: OpenObjectSchema,
+    resources: z.array(OpenObjectSchema),
+  })
+  .passthrough();
+export type GetAgentResourcesOutput = z.infer<
+  typeof GetAgentResourcesOutputSchema
+>;

--- a/schemas-src/mcp-tools/feed.ts
+++ b/schemas-src/mcp-tools/feed.ts
@@ -1,0 +1,53 @@
+// MCP tool `get_feed` (types-epic E batch 12, #8075). Lives in its own
+// src/feed-mcp.ts (its `GET_FEED_MCP_TOOL`/`GET_FEED_OUTPUT_SCHEMA` spread
+// into mcp-server.ts's MCP_TOOLS array). Does not mirror an existing
+// schemas-src/routes/ REST schema -- modeled fresh, matching the
+// hand-written literal field-for-field. FEED_KINDS and FEED_MAX_ITEMS are
+// symbolic in the hand-written original (src/feeds.ts's own exports),
+// cross-checked against the actual runtime source at the time of writing.
+import { z } from "zod";
+
+const FEED_KINDS = ["registry", "incidents", "gaps", "subnet"] as const;
+const FEED_MAX_ITEMS = 50;
+
+export const GetFeedInputSchema = z
+  .object({
+    kind: z.enum(FEED_KINDS),
+    netuid: z.int().min(0).optional(),
+    tag: z.string().optional(),
+    since: z.string().optional(),
+    until: z.string().optional(),
+    limit: z.int().min(1).max(FEED_MAX_ITEMS).optional(),
+  })
+  .strict();
+export type GetFeedInput = z.infer<typeof GetFeedInputSchema>;
+
+const FeedItemSchema = z
+  .object({
+    id: z.string(),
+    url: z.string(),
+    title: z.string(),
+    summary: z.string(),
+    timestamp: z.string(),
+    tags: z.array(z.string()),
+  })
+  .passthrough();
+
+export const GetFeedOutputSchema = z
+  .object({
+    kind: z.enum(FEED_KINDS),
+    netuid: z.int().nullable().optional(),
+    filters: z
+      .object({
+        tag: z.string().nullable().optional(),
+        since: z.string().nullable().optional(),
+        until: z.string().nullable().optional(),
+        limit: z.int().optional(),
+      })
+      .passthrough()
+      .optional(),
+    returned: z.int(),
+    items: z.array(FeedItemSchema),
+  })
+  .passthrough();
+export type GetFeedOutput = z.infer<typeof GetFeedOutputSchema>;

--- a/schemas-src/mcp-tools/get-adapter.ts
+++ b/schemas-src/mcp-tools/get-adapter.ts
@@ -1,0 +1,38 @@
+// MCP tool `get_adapter` (types-epic E batch 12, #8075). Lives in its own
+// src/adapters-mcp.ts (its `GET_ADAPTER_MCP_TOOL`/`GET_ADAPTER_OUTPUT_SCHEMA`
+// spread into mcp-server.ts's MCP_TOOLS array). Does not mirror an existing
+// schemas-src/routes/ REST schema -- modeled fresh, matching the
+// hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+// `notes: {type:["array","string","null"], items:{type:"string"}}` -- this
+// batch's shared.ts predates the NotesFieldSchema helper hoisted in batch 10
+// (#8074), still unmerged as of this batch (#8075) -- inlined here rather
+// than depending on unmerged parallel work.
+const NotesFieldSchema = z
+  .union([z.array(z.string()), z.string()])
+  .nullable()
+  .optional();
+
+export const GetAdapterInputSchema = z
+  .object({
+    slug: z.string().regex(/^[a-z0-9-]+$/),
+  })
+  .strict();
+export type GetAdapterInput = z.infer<typeof GetAdapterInputSchema>;
+
+export const GetAdapterOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    contract_version: z.string().nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+    slug: z.string(),
+    subnet: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    notes: NotesFieldSchema,
+    snapshot: OpenObjectSchema.nullable().optional(),
+    extensions: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetAdapterOutput = z.infer<typeof GetAdapterOutputSchema>;

--- a/schemas-src/mcp-tools/meta-artifacts-1.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-1.ts
@@ -1,0 +1,79 @@
+// MCP tools `get_lineage`, `get_freshness`, `get_contracts`,
+// `get_source_health` (types-epic E batch 12, #8075). `get_lineage` and
+// `get_source_health` are defined inline in src/mcp-server.ts's MCP_TOOLS
+// array; `get_freshness` is also inline but shares this file's grouping by
+// shape; `get_contracts` lives in its own src/contracts-mcp.ts (its
+// `GET_CONTRACTS_MCP_TOOL`/`GET_CONTRACTS_OUTPUT_SCHEMA` spread into
+// mcp-server.ts's MCP_TOOLS array). All four are no-input, baked-artifact
+// passthrough tools. None mirror an existing schemas-src/routes/ REST
+// schema -- modeled fresh, matching each hand-written literal
+// field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+// `notes: {type:["array","string","null"], items:{type:"string"}}` -- this
+// batch's shared.ts predates the NotesFieldSchema helper hoisted in batch 10
+// (#8074), still unmerged as of this batch (#8075) -- inlined here rather
+// than depending on unmerged parallel work.
+const NotesFieldSchema = z
+  .union([z.array(z.string()), z.string()])
+  .nullable()
+  .optional();
+
+export const GetLineageInputSchema = z.object({}).strict();
+export type GetLineageInput = z.infer<typeof GetLineageInputSchema>;
+
+export const GetLineageOutputSchema = z
+  .object({
+    link_count: z.int().optional(),
+    graduated_subnet_count: z.int().optional(),
+    broken_link_count: z.int().optional(),
+    links: z.array(OpenObjectSchema).optional(),
+    broken_links: z.array(OpenObjectSchema).optional(),
+    generated_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetLineageOutput = z.infer<typeof GetLineageOutputSchema>;
+
+export const GetFreshnessInputSchema = z.object({}).strict();
+export type GetFreshnessInput = z.infer<typeof GetFreshnessInputSchema>;
+
+export const GetFreshnessOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    sources: z.array(OpenObjectSchema),
+    summary: OpenObjectSchema.nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetFreshnessOutput = z.infer<typeof GetFreshnessOutputSchema>;
+
+export const GetContractsInputSchema = z.object({}).strict();
+export type GetContractsInput = z.infer<typeof GetContractsInputSchema>;
+
+export const GetContractsOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    contract_version: z.string().nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    base_path: z.string().nullable().optional(),
+    primary_domain: z.string().nullable().optional(),
+    openapi_url: z.string().nullable().optional(),
+    type_definitions_url: z.string().nullable().optional(),
+    notes: NotesFieldSchema,
+    artifacts: z.array(OpenObjectSchema),
+  })
+  .passthrough();
+export type GetContractsOutput = z.infer<typeof GetContractsOutputSchema>;
+
+export const GetSourceHealthInputSchema = z.object({}).strict();
+export type GetSourceHealthInput = z.infer<typeof GetSourceHealthInputSchema>;
+
+export const GetSourceHealthOutputSchema = z
+  .object({
+    providers: z.array(OpenObjectSchema),
+    generated_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GetSourceHealthOutput = z.infer<typeof GetSourceHealthOutputSchema>;

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -1,0 +1,98 @@
+// MCP tools `get_changelog`, `get_build`, `get_coverage`,
+// `get_coverage_depth` (types-epic E batch 12, #8075). `get_changelog`,
+// `get_build`, and `get_coverage` each live in their own dedicated file
+// (src/changelog-mcp.ts, src/build-mcp.ts, src/registry-coverage.ts --
+// their `GET_X_MCP_TOOL`/`GET_X_OUTPUT_SCHEMA` spread into mcp-server.ts's
+// MCP_TOOLS array); `get_coverage_depth` is defined inline in
+// src/mcp-server.ts. All four are no-input, baked-artifact passthrough
+// tools. None mirror an existing schemas-src/routes/ REST schema -- modeled
+// fresh, matching each hand-written literal field-for-field.
+// `get_coverage_depth`'s output declares NO `required` key at all (unlike
+// every sibling in this file, which declares an explicit list or an empty
+// array) -- a genuine, pre-existing difference, preserved as-is.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+// `notes: {type:["array","string","null"], items:{type:"string"}}` -- this
+// batch's shared.ts predates the NotesFieldSchema helper hoisted in batch 10
+// (#8074), still unmerged as of this batch (#8075) -- inlined here rather
+// than depending on unmerged parallel work.
+const NotesFieldSchema = z
+  .union([z.array(z.string()), z.string()])
+  .nullable()
+  .optional();
+
+export const GetChangelogInputSchema = z.object({}).strict();
+export type GetChangelogInput = z.infer<typeof GetChangelogInputSchema>;
+
+export const GetChangelogOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    source: z.string().nullable(),
+    notes: NotesFieldSchema,
+    summary: OpenObjectSchema,
+    artifacts: OpenObjectSchema,
+    subnets: OpenObjectSchema,
+    coverage_delta: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetChangelogOutput = z.infer<typeof GetChangelogOutputSchema>;
+
+export const GetBuildInputSchema = z.object({}).strict();
+export type GetBuildInput = z.infer<typeof GetBuildInputSchema>;
+
+export const GetBuildOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    contract_version: z.string().nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+    published_at: z.string().nullable().optional(),
+    adapter_count: z.int().nullable().optional(),
+    artifact_count: z.int(),
+    artifact_size_bytes: z.int().nullable().optional(),
+    subnet_count: z.int().nullable().optional(),
+    surface_count: z.int().nullable().optional(),
+    provider_count: z.int().nullable().optional(),
+    artifacts: z.array(OpenObjectSchema).nullable().optional(),
+    coverage: OpenObjectSchema.nullable().optional(),
+    artifact_budget_summary: OpenObjectSchema.nullable().optional(),
+  })
+  .passthrough();
+export type GetBuildOutput = z.infer<typeof GetBuildOutputSchema>;
+
+export const GetCoverageInputSchema = z.object({}).strict();
+export type GetCoverageInput = z.infer<typeof GetCoverageInputSchema>;
+
+export const GetCoverageOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    surface_count: z.int(),
+    official_surface_count: z.int().optional(),
+    first_party_subnet_count: z.int().optional(),
+    chain_subnet_count: z.int().optional(),
+    candidate_count: z.int().optional(),
+    probed_count: z.int().optional(),
+    domain_coverage: OpenObjectSchema.optional(),
+    completeness: OpenObjectSchema,
+    subnets_without_official_surface: z.int().optional(),
+  })
+  .passthrough();
+export type GetCoverageOutput = z.infer<typeof GetCoverageOutputSchema>;
+
+export const GetCoverageDepthInputSchema = z.object({}).strict();
+export type GetCoverageDepthInput = z.infer<typeof GetCoverageDepthInputSchema>;
+
+// No `required` key in the hand-written original, unlike this file's other
+// three tools.
+export const GetCoverageDepthOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    generated_at: z.string().nullable().optional(),
+    coverage_depth_version: z.string().nullable().optional(),
+    rows: z.array(OpenObjectSchema).optional(),
+    ranked_queue: z.array(OpenObjectSchema).optional(),
+  })
+  .passthrough();
+export type GetCoverageDepthOutput = z.infer<
+  typeof GetCoverageDepthOutputSchema
+>;

--- a/schemas-src/mcp-tools/query-tools.ts
+++ b/schemas-src/mcp-tools/query-tools.ts
@@ -1,0 +1,64 @@
+// MCP tools `query_graphql`, `run_saved_query` (types-epic E batch 12,
+// #8075). Both are defined inline in src/mcp-server.ts's MCP_TOOLS array,
+// and unlike every other tool in this epic (whose output schema lives in
+// the shared TOOL_OUTPUT_SCHEMAS map), both declare their `outputSchema`
+// INLINE on the tool object itself -- same treatment as the existing
+// decode_evm_call tool (an earlier batch). Neither mirrors an existing
+// schemas-src/routes/ REST schema -- modeled fresh, matching each
+// hand-written literal field-for-field.
+//
+// query_graphql's hand-written `data` field declares `nullable: true`, an
+// OpenAPI-3.0-ism with NO effect under JSON Schema draft 2020-12 (which has
+// no `nullable` keyword) -- so under the target's own spec, `data` was
+// already (inertly) a plain non-nullable object. Preserved literally as
+// non-nullable here rather than "fixed" into a real `.nullable()`, since
+// doing so would make the new schema accept something the old one's actual
+// declared (2020-12) semantics didn't -- the opposite direction from this
+// epic's wire-compatibility mandate.
+//
+// run_saved_query's output declares `additionalProperties: false` (.strict()
+// below), unlike nearly every other output schema in this epic (which are
+// passthrough) -- a genuine, deliberate difference, preserved as-is.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const QueryGraphqlInputSchema = z
+  .object({
+    query: z.string(),
+    variables: OpenObjectSchema.optional(),
+  })
+  .strict();
+export type QueryGraphqlInput = z.infer<typeof QueryGraphqlInputSchema>;
+
+export const QueryGraphqlOutputSchema = z
+  .object({
+    data: OpenObjectSchema.optional(),
+    errors: z.array(OpenObjectSchema).optional(),
+  })
+  .passthrough();
+export type QueryGraphqlOutput = z.infer<typeof QueryGraphqlOutputSchema>;
+
+// Symbolic in the hand-written original (src/saved-queries.ts's
+// SAVED_QUERY_TEMPLATES.map((t) => t.id)), cross-checked against the actual
+// runtime source at the time of writing.
+const SAVED_QUERY_IDS = [
+  "subnet-leaderboard",
+  "chain-registrations-window",
+] as const;
+
+export const RunSavedQueryInputSchema = z
+  .object({
+    query_id: z.enum(SAVED_QUERY_IDS),
+    params: OpenObjectSchema.optional(),
+  })
+  .strict();
+export type RunSavedQueryInput = z.infer<typeof RunSavedQueryInputSchema>;
+
+export const RunSavedQueryOutputSchema = z
+  .object({
+    query_id: z.string(),
+    params: OpenObjectSchema,
+    data: z.unknown(),
+  })
+  .strict();
+export type RunSavedQueryOutput = z.infer<typeof RunSavedQueryOutputSchema>;

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -1,0 +1,192 @@
+// MCP tools `registry_summary`, `list_enrichment_targets`, `get_subnet_gaps`,
+// `list_subnet_gaps` (types-epic E batch 12, #8075). The first three are
+// defined inline in src/mcp-server.ts's MCP_TOOLS array; `list_subnet_gaps`
+// lives in its own src/subnet-gaps-mcp.ts (its `LIST_SUBNET_GAPS_MCP_TOOL`/
+// `LIST_SUBNET_GAPS_OUTPUT_SCHEMA` spread into mcp-server.ts's MCP_TOOLS
+// array). None mirror an existing schemas-src/routes/ REST schema --
+// modeled fresh, matching each hand-written literal field-for-field.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+export const RegistrySummaryInputSchema = z.object({}).strict();
+export type RegistrySummaryInput = z.infer<typeof RegistrySummaryInputSchema>;
+
+export const RegistrySummaryOutputSchema = z
+  .object({
+    subnet_count: z.int(),
+    counts: OpenObjectSchema,
+    coverage: OpenObjectSchema.optional(),
+    curation_level_counts: OpenObjectSchema.optional(),
+    profile_level_counts: OpenObjectSchema.optional(),
+    recent_changes: OpenObjectSchema.optional(),
+    top_subnets: z.array(OpenObjectSchema).optional(),
+    generated_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type RegistrySummaryOutput = z.infer<typeof RegistrySummaryOutputSchema>;
+
+// Symbolic in the hand-written original (src/contracts.ts's
+// QUERY_ENUMS.agentReadinessStatus and mcp-server.ts's own
+// COVERAGE_DEPTH_TIERS/COVERAGE_DEPTH_SEVERITIES constants), cross-checked
+// against the actual runtime source at the time of writing.
+const COVERAGE_DEPTH_TIERS = [
+  "agent-ready",
+  "machine-usable",
+  "candidate-review",
+  "needs-evidence",
+  "hard-blocked",
+  "missing-interface",
+] as const;
+const COVERAGE_DEPTH_SEVERITIES = [
+  "hard",
+  "missing-data",
+  "needs-review",
+] as const;
+const AGENT_READINESS_STATUSES = [
+  "callable",
+  "base-layer",
+  "candidate",
+  "needs-evidence",
+  "blocked",
+] as const;
+
+export const ListEnrichmentTargetsInputSchema = z
+  .object({
+    limit: z.int().min(1).max(50).optional(),
+    tier: z.enum(COVERAGE_DEPTH_TIERS).optional(),
+    severity: z.enum(COVERAGE_DEPTH_SEVERITIES).optional(),
+    gap_code: z
+      .string()
+      .regex(/^[a-z0-9-]+$/)
+      .optional(),
+    agent_status: z.enum(AGENT_READINESS_STATUSES).optional(),
+    netuid: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListEnrichmentTargetsInput = z.infer<
+  typeof ListEnrichmentTargetsInputSchema
+>;
+
+const EnrichmentTargetItemSchema = z
+  .object({
+    rank: z.int().nullable().optional(),
+    netuid: z.int().optional(),
+    slug: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    tier: z.string().optional(),
+    score: z.int().optional(),
+    priority_score: z.int().optional(),
+    agent_status: z.string().optional(),
+    blocker_level: z.string().optional(),
+    top_gap_codes: z.array(z.unknown()).optional(),
+    top_gaps: z.array(OpenObjectSchema).optional(),
+    recommended_next_action: z.string().nullable().optional(),
+    dimensions: OpenObjectSchema.optional(),
+  })
+  .passthrough();
+
+export const ListEnrichmentTargetsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    coverage_depth_version: z.unknown().optional(),
+    total_rows: z.int(),
+    queue_count: z.int(),
+    returned: z.int(),
+    filters: OpenObjectSchema.optional(),
+    note: z.string().optional(),
+    targets: z.array(EnrichmentTargetItemSchema),
+  })
+  .passthrough();
+export type ListEnrichmentTargetsOutput = z.infer<
+  typeof ListEnrichmentTargetsOutputSchema
+>;
+
+export const GetSubnetGapsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+  })
+  .strict();
+export type GetSubnetGapsInput = z.infer<typeof GetSubnetGapsInputSchema>;
+
+export const GetSubnetGapsOutputSchema = z
+  .object({
+    schema_version: z.int().optional(),
+    contract_version: z.string().nullable().optional(),
+    generated_at: z.string().nullable().optional(),
+    netuid: z.int(),
+    slug: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    priorities: z.array(OpenObjectSchema),
+    enrichment_queue: z.array(OpenObjectSchema),
+  })
+  .passthrough();
+export type GetSubnetGapsOutput = z.infer<typeof GetSubnetGapsOutputSchema>;
+
+const CURATION_LEVELS = [
+  "native",
+  "candidate-discovered",
+  "community-seeded",
+  "machine-verified",
+  "maintainer-reviewed",
+  "adapter-backed",
+] as const;
+const SURFACE_KINDS = [
+  "archive",
+  "dashboard",
+  "data-artifact",
+  "docs",
+  "example",
+  "openapi",
+  "repo-registry",
+  "sdk",
+  "source-repo",
+  "sse",
+  "subnet-api",
+  "subtensor-rpc",
+  "subtensor-wss",
+  "website",
+] as const;
+// The REST route pages this artifact through the review-gap-priorities
+// collection (rows live under `priorities`), not the network-wide `gaps`
+// collection -- same sort fields as list_review_gaps (batch 10, #8074).
+const GAP_PRIORITY_SORT_FIELDS = [
+  "candidate_count",
+  "curation_level",
+  "missing_kinds",
+  "name",
+  "netuid",
+  "priority_score",
+  "surface_count",
+  "verified_candidate_count",
+] as const;
+
+export const ListSubnetGapsInputSchema = z
+  .object({
+    netuid: z.int().min(0),
+    curation_level: z.enum(CURATION_LEVELS).optional(),
+    missing_kinds: z.enum(SURFACE_KINDS).optional(),
+    review_state: z.string().optional(),
+    sort: z.enum(GAP_PRIORITY_SORT_FIELDS).optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+    fields: z.string().optional(),
+    limit: z.int().min(1).max(100).optional(),
+    cursor: z.int().min(0).optional(),
+  })
+  .strict();
+export type ListSubnetGapsInput = z.infer<typeof ListSubnetGapsInputSchema>;
+
+export const ListSubnetGapsOutputSchema = z
+  .object({
+    generated_at: z.string().nullable().optional(),
+    netuid: z.int().nullable().optional(),
+    priorities: z.array(OpenObjectSchema),
+    total: z.int().optional(),
+    returned: z.int().optional(),
+    limit: z.int().optional(),
+    cursor: z.int().optional(),
+    next_cursor: z.int().nullable().optional(),
+    sort: z.string().nullable().optional(),
+    order: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type ListSubnetGapsOutput = z.infer<typeof ListSubnetGapsOutputSchema>;

--- a/schemas-src/mcp-tools/rpc-tools.ts
+++ b/schemas-src/mcp-tools/rpc-tools.ts
@@ -1,0 +1,142 @@
+// MCP tools `get_rpc_usage`, `get_best_rpc_endpoint`, `call_rpc`
+// (types-epic E batch 12, #8075). All three are defined inline in
+// src/mcp-server.ts's MCP_TOOLS array. None mirror an existing
+// schemas-src/routes/ REST schema -- modeled fresh, matching each
+// hand-written literal field-for-field. Unlike this epic's objectItems()-
+// built array items (which never declare item-level `required`),
+// get_rpc_usage's four nested shapes (summary/latency_ms/endpoints/
+// networks/buckets, formerly mcp-server.ts's own RPC_USAGE_* constants) DO
+// declare real item-level required fields -- preserved exactly, not loosened
+// to match this epic's usual item-shape convention.
+import { z } from "zod";
+import { OpenObjectSchema } from "./shared.ts";
+
+const RpcUsageLatencyMsSchema = z
+  .object({
+    p50: z.int().nullable(),
+    p95: z.int().nullable(),
+    avg: z.int().nullable(),
+  })
+  .passthrough();
+
+const RpcUsageSummarySchema = z
+  .object({
+    total_requests: z.int().min(0),
+    ok_requests: z.int().min(0),
+    error_requests: z.int().min(0),
+    error_rate: z.number().nullable().optional(),
+    failover_requests: z.int().min(0).optional(),
+    failover_rate: z.number().nullable().optional(),
+    cache_hits: z.int().min(0).optional(),
+    cache_hit_rate: z.number().nullable().optional(),
+    latency_ms: RpcUsageLatencyMsSchema,
+  })
+  .passthrough();
+
+const RpcUsageEndpointItemSchema = z
+  .object({
+    rank: z.int().min(1).optional(),
+    endpoint_id: z.string().nullable(),
+    provider: z.string().nullable().optional(),
+    requests: z.int().min(0),
+    ok_requests: z.int().min(0),
+    error_rate: z.number().nullable().optional(),
+    avg_latency_ms: z.int().nullable().optional(),
+  })
+  .passthrough();
+
+const RpcUsageNetworkItemSchema = z
+  .object({
+    network: z.string(),
+    requests: z.int().min(0),
+    ok_requests: z.int().min(0),
+    error_rate: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+const RpcUsageBucketItemSchema = z
+  .object({
+    ts: z.int().min(0),
+    requests: z.int().min(0),
+    errors: z.int().min(0),
+    avg_latency_ms: z.int().nullable(),
+  })
+  .passthrough();
+
+export const GetRpcUsageInputSchema = z
+  .object({
+    window: z.enum(["7d", "30d"]).optional(),
+  })
+  .strict();
+export type GetRpcUsageInput = z.infer<typeof GetRpcUsageInputSchema>;
+
+export const GetRpcUsageOutputSchema = z
+  .object({
+    schema_version: z.int(),
+    window: z.string().nullable().optional(),
+    bucket_granularity: z.string().nullable().optional(),
+    observed_at: z.string().nullable().optional(),
+    source: z.string(),
+    summary: RpcUsageSummarySchema,
+    endpoints: z.array(RpcUsageEndpointItemSchema),
+    networks: z.array(RpcUsageNetworkItemSchema),
+    buckets: z.array(RpcUsageBucketItemSchema),
+  })
+  .passthrough();
+export type GetRpcUsageOutput = z.infer<typeof GetRpcUsageOutputSchema>;
+
+export const GetBestRpcEndpointInputSchema = z
+  .object({
+    limit: z.int().min(1).max(10).optional(),
+  })
+  .strict();
+export type GetBestRpcEndpointInput = z.infer<
+  typeof GetBestRpcEndpointInputSchema
+>;
+
+const BestRpcEndpointItemSchema = z
+  .object({
+    id: z.string().optional(),
+    url: z.string().nullable().optional(),
+    provider: z.string().nullable().optional(),
+    kind: z.string().nullable().optional(),
+    score: z.unknown().optional(),
+    latency_ms: z.int().nullable().optional(),
+    status: z.string().nullable().optional(),
+    health_source: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const GetBestRpcEndpointOutputSchema = z
+  .object({
+    eligible_count: z.int(),
+    live_health: z.unknown().optional(),
+    endpoints: z.array(BestRpcEndpointItemSchema),
+  })
+  .passthrough();
+export type GetBestRpcEndpointOutput = z.infer<
+  typeof GetBestRpcEndpointOutputSchema
+>;
+
+export const CallRpcInputSchema = z
+  .object({
+    method: z.string(),
+    params: z.array(z.unknown()).optional(),
+    network: z.enum(["finney", "test"]).optional(),
+  })
+  .strict();
+export type CallRpcInput = z.infer<typeof CallRpcInputSchema>;
+
+export const CallRpcOutputSchema = z
+  .object({
+    network: z.string(),
+    method: z.string(),
+    jsonrpc: z.string(),
+    result: z.unknown().optional(),
+    error: OpenObjectSchema.nullable().optional(),
+    endpoint_id: z.string().nullable().optional(),
+    provider: z.string().nullable().optional(),
+    cache: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type CallRpcOutput = z.infer<typeof CallRpcOutputSchema>;

--- a/scripts/diff-mcp-tool-schemas.ts
+++ b/scripts/diff-mcp-tool-schemas.ts
@@ -560,6 +560,64 @@ import {
   ListProviderEndpointsInputSchema,
   ListProviderEndpointsOutputSchema,
 } from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
+import {
+  GetLineageInputSchema,
+  GetLineageOutputSchema,
+  GetFreshnessInputSchema,
+  GetFreshnessOutputSchema,
+  GetContractsInputSchema,
+  GetContractsOutputSchema,
+  GetSourceHealthInputSchema,
+  GetSourceHealthOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-1.ts";
+import {
+  GetChangelogInputSchema,
+  GetChangelogOutputSchema,
+  GetBuildInputSchema,
+  GetBuildOutputSchema,
+  GetCoverageInputSchema,
+  GetCoverageOutputSchema,
+  GetCoverageDepthInputSchema,
+  GetCoverageDepthOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-2.ts";
+import {
+  GetFeedInputSchema,
+  GetFeedOutputSchema,
+} from "../schemas-src/mcp-tools/feed.ts";
+import {
+  GetAdapterInputSchema,
+  GetAdapterOutputSchema,
+} from "../schemas-src/mcp-tools/get-adapter.ts";
+import {
+  GetAgentCatalogInputSchema,
+  GetAgentCatalogOutputSchema,
+  GetAgentResourcesInputSchema,
+  GetAgentResourcesOutputSchema,
+} from "../schemas-src/mcp-tools/agent-catalog-resources.ts";
+import {
+  GetRpcUsageInputSchema,
+  GetRpcUsageOutputSchema,
+  GetBestRpcEndpointInputSchema,
+  GetBestRpcEndpointOutputSchema,
+  CallRpcInputSchema,
+  CallRpcOutputSchema,
+} from "../schemas-src/mcp-tools/rpc-tools.ts";
+import {
+  QueryGraphqlInputSchema,
+  QueryGraphqlOutputSchema,
+  RunSavedQueryInputSchema,
+  RunSavedQueryOutputSchema,
+} from "../schemas-src/mcp-tools/query-tools.ts";
+import {
+  RegistrySummaryInputSchema,
+  RegistrySummaryOutputSchema,
+  ListEnrichmentTargetsInputSchema,
+  ListEnrichmentTargetsOutputSchema,
+  GetSubnetGapsInputSchema,
+  GetSubnetGapsOutputSchema,
+  ListSubnetGapsInputSchema,
+  ListSubnetGapsOutputSchema,
+} from "../schemas-src/mcp-tools/registry-summary-gaps.ts";
 
 type Row = Record<string, unknown>;
 
@@ -1068,6 +1126,45 @@ const INCIDENT_SORT_FIELDS = [
   "severity",
   "state",
   "status",
+];
+
+// Batch 12 (#8075) resolved enum values, same treatment as above -- symbolic
+// in the hand-written originals (src/contracts.ts's
+// QUERY_ENUMS.agentReadinessStatus, mcp-server.ts's own
+// COVERAGE_DEPTH_TIERS/COVERAGE_DEPTH_SEVERITIES constants, src/feed-mcp.ts's
+// FEED_KINDS/FEED_MAX_ITEMS, and src/saved-queries.ts's
+// SAVED_QUERY_TEMPLATES.map((t) => t.id)), cross-checked against the actual
+// runtime source at the time of writing. Reuses SURFACE_KIND/CURATION_LEVEL
+// already defined above (batches 1-4) -- confirmed identical to this
+// batch's own symbolic references, not just reused by name.
+const AGENT_READINESS_STATUSES = [
+  "callable",
+  "base-layer",
+  "candidate",
+  "needs-evidence",
+  "blocked",
+];
+const COVERAGE_DEPTH_TIERS_12 = [
+  "agent-ready",
+  "machine-usable",
+  "candidate-review",
+  "needs-evidence",
+  "hard-blocked",
+  "missing-interface",
+];
+const COVERAGE_DEPTH_SEVERITIES_12 = ["hard", "missing-data", "needs-review"];
+const FEED_KINDS = ["registry", "incidents", "gaps", "subnet"];
+const FEED_MAX_ITEMS = 50;
+const SAVED_QUERY_IDS = ["subnet-leaderboard", "chain-registrations-window"];
+const GAP_PRIORITY_SORT_FIELDS = [
+  "candidate_count",
+  "curation_level",
+  "missing_kinds",
+  "name",
+  "netuid",
+  "priority_score",
+  "surface_count",
+  "verified_candidate_count",
 ];
 
 const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
@@ -7360,6 +7457,640 @@ const OLD_SCHEMAS: Record<string, { input: Row; output: Row }> = {
       },
     },
   },
+  get_lineage: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        link_count: { type: "integer" },
+        graduated_subnet_count: { type: "integer" },
+        broken_link_count: { type: "integer" },
+        links: { type: "array", items: { type: "object" } },
+        broken_links: { type: "array", items: { type: "object" } },
+        generated_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_freshness: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["sources"],
+      properties: {
+        schema_version: { type: "integer" },
+        sources: { type: "array", items: { type: "object" } },
+        summary: { type: ["object", "null"] },
+        generated_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_contracts: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["schema_version", "artifacts"],
+      properties: {
+        schema_version: { type: "integer" },
+        contract_version: NULLABLE_STRING,
+        generated_at: NULLABLE_STRING,
+        name: NULLABLE_STRING,
+        base_path: NULLABLE_STRING,
+        primary_domain: NULLABLE_STRING,
+        openapi_url: NULLABLE_STRING,
+        type_definitions_url: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        artifacts: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  get_source_health: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["providers"],
+      properties: {
+        providers: { type: "array", items: { type: "object" } },
+        generated_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_changelog: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["source", "summary", "artifacts", "subnets"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        source: NULLABLE_STRING,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        summary: { type: "object" },
+        artifacts: { type: "object" },
+        subnets: { type: "object" },
+        coverage_delta: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_feed: {
+    input: {
+      type: "object",
+      properties: {
+        kind: { type: "string", enum: FEED_KINDS },
+        netuid: { type: "integer", minimum: 0 },
+        tag: { type: "string" },
+        since: { type: "string" },
+        until: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: FEED_MAX_ITEMS },
+      },
+      required: ["kind"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["kind", "returned", "items"],
+      properties: {
+        kind: { type: "string", enum: FEED_KINDS },
+        netuid: NULLABLE_INT,
+        filters: {
+          type: "object",
+          additionalProperties: true,
+          properties: {
+            tag: NULLABLE_STRING,
+            since: NULLABLE_STRING,
+            until: NULLABLE_STRING,
+            limit: { type: "integer" },
+          },
+        },
+        returned: { type: "integer" },
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            required: ["id", "url", "title", "summary", "timestamp", "tags"],
+            properties: {
+              id: { type: "string" },
+              url: { type: "string" },
+              title: { type: "string" },
+              summary: { type: "string" },
+              timestamp: { type: "string" },
+              tags: { type: "array", items: { type: "string" } },
+            },
+          },
+        },
+      },
+    },
+  },
+  get_build: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["schema_version", "artifact_count"],
+      properties: {
+        schema_version: { type: "integer" },
+        contract_version: NULLABLE_STRING,
+        generated_at: NULLABLE_STRING,
+        published_at: NULLABLE_STRING,
+        adapter_count: { type: ["integer", "null"] },
+        artifact_count: { type: "integer" },
+        artifact_size_bytes: { type: ["integer", "null"] },
+        subnet_count: { type: ["integer", "null"] },
+        surface_count: { type: ["integer", "null"] },
+        provider_count: { type: ["integer", "null"] },
+        artifacts: {
+          type: ["array", "null"],
+          items: { type: "object" },
+        },
+        coverage: { type: ["object", "null"] },
+        artifact_budget_summary: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_adapter: {
+    input: {
+      type: "object",
+      properties: {
+        slug: { type: "string", pattern: "^[a-z0-9-]+$" },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["schema_version", "slug"],
+      properties: {
+        schema_version: { type: "integer" },
+        contract_version: NULLABLE_STRING,
+        generated_at: NULLABLE_STRING,
+        slug: { type: "string" },
+        subnet: NULLABLE_STRING,
+        netuid: NULLABLE_INT,
+        notes: {
+          type: ["array", "string", "null"],
+          items: { type: "string" },
+        },
+        snapshot: { type: ["object", "null"] },
+        extensions: { type: ["object", "null"] },
+      },
+    },
+  },
+  get_agent_catalog: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [],
+      properties: {
+        subnet_count: { type: "integer" },
+        total_subnet_count: { type: "integer" },
+        callable_service_count: { type: "integer" },
+        content_hash: NULLABLE_STRING,
+        generated_at: NULLABLE_STRING,
+        published_at: NULLABLE_STRING,
+        subnets: { type: "array", items: { type: "object" } },
+        operational_observed_at: NULLABLE_STRING,
+        health_source: NULLABLE_STRING,
+      },
+    },
+  },
+  get_agent_resources: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["resources", "mcp"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        published_at: NULLABLE_STRING,
+        content_hash: NULLABLE_STRING,
+        summary: { type: "object" },
+        copyable_agent: { type: "object" },
+        mcp: { type: "object" },
+        resources: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  get_rpc_usage: {
+    input: {
+      type: "object",
+      properties: {
+        window: { type: "string", enum: ["7d", "30d"] },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: [
+        "schema_version",
+        "source",
+        "summary",
+        "endpoints",
+        "networks",
+        "buckets",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        window: NULLABLE_STRING,
+        bucket_granularity: NULLABLE_STRING,
+        observed_at: NULLABLE_STRING,
+        source: { type: "string" },
+        summary: {
+          type: "object",
+          additionalProperties: true,
+          required: [
+            "total_requests",
+            "ok_requests",
+            "error_requests",
+            "latency_ms",
+          ],
+          properties: {
+            total_requests: { type: "integer", minimum: 0 },
+            ok_requests: { type: "integer", minimum: 0 },
+            error_requests: { type: "integer", minimum: 0 },
+            error_rate: { type: ["number", "null"] },
+            failover_requests: { type: "integer", minimum: 0 },
+            failover_rate: { type: ["number", "null"] },
+            cache_hits: { type: "integer", minimum: 0 },
+            cache_hit_rate: { type: ["number", "null"] },
+            latency_ms: {
+              type: "object",
+              additionalProperties: true,
+              required: ["p50", "p95", "avg"],
+              properties: {
+                p50: NULLABLE_INT,
+                p95: NULLABLE_INT,
+                avg: NULLABLE_INT,
+              },
+            },
+          },
+        },
+        endpoints: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            required: ["endpoint_id", "requests", "ok_requests"],
+            properties: {
+              rank: { type: "integer", minimum: 1 },
+              endpoint_id: NULLABLE_STRING,
+              provider: NULLABLE_STRING,
+              requests: { type: "integer", minimum: 0 },
+              ok_requests: { type: "integer", minimum: 0 },
+              error_rate: { type: ["number", "null"] },
+              avg_latency_ms: NULLABLE_INT,
+            },
+          },
+        },
+        networks: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            required: ["network", "requests", "ok_requests"],
+            properties: {
+              network: { type: "string" },
+              requests: { type: "integer", minimum: 0 },
+              ok_requests: { type: "integer", minimum: 0 },
+              error_rate: { type: ["number", "null"] },
+            },
+          },
+        },
+        buckets: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            required: ["ts", "requests", "errors", "avg_latency_ms"],
+            properties: {
+              ts: { type: "integer", minimum: 0 },
+              requests: { type: "integer", minimum: 0 },
+              errors: { type: "integer", minimum: 0 },
+              avg_latency_ms: NULLABLE_INT,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_best_rpc_endpoint: {
+    input: {
+      type: "object",
+      properties: {
+        limit: { type: "integer", minimum: 1, maximum: 10 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["eligible_count", "endpoints"],
+      properties: {
+        eligible_count: { type: "integer" },
+        live_health: ANY,
+        endpoints: objectItems({
+          id: { type: "string" },
+          url: NULLABLE_STRING,
+          provider: NULLABLE_STRING,
+          kind: NULLABLE_STRING,
+          score: ANY,
+          latency_ms: NULLABLE_INT,
+          status: NULLABLE_STRING,
+          health_source: NULLABLE_STRING,
+        }),
+      },
+    },
+  },
+  call_rpc: {
+    input: {
+      type: "object",
+      properties: {
+        method: { type: "string" },
+        params: { type: "array" },
+        network: { type: "string", enum: ["finney", "test"] },
+      },
+      required: ["method"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["network", "method", "jsonrpc"],
+      properties: {
+        network: { type: "string" },
+        method: { type: "string" },
+        jsonrpc: { type: "string" },
+        result: ANY,
+        error: { type: ["object", "null"] },
+        endpoint_id: NULLABLE_STRING,
+        provider: NULLABLE_STRING,
+        cache: NULLABLE_STRING,
+      },
+    },
+  },
+  query_graphql: {
+    input: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        variables: { type: "object", additionalProperties: true },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      properties: {
+        data: {
+          type: "object",
+          additionalProperties: true,
+          nullable: true,
+        },
+        errors: {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+        },
+      },
+      additionalProperties: true,
+    },
+  },
+  registry_summary: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["subnet_count", "counts"],
+      properties: {
+        subnet_count: { type: "integer" },
+        counts: { type: "object" },
+        coverage: { type: "object" },
+        curation_level_counts: { type: "object" },
+        profile_level_counts: { type: "object" },
+        recent_changes: { type: "object" },
+        top_subnets: { type: "array", items: { type: "object" } },
+        generated_at: NULLABLE_STRING,
+      },
+    },
+  },
+  get_coverage: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["surface_count", "completeness"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        surface_count: { type: "integer" },
+        official_surface_count: { type: "integer" },
+        first_party_subnet_count: { type: "integer" },
+        chain_subnet_count: { type: "integer" },
+        candidate_count: { type: "integer" },
+        probed_count: { type: "integer" },
+        domain_coverage: { type: "object" },
+        completeness: { type: "object" },
+        subnets_without_official_surface: { type: "integer" },
+      },
+    },
+  },
+  get_coverage_depth: {
+    input: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      properties: {
+        schema_version: { type: "integer" },
+        generated_at: NULLABLE_STRING,
+        coverage_depth_version: { type: ["string", "null"] },
+        rows: { type: "array", items: { type: "object" } },
+        ranked_queue: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  list_enrichment_targets: {
+    input: {
+      type: "object",
+      properties: {
+        limit: { type: "integer", minimum: 1, maximum: 50 },
+        tier: { type: "string", enum: COVERAGE_DEPTH_TIERS_12 },
+        severity: { type: "string", enum: COVERAGE_DEPTH_SEVERITIES_12 },
+        gap_code: { type: "string", pattern: "^[a-z0-9-]+$" },
+        agent_status: { type: "string", enum: AGENT_READINESS_STATUSES },
+        netuid: { type: "integer", minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["total_rows", "queue_count", "returned", "targets"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        coverage_depth_version: ANY,
+        total_rows: { type: "integer" },
+        queue_count: { type: "integer" },
+        returned: { type: "integer" },
+        filters: { type: "object" },
+        note: { type: "string" },
+        targets: objectItems({
+          rank: NULLABLE_INT,
+          netuid: { type: "integer" },
+          slug: NULLABLE_STRING,
+          name: NULLABLE_STRING,
+          tier: { type: "string" },
+          score: { type: "integer" },
+          priority_score: { type: "integer" },
+          agent_status: { type: "string" },
+          blocker_level: { type: "string" },
+          top_gap_codes: { type: "array" },
+          top_gaps: { type: "array", items: { type: "object" } },
+          recommended_next_action: NULLABLE_STRING,
+          dimensions: { type: "object" },
+        }),
+      },
+    },
+  },
+  get_subnet_gaps: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["netuid", "priorities", "enrichment_queue"],
+      properties: {
+        schema_version: { type: "integer" },
+        contract_version: NULLABLE_STRING,
+        generated_at: NULLABLE_STRING,
+        netuid: { type: "integer" },
+        slug: NULLABLE_STRING,
+        name: NULLABLE_STRING,
+        priorities: { type: "array", items: { type: "object" } },
+        enrichment_queue: { type: "array", items: { type: "object" } },
+      },
+    },
+  },
+  list_subnet_gaps: {
+    input: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        curation_level: { type: "string", enum: CURATION_LEVEL },
+        missing_kinds: { type: "string", enum: SURFACE_KIND },
+        review_state: { type: "string" },
+        sort: { type: "string", enum: GAP_PRIORITY_SORT_FIELDS },
+        order: { type: "string", enum: ["asc", "desc"] },
+        fields: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+        cursor: { type: "integer", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: true,
+      required: ["priorities"],
+      properties: {
+        generated_at: NULLABLE_STRING,
+        netuid: NULLABLE_INT,
+        priorities: { type: "array", items: { type: "object" } },
+        total: { type: "integer" },
+        returned: { type: "integer" },
+        limit: { type: "integer" },
+        cursor: { type: "integer" },
+        next_cursor: NULLABLE_INT,
+        sort: NULLABLE_STRING,
+        order: NULLABLE_STRING,
+      },
+    },
+  },
+  run_saved_query: {
+    input: {
+      type: "object",
+      required: ["query_id"],
+      properties: {
+        query_id: { type: "string", enum: SAVED_QUERY_IDS },
+        params: { type: "object" },
+      },
+      additionalProperties: false,
+    },
+    output: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query_id", "params", "data"],
+      properties: {
+        query_id: { type: "string" },
+        params: { type: "object" },
+        data: {},
+      },
+    },
+  },
 };
 
 const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
@@ -8064,6 +8795,90 @@ const NEW_SCHEMAS: Record<string, { input: z.ZodType; output: z.ZodType }> = {
     input: ListProviderEndpointsInputSchema,
     output: ListProviderEndpointsOutputSchema,
   },
+  get_lineage: {
+    input: GetLineageInputSchema,
+    output: GetLineageOutputSchema,
+  },
+  get_freshness: {
+    input: GetFreshnessInputSchema,
+    output: GetFreshnessOutputSchema,
+  },
+  get_contracts: {
+    input: GetContractsInputSchema,
+    output: GetContractsOutputSchema,
+  },
+  get_source_health: {
+    input: GetSourceHealthInputSchema,
+    output: GetSourceHealthOutputSchema,
+  },
+  get_changelog: {
+    input: GetChangelogInputSchema,
+    output: GetChangelogOutputSchema,
+  },
+  get_feed: {
+    input: GetFeedInputSchema,
+    output: GetFeedOutputSchema,
+  },
+  get_build: {
+    input: GetBuildInputSchema,
+    output: GetBuildOutputSchema,
+  },
+  get_adapter: {
+    input: GetAdapterInputSchema,
+    output: GetAdapterOutputSchema,
+  },
+  get_agent_catalog: {
+    input: GetAgentCatalogInputSchema,
+    output: GetAgentCatalogOutputSchema,
+  },
+  get_agent_resources: {
+    input: GetAgentResourcesInputSchema,
+    output: GetAgentResourcesOutputSchema,
+  },
+  get_rpc_usage: {
+    input: GetRpcUsageInputSchema,
+    output: GetRpcUsageOutputSchema,
+  },
+  get_best_rpc_endpoint: {
+    input: GetBestRpcEndpointInputSchema,
+    output: GetBestRpcEndpointOutputSchema,
+  },
+  call_rpc: {
+    input: CallRpcInputSchema,
+    output: CallRpcOutputSchema,
+  },
+  query_graphql: {
+    input: QueryGraphqlInputSchema,
+    output: QueryGraphqlOutputSchema,
+  },
+  registry_summary: {
+    input: RegistrySummaryInputSchema,
+    output: RegistrySummaryOutputSchema,
+  },
+  get_coverage: {
+    input: GetCoverageInputSchema,
+    output: GetCoverageOutputSchema,
+  },
+  get_coverage_depth: {
+    input: GetCoverageDepthInputSchema,
+    output: GetCoverageDepthOutputSchema,
+  },
+  list_enrichment_targets: {
+    input: ListEnrichmentTargetsInputSchema,
+    output: ListEnrichmentTargetsOutputSchema,
+  },
+  get_subnet_gaps: {
+    input: GetSubnetGapsInputSchema,
+    output: GetSubnetGapsOutputSchema,
+  },
+  list_subnet_gaps: {
+    input: ListSubnetGapsInputSchema,
+    output: ListSubnetGapsOutputSchema,
+  },
+  run_saved_query: {
+    input: RunSavedQueryInputSchema,
+    output: RunSavedQueryOutputSchema,
+  },
 };
 
 const MAX_SAFE_INT = Number.MAX_SAFE_INTEGER;
@@ -8083,6 +8898,17 @@ const MAX_SAFE_INT = Number.MAX_SAFE_INTEGER;
 // bare MCP output schema never declared. None can ever reject a REAL
 // response (computeStakeQuote() cannot produce a value outside these
 // bounds) -- verified, not assumed.
+// query_graphql.output.data's hand-written original declares `nullable:
+// true` -- an OpenAPI-3.0-ism with NO effect under JSON Schema draft
+// 2020-12 (which has no `nullable` keyword at all), so under the target
+// spec's own semantics `data` was already (inertly) a plain non-nullable
+// object. The Zod conversion (batch 12, #8075) declares `data` as a plain
+// non-nullable object to match that literal 2020-12 reading, rather than
+// translating the inert marker into a real `.nullable()` -- doing so would
+// make the NEW schema accept something the OLD one's actual declared
+// semantics didn't, the wrong direction for this epic's wire-compatibility
+// mandate. Stripping the dead `nullable` key here just lets both sides
+// compare as the equivalent-under-2020-12 objects they already are.
 const ACCEPTED_TIGHTENINGS = new Set([
   "get_subnet_stake_quote.output.amount",
   "get_subnet_stake_quote.output.effective_price_tao",
@@ -8090,6 +8916,7 @@ const ACCEPTED_TIGHTENINGS = new Set([
   "get_subnet_stake_quote.output.price_impact_pct",
   "get_subnet_stake_quote.output.spot_price_tao",
   "get_subnet_stake_quote.output.netuid",
+  "query_graphql.output.data",
 ]);
 
 function normalize(node: unknown, path: string): unknown {
@@ -8148,7 +8975,7 @@ function normalize(node: unknown, path: string): unknown {
 
     if (
       ACCEPTED_TIGHTENINGS.has(path) &&
-      (key === "exclusiveMinimum" || key === "minimum")
+      (key === "exclusiveMinimum" || key === "minimum" || key === "nullable")
     ) {
       continue;
     }

--- a/src/adapters-mcp.ts
+++ b/src/adapters-mcp.ts
@@ -2,7 +2,12 @@
 // Serves the baked /metagraph/adapters/{slug}.json artifact (adapter-backed
 // public metrics for one subnet slug).
 
+import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  GetAdapterInputSchema,
+  GetAdapterOutputSchema,
+} from "../schemas-src/mcp-tools/get-adapter.ts";
 
 export const ADAPTER_SLUG_PATTERN = /^[a-z0-9-]+$/;
 
@@ -94,39 +99,14 @@ export const GET_ADAPTER_MCP_TOOL = {
     "captured adapter snapshot, extension metadata, and netuid linkage. Use it " +
     "after list_candidates or get_subnet to inspect how a subnet's public metrics " +
     "are adapter-projected. Mirrors GET /api/v1/adapters/{slug}.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      slug: {
-        type: "string",
-        pattern: "^[a-z0-9-]+$",
-        description: "Adapter slug, e.g. 'gittensor', 'allways', or 'sn-64'.",
-      },
-    },
-    required: ["slug"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetAdapterInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const GET_ADAPTER_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["schema_version", "slug"],
-  properties: {
-    schema_version: { type: "integer" },
-    contract_version: NULLABLE_STRING,
-    generated_at: NULLABLE_STRING,
-    slug: { type: "string" },
-    subnet: NULLABLE_STRING,
-    netuid: NULLABLE_INT,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    snapshot: { type: ["object", "null"] },
-    extensions: { type: ["object", "null"] },
+export const GET_ADAPTER_OUTPUT_SCHEMA = z.toJSONSchema(
+  GetAdapterOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/agent-resources-mcp.ts
+++ b/src/agent-resources-mcp.ts
@@ -2,7 +2,12 @@
 // Serves the baked /metagraph/agent-resources.json artifact (copyable agent,
 // MCP install metadata, skill/OpenAPI links, and the agent-facing API index).
 
+import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  GetAgentResourcesInputSchema,
+  GetAgentResourcesOutputSchema,
+} from "../schemas-src/mcp-tools/agent-catalog-resources.ts";
 
 export const AGENT_RESOURCES_ARTIFACT = "/metagraph/agent-resources.json";
 
@@ -72,26 +77,14 @@ export const GET_AGENT_RESOURCES_MCP_TOOL = {
     "semantic search, ask, fixtures, lineage). Use it to bootstrap an agent " +
     "integration session before calling get_agent_catalog or list_fixtures. " +
     "Mirrors GET /api/v1/agent-resources.",
-  inputSchema: {
-    type: "object",
-    properties: {},
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetAgentResourcesInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-
-export const GET_AGENT_RESOURCES_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["resources", "mcp"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    published_at: NULLABLE_STRING,
-    content_hash: NULLABLE_STRING,
-    summary: { type: "object" },
-    copyable_agent: { type: "object" },
-    mcp: { type: "object" },
-    resources: { type: "array", items: { type: "object" } },
+export const GET_AGENT_RESOURCES_OUTPUT_SCHEMA = z.toJSONSchema(
+  GetAgentResourcesOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/build-mcp.ts
+++ b/src/build-mcp.ts
@@ -2,7 +2,12 @@
 // Serves the baked /metagraph/build-summary.json artifact (artifact inventory,
 // counts, and publish metadata).
 
+import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  GetBuildInputSchema,
+  GetBuildOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-2.ts";
 
 export const BUILD_SUMMARY_ARTIFACT = "/metagraph/build-summary.json";
 
@@ -60,35 +65,11 @@ export const GET_BUILD_MCP_TOOL = {
     "subnet/provider/surface totals, coverage rollup, and publish metadata. " +
     "Use it to inspect the latest registry publish footprint before drilling " +
     "into get_changelog or get_freshness. Mirrors GET /api/v1/build.",
-  inputSchema: {
-    type: "object",
-    properties: {},
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetBuildInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-
-export const GET_BUILD_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["schema_version", "artifact_count"],
-  properties: {
-    schema_version: { type: "integer" },
-    contract_version: NULLABLE_STRING,
-    generated_at: NULLABLE_STRING,
-    published_at: NULLABLE_STRING,
-    adapter_count: { type: ["integer", "null"] },
-    artifact_count: { type: "integer" },
-    artifact_size_bytes: { type: ["integer", "null"] },
-    subnet_count: { type: ["integer", "null"] },
-    surface_count: { type: ["integer", "null"] },
-    provider_count: { type: ["integer", "null"] },
-    artifacts: {
-      type: ["array", "null"],
-      items: { type: "object" },
-    },
-    coverage: { type: ["object", "null"] },
-    artifact_budget_summary: { type: ["object", "null"] },
-  },
-};
+export const GET_BUILD_OUTPUT_SCHEMA = z.toJSONSchema(GetBuildOutputSchema, {
+  target: "draft-2020-12",
+});

--- a/src/changelog-mcp.ts
+++ b/src/changelog-mcp.ts
@@ -2,7 +2,12 @@
 // Serves the baked /metagraph/changelog.json artifact (publish-time artifact,
 // subnet, and coverage diffs).
 
+import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  GetChangelogInputSchema,
+  GetChangelogOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-2.ts";
 
 export const CHANGELOG_ARTIFACT = "/metagraph/changelog.json";
 
@@ -64,29 +69,14 @@ export const GET_CHANGELOG_MCP_TOOL = {
     "previous publish. Use it to see what changed between registry publishes " +
     "before drilling into registry_summary or list_enrichment_targets. Mirrors " +
     "GET /api/v1/changelog.",
-  inputSchema: {
-    type: "object",
-    properties: {},
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetChangelogInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-
-export const GET_CHANGELOG_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["source", "summary", "artifacts", "subnets"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    source: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    summary: { type: "object" },
-    artifacts: { type: "object" },
-    subnets: { type: "object" },
-    coverage_delta: { type: ["object", "null"] },
+export const GET_CHANGELOG_OUTPUT_SCHEMA = z.toJSONSchema(
+  GetChangelogOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/contracts-mcp.ts
+++ b/src/contracts-mcp.ts
@@ -2,7 +2,12 @@
 // Serves the baked /metagraph/contracts.json artifact (public artifact
 // contract metadata for registry consumers).
 
+import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  GetContractsInputSchema,
+  GetContractsOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-1.ts";
 
 export const CONTRACTS_ARTIFACT = "/metagraph/contracts.json";
 
@@ -63,35 +68,14 @@ export const GET_CONTRACTS_MCP_TOOL = {
     "artifact path, storage tier, schema reference, and consumer notes. Use it " +
     "to discover which artifacts exist and how to read them before calling " +
     "get_api_schema or list_schemas. Mirrors GET /api/v1/contracts.",
-  inputSchema: {
-    type: "object",
-    properties: {},
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetContractsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-
-export const GET_CONTRACTS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["schema_version", "artifacts"],
-  properties: {
-    schema_version: { type: "integer" },
-    contract_version: NULLABLE_STRING,
-    generated_at: NULLABLE_STRING,
-    name: NULLABLE_STRING,
-    base_path: NULLABLE_STRING,
-    primary_domain: NULLABLE_STRING,
-    openapi_url: NULLABLE_STRING,
-    type_definitions_url: NULLABLE_STRING,
-    notes: {
-      type: ["array", "string", "null"],
-      items: { type: "string" },
-    },
-    artifacts: {
-      type: "array",
-      items: { type: "object" },
-    },
+export const GET_CONTRACTS_OUTPUT_SCHEMA = z.toJSONSchema(
+  GetContractsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/feed-mcp.ts
+++ b/src/feed-mcp.ts
@@ -12,6 +12,7 @@
 // wiring instead of a second path that would bypass the module's
 // injected-KV convention (see mcp-server.mjs's header comment).
 
+import { z } from "zod";
 import {
   FEED_MAX_ITEMS,
   filterByTag,
@@ -25,6 +26,10 @@ import {
 } from "./feeds.ts";
 import { loadChangelog } from "./changelog-mcp.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  GetFeedInputSchema,
+  GetFeedOutputSchema,
+} from "../schemas-src/mcp-tools/feed.ts";
 
 export const FEED_KINDS = ["registry", "incidents", "gaps", "subnet"];
 const ENRICHMENT_QUEUE_ARTIFACT = "/metagraph/review/enrichment-queue.json";
@@ -247,85 +252,11 @@ export const GET_FEED_MCP_TOOL = {
     "polling instead of re-fetching and diffing the full registry. Mirrors the " +
     "JSON Feed variant of GET /api/v1/feeds/registry, /api/v1/feeds/incidents, " +
     "/api/v1/feeds/gaps, and /api/v1/feeds/subnets/{netuid}.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      kind: {
-        type: "string",
-        enum: FEED_KINDS,
-        description:
-          "Which feed to fetch. `subnet` requires netuid and combines that " +
-          "subnet's registry changes + incidents.",
-      },
-      netuid: {
-        type: "integer",
-        description:
-          "Subnet netuid. Required when kind is `subnet`, unused otherwise.",
-        minimum: 0,
-      },
-      tag: {
-        type: "string",
-        description:
-          "Optional tag filter, e.g. incident, coverage, added, removed, renamed.",
-      },
-      since: {
-        type: "string",
-        description:
-          "Optional ISO-8601 date or date-time lower bound, e.g. 2026-06-01 or 2026-06-01T00:00:00Z.",
-      },
-      until: {
-        type: "string",
-        description:
-          "Optional ISO-8601 date or date-time upper bound (a bare date is inclusive of the whole day).",
-      },
-      limit: {
-        type: "integer",
-        description: `Max items to return (1-${FEED_MAX_ITEMS}, default ${FEED_MAX_ITEMS}).`,
-        minimum: 1,
-        maximum: FEED_MAX_ITEMS,
-      },
-    },
-    required: ["kind"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetFeedInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const GET_FEED_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["kind", "returned", "items"],
-  properties: {
-    kind: { type: "string", enum: FEED_KINDS },
-    netuid: NULLABLE_INT,
-    filters: {
-      type: "object",
-      additionalProperties: true,
-      properties: {
-        tag: NULLABLE_STRING,
-        since: NULLABLE_STRING,
-        until: NULLABLE_STRING,
-        limit: { type: "integer" },
-      },
-    },
-    returned: { type: "integer" },
-    items: {
-      type: "array",
-      items: {
-        type: "object",
-        additionalProperties: true,
-        required: ["id", "url", "title", "summary", "timestamp", "tags"],
-        properties: {
-          id: { type: "string" },
-          url: { type: "string" },
-          title: { type: "string" },
-          summary: { type: "string" },
-          timestamp: { type: "string" },
-          tags: { type: "array", items: { type: "string" } },
-        },
-      },
-    },
-  },
-};
+export const GET_FEED_OUTPUT_SCHEMA = z.toJSONSchema(GetFeedOutputSchema, {
+  target: "draft-2020-12",
+});

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -807,6 +807,47 @@ import {
   ListProviderEndpointsInputSchema,
 } from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
 import {
+  GetLineageInputSchema,
+  GetLineageOutputSchema,
+  GetFreshnessInputSchema,
+  GetFreshnessOutputSchema,
+  GetSourceHealthInputSchema,
+  GetSourceHealthOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-1.ts";
+import {
+  GetCoverageDepthInputSchema,
+  GetCoverageDepthOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-2.ts";
+import { GetFeedInputSchema } from "../schemas-src/mcp-tools/feed.ts";
+import { GetAdapterInputSchema } from "../schemas-src/mcp-tools/get-adapter.ts";
+import {
+  GetAgentCatalogInputSchema,
+  GetAgentCatalogOutputSchema,
+} from "../schemas-src/mcp-tools/agent-catalog-resources.ts";
+import {
+  GetRpcUsageInputSchema,
+  GetRpcUsageOutputSchema,
+  GetBestRpcEndpointInputSchema,
+  GetBestRpcEndpointOutputSchema,
+  CallRpcInputSchema,
+  CallRpcOutputSchema,
+} from "../schemas-src/mcp-tools/rpc-tools.ts";
+import {
+  QueryGraphqlInputSchema,
+  QueryGraphqlOutputSchema,
+  RunSavedQueryInputSchema,
+  RunSavedQueryOutputSchema,
+} from "../schemas-src/mcp-tools/query-tools.ts";
+import {
+  RegistrySummaryInputSchema,
+  RegistrySummaryOutputSchema,
+  ListEnrichmentTargetsInputSchema,
+  ListEnrichmentTargetsOutputSchema,
+  GetSubnetGapsInputSchema,
+  GetSubnetGapsOutputSchema,
+  ListSubnetGapsInputSchema,
+} from "../schemas-src/mcp-tools/registry-summary-gaps.ts";
+import {
   buildChainConcentration,
   buildConcentration,
   buildConcentrationHistory,
@@ -2960,6 +3001,17 @@ const ENDPOINTS_QUERY_FILTER_NAMES = [
   "publication_state",
   "status",
 ];
+
+// z.toJSONSchema() always injects a `$schema` key. get_coverage_depth's own
+// pre-existing test (#6983, predates the Zod-conversion epic) asserts its
+// inputSchema strictly equals the bare {type,properties,additionalProperties}
+// shape the hand-written literal always had, with no such key present -- this
+// strips it for that one call site rather than editing that intentionally
+// strict, unrelated test (types-epic E batch 12, #8075).
+function withoutSchemaMeta(schema: Row): Row {
+  const { $schema: _schema, ...rest } = schema;
+  return rest;
+}
 
 // ---------------------------------------------------------------------------
 // Tool registry. Each tool is a thin wrapper over artifact/KV reads.
@@ -8787,11 +8839,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "subnets have graduated to mainnet (mainnet ↔ testnet pairs with the match " +
       "evidence), plus any flagged broken links. Use it to map a mainnet subnet " +
       "to its testnet counterpart or vice versa. Mirrors GET /api/v1/lineage.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetLineageInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/lineage.json");
     },
@@ -8806,11 +8856,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "health, etc.). The operational surface-health source is overlaid with the " +
       "live 15-minute prober's last run. Use it to judge how current the data is " +
       "before relying on it. Mirrors GET /api/v1/freshness.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetFreshnessInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadFreshness(ctx);
     },
@@ -8830,11 +8878,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "/ dead), endpoint and RPC-endpoint counts, verification-result count, and " +
       "an overall status. Use it to see which providers are publishing healthy, " +
       "still-reachable surfaces. Mirrors GET /api/v1/source-health.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(GetSourceHealthInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/source-health.json");
     },
@@ -8847,7 +8893,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...GET_FEED_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof GetFeedInputSchema>, ctx: McpCtx) {
       return loadFeedItems(asMcpLoaderCtx(ctx), args, {
         // Same cross-subnet incident ledger + wiring get_global_incidents uses
         // (mcpObservedAt), widest window (30d) -- get_feed's own since/until
@@ -8869,7 +8915,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...GET_ADAPTER_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(args: z.infer<typeof GetAdapterInputSchema>, ctx: McpCtx) {
       return loadAdapter(asMcpLoaderCtx(ctx), args);
     },
   },
@@ -8880,18 +8926,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Fetch the machine-readable agent capability catalog. With no argument " +
       "returns the global index of subnets exposing callable services; with a " +
       "netuid returns that subnet's full per-service catalog.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: {
-          type: "integer",
-          description: "Optional subnet netuid for the per-subnet catalog.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetAgentCatalogInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetAgentCatalogInputSchema>,
+      ctx: McpCtx,
+    ) {
       const live = await mcpLiveHealth(ctx);
       if (args?.netuid === undefined || args?.netuid === null) {
         const index = await loadArtifactData(
@@ -8925,19 +8966,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "rpc_proxy_events D1 telemetry. Use alongside get_best_rpc_endpoint to see " +
       "which endpoints are actually carrying traffic. Mirrors " +
       "GET /api/v1/rpc/usage.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        window: {
-          type: "string",
-          enum: ["7d", "30d"],
-          description: "Aggregation window (default 7d).",
-        },
-      },
-      required: [],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetRpcUsageInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetRpcUsageInputSchema>, ctx: McpCtx) {
       const parsed = parseAnalyticsWindow(args?.window ?? "7d");
       if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
@@ -8963,19 +8995,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Return the best currently-eligible Bittensor base-layer RPC/WSS " +
       "endpoint(s), scored and filtered by live health (down endpoints are " +
       "excluded). Use this to pick a node endpoint for on-chain reads.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        limit: {
-          type: "integer",
-          description: "Max endpoints to return (1-10, default 3).",
-          minimum: 1,
-          maximum: 10,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetBestRpcEndpointInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof GetBestRpcEndpointInputSchema>,
+      ctx: McpCtx,
+    ) {
       const limit = clampLimit(args?.limit, 3, 10);
       const poolData = await loadArtifactData(ctx, "/metagraph/rpc/pools.json");
       const liveRpcPool = ctx.readHealthKv
@@ -9041,29 +9067,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "rate limiting, and endpoint failover as the public proxy. Use " +
       "get_best_rpc_endpoint to pick a node for direct WSS access instead. " +
       "Mirrors POST /rpc/v1/{network}.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        method: {
-          type: "string",
-          description:
-            "The JSON-RPC method name, e.g. 'chain_getBlockHash' or 'state_getStorage'.",
-        },
-        params: {
-          type: "array",
-          description:
-            "JSON-RPC positional params for the method. Omit for none.",
-        },
-        network: {
-          type: "string",
-          enum: ["finney", "test"],
-          description: "Bittensor network to query (default 'finney').",
-        },
-      },
-      required: ["method"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(CallRpcInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof CallRpcInputSchema>, ctx: McpCtx) {
       if (typeof args?.method !== "string" || !args.method) {
         throw toolError(
           "invalid_params",
@@ -9158,43 +9165,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "REST GraphQL endpoint -- a query that exceeds them is rejected. Pass the " +
       "query string in `query` and any GraphQL variables as an object in " +
       "`variables`.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        query: {
-          type: "string",
-          description:
-            "The GraphQL query document, e.g. '{ subnet(netuid: 1) { name } }'.",
-        },
-        variables: {
-          type: "object",
-          description:
-            "Optional GraphQL variables keyed by name, e.g. { netuid: 1 }.",
-          additionalProperties: true,
-        },
-      },
-      required: ["query"],
-      additionalProperties: false,
-    },
-    outputSchema: {
-      type: "object",
-      properties: {
-        data: {
-          type: "object",
-          description: "The query result, or null when the query errored.",
-          additionalProperties: true,
-          nullable: true,
-        },
-        errors: {
-          type: "array",
-          description:
-            "GraphQL errors (validation, depth/complexity, or resolver), when any.",
-          items: { type: "object", additionalProperties: true },
-        },
-      },
-      additionalProperties: true,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(QueryGraphqlInputSchema, {
+      target: "draft-2020-12",
+    }),
+    outputSchema: z.toJSONSchema(QueryGraphqlOutputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof QueryGraphqlInputSchema>, ctx: McpCtx) {
       const query = requireString(args, "query");
       if (
         args?.variables !== undefined &&
@@ -9253,11 +9230,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "Fetch the registry-wide summary: overall completeness, the most " +
       "complete subnets, coverage-level counts, and the latest registry " +
       "changes. A fast orientation for the whole Bittensor application layer.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: z.toJSONSchema(RegistrySummaryInputSchema, {
+      target: "draft-2020-12",
+    }),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/registry-summary.json");
     },
@@ -9276,11 +9251,11 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "enrichment queue: per-subnet tier/score/priority rows plus the ranked " +
       "queue of enrichment targets. The raw passthrough companion of the " +
       "filtered list_enrichment_targets tool. Mirrors GET /api/v1/coverage-depth.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
+    inputSchema: withoutSchemaMeta(
+      z.toJSONSchema(GetCoverageDepthInputSchema, {
+        target: "draft-2020-12",
+      }),
+    ),
     async handler(_args: unknown, ctx: McpCtx) {
       return loadArtifactData(ctx, "/metagraph/coverage-depth.json");
     },
@@ -9293,49 +9268,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "subnets need schema, fixture, example/SDK, provenance, candidate-review, " +
       "or hard-blocker follow-up next. Use this for curation/work-planning, not " +
       "live uptime; call get_subnet_health for current health.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        limit: {
-          type: "integer",
-          description: "Max targets to return (1-50, default 10).",
-          minimum: 1,
-          maximum: 50,
-        },
-        tier: {
-          type: "string",
-          enum: COVERAGE_DEPTH_TIERS,
-          description:
-            "Optional coverage-depth tier filter, e.g. machine-usable.",
-        },
-        severity: {
-          type: "string",
-          enum: COVERAGE_DEPTH_SEVERITIES,
-          description:
-            "Optional gap severity filter: missing-data, needs-review, or hard.",
-        },
-        gap_code: {
-          type: "string",
-          description:
-            "Optional stable gap code filter, e.g. missing-fixture or missing-schema.",
-          pattern: "^[a-z0-9-]+$",
-        },
-        agent_status: {
-          type: "string",
-          enum: QUERY_ENUMS.agentReadinessStatus,
-          description:
-            "Optional agent-readiness filter: callable, base-layer, candidate, needs-evidence, or blocked.",
-        },
-        netuid: {
-          type: "integer",
-          description:
-            "Optional subnet netuid. When present, returns that subnet's scorecard row instead of only ranked-queue entries.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(ListEnrichmentTargetsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(
+      args: z.infer<typeof ListEnrichmentTargetsInputSchema>,
+      ctx: McpCtx,
+    ) {
       const limit = clampLimit(args?.limit, 10, 50);
       const tier = optionalEnum(args, "tier", COVERAGE_DEPTH_TIERS);
       const severity = optionalEnum(
@@ -9415,19 +9354,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "view behind GET /api/v1/subnets/{netuid}/gaps — distinct from " +
       "list_enrichment_targets, which ranks the registry-wide coverage-depth " +
       "scorecard.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: {
-          type: "integer",
-          description: "Subnet netuid.",
-          minimum: 0,
-        },
-      },
-      required: ["netuid"],
-      additionalProperties: false,
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(GetSubnetGapsInputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof GetSubnetGapsInputSchema>, ctx: McpCtx) {
       const netuid = requireNetuid(args);
       const gaps = await loadOptionalArtifact(
         ctx,
@@ -9445,7 +9375,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     ...LIST_SUBNET_GAPS_MCP_TOOL,
-    async handler(args: Row, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListSubnetGapsInputSchema>,
+      ctx: McpCtx,
+    ) {
       return loadSubnetGapsList(asMcpLoaderCtx(ctx), args);
     },
   },
@@ -10268,34 +10201,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
                 .join(", ")}.`
             : " No params."),
       ).join(" | "),
-    inputSchema: {
-      type: "object",
-      required: ["query_id"],
-      properties: {
-        query_id: {
-          type: "string",
-          enum: SAVED_QUERY_TEMPLATES.map((template) => template.id),
-          description: "Which curated template to run.",
-        },
-        params: {
-          type: "object",
-          description:
-            "The chosen template's own params (see the tool description). Omit for a template with no required params.",
-        },
-      },
-      additionalProperties: false,
-    },
-    outputSchema: {
-      type: "object",
-      additionalProperties: false,
-      required: ["query_id", "params", "data"],
-      properties: {
-        query_id: { type: "string" },
-        params: { type: "object" },
-        data: {},
-      },
-    },
-    async handler(args: Row, ctx: McpCtx) {
+    inputSchema: z.toJSONSchema(RunSavedQueryInputSchema, {
+      target: "draft-2020-12",
+    }),
+    outputSchema: z.toJSONSchema(RunSavedQueryOutputSchema, {
+      target: "draft-2020-12",
+    }),
+    async handler(args: z.infer<typeof RunSavedQueryInputSchema>, ctx: McpCtx) {
       if (typeof args?.query_id !== "string" || !args.query_id) {
         throw toolError("invalid_params", "Argument `query_id` is required.");
       }
@@ -10397,79 +10309,6 @@ const objectItems = (properties = {}) => ({
   type: "array",
   items: { type: "object", additionalProperties: true, properties },
 });
-// RpcUsageArtifact item shapes — shared by get_rpc_usage outputSchema (mirrors
-// schemas/api-components.schema.json#/components/schemas/RpcUsageArtifact).
-const RPC_USAGE_LATENCY_MS = {
-  type: "object",
-  additionalProperties: true,
-  required: ["p50", "p95", "avg"],
-  properties: {
-    p50: NULLABLE_INT,
-    p95: NULLABLE_INT,
-    avg: NULLABLE_INT,
-  },
-};
-const RPC_USAGE_SUMMARY = {
-  type: "object",
-  additionalProperties: true,
-  required: ["total_requests", "ok_requests", "error_requests", "latency_ms"],
-  properties: {
-    total_requests: { type: "integer", minimum: 0 },
-    ok_requests: { type: "integer", minimum: 0 },
-    error_requests: { type: "integer", minimum: 0 },
-    error_rate: { type: ["number", "null"] },
-    failover_requests: { type: "integer", minimum: 0 },
-    failover_rate: { type: ["number", "null"] },
-    cache_hits: { type: "integer", minimum: 0 },
-    cache_hit_rate: { type: ["number", "null"] },
-    latency_ms: RPC_USAGE_LATENCY_MS,
-  },
-};
-const RPC_USAGE_ENDPOINTS = {
-  type: "array",
-  items: {
-    type: "object",
-    additionalProperties: true,
-    required: ["endpoint_id", "requests", "ok_requests"],
-    properties: {
-      rank: { type: "integer", minimum: 1 },
-      endpoint_id: NULLABLE_STRING,
-      provider: NULLABLE_STRING,
-      requests: { type: "integer", minimum: 0 },
-      ok_requests: { type: "integer", minimum: 0 },
-      error_rate: { type: ["number", "null"] },
-      avg_latency_ms: NULLABLE_INT,
-    },
-  },
-};
-const RPC_USAGE_NETWORKS = {
-  type: "array",
-  items: {
-    type: "object",
-    additionalProperties: true,
-    required: ["network", "requests", "ok_requests"],
-    properties: {
-      network: { type: "string" },
-      requests: { type: "integer", minimum: 0 },
-      ok_requests: { type: "integer", minimum: 0 },
-      error_rate: { type: ["number", "null"] },
-    },
-  },
-};
-const RPC_USAGE_BUCKETS = {
-  type: "array",
-  items: {
-    type: "object",
-    additionalProperties: true,
-    required: ["ts", "requests", "errors", "avg_latency_ms"],
-    properties: {
-      ts: { type: "integer", minimum: 0 },
-      requests: { type: "integer", minimum: 0 },
-      errors: { type: "integer", minimum: 0 },
-      avg_latency_ms: NULLABLE_INT,
-    },
-  },
-};
 const TOOL_OUTPUT_SCHEMAS = {
   search_subnets: z.toJSONSchema(SearchSubnetsOutputSchema, {
     target: "draft-2020-12",
@@ -10916,29 +10755,9 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_network_activity: z.toJSONSchema(GetNetworkActivityOutputSchema, {
     target: "draft-2020-12",
   }),
-  get_rpc_usage: {
-    type: "object",
-    additionalProperties: true,
-    required: [
-      "schema_version",
-      "source",
-      "summary",
-      "endpoints",
-      "networks",
-      "buckets",
-    ],
-    properties: {
-      schema_version: { type: "integer" },
-      window: NULLABLE_STRING,
-      bucket_granularity: NULLABLE_STRING,
-      observed_at: NULLABLE_STRING,
-      source: { type: "string" },
-      summary: RPC_USAGE_SUMMARY,
-      endpoints: RPC_USAGE_ENDPOINTS,
-      networks: RPC_USAGE_NETWORKS,
-      buckets: RPC_USAGE_BUCKETS,
-    },
-  },
+  get_rpc_usage: z.toJSONSchema(GetRpcUsageOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_subnet_apis: z.toJSONSchema(ListSubnetApisOutputSchema, {
     target: "draft-2020-12",
   }),
@@ -10997,169 +10816,43 @@ const TOOL_OUTPUT_SCHEMAS = {
   list_endpoint_pools: LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
   list_endpoint_incidents: LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
   list_provider_endpoints: LIST_PROVIDER_ENDPOINTS_OUTPUT_SCHEMA,
-  get_lineage: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      link_count: { type: "integer" },
-      graduated_subnet_count: { type: "integer" },
-      broken_link_count: { type: "integer" },
-      links: { type: "array", items: { type: "object" } },
-      broken_links: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-    },
-  },
-  get_freshness: {
-    type: "object",
-    additionalProperties: true,
-    required: ["sources"],
-    properties: {
-      schema_version: { type: "integer" },
-      sources: { type: "array", items: { type: "object" } },
-      summary: { type: ["object", "null"] },
-      generated_at: NULLABLE_STRING,
-    },
-  },
+  get_lineage: z.toJSONSchema(GetLineageOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_freshness: z.toJSONSchema(GetFreshnessOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_contracts: GET_CONTRACTS_OUTPUT_SCHEMA,
-  get_source_health: {
-    type: "object",
-    additionalProperties: true,
-    required: ["providers"],
-    properties: {
-      providers: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-    },
-  },
+  get_source_health: z.toJSONSchema(GetSourceHealthOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_changelog: GET_CHANGELOG_OUTPUT_SCHEMA,
   get_feed: GET_FEED_OUTPUT_SCHEMA,
   get_build: GET_BUILD_OUTPUT_SCHEMA,
   get_adapter: GET_ADAPTER_OUTPUT_SCHEMA,
-  get_agent_catalog: {
-    // Two shapes: the global index (no netuid) and a single-subnet catalog
-    // (with a netuid). They share few keys, so nothing is required; the
-    // properties below describe the global index when present.
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      subnet_count: { type: "integer" },
-      total_subnet_count: { type: "integer" },
-      callable_service_count: { type: "integer" },
-      content_hash: NULLABLE_STRING,
-      generated_at: NULLABLE_STRING,
-      published_at: NULLABLE_STRING,
-      subnets: { type: "array", items: { type: "object" } },
-      operational_observed_at: NULLABLE_STRING,
-      health_source: NULLABLE_STRING,
-    },
-  },
+  get_agent_catalog: z.toJSONSchema(GetAgentCatalogOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_agent_resources: GET_AGENT_RESOURCES_OUTPUT_SCHEMA,
-  get_best_rpc_endpoint: {
-    type: "object",
-    additionalProperties: true,
-    required: ["eligible_count", "endpoints"],
-    properties: {
-      eligible_count: { type: "integer" },
-      live_health: ANY,
-      endpoints: objectItems({
-        id: { type: "string" },
-        url: NULLABLE_STRING,
-        provider: NULLABLE_STRING,
-        kind: NULLABLE_STRING,
-        score: ANY,
-        latency_ms: NULLABLE_INT,
-        status: NULLABLE_STRING,
-        health_source: NULLABLE_STRING,
-      }),
-    },
-  },
-  call_rpc: {
-    type: "object",
-    additionalProperties: true,
-    required: ["network", "method", "jsonrpc"],
-    properties: {
-      network: { type: "string" },
-      method: { type: "string" },
-      jsonrpc: { type: "string" },
-      result: ANY,
-      error: { type: ["object", "null"] },
-      endpoint_id: NULLABLE_STRING,
-      provider: NULLABLE_STRING,
-      cache: NULLABLE_STRING,
-    },
-  },
-  registry_summary: {
-    type: "object",
-    additionalProperties: true,
-    required: ["subnet_count", "counts"],
-    properties: {
-      subnet_count: { type: "integer" },
-      counts: { type: "object" },
-      coverage: { type: "object" },
-      curation_level_counts: { type: "object" },
-      profile_level_counts: { type: "object" },
-      recent_changes: { type: "object" },
-      top_subnets: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-    },
-  },
+  get_best_rpc_endpoint: z.toJSONSchema(GetBestRpcEndpointOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  call_rpc: z.toJSONSchema(CallRpcOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  registry_summary: z.toJSONSchema(RegistrySummaryOutputSchema, {
+    target: "draft-2020-12",
+  }),
   get_coverage: GET_COVERAGE_OUTPUT_SCHEMA,
-  get_coverage_depth: {
-    type: "object",
-    additionalProperties: true,
-    properties: {
-      schema_version: { type: "integer" },
-      generated_at: NULLABLE_STRING,
-      coverage_depth_version: { type: ["string", "null"] },
-      rows: { type: "array", items: { type: "object" } },
-      ranked_queue: { type: "array", items: { type: "object" } },
-    },
-  },
-  list_enrichment_targets: {
-    type: "object",
-    additionalProperties: true,
-    required: ["total_rows", "queue_count", "returned", "targets"],
-    properties: {
-      generated_at: NULLABLE_STRING,
-      coverage_depth_version: ANY,
-      total_rows: { type: "integer" },
-      queue_count: { type: "integer" },
-      returned: { type: "integer" },
-      filters: { type: "object" },
-      note: { type: "string" },
-      targets: objectItems({
-        rank: NULLABLE_INT,
-        netuid: { type: "integer" },
-        slug: NULLABLE_STRING,
-        name: NULLABLE_STRING,
-        tier: { type: "string" },
-        score: { type: "integer" },
-        priority_score: { type: "integer" },
-        agent_status: { type: "string" },
-        blocker_level: { type: "string" },
-        top_gap_codes: { type: "array" },
-        top_gaps: { type: "array", items: { type: "object" } },
-        recommended_next_action: NULLABLE_STRING,
-        dimensions: { type: "object" },
-      }),
-    },
-  },
-  get_subnet_gaps: {
-    type: "object",
-    additionalProperties: true,
-    required: ["netuid", "priorities", "enrichment_queue"],
-    properties: {
-      schema_version: { type: "integer" },
-      contract_version: NULLABLE_STRING,
-      generated_at: NULLABLE_STRING,
-      netuid: { type: "integer" },
-      slug: NULLABLE_STRING,
-      name: NULLABLE_STRING,
-      priorities: { type: "array", items: { type: "object" } },
-      enrichment_queue: { type: "array", items: { type: "object" } },
-    },
-  },
+  get_coverage_depth: z.toJSONSchema(GetCoverageDepthOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  list_enrichment_targets: z.toJSONSchema(ListEnrichmentTargetsOutputSchema, {
+    target: "draft-2020-12",
+  }),
+  get_subnet_gaps: z.toJSONSchema(GetSubnetGapsOutputSchema, {
+    target: "draft-2020-12",
+  }),
   list_subnet_gaps: LIST_SUBNET_GAPS_OUTPUT_SCHEMA,
   find_subnet_for_task: {
     type: "object",

--- a/src/registry-coverage.ts
+++ b/src/registry-coverage.ts
@@ -1,7 +1,12 @@
 // Registry coverage loader for MCP parity on GET /api/v1/coverage.
 // Serves the baked /metagraph/coverage.json artifact (surface counts,
 // completeness aggregate, domain breakdown).
+import { z } from "zod";
 import type { StorageReadResult } from "../workers/storage.ts";
+import {
+  GetCoverageInputSchema,
+  GetCoverageOutputSchema,
+} from "../schemas-src/mcp-tools/meta-artifacts-2.ts";
 
 export const REGISTRY_COVERAGE_ARTIFACT = "/metagraph/coverage.json";
 
@@ -64,29 +69,14 @@ export const GET_COVERAGE_MCP_TOOL = {
     "Use for a fast registry-wide coverage snapshot before drilling into " +
     "list_enrichment_targets (coverage-depth queue) or registry_summary. " +
     "Mirrors GET /api/v1/coverage.",
-  inputSchema: {
-    type: "object",
-    properties: {},
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(GetCoverageInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-
-export const GET_COVERAGE_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["surface_count", "completeness"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    surface_count: { type: "integer" },
-    official_surface_count: { type: "integer" },
-    first_party_subnet_count: { type: "integer" },
-    chain_subnet_count: { type: "integer" },
-    candidate_count: { type: "integer" },
-    probed_count: { type: "integer" },
-    domain_coverage: { type: "object" },
-    completeness: { type: "object" },
-    subnets_without_official_surface: { type: "integer" },
+export const GET_COVERAGE_OUTPUT_SCHEMA = z.toJSONSchema(
+  GetCoverageOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/src/subnet-gaps-mcp.ts
+++ b/src/subnet-gaps-mcp.ts
@@ -3,9 +3,14 @@
 // as the REST route over the baked /metagraph/review/gaps/{netuid}.json
 // artifact.
 
+import { z } from "zod";
 import { applyQueryFilters, type Row } from "../workers/list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
+import {
+  ListSubnetGapsInputSchema,
+  ListSubnetGapsOutputSchema,
+} from "../schemas-src/mcp-tools/registry-summary-gaps.ts";
 
 // The REST route pages this artifact through the review-gap-priorities
 // collection (rows live under `priorities`), not the network-wide `gaps`
@@ -216,77 +221,14 @@ export const LIST_SUBNET_GAPS_MCP_TOOL = {
     "or review_state; sort with sort + order; and page with limit (1-100) / " +
     "cursor. Distinct from get_subnet_gaps (raw artifact dump, which also " +
     "carries the enrichment queue). Mirrors GET /api/v1/subnets/{netuid}/gaps.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      netuid: {
-        type: "integer",
-        description: "Subnet netuid.",
-        minimum: 0,
-      },
-      curation_level: {
-        type: "string",
-        enum: CURATION_LEVELS,
-        description: "Filter by the subnet's curation level.",
-      },
-      missing_kinds: {
-        type: "string",
-        enum: SURFACE_KINDS,
-        description: "Filter to rows missing this surface kind.",
-      },
-      review_state: {
-        type: "string",
-        description: "Filter by review state.",
-      },
-      sort: {
-        type: "string",
-        enum: GAP_PRIORITY_SORT_FIELDS,
-        description: "Field to sort by before paging.",
-      },
-      order: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Sort direction for sort (default asc).",
-      },
-      fields: {
-        type: "string",
-        description:
-          "Comma-separated projection of gap-priority row fields to return.",
-      },
-      limit: {
-        type: "integer",
-        description: "Max rows to return (1-100). Enables pagination.",
-        minimum: 1,
-        maximum: 100,
-      },
-      cursor: {
-        type: "integer",
-        description: "Pagination cursor from a prior response's next_cursor.",
-        minimum: 0,
-      },
-    },
-    required: ["netuid"],
-    additionalProperties: false,
-  },
+  inputSchema: z.toJSONSchema(ListSubnetGapsInputSchema, {
+    target: "draft-2020-12",
+  }),
 };
 
-const NULLABLE_STRING = { type: ["string", "null"] };
-const NULLABLE_INT = { type: ["integer", "null"] };
-
-export const LIST_SUBNET_GAPS_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-  required: ["priorities"],
-  properties: {
-    generated_at: NULLABLE_STRING,
-    netuid: NULLABLE_INT,
-    priorities: { type: "array", items: { type: "object" } },
-    total: { type: "integer" },
-    returned: { type: "integer" },
-    limit: { type: "integer" },
-    cursor: { type: "integer" },
-    next_cursor: NULLABLE_INT,
-    sort: NULLABLE_STRING,
-    order: NULLABLE_STRING,
+export const LIST_SUBNET_GAPS_OUTPUT_SCHEMA = z.toJSONSchema(
+  ListSubnetGapsOutputSchema,
+  {
+    target: "draft-2020-12",
   },
-};
+);

--- a/tests/adapters-mcp.test.ts
+++ b/tests/adapters-mcp.test.ts
@@ -169,9 +169,11 @@ describe("adapters-mcp", () => {
   test("MCP tool metadata and outputSchema compile", () => {
     assert.equal(GET_ADAPTER_MCP_TOOL.name, "get_adapter");
     assert.match(GET_ADAPTER_INSTRUCTIONS, /get_adapter/);
-    assert.deepEqual(Object.keys(GET_ADAPTER_MCP_TOOL.inputSchema.properties), [
-      "slug",
-    ]);
+    assert.deepEqual(
+      // z.toJSONSchema()'s return type declares `properties` as optional (#8075).
+      Object.keys(GET_ADAPTER_MCP_TOOL.inputSchema.properties ?? {}),
+      ["slug"],
+    );
     assert.ok(
       new Ajv2020({ strict: false }).compile(GET_ADAPTER_OUTPUT_SCHEMA),
     );

--- a/tests/agent-resources-mcp.test.ts
+++ b/tests/agent-resources-mcp.test.ts
@@ -145,7 +145,8 @@ describe("agent-resources-mcp", () => {
     assert.equal(GET_AGENT_RESOURCES_MCP_TOOL.name, "get_agent_resources");
     assert.match(GET_AGENT_RESOURCES_INSTRUCTIONS, /get_agent_resources/);
     assert.deepEqual(
-      Object.keys(GET_AGENT_RESOURCES_MCP_TOOL.inputSchema.properties),
+      // z.toJSONSchema()'s return type declares `properties` as optional (#8075).
+      Object.keys(GET_AGENT_RESOURCES_MCP_TOOL.inputSchema.properties ?? {}),
       [],
     );
     assert.ok(

--- a/tests/build-mcp.test.ts
+++ b/tests/build-mcp.test.ts
@@ -116,7 +116,8 @@ describe("build-mcp", () => {
     assert.equal(GET_BUILD_MCP_TOOL.name, "get_build");
     assert.match(GET_BUILD_INSTRUCTIONS, /get_build/);
     assert.deepEqual(
-      Object.keys(GET_BUILD_MCP_TOOL.inputSchema.properties),
+      // z.toJSONSchema()'s return type declares `properties` as optional (#8075).
+      Object.keys(GET_BUILD_MCP_TOOL.inputSchema.properties ?? {}),
       [],
     );
     assert.ok(new Ajv2020({ strict: false }).compile(GET_BUILD_OUTPUT_SCHEMA));

--- a/tests/changelog-mcp.test.ts
+++ b/tests/changelog-mcp.test.ts
@@ -117,7 +117,8 @@ describe("changelog-mcp", () => {
     assert.equal(GET_CHANGELOG_MCP_TOOL.name, "get_changelog");
     assert.match(GET_CHANGELOG_INSTRUCTIONS, /get_changelog/);
     assert.deepEqual(
-      Object.keys(GET_CHANGELOG_MCP_TOOL.inputSchema.properties),
+      // z.toJSONSchema()'s return type declares `properties` as optional (#8075).
+      Object.keys(GET_CHANGELOG_MCP_TOOL.inputSchema.properties ?? {}),
       [],
     );
     assert.ok(

--- a/tests/contracts-mcp.test.ts
+++ b/tests/contracts-mcp.test.ts
@@ -119,7 +119,8 @@ describe("contracts-mcp", () => {
     assert.equal(GET_CONTRACTS_MCP_TOOL.name, "get_contracts");
     assert.match(GET_CONTRACTS_INSTRUCTIONS, /get_contracts/);
     assert.deepEqual(
-      Object.keys(GET_CONTRACTS_MCP_TOOL.inputSchema.properties),
+      // z.toJSONSchema()'s return type declares `properties` as optional (#8075).
+      Object.keys(GET_CONTRACTS_MCP_TOOL.inputSchema.properties ?? {}),
       [],
     );
     assert.ok(

--- a/tests/registry-coverage.test.ts
+++ b/tests/registry-coverage.test.ts
@@ -103,7 +103,8 @@ describe("registry-coverage", () => {
     assert.equal(GET_COVERAGE_MCP_TOOL.name, "get_coverage");
     assert.match(GET_COVERAGE_INSTRUCTIONS, /get_coverage/);
     assert.deepEqual(
-      Object.keys(GET_COVERAGE_MCP_TOOL.inputSchema.properties),
+      // z.toJSONSchema()'s return type declares `properties` as optional (#8075).
+      Object.keys(GET_COVERAGE_MCP_TOOL.inputSchema.properties ?? {}),
       [],
     );
     assert.ok(


### PR DESCRIPTION
## Summary

Converts 21 MCP tools from hand-written JSON Schema literals to
`z.toJSONSchema(<ZodSchema>, { target: "draft-2020-12" })`, matching the
wire-compatibility pattern established in prior types-epic E batches:

`get_lineage`, `get_freshness`, `get_contracts`, `get_source_health`,
`get_changelog`, `get_feed`, `get_build`, `get_adapter`,
`get_agent_catalog`, `get_agent_resources`, `get_rpc_usage`,
`get_best_rpc_endpoint`, `call_rpc`, `query_graphql`, `run_saved_query`,
`registry_summary`, `get_coverage`, `get_coverage_depth`,
`list_enrichment_targets`, `get_subnet_gaps`, `list_subnet_gaps`.

Closes #8075.

## New schemas-src files

8 files under `schemas-src/mcp-tools/`: `meta-artifacts-1.ts`,
`meta-artifacts-2.ts`, `feed.ts`, `get-adapter.ts`,
`agent-catalog-resources.ts`, `rpc-tools.ts`, `query-tools.ts`,
`registry-summary-gaps.ts`.

## Diff-audit results

`scripts/diff-mcp-tool-schemas.ts`: 42/42 new checks PASS (392/394
total; the 2 remaining DIFFs predate this batch, from #8067/#8069).

Found and fixed 2 real bugs against the hand-written originals during
the audit:
- `get_changelog.output.source` was modeled as optional; the
  hand-written original has it in `required` (nullable, not optional).
- `get_agent_resources.output`'s `summary`/`copyable_agent` were
  modeled as required; the original's `required` array is only
  `["resources", "mcp"]` — both are optional.

One deliberate, verified difference extended `ACCEPTED_TIGHTENINGS`:
`query_graphql.output.data`'s hand-written `nullable: true` is an inert
OpenAPI-3.0-ism with no effect under JSON Schema draft 2020-12 (the
target both sides compare under), so the Zod side models the
semantically equivalent non-nullable optional shape rather than a
literal (but meaningless) `.nullable()` copy — documented at length in
`query-tools.ts`.

## Pre-existing test fix

`get_coverage_depth`'s own test (#6983, predates this epic) asserts its
`inputSchema` strictly equals `{type, properties, additionalProperties}`
with no `$schema` key — but `z.toJSONSchema()` always injects one, with
no suppression option. Rather than edit that protected, intentionally
strict, unrelated test, added a small `withoutSchemaMeta()` helper in
`mcp-server.ts`, applied only at that one call site.

## Reuse notes

`NotesFieldSchema` (hoisted into `shared.ts` by batch 10 / #8074) is
inlined locally in the 3 files that need it, since this batch's branch
forked before #8074 merged.

## Verification

- `tsc --noEmit`: clean
- `eslint` / `prettier --check`: clean
- `scripts/diff-mcp-tool-schemas.ts`: 392/394 (42/42 new checks pass)
- `scripts/validate-mcp.ts`: 204 tools, clean
- Full `vitest` suite: 11957 tests, all passing (15 failures seen on one
  contended run — registry-build-determinism/git-dirty-tracking/timeout
  tests in files this PR never touches — reproduced as environmental
  and confirmed passing in isolation once machine load cleared)

## Test plan

- [x] `npx tsc --noEmit -p .`
- [x] `npx eslint` / `npx prettier --check` on all changed files
- [x] `npx tsx scripts/diff-mcp-tool-schemas.ts`
- [x] `npx tsx scripts/validate-mcp.ts`
- [x] `npx vitest run` (full suite)