### PR TITLE
fix(postgres): add observed_at-ordered extrinsics indexes for signer + call_module scans

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -75,6 +75,27 @@ CREATE INDEX IF NOT EXISTS idx_extrinsics_signer_block
 -- #2082 sibling: extrinsics-feed call_module/call_function/success filters.
 CREATE INDEX IF NOT EXISTS idx_extrinsics_call
   ON extrinsics (call_module, call_function, success, block_number DESC);
+-- #8175: the /accounts/{ss58}/extrinsics feed and the account-summary
+-- tx-count/module-mix aggregates all lead their ORDER BY with observed_at
+-- (hypertable chunk exclusion), which idx_extrinsics_signer_block above
+-- (block_number-led tail) can't satisfy without a per-chunk Sort of the
+-- signer's ENTIRE matching set -- the same "index doesn't match this
+-- ORDER BY" class fixed for account_events by idx_ae_hotkey_observed/
+-- idx_ae_coldkey_observed (#8153/#8154; see that comment block for why
+-- the full 4-column key is required -- observed_at is a per-flush batch
+-- timestamp, so the block_number/extrinsic_index tiebreak columns must be
+-- in the index too). idx_extrinsics_signer_block stays: it still backs the
+-- block_start/block_end-range variants of the same routes.
+CREATE INDEX IF NOT EXISTS idx_extrinsics_signer_observed
+  ON extrinsics (signer, observed_at DESC, block_number DESC, extrinsic_index DESC);
+-- #8176: same class one level down -- /api/v1/sudo and
+-- /api/v1/governance/config-changes filter by a fixed call_module with the
+-- same observed_at-leading ORDER BY, which idx_extrinsics_call above
+-- (call_function/success/block_number tail) can't back either.
+-- idx_extrinsics_call stays for the general extrinsics-feed
+-- call_module/call_function/success filter combinations.
+CREATE INDEX IF NOT EXISTS idx_extrinsics_call_observed
+  ON extrinsics (call_module, observed_at DESC, block_number DESC, extrinsic_index DESC);
 
 CREATE TABLE IF NOT EXISTS account_events (
   block_number     BIGINT NOT NULL,


### PR DESCRIPTION
Closes #8175. Closes #8176.

Adds the two `observed_at`-leading composite indexes both issues specify, following the exact `account_events` precedent (#8153/#8154):

- `idx_extrinsics_signer_observed (signer, observed_at DESC, block_number DESC, extrinsic_index DESC)` — backs `GET /api/v1/accounts/{ss58}/extrinsics` and the account-summary tx-count/module-mix aggregate scans.
- `idx_extrinsics_call_observed (call_module, observed_at DESC, block_number DESC, extrinsic_index DESC)` — backs `GET /api/v1/sudo` and `GET /api/v1/governance/config-changes`.

Both pre-existing indexes stay in place, per each issue's own requirement: `idx_extrinsics_signer_block` still backs the `block_start`/`block_end`-range variants (block_number-leading predicate), and `idx_extrinsics_call` still backs the general extrinsics-feed `call_module`/`call_function`/`success` filter combinations.

## Applied to production

Both indexes created live on the indexer box's TimescaleDB (plain `CREATE INDEX` — hypertables reject `CONCURRENTLY`, per #4832's precedent), 2026-07-26. Live catalog confirmed in sync with the committed schema:

```
 public | idx_extrinsics_call            | index | metagraphed | extrinsics
 public | idx_extrinsics_call_observed   | index | metagraphed | extrinsics
 public | idx_extrinsics_hash            | index | metagraphed | extrinsics
 public | idx_extrinsics_observed        | index | metagraphed | extrinsics
 public | idx_extrinsics_signer_block    | index | metagraphed | extrinsics
 public | idx_extrinsics_signer_observed | index | metagraphed | extrinsics
```

## EXPLAIN evidence

Representative signer = the busiest 24h signer (`5E2LP…KeZ5u`, 2,605 extrinsics/day); `call_module` verified for both `'Sudo'` and `'AdminUtils'`.

**Before** — every one of the 42 chunks got a `Sort` over its **entire** matching set (excerpt, signer feed; the sudo/AdminUtils and summary-aggregate plans had the identical shape, 42 Sort nodes each):

```
 Limit
   -> Custom Scan (ChunkAppend) on extrinsics
        Order: observed_at DESC, block_number DESC, extrinsic_index DESC
        -> Sort
             Sort Key: _hyper_2_780_chunk.observed_at DESC, ...
             -> Bitmap Heap Scan on _hyper_2_780_chunk
                  -> Bitmap Index Scan on ..._idx_extrinsics_signer_block
        -> Sort
             Sort Key: _hyper_2_770_chunk.observed_at DESC, ...
             -> Bitmap Heap Scan on _hyper_2_770_chunk (rows=2649)
        ... (x42 chunks)
```

**After** — every uncompressed chunk is a true ordered index scan on the new index, no executed Sort node anywhere; ChunkAppend early-exits at the LIMIT (`EXPLAIN ANALYZE`, signer feed):

```
 Limit  (actual time=0.382..1.649 rows=25)
   -> Custom Scan (ChunkAppend) on extrinsics  (actual time=0.057..0.329 rows=25)
        Order: observed_at DESC, block_number DESC, extrinsic_index DESC
        -> Index Scan using _hyper_2_780_chunk_idx_extrinsics_signer_observed  (actual ... rows=25)
        -> Index Scan using _hyper_2_770_chunk_idx_extrinsics_signer_observed  (never executed)
        -> Index Scan using _hyper_2_761_chunk_idx_extrinsics_signer_observed  (never executed)
        ...
```

The only remaining `Sort` nodes in any after-plan sit over `DecompressChunk` scans of **compressed** chunks (older data) — inherent to TimescaleDB compression (a btree on the hypertable can't order a compressed chunk), present identically in the before-plans, and `(never executed)` for the signer feed since the newest chunk satisfies the LIMIT.

**Measured (`EXPLAIN ANALYZE`, after):**

| Query | Execution time |
| --- | --- |
| `/accounts/{ss58}/extrinsics` feed (busiest signer) | 2.9 ms |
| account-summary tx-count/fee aggregate (LIMIT 1000 subquery) | 11.8 ms |
| `/sudo` (`call_module = 'Sudo'`) | 283.8 ms* |
| `/governance/config-changes` (`call_module = 'AdminUtils'`) | 20.3 ms |

\* Sudo rows are sparse in recent chunks, so the scan legitimately walks back into compressed chunks (decompression cost, not a Sort) — still using the new index on every uncompressed chunk.

## Verification

- Route tests unchanged and green: `tests/sudo.test.ts`, `tests/governance-config-changes.test.ts`, `tests/extrinsics.test.ts`, `tests/extrinsic-detail.test.ts`, `tests/account-routes.test.ts` (119 tests).
- Schema-only diff — no behavior change.
