### PR TITLE
refactor(api): type D-batch-2 GraphQL resolver args from generated types (#8159)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -519,11 +519,28 @@ import { SDL } from "./graphql-sdl.ts";
 // here, not the Resolver wrapper. Same class of codegen/runtime-convention
 // mismatch the epic already anticipated for the Subscription resolver.
 import type {
+  QueryCompare_ValidatorsArgs,
+  QueryDomain_SummaryArgs,
   QueryEconomicsArgs,
+  QuerySearch_IndexArgs,
   QuerySubnetArgs,
   QuerySubnetsArgs,
+  QuerySubnet_Axon_RemovalsArgs,
+  QuerySubnet_CandidatesArgs,
+  QuerySubnet_EndpointsArgs,
+  QuerySubnet_EvidenceArgs,
+  QuerySubnet_Event_SummaryArgs,
+  QuerySubnet_EventsArgs,
+  QuerySubnet_GapsArgs,
   QuerySubnet_HealthArgs,
+  QuerySubnet_Idle_StakeArgs,
+  QuerySubnet_OhlcArgs,
+  QuerySubnet_Stake_FlowArgs,
+  QuerySubnet_Stake_MovesArgs,
   QuerySubnet_Stake_QuoteArgs,
+  QuerySubnet_Stake_TransfersArgs,
+  QuerySubnet_ValidatorsArgs,
+  QuerySubnet_WeightsArgs,
 } from "../generated/graphql/types.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1662,13 +1679,20 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batch N (types-epic D, #7862 tracks follow-up
-// batches). Only the 5 Query fields with a Zod-covered REST mirror from
-// types-epic A (subnets, subnet, subnet_health, subnet_stake_quote,
-// economics) are typed against the generated Args types below; the
-// remaining ~150 root fields on this object keep their `Row`-typed
-// destructured params for now, adopted incrementally in later batches
-// rather than all at once here.
+// Row-erased: pending D batches 1, 3-9 (types-epic D, #7862 tracks
+// follow-up batches -- this note reflects only this PR's own base commit;
+// batch 1 (#8158) is a separate not-yet-merged PR touching this same
+// region). The 5 pilot fields (subnets, subnet, subnet_health,
+// subnet_stake_quote, economics) plus D batch 2's 20 fields (search_index,
+// domains, domain_summary, compare_validators, coverage, coverage_depth,
+// subnet_ohlc, subnet_validators, subnet_event_summary, subnet_gaps,
+// subnet_evidence, subnet_candidates, subnet_endpoints,
+// subnet_axon_removals, subnet_weights, subnet_stake_moves,
+// subnet_stake_transfers, subnet_idle_stake, subnet_stake_flow,
+// subnet_events) are typed against the generated Args types below; the
+// remaining root fields on this object keep their `Row`-typed destructured
+// params for now, adopted incrementally in later batches rather than all
+// at once here.
 const rootValue = {
   subnets(
     {
@@ -2093,7 +2117,10 @@ const rootValue = {
     };
   },
 
-  async subnet_axon_removals({ netuid, window }: Row, context: GqlContext) {
+  async subnet_axon_removals(
+    { netuid, window }: QuerySubnet_Axon_RemovalsArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetAxonRemovals uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
@@ -2523,7 +2550,10 @@ const rootValue = {
     };
   },
 
-  async subnet_weights({ netuid, window }: Row, context: GqlContext) {
+  async subnet_weights(
+    { netuid, window }: QuerySubnet_WeightsArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetWeights uses -- an unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_WEIGHTS_WINDOW;
@@ -2561,7 +2591,10 @@ const rootValue = {
     };
   },
 
-  async subnet_stake_moves({ netuid, window }: Row, context: GqlContext) {
+  async subnet_stake_moves(
+    { netuid, window }: QuerySubnet_Stake_MovesArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetStakeMoves uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_STAKE_MOVES_WINDOW;
@@ -2599,7 +2632,10 @@ const rootValue = {
     };
   },
 
-  async subnet_stake_transfers({ netuid, window }: Row, context: GqlContext) {
+  async subnet_stake_transfers(
+    { netuid, window }: QuerySubnet_Stake_TransfersArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetStakeTransfers uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
@@ -2637,7 +2673,10 @@ const rootValue = {
     };
   },
 
-  async subnet_idle_stake({ netuid }: Row, context: GqlContext) {
+  async subnet_idle_stake(
+    { netuid }: QuerySubnet_Idle_StakeArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2664,7 +2703,7 @@ const rootValue = {
   },
 
   async subnet_stake_flow(
-    { netuid, window, direction }: Row,
+    { netuid, window, direction }: QuerySubnet_Stake_FlowArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -2721,7 +2760,14 @@ const rootValue = {
   },
 
   async subnet_events(
-    { netuid, kind, block_start, block_end, limit, offset }: Row,
+    {
+      netuid,
+      kind,
+      block_start,
+      block_end,
+      limit,
+      offset,
+    }: QuerySubnet_EventsArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -3387,7 +3433,7 @@ const rootValue = {
   // limit/cursor validation and filtering are all handled by the loader --
   // an invalid arg throws and becomes a GraphQL error, matching every other
   // filtered field's convention (search/source_snapshots/evidence/profiles).
-  search_index(args: Row, context: GqlContext) {
+  search_index(args: QuerySearch_IndexArgs, context: GqlContext) {
     return loadSearchIndexList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3401,7 +3447,7 @@ const rootValue = {
     return buildDomainOverview(subnetRows, economicsRows);
   },
 
-  async domain_summary({ tag }: Row, context: GqlContext) {
+  async domain_summary({ tag }: QueryDomain_SummaryArgs, context: GqlContext) {
     // The same fixed 14-tag enum ?domain= validates on subnets -- an unknown
     // tag is a GraphQL BAD_USER_INPUT error, not an empty rollup.
     if (!DOMAIN_TAGS.includes(tag)) {
@@ -3416,7 +3462,10 @@ const rootValue = {
     return buildDomainSummary(tag, subnetRows, economicsRows);
   },
 
-  async compare_validators({ hotkeys, netuid }: Row, context: GqlContext) {
+  async compare_validators(
+    { hotkeys, netuid }: QueryCompare_ValidatorsArgs,
+    context: GqlContext,
+  ) {
     // Same parse/validate contract the REST route + compare_validators MCP
     // tool share: 1..COMPARE_VALIDATORS_MAX distinct SS58 addresses.
     const parsed = parseCompareHotkeyList(hotkeys);
@@ -3528,7 +3577,10 @@ const rootValue = {
     };
   },
 
-  async subnet_ohlc({ netuid, interval, days }: Row, context: GqlContext) {
+  async subnet_ohlc(
+    { netuid, interval, days }: QuerySubnet_OhlcArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -3611,7 +3663,10 @@ const rootValue = {
     return { schema_version: 1, ...result.quote };
   },
 
-  async subnet_validators({ netuid }: Row, context: GqlContext) {
+  async subnet_validators(
+    { netuid }: QuerySubnet_ValidatorsArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -3687,7 +3742,7 @@ const rootValue = {
   },
 
   async subnet_event_summary(
-    { netuid, window, limit }: Row,
+    { netuid, window, limit }: QuerySubnet_Event_SummaryArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -3748,7 +3803,7 @@ const rootValue = {
     };
   },
 
-  async subnet_gaps(args: Row, context: GqlContext) {
+  async subnet_gaps(args: QuerySubnet_GapsArgs, context: GqlContext) {
     const { netuid } = args;
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
@@ -3812,7 +3867,7 @@ const rootValue = {
     };
   },
 
-  async subnet_evidence(args: Row, context: GqlContext) {
+  async subnet_evidence(args: QuerySubnet_EvidenceArgs, context: GqlContext) {
     const { netuid } = args;
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
@@ -3847,7 +3902,10 @@ const rootValue = {
     }
   },
 
-  async subnet_candidates(args: Row, context: GqlContext) {
+  async subnet_candidates(
+    args: QuerySubnet_CandidatesArgs,
+    context: GqlContext,
+  ) {
     const { netuid } = args;
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
@@ -3894,7 +3952,7 @@ const rootValue = {
   // GraphQL error, matching the subnet_candidates sibling's convention. A cold/
   // absent per-subnet artifact stays null (the documented per-subnet contract),
   // never a silently substituted empty list.
-  async subnet_endpoints(args: Row, context: GqlContext) {
+  async subnet_endpoints(args: QuerySubnet_EndpointsArgs, context: GqlContext) {
     try {
       return await loadSubnetEndpointsList(mcpCtx(context), args, {
         readArtifact,


### PR DESCRIPTION
Closes #8159.

Converts this batch's 20 `Query` root fields from `Row`-typed `args`/`context` to the generated `Query<Field>Args` types, following PR #8005/#8194's established process.

## Fields converted (20)

`search_index`, `domains`, `domain_summary`, `compare_validators`, `coverage`, `coverage_depth`, `subnet_ohlc`, `subnet_validators`, `subnet_event_summary`, `subnet_gaps`, `subnet_evidence`, `subnet_candidates`, `subnet_endpoints`, `subnet_axon_removals`, `subnet_weights`, `subnet_stake_moves`, `subnet_stake_transfers`, `subnet_idle_stake`, `subnet_stake_flow`, `subnet_events`.

3 of these (`domains`, `coverage`, `coverage_depth`) take zero SDL arguments, so `@graphql-codegen` never generates an `Args` type for them — their resolvers already used `_args: unknown` rather than `Row`, so there was nothing to change beyond removing them from the pending-batch note.

## Step 2: checked every resolver for a real SDL/resolver mismatch

Read every non-argless resolver body against its SDL definition in `src/graphql-sdl.ts`. Found zero mismatches. Four fields (`search_index`, `subnet_evidence`, `subnet_candidates`, `subnet_endpoints`) forward the whole `args` object straight into a shared loader (`loadSearchIndexList`, `loadSubnetEvidenceList`, `loadSubnetCandidatesList`, `loadSubnetEndpointsList`); all four loaders' own parameter type is `Record<string, unknown> | null | undefined`, so the generated Args types are structurally assignable with no cast needed.

## Instrumentation

No new error-tracking instrumentation needed, same rationale as PR #8194: GraphQL resolver faults are captured for every field at the single `execute()` call site in `src/graphql.ts` (`recordExceptionEvent`, route "graphql") regardless of argument typing. This PR is a pure argument-typing change with zero control-flow changes.

## Note on this PR's base

This branch was cut from `origin/main` before batch 1 (#8158, PR #8194) merged, so the `// Row-erased: pending D batch...` comment and `import type { ... }` block in this diff reflect only batches 2 + the pilot as "done" — batch 1's own additions to that same region will need a straightforward manual merge (both sides purely append names/imports, no logic conflict) whenever these land in whatever order.

## Verification

- `npx tsc --noEmit` clean, repo-wide.
- `node scripts/validate-graphql-types-drift.ts` — generated types current, no drift.
- `npx eslint src/graphql.ts` / `npx prettier --check src/graphql.ts` clean.
- `tests/graphql.test.ts` (1022), `tests/chain-firehose-hub.test.ts` (126), `tests/chain-firehose-routes.test.ts` (15), `tests/pipeline-validator-parity.test.ts` (2) — all 1165 passing, assertions unchanged.
