### PR TITLE
refactor(api): type D-batch-1 GraphQL resolver args from generated types (#8158)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -519,11 +519,27 @@ import { SDL } from "./graphql-sdl.ts";
 // here, not the Resolver wrapper. Same class of codegen/runtime-convention
 // mismatch the epic already anticipated for the Subscription resolver.
 import type {
+  QueryAgent_CatalogArgs,
+  QueryCandidatesArgs,
   QueryEconomicsArgs,
+  QueryFixtureArgs,
+  QuerySaved_QueryArgs,
+  QuerySearchArgs,
   QuerySubnetArgs,
   QuerySubnetsArgs,
+  QuerySubnet_DeregistrationsArgs,
   QuerySubnet_HealthArgs,
+  QuerySubnet_Health_IncidentsArgs,
+  QuerySubnet_Health_PercentilesArgs,
+  QuerySubnet_Health_TrendsArgs,
+  QuerySubnet_HyperparametersArgs,
+  QuerySubnet_Hyperparameters_HistoryArgs,
+  QuerySubnet_RegistrationsArgs,
+  QuerySubnet_ServingArgs,
   QuerySubnet_Stake_QuoteArgs,
+  QuerySubnet_UptimeArgs,
+  QuerySubnet_VolumeArgs,
+  QueryTop_HoldersArgs,
 } from "../generated/graphql/types.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1662,11 +1678,16 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batch N (types-epic D, #7862 tracks follow-up
-// batches). Only the 5 Query fields with a Zod-covered REST mirror from
-// types-epic A (subnets, subnet, subnet_health, subnet_stake_quote,
-// economics) are typed against the generated Args types below; the
-// remaining ~150 root fields on this object keep their `Row`-typed
+// Row-erased: pending D batches 2-9 (types-epic D, #7862 tracks follow-up
+// batches). The 5 pilot fields (subnets, subnet, subnet_health,
+// subnet_stake_quote, economics) plus D batch 1's 20 fields
+// (subnet_registrations, subnet_hyperparameters,
+// subnet_hyperparameters_history, subnet_deregistrations, subnet_serving,
+// subnet_health_trends, subnet_uptime, subnet_health_incidents,
+// subnet_health_percentiles, subnet_volume, agent_resources, curation,
+// candidates, saved_query, fixtures, fixture, agent_catalog, freshness,
+// top_holders, search) are typed against the generated Args types below;
+// the remaining ~130 root fields on this object keep their `Row`-typed
 // destructured params for now, adopted incrementally in later batches
 // rather than all at once here.
 const rootValue = {
@@ -1733,7 +1754,10 @@ const rootValue = {
     });
   },
 
-  async subnet_hyperparameters({ netuid }: Row, context: GqlContext) {
+  async subnet_hyperparameters(
+    { netuid }: QuerySubnet_HyperparametersArgs,
+    context: GqlContext,
+  ) {
     // Same tryPostgresTier(METAGRAPH_SUBNET_HYPERPARAMS_SOURCE) -> buildSubnetHyperparams
     // fallback contract handleSubnetHyperparams uses. The D1 write path is retired, so a
     // cold tier is an expected steady state, not an error: it yields a schema-stable card
@@ -1760,7 +1784,7 @@ const rootValue = {
   },
 
   async subnet_hyperparameters_history(
-    { netuid, limit, offset, cursor }: Row,
+    { netuid, limit, offset, cursor }: QuerySubnet_Hyperparameters_HistoryArgs,
     context: GqlContext,
   ) {
     // Same FEED_PAGINATION bounds parsePagination applies for REST, so a GraphQL
@@ -1870,7 +1894,7 @@ const rootValue = {
   // included, matching GET /api/v1/candidates. An invalid filter/sort value or a
   // cold/absent artifact throws, becoming a GraphQL error (matching the sibling
   // gaps / subnet_candidates convention), rather than a silent default.
-  candidates(args: Row, context: GqlContext) {
+  candidates(args: QueryCandidatesArgs, context: GqlContext) {
     return loadCandidatesList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -1883,7 +1907,7 @@ const rootValue = {
   // path as REST GET /api/v1/fixtures/{surface_id}. invalid_params becomes
   // BAD_USER_INPUT; any other loader miss (not_found / cold R2) resolves to
   // null, matching adapter's cold/absent convention.
-  async fixture(args: Row, context: GqlContext) {
+  async fixture(args: QueryFixtureArgs, context: GqlContext) {
     try {
       return await loadFixture(mcpCtx(context), args, { readArtifact });
     } catch (rawErr) {
@@ -1898,7 +1922,7 @@ const rootValue = {
     }
   },
 
-  async agent_catalog({ netuid }: Row, context: GqlContext) {
+  async agent_catalog({ netuid }: QueryAgent_CatalogArgs, context: GqlContext) {
     const live = await loadLiveHealth(context);
     if (netuid == null) {
       const index = await loadArtifact(
@@ -1925,7 +1949,10 @@ const rootValue = {
     return mergeFreshness(base, meta) ?? base;
   },
 
-  async top_holders({ sort, limit }: Row, context: GqlContext) {
+  async top_holders(
+    { sort, limit }: QueryTop_HoldersArgs,
+    context: GqlContext,
+  ) {
     // Same allowlist REST enforces -- an unknown sort is BAD_USER_INPUT rather
     // than silently falling back, mirroring the route's invalid_query 400.
     if (sort != null && !TOP_HOLDERS_SORTS.includes(sort)) {
@@ -1979,7 +2006,10 @@ const rootValue = {
     };
   },
 
-  async subnet_registrations({ netuid, window }: Row, context: GqlContext) {
+  async subnet_registrations(
+    { netuid, window }: QuerySubnet_RegistrationsArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetRegistrations uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_REGISTRATIONS_WINDOW;
@@ -2017,7 +2047,10 @@ const rootValue = {
     };
   },
 
-  async subnet_deregistrations({ netuid, window }: Row, context: GqlContext) {
+  async subnet_deregistrations(
+    { netuid, window }: QuerySubnet_DeregistrationsArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetDeregistrations uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW;
@@ -2055,7 +2088,10 @@ const rootValue = {
     };
   },
 
-  async subnet_serving({ netuid, window }: Row, context: GqlContext) {
+  async subnet_serving(
+    { netuid, window }: QuerySubnet_ServingArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetServing uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_SERVING_WINDOW;
@@ -3087,7 +3123,7 @@ const rootValue = {
     return loadArtifact(context, "/metagraph/registry-summary.json");
   },
 
-  async saved_query({ id, params }: Row, context: GqlContext) {
+  async saved_query({ id, params }: QuerySaved_QueryArgs, context: GqlContext) {
     // #7642: the same maintainer-curated template executor the REST route and
     // run_saved_query MCP tool share (src/saved-queries.ts) -- template
     // lookup, param coercion/validation, and execution are all its. Its
@@ -3095,7 +3131,10 @@ const rootValue = {
     // BAD_USER_INPUT, matching this file's invalid-argument convention; any
     // other executor failure surfaces as a normal GraphQL error.
     try {
-      return await runSavedQuery(context.env, id, params ?? {});
+      // params is the JSON scalar (unknown); runSavedQuery's Row param is the
+      // same "read for template-defined coercion, never trusted for control
+      // flow" contract as every other opaque-JSON boundary in this file.
+      return await runSavedQuery(context.env, id, (params ?? {}) as Row);
     } catch (rawErr) {
       const err = rawErr as Row;
       if (
@@ -3378,7 +3417,7 @@ const rootValue = {
   // list-query transforms REST and MCP already apply -- so the GraphQL search
   // field cannot drift from them. An unsupported filter/sort or a cold artifact
   // is a GraphQL error, matching source_snapshots/evidence/profiles.
-  search(args: Row, context: GqlContext) {
+  search(args: QuerySearchArgs, context: GqlContext) {
     return loadSearchList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3484,7 +3523,7 @@ const rootValue = {
     return loadArtifact(context, "/metagraph/coverage-depth.json");
   },
 
-  async subnet_volume({ netuid }: Row, context: GqlContext) {
+  async subnet_volume({ netuid }: QuerySubnet_VolumeArgs, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -3637,7 +3676,7 @@ const rootValue = {
   },
 
   async subnet_health_percentiles(
-    { netuid, window }: Row,
+    { netuid, window }: QuerySubnet_Health_PercentilesArgs,
     context: GqlContext,
   ) {
     // Reuse the exact analyticsWindow parse/validate REST's percentiles handler
@@ -3916,7 +3955,10 @@ const rootValue = {
     }
   },
 
-  async subnet_health_incidents({ netuid, window }: Row, context: GqlContext) {
+  async subnet_health_incidents(
+    { netuid, window }: QuerySubnet_Health_IncidentsArgs,
+    context: GqlContext,
+  ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleHealthIncidents
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
     // BAD_USER_INPUT error, not a silent empty result.
@@ -6752,7 +6794,10 @@ const rootValue = {
     };
   },
 
-  async subnet_health_trends({ netuid }: Row, context: GqlContext) {
+  async subnet_health_trends(
+    { netuid }: QuerySubnet_Health_TrendsArgs,
+    context: GqlContext,
+  ) {
     // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadSubnetHealthTrends D1
     // fallback contract REST's handleHealthTrends and the
     // get_subnet_health_trends MCP tool share -- the route takes no window arg
@@ -6878,7 +6923,7 @@ const rootValue = {
   },
 
   async subnet_uptime(
-    { netuid, window, min_samples: minSamples }: Row,
+    { netuid, window, min_samples: minSamples }: QuerySubnet_UptimeArgs,
     context: GqlContext,
   ) {
     // Same 90d/1y window validation handleUptime / get_subnet_uptime use -- an


### PR DESCRIPTION
Closes #8158.

Converts this batch's 20 `Query` root fields from `Row`-typed `args`/`context` to the generated `Query<Field>Args` types, following PR #8005's pilot process exactly (see that PR for the codegen mechanism / calling-convention rationale).

## Fields converted (20)

`subnet_registrations`, `subnet_hyperparameters`, `subnet_hyperparameters_history`, `subnet_deregistrations`, `subnet_serving`, `subnet_health_trends`, `subnet_uptime`, `subnet_health_incidents`, `subnet_health_percentiles`, `subnet_volume`, `agent_resources`, `curation`, `candidates`, `saved_query`, `fixtures`, `fixture`, `agent_catalog`, `freshness`, `top_holders`, `search`.

4 of these (`agent_resources`, `curation`, `fixtures`, `freshness`) take zero SDL arguments, so `@graphql-codegen` never generates an `Args` type for them — their resolvers already used `_args: unknown` rather than `Row`, so there was nothing to change beyond removing them from the pending-batch note at the `rootValue` declaration.

## Step 2: checked every resolver for a real SDL/resolver mismatch

Read every non-argless resolver body against its SDL definition in `src/graphql-sdl.ts`. Found zero mismatches — every destructured parameter name and nullability matches its generated `Query<Field>Args` type exactly.

One cast was needed, not a mismatch: `saved_query`'s SDL `params: JSON` types as `unknown` post-conversion (the `JSON` scalar maps to `unknown`), but the shared `runSavedQuery` executor (`src/saved-queries.ts`, also used by REST/MCP) takes a concrete `Row`. Cast at the call site (`(params ?? {}) as Row`) with a comment explaining why — same "opaque JSON boundary" convention as every other `Row`-adjacent cast in this file, not a behavior change.

## Instrumentation

No new error-tracking instrumentation needed. GraphQL resolver faults are already captured for every field, argless or not, at the single `execute()` boundary (`recordExceptionEvent`, `route: "graphql"`, `errorCode: "graphql_execution_error"` — see the comment above that call in `src/graphql.ts`). This PR is a pure argument-typing change with zero control-flow changes, so that existing coverage applies unchanged.

## Verification

- `npx tsc --noEmit` clean, repo-wide.
- `node scripts/validate-graphql-types-drift.ts` — generated types still current, no drift.
- `npx eslint src/graphql.ts` / `npx prettier --check src/graphql.ts` clean.
- `tests/graphql.test.ts`, `tests/chain-firehose-hub.test.ts`, `tests/chain-firehose-routes.test.ts`, `tests/pipeline-validator-parity.test.ts` — all passing, assertions unchanged.
- `tests/zod-schemas.test.ts` has 5 pre-existing failing assertions (routes 404 against the local artifact test env) — confirmed via `git stash` that these fail identically on `origin/main` with none of this PR's changes applied, so they are unrelated and pre-existing. Flagged separately (not fixed here, to keep this PR's scope to the batch-1 typing change only, per this issue's own non-goals).
