### PR TITLE
refactor(graphql): remove unused GqlContext.reportError field

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -556,7 +556,6 @@ export interface GqlContext {
   clientIp?: string | null;
   graphqlWsConnection?: unknown;
   chainFirehose?: unknown;
-  reportError?: (err: unknown) => void;
 }
 
 export const GRAPHQL_MAX_DEPTH = 7;


### PR DESCRIPTION
## Summary

- Removes the dead `reportError?: (err: unknown) => void;` field from the `GqlContext` interface in `src/graphql.ts`. It was never assigned anywhere in the codebase. The two call sites that look like matches (`maxDepthRule`/`maxComplexityRule`) actually invoke graphql-js's own `ValidationContext.reportError`, on an unrelated `Row`-typed parameter — not `GqlContext`.

## What Changed

- `src/graphql.ts`: delete one line from the `GqlContext` interface. No behavior change, no schema/API/registry impact.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched.
- [x] No public API/OpenAPI/schema changes.
- Owner PR (JSONbored) — no linked issue per established maintainer-PR exemption.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck` (clean aside from pre-existing, unrelated `openapi-codegen`/`kanel` module-resolution errors reproduced identically on a clean checkout without this change)
- [x] `npm run validate`
- [x] `npm run test:coverage` (clean aside from the same pre-existing, unrelated `openapi-typescript` module-resolution failures in `tests/artifacts.test.ts`, reproduced identically without this change)
- [x] `npx vitest run tests/graphql.test.ts tests/graphql-sentry-and-error-code.test.ts` (1028 tests passed)
- [x] `git diff --check`