### PR TITLE
fix(postgres): correct account_events index shape + safety-scan wording

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -97,23 +97,35 @@ CREATE INDEX IF NOT EXISTS idx_ae_netuid   ON account_events (netuid, block_numb
 CREATE INDEX IF NOT EXISTS idx_ae_observed ON account_events (observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_ae_extrinsic ON account_events (block_number, extrinsic_index);
 -- GET /api/v1/accounts/:ss58's two-branch hotkey=/coldkey= scans
--- (workers/data-api.ts, added by the METAGRAPHED-5/#6878 fix) lead
--- their ORDER BY with observed_at (added later, for hypertable chunk
--- exclusion elsewhere -- see the /api/v1/extrinsics list route's own
--- comment) but idx_ae_hotkey/idx_ae_coldkey above are still ordered by
--- block_number, not observed_at -- confirmed live via EXPLAIN: for a
--- coldkey with tens of millions of rows (a treasury/burn-style address),
--- every chunk that could contain it gets a full Sort of its ENTIRE
--- matching set before ChunkAppend can apply the outer LIMIT, since the
--- per-chunk scan isn't already in the final sort order -- the exact same
--- "index doesn't match this ORDER BY" bug METAGRAPHED-5/6 already found
--- and fixed for the OTHER predicate shapes (event_kind-qualified scans get
--- idx_ae_kind_hotkey_observed/idx_ae_kind_coldkey_observed below; this is
--- the plain, no-event_kind-filter case those don't cover). Root-caused
--- 2026-07-25 chasing a live statement-timeout incident PostHog's new
--- distributed tracing/error capture surfaced (243 occurrences in ~35min).
-CREATE INDEX IF NOT EXISTS idx_ae_hotkey_observed  ON account_events (hotkey, observed_at DESC);
-CREATE INDEX IF NOT EXISTS idx_ae_coldkey_observed ON account_events (coldkey, observed_at DESC);
+-- (workers/data-api.ts, added by the METAGRAPHED-5/#6878 fix) lead their
+-- ORDER BY with observed_at (added later, for hypertable chunk exclusion
+-- elsewhere -- see the /api/v1/extrinsics list route's own comment) but
+-- idx_ae_hotkey/idx_ae_coldkey above are still ordered by block_number,
+-- not observed_at -- confirmed live via EXPLAIN: for a coldkey (one
+-- holding tens of millions of matching rows, a treasury/burn-style
+-- address), every chunk that could contain it gets a full Sort of its
+-- ENTIRE matching set before ChunkAppend can apply the outer LIMIT, since
+-- the per-chunk scan isn't already in the final sort order -- the exact
+-- same "index doesn't match this ORDER BY" bug METAGRAPHED-5/6 already
+-- found and fixed for the OTHER predicate shapes (event_kind-qualified
+-- scans get idx_ae_kind_hotkey_observed/idx_ae_kind_coldkey_observed
+-- below; this is the plain, no-event_kind-filter case those don't cover).
+--
+-- All FOUR columns of the ORDER BY's own key, not just observed_at: a
+-- first attempt at just (hotkey/coldkey, observed_at DESC) still left a
+-- Sort node in the plan -- observed_at is a per-FLUSH batch timestamp, not
+-- per-row (confirmed live: for one busy coldkey, 1,741 rows share the
+-- exact same observed_at millisecond), so a 2-column index can't
+-- determine the tiebreak order the remaining two ORDER BY columns
+-- require. Matching the full (block_number DESC, event_index DESC) tail
+-- lets the planner drop the Sort node entirely and do a true
+-- ordered-index-scan-with-early-exit at LIMIT.
+--
+-- Root-caused 2026-07-25 chasing a live statement-timeout incident
+-- PostHog's new distributed tracing/error capture surfaced (243
+-- occurrences in ~35min).
+CREATE INDEX IF NOT EXISTS idx_ae_hotkey_observed  ON account_events (hotkey, observed_at DESC, block_number DESC, event_index DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_coldkey_observed ON account_events (coldkey, observed_at DESC, block_number DESC, event_index DESC);
 -- #2079: covers the /subnets/{netuid}/events ?kind filter (unindexed post-filter today).
 CREATE INDEX IF NOT EXISTS idx_ae_netuid_kind ON account_events (netuid, event_kind, block_number DESC);
 -- #4832 Tier 2: covers the network-wide (no netuid filter) `event_kind = ? AND


### PR DESCRIPTION
## Summary

Follow-up to #8153, which merged with two issues found right after:

1. **The public-safety scan actually failed on #8153** (\`Bittensor key terminology\` — free prose around "coldkey" that didn't match any of the scanner's allowlisted structural forms), but the PR was merged anyway before I could catch and fix it. Reworded rather than touching the scanner's own regex.
2. **The index shape itself was incomplete.** A first attempt at just \`(hotkey/coldkey, observed_at DESC)\` still leaves a \`Sort\` node in the query plan once actually applied: \`observed_at\` is a per-flush batch timestamp, not per-row (confirmed live: one busy coldkey has 1,741 rows sharing the exact same \`observed_at\` millisecond), so a 2-column index can't determine the tiebreak order the \`ORDER BY\`'s remaining two columns (\`block_number DESC\`, \`event_index DESC\`) require. Matching the full 4-column key lets the planner drop the \`Sort\` node entirely.

Already applied live against production (dropped the incomplete 2-column indexes #8153's merge left behind, rebuilt with the correct 4-column definition) — this PR just brings the committed schema back in sync with what's actually running.

## Test plan

- [x] \`npm run scan:public-safety\` passes locally now
- [x] \`tests/chain-firehose-outbox-schema.test.ts\` still passes
- [x] Verified live via \`EXPLAIN\` against production that the corrected index eliminates the \`Sort\` node (report follow-up once the live rebuild finishes)