### PR TITLE
fix(postgres): add observed_at-ordered indexes for account_events hotkey/coldkey scans

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -96,6 +96,24 @@ CREATE INDEX IF NOT EXISTS idx_ae_coldkey  ON account_events (coldkey, block_num
 CREATE INDEX IF NOT EXISTS idx_ae_netuid   ON account_events (netuid, block_number DESC);
 CREATE INDEX IF NOT EXISTS idx_ae_observed ON account_events (observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_ae_extrinsic ON account_events (block_number, extrinsic_index);
+-- GET /api/v1/accounts/:ss58's two-branch hotkey=/coldkey= scans
+-- (workers/data-api.ts, added by the METAGRAPHED-5/#6878 fix) lead
+-- their ORDER BY with observed_at (added later, for hypertable chunk
+-- exclusion elsewhere -- see the /api/v1/extrinsics list route's own
+-- comment) but idx_ae_hotkey/idx_ae_coldkey above are still ordered by
+-- block_number, not observed_at -- confirmed live via EXPLAIN: for a
+-- coldkey with tens of millions of rows (a treasury/burn-style address),
+-- every chunk that could contain it gets a full Sort of its ENTIRE
+-- matching set before ChunkAppend can apply the outer LIMIT, since the
+-- per-chunk scan isn't already in the final sort order -- the exact same
+-- "index doesn't match this ORDER BY" bug METAGRAPHED-5/6 already found
+-- and fixed for the OTHER predicate shapes (event_kind-qualified scans get
+-- idx_ae_kind_hotkey_observed/idx_ae_kind_coldkey_observed below; this is
+-- the plain, no-event_kind-filter case those don't cover). Root-caused
+-- 2026-07-25 chasing a live statement-timeout incident PostHog's new
+-- distributed tracing/error capture surfaced (243 occurrences in ~35min).
+CREATE INDEX IF NOT EXISTS idx_ae_hotkey_observed  ON account_events (hotkey, observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_coldkey_observed ON account_events (coldkey, observed_at DESC);
 -- #2079: covers the /subnets/{netuid}/events ?kind filter (unindexed post-filter today).
 CREATE INDEX IF NOT EXISTS idx_ae_netuid_kind ON account_events (netuid, event_kind, block_number DESC);
 -- #4832 Tier 2: covers the network-wide (no netuid filter) `event_kind = ? AND


### PR DESCRIPTION
## Summary

Root-caused chasing a live statement-timeout incident that PostHog's new distributed tracing/error capture (#7768/#7766, merged in #8147) surfaced — 243 occurrences of `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` degrading to the empty-response fallback in ~35 minutes, correlated with matching `canceling statement due to statement timeout` entries in Postgres's own log for the exact query text below.

`GET /api/v1/accounts/:ss58`'s two-branch `hotkey=`/`coldkey=` scans (the METAGRAPHED-5/#6878 fix) lead their `ORDER BY` with `observed_at` (added later, for hypertable chunk exclusion — see the `/api/v1/extrinsics` list route's own comment), but `idx_ae_hotkey`/`idx_ae_coldkey` are still ordered by `block_number`, not `observed_at`. Confirmed live via `EXPLAIN` against production: for a coldkey with tens of millions of rows (a treasury/burn-style address — one holds 34M of the table's 66.7M total rows), every chunk that could contain it needs a full `Sort` of its entire matching set before `ChunkAppend` can apply the outer `LIMIT`, since the per-chunk index scan isn't already in the final sort order. Same "index doesn't match this `ORDER BY`" bug class METAGRAPHED-5/6 already found and fixed for the `event_kind`-qualified query shapes (`idx_ae_kind_hotkey_observed`/`idx_ae_kind_coldkey_observed` already cover those) — this is the plain, no-`event_kind`-filter case those don't cover.

Additive only: new `idx_ae_hotkey_observed`/`idx_ae_coldkey_observed` indexes, nothing dropped or changed. `idx_ae_hotkey`/`idx_ae_coldkey` stay in place for any other query still ordering by `block_number`.

**Follow-up needed once this merges**: a metagraphed-infra PR bumping `metagraphed_schema_ref` to this commit (this repo's established schema-change process — `deploy/postgres/schema.sql` is pinned by SHA, not floated), plus actually applying the new indexes to the live production table. Flagging separately since TimescaleDB hypertables here reject `CREATE INDEX CONCURRENTLY` (per this same file's own existing comment) — a plain `CREATE INDEX` on a 66.7M-row continuously-written table blocks writes for the build duration, which needs a deliberate, watched window rather than an unattended Ansible apply.

## Test plan

- [x] `EXPLAIN` against live production confirmed the root cause (per-chunk `Sort` nodes over 500K-1M+ rows each) before writing the fix
- [x] `tests/chain-firehose-outbox-schema.test.ts` (the one existing test that reads `schema.sql`) still passes
- [ ] Live application + `EXPLAIN ANALYZE` re-verification against production, once the follow-up infra PR lands