### PR TITLE
fix(data): consolidate 16 duplicated percentile()/median() copies into shared src/lib/stats.ts

### DIFF
--- a/src/blocks-summary.ts
+++ b/src/blocks-summary.ts
@@ -11,6 +11,7 @@
 // blocks, a base-layer validator-set decentralization signal, not a tx-fee signal.
 
 import { computeConcentration } from "./concentration.ts";
+import { percentile } from "./lib/stats.ts";
 
 // The `blocks` columns the summary reads. `author` is best-effort/nullable; the
 // counts are nullable INTEGERs; `observed_at` is the block timestamp (epoch ms).
@@ -63,13 +64,6 @@ function toCount(value: unknown): number {
   return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : 0;
 }
 
-// Nearest-rank percentile over a non-empty ascending array (rank = ceil(p/100 · n),
-// 1-based). Only called after the caller establishes the array is non-empty.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.max(1, Math.ceil((p / 100) * ascending.length));
-  return ascending[rank - 1];
-}
-
 interface BlockTimeDistribution {
   count: number;
   mean_ms: number;
@@ -95,7 +89,9 @@ function blockTimeDistribution(
     max_ms: roundMs(ascending[count - 1]),
   };
   for (const p of BLOCK_TIME_PERCENTILES) {
-    summary[`p${p}_ms`] = roundMs(percentile(ascending, p));
+    // ascending is non-empty here (count === 0 returned above), so the shared
+    // percentile() never hits its empty-array null.
+    summary[`p${p}_ms`] = roundMs(percentile(ascending, p)!);
   }
   return summary;
 }

--- a/src/chain-alpha-volume.ts
+++ b/src/chain-alpha-volume.ts
@@ -22,6 +22,7 @@ import {
   type AlphaVolumeResult,
   type AlphaVolumeSentiment,
 } from "./alpha-volume.ts";
+import { median, percentile } from "./lib/stats.ts";
 
 export const CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT = 20;
 export const CHAIN_ALPHA_VOLUME_LIMIT_MAX = 100;
@@ -61,23 +62,6 @@ function toIso(value: unknown): string | null {
   return n == null ? null : new Date(n).toISOString();
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array. Mirrors
-// chain-stake-flow.ts's percentile, applied here to total_volume_tao instead of net flow.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd
-// count, the mean of the two middle values for an even count. Mirrors chain-stake-flow.ts's
-// median (itself matching subnet-yield.ts / chain-yield.ts), applied to total_volume_tao.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return roundUnit(
-    (ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2,
-  );
-}
-
 export interface VolumeDistribution {
   count: number;
   mean: number;
@@ -101,10 +85,12 @@ function volumeDistribution(values: number[]): VolumeDistribution | null {
     count: ascending.length,
     mean: roundUnit(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: roundUnit(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-axon-removals.ts
+++ b/src/chain-axon-removals.ts
@@ -9,6 +9,8 @@
 // same account_events [netuid, hotkey] tuple AxonServed uses — the network-wide companion to the
 // per-subnet /api/v1/subnets/{netuid}/axon-removals.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron's announced axon endpoint is removed on a subnet.
 export const AXON_REMOVAL_EVENT_KIND = "AxonInfoRemoved";
 
@@ -72,25 +74,6 @@ function removalsPerRemover(removals: number, removers: number): number | null {
   return round(removals / removers);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -114,10 +97,12 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-deregistrations.ts
+++ b/src/chain-deregistrations.ts
@@ -9,6 +9,8 @@
 // tryPostgresTier() ?? buildChainDeregistrations([]). The field semantics live in
 // schemas/components/05-subnets.schema.json (ChainDeregistrationsArtifact).
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron is deregistered (evicted) from a subnet.
 export const DEREGISTRATION_EVENT_KIND = "NeuronDeregistered";
 
@@ -76,25 +78,6 @@ function deregistrationsPerHotkey(
   return round(deregistrations / hotkeys);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -118,10 +101,12 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-performance.ts
+++ b/src/chain-performance.ts
@@ -9,6 +9,7 @@
 // envelope. Null-safe: an empty snapshot yields a schema-stable `null` block.
 
 import { computeConcentration } from "./concentration.ts";
+import { percentile } from "./lib/stats.ts";
 
 // The neurons-tier columns the network performance handler reads — like the
 // per-subnet read but with `netuid`, so the artifact can report how many subnets
@@ -73,14 +74,6 @@ function finiteValues(values: unknown[]): number[] {
   return out;
 }
 
-// Nearest-rank percentile over a non-empty ascending array (rank = ceil(p/100 · n),
-// 1-based), matching the subnet-yield / health-percentile convention. Only called
-// after scoreDistribution has established count > 0, so the array is never empty.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.max(1, Math.ceil((p / 100) * ascending.length));
-  return ascending[rank - 1];
-}
-
 export interface ScoreDistribution {
   count: number;
   mean: number;
@@ -105,7 +98,9 @@ export function scoreDistribution(values: unknown[]): ScoreDistribution | null {
     max: round(ascending[count - 1]),
   };
   for (const p of SCORE_PERCENTILES) {
-    summary[`p${p}`] = round(percentile(ascending, p));
+    // ascending is non-empty here (count === 0 returned above), so the shared
+    // percentile() never hits its empty-array null.
+    summary[`p${p}`] = round(percentile(ascending, p)!);
   }
   return summary;
 }

--- a/src/chain-prometheus.ts
+++ b/src/chain-prometheus.ts
@@ -7,6 +7,8 @@
 // the metrics endpoint a neuron exposes (which subnets run observability infrastructure), read from
 // the same account_events [netuid, hotkey] tuple AxonServed uses.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron announces its Prometheus telemetry endpoint on a subnet.
 export const PROMETHEUS_EVENT_KIND = "PrometheusServed";
 
@@ -73,25 +75,6 @@ function announcementsPerExporter(
   return round(announcements / exporters);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -115,10 +98,12 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-registrations.ts
+++ b/src/chain-registrations.ts
@@ -7,6 +7,8 @@
 // -- see #6013). Callers now go tryPostgresTier() ?? buildChainRegistrations([]). The field
 // semantics live in schemas/components/05-subnets.schema.json (ChainRegistrationsArtifact).
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron registers (or re-registers) on a subnet.
 export const REGISTRATION_EVENT_KIND = "NeuronRegistered";
 
@@ -72,25 +74,6 @@ function registrationsPerRegistrant(
   return round(registrations / registrants);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -114,10 +97,12 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-serving.ts
+++ b/src/chain-serving.ts
@@ -4,6 +4,8 @@
 // in #4772, so it always missed -- see #6013). Callers now go tryPostgresTier() ?? buildChainServing([]).
 // The field semantics live in schemas/components/05-subnets.schema.json (ChainServingArtifact).
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a neuron announces its axon endpoint on a subnet.
 export const SERVING_EVENT_KIND = "AxonServed";
 
@@ -70,25 +72,6 @@ function announcementsPerHotkey(
   return round(announcements / hotkeys);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -112,10 +95,12 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-stake-flow.ts
+++ b/src/chain-stake-flow.ts
@@ -7,6 +7,8 @@
 // REST envelope. Null-safe: a cold store or an empty window yields schema-stable zeros
 // (never throws), matching the sibling live tiers.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The two account_events kinds that move stake: StakeAdded is capital entering a subnet,
 // StakeRemoved is capital leaving. Both carry a positive amount_tao, so net = staked - unstaked.
 export const STAKE_ADDED_KIND = "StakeAdded";
@@ -84,23 +86,6 @@ function classifyDirection(
   return net > 0 ? "inflow" : "outflow";
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (net flow can be negative).
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array (net flow can be negative): the middle
-// value for an odd count, the mean of the two middle values for an even count (so an even count
-// returns the average of the two middles, not the lower-middle a nearest-rank p50 gives). The
-// averaging form needs no odd/even branch — for an odd count the two indices coincide and it returns
-// that middle value unchanged. Matches median() in chain-yield.ts / subnet-yield.ts so a `median`
-// field is the same statistic across the API. Reached only after netFlowDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return roundTao((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface NetFlowDistribution {
   count: number;
   mean: number;
@@ -123,10 +108,12 @@ function netFlowDistribution(values: number[]): NetFlowDistribution | null {
     count: ascending.length,
     mean: roundTao(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: roundTao(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-stake-moves.ts
+++ b/src/chain-stake-moves.ts
@@ -12,6 +12,8 @@
 // the table is dropped in production (#4772 / #4909), so serving goes tryPostgresTier →
 // schema-stable empty stub, never D1.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a coldkey moves stake between hotkeys/subnets (move_stake).
 export const STAKE_MOVED_EVENT_KIND = "StakeMoved";
 
@@ -75,25 +77,6 @@ function movementsPerMover(movements: number, movers: number): number | null {
   return round(movements / movers);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -117,10 +100,12 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-stake-transfers.ts
+++ b/src/chain-stake-transfers.ts
@@ -14,6 +14,8 @@
 // and the table is dropped in production (#4772 / #4909), so serving goes tryPostgresTier →
 // schema-stable empty stub, never D1.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a coldkey transfers stake to another coldkey (transfer_stake).
 export const STAKE_TRANSFERRED_EVENT_KIND = "StakeTransferred";
 
@@ -77,26 +79,6 @@ function transfersPerSender(transfers: number, senders: number): number | null {
   return round(transfers / senders);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts and the chain-activity distribution family
-// (#3200) so a `median` field is the same statistic across the API. Reached only after the empty
-// short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -120,10 +102,12 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-turnover.ts
+++ b/src/chain-turnover.ts
@@ -6,6 +6,8 @@
 // for unit tests; the Worker does the D1 reads + envelope. Scoped to validator_permit rows
 // so the two-snapshot read stays bounded (validators, not every neuron across the network).
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The neuron_daily columns the handler reads — its D1 read contract. `hotkey` is public
 // metagraph vocabulary, not a secret; kept next to its consumer so the handler stays a thin SELECT.
 export const CHAIN_TURNOVER_READ_COLUMNS =
@@ -51,25 +53,6 @@ function stabilityScore(retention: number): number {
   return score;
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation) — mirrors src/subnet-yield.ts. Only called from stabilityDistribution,
-// which short-circuits an empty score set to null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so [33, 100] -> 66.5, not the lower-middle 33
-// a nearest-rank p50 gives). The averaging form needs no odd/even branch — for an odd count the two
-// indices coincide and it returns that middle value unchanged. Matches median() in chain-yield.ts /
-// subnet-yield.ts so a `median` field is the same statistic across the API. Reached only after
-// stabilityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface StabilityDistribution {
   count: number;
   mean: number;
@@ -93,10 +76,12 @@ function stabilityDistribution(scores: number[]): StabilityDistribution | null {
     count: ascending.length,
     mean: Math.round((sum / ascending.length) * 100) / 100,
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-weights.ts
+++ b/src/chain-weights.ts
@@ -3,6 +3,8 @@
 // kind-filtered sibling of chain-transfers / chain-stake-flow. Pure shaping + a thin D1 loader; the
 // Worker adds the envelope. See the schema/contracts for the full response contract.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The account_events kind emitted when a validator sets weights on a subnet.
 export const WEIGHTS_EVENT_KIND = "WeightsSet";
 
@@ -65,25 +67,6 @@ function setsPerSetter(sets: number, setters: number): number | null {
   return round(sets / setters);
 }
 
-// Nearest-rank percentile of a NON-EMPTY ascending numeric array (deterministic, no
-// interpolation). Only called from intensityDistribution, which short-circuits an empty set to
-// null before reaching here.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.ceil((p / 100) * ascending.length);
-  return ascending[Math.min(rank, ascending.length) - 1];
-}
-
-// Conventional median of a NON-EMPTY ascending numeric array: the middle value for an odd count,
-// the mean of the two middle values for an even count (so an even count returns the average of the
-// two middles, not the lower-middle a nearest-rank p50 gives). The averaging form needs no odd/even
-// branch — for an odd count the two indices coincide and it returns that middle value unchanged.
-// Matches median() in chain-yield.ts / subnet-yield.ts so a `median` field is the same statistic
-// across the API. Reached only after intensityDistribution's empty short-circuit.
-function median(ascending: number[]): number {
-  const mid = (ascending.length - 1) / 2;
-  return round((ascending[Math.floor(mid)] + ascending[Math.ceil(mid)]) / 2);
-}
-
 export interface IntensityDistribution {
   count: number;
   mean: number;
@@ -108,10 +91,12 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
     count: ascending.length,
     mean: round(sum / ascending.length),
     min: ascending[0],
-    p25: percentile(ascending, 25),
-    median: median(ascending),
-    p75: percentile(ascending, 75),
-    p90: percentile(ascending, 90),
+    // ascending is non-empty here (the empty case returned null above), so the
+    // shared percentile()/median() never hit their empty-array null.
+    p25: percentile(ascending, 25)!,
+    median: round(median(ascending)!),
+    p75: percentile(ascending, 75)!,
+    p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
   };
 }

--- a/src/chain-yield.ts
+++ b/src/chain-yield.ts
@@ -8,6 +8,8 @@
 // function is pure + exported for unit tests; the Worker does the D1 read +
 // envelope. Null-safe: an empty snapshot yields a schema-stable zeroed card.
 
+import { median, percentile } from "./lib/stats.ts";
+
 // The neurons-tier columns the network yield handler reads. `netuid` lets the
 // artifact report how many subnets the snapshot spans (mirrors
 // CHAIN_PERFORMANCE_READ_COLUMNS); no per-UID list is served, so only the economic
@@ -100,24 +102,6 @@ function computeYieldValue(
   return round9(emission / stake);
 }
 
-// Nearest-rank percentile over a non-empty ascending array (rank = ceil(p/100 · n),
-// 1-based), matching the subnet-yield / chain-performance convention. Only called
-// after yieldDistribution has established count > 0, so it is never empty.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.max(1, Math.ceil((p / 100) * ascending.length));
-  return ascending[rank - 1];
-}
-
-// Conventional median of an ascending array: the middle value for an odd count,
-// the average of the two middle values for an even count (so [0.2, 0.4] -> 0.3,
-// not the lower-middle a nearest-rank p50 would give). Only called after count > 0.
-function median(ascending: number[]): number {
-  const mid = Math.floor(ascending.length / 2);
-  return ascending.length % 2 === 1
-    ? ascending[mid]
-    : round9((ascending[mid - 1] + ascending[mid]) / 2);
-}
-
 export interface YieldDistribution {
   count: number;
   mean: number;
@@ -142,12 +126,17 @@ export function yieldDistribution(
   const summary: YieldDistribution = {
     count,
     mean: round9(total / count),
-    median: median(defined),
+    // defined is non-empty here (count === 0 returned above), so the shared
+    // median()/percentile() never hit their empty-array null. Every element is
+    // already round9-precision, so rounding the raw median keeps odd counts
+    // (a single middle element) unchanged and rounds even-count averages as
+    // before.
+    median: round9(median(defined)!),
     min: round9(defined[0]),
     max: round9(defined[count - 1]),
   };
   for (const p of YIELD_PERCENTILES) {
-    summary[`p${p}`] = round9(percentile(defined, p));
+    summary[`p${p}`] = round9(percentile(defined, p)!);
   }
   return summary;
 }

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,33 @@
+// Canonical percentile()/median() for the chain-*/subnet-*/blocks-summary
+// analytics family. Every distribution builder used to carry its own copy-pasted
+// variant of these two functions (16 files), and the copies drifted: most had no
+// empty-array guard and no lower-bound clamp, so percentile(arr, 0) indexed
+// arr[-1] and returned undefined. This module standardizes on the fully-guarded
+// subnet-yield.ts variant: null on an empty array, both bounds clamped (p <= 0
+// returns the minimum, p >= 100 the maximum).
+//
+// Both functions return the RAW statistic. Each caller keeps applying its own
+// precision helper (round, round9, roundTao, roundUnit, roundMs, ...) at the
+// call site, exactly as it did before the extraction.
+
+// Nearest-rank percentile of an ascending numeric array (deterministic, no
+// interpolation ambiguity): rank = ceil(p/100 * n), 0-indexed and clamped to
+// [0, n - 1]. Null on an empty array.
+export function percentile(ascending: number[], p: number): number | null {
+  if (ascending.length === 0) return null;
+  const rank = Math.ceil((p / 100) * ascending.length) - 1;
+  const index = Math.min(ascending.length - 1, Math.max(0, rank));
+  return ascending[index];
+}
+
+// Conventional median of an ascending array: the middle value for an odd count,
+// the average of the two middle values for an even count (so [0.2, 0.4] -> 0.3,
+// not the lower-middle a nearest-rank p50 would give). Null on an empty array.
+export function median(ascending: number[]): number | null {
+  const n = ascending.length;
+  if (n === 0) return null;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 1
+    ? ascending[mid]
+    : (ascending[mid - 1] + ascending[mid]) / 2;
+}

--- a/src/neuron-history.ts
+++ b/src/neuron-history.ts
@@ -6,6 +6,7 @@
 // one. Pure + injectable for tests — the Worker handlers run the D1 query and call
 // these.
 import { NEURON_COLUMNS, formatNeuron } from "./metagraph-neurons.ts";
+import { median } from "./lib/stats.ts";
 
 type Row = Record<string, unknown>;
 
@@ -202,7 +203,7 @@ export function buildEconomicsTrends(
       acc.weighted_price_den > 0
         ? roundPrice(acc.weighted_price_num / acc.weighted_price_den)
         : null,
-    alpha_price_tao_median: median(acc.prices),
+    alpha_price_tao_median: priceMedian(acc.prices),
     validator_count: acc.validator_seen ? acc.validator_sum : null,
     miner_count: acc.miner_seen ? acc.miner_sum : null,
     mean_emission_share:
@@ -264,13 +265,9 @@ function roundShare(v: number): number {
   return Math.round(v * 1e6) / 1e6;
 }
 
-function median(values: number[]): number | null {
-  if (!values.length) return null;
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  const raw =
-    sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-  return roundPrice(raw);
+function priceMedian(values: number[]): number | null {
+  const m = median([...values].sort((a, b) => a - b));
+  return m == null ? null : roundPrice(m);
 }
 
 // Per-subnet metric-over-time: the daily count + a couple of cheap aggregates per

--- a/src/subnet-performance.ts
+++ b/src/subnet-performance.ts
@@ -9,6 +9,7 @@
 // `null` block (never throws), matching the concentration tier it mirrors.
 
 import { computeConcentration } from "./concentration.ts";
+import { median, percentile } from "./lib/stats.ts";
 
 type Row = Record<string, unknown>;
 type D1Runner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -74,14 +75,6 @@ function finiteValues(values: unknown[]): number[] {
   return out;
 }
 
-// Nearest-rank percentile over a non-empty ascending array (rank = ceil(p/100 · n),
-// 1-based), matching the subnet-yield / health-percentile convention. Only called
-// after scoreDistribution has established count > 0, so the array is never empty.
-function percentile(ascending: number[], p: number): number {
-  const rank = Math.max(1, Math.ceil((p / 100) * ascending.length));
-  return ascending[rank - 1];
-}
-
 // Conventional median of a 0..1 score column: the middle value for an odd count,
 // the average of the two middle values for an even count — NOT the nearest-rank
 // p50, which returns the lower-middle for an even count (e.g. [0.2, 0.8] -> 0.2).
@@ -90,13 +83,8 @@ function percentile(ascending: number[], p: number): number {
 // *_median reports the same statistic across both modules. Callers pass a raw
 // column array (dayRows.map(...)); returns null when no neuron carries a finite value.
 function scoreMedian(values: unknown[]): number | null {
-  const ascending = finiteValues(values).sort((a, b) => a - b);
-  const n = ascending.length;
-  if (n === 0) return null;
-  const mid = Math.floor(n / 2);
-  return n % 2 === 1
-    ? round(ascending[mid])
-    : round((ascending[mid - 1] + ascending[mid]) / 2);
+  const m = median(finiteValues(values).sort((a, b) => a - b));
+  return m == null ? null : round(m);
 }
 
 export interface ScoreDistribution {
@@ -125,7 +113,9 @@ export function scoreDistribution(
     max: round(ascending[count - 1]),
   };
   for (const p of SCORE_PERCENTILES) {
-    summary[`p${p}`] = round(percentile(ascending, p));
+    // ascending is non-empty here (count === 0 returned above), so the shared
+    // percentile() never hits its empty-array null.
+    summary[`p${p}`] = round(percentile(ascending, p)!);
   }
   return summary;
 }

--- a/src/subnet-yield.ts
+++ b/src/subnet-yield.ts
@@ -7,6 +7,8 @@
 // the most emission per unit of stake, and how is that return distributed across the set".
 // Null-safe: a cold/empty subnet yields a zeroed, empty-neuron card (never throws).
 
+import { median, percentile } from "./lib/stats.ts";
+
 type Row = Record<string, unknown>;
 type D1Runner = (sql: string, params: unknown[]) => Promise<Row[]>;
 
@@ -86,25 +88,13 @@ function computeYieldValue(
   return round9(emission / stake);
 }
 
-// Nearest-rank percentile of an ascending numeric array (deterministic, no interpolation
-// ambiguity), used for the p25/p75/p90 spread. Null on an empty set.
-function percentile(ascending: number[], p: number): number | null {
-  if (ascending.length === 0) return null;
-  const rank = Math.ceil((p / 100) * ascending.length) - 1;
-  const index = Math.min(ascending.length - 1, Math.max(0, rank));
-  return ascending[index];
-}
-
-// Conventional median of an ascending array: the middle value for an odd count, the
-// average of the two middle values for an even count (so [0.2, 0.4] -> 0.3, not the
-// lower-middle a nearest-rank p50 would give). Null on an empty set.
-function median(ascending: number[]): number | null {
-  const n = ascending.length;
-  if (n === 0) return null;
-  const mid = Math.floor(n / 2);
-  return n % 2 === 1
-    ? ascending[mid]
-    : round9((ascending[mid - 1] + ascending[mid]) / 2);
+// The shared median() returns the raw statistic -- keep this module's round9
+// precision here, preserving null (an empty yield set) rather than coercing it
+// to 0. Every yield is already round9-precision, so this only rounds the
+// even-count two-middle average, exactly as the local median() did before.
+function yieldMedian(ascending: number[]): number | null {
+  const m = median(ascending);
+  return m == null ? null : round9(m);
 }
 
 interface YieldNeuron {
@@ -187,7 +177,7 @@ export function buildSubnetYield(
     .map((n) => n.yield)
     .filter((y): y is number => y != null)
     .sort((a, b) => a - b);
-  const medianYield = median(definedYields);
+  const medianYield = yieldMedian(definedYields);
   const meanYield =
     definedYields.length > 0
       ? round9(
@@ -331,7 +321,7 @@ function yieldHistoryPoint(date: string, dayRows: Row[]): Row {
     yield_count: definedYields.length,
     subnet_yield: yieldStake > 0 ? round9(yieldEmission / yieldStake) : null,
     mean_yield: meanYield,
-    median_yield: median(definedYields),
+    median_yield: yieldMedian(definedYields),
     p25_yield: percentile(definedYields, 25),
     p75_yield: percentile(definedYields, 75),
     p90_yield: percentile(definedYields, 90),

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { median, percentile } from "../src/lib/stats.ts";
+
+// Direct unit tests for the canonical percentile()/median() the chain-*/subnet-*/
+// blocks-summary distribution builders share (issue #8178). The edge cases here
+// are exactly the ones the pre-consolidation per-file copies diverged on:
+// p=0 / p=100 (most copies indexed arr[-1] -> undefined at p=0), a single-element
+// array, and an empty array (undefined instead of null in all but one copy).
+
+describe("percentile", () => {
+  test("p=0 returns the minimum, not undefined", () => {
+    assert.equal(percentile([1, 2, 3, 4], 0), 1);
+  });
+
+  test("p=100 returns the maximum", () => {
+    assert.equal(percentile([1, 2, 3, 4], 100), 4);
+  });
+
+  test("nearest-rank interior percentiles match the family convention", () => {
+    const ascending = [10, 20, 30, 40];
+    assert.equal(percentile(ascending, 25), 10); // rank ceil(1) -> 1st
+    assert.equal(percentile(ascending, 50), 20); // rank ceil(2) -> 2nd (lower-middle)
+    assert.equal(percentile(ascending, 75), 30); // rank ceil(3) -> 3rd
+    assert.equal(percentile(ascending, 90), 40); // rank ceil(3.6) -> 4th
+  });
+
+  test("single-element array returns that element for any p", () => {
+    assert.equal(percentile([7], 0), 7);
+    assert.equal(percentile([7], 50), 7);
+    assert.equal(percentile([7], 100), 7);
+  });
+
+  test("empty array returns null, not undefined", () => {
+    assert.equal(percentile([], 50), null);
+    assert.equal(percentile([], 0), null);
+  });
+
+  test("out-of-range p clamps to the array bounds", () => {
+    assert.equal(percentile([1, 2, 3], -10), 1);
+    assert.equal(percentile([1, 2, 3], 250), 3);
+  });
+});
+
+describe("median", () => {
+  test("odd count returns the middle value unchanged", () => {
+    assert.equal(median([0.04, 0.05, 0.1]), 0.05);
+  });
+
+  test("even count averages the two middle values (not lower-middle)", () => {
+    // Raw, unrounded average -- callers apply their own precision helper.
+    assert.equal(median([1, 2]), 1.5);
+    assert.equal(median([0.25, 0.75]), 0.5);
+    assert.equal(median([1, 2, 4, 8]), 3);
+  });
+
+  test("single-element array returns that element", () => {
+    assert.equal(median([42]), 42);
+  });
+
+  test("empty array returns null, not undefined", () => {
+    assert.equal(median([]), null);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates the 16 copy-pasted, behaviorally-divergent `percentile()`/`median()` implementations across the chain-*/subnet-*/blocks-summary analytics family into one canonical, fully-guarded shared module, `src/lib/stats.ts`, standardized on `subnet-yield.ts`'s variant (empty-array-safe `null` return, both rank bounds clamped so `p=0` returns the minimum instead of indexing `arr[-1]` → `undefined`).

Closes #8178

## What changed

- **New `src/lib/stats.ts`** — canonical nearest-rank `percentile()` and conventional `median()`, both returning the raw statistic (`number | null`, `null` on an empty array). Precision stays a caller concern.
- **All 16 files** (`chain-alpha-volume`, `chain-axon-removals`, `chain-deregistrations`, `chain-performance`, `chain-prometheus`, `chain-registrations`, `chain-serving`, `chain-stake-flow`, `chain-stake-moves`, `chain-stake-transfers`, `chain-turnover`, `chain-weights`, `chain-yield`, `subnet-performance`, `subnet-yield`, `blocks-summary`) now import from the shared module; every local `percentile()`/`median()` definition is deleted.
- **Each call site's own rounding stays at the call site**, exactly as before: the eleven "unguarded-variant" files keep their `roundUnit`/`round`/`roundTao` on the median (they always rounded, odd and even counts alike); `chain-yield`/`subnet-yield` keep `round9`; `subnet-performance`'s `scoreMedian` keeps `round`; `blocks-summary`/`chain-performance` keep `roundMs`/`round` on percentiles.
- Call sites that run strictly after a `count === 0` short-circuit assert the non-null result (`!`) with a comment; call sites that can legitimately see an empty set (`subnet-yield`'s `median_yield`, `neuron-history`'s `alpha_price_tao_median`) preserve `null` via tiny named wrappers (`yieldMedian`, `priceMedian`) that keep the module's own rounding.
- **`src/neuron-history.ts`** (one file beyond the issue's 16): its top-level `function median(...)` would have kept the issue's falsifiable check — `grep -rn "^function percentile\|^function median" src/*.ts` returning zero matches — from passing, so its copy is consolidated onto the shared `median()` too (renamed wrapper `priceMedian`, identical behavior incl. the `roundPrice` precision and `null` on empty).
- **New `tests/stats.test.ts`** — direct unit tests for the shared functions covering exactly the drift-fixed edge cases: `p=0` → minimum (not `undefined`), `p=100` → maximum, out-of-range `p` clamping, single-element arrays, and empty arrays → `null`, plus the family's nearest-rank interior-percentile and even-count-average median conventions.

## Behavioral equivalence

Provably no change for every currently-exercised call:

- All three legacy percentile variants compute the same index for every `p` actually used today (10/25/50/75/90/95/99 on non-empty arrays): `ceil(p·n/100)` clamped only differs from the shared form at `p ≤ 0` (previously `undefined`) / `p > 100`.
- All legacy median variants reduce to the same floor/ceil-average around `floor(n/2)`; where a file rounded internally, the identical rounder now wraps the shared call. For `chain-yield`/`subnet-yield` (which only rounded the even-count average), every element is already `round9`-precision, so rounding the raw median is the identity for odd counts and matches the old rounding for even counts.
- The fix only changes behavior for the previously-unreachable `p=0`/`p=100`/empty-array edge cases (now correct boundary values / `null` instead of `undefined`).

## Verification

- `grep -rn "^function percentile\|^function median" src/*.ts` → zero matches (the shared module lives in `src/lib/`).
- All 460 existing tests in the 18 affected suites pass unchanged; full `vitest run` green (494 files / 12,181 tests).
- `npx tsc --noEmit`, `npx eslint` and `npx prettier --check` clean on every touched file.
- Every instrumented line added in `src/**` is exercised by tests (patch coverage 100% of coverable added lines).
