### PR TITLE
feat(graphql): add block_start/block_end/from/to filters to the sudo field

### DIFF
--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -776,6 +776,10 @@ export const SDL = /* GraphQL */ `
       block: Int
       call_function: String
       success: Boolean
+      block_start: Int
+      block_end: Int
+      from: Int
+      to: Int
     ): ExtrinsicList!
   }
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3768,16 +3768,39 @@ const rootValue = {
   },
 
   async sudo(
-    { limit, offset, cursor, block, call_function: callFunction, success }: Row,
+    {
+      limit,
+      offset,
+      cursor,
+      block,
+      call_function: callFunction,
+      success,
+      block_start: blockStart,
+      block_end: blockEnd,
+      from,
+      to,
+    }: Row,
     context: GqlContext,
   ) {
     // The Sudo governance feed is the /extrinsics feed with call_module fixed
     // to Sudo by the route itself, so it takes no signer/call_module args and
     // reuses the identical extrinsics source + ExtrinsicList shape.
-    if (block != null && (!Number.isInteger(block) || block < 0)) {
-      throw new GraphQLError("block must be a non-negative integer.", {
-        extensions: { code: "BAD_USER_INPUT" },
-      });
+    // #7874: every numeric bound shares one guard, so an invalid one is a
+    // BAD_USER_INPUT error rather than a silently dropped filter -- the same
+    // block_start/block_end (block_number) and from/to (observed_at epoch)
+    // params GET /api/v1/sudo and MCP get_sudo validate as non-negative ints.
+    for (const [name, value] of [
+      ["block", block],
+      ["block_start", blockStart],
+      ["block_end", blockEnd],
+      ["from", from],
+      ["to", to],
+    ] as const) {
+      if (value != null && (!Number.isInteger(value) || value < 0)) {
+        throw new GraphQLError(`${name} must be a non-negative integer.`, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
     }
     const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
     const safeOffset = clampOffset(offset);
@@ -3788,6 +3811,10 @@ const rootValue = {
     if (block != null) params.set("block", String(block));
     if (callFunction) params.set("call_function", callFunction);
     if (success != null) params.set("success", String(success));
+    if (blockStart != null) params.set("block_start", String(blockStart));
+    if (blockEnd != null) params.set("block_end", String(blockEnd));
+    if (from != null) params.set("from", String(from));
+    if (to != null) params.set("to", String(to));
     const data =
       ((await tryPostgresTier(
         context.env,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -21161,3 +21161,87 @@ describe("graphql — subnet_hyperparameters_history cursor (#7882)", () => {
     assert.equal(new URL(seen.url!).searchParams.has("cursor"), false);
   });
 });
+
+// #7874: the sudo field gained block_start/block_end/from/to, the same range
+// filters GET /api/v1/sudo and MCP get_sudo accept, forwarded verbatim to the
+// Postgres tier (the /sudo route is the extrinsics feed with call_module fixed
+// to Sudo).
+describe("graphql — sudo range filters (#7874)", () => {
+  function capturingEnv(seen: { url?: URL }) {
+    return {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req: Request) => {
+          seen.url = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 20,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+  }
+
+  test("forwards a block_start/block_end range to /api/v1/sudo", async () => {
+    const seen: { url?: URL } = {};
+    const { status } = await gql(
+      `{ sudo(block_start: 100, block_end: 200) { total } }`,
+      capturingEnv(seen) as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(seen.url!.pathname, "/api/v1/sudo");
+    assert.equal(seen.url!.searchParams.get("block_start"), "100");
+    assert.equal(seen.url!.searchParams.get("block_end"), "200");
+  });
+
+  test("forwards a from/to observed_at range", async () => {
+    const seen: { url?: URL } = {};
+    await gql(
+      `{ sudo(from: 1700000000, to: 1700003600) { total } }`,
+      capturingEnv(seen) as unknown as Env,
+    );
+    assert.equal(seen.url!.searchParams.get("from"), "1700000000");
+    assert.equal(seen.url!.searchParams.get("to"), "1700003600");
+  });
+
+  test("omits every new param when none is supplied", async () => {
+    const seen: { url?: URL } = {};
+    await gql(`{ sudo { total } }`, capturingEnv(seen) as unknown as Env);
+    for (const key of ["block_start", "block_end", "from", "to"]) {
+      assert.equal(seen.url!.searchParams.has(key), false);
+    }
+  });
+
+  test("rejects a negative range bound as BAD_USER_INPUT, not a dropped filter", async () => {
+    for (const [arg, name] of [
+      ["block_start: -1", "block_start"],
+      ["block_end: -5", "block_end"],
+      ["from: -1", "from"],
+      ["to: -2", "to"],
+    ] as const) {
+      const seen: { url?: URL } = {};
+      const { body } = await gql(
+        `{ sudo(${arg}) { total } }`,
+        capturingEnv(seen) as unknown as Env,
+      );
+      assert.ok(
+        body.errors?.find((e: Row) => e.extensions?.code === "BAD_USER_INPUT"),
+        `${name} should be rejected`,
+      );
+      assert.match(body.errors[0].message, new RegExp(name));
+    }
+  });
+
+  test("still rejects a non-integer bound", async () => {
+    const seen: { url?: URL } = {};
+    const { body } = await gql(
+      `{ sudo(block_end: 1.5) { total } }`,
+      capturingEnv(seen) as unknown as Env,
+    );
+    assert.ok(body.errors?.length);
+  });
+});


### PR DESCRIPTION
Adds block_start/block_end (block-number bounds) and from/to (observed_at epoch bounds) to the GraphQL sudo field, matching GET /api/v1/sudo + MCP get_sudo (the /sudo route is the extrinsics feed with call_module fixed to Sudo). Every numeric bound shares one BAD_USER_INPUT guard; none forwarded when absent (existing queries byte-identical); from/to are Int (epoch vs observed_at), not the issue's String. 5 new tests; backend-only. Closes #7874