### PR TITLE
fix(data): consolidate percentile/median into a shared stats module

### DIFF
--- a/src/blocks-summary.ts
+++ b/src/blocks-summary.ts
@@ -11,6 +11,7 @@
 // blocks, a base-layer validator-set decentralization signal, not a tx-fee signal.
 
 import { computeConcentration } from "./concentration.ts";
+import { percentile } from "./lib/stats.ts";
 
 // The `blocks` columns the summary reads. `author` is best-effort/nullable; the
 // counts are nullable INTEGERs; `observed_at` is the block timestamp (epoch ms).
@@ -63,13 +64,6 @@ function toCount(value: unknown): number {
   return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : 0;
 }
 
-// Nearest-rank percentile over a non-empty ascending array (rank = ceil(p/100 · n),
-// 1-based). Only called after the caller establishes the array is non-empty.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.max(1, Math.ceil((p / 100) * ascending.length));
-  return ascending[rank - 1];
-}
-
 interface BlockTimeDistribution {
   count: number;
   mean_ms: number;
@@ -95,7 +89,7 @@ function blockTimeDistribution(
     max_ms: roundMs(ascending[count - 1]),
   };
   for (const p of BLOCK_TIME_PERCENTILES) {
-    summary[`p${p}_ms`] = roundMs(percentile(ascending, p));
+    summary[`p${p}_ms`] = roundMs(percentile(ascending, p)!);
   }
   return summary;
 }

--- a/src/chain-alpha-volume.ts
+++ b/src/chain-alpha-volume.ts
@@ -22,6 +22,7 @@ import {
   type AlphaVolumeResult,
   type AlphaVolumeSentiment,
 } from "./alpha-volume.ts";
+import { median, percentile } from "./lib/stats.ts";
 
 export const CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT = 20;
 export const CHAIN_ALPHA_VOLUME_LIMIT_MAX = 100;
@@ -61,23 +62,6 @@ function toIso(value: unknown): string | null {
   return n == null ? null : new Date(n).toISOString();
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array. Mirrors
-// chain-stake-flow.ts's percentile, applied here to total_volume_tao instead of net flow.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd
-// count, the mean of the two middle values for an even count. Mirrors chain-stake-flow.ts's
-// median (itself matching subnet-yield.ts / chain-yield.ts), applied to total_volume_tao.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return roundUnit(
-    (ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2,
-  );
-}
-
 export interface VolumeDistribution {
   count: number;
   mean: number;
@@ -101,10 +85,10 @@ function volumeDistribution(values: number[]): VolumeDistribution | null {
     count: ascending.length,
     mean: roundUnit(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: roundUnit(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-axon-removals.ts
+++ b/src/chain-axon-removals.ts
@@ -9,6 +9,8 @@
 // same account_events [netuid, hotkey] tuple AxonServed uses — the network-wide companion to the
 // per-subnet /api/v1/subnets/{netuid}/axon-removals.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron's announced axon endpoint is removed on a subnet.
 export const AXON_REMOVAL_EVENT_KIND = "AxonInfoRemoved";
 
@@ -72,25 +74,6 @@ function removalsPerRemover(removals: number, removers: number): number | null {
   return round(removals / removers);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -114,10 +97,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-deregistrations.ts
+++ b/src/chain-deregistrations.ts
@@ -9,6 +9,8 @@
 // tryPostgresTier() ?? buildChainDeregistrations([]). The field semantics live in
 // schemas/components/05-subnets.schema.json (ChainDeregistrationsArtifact).
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron is deregistered (evicted) from a subnet.
 export const DEREGISTRATION_EVENT_KIND = "NeuronDeregistered";
 
@@ -76,25 +78,6 @@ function deregistrationsPerHotkey(
   return round(deregistrations / hotkeys);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -118,10 +101,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-performance.ts
+++ b/src/chain-performance.ts
@@ -9,6 +9,7 @@
 // envelope. Null-safe: an empty snapshot yields a schema-stable `null` block.
 
 import { computeConcentration } from "./concentration.ts";
+import { percentile } from "./lib/stats.ts";
 
 // The neurons-tier columns the network performance handler reads — like the
 // per-subnet read but with `netuid`, so the artifact can report how many subnets
@@ -73,14 +74,6 @@ function finiteValues(values: unknown[]): number[] {
   return out;
 }
 
-// Nearest-rank percentile over a non-empty ascending array (rank = ceil(p/100 · n),
-// 1-based), matching the subnet-yield / health-percentile convention. Only called
-// after scoreDistribution has established count > 0, so the array is never empty.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.max(1, Math.ceil((p / 100) * ascending.length));
-  return ascending[rank - 1];
-}
-
 export interface ScoreDistribution {
   count: number;
   mean: number;
@@ -105,7 +98,7 @@ export function scoreDistribution(values: unknown[]): ScoreDistribution | null {
     max: round(ascending[count - 1]),
   };
   for (const p of SCORE_PERCENTILES) {
-    summary[`p${p}`] = round(percentile(ascending, p));
+    summary[`p${p}`] = round(percentile(ascending, p)!);
   }
   return summary;
 }

--- a/src/chain-prometheus.ts
+++ b/src/chain-prometheus.ts
@@ -7,6 +7,8 @@
 // the metrics endpoint a neuron exposes (which subnets run observability infrastructure), read from
 // the same account_events [netuid, hotkey] tuple AxonServed uses.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron announces its Prometheus telemetry endpoint on a subnet.
 export const PROMETHEUS_EVENT_KIND = "PrometheusServed";
 
@@ -73,25 +75,6 @@ function announcementsPerExporter(
   return round(announcements / exporters);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -115,10 +98,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-registrations.ts
+++ b/src/chain-registrations.ts
@@ -7,6 +7,8 @@
 // -- see #6013). Callers now go tryPostgresTier() ?? buildChainRegistrations([]). The field
 // semantics live in schemas/components/05-subnets.schema.json (ChainRegistrationsArtifact).
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron registers (or re-registers) on a subnet.
 export const REGISTRATION_EVENT_KIND = "NeuronRegistered";
 
@@ -72,25 +74,6 @@ function registrationsPerRegistrant(
   return round(registrations / registrants);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -114,10 +97,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-serving.ts
+++ b/src/chain-serving.ts
@@ -4,6 +4,8 @@
 // in #4772, so it always missed -- see #6013). Callers now go tryPostgresTier() ?? buildChainServing([]).
 // The field semantics live in schemas/components/05-subnets.schema.json (ChainServingArtifact).
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron announces its axon endpoint on a subnet.
 export const SERVING_EVENT_KIND = "AxonServed";
 
@@ -70,25 +72,6 @@ function announcementsPerHotkey(
   return round(announcements / hotkeys);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -112,10 +95,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-stake-flow.ts
+++ b/src/chain-stake-flow.ts
@@ -7,6 +7,8 @@
 // REST envelope. Null-safe: a cold store or an empty window yields schema-stable zeros
 // (never throws), matching the sibling live tiers.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The two account_events kinds that move stake: StakeAdded is capital entering a subnet,
 // StakeRemoved is capital leaving. Both carry a positive amount_tao, so net = staked - unstaked.
 export const STAKE_ADDED_KIND = "StakeAdded";
@@ -84,23 +86,6 @@ function classifyDirection(
   return net > 0 ? "inflow" : "outflow";
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (net flow can be negative).
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array (net flow can be negative): the middle
-// value for an odd count, the mean of the two middle values for an even count (so an even count
-// returns the average of the two middles, not the lower-middle a nearest-rank p50 gives). The
-// averaging form needs no odd/even branch — for an odd count the two indices coincide and it returns
-// that middle value unchanged. Matches median() in chain-yield.ts / subnet-yield.ts so a `median`
-// field is the same statistic across the API. Reached only after netFlowDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return roundTao((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface NetFlowDistribution {
   count: number;
   mean: number;
@@ -123,10 +108,10 @@ function netFlowDistribution(values: number[]): NetFlowDistribution | null {
     count: ascending.length,
     mean: roundTao(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: roundTao(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-stake-moves.ts
+++ b/src/chain-stake-moves.ts
@@ -12,6 +12,8 @@
 // the table is dropped in production (#4772 / #4909), so serving goes tryPostgresTier →
 // schema-stable empty stub, never D1.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a coldkey moves stake between hotkeys/subnets (move_stake).
 export const STAKE_MOVED_EVENT_KIND = "StakeMoved";
 
@@ -75,25 +77,6 @@ function movementsPerMover(movements: number, movers: number): number | null {
   return round(movements / movers);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -117,10 +100,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-stake-transfers.ts
+++ b/src/chain-stake-transfers.ts
@@ -14,6 +14,8 @@
 // and the table is dropped in production (#4772 / #4909), so serving goes tryPostgresTier →
 // schema-stable empty stub, never D1.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a coldkey transfers stake to another coldkey (transfer_stake).
 export const STAKE_TRANSFERRED_EVENT_KIND = "StakeTransferred";
 
@@ -77,26 +79,6 @@ function transfersPerSender(transfers: number, senders: number): number | null {
   return round(transfers / senders);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts and the chain-activity distribution family
-// (#3200) so a `median` field is the same statistic across the API. Reached only after the empty
-// short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -120,10 +102,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-turnover.ts
+++ b/src/chain-turnover.ts
@@ -6,6 +6,8 @@
 // for unit tests; the Worker does the D1 reads + envelope. Scoped to validator_permit rows
 // so the two-snapshot read stays bounded (validators, not every neuron across the network).
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The neuron_daily columns the handler reads — its D1 read contract. `hotkey` is public
 // metagraph vocabulary, not a secret; kept next to its consumer so the handler stays a thin SELECT.
 export const CHAIN_TURNOVER_READ_COLUMNS =
@@ -51,25 +53,6 @@ function stabilityScore(retention: number): number {
   return score;
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation) — mirrors src/subnet-yield.ts. Only called from stabilityDistribution,
-// which short-circuits an empty score set to null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so [33, 100] -> 66.5, not the lower-middle 33
-// a nearest-rank p50 gives). The averaging form needs no odd/even branch — for an odd count the two
-// indices coincide and it returns that middle value unchanged. Matches median() in chain-yield.ts /
-// subnet-yield.ts so a `median` field is the same statistic across the API. Reached only after
-// stabilityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface StabilityDistribution {
   count: number;
   mean: number;
@@ -93,10 +76,10 @@ function stabilityDistribution(scores: number[]): StabilityDistribution | null {
     count: ascending.length,
     mean: Math.round((sum / ascending.length) * 100) / 100,
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-weights.ts
+++ b/src/chain-weights.ts
@@ -3,6 +3,8 @@
 // kind-filtered sibling of chain-transfers / chain-stake-flow. Pure shaping + a thin D1 loader; the
 // Worker adds the envelope. See the schema/contracts for the full response contract.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a validator sets weights on a subnet.
 export const WEIGHTS_EVENT_KIND = "WeightsSet";
 
@@ -65,25 +67,6 @@ function setsPerSetter(sets: number, setters: number): number | null {
   return round(sets / setters);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -108,10 +91,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-yield.ts
+++ b/src/chain-yield.ts
@@ -8,6 +8,8 @@
 // function is pure + exported for unit tests; the Worker does the D1 read +
 // envelope. Null-safe: an empty snapshot yields a schema-stable zeroed card.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The neurons-tier columns the network yield handler reads. `netuid` lets the
 // artifact report how many subnets the snapshot spans (mirrors
 // CHAIN_PERFORMANCE_READ_COLUMNS); no per-UID list is served, so only the economic
@@ -100,24 +102,6 @@ function computeYieldValue(
   return round9(emission / stake);
 }
 
-// Nearest-rank percentile over a non-empty ascending array (rank = ceil(p/100 · n),
-// 1-based), matching the subnet-yield / chain-performance convention. Only called
-// after yieldDistribution has established count > 0, so it is never empty.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.max(1, Math.ceil((p / 100) * ascending.length));
-  return ascending[rank - 1];
-}
-
-// Conventional median of an ascending array: the middle value for an odd count,
-// the average of the two middle values for an even count (so [0.2, 0.4] -> 0.3,
-// not the lower-middle a nearest-rank p50 would give). Only called after count > 0.
-function median(ascending: number[]): number {
-  const mid = Math.floor(ascending.length / 2);
-  return ascending.length % 2 === 1
-    ? ascending[mid]
-    : round9((ascending[mid - 1] + ascending[mid]) / 2);
-}
-
 export interface YieldDistribution {
   count: number;
   mean: number;
@@ -142,12 +126,12 @@ export function yieldDistribution(
   const summary: YieldDistribution = {
     count,
     mean: round9(total / count),
-    median: median(defined),
+    median: round9(median(defined)!),
     min: round9(defined[0]),
     max: round9(defined[count - 1]),
   };
   for (const p of YIELD_PERCENTILES) {
-    summary[`p${p}`] = round9(percentile(defined, p));
+    summary[`p${p}`] = round9(percentile(defined, p)!);
   }
   return summary;
 }

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,25 @@
+// Nearest-rank percentile of an ascending numeric array (deterministic, no
+// interpolation ambiguity): rank = ceil(p/100 * n), 0-indexed and clamped to
+// [0, n-1], so p<=0 returns the minimum and p>=100 returns the maximum. Null on
+// an empty array. The single canonical implementation for every distribution's
+// percentile field across the chain-*/subnet-*/blocks-summary analytics family.
+export function percentile(ascending: number[], p: number): number | null {
+  if (ascending.length === 0) return null;
+  const rank = Math.ceil((p / 100) * ascending.length) - 1;
+  const index = Math.min(ascending.length - 1, Math.max(0, rank));
+  return ascending[index];
+}
+
+// Conventional median of an ascending array: the middle value for an odd count,
+// the average of the two middle values for an even count (so [0.2, 0.4] -> 0.3,
+// not the lower-middle a nearest-rank p50 would give). Null on an empty array.
+// Returns the raw, unrounded value -- callers apply their own precision (round9,
+// roundTao, roundUnit, roundMs, ...) to the result, same as before extraction.
+export function median(ascending: number[]): number | null {
+  const n = ascending.length;
+  if (n === 0) return null;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 1
+    ? ascending[mid]
+    : (ascending[mid - 1] + ascending[mid]) / 2;
+}

--- a/src/subnet-performance.ts
+++ b/src/subnet-performance.ts
@@ -9,6 +9,7 @@
 // `null` block (never throws), matching the concentration tier it mirrors.
 
 import { computeConcentration } from "./concentration.ts";
+import { percentile } from "./lib/stats.ts";
 
 type Row = Record<string, unknown>;
 type D1Runner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -74,14 +75,6 @@ function finiteValues(values: unknown[]): number[] {
   return out;
 }
 
-// Nearest-rank percentile over a non-empty ascending array (rank = ceil(p/100 · n),
-// 1-based), matching the subnet-yield / health-percentile convention. Only called
-// after scoreDistribution has established count > 0, so the array is never empty.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.max(1, Math.ceil((p / 100) * ascending.length));
-  return ascending[rank - 1];
-}
-
 // Conventional median of a 0..1 score column: the middle value for an odd count,
 // the average of the two middle values for an even count — NOT the nearest-rank
 // p50, which returns the lower-middle for an even count (e.g. [0.2, 0.8] -> 0.2).
@@ -125,7 +118,7 @@ export function scoreDistribution(
     max: round(ascending[count - 1]),
   };
   for (const p of SCORE_PERCENTILES) {
-    summary[`p${p}`] = round(percentile(ascending, p));
+    summary[`p${p}`] = round(percentile(ascending, p)!);
   }
   return summary;
 }

--- a/src/subnet-yield.ts
+++ b/src/subnet-yield.ts
@@ -7,6 +7,8 @@
 // the most emission per unit of stake, and how is that return distributed across the set".
 // Null-safe: a cold/empty subnet yields a zeroed, empty-neuron card (never throws).
 
+import { median, percentile } from "./lib/stats.ts";
+
 type Row = Record<string, unknown>;
 type D1Runner = (sql: string, params: unknown[]) => Promise<Row[]>;
 
@@ -16,6 +18,13 @@ const SCALE = 1e9;
 function round9(value: unknown): number {
   const n = toNumber(value);
   return Math.round(n * SCALE) / SCALE;
+}
+
+// The shared median() returns its raw, unrounded value -- round it to rao precision
+// here, preserving null (an empty yield set) rather than coercing it to 0.
+function roundedMedian(ascending: number[]): number | null {
+  const m = median(ascending);
+  return m == null ? null : round9(m);
 }
 
 // Coerce a D1 numeric cell (number, numeric string, or null) to a finite number.
@@ -84,27 +93,6 @@ function computeYieldValue(
   if (!(stake != null && stake > 0)) return null;
   if (emission == null) return null;
   return round9(emission / stake);
-}
-
-// Nearest-rank percentile of an ascending numeric array (deterministic, no interpolation
-// ambiguity), used for the p25/p75/p90 spread. Null on an empty set.
-function percentile(ascending: number[], p: number): number | null {
-  if (ascending.length === 0) return null;
-  const rank = Math.ceil((p / 100) * ascending.length) - 1;
-  const index = Math.min(ascending.length - 1, Math.max(0, rank));
-  return ascending[index];
-}
-
-// Conventional median of an ascending array: the middle value for an odd count, the
-// average of the two middle values for an even count (so [0.2, 0.4] -> 0.3, not the
-// lower-middle a nearest-rank p50 would give). Null on an empty set.
-function median(ascending: number[]): number | null {
-  const n = ascending.length;
-  if (n === 0) return null;
-  const mid = Math.floor(n / 2);
-  return n % 2 === 1
-    ? ascending[mid]
-    : round9((ascending[mid - 1] + ascending[mid]) / 2);
 }
 
 interface YieldNeuron {
@@ -187,7 +175,7 @@ export function buildSubnetYield(
     .map((n) => n.yield)
     .filter((y): y is number => y != null)
     .sort((a, b) => a - b);
-  const medianYield = median(definedYields);
+  const medianYield = roundedMedian(definedYields);
   const meanYield =
     definedYields.length > 0
       ? round9(
@@ -331,7 +319,7 @@ function yieldHistoryPoint(date: string, dayRows: Row[]): Row {
     yield_count: definedYields.length,
     subnet_yield: yieldStake > 0 ? round9(yieldEmission / yieldStake) : null,
     mean_yield: meanYield,
-    median_yield: median(definedYields),
+    median_yield: roundedMedian(definedYields),
     p25_yield: percentile(definedYields, 25),
     p75_yield: percentile(definedYields, 75),
     p90_yield: percentile(definedYields, 90),

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { median, percentile } from "../src/lib/stats.ts";
+
+describe("percentile", () => {
+  test("empty array returns null", () => {
+    assert.equal(percentile([], 50), null);
+  });
+
+  test("p=0 returns the minimum, not undefined", () => {
+    assert.equal(percentile([10, 20, 30, 40], 0), 10);
+  });
+
+  test("p=100 returns the maximum", () => {
+    assert.equal(percentile([10, 20, 30, 40], 100), 40);
+  });
+
+  test("single-element array returns that element for any p", () => {
+    assert.equal(percentile([42], 0), 42);
+    assert.equal(percentile([42], 50), 42);
+    assert.equal(percentile([42], 100), 42);
+  });
+
+  test("nearest-rank percentiles match the values exercised by callers today", () => {
+    const ascending = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    assert.equal(percentile(ascending, 10), 10);
+    assert.equal(percentile(ascending, 25), 30);
+    assert.equal(percentile(ascending, 50), 50);
+    assert.equal(percentile(ascending, 75), 80);
+    assert.equal(percentile(ascending, 90), 90);
+    assert.equal(percentile(ascending, 95), 100);
+    assert.equal(percentile(ascending, 99), 100);
+  });
+});
+
+describe("median", () => {
+  test("empty array returns null", () => {
+    assert.equal(median([]), null);
+  });
+
+  test("single-element array returns that element", () => {
+    assert.equal(median([7]), 7);
+  });
+
+  test("odd count returns the middle value", () => {
+    assert.equal(median([1, 2, 3, 4, 5]), 3);
+  });
+
+  test("even count returns the unrounded average of the two middle values", () => {
+    assert.equal(median([0.2, 0.4]), 0.30000000000000004);
+    assert.equal(median([10, 20, 30, 100]), 25);
+  });
+});


### PR DESCRIPTION
fix(data): consolidate percentile/median into a shared stats module

percentile()/median() were copy-pasted into 16 files and had already
drifted into three behaviorally divergent variants -- 11 files return
undefined for percentile(arr, 0) or an empty array instead of a real
boundary value. Extract one canonical, empty-safe implementation into
src/lib/stats.ts (based on subnet-yield.ts's guarded variant) and point
every file at it. median() stays rounding-free so each call site keeps
applying its own precision (round9/roundTao/roundUnit/roundMs/round),
matching prior behavior exactly for every currently exercised p value.

Closes #8178

