### PR TITLE
feat(indexer-rs): add PostHog error tracking

### DIFF
--- a/apps/indexer-rs/src/bin/poller/main.rs
+++ b/apps/indexer-rs/src/bin/poller/main.rs
@@ -64,9 +64,12 @@
 
 mod jobs;
 
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use backfill_rs::observability::CaptureWindow;
 
 /// What a single job tick reports back to its own `run_loop` -- lets every
 /// job apply the same `log_job_outcome` logging convention instead of each
@@ -76,6 +79,27 @@ pub struct JobOutcome {
     pub written: u64,
     pub errors: u64,
 }
+
+// metagraphed#7766: one CaptureWindow per job name, keyed here rather than
+// threaded through every job's own `run_loop` -- log_job_outcome is
+// already the one function every job calls after each tick (see this
+// file's own module doc comment for why there's no generic scheduler to
+// hang this off instead), so extending it here keeps every job's own
+// run_loop unchanged. A plain Mutex<HashMap>, not per-job state owned by
+// each run_loop: log_job_outcome's own signature (name: &str, not a
+// &mut self) has nowhere else to keep it, and contention is a non-issue
+// (this only locks once per job tick -- minutes to hours apart per job,
+// never a hot path).
+fn capture_windows() -> &'static Mutex<HashMap<String, CaptureWindow>> {
+    static WINDOWS: OnceLock<Mutex<HashMap<String, CaptureWindow>>> = OnceLock::new();
+    WINDOWS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+// Same threshold/interval defaults as every other CaptureWindow consumer in
+// this program (validator-ops' observability.py, chain-firehose-relay.ts) --
+// no single value is load-bearing here, just consistency across dashboards.
+const CAPTURE_THRESHOLD: u32 = 10;
+const CAPTURE_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Shared logging policy every job's own `run_loop` calls after each tick.
 pub fn log_job_outcome(
@@ -95,6 +119,15 @@ pub fn log_job_outcome(
             eprintln!(
                 "{name}: tick failed ({e:#}) -- retrying in {interval:?} ({elapsed:?} elapsed)"
             );
+            let mut windows = capture_windows()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            windows.entry(name.to_string()).or_default().record(
+                name,
+                e,
+                CAPTURE_THRESHOLD,
+                CAPTURE_INTERVAL,
+            );
         }
     }
 }
@@ -103,8 +136,22 @@ fn env_u64(k: &str) -> Option<u64> {
     std::env::var(k).ok().and_then(|v| v.parse().ok())
 }
 
+// PostHog capture on the fatal path only -- see main.rs's own identical
+// wrapper (this crate's sibling binary) for the full reasoning. Here, the
+// only way `run()` below returns `Err` at all is a genuine job-task panic
+// (see the `select_all` loop's own comment for why every other failure
+// mode -- a job returning cleanly, or retrying forever internally -- never
+// reaches this point).
 #[tokio::main]
 async fn main() -> Result<()> {
+    let result = run().await;
+    if let Err(err) = &result {
+        backfill_rs::observability::capture_exception_immediate("indexer-rs-poller", err).await;
+    }
+    result
+}
+
+async fn run() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();

--- a/apps/indexer-rs/src/lib.rs
+++ b/apps/indexer-rs/src/lib.rs
@@ -14,6 +14,8 @@ use subxt::config::PolkadotConfig;
 use subxt::OnlineClient;
 use tokio::sync::RwLock;
 
+pub mod observability;
+
 pub type Api = OnlineClient<PolkadotConfig>;
 /// A client snapshotted at one block -- what `api.at_current_block()` returns.
 /// Fetch this ONCE per unit of work and reuse it for every storage call in

--- a/apps/indexer-rs/src/main.rs
+++ b/apps/indexer-rs/src/main.rs
@@ -357,8 +357,8 @@ fn authority_accounts(v: &Value<()>) -> Vec<String> {
     list.iter().filter_map(|a| acct(a)).collect()
 }
 
-/// Postgres `jsonb` cannot store ` ` (null). EVM/Ethereum event `data` (and
-/// some call args) are raw bytes that serialize to a string full of ` `
+/// Postgres `jsonb` cannot store `\x00` (null). EVM/Ethereum event `data` (and
+/// some call args) are raw bytes that serialize to a string full of `\x00`
 /// escapes — one such row fails the WHOLE multi-row chain_events insert, silently
 /// dropping every event in the chunk. Strip them so the event is still stored
 /// (this is the verbatim display tier; exact EVM bytes come from the extrinsic).
@@ -1502,8 +1502,26 @@ fn track_stuck_block(
 // existing curl-based alerting convention (metagraphed-infra's
 // send-alert.sh) for a single, rare, non-hot-path POST.
 async fn alert_stuck_block(webhook_url: Option<&str>, block: u64, ticks: u64, poll_secs: u64) {
-    let Some(url) = webhook_url else { return };
     let minutes = (ticks * poll_secs) / 60;
+    // metagraphed#7766: also reaches PostHog, not just Discord -- the
+    // caller (run_live's own track_stuck_block/should_alert logic) already
+    // rate-limits how often this whole function runs, so no separate
+    // CaptureWindow needed here on top of that. Discord is "something's
+    // wrong right now"; PostHog is "trend this over time, correlate with
+    // everything else" -- same dual-channel split as every other
+    // Discord-alerted component in this program.
+    let stuck_err = anyhow::anyhow!(
+        "live ingestion stuck on block #{block} for ~{minutes}min ({ticks} retries) -- possible permanent decode failure"
+    );
+    backfill_rs::observability::capture_exception(
+        "indexer-rs-live",
+        &stuck_err,
+        &[
+            ("block", block.to_string()),
+            ("stuck_ticks", ticks.to_string()),
+        ],
+    );
+    let Some(url) = webhook_url else { return };
     let content = format!(
         "🔴 metagraphed-indexer-rs: live ingestion stuck on block #{block} for ~{minutes}min ({ticks} retries) — possible permanent decode failure, check logs."
     );
@@ -1632,8 +1650,26 @@ async fn run_live(client: &ChainClient, pg: &mut tokio_postgres::Client) -> Resu
     }
 }
 
+// PostHog capture on the fatal path only: `run()` below is this crate's
+// entire actual `main` body, unchanged -- this wrapper's only job is
+// awaiting a capture before the process exits on an unhandled `Err`, the
+// same "must complete before exit, not just get queued" reasoning every
+// other component's own fatal-path capture (captureFatalAndExit,
+// handleFatal) already documents. `#[tokio::main]` stays on this outer
+// function (not `run`) so the SAME runtime instance serves the actual work
+// and this capture -- a second `#[tokio::main]`-wrapped async fn would spin
+// up its own separate runtime, which panics if called from inside one
+// that's already running.
 #[tokio::main]
 async fn main() -> Result<()> {
+    let result = run().await;
+    if let Err(err) = &result {
+        backfill_rs::observability::capture_exception_immediate("indexer-rs", err).await;
+    }
+    result
+}
+
+async fn run() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();

--- a/apps/indexer-rs/src/observability.rs
+++ b/apps/indexer-rs/src/observability.rs
@@ -1,0 +1,306 @@
+// PostHog error tracking for both of this crate's binaries (../main.rs and
+// bin/poller/). No prior Sentry footprint here at all -- this is a new
+// capability, not a migration -- added alongside metagraphed#7766's
+// "eliminate Sentry, PostHog everywhere" pass once it surfaced that this
+// crate (a first-party service that runs continuously against production
+// chain data) had zero error-tracking of any kind, only stdout/stderr logs
+// via tracing-subscriber plus one narrow Discord webhook for a single
+// specific failure mode (main.rs's own alert_stuck_block).
+//
+// Same shape as every other component's PostHog capture (src/usage-
+// telemetry.ts's recordExceptionEvent): a manually-built `$exception` event
+// posted to PostHog's raw capture endpoint, no SDK. Unlike the Workers
+// (bundle-budget constrained) this crate has no such constraint -- a native
+// binary pays no bundle-size cost either way -- but there's still no
+// mature, widely-adopted official PostHog Rust SDK the way posthog-node/
+// posthog (Python) are for the other native components in this program, so
+// hand-rolled raw capture stays the more consistent, lower-risk choice here
+// too. Shells out to curl via tokio::process::Command rather than adding an
+// HTTP client crate (reqwest et al.) as a new dependency, matching this
+// crate's own established convention (see lib.rs's post_sync_json and
+// main.rs's alert_stuck_block, both doing the same for their own rare,
+// non-hot-path POSTs).
+//
+// Rust has no JS-style `Error.stack` to walk (no PostHog SDK's manual-
+// capture stacktrace.frames shape without adding a `backtrace` dependency
+// and parsing its text output, for uncertain added value) -- `value` below
+// is instead anyhow's own `{:#}` alternate Display, which already chains
+// every `.context()` layer from the error site up to wherever it was
+// finally handled into one readable message. That's the same diagnostic
+// depth this crate's own `eprintln!("... ({e:#}) ...")` calls already rely
+// on everywhere else.
+
+const POSTHOG_CAPTURE_PATH: &str = "/i/v0/e/";
+const DEFAULT_POSTHOG_HOST: &str = "https://us.i.posthog.com";
+// Stable, shared distinct_id -- matches every other box-side/infra
+// component's own POSTHOG_DISTINCT_ID convention (one logical "service"
+// identity, not per-process/per-machine).
+const POSTHOG_DISTINCT_ID: &str = "metagraphed-infra";
+
+fn posthog_token() -> Option<String> {
+    std::env::var("POSTHOG_PROJECT_TOKEN")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
+fn posthog_host() -> String {
+    std::env::var("POSTHOG_HOST")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_POSTHOG_HOST.to_string())
+}
+
+/// Builds the same `$exception` event shape recordExceptionEvent
+/// (src/usage-telemetry.ts) sends, so a captured error here reads
+/// consistently with every other component's PostHog issues list.
+/// `component` becomes both the `component` property and half of the
+/// `$exception_fingerprint` (paired with the error's Display, the closest
+/// Rust equivalent to a JS Error's `name`/type) -- grouping every
+/// occurrence of "this component threw this shape of error" into one
+/// PostHog issue, same convention as the TS side's route/mcp_tool pairing.
+fn exception_body(
+    token: &str,
+    component: &str,
+    err: &anyhow::Error,
+    tags: &[(&str, String)],
+) -> String {
+    let value = format!("{err:#}");
+    let mut properties = serde_json::Map::new();
+    properties.insert(
+        "$exception_list".to_string(),
+        serde_json::json!([{
+            "type": "Error",
+            "value": value,
+            "mechanism": {"handled": true, "synthetic": false},
+        }]),
+    );
+    properties.insert(
+        "$exception_fingerprint".to_string(),
+        serde_json::json!(format!("{component}:Error")),
+    );
+    properties.insert("component".to_string(), serde_json::json!(component));
+    for (key, val) in tags {
+        properties.insert((*key).to_string(), serde_json::json!(val));
+    }
+    serde_json::json!({
+        "api_key": token,
+        "event": "$exception",
+        "distinct_id": POSTHOG_DISTINCT_ID,
+        "properties": properties,
+    })
+    .to_string()
+}
+
+async fn post_capture(body: String) {
+    use tokio::io::AsyncWriteExt;
+    let url = format!("{}{POSTHOG_CAPTURE_PATH}", posthog_host());
+    let child = tokio::process::Command::new("curl")
+        .args([
+            "-fsS",
+            "-m",
+            "10",
+            "-X",
+            "POST",
+            &url,
+            "-H",
+            "content-type: application/json",
+            "-d",
+            "@-",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn();
+    let mut child = match child {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("observability: spawn curl failed: {e}");
+            return;
+        }
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(e) = stdin.write_all(body.as_bytes()).await {
+            eprintln!("observability: write curl stdin failed: {e}");
+            return;
+        }
+    }
+    match child.wait_with_output().await {
+        Ok(out) if !out.status.success() => {
+            eprintln!(
+                "observability: PostHog capture POST failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Err(e) => eprintln!("observability: wait for curl failed: {e}"),
+        _ => {}
+    }
+}
+
+/// Fire-and-forget capture -- for a non-fatal fault the caller is already
+/// retrying/recovering from on its own (a job tick failure, a stuck-block
+/// tick). Spawned as a detached tokio task so a slow/hung PostHog endpoint
+/// can never add latency to the actual indexing/polling work it's
+/// reporting on. No-ops silently (no task spawned at all) if
+/// POSTHOG_PROJECT_TOKEN is unset, matching every other capture site in
+/// this program's "optional, no-op-when-unconfigured" convention.
+pub fn capture_exception(component: &str, err: &anyhow::Error, tags: &[(&str, String)]) {
+    let Some(token) = posthog_token() else {
+        return;
+    };
+    let body = exception_body(&token, component, err, tags);
+    tokio::spawn(post_capture(body));
+}
+
+/// Awaited capture -- for the fatal path only (a top-level `Err` about to
+/// end the process). Unlike `capture_exception` above, this is NOT spawned
+/// detached: the process exits right after the caller returns, so the
+/// capture must actually complete (or fail trying) before that happens,
+/// not just get queued and then killed mid-flight along with everything
+/// else. Same no-op-when-unconfigured contract.
+pub async fn capture_exception_immediate(component: &str, err: &anyhow::Error) {
+    let Some(token) = posthog_token() else {
+        return;
+    };
+    let body = exception_body(&token, component, err, &[]);
+    post_capture(body).await;
+}
+
+/// Per-key aggregation window, matching the same "escalate periodically,
+/// don't spam" shape used everywhere else a persistently-failing loop
+/// could otherwise call capture_exception once per tick for as long as the
+/// underlying condition lasts (scripts/chain-firehose-relay.ts's
+/// computeDropWindowUpdate, deploy/wss-lb's computeNoUpstreamWindowUpdate,
+/// metagraphed-infra's validator-ops observability.py windowed_capture_
+/// exception -- see any of those for the full reasoning). `key` should
+/// identify one logical failure stream (e.g. a job name) so one
+/// persistently-broken job's spam never suppresses or delays reporting for
+/// a different job's independent issue.
+pub struct CaptureWindow {
+    count: u32,
+    started_at: std::time::Instant,
+}
+
+impl Default for CaptureWindow {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            started_at: std::time::Instant::now(),
+        }
+    }
+}
+
+impl CaptureWindow {
+    /// Registers one more occurrence; captures (and resets the window) once
+    /// `threshold` occurrences or `interval` elapsed, whichever comes
+    /// first. Returns true when it actually captured, purely so callers can
+    /// log/test the decision without needing to inspect internal state.
+    pub fn record(
+        &mut self,
+        component: &str,
+        err: &anyhow::Error,
+        threshold: u32,
+        interval: std::time::Duration,
+    ) -> bool {
+        if self.count == 0 {
+            self.started_at = std::time::Instant::now();
+        }
+        self.count += 1;
+        let elapsed = self.started_at.elapsed();
+        if self.count >= threshold || elapsed >= interval {
+            let occurrences = self.count.to_string();
+            let window_seconds = elapsed.as_secs().to_string();
+            capture_exception(
+                component,
+                err,
+                &[
+                    ("occurrences", occurrences),
+                    ("window_seconds", window_seconds),
+                ],
+            );
+            self.count = 0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exception_body_includes_the_anyhow_context_chain_and_component_fingerprint() {
+        let err = anyhow::anyhow!("root cause")
+            .context("mid layer")
+            .context("top layer");
+        let body = exception_body("phc_test", "subnet-ownership", &err, &[]);
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["api_key"], "phc_test");
+        assert_eq!(parsed["event"], "$exception");
+        assert_eq!(parsed["distinct_id"], POSTHOG_DISTINCT_ID);
+        assert_eq!(
+            parsed["properties"]["$exception_fingerprint"],
+            "subnet-ownership:Error"
+        );
+        assert_eq!(parsed["properties"]["component"], "subnet-ownership");
+        let value = parsed["properties"]["$exception_list"][0]["value"]
+            .as_str()
+            .unwrap();
+        assert!(value.contains("top layer"));
+        assert!(value.contains("mid layer"));
+        assert!(value.contains("root cause"));
+        assert_eq!(
+            parsed["properties"]["$exception_list"][0]["mechanism"]["handled"],
+            true
+        );
+    }
+
+    #[test]
+    fn exception_body_carries_extra_tags_as_flat_properties() {
+        let err = anyhow::anyhow!("boom");
+        let body = exception_body(
+            "phc_test",
+            "poller",
+            &err,
+            &[("job", "metagraph".to_string())],
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["properties"]["job"], "metagraph");
+    }
+
+    #[test]
+    fn capture_window_does_not_fire_before_the_threshold_or_interval() {
+        let mut window = CaptureWindow::default();
+        let err = anyhow::anyhow!("transient");
+        for _ in 0..9 {
+            assert!(!window.record("job", &err, 10, std::time::Duration::from_secs(300)));
+        }
+    }
+
+    #[test]
+    fn capture_window_fires_once_the_threshold_is_crossed_and_resets() {
+        let mut window = CaptureWindow::default();
+        let err = anyhow::anyhow!("transient");
+        let mut fired = false;
+        for _ in 0..10 {
+            fired = window.record("job", &err, 10, std::time::Duration::from_secs(300));
+        }
+        assert!(fired);
+        assert_eq!(window.count, 0);
+    }
+
+    #[test]
+    fn capture_window_fires_on_interval_elapsed_even_below_the_count_threshold() {
+        let mut window = CaptureWindow::default();
+        let err = anyhow::anyhow!("transient");
+        // Establishes the window for real (count 0 -> 1, started_at set) --
+        // backdating started_at before any real occurrence would just get
+        // overwritten by record()'s own "count == 0 means a fresh window"
+        // reset, which is correct: an empty window has no meaningful start
+        // time to backdate in the first place.
+        assert!(!window.record("job", &err, 10, std::time::Duration::from_secs(300)));
+        window.started_at = std::time::Instant::now() - std::time::Duration::from_secs(301);
+        assert!(window.record("job", &err, 10, std::time::Duration::from_secs(300)));
+    }
+}


### PR DESCRIPTION
## Summary

Found while auditing how completely PostHog is actually implemented across the stack (following the Sentry-elimination pass in #8147): `apps/indexer-rs` (the live-follow chain indexer + the consolidated poller, both first-party services running continuously against production chain data) had **zero error tracking of any kind** -- only stdout/stderr logs and one narrow Discord webhook for a single failure mode. This is new capability, not a Sentry migration -- there was never any Sentry here to remove.

- New `src/observability.rs`: hand-rolled PostHog `$exception` capture (no SDK -- no mature official PostHog Rust SDK the way posthog-node/posthog-python are for this program's other native components), same event shape as `src/usage-telemetry.ts`'s `recordExceptionEvent`. Shells out to `curl` via `tokio::process::Command` rather than adding an HTTP client crate, matching this crate's own established convention (`lib.rs`'s `post_sync_json`, `main.rs`'s `alert_stuck_block`). Fire-and-forget `capture_exception` for non-fatal faults already being retried; awaited `capture_exception_immediate` for the fatal path; `CaptureWindow` for the same "escalate periodically, don't spam" aggregation used everywhere else in this program.
- Both binaries' `main()`s split into a thin capture-on-fatal-error wrapper around the unchanged real body (now `run()`). `alert_stuck_block` now also reaches PostHog, not just Discord. The poller's `log_job_outcome` (the one function every job's `run_loop` already calls) gained a per-job-name `CaptureWindow`.
- Unrelated bug fix found along the way: `main.rs` had a literal NUL byte embedded in a doc comment (meant to be the text `\x00`), which silently made every grep-based tool treat the file as binary and skip it.

## Test plan

- [x] `cargo fmt --check` / `cargo build --locked` / `cargo test --locked` (the exact steps `.github/workflows/validate-indexer-rs.yml` runs) all clean
- [x] `cargo clippy --all-targets` clean
- [x] Zero new dependencies added (`Cargo.toml`/`Cargo.lock` untouched)
- [x] 5 new unit tests for `observability.rs` (event shape, tag propagation, windowing threshold/interval/reset)