### PR TITLE
fix(security): flag Telegram bot tokens and Discord webhook URLs in the public-safety scan

### DIFF
--- a/scripts/scan-public-safety.ts
+++ b/scripts/scan-public-safety.ts
@@ -129,6 +129,22 @@ const patterns: SafetyPattern[] = [
   // unambiguous format that a leaked Maps/Cloud key takes; none of the URL/token
   // rules above catch a bare key value.
   { name: "google api key", regex: /AIza[0-9A-Za-z_-]{35}/ },
+  // Telegram bot token: an 8-10 digit bot id, a colon, then a 35-char secret
+  // (e.g. 123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw). This repo actively
+  // builds api.telegram.org/bot${token}/sendMessage requests (src/alert-
+  // delivery.ts), so a leaked token is a real credential; the colon-joined
+  // id:secret shape is unambiguous and no URL/token rule above catches a bare
+  // literal of it.
+  { name: "telegram bot token", regex: /\b\d{8,10}:[A-Za-z0-9_-]{35}\b/ },
+  // Discord webhook URL: a Discord webhook URL is itself a bearer credential —
+  // anyone holding it can post to that channel. This repo builds them in
+  // src/alert-delivery.ts's buildDiscordDeliveryRequest. The fixed
+  // /api/webhooks/{id}/{token} path is distinctive; the generic private/token
+  // rules do not flag a public discord.com URL.
+  {
+    name: "discord webhook url",
+    regex: /https:\/\/discord(?:app)?\.com\/api\/webhooks\/\d+\/[A-Za-z0-9_-]+/,
+  },
   {
     name: "private or loopback URL",
     // Includes link-local 169.254.0.0/16 — the cloud-metadata endpoint

--- a/tests/public-safety.test.ts
+++ b/tests/public-safety.test.ts
@@ -324,6 +324,42 @@ describe("captured-fixture body scan", () => {
     }
   });
 
+  test("flags a bare Telegram bot token", async () => {
+    // src/alert-delivery.ts builds api.telegram.org/bot${token}/sendMessage, so
+    // a leaked bot token is a real credential. Assemble the id:secret shape at
+    // runtime so the source never commits a contiguous token-shaped literal
+    // (the AWS-key test above sets this precedent).
+    // The secret half is exactly 35 URL-safe chars (the real bot-token shape and
+    // what the pattern matches); assemble it from parts so no contiguous
+    // token-shaped literal is committed.
+    const botId = "123456789";
+    const secret = ["AAHdqTcvCH1vGWJxfSeofSAs", "0K5PALDsaw", "x"].join("");
+    assert.equal(secret.length, 35);
+    await fs.writeFile(TEST_PUBLIC_PATH, `${botId}:${secret}\n`, "utf8");
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:1: telegram bot token`),
+      `Telegram bot token must be flagged; got:\n${output}`,
+    );
+  });
+
+  test("flags a bare Discord webhook URL", async () => {
+    // A Discord webhook URL is itself a bearer credential (src/alert-delivery.ts
+    // buildDiscordDeliveryRequest posts to it). Assemble it from parts so the
+    // source never commits a contiguous webhook-shaped literal.
+    const webhook = [
+      "https://discord.com/api/webhooks/",
+      "123456789012345678/",
+      ["Abcd_efGH", "ijkLMNop-qrST"].join(""),
+    ].join("");
+    await fs.writeFile(TEST_PUBLIC_PATH, `${webhook}\n`, "utf8");
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:1: discord webhook url`),
+      `Discord webhook URL must be flagged; got:\n${output}`,
+    );
+  });
+
   test("does not flag soft Bittensor terminology in a mirrored fixture body", async () => {
     // Regression for the publish-wedging false positive: upstream API docs
     // legitimately say "miner hotkey" / "validator hotkey path".


### PR DESCRIPTION
## Summary

`scripts/scan-public-safety.ts` (the CI credential-leak gate) has patterns for GitHub / GitLab / npm / OpenAI / Slack / AWS / Google credentials — none of which this repo integrates — but had **zero coverage** for the two delivery credentials it actually uses: **Telegram bot tokens** (`src/alert-delivery.ts` builds `api.telegram.org/bot${token}/sendMessage`) and **Discord webhook URLs** (`buildDiscordDeliveryRequest` — a webhook URL is itself a bearer credential). Neither is caught by the generic `key = value` rule (assignment shape only, not a bare literal in a fixture/doc/comment).

Closes #8180

## Changes
- Two new patterns (with doc comments matching the file's convention, modeled on `google api key`):
  - `telegram bot token` → `/\b\d{8,10}:[A-Za-z0-9_-]{35}\b/`
  - `discord webhook url` → `/https:\/\/discord(?:app)?\.com\/api\/webhooks\/\d+\/[A-Za-z0-9_-]+/`
- A test per pattern in `tests/public-safety.test.ts`, assembling the fake credential from parts at runtime (the AWS-key precedent) so no contiguous secret-shaped literal is committed.

## Verification
Both new tests pass; the full `public-safety.test.ts` suite is **48/48**; `npm run scan:public-safety` still passes clean on the unmodified repo (no new false positives).

## Note on the issue's example
The issue's example token has a **34-char** secret, but its own regex — and a real Telegram token — is **35**. I kept the regex at 35 and made the test fixture's secret exactly 35.

## Scope
Two cold-path files: `scripts/scan-public-safety.ts`, `tests/public-safety.test.ts`. No apps/ui, no generated artifacts.