### PR TITLE
fix(ui): cancel the pending debounced flush on chain-stream reconnect and unmount

### DIFF
--- a/apps/ui/src/hooks/use-chain-stream.test.ts
+++ b/apps/ui/src/hooks/use-chain-stream.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { ChainStreamSource, ChainStreamSessionDeps } from "./use-chain-stream";
 import {
   buildChainStreamUrl,
   chainStreamEventMatchesFilters,
+  createChainStreamSession,
   createDebouncedHandler,
   parseChainStreamPayload,
 } from "./use-chain-stream";
@@ -68,6 +70,129 @@ describe("createDebouncedHandler", () => {
 
     vi.advanceTimersByTime(400);
     expect(run).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it("cancel() drops a scheduled, not-yet-fired invocation (#8179)", () => {
+    vi.useFakeTimers();
+    const run = vi.fn();
+    const debounced = createDebouncedHandler(run, 400);
+
+    debounced();
+    debounced.cancel();
+
+    vi.advanceTimersByTime(1000);
+    expect(run).not.toHaveBeenCalled();
+
+    // The handler stays usable after a cancel.
+    debounced();
+    vi.advanceTimersByTime(400);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+});
+
+/**
+ * Minimal stand-in for the `EventSource` slice `createChainStreamSession`
+ * consumes (same plain-node approach as `use-in-view.test.ts`'s
+ * IntersectionObserver mock -- no jsdom/renderHook in this suite).
+ */
+class MockChainSource implements ChainStreamSource {
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  closed = false;
+  private listeners = new Map<string, Array<(ev: Event) => void>>();
+
+  addEventListener(type: string, listener: (ev: Event) => void): void {
+    const arr = this.listeners.get(type) ?? [];
+    arr.push(listener);
+    this.listeners.set(type, arr);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emitChain(payload: unknown): void {
+    const ev = { data: JSON.stringify(payload) } as MessageEvent;
+    for (const listener of this.listeners.get("chain") ?? []) listener(ev);
+  }
+}
+
+describe("createChainStreamSession", () => {
+  function makeSession(overrides: Partial<ChainStreamSessionDeps> = {}) {
+    const sources: MockChainSource[] = [];
+    const onEvent = vi.fn();
+    const session = createChainStreamSession({
+      openSource: () => {
+        const source = new MockChainSource();
+        sources.push(source);
+        return source;
+      },
+      getOnEvent: () => onEvent,
+      getMatches: () => undefined,
+      debounceMs: 400,
+      setStatus: () => {},
+      markActivity: () => {},
+      ...overrides,
+    });
+    return { session, sources, onEvent };
+  }
+
+  it("delivers a debounced frame that is not superseded by a reconnect", () => {
+    vi.useFakeTimers();
+    const { session, sources, onEvent } = makeSession();
+
+    session.connect();
+    sources[0].emitChain({ table: "chain_events", pallet: "Balances" });
+    expect(onEvent).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(400);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith({ table: "chain_events", pallet: "Balances" });
+
+    vi.useRealTimers();
+  });
+
+  it("reconnect before the debounce fires drops the stale connection's frame (#8179)", () => {
+    vi.useFakeTimers();
+    const { session, sources, onEvent } = makeSession();
+
+    session.connect();
+    sources[0].emitChain({ table: "chain_events", network: "old-network" });
+
+    // Network/API-base switch mid-debounce: the old source is closed and the
+    // old pending flush must never reach onEvent.
+    vi.advanceTimersByTime(200);
+    session.connect();
+    expect(sources[0].closed).toBe(true);
+
+    vi.advanceTimersByTime(1000);
+    expect(onEvent).not.toHaveBeenCalled();
+
+    // The new connection's frames still flow.
+    sources[1].emitChain({ table: "chain_events", network: "new-network" });
+    vi.advanceTimersByTime(400);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith({ table: "chain_events", network: "new-network" });
+
+    vi.useRealTimers();
+  });
+
+  it("dispose (unmount) before the debounce fires drops the pending frame (#8179)", () => {
+    vi.useFakeTimers();
+    const { session, sources, onEvent } = makeSession();
+
+    session.connect();
+    sources[0].emitChain({ table: "chain_events", network: "old-network" });
+
+    vi.advanceTimersByTime(200);
+    session.dispose();
+    expect(sources[0].closed).toBe(true);
+
+    vi.advanceTimersByTime(1000);
+    expect(onEvent).not.toHaveBeenCalled();
 
     vi.useRealTimers();
   });

--- a/apps/ui/src/hooks/use-chain-stream.ts
+++ b/apps/ui/src/hooks/use-chain-stream.ts
@@ -53,16 +53,33 @@ export function chainStreamEventMatchesFilters(
   return true;
 }
 
+/**
+ * Debounced trigger with an out-of-band cancel handle, so a connection
+ * teardown can drop a scheduled-but-not-yet-fired flush (#8179).
+ */
+export interface DebouncedHandler {
+  (): void;
+  /** Drop the pending, not-yet-fired invocation (if any) without running it. */
+  cancel: () => void;
+}
+
 /** Pure debounce helper; exported for unit tests. */
-export function createDebouncedHandler(run: () => void, waitMs: number): () => void {
+export function createDebouncedHandler(run: () => void, waitMs: number): DebouncedHandler {
   let timer: ReturnType<typeof setTimeout> | null = null;
-  return () => {
+  const cancel = () => {
     if (timer != null) clearTimeout(timer);
-    timer = setTimeout(() => {
-      timer = null;
-      run();
-    }, waitMs);
+    timer = null;
   };
+  return Object.assign(
+    () => {
+      if (timer != null) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        run();
+      }, waitMs);
+    },
+    { cancel },
+  );
 }
 
 /** Parse an SSE MessageEvent's `data` as JSON; null on empty/malformed. */
@@ -73,6 +90,102 @@ export function parseChainStreamPayload(data: unknown): unknown | null {
   } catch {
     return null;
   }
+}
+
+/** The slice of `EventSource` the session logic needs; injected for unit tests. */
+export interface ChainStreamSource {
+  addEventListener(type: string, listener: (ev: Event) => void): void;
+  close(): void;
+  onmessage: ((ev: MessageEvent) => void) | null;
+}
+
+export interface ChainStreamSessionDeps {
+  /** Open a fresh source for the current network/API base; may throw. */
+  openSource: () => ChainStreamSource;
+  /** Read through to the caller's latest `onEvent` (ref-backed in the hook). */
+  getOnEvent: () => ((payload: unknown) => void) | undefined;
+  /** Read through to the caller's latest `matches` (ref-backed in the hook). */
+  getMatches: () => ((payload: unknown) => boolean) | undefined;
+  debounceMs: number;
+  setStatus: (s: SseStatus) => void;
+  /** Called on every accepted frame (feeds `lastEventAt`). */
+  markActivity: () => void;
+}
+
+/**
+ * Connection lifecycle for `useChainStream`, extracted so the reconnect /
+ * teardown behavior is unit-testable in this suite's plain-node environment
+ * (no jsdom/renderHook -- see `apps/ui/vitest.config.ts`).
+ *
+ * #8179: `teardown()` cancels the previous connection's pending debounce in
+ * addition to closing its source. Without that, a frame received on the old
+ * connection could sit in a scheduled `flush()` timer across a
+ * network/API-base reconnect and fire *after* the switch, delivering a stale
+ * cross-network payload to `onEvent`.
+ */
+export function createChainStreamSession(deps: ChainStreamSessionDeps): {
+  connect: () => void;
+  dispose: () => void;
+} {
+  let es: ChainStreamSource | null = null;
+  let disposed = false;
+  let cancelPendingFlush: (() => void) | null = null;
+  const set = (s: SseStatus) => {
+    if (!disposed) deps.setStatus(s);
+  };
+
+  const teardown = () => {
+    cancelPendingFlush?.();
+    cancelPendingFlush = null;
+    es?.close();
+    es = null;
+  };
+
+  const connect = () => {
+    teardown();
+    set("connecting");
+    try {
+      es = deps.openSource();
+    } catch {
+      es = null;
+      set("error");
+      return;
+    }
+
+    let pending: unknown = null;
+    const flush = createDebouncedHandler(() => {
+      if (pending === null || disposed) return;
+      const payload = pending;
+      pending = null;
+      deps.getOnEvent()?.(payload);
+    }, deps.debounceMs);
+    cancelPendingFlush = flush.cancel;
+
+    const handle = (ev: Event) => {
+      if (disposed) return;
+      const payload = parseChainStreamPayload((ev as MessageEvent).data);
+      if (payload == null) return;
+      const match = deps.getMatches();
+      if (match && !match(payload)) return;
+      deps.markActivity();
+      pending = payload;
+      flush();
+    };
+
+    es.addEventListener("chain", handle);
+    // Some proxies strip named SSE events into unnamed `message` frames.
+    es.onmessage = handle;
+    es.addEventListener("open", () => set("open"));
+    // onerror: EventSource auto-reconnects; polling/manual refresh covers the gap.
+    es.addEventListener("error", () => set("error"));
+  };
+
+  const dispose = () => {
+    disposed = true;
+    teardown();
+  };
+
+  return { connect, dispose };
 }
 
 export interface UseChainStreamOptions {
@@ -124,67 +237,26 @@ export function useChainStream(options: UseChainStreamOptions = {}): {
       return;
     }
 
-    let es: EventSource | null = null;
-    let cancelled = false;
-    const set = (s: SseStatus) => {
-      if (!cancelled) setStatus(s);
-    };
-
-    const teardown = () => {
-      es?.close();
-      es = null;
-    };
-
     const topicList = topicsKey
       ? topicsKey.split(",").filter(Boolean)
       : (["chain_events"] as string[]);
 
-    const connect = () => {
-      teardown();
-      set("connecting");
-      try {
-        es = new EventSource(buildChainStreamUrl(topicList));
-      } catch {
-        es = null;
-        set("error");
-        return;
-      }
+    const session = createChainStreamSession({
+      openSource: () => new EventSource(buildChainStreamUrl(topicList)),
+      getOnEvent: () => onEventRef.current,
+      getMatches: () => matchesRef.current,
+      debounceMs,
+      setStatus,
+      markActivity: () => setLastEventAt(new Date().toISOString()),
+    });
 
-      let pending: unknown = null;
-      const flush = createDebouncedHandler(() => {
-        if (pending === null || cancelled) return;
-        const payload = pending;
-        pending = null;
-        onEventRef.current?.(payload);
-      }, debounceMs);
-
-      const handle = (ev: Event) => {
-        if (cancelled) return;
-        const payload = parseChainStreamPayload((ev as MessageEvent).data);
-        if (payload == null) return;
-        const match = matchesRef.current;
-        if (match && !match(payload)) return;
-        if (!cancelled) setLastEventAt(new Date().toISOString());
-        pending = payload;
-        flush();
-      };
-
-      es.addEventListener("chain", handle);
-      // Some proxies strip named SSE events into unnamed `message` frames.
-      es.onmessage = handle;
-      es.addEventListener("open", () => set("open"));
-      // onerror: EventSource auto-reconnects; polling/manual refresh covers the gap.
-      es.addEventListener("error", () => set("error"));
-    };
-
-    connect();
-    const offNetwork = onNetworkChange(connect);
-    const offApiBase = onApiBaseChange(connect);
+    session.connect();
+    const offNetwork = onNetworkChange(session.connect);
+    const offApiBase = onApiBaseChange(session.connect);
     return () => {
-      cancelled = true;
       offNetwork();
       offApiBase();
-      teardown();
+      session.dispose();
     };
   }, [enabled, topicsKey, debounceMs]);
 


### PR DESCRIPTION
## Summary

A `chain` frame that arrived just before a network/API-base switch could sit in its debounce window (default 400ms) across the reconnect and fire afterwards: `connect()`'s `teardown()` only closed the previous `EventSource`, and `createDebouncedHandler` exposed no way to cancel an already-scheduled flush. The stale timer then delivered the superseded connection's payload to `onEvent` *after* the switch — indistinguishable from a legitimate event on the new network.

## What changed (`apps/ui/src/hooks/use-chain-stream.ts`)

- **`createDebouncedHandler` now exposes `cancel()`** — it returns the same callable trigger as before, with a `cancel` property that drops a scheduled, not-yet-fired invocation (`DebouncedHandler` interface). Keeping the trigger callable (rather than `{ trigger, cancel }`) means every existing call site and the existing `createDebouncedHandler` test keep working unchanged, while teardown gains the out-of-band cancel handle the fix needs.
- **Teardown cancels the pending debounce.** The connection lifecycle now stores the current connection's `flush.cancel`, and `teardown()` runs it (then clears it) before closing the source — on every reconnect path (`connect()`'s own initial `teardown()`) and on effect cleanup/unmount (`dispose()` sets `disposed` and tears down).
- **Lifecycle extracted as `createChainStreamSession(deps)`** (`connect`/`dispose`, dependency-injected source factory and ref-backed callbacks). This is the same pattern this suite already uses for DOM-dependent hooks (`use-in-view.test.ts`'s IntersectionObserver mock): the vitest config is plain-node with no jsdom/renderHook, so the reconnect requirement is only testable by exercising the extracted lifecycle directly. The effect body wires the session with a real `EventSource` factory exactly as before; connect/teardown logic itself is unchanged apart from the cancel call.

Happy path is untouched: a frame not superseded within its debounce window still reaches `onEvent` exactly as before (covered by a new test).

## Tests (`apps/ui/src/hooks/use-chain-stream.test.ts`)

All existing assertions unchanged. New:

- `createDebouncedHandler` — `cancel()` drops a scheduled invocation; the handler stays usable afterwards.
- `createChainStreamSession` (with a minimal `ChainStreamSource` mock + fake timers):
  - happy path: a debounced frame not superseded by a reconnect is delivered once;
  - **the reported bug**: frame arrives, reconnect happens 200ms into the 400ms window — the old source is closed and the stale frame's `onEvent` never fires, while the new connection's frames still flow;
  - unmount variant: `dispose()` mid-window — the pending frame never fires.

## Verification

From `apps/ui/` (all clean/passing):

- `npx eslint src/hooks/use-chain-stream.ts src/hooks/use-chain-stream.test.ts`
- `npx tsc --noEmit`
- `npx prettier --check` on both touched files
- `npx vitest run` — 191 files, 1464 tests passed
- `npm run build` (vite build)

Only `apps/ui` files are touched.

Closes #8179
