### PR TITLE
refactor(ui): unify duplicated getApi()/session-id/fee-estimate plumbing across stake/take hooks

### DIFF
--- a/apps/ui/src/hooks/use-flow-session.ts
+++ b/apps/ui/src/hooks/use-flow-session.ts
@@ -1,0 +1,84 @@
+// Shared plumbing for the stake/take signing flows (use-stake-flow.ts,
+// use-move-stake-flow.ts, use-take-flow.ts): a client-only session id, the
+// getApi() connect effect, and the PreSignConfirmation fee-estimate dry-run
+// -- each was previously duplicated near-verbatim across all three hooks
+// (#7912). Pure internal dedup: every effect below is byte-for-byte the
+// logic each hook already ran inline, just relocated here.
+
+import { useEffect, useState } from "react";
+import type { ApiPromise } from "@polkadot/api";
+import type { TxUiStatus } from "./use-tx-status";
+import type { ConnectedWallet } from "@/lib/metagraphed/wallet";
+import { getApi, buildExtrinsic, type StakeCallParams } from "@/lib/metagraphed/chain-connection";
+import { estimateFee } from "@/lib/metagraphed/tx-fee";
+import type { Rao } from "@/lib/metagraphed/units";
+
+export interface UseFlowSessionResult {
+  sessionId: string;
+  api: ApiPromise | null;
+}
+
+/**
+ * A client-only session id (crypto.randomUUID(), generated post-mount to
+ * avoid an SSR/CSR hydration mismatch) plus the wallet-gated getApi()
+ * connect effect -- every stake/take flow hook needs both, always together,
+ * to submit its own extrinsic later.
+ */
+export function useFlowSession(walletStatus: string): UseFlowSessionResult {
+  const [sessionId, setSessionId] = useState("");
+  useEffect(() => {
+    setSessionId(crypto.randomUUID());
+  }, []);
+
+  const [api, setApi] = useState<ApiPromise | null>(null);
+  useEffect(() => {
+    if (walletStatus !== "connected") return;
+    let cancelled = false;
+    getApi()
+      .then((connected) => {
+        if (!cancelled) setApi(connected);
+      })
+      .catch(() => {
+        /* best-effort; callers' own dependent data simply stays unavailable */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [walletStatus]);
+
+  return { sessionId, api };
+}
+
+/**
+ * The PreSignConfirmation fee dry-run -- identical across all three stake/
+ * take flows: only fetched once the user has reached "confirm" with a
+ * resolved, idle tx and a buildable params object.
+ */
+export function useFeeEstimate(
+  confirmed: boolean,
+  txStatus: TxUiStatus,
+  api: ApiPromise | null,
+  walletAccount: ConnectedWallet | null,
+  params: StakeCallParams | null,
+): Rao | null {
+  const [feeRao, setFeeRao] = useState<Rao | null>(null);
+  useEffect(() => {
+    setFeeRao(null);
+    if (!confirmed || txStatus !== "idle") return;
+    if (!api || !walletAccount || !params) return;
+    let cancelled = false;
+    const extrinsic = buildExtrinsic(api, params);
+    estimateFee(extrinsic, walletAccount.address)
+      .then((fee) => {
+        if (!cancelled) setFeeRao(fee);
+      })
+      .catch(() => {
+        /* best-effort; the confirm screen just keeps showing "Estimating..." */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [confirmed, txStatus, api, walletAccount, params]);
+
+  return feeRao;
+}

--- a/apps/ui/src/hooks/use-move-stake-flow.ts
+++ b/apps/ui/src/hooks/use-move-stake-flow.ts
@@ -17,10 +17,10 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import type { ApiPromise } from "@polkadot/api";
 import { useWallet } from "./use-wallet";
 import { useTxStatus, type TxUiStatus, type UseTxStatusResult } from "./use-tx-status";
 import { DEFAULT_TOLERANCE_PCT } from "./use-stake-flow";
+import { useFlowSession, useFeeEstimate } from "./use-flow-session";
 import { subnetStakeQuoteQuery, subnetsQuery } from "@/lib/metagraphed/queries";
 import type { SubnetStakeQuote, Subnet } from "@/lib/metagraphed/types";
 import {
@@ -40,15 +40,9 @@ import {
   type SwapStakeLimitParams,
   type StakeValidationIssue,
 } from "@/lib/metagraphed/stake-extrinsics";
-import {
-  getApi,
-  getMinStake,
-  getNextNonce,
-  buildExtrinsic,
-} from "@/lib/metagraphed/chain-connection";
+import { getMinStake, getNextNonce, buildExtrinsic } from "@/lib/metagraphed/chain-connection";
 import { getSigner } from "@/lib/metagraphed/wallet-injected";
 import { computeIdempotencyKey } from "@/lib/metagraphed/broadcast";
-import { estimateFee } from "@/lib/metagraphed/tx-fee";
 
 export type MoveStakeFlowPhase =
   "connect" | "amount" | "confirm" | "signing" | "broadcasting" | "failed" | "done";
@@ -281,28 +275,8 @@ export function useMoveStakeFlow(
   const [tolerancePct, setTolerancePct] = useState(DEFAULT_TOLERANCE_PCT);
   const [confirmed, setConfirmed] = useState(false);
 
-  // Generated client-only -- see use-stake-flow.ts's identical pattern for
-  // why (avoids an SSR/CSR hydration mismatch).
-  const [sessionId, setSessionId] = useState("");
-  useEffect(() => {
-    setSessionId(crypto.randomUUID());
-  }, []);
-
-  const [api, setApi] = useState<ApiPromise | null>(null);
-  useEffect(() => {
-    if (wallet.status !== "connected") return;
-    let cancelled = false;
-    getApi()
-      .then((connected) => {
-        if (!cancelled) setApi(connected);
-      })
-      .catch(() => {
-        /* best-effort; minStake/submit simply stay unavailable */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [wallet.status]);
+  // Shared across all three stake/take flows -- see use-flow-session.ts.
+  const { sessionId, api } = useFlowSession(wallet.status);
 
   const [minStakeRao, setMinStakeRao] = useState<Rao | null>(null);
   useEffect(() => {
@@ -425,24 +399,7 @@ export function useMoveStakeFlow(
   // Fee dry-run for the PreSignConfirmation screen -- identical posture to
   // use-stake-flow.ts's: only fetched once the user has reached "confirm"
   // with a resolved, idle tx.
-  const [feeRao, setFeeRao] = useState<Rao | null>(null);
-  useEffect(() => {
-    setFeeRao(null);
-    if (!confirmed || txStatus.status !== "idle") return;
-    if (!api || !wallet.wallet || !params) return;
-    let cancelled = false;
-    const extrinsic = buildExtrinsic(api, params);
-    estimateFee(extrinsic, wallet.wallet.address)
-      .then((fee) => {
-        if (!cancelled) setFeeRao(fee);
-      })
-      .catch(() => {
-        /* best-effort; the confirm screen just keeps showing "Estimating..." */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [confirmed, txStatus.status, api, wallet.wallet, params]);
+  const feeRao = useFeeEstimate(confirmed, txStatus.status, api, wallet.wallet, params);
 
   const confirm = useCallback(() => setConfirmed(true), []);
   const editAmount = useCallback(() => {

--- a/apps/ui/src/hooks/use-stake-flow.ts
+++ b/apps/ui/src/hooks/use-stake-flow.ts
@@ -10,9 +10,9 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import type { ApiPromise } from "@polkadot/api";
 import { useWallet } from "./use-wallet";
 import { useTxStatus, type TxUiStatus, type UseTxStatusResult } from "./use-tx-status";
+import { useFlowSession, useFeeEstimate } from "./use-flow-session";
 import {
   subnetStakeQuoteQuery,
   economicsQuery,
@@ -31,7 +31,6 @@ import {
   type StakeValidationIssue,
 } from "@/lib/metagraphed/stake-extrinsics";
 import {
-  getApi,
   getMinStake,
   getFreeBalance,
   getNextNonce,
@@ -39,7 +38,6 @@ import {
 } from "@/lib/metagraphed/chain-connection";
 import { getSigner } from "@/lib/metagraphed/wallet-injected";
 import { computeIdempotencyKey } from "@/lib/metagraphed/broadcast";
-import { estimateFee } from "@/lib/metagraphed/tx-fee";
 
 export type StakeFlowAction = "stake" | "unstake";
 export type StakeFlowUnit = "tao" | "alpha";
@@ -275,30 +273,8 @@ export function useStakeFlow(hotkey: string, netuid: number): UseStakeFlowResult
   const [tolerancePct, setTolerancePct] = useState(DEFAULT_TOLERANCE_PCT);
   const [confirmed, setConfirmed] = useState(false);
 
-  // Generated client-only (never in the render body) to avoid an SSR/CSR
-  // hydration mismatch -- see wallet-injected.ts's header comment for why
-  // this file's SSR-safety convention applies here too, even though this
-  // value itself never touches @polkadot/*.
-  const [sessionId, setSessionId] = useState("");
-  useEffect(() => {
-    setSessionId(crypto.randomUUID());
-  }, []);
-
-  const [api, setApi] = useState<ApiPromise | null>(null);
-  useEffect(() => {
-    if (wallet.status !== "connected") return;
-    let cancelled = false;
-    getApi()
-      .then((connected) => {
-        if (!cancelled) setApi(connected);
-      })
-      .catch(() => {
-        /* best-effort; freeBalance/minStake/submit simply stay unavailable */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [wallet.status]);
+  // Shared across all three stake/take flows -- see use-flow-session.ts.
+  const { sessionId, api } = useFlowSession(wallet.status);
 
   const [freeBalanceRao, setFreeBalanceRao] = useState<Rao | null>(null);
   const [minStakeRao, setMinStakeRao] = useState<Rao | null>(null);
@@ -418,24 +394,7 @@ export function useStakeFlow(hotkey: string, netuid: number): UseStakeFlowResult
   // Fee dry-run for the PreSignConfirmation screen -- only ever fetched once
   // the user has reached "confirm" with a resolved, idle tx, so an amount
   // that's still being edited never fires a paymentInfo() round-trip.
-  const [feeRao, setFeeRao] = useState<Rao | null>(null);
-  useEffect(() => {
-    setFeeRao(null);
-    if (!confirmed || txStatus.status !== "idle") return;
-    if (!api || !wallet.wallet || !params) return;
-    let cancelled = false;
-    const extrinsic = buildExtrinsic(api, params);
-    estimateFee(extrinsic, wallet.wallet.address)
-      .then((fee) => {
-        if (!cancelled) setFeeRao(fee);
-      })
-      .catch(() => {
-        /* best-effort; the confirm screen just keeps showing "Estimating..." */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [confirmed, txStatus.status, api, wallet.wallet, params]);
+  const feeRao = useFeeEstimate(confirmed, txStatus.status, api, wallet.wallet, params);
 
   const applyMaxStake = useCallback(() => {
     if (maxStakeRao != null) setAmountInput(raoToTao(maxStakeRao));

--- a/apps/ui/src/hooks/use-take-flow.ts
+++ b/apps/ui/src/hooks/use-take-flow.ts
@@ -7,9 +7,9 @@
 // here at all.
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { ApiPromise } from "@polkadot/api";
 import { useWallet } from "./use-wallet";
 import { useTxStatus, type TxUiStatus, type UseTxStatusResult } from "./use-tx-status";
+import { useFlowSession, useFeeEstimate } from "./use-flow-session";
 import { raoToTao, type Rao } from "@/lib/metagraphed/units";
 import {
   percentToTakeParts,
@@ -26,7 +26,6 @@ import {
   type TakeValidationIssue,
 } from "@/lib/metagraphed/take-extrinsics";
 import {
-  getApi,
   getCurrentBlock,
   getMaxDelegateTake,
   getMinDelegateTake,
@@ -38,7 +37,6 @@ import {
 } from "@/lib/metagraphed/chain-connection";
 import { getSigner } from "@/lib/metagraphed/wallet-injected";
 import { computeIdempotencyKey } from "@/lib/metagraphed/broadcast";
-import { estimateFee } from "@/lib/metagraphed/tx-fee";
 
 export type TakeFlowPhase =
   "connect" | "amount" | "confirm" | "signing" | "broadcasting" | "failed" | "done";
@@ -120,28 +118,8 @@ export function useTakeFlow(hotkey: string, ownerColdkey: string | null): UseTak
 
   const isOwner = !!ownerColdkey && wallet.wallet?.address === ownerColdkey;
 
-  // Generated client-only -- see use-stake-flow.ts's identical pattern for
-  // why (avoids an SSR/CSR hydration mismatch).
-  const [sessionId, setSessionId] = useState("");
-  useEffect(() => {
-    setSessionId(crypto.randomUUID());
-  }, []);
-
-  const [api, setApi] = useState<ApiPromise | null>(null);
-  useEffect(() => {
-    if (wallet.status !== "connected") return;
-    let cancelled = false;
-    getApi()
-      .then((connected) => {
-        if (!cancelled) setApi(connected);
-      })
-      .catch(() => {
-        /* best-effort; bounds/submit simply stay unavailable */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [wallet.status]);
+  // Shared across all three stake/take flows -- see use-flow-session.ts.
+  const { sessionId, api } = useFlowSession(wallet.status);
 
   const [bounds, setBounds] = useState<TakeBounds | null>(null);
   useEffect(() => {
@@ -229,24 +207,7 @@ export function useTakeFlow(hotkey: string, ownerColdkey: string | null): UseTak
 
   // Fee dry-run -- identical posture to use-stake-flow.ts's: only fetched
   // once the user has reached "confirm" with a resolved, idle tx.
-  const [feeRao, setFeeRao] = useState<Rao | null>(null);
-  useEffect(() => {
-    setFeeRao(null);
-    if (!confirmed || txStatus.status !== "idle") return;
-    if (!api || !wallet.wallet || !params) return;
-    let cancelled = false;
-    const extrinsic = buildExtrinsic(api, params);
-    estimateFee(extrinsic, wallet.wallet.address)
-      .then((fee) => {
-        if (!cancelled) setFeeRao(fee);
-      })
-      .catch(() => {
-        /* best-effort; the confirm screen just keeps showing "Estimating..." */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [confirmed, txStatus.status, api, wallet.wallet, params]);
+  const feeRao = useFeeEstimate(confirmed, txStatus.status, api, wallet.wallet, params);
 
   const confirm = useCallback(() => setConfirmed(true), []);
   const editAmount = useCallback(() => {


### PR DESCRIPTION
Closes #7912

`use-move-stake-flow.ts`, `use-stake-flow.ts`, and `use-take-flow.ts` each independently implemented the same three effects: a client-only `sessionId` via `crypto.randomUUID()` in a mount effect, a wallet-gated `getApi()`-connect effect, and a PreSignConfirmation fee-estimate dry-run with an identical `cancelled`-guard shape.

## Change

Extracts the shared plumbing into `apps/ui/src/hooks/use-flow-session.ts`:
- `useFlowSession(walletStatus)` — the session-id generation + `getApi()` connect effect, always used together by all three hooks.
- `useFeeEstimate(confirmed, txStatus, api, walletAccount, params)` — the fee dry-run effect.

`buildExtrinsic`/`estimateFee` are already typed against the umbrella `StakeCallParams` union (`chain-connection.ts`), so `useFeeEstimate` needed no generic type parameter to cover all three hooks' own narrower param unions (`AddStakeLimitParams | RemoveStakeLimitParams`, `MoveStakeParams | SwapStakeLimitParams`, `IncreaseTakeParams | DecreaseTakeParams`).

All three hooks updated to use it in place of their own inline copies. Pure internal dedup — no behavior change, and every dependency array is preserved exactly (e.g. `useFeeEstimate` still depends on the whole `wallet.wallet` object reference and `txStatus.status`, matching each hook's original effect exactly).

## No visual change

This PR is confined to `apps/ui/src/hooks/**` — no component, route, or style changes, so no before/after screenshots apply here.

## Verification

- [x] `npx vitest run` on all three hooks' existing test suites — 75/75 tests pass unmodified
- [x] `npx tsc --noEmit` — no errors introduced by this change (repo has pre-existing, unrelated `@jsonbored/ui-kit` declaration-file errors in this checkout, none touching these files)
- [x] `npx eslint` on all 4 changed files — clean