### PR TITLE
refactor(api): type D-batch-4 GraphQL resolver args from generated types (#8161)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -520,6 +520,22 @@ import { SDL } from "./graphql-sdl.ts";
 // mismatch the epic already anticipated for the Subscription resolver.
 import type {
   QueryEconomicsArgs,
+  QueryEndpointsArgs,
+  QueryEndpoint_IncidentsArgs,
+  QueryEndpoint_PoolsArgs,
+  QueryEvidenceArgs,
+  QueryGapsArgs,
+  QueryProfilesArgs,
+  QueryProvider_EndpointsArgs,
+  QueryReview_Adapter_CandidatesArgs,
+  QueryReview_Enrichment_EvidenceArgs,
+  QueryReview_Enrichment_QueueArgs,
+  QueryReview_Enrichment_TargetsArgs,
+  QueryReview_GapsArgs,
+  QueryReview_Profile_CompletenessArgs,
+  QueryRpc_EndpointsArgs,
+  QueryRpc_PoolsArgs,
+  QuerySource_SnapshotsArgs,
   QuerySubnetArgs,
   QuerySubnetsArgs,
   QuerySubnet_HealthArgs,
@@ -1663,12 +1679,18 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
 }
 
 // Row-erased: pending D batch N (types-epic D, #7862 tracks follow-up
-// batches). Only the 5 Query fields with a Zod-covered REST mirror from
-// types-epic A (subnets, subnet, subnet_health, subnet_stake_quote,
-// economics) are typed against the generated Args types below; the
-// remaining ~150 root fields on this object keep their `Row`-typed
-// destructured params for now, adopted incrementally in later batches
-// rather than all at once here.
+// batches). The 5 pilot fields (subnets, subnet, subnet_health,
+// subnet_stake_quote, economics) plus D-batch-4's 20 fields (endpoints,
+// provider_endpoints, endpoint_pools, rpc_pools, endpoint_incidents,
+// source_snapshots, gaps, evidence, profiles, review_adapter_candidates,
+// review_enrichment_evidence, review_enrichment_queue,
+// review_enrichment_targets, review_gaps, review_profile_completeness,
+// registry_summary, schemas, source_health, lineage, rpc_endpoints) are typed
+// against the generated Args types below. This note reflects only this PR's
+// own base commit; batches 1-3 (#8158, #8159, #8160) are separate,
+// not-yet-merged PRs touching this same region. The remaining root fields on
+// this object keep their `Row`-typed destructured params for now, adopted
+// incrementally in later batches rather than all at once here.
 const rootValue = {
   subnets(
     {
@@ -3001,7 +3023,7 @@ const rootValue = {
     });
   },
 
-  endpoints(args: Row, context: GqlContext) {
+  endpoints(args: QueryEndpointsArgs, context: GqlContext) {
     return loadEndpointsPage(context, args);
   },
 
@@ -3012,7 +3034,7 @@ const rootValue = {
   // that throw becomes a GraphQL error, matching endpoint_pools/gaps' "an
   // unsupported filter/sort is a GraphQL error, not a silently substituted
   // default" convention.
-  provider_endpoints(args: Row, context: GqlContext) {
+  provider_endpoints(args: QueryProvider_EndpointsArgs, context: GqlContext) {
     return loadProviderEndpointsList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3024,11 +3046,11 @@ const rootValue = {
   // executor surfaces as a normal GraphQL error, matching every other field's
   // "an unsupported filter/sort is a GraphQL error, not a silently substituted
   // default" convention.
-  endpoint_pools(args: Row, context: GqlContext) {
+  endpoint_pools(args: QueryEndpoint_PoolsArgs, context: GqlContext) {
     return loadEndpointPoolsList(mcpCtx(context), args, { readArtifact });
   },
 
-  rpc_pools(args: Row, context: GqlContext) {
+  rpc_pools(args: QueryRpc_PoolsArgs, context: GqlContext) {
     // rpc-pools' loader additionally reads ctx.readHealthKv for its live
     // 15-minute cron eligibility overlay (rpc-pools-mcp.ts) -- graphql.mjs's
     // own context has no such property, so it's supplied here from the same
@@ -3042,7 +3064,7 @@ const rootValue = {
     );
   },
 
-  endpoint_incidents(args: Row, context: GqlContext) {
+  endpoint_incidents(args: QueryEndpoint_IncidentsArgs, context: GqlContext) {
     return loadEndpointIncidentsList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3052,7 +3074,7 @@ const rootValue = {
   // as a normal GraphQL error, matching every other field's "an unsupported
   // filter/sort is a GraphQL error, not a silently substituted default"
   // convention.
-  source_snapshots(args: Row, context: GqlContext) {
+  source_snapshots(args: QuerySource_SnapshotsArgs, context: GqlContext) {
     return loadSourceSnapshotsList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3061,11 +3083,11 @@ const rootValue = {
   // error, matching source_snapshots' "unsupported filter/sort is a GraphQL
   // error, not a silently substituted default" convention. A cold/absent
   // artifact is likewise a GraphQL error (matching REST/MCP not_found).
-  gaps(args: Row, context: GqlContext) {
+  gaps(args: QueryGapsArgs, context: GqlContext) {
     return loadGapsList(mcpCtx(context), args, { readArtifact });
   },
 
-  evidence(args: Row, context: GqlContext) {
+  evidence(args: QueryEvidenceArgs, context: GqlContext) {
     return loadEvidenceList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3074,7 +3096,7 @@ const rootValue = {
   // (not a throw) -- this file's own loadArtifact(context, path) already has
   // exactly that shape (readArtifact(context.env, path), null if not ok), so
   // it's reused directly rather than adding a redundant wrapper.
-  profiles(args: Row, context: GqlContext) {
+  profiles(args: QueryProfilesArgs, context: GqlContext) {
     return loadProfilesList(mcpCtx(context), args, {
       readOptionalArtifact: loadArtifact as AnyFn,
     });
@@ -3120,7 +3142,7 @@ const rootValue = {
     return loadArtifact(context, "/metagraph/lineage.json");
   },
 
-  rpc_endpoints(args: Row, context: GqlContext) {
+  rpc_endpoints(args: QueryRpc_EndpointsArgs, context: GqlContext) {
     // #7886: reuse loadRpcEndpointsList — same live 15-minute cron overlay +
     // endpoints-collection list-query transforms REST applies. The loader
     // validates its own args and throws on an invalid filter/sort or a cold
@@ -3177,29 +3199,44 @@ const rootValue = {
   // filter/sort is a GraphQL error, not a silently substituted default"
   // convention. A cold/missing artifact is also a GraphQL error (matches
   // REST 404 / MCP not_found); an empty filtered page is a success with total 0.
-  review_adapter_candidates(args: Row, context: GqlContext) {
+  review_adapter_candidates(
+    args: QueryReview_Adapter_CandidatesArgs,
+    context: GqlContext,
+  ) {
     return loadAdapterCandidatesList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_evidence(args: Row, context: GqlContext) {
+  review_enrichment_evidence(
+    args: QueryReview_Enrichment_EvidenceArgs,
+    context: GqlContext,
+  ) {
     return loadEnrichmentEvidenceList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_queue(args: Row, context: GqlContext) {
+  review_enrichment_queue(
+    args: QueryReview_Enrichment_QueueArgs,
+    context: GqlContext,
+  ) {
     return loadEnrichmentQueueList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_targets(args: Row, context: GqlContext) {
+  review_enrichment_targets(
+    args: QueryReview_Enrichment_TargetsArgs,
+    context: GqlContext,
+  ) {
     return loadReviewEnrichmentTargetsList(mcpCtx(context), args, {
       readArtifact,
     });
   },
 
-  review_gaps(args: Row, context: GqlContext) {
+  review_gaps(args: QueryReview_GapsArgs, context: GqlContext) {
     return loadReviewGapsList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_profile_completeness(args: Row, context: GqlContext) {
+  review_profile_completeness(
+    args: QueryReview_Profile_CompletenessArgs,
+    context: GqlContext,
+  ) {
     return loadProfileCompletenessList(mcpCtx(context), args, { readArtifact });
   },
 


### PR DESCRIPTION
Closes #8161.

Converts this batch's 20 `Query` root fields from `Row`-typed `args`/`context` to the generated `Query<Field>Args` types, following PR #8005/#8194/#8195/#8196's established process.

## Fields converted (20)

`endpoints`, `provider_endpoints`, `endpoint_pools`, `rpc_pools`, `endpoint_incidents`, `source_snapshots`, `gaps`, `evidence`, `profiles`, `review_adapter_candidates`, `review_enrichment_evidence`, `review_enrichment_queue`, `review_enrichment_targets`, `review_gaps`, `review_profile_completeness`, `registry_summary`, `schemas`, `source_health`, `lineage`, `rpc_endpoints`.

4 of these (`registry_summary`, `schemas`, `source_health`, `lineage`) take zero SDL arguments, so `@graphql-codegen` never generates an `Args` type for them — their resolvers already used `_args: unknown` rather than `Row`, so there was nothing to change beyond removing them from the pending-batch note.

## Step 2: checked every resolver for a real SDL/resolver mismatch

Read every non-argless resolver body against its SDL definition in `src/graphql-sdl.ts`. Found zero mismatches. All 16 non-argless fields forward their whole `args` object straight into a shared MCP loader (`loadEndpointsPage`, `loadProviderEndpointsList`, `loadEndpointPoolsList`, `loadRpcPoolsList`, `loadEndpointIncidentsList`, `loadSourceSnapshotsList`, `loadGapsList`, `loadEvidenceList`, `loadProfilesList`, `loadRpcEndpointsList`, and the five `review_*` loaders); every one of those loaders' own parameter type is `Row`/`Record<string, unknown> | null | undefined`, so the generated Args types are structurally assignable with no cast needed — same pattern as batches 2 and 3's shared-loader fields.

## Instrumentation

No new error-tracking instrumentation needed, same rationale as PRs #8194/#8195/#8196: GraphQL resolver faults are captured for every field at the single `execute()` call site in `src/graphql.ts` (`recordExceptionEvent`, route "graphql") regardless of argument typing. This PR is a pure argument-typing change with zero control-flow changes.

## Note on this PR's base

This branch was cut fresh from `origin/main`, before batches 1-3 (#8158/#8194, #8159/#8195, #8160/#8196) merged, so the `// Row-erased: pending D batch...` comment and `import type { ... }` block in this diff reflect only batch 4 + the pilot as "done" — batches 1-3's own additions to that same region will need a straightforward manual merge (all sides purely append names/imports, no logic conflict) whenever these land in whatever order.

## Verification

- `npx tsc --noEmit` clean, repo-wide.
- `node scripts/validate-graphql-types-drift.ts` — generated types current, no drift.
- `npx eslint src/graphql.ts` / `npx prettier --check src/graphql.ts` clean.
- `tests/graphql.test.ts` (1022), `tests/chain-firehose-hub.test.ts` (126), `tests/chain-firehose-routes.test.ts` (15), `tests/pipeline-validator-parity.test.ts` (2) — all 1165 passing, assertions unchanged.
