### PR TITLE
style: fix Prettier formatting on coverage-fix test files

### DIFF
--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -3565,8 +3565,7 @@ test("emits a PostHog trace span for the request when sampled", async () => {
     expect(res.status).toBe(404);
     expect(posted.length).toBe(1);
     expect(posted[0].url.endsWith("/i/v1/traces")).toBe(true);
-    const span =
-      posted[0].body.resourceSpans[0].scopeSpans[0].spans[0];
+    const span = posted[0].body.resourceSpans[0].scopeSpans[0].spans[0];
     expect(span.name).toBe("/api/v1/internal/does-not-exist");
     expect(span.status.code).toBe(1); // OK -- 404 is < 500
   } finally {
@@ -3580,7 +3579,9 @@ test("emits a PostHog trace span for the request when sampled", async () => {
 // registered with waitUntil, so the response must still serve cleanly.
 test("still returns the response cleanly when sampled but no usable ExecutionContext is supplied", async () => {
   const original = globalThis.fetch;
-  globalThis.fetch = (async () => ({ ok: true })) as unknown as typeof globalThis.fetch;
+  globalThis.fetch = (async () => ({
+    ok: true,
+  })) as unknown as typeof globalThis.fetch;
   try {
     const res = await worker.fetch(
       new Request("https://d/api/v1/internal/does-not-exist"),
@@ -3614,9 +3615,7 @@ test("survives recordTraceSpan itself rejecting, not just its own internal failu
   });
   vi.resetModules();
   try {
-    const { default: workerRejecting } = await import(
-      "../workers/data-api.ts"
-    );
+    const { default: workerRejecting } = await import("../workers/data-api.ts");
     const res = await workerRejecting.fetch(
       new Request("https://d/api/v1/internal/does-not-exist"),
       {

--- a/tests/mcp-server-trace-span-args-safety.test.ts
+++ b/tests/mcp-server-trace-span-args-safety.test.ts
@@ -126,9 +126,8 @@ test("a rejected recordTraceSpan call never surfaces into the tool result", asyn
     };
   });
   vi.resetModules();
-  const { handleMcpRequest: handleMcpRequestRejecting } = await import(
-    "../src/mcp-server.ts"
-  );
+  const { handleMcpRequest: handleMcpRequestRejecting } =
+    await import("../src/mcp-server.ts");
   const of = globalThis.fetch;
   globalThis.fetch = async () =>
     new Response("{}", {

--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -479,7 +479,8 @@ describe("withUsageTelemetry", () => {
     // never registered with waitUntil, so the response must still serve
     // cleanly regardless.
     test("still returns the response cleanly when sampled but no usable ExecutionContext is supplied", async () => {
-      globalThis.fetch = (async () => new Response(null, { status: 200 })) as typeof fetch;
+      globalThis.fetch = (async () =>
+        new Response(null, { status: 200 })) as typeof fetch;
 
       const response = await withUsageTelemetry(
         req(),


### PR DESCRIPTION
## Summary

Follow-up to #8147, which just merged with a broken \`Lint + format\` check on main: the coverage-fix commit in that PR added/edited three test files (\`tests/data-api.test.ts\`, \`tests/mcp-server-trace-span-args-safety.test.ts\`, \`tests/request-usage-telemetry.test.ts\`) after the earlier Prettier fix had already been applied to the files CI flagged at that point — these three never got the same pass.

- \`npx prettier --write\` scoped to exactly these 3 files (never a whole-repo \`--write\`).
- No content/logic changes — formatting only.

## Test plan

- [x] \`npx prettier --check\` clean on all 3 files
- [x] \`npx vitest run\` on all 3 files: 574/574 passing
- [x] \`npx tsc --noEmit\` clean