### PR TITLE
fix(data-api): widen accounts-summary route's statement_timeout to 10s

### DIFF
--- a/tests/data-api.test.ts
+++ b/tests/data-api.test.ts
@@ -1341,6 +1341,7 @@ test("GET /api/v1/extrinsics/:ref skips the embedded-events query on an unresolv
 test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from two merged, re-capped bounded scans", async () => {
   mockQueue.current = [
     [], // SET
+    [], // SET LOCAL statement_timeout
     [ACCOUNT_EVENT_ROW], // hotkeyScanRows
     [{ ...ACCOUNT_EVENT_ROW, netuid: 5 }], // coldkeyScanRows
     [{ netuid: 4, uid: 1, stake_tao: "10", validator_permit: 1, active: 1 }], // regRows
@@ -1375,6 +1376,7 @@ test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from two merged
 test("GET /api/v1/accounts/:ss58 ignores null netuid events in subnet_count", async () => {
   mockQueue.current = [
     [], // SET
+    [], // SET LOCAL statement_timeout
     [ACCOUNT_EVENT_ROW], // hotkeyScanRows
     [{ ...ACCOUNT_EVENT_ROW, netuid: null }], // coldkeyScanRows
     [], // regRows
@@ -1423,6 +1425,7 @@ test("GET /api/v1/accounts/:ss58 merges, re-sorts, and re-caps events from BOTH 
   };
   mockQueue.current = [
     [], // SET
+    [], // SET LOCAL statement_timeout
     [hotkeyRow], // hotkeyScanRows
     [coldkeyRowNewer, coldkeyRowOlder], // coldkeyScanRows
     [], // regRows
@@ -1468,6 +1471,7 @@ test("GET /api/v1/accounts/:ss58 breaks a same-block tie between branches by eve
   };
   mockQueue.current = [
     [], // SET
+    [], // SET LOCAL statement_timeout
     [hotkeyRow], // hotkeyScanRows
     [coldkeyRow], // coldkeyScanRows
     [], // regRows

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -5377,6 +5377,21 @@ async function dispatchDataApiRequest(
           // already re-derives the true block_number/event_index order
           // afterward, so which order SQL fetches the top CAP+1 rows in
           // doesn't change the final output (METAGRAPHED-6-class fix).
+          //
+          // Confirmed live 2026-07-25: even with that fix (no Sort node,
+          // idx_ae_hotkey_observed/idx_ae_coldkey_observed both used), this
+          // route still tripped the shared 3000ms default under real
+          // concurrent load -- two sequential 87-chunk scans per request,
+          // contending with this box's other concurrent readers/writers for
+          // buffer/CPU access, occasionally pushed total time past the
+          // blanket budget (pg_stat_activity + docker logs both showed
+          // `canceling statement due to statement timeout` still firing on
+          // this route's exact query text). The sibling
+          // /api/v1/accounts/:ss58/events route hit this same class of
+          // problem first and already widens its own budget below (10000ms)
+          // rather than raising the global default for every other, much
+          // lighter route in this dispatcher -- same fix, ported here.
+          await sql`SET LOCAL statement_timeout = '10000ms'`;
           const hotkeyScanRows = await sql<AccountEventReadRow[]>`
           SELECT block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index
           FROM account_events WHERE hotkey = ${ss58}


### PR DESCRIPTION
## Summary
- Confirmed live in production (pg_stat_activity + Postgres container logs) that `GET /api/v1/accounts/:ss58` was still tripping `canceling statement due to statement timeout` after #8154's index fix — the query plan is correct now (no Sort, both new indexes used), but the route's two sequential hotkey/coldkey scans across account_events' 87 chunks still occasionally exceed the dispatcher's shared 3000ms default under real concurrent load.
- The sibling `/api/v1/accounts/:ss58/events` route hit this exact class of problem first and already carries its own `SET LOCAL statement_timeout = '10000ms'` override rather than raising the global default for every other, lighter route. Ports that same override to the summary route.

## Test plan
- [x] `npx vitest run tests/data-api.test.ts` — 543/543 pass (4 tests updated for the new SET LOCAL call in the mock queue)
- [x] `npx tsc --noEmit` — clean (pre-existing unrelated codegen errors only)
- [x] `npx tsx scripts/scan-public-safety.ts` — passed
- [x] `npx prettier --check` — clean