### PR TITLE
refactor(api): type D-batches 2-9 GraphQL resolver args from generated types (#8159-#8166)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -550,6 +550,8 @@ import type {
   QueryBlock_ExtrinsicsArgs,
   QueryCandidatesArgs,
   QueryChain_ActivityArgs,
+  QueryChain_Alpha_VolumeArgs,
+  QueryChain_Axon_RemovalsArgs,
   QueryChain_CallsArgs,
   QueryChain_DeregistrationsArgs,
   QueryChain_EventsArgs,
@@ -559,7 +561,14 @@ import type {
   QueryChain_PrometheusArgs,
   QueryChain_RegistrationsArgs,
   QueryChain_ServingArgs,
+  QueryChain_SignersArgs,
+  QueryChain_Stake_FlowArgs,
+  QueryChain_Stake_MovesArgs,
+  QueryChain_Stake_TransfersArgs,
+  QueryChain_Transfer_PairsArgs,
+  QueryChain_TransfersArgs,
   QueryChain_TurnoverArgs,
+  QueryChain_Weight_SettersArgs,
   QueryChain_WeightsArgs,
   QueryCompareArgs,
   QueryCompare_ValidatorsArgs,
@@ -594,15 +603,18 @@ import type {
   QueryRegistry_LeaderboardsArgs,
   QueryRpc_EndpointsArgs,
   QueryRpc_PoolsArgs,
+  QueryRpc_UsageArgs,
   QuerySaved_QueryArgs,
   QuerySearchArgs,
   QuerySearch_IndexArgs,
   QuerySource_SnapshotsArgs,
   QuerySubnetArgs,
   QuerySubnet_Axon_RemovalsArgs,
+  QuerySubnet_BurnArgs,
   QuerySubnet_CandidatesArgs,
   QuerySubnet_ConcentrationArgs,
   QuerySubnet_Concentration_HistoryArgs,
+  QuerySubnet_ConvictionArgs,
   QuerySubnet_DeregistrationsArgs,
   QuerySubnet_EndpointsArgs,
   QuerySubnet_Event_SummaryArgs,
@@ -621,11 +633,13 @@ import type {
   QuerySubnet_MetagraphArgs,
   QuerySubnet_MoversArgs,
   QuerySubnet_OhlcArgs,
+  QuerySubnet_Ownership_HistoryArgs,
   QuerySubnet_OverviewArgs,
   QuerySubnet_PerformanceArgs,
   QuerySubnet_Performance_HistoryArgs,
   QuerySubnet_ProfileArgs,
   QuerySubnet_PrometheusArgs,
+  QuerySubnet_RecycledArgs,
   QuerySubnet_RegistrationsArgs,
   QuerySubnet_ServingArgs,
   QuerySubnet_Stake_FlowArgs,
@@ -633,6 +647,7 @@ import type {
   QuerySubnet_Stake_QuoteArgs,
   QuerySubnet_Stake_TransfersArgs,
   QuerySubnet_TrajectoryArgs,
+  QuerySubnet_TurnoverArgs,
   QuerySubnet_UptimeArgs,
   QuerySubnet_ValidatorsArgs,
   QuerySubnet_VolumeArgs,
@@ -1785,12 +1800,12 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batches 8-9 (types-epic D, #7862 tracks follow-up
+// Row-erased: pending D batch 9 (types-epic D, #7862 tracks follow-up
 // batches -- see #8158-#8166 for each batch's exact field list). The 5 pilot
-// fields plus D batches 1-7's 135 fields (#8158-#8164) are typed against the
+// fields plus D batches 1-8's 155 fields (#8158-#8165) are typed against the
 // generated Args types below; the remaining root fields on this object keep
 // their `Row`-typed destructured params for now, adopted incrementally in
-// later batches rather than all at once here.
+// the final batch rather than all at once here.
 const rootValue = {
   subnets(
     {
@@ -6477,7 +6492,10 @@ const rootValue = {
     };
   },
 
-  async chain_axon_removals({ window, limit }: Row, context: GqlContext) {
+  async chain_axon_removals(
+    { window, limit }: QueryChain_Axon_RemovalsArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
     if (!Object.hasOwn(CHAIN_AXON_REMOVALS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6664,7 +6682,7 @@ const rootValue = {
   },
 
   async chain_signers(
-    { window, limit, sort, call_module: callModule }: Row,
+    { window, limit, sort, call_module: callModule }: QueryChain_SignersArgs,
     context: GqlContext,
   ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleChainSigners
@@ -6719,7 +6737,7 @@ const rootValue = {
       (tier as Row | null) ??
       buildChainSigners({
         window: label,
-        sort,
+        sort: sort ?? undefined,
         observedAt: await loadObservedAt(context),
         rows: [],
       });
@@ -6739,7 +6757,10 @@ const rootValue = {
     };
   },
 
-  async chain_weight_setters({ window, limit }: Row, context: GqlContext) {
+  async chain_weight_setters(
+    { window, limit }: QueryChain_Weight_SettersArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW;
     if (!Object.hasOwn(CHAIN_WEIGHT_SETTERS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6778,7 +6799,10 @@ const rootValue = {
     };
   },
 
-  async chain_alpha_volume({ limit }: Row, context: GqlContext) {
+  async chain_alpha_volume(
+    { limit }: QueryChain_Alpha_VolumeArgs,
+    context: GqlContext,
+  ) {
     const safeLimit = clampLimit(limit, {
       defaultLimit: CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
       maxLimit: CHAIN_ALPHA_VOLUME_LIMIT_MAX,
@@ -6840,7 +6864,10 @@ const rootValue = {
     };
   },
 
-  async chain_stake_flow({ window, limit }: Row, context: GqlContext) {
+  async chain_stake_flow(
+    { window, limit }: QueryChain_Stake_FlowArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_FLOW_WINDOW;
     if (!Object.hasOwn(CHAIN_STAKE_FLOW_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6889,7 +6916,10 @@ const rootValue = {
     };
   },
 
-  async chain_stake_moves({ window, limit }: Row, context: GqlContext) {
+  async chain_stake_moves(
+    { window, limit }: QueryChain_Stake_MovesArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_MOVES_WINDOW;
     if (!Object.hasOwn(CHAIN_STAKE_MOVES_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6932,7 +6962,10 @@ const rootValue = {
     };
   },
 
-  async chain_stake_transfers({ window, limit }: Row, context: GqlContext) {
+  async chain_stake_transfers(
+    { window, limit }: QueryChain_Stake_TransfersArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW;
     if (!Object.hasOwn(CHAIN_STAKE_TRANSFERS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6979,7 +7012,7 @@ const rootValue = {
   },
 
   async chain_transfer_pairs(
-    { window, sort, limit }: Row,
+    { window, sort, limit }: QueryChain_Transfer_PairsArgs,
     context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW;
@@ -7035,7 +7068,10 @@ const rootValue = {
     };
   },
 
-  async chain_transfers({ window, limit }: Row, context: GqlContext) {
+  async chain_transfers(
+    { window, limit }: QueryChain_TransfersArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_TRANSFER_WINDOW;
     if (!Object.hasOwn(CHAIN_TRANSFER_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -7287,7 +7323,7 @@ const rootValue = {
     };
   },
 
-  async rpc_usage({ window }: Row, context: GqlContext) {
+  async rpc_usage({ window }: QueryRpc_UsageArgs, context: GqlContext) {
     const requestedWindow = window ?? DEFAULT_ANALYTICS_WINDOW;
     if (!Object.hasOwn(ANALYTICS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -7480,7 +7516,10 @@ const rootValue = {
     };
   },
 
-  async subnet_recycled({ netuid }: Row, context: GqlContext) {
+  async subnet_recycled(
+    { netuid }: QuerySubnet_RecycledArgs,
+    context: GqlContext,
+  ) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -7495,7 +7534,7 @@ const rootValue = {
     return loadSubnetRecycled(context.env, netuid);
   },
 
-  async subnet_burn({ netuid }: Row, context: GqlContext) {
+  async subnet_burn({ netuid }: QuerySubnet_BurnArgs, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -7510,7 +7549,10 @@ const rootValue = {
     return loadSubnetBurn(context.env, netuid);
   },
 
-  async subnet_turnover({ netuid, window, changes }: Row, context: GqlContext) {
+  async subnet_turnover(
+    { netuid, window, changes }: QuerySubnet_TurnoverArgs,
+    context: GqlContext,
+  ) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError("netuid must be a u16 subnet id (0-65535).", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7567,7 +7609,10 @@ const rootValue = {
     };
   },
 
-  async subnet_ownership_history({ netuid }: Row, context: GqlContext) {
+  async subnet_ownership_history(
+    { netuid }: QuerySubnet_Ownership_HistoryArgs,
+    context: GqlContext,
+  ) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -7588,7 +7633,10 @@ const rootValue = {
     };
   },
 
-  async subnet_conviction({ netuid }: Row, context: GqlContext) {
+  async subnet_conviction(
+    { netuid }: QuerySubnet_ConvictionArgs,
+    context: GqlContext,
+  ) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -521,7 +521,15 @@ import { SDL } from "./graphql-sdl.ts";
 import type {
   QueryAdapterArgs,
   QueryAgent_CatalogArgs,
+  QueryBlockArgs,
+  QueryBlocksArgs,
+  QueryBlock_Chain_EventsArgs,
+  QueryBlock_EventsArgs,
+  QueryBlock_ExtrinsicsArgs,
   QueryCandidatesArgs,
+  QueryChain_EventsArgs,
+  QueryChain_Events_StatsArgs,
+  QueryCompareArgs,
   QueryCompare_ValidatorsArgs,
   QueryDomain_SummaryArgs,
   QueryEconomicsArgs,
@@ -529,10 +537,17 @@ import type {
   QueryEndpoint_PoolsArgs,
   QueryEndpointsArgs,
   QueryEvidenceArgs,
+  QueryExtrinsicArgs,
+  QueryExtrinsicsArgs,
   QueryFixtureArgs,
   QueryGapsArgs,
+  QueryGlobal_IncidentsArgs,
+  QueryGovernance_Config_ChangesArgs,
+  QueryHealth_HistoryArgs,
+  QueryIncidentsArgs,
   QueryNeuronArgs,
   QueryNeuron_HistoryArgs,
+  QueryOpportunity_BoardsArgs,
   QueryProfilesArgs,
   QueryProviderArgs,
   QueryProvider_EndpointsArgs,
@@ -1731,35 +1746,12 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batches 5-9 (types-epic D, #7862 tracks follow-up
-// batches). The 5 pilot fields (subnets, subnet, subnet_health,
-// subnet_stake_quote, economics) plus D batch 1's 20 fields
-// (subnet_registrations, subnet_hyperparameters,
-// subnet_hyperparameters_history, subnet_deregistrations, subnet_serving,
-// subnet_health_trends, subnet_uptime, subnet_health_incidents,
-// subnet_health_percentiles, subnet_volume, agent_resources, curation,
-// candidates, saved_query, fixtures, fixture, agent_catalog, freshness,
-// top_holders, search) plus D batch 2's 20 fields (search_index, domains,
-// domain_summary, compare_validators, coverage, coverage_depth,
-// subnet_ohlc, subnet_validators, subnet_event_summary, subnet_gaps,
-// subnet_evidence, subnet_candidates, subnet_endpoints,
-// subnet_axon_removals, subnet_weights, subnet_stake_moves,
-// subnet_stake_transfers, subnet_idle_stake, subnet_stake_flow,
-// subnet_events) plus D batch 3's 20 fields (subnet_history,
-// subnet_prometheus, subnet_weight_setters, subnet_yield,
-// subnet_yield_history, subnet_performance, subnet_performance_history,
-// subnet_concentration, subnet_concentration_history, neuron, neuron_history,
-// subnet_identity_history, subnet_trajectory, subnet_metagraph,
-// subnet_overview, subnet_profile, providers, provider, adapter, surfaces)
-// plus D batch 4's 20 fields (endpoints, provider_endpoints, endpoint_pools,
-// rpc_pools, endpoint_incidents, source_snapshots, gaps, evidence, profiles,
-// review_adapter_candidates, review_enrichment_evidence,
-// review_enrichment_queue, review_enrichment_targets, review_gaps,
-// review_profile_completeness, registry_summary, schemas, source_health,
-// lineage, rpc_endpoints) are typed against the generated Args types below;
-// the remaining root fields on this object keep their `Row`-typed
-// destructured params for now, adopted incrementally in later batches
-// rather than all at once here.
+// Row-erased: pending D batches 6-9 (types-epic D, #7862 tracks follow-up
+// batches -- see #8158-#8166 for each batch's exact field list). The 5 pilot
+// fields plus D batches 1-5's 95 fields (#8158-#8162) are typed against the
+// generated Args types below; the remaining root fields on this object keep
+// their `Row`-typed destructured params for now, adopted incrementally in
+// later batches rather than all at once here.
 const rootValue = {
   subnets(
     {
@@ -3325,7 +3317,7 @@ const rootValue = {
   // and throws invalid_params on a bad one / not_found on a missing snapshot;
   // that throw becomes a GraphQL error, matching every other field's "an
   // unsupported filter/sort is a GraphQL error, not a silent default".
-  health_history(args: Row, context: GqlContext) {
+  health_history(args: QueryHealth_HistoryArgs, context: GqlContext) {
     return loadHealthHistory(context, args, {
       readArtifact: loadArtifact as AnyFn,
     });
@@ -3395,7 +3387,10 @@ const rootValue = {
     };
   },
 
-  async opportunity_boards({ limit }: Row, context: GqlContext) {
+  async opportunity_boards(
+    { limit }: QueryOpportunity_BoardsArgs,
+    context: GqlContext,
+  ) {
     const data = await loadEconomics(context);
     const rows = Array.isArray(data?.subnets) ? data.subnets : [];
     // Reuse the live economics tier + the leaderboard ranking, so the boards
@@ -3423,7 +3418,10 @@ const rootValue = {
     };
   },
 
-  async compare({ netuids, dimensions }: Row, context: GqlContext) {
+  async compare(
+    { netuids, dimensions }: QueryCompareArgs,
+    context: GqlContext,
+  ) {
     // Reuse the REST/MCP shared parsers so the GraphQL contract matches
     // /api/v1/compare and the compare_subnets MCP tool exactly (distinctness +
     // range + the dimension whitelist), then the shared loader composes the rows.
@@ -3457,7 +3455,7 @@ const rootValue = {
   },
 
   async incidents(
-    { window, netuid, sort, order, limit, cursor }: Row,
+    { window, netuid, sort, order, limit, cursor }: QueryIncidentsArgs,
     context: GqlContext,
   ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleGlobalIncidents
@@ -3544,7 +3542,7 @@ const rootValue = {
   // Identical window validation (7d/30d -> BAD_USER_INPUT), Postgres-tier ->
   // retired-D1 fallback, and schema-stable cold-tier degradation; nothing
   // re-derived. Distinct from endpoint_incidents (the active endpoint feed).
-  async global_incidents(args: Row, context: GqlContext) {
+  async global_incidents(args: QueryGlobal_IncidentsArgs, context: GqlContext) {
     return rootValue.incidents(args, context);
   },
 
@@ -4168,7 +4166,7 @@ const rootValue = {
       block_end: blockEnd,
       from,
       to,
-    }: Row,
+    }: QueryExtrinsicsArgs,
     context: GqlContext,
   ) {
     if (block != null && (!Number.isInteger(block) || block < 0)) {
@@ -4220,7 +4218,15 @@ const rootValue = {
   // schema-stable empty feed, never a GraphQL error — matching extrinsics'
   // cold-empty convention. Distinct from Subscription.chainEvents.
   async chain_events(
-    { pallet, method, block, extrinsic, cursor, before, limit }: Row,
+    {
+      pallet,
+      method,
+      block,
+      extrinsic,
+      cursor,
+      before,
+      limit,
+    }: QueryChain_EventsArgs,
     context: GqlContext,
   ) {
     try {
@@ -4272,7 +4278,10 @@ const rootValue = {
   // (the same 1000-default/positive-integer/1-5000-cap validation MCP's
   // get_chain_activity applies) then loadChainActivity — both relocated to
   // data-api-mcp.ts beside loadChainEventsFeed.
-  async chain_events_stats({ blocks }: Row, context: GqlContext) {
+  async chain_events_stats(
+    { blocks }: QueryChain_Events_StatsArgs,
+    context: GqlContext,
+  ) {
     let window;
     try {
       window = optionalBlocksWindow({ blocks });
@@ -4353,7 +4362,7 @@ const rootValue = {
     };
   },
 
-  async extrinsic({ ref }: Row, context: GqlContext) {
+  async extrinsic({ ref }: QueryExtrinsicArgs, context: GqlContext) {
     const data =
       ((await tryPostgresTier(
         context.env,
@@ -4381,7 +4390,7 @@ const rootValue = {
       block_end: blockEnd,
       from,
       to,
-    }: Row,
+    }: QueryGovernance_Config_ChangesArgs,
     context: GqlContext,
   ) {
     if (block != null && (!Number.isInteger(block) || block < 0)) {
@@ -4458,7 +4467,7 @@ const rootValue = {
       to,
       min_extrinsics: minExtrinsics,
       min_events: minEvents,
-    }: Row,
+    }: QueryBlocksArgs,
     context: GqlContext,
   ) {
     const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
@@ -4552,7 +4561,7 @@ const rootValue = {
     };
   },
 
-  async block({ ref }: Row, context: GqlContext) {
+  async block({ ref }: QueryBlockArgs, context: GqlContext) {
     const data =
       ((await tryPostgresTier(
         context.env,
@@ -4574,13 +4583,18 @@ const rootValue = {
   // Postgres tier + schema-stable fallback builder REST and MCP already use. The
   // /blocks/:ref/{extrinsics,events} routes wrap their body in `{ data }` (unlike
   // the flat /blocks/:ref route), so the tier result is destructured accordingly.
-  async block_extrinsics({ ref, limit, offset }: Row, context: GqlContext) {
-    const safeLimit = Number.isFinite(limit)
-      ? Math.max(1, Math.min(100, Math.floor(limit)))
-      : 50;
-    const safeOffset = Number.isFinite(offset)
-      ? Math.max(0, Math.floor(offset))
-      : 0;
+  async block_extrinsics(
+    { ref, limit, offset }: QueryBlock_ExtrinsicsArgs,
+    context: GqlContext,
+  ) {
+    const safeLimit =
+      typeof limit === "number" && Number.isFinite(limit)
+        ? Math.max(1, Math.min(100, Math.floor(limit)))
+        : 50;
+    const safeOffset =
+      typeof offset === "number" && Number.isFinite(offset)
+        ? Math.max(0, Math.floor(offset))
+        : 0;
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
@@ -4601,13 +4615,18 @@ const rootValue = {
     return data;
   },
 
-  async block_events({ ref, limit, offset }: Row, context: GqlContext) {
-    const safeLimit = Number.isFinite(limit)
-      ? Math.max(1, Math.min(1000, Math.floor(limit)))
-      : 100;
-    const safeOffset = Number.isFinite(offset)
-      ? Math.max(0, Math.floor(offset))
-      : 0;
+  async block_events(
+    { ref, limit, offset }: QueryBlock_EventsArgs,
+    context: GqlContext,
+  ) {
+    const safeLimit =
+      typeof limit === "number" && Number.isFinite(limit)
+        ? Math.max(1, Math.min(1000, Math.floor(limit)))
+        : 100;
+    const safeOffset =
+      typeof offset === "number" && Number.isFinite(offset)
+        ? Math.max(0, Math.floor(offset))
+        : 0;
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
@@ -4631,7 +4650,10 @@ const rootValue = {
   // Reuses loadBlockChainEvents unchanged (the get_block_chain_events tool's own
   // loader); it throws invalid_params on a bad block_number and tier_unavailable
   // where the all-events Worker is absent -- both surface as normal GraphQL errors.
-  block_chain_events({ block_number: blockNumber }: Row, context: GqlContext) {
+  block_chain_events(
+    { block_number: blockNumber }: QueryBlock_Chain_EventsArgs,
+    context: GqlContext,
+  ) {
     return loadBlockChainEvents(mcpCtx(context), blockNumber);
   },
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -525,14 +525,30 @@ import type {
   QueryCompare_ValidatorsArgs,
   QueryDomain_SummaryArgs,
   QueryEconomicsArgs,
+  QueryEndpoint_IncidentsArgs,
+  QueryEndpoint_PoolsArgs,
+  QueryEndpointsArgs,
+  QueryEvidenceArgs,
   QueryFixtureArgs,
+  QueryGapsArgs,
   QueryNeuronArgs,
   QueryNeuron_HistoryArgs,
+  QueryProfilesArgs,
   QueryProviderArgs,
+  QueryProvider_EndpointsArgs,
   QueryProvidersArgs,
+  QueryReview_Adapter_CandidatesArgs,
+  QueryReview_Enrichment_EvidenceArgs,
+  QueryReview_Enrichment_QueueArgs,
+  QueryReview_Enrichment_TargetsArgs,
+  QueryReview_GapsArgs,
+  QueryReview_Profile_CompletenessArgs,
+  QueryRpc_EndpointsArgs,
+  QueryRpc_PoolsArgs,
   QuerySaved_QueryArgs,
   QuerySearchArgs,
   QuerySearch_IndexArgs,
+  QuerySource_SnapshotsArgs,
   QuerySubnetArgs,
   QuerySubnet_Axon_RemovalsArgs,
   QuerySubnet_CandidatesArgs,
@@ -1715,7 +1731,7 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batches 4-9 (types-epic D, #7862 tracks follow-up
+// Row-erased: pending D batches 5-9 (types-epic D, #7862 tracks follow-up
 // batches). The 5 pilot fields (subnets, subnet, subnet_health,
 // subnet_stake_quote, economics) plus D batch 1's 20 fields
 // (subnet_registrations, subnet_hyperparameters,
@@ -1735,9 +1751,15 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
 // subnet_concentration, subnet_concentration_history, neuron, neuron_history,
 // subnet_identity_history, subnet_trajectory, subnet_metagraph,
 // subnet_overview, subnet_profile, providers, provider, adapter, surfaces)
-// are typed against the generated Args types below; the remaining root
-// fields on this object keep their `Row`-typed destructured params for now,
-// adopted incrementally in later batches rather than all at once here.
+// plus D batch 4's 20 fields (endpoints, provider_endpoints, endpoint_pools,
+// rpc_pools, endpoint_incidents, source_snapshots, gaps, evidence, profiles,
+// review_adapter_candidates, review_enrichment_evidence,
+// review_enrichment_queue, review_enrichment_targets, review_gaps,
+// review_profile_completeness, registry_summary, schemas, source_health,
+// lineage, rpc_endpoints) are typed against the generated Args types below;
+// the remaining root fields on this object keep their `Row`-typed
+// destructured params for now, adopted incrementally in later batches
+// rather than all at once here.
 const rootValue = {
   subnets(
     {
@@ -3137,7 +3159,7 @@ const rootValue = {
     });
   },
 
-  endpoints(args: Row, context: GqlContext) {
+  endpoints(args: QueryEndpointsArgs, context: GqlContext) {
     return loadEndpointsPage(context, args);
   },
 
@@ -3148,7 +3170,7 @@ const rootValue = {
   // that throw becomes a GraphQL error, matching endpoint_pools/gaps' "an
   // unsupported filter/sort is a GraphQL error, not a silently substituted
   // default" convention.
-  provider_endpoints(args: Row, context: GqlContext) {
+  provider_endpoints(args: QueryProvider_EndpointsArgs, context: GqlContext) {
     return loadProviderEndpointsList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3160,11 +3182,11 @@ const rootValue = {
   // executor surfaces as a normal GraphQL error, matching every other field's
   // "an unsupported filter/sort is a GraphQL error, not a silently substituted
   // default" convention.
-  endpoint_pools(args: Row, context: GqlContext) {
+  endpoint_pools(args: QueryEndpoint_PoolsArgs, context: GqlContext) {
     return loadEndpointPoolsList(mcpCtx(context), args, { readArtifact });
   },
 
-  rpc_pools(args: Row, context: GqlContext) {
+  rpc_pools(args: QueryRpc_PoolsArgs, context: GqlContext) {
     // rpc-pools' loader additionally reads ctx.readHealthKv for its live
     // 15-minute cron eligibility overlay (rpc-pools-mcp.ts) -- graphql.mjs's
     // own context has no such property, so it's supplied here from the same
@@ -3178,7 +3200,7 @@ const rootValue = {
     );
   },
 
-  endpoint_incidents(args: Row, context: GqlContext) {
+  endpoint_incidents(args: QueryEndpoint_IncidentsArgs, context: GqlContext) {
     return loadEndpointIncidentsList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3188,7 +3210,7 @@ const rootValue = {
   // as a normal GraphQL error, matching every other field's "an unsupported
   // filter/sort is a GraphQL error, not a silently substituted default"
   // convention.
-  source_snapshots(args: Row, context: GqlContext) {
+  source_snapshots(args: QuerySource_SnapshotsArgs, context: GqlContext) {
     return loadSourceSnapshotsList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3197,11 +3219,11 @@ const rootValue = {
   // error, matching source_snapshots' "unsupported filter/sort is a GraphQL
   // error, not a silently substituted default" convention. A cold/absent
   // artifact is likewise a GraphQL error (matching REST/MCP not_found).
-  gaps(args: Row, context: GqlContext) {
+  gaps(args: QueryGapsArgs, context: GqlContext) {
     return loadGapsList(mcpCtx(context), args, { readArtifact });
   },
 
-  evidence(args: Row, context: GqlContext) {
+  evidence(args: QueryEvidenceArgs, context: GqlContext) {
     return loadEvidenceList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3210,7 +3232,7 @@ const rootValue = {
   // (not a throw) -- this file's own loadArtifact(context, path) already has
   // exactly that shape (readArtifact(context.env, path), null if not ok), so
   // it's reused directly rather than adding a redundant wrapper.
-  profiles(args: Row, context: GqlContext) {
+  profiles(args: QueryProfilesArgs, context: GqlContext) {
     return loadProfilesList(mcpCtx(context), args, {
       readOptionalArtifact: loadArtifact as AnyFn,
     });
@@ -3259,7 +3281,7 @@ const rootValue = {
     return loadArtifact(context, "/metagraph/lineage.json");
   },
 
-  rpc_endpoints(args: Row, context: GqlContext) {
+  rpc_endpoints(args: QueryRpc_EndpointsArgs, context: GqlContext) {
     // #7886: reuse loadRpcEndpointsList — same live 15-minute cron overlay +
     // endpoints-collection list-query transforms REST applies. The loader
     // validates its own args and throws on an invalid filter/sort or a cold
@@ -3316,29 +3338,44 @@ const rootValue = {
   // filter/sort is a GraphQL error, not a silently substituted default"
   // convention. A cold/missing artifact is also a GraphQL error (matches
   // REST 404 / MCP not_found); an empty filtered page is a success with total 0.
-  review_adapter_candidates(args: Row, context: GqlContext) {
+  review_adapter_candidates(
+    args: QueryReview_Adapter_CandidatesArgs,
+    context: GqlContext,
+  ) {
     return loadAdapterCandidatesList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_evidence(args: Row, context: GqlContext) {
+  review_enrichment_evidence(
+    args: QueryReview_Enrichment_EvidenceArgs,
+    context: GqlContext,
+  ) {
     return loadEnrichmentEvidenceList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_queue(args: Row, context: GqlContext) {
+  review_enrichment_queue(
+    args: QueryReview_Enrichment_QueueArgs,
+    context: GqlContext,
+  ) {
     return loadEnrichmentQueueList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_enrichment_targets(args: Row, context: GqlContext) {
+  review_enrichment_targets(
+    args: QueryReview_Enrichment_TargetsArgs,
+    context: GqlContext,
+  ) {
     return loadReviewEnrichmentTargetsList(mcpCtx(context), args, {
       readArtifact,
     });
   },
 
-  review_gaps(args: Row, context: GqlContext) {
+  review_gaps(args: QueryReview_GapsArgs, context: GqlContext) {
     return loadReviewGapsList(mcpCtx(context), args, { readArtifact });
   },
 
-  review_profile_completeness(args: Row, context: GqlContext) {
+  review_profile_completeness(
+    args: QueryReview_Profile_CompletenessArgs,
+    context: GqlContext,
+  ) {
     return loadProfileCompletenessList(mcpCtx(context), args, { readArtifact });
   },
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -519,6 +519,21 @@ import { SDL } from "./graphql-sdl.ts";
 // here, not the Resolver wrapper. Same class of codegen/runtime-convention
 // mismatch the epic already anticipated for the Subscription resolver.
 import type {
+  QueryAccountArgs,
+  QueryAccountsArgs,
+  QueryAccount_Axon_RemovalsArgs,
+  QueryAccount_DeregistrationsArgs,
+  QueryAccount_EntitiesArgs,
+  QueryAccount_PortfolioArgs,
+  QueryAccount_Position_HistoryArgs,
+  QueryAccount_PositionsArgs,
+  QueryAccount_PrometheusArgs,
+  QueryAccount_RegistrationsArgs,
+  QueryAccount_ServingArgs,
+  QueryAccount_Stake_FlowArgs,
+  QueryAccount_Stake_MovesArgs,
+  QueryAccount_SubnetsArgs,
+  QueryAccount_Weight_SettersArgs,
   QueryAdapterArgs,
   QueryAgent_CatalogArgs,
   QueryBlockArgs,
@@ -608,6 +623,10 @@ import type {
   QuerySubnetsArgs,
   QuerySurfacesArgs,
   QueryTop_HoldersArgs,
+  QueryValidatorArgs,
+  QueryValidatorsArgs,
+  QueryValidator_HistoryArgs,
+  QueryValidator_NominatorsArgs,
 } from "../generated/graphql/types.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1746,9 +1765,9 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batches 6-9 (types-epic D, #7862 tracks follow-up
+// Row-erased: pending D batches 7-9 (types-epic D, #7862 tracks follow-up
 // batches -- see #8158-#8166 for each batch's exact field list). The 5 pilot
-// fields plus D batches 1-5's 95 fields (#8158-#8162) are typed against the
+// fields plus D batches 1-6's 115 fields (#8158-#8163) are typed against the
 // generated Args types below; the remaining root fields on this object keep
 // their `Row`-typed destructured params for now, adopted incrementally in
 // later batches rather than all at once here.
@@ -4657,7 +4676,10 @@ const rootValue = {
     return loadBlockChainEvents(mcpCtx(context), blockNumber);
   },
 
-  async validators({ sort, limit, cursor }: Row, context: GqlContext) {
+  async validators(
+    { sort, limit, cursor }: QueryValidatorsArgs,
+    context: GqlContext,
+  ) {
     const requestedSort = sort ?? DEFAULT_GLOBAL_VALIDATOR_SORT;
     if (!GLOBAL_VALIDATOR_SORTS.includes(requestedSort)) {
       throw new GraphQLError(
@@ -4699,7 +4721,7 @@ const rootValue = {
   },
 
   async validator_nominators(
-    { hotkey, window, sort, coldkey }: Row,
+    { hotkey, window, sort, coldkey }: QueryValidator_NominatorsArgs,
     context: GqlContext,
   ) {
     // Same window/sort allow-lists handleValidatorNominators validates against --
@@ -4769,7 +4791,7 @@ const rootValue = {
     };
   },
 
-  async validator({ hotkey }: Row, context: GqlContext) {
+  async validator({ hotkey }: QueryValidatorArgs, context: GqlContext) {
     const data = await tryPostgresTier(
       context.env,
       postgresTierRequest(
@@ -4781,7 +4803,10 @@ const rootValue = {
     return validatorDetailNode(data as Row, hotkey);
   },
 
-  async validator_history({ hotkey, window }: Row, context: GqlContext) {
+  async validator_history(
+    { hotkey, window }: QueryValidator_HistoryArgs,
+    context: GqlContext,
+  ) {
     // Same parseHistoryWindow REST's handleValidatorHistory uses, so accepted
     // window labels (7d/30d/90d/1y/all, default 30d) match exactly.
     const windowResult = parseHistoryWindow(window);
@@ -4818,7 +4843,7 @@ const rootValue = {
   },
 
   async account_position_history(
-    { ss58, netuid, window }: Row,
+    { ss58, netuid, window }: QueryAccount_Position_HistoryArgs,
     context: GqlContext,
   ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
@@ -4868,7 +4893,7 @@ const rootValue = {
     };
   },
 
-  async accounts({ sort, limit }: Row, context: GqlContext) {
+  async accounts({ sort, limit }: QueryAccountsArgs, context: GqlContext) {
     const requestedSort = sort ?? DEFAULT_ACCOUNTS_LIST_SORT;
     if (!ACCOUNTS_LIST_SORTS.includes(requestedSort)) {
       throw new GraphQLError(
@@ -4902,7 +4927,7 @@ const rootValue = {
     };
   },
 
-  async account({ ss58 }: Row, context: GqlContext) {
+  async account({ ss58 }: QueryAccountArgs, context: GqlContext) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -4920,7 +4945,10 @@ const rootValue = {
     return accountSummaryNode(data, ss58);
   },
 
-  async account_prometheus({ ss58, window }: Row, context: GqlContext) {
+  async account_prometheus(
+    { ss58, window }: QueryAccount_PrometheusArgs,
+    context: GqlContext,
+  ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -4965,7 +4993,7 @@ const rootValue = {
   },
 
   async account_stake_flow(
-    { ss58, window, direction }: Row,
+    { ss58, window, direction }: QueryAccount_Stake_FlowArgs,
     context: GqlContext,
   ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
@@ -5026,7 +5054,10 @@ const rootValue = {
     };
   },
 
-  async account_portfolio({ ss58 }: Row, context: GqlContext) {
+  async account_portfolio(
+    { ss58 }: QueryAccount_PortfolioArgs,
+    context: GqlContext,
+  ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5061,7 +5092,10 @@ const rootValue = {
     };
   },
 
-  async account_positions({ ss58 }: Row, context: GqlContext) {
+  async account_positions(
+    { ss58 }: QueryAccount_PositionsArgs,
+    context: GqlContext,
+  ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5091,7 +5125,10 @@ const rootValue = {
     };
   },
 
-  async account_subnets({ ss58 }: Row, context: GqlContext) {
+  async account_subnets(
+    { ss58 }: QueryAccount_SubnetsArgs,
+    context: GqlContext,
+  ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5119,7 +5156,10 @@ const rootValue = {
     };
   },
 
-  async account_registrations({ ss58, window }: Row, context: GqlContext) {
+  async account_registrations(
+    { ss58, window }: QueryAccount_RegistrationsArgs,
+    context: GqlContext,
+  ) {
     // Same SS58 + window validation handleAccountRegistrations (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -5170,7 +5210,10 @@ const rootValue = {
     };
   },
 
-  async account_deregistrations({ ss58, window }: Row, context: GqlContext) {
+  async account_deregistrations(
+    { ss58, window }: QueryAccount_DeregistrationsArgs,
+    context: GqlContext,
+  ) {
     // Same SS58 + window validation handleAccountDeregistrations (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -5221,7 +5264,10 @@ const rootValue = {
     };
   },
 
-  async account_serving({ ss58, window }: Row, context: GqlContext) {
+  async account_serving(
+    { ss58, window }: QueryAccount_ServingArgs,
+    context: GqlContext,
+  ) {
     // Same SS58 + window validation handleAccountServing (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -5272,7 +5318,10 @@ const rootValue = {
     };
   },
 
-  async account_axon_removals({ ss58, window }: Row, context: GqlContext) {
+  async account_axon_removals(
+    { ss58, window }: QueryAccount_Axon_RemovalsArgs,
+    context: GqlContext,
+  ) {
     // Same SS58 + window validation handleAccountAxonRemovals (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -5323,7 +5372,10 @@ const rootValue = {
     };
   },
 
-  async account_stake_moves({ ss58, window }: Row, context: GqlContext) {
+  async account_stake_moves(
+    { ss58, window }: QueryAccount_Stake_MovesArgs,
+    context: GqlContext,
+  ) {
     // Same SS58 + window validation handleAccountStakeMoves (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -5375,7 +5427,10 @@ const rootValue = {
     };
   },
 
-  async account_weight_setters({ ss58, window }: Row, context: GqlContext) {
+  async account_weight_setters(
+    { ss58, window }: QueryAccount_Weight_SettersArgs,
+    context: GqlContext,
+  ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -5420,7 +5475,10 @@ const rootValue = {
     };
   },
 
-  async account_entities({ ss58 }: Row, context: GqlContext) {
+  async account_entities(
+    { ss58 }: QueryAccount_EntitiesArgs,
+    context: GqlContext,
+  ) {
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
       throw new GraphQLError("ss58 must be a valid SS58 address.", {
         extensions: { code: "BAD_USER_INPUT" },

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -519,18 +519,25 @@ import { SDL } from "./graphql-sdl.ts";
 // here, not the Resolver wrapper. Same class of codegen/runtime-convention
 // mismatch the epic already anticipated for the Subscription resolver.
 import type {
+  QueryAdapterArgs,
   QueryAgent_CatalogArgs,
   QueryCandidatesArgs,
   QueryCompare_ValidatorsArgs,
   QueryDomain_SummaryArgs,
   QueryEconomicsArgs,
   QueryFixtureArgs,
+  QueryNeuronArgs,
+  QueryNeuron_HistoryArgs,
+  QueryProviderArgs,
+  QueryProvidersArgs,
   QuerySaved_QueryArgs,
   QuerySearchArgs,
   QuerySearch_IndexArgs,
   QuerySubnetArgs,
   QuerySubnet_Axon_RemovalsArgs,
   QuerySubnet_CandidatesArgs,
+  QuerySubnet_ConcentrationArgs,
+  QuerySubnet_Concentration_HistoryArgs,
   QuerySubnet_DeregistrationsArgs,
   QuerySubnet_EndpointsArgs,
   QuerySubnet_Event_SummaryArgs,
@@ -541,21 +548,34 @@ import type {
   QuerySubnet_Health_IncidentsArgs,
   QuerySubnet_Health_PercentilesArgs,
   QuerySubnet_Health_TrendsArgs,
+  QuerySubnet_HistoryArgs,
   QuerySubnet_HyperparametersArgs,
   QuerySubnet_Hyperparameters_HistoryArgs,
+  QuerySubnet_Identity_HistoryArgs,
   QuerySubnet_Idle_StakeArgs,
+  QuerySubnet_MetagraphArgs,
   QuerySubnet_OhlcArgs,
+  QuerySubnet_OverviewArgs,
+  QuerySubnet_PerformanceArgs,
+  QuerySubnet_Performance_HistoryArgs,
+  QuerySubnet_ProfileArgs,
+  QuerySubnet_PrometheusArgs,
   QuerySubnet_RegistrationsArgs,
   QuerySubnet_ServingArgs,
   QuerySubnet_Stake_FlowArgs,
   QuerySubnet_Stake_MovesArgs,
   QuerySubnet_Stake_QuoteArgs,
   QuerySubnet_Stake_TransfersArgs,
+  QuerySubnet_TrajectoryArgs,
   QuerySubnet_UptimeArgs,
   QuerySubnet_ValidatorsArgs,
   QuerySubnet_VolumeArgs,
+  QuerySubnet_Weight_SettersArgs,
   QuerySubnet_WeightsArgs,
+  QuerySubnet_YieldArgs,
+  QuerySubnet_Yield_HistoryArgs,
   QuerySubnetsArgs,
+  QuerySurfacesArgs,
   QueryTop_HoldersArgs,
 } from "../generated/graphql/types.ts";
 
@@ -1695,7 +1715,7 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batches 3-9 (types-epic D, #7862 tracks follow-up
+// Row-erased: pending D batches 4-9 (types-epic D, #7862 tracks follow-up
 // batches). The 5 pilot fields (subnets, subnet, subnet_health,
 // subnet_stake_quote, economics) plus D batch 1's 20 fields
 // (subnet_registrations, subnet_hyperparameters,
@@ -1709,10 +1729,15 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
 // subnet_evidence, subnet_candidates, subnet_endpoints,
 // subnet_axon_removals, subnet_weights, subnet_stake_moves,
 // subnet_stake_transfers, subnet_idle_stake, subnet_stake_flow,
-// subnet_events) are typed against the generated Args types below; the
-// remaining root fields on this object keep their `Row`-typed destructured
-// params for now, adopted incrementally in later batches rather than all
-// at once here.
+// subnet_events) plus D batch 3's 20 fields (subnet_history,
+// subnet_prometheus, subnet_weight_setters, subnet_yield,
+// subnet_yield_history, subnet_performance, subnet_performance_history,
+// subnet_concentration, subnet_concentration_history, neuron, neuron_history,
+// subnet_identity_history, subnet_trajectory, subnet_metagraph,
+// subnet_overview, subnet_profile, providers, provider, adapter, surfaces)
+// are typed against the generated Args types below; the remaining root
+// fields on this object keep their `Row`-typed destructured params for now,
+// adopted incrementally in later batches rather than all at once here.
 const rootValue = {
   subnets(
     {
@@ -1854,7 +1879,7 @@ const rootValue = {
   // reuses exactly what REST/MCP already call, so the three surfaces can't
   // drift.
   async subnet_metagraph(
-    { netuid, validator_permit }: Row,
+    { netuid, validator_permit }: QuerySubnet_MetagraphArgs,
     context: GqlContext,
   ) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetMetagraph
@@ -1875,7 +1900,10 @@ const rootValue = {
     );
   },
 
-  async subnet_overview({ netuid }: Row, context: GqlContext) {
+  async subnet_overview(
+    { netuid }: QuerySubnet_OverviewArgs,
+    context: GqlContext,
+  ) {
     // Same baked-overview + overlayOverviewHealth composition the REST
     // "subnet-overview" case and the get_subnet MCP tool perform. An
     // un-baked netuid resolves to null rather than a GraphQL error.
@@ -1888,7 +1916,10 @@ const rootValue = {
     return overlayOverviewHealth(overview, live, netuid) || overview;
   },
 
-  async subnet_profile({ netuid }: Row, context: GqlContext) {
+  async subnet_profile(
+    { netuid }: QuerySubnet_ProfileArgs,
+    context: GqlContext,
+  ) {
     // Reuse loadSubnetProfile (the loader get_subnet_profile already calls)
     // unchanged; its deps.readArtifact is invoked as (ctx, path) -- exactly
     // loadArtifact's shape -- so the read shares the request-scoped once()
@@ -2005,7 +2036,10 @@ const rootValue = {
     );
   },
 
-  async subnet_trajectory({ netuid }: Row, context: GqlContext) {
+  async subnet_trajectory(
+    { netuid }: QuerySubnet_TrajectoryArgs,
+    context: GqlContext,
+  ) {
     // Same tryPostgresTier(METAGRAPH_SUBNET_SNAPSHOTS_SOURCE) -> loadSubnetTrajectory
     // fallback contract handleTrajectory uses; a subnet with no daily snapshots is
     // a schema-stable empty trajectory, never a GraphQL error.
@@ -2194,7 +2228,7 @@ const rootValue = {
   },
 
   async subnet_identity_history(
-    { netuid, limit, offset, cursor }: Row,
+    { netuid, limit, offset, cursor }: QuerySubnet_Identity_HistoryArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -2263,7 +2297,10 @@ const rootValue = {
     };
   },
 
-  async subnet_performance({ netuid }: Row, context: GqlContext) {
+  async subnet_performance(
+    { netuid }: QuerySubnet_PerformanceArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2298,7 +2335,10 @@ const rootValue = {
     };
   },
 
-  async subnet_concentration({ netuid }: Row, context: GqlContext) {
+  async subnet_concentration(
+    { netuid }: QuerySubnet_ConcentrationArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2334,7 +2374,7 @@ const rootValue = {
   },
 
   async subnet_performance_history(
-    { netuid, window }: Row,
+    { netuid, window }: QuerySubnet_Performance_HistoryArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -2379,7 +2419,10 @@ const rootValue = {
     };
   },
 
-  async subnet_yield_history({ netuid, window }: Row, context: GqlContext) {
+  async subnet_yield_history(
+    { netuid, window }: QuerySubnet_Yield_HistoryArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2423,7 +2466,7 @@ const rootValue = {
   },
 
   async subnet_concentration_history(
-    { netuid, window }: Row,
+    { netuid, window }: QuerySubnet_Concentration_HistoryArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -2468,7 +2511,7 @@ const rootValue = {
     };
   },
 
-  async neuron({ netuid, uid }: Row, context: GqlContext) {
+  async neuron({ netuid, uid }: QueryNeuronArgs, context: GqlContext) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2500,7 +2543,10 @@ const rootValue = {
     };
   },
 
-  async neuron_history({ netuid, uid, window }: Row, context: GqlContext) {
+  async neuron_history(
+    { netuid, uid, window }: QueryNeuron_HistoryArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2548,7 +2594,7 @@ const rootValue = {
     };
   },
 
-  async subnet_yield({ netuid }: Row, context: GqlContext) {
+  async subnet_yield({ netuid }: QuerySubnet_YieldArgs, context: GqlContext) {
     // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetYield cold
     // fallback contract handleSubnetYield uses: a subnet with no neurons is a
     // schema-stable zeroed card, never a GraphQL error. No window param — the
@@ -2854,7 +2900,10 @@ const rootValue = {
     };
   },
 
-  async subnet_history({ netuid, window }: Row, context: GqlContext) {
+  async subnet_history(
+    { netuid, window }: QuerySubnet_HistoryArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2894,7 +2943,10 @@ const rootValue = {
     };
   },
 
-  async subnet_prometheus({ netuid, window }: Row, context: GqlContext) {
+  async subnet_prometheus(
+    { netuid, window }: QuerySubnet_PrometheusArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2938,7 +2990,10 @@ const rootValue = {
     };
   },
 
-  async subnet_weight_setters({ netuid, window }: Row, context: GqlContext) {
+  async subnet_weight_setters(
+    { netuid, window }: QuerySubnet_Weight_SettersArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2987,7 +3042,7 @@ const rootValue = {
   // #7920: opaque string id-keyset cursor/next_cursor (not REST's Int offset)
   // and schema-stable empty list on a cold/absent artifact (not a GraphQL
   // error). limit/cursor are applied here via paginate, not the loader.
-  async providers(args: Row, context: GqlContext) {
+  async providers(args: QueryProvidersArgs, context: GqlContext) {
     const { limit, cursor, ...filters } = args;
     // Default empty list; only overwrite on a successful load. Cold/absent
     // (or any non-invalid_params loader failure) keeps this historical contract.
@@ -3028,7 +3083,7 @@ const rootValue = {
     };
   },
 
-  async provider({ id }: Row, context: GqlContext) {
+  async provider({ id }: QueryProviderArgs, context: GqlContext) {
     if (typeof id !== "string" || !VALID_PROVIDER_ID.test(id)) return null;
     const data = await loadArtifact(context, `/metagraph/providers/${id}.json`);
     if (!data) return null;
@@ -3041,7 +3096,7 @@ const rootValue = {
   // loader miss (not_found / cold R2 / unavailable) resolves to null
   // (schema-stable), matching provider's cold/absent convention -- never a
   // GraphQL error for an unregistered slug.
-  async adapter({ slug }: Row, context: GqlContext) {
+  async adapter({ slug }: QueryAdapterArgs, context: GqlContext) {
     try {
       return await loadAdapter(mcpCtx(context), { slug }, { readArtifact });
     } catch (rawErr) {
@@ -3073,7 +3128,7 @@ const rootValue = {
     };
   },
 
-  surfaces({ netuid, limit, cursor }: Row, context: GqlContext) {
+  surfaces({ netuid, limit, cursor }: QuerySurfacesArgs, context: GqlContext) {
     return listPage(context, ARTIFACT.surfaces, "surfaces", {
       limit,
       cursor,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -521,7 +521,9 @@ import { SDL } from "./graphql-sdl.ts";
 import type {
   QueryAccountArgs,
   QueryAccountsArgs,
+  QueryAccount_BalanceArgs,
   QueryAccount_Axon_RemovalsArgs,
+  QueryAccount_ChildrenArgs,
   QueryAccount_CounterpartiesArgs,
   QueryAccount_DeregistrationsArgs,
   QueryAccount_EntitiesArgs,
@@ -530,11 +532,13 @@ import type {
   QueryAccount_HistoryArgs,
   QueryAccount_IdentityArgs,
   QueryAccount_Identity_HistoryArgs,
+  QueryAccount_ParentsArgs,
   QueryAccount_PortfolioArgs,
   QueryAccount_Position_HistoryArgs,
   QueryAccount_PositionsArgs,
   QueryAccount_PrometheusArgs,
   QueryAccount_RegistrationsArgs,
+  QueryAccount_Root_ClaimArgs,
   QueryAccount_ServingArgs,
   QueryAccount_Stake_FlowArgs,
   QueryAccount_Stake_MovesArgs,
@@ -579,6 +583,8 @@ import type {
   QueryEndpoint_PoolsArgs,
   QueryEndpointsArgs,
   QueryEvidenceArgs,
+  QueryEvm_AddressArgs,
+  QueryEvm_Address_MappingArgs,
   QueryExtrinsicArgs,
   QueryExtrinsicsArgs,
   QueryFixtureArgs,
@@ -609,6 +615,7 @@ import type {
   QuerySearch_IndexArgs,
   QuerySource_SnapshotsArgs,
   QuerySubnetArgs,
+  QuerySudoArgs,
   QuerySubnet_Axon_RemovalsArgs,
   QuerySubnet_BurnArgs,
   QuerySubnet_CandidatesArgs,
@@ -630,6 +637,8 @@ import type {
   QuerySubnet_Hyperparameters_HistoryArgs,
   QuerySubnet_Identity_HistoryArgs,
   QuerySubnet_Idle_StakeArgs,
+  QuerySubnet_LeaseArgs,
+  QuerySubnet_Lease_HistoryArgs,
   QuerySubnet_MetagraphArgs,
   QuerySubnet_MoversArgs,
   QuerySubnet_OhlcArgs,
@@ -1800,12 +1809,10 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batch 9 (types-epic D, #7862 tracks follow-up
-// batches -- see #8158-#8166 for each batch's exact field list). The 5 pilot
-// fields plus D batches 1-8's 155 fields (#8158-#8165) are typed against the
-// generated Args types below; the remaining root fields on this object keep
-// their `Row`-typed destructured params for now, adopted incrementally in
-// the final batch rather than all at once here.
+// Row-erased (types-epic D, #7862, batches #8158-#8166 -- see PR #8005 for
+// the pilot conversion + the codegen mechanism). Every Query root field on
+// this object is now typed against the generated Query<Field>Args types
+// below rather than a Row-typed destructured param.
 const rootValue = {
   subnets(
     {
@@ -4373,7 +4380,7 @@ const rootValue = {
       to,
       call_function: callFunction,
       success,
-    }: Row,
+    }: QuerySudoArgs,
     context: GqlContext,
   ) {
     // The Sudo governance feed is the /extrinsics feed with call_module fixed
@@ -7659,7 +7666,10 @@ const rootValue = {
     };
   },
 
-  async subnet_lease_history({ netuid }: Row, context: GqlContext) {
+  async subnet_lease_history(
+    { netuid }: QuerySubnet_Lease_HistoryArgs,
+    context: GqlContext,
+  ) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -7678,7 +7688,7 @@ const rootValue = {
     };
   },
 
-  async subnet_lease({ netuid }: Row, context: GqlContext) {
+  async subnet_lease({ netuid }: QuerySubnet_LeaseArgs, context: GqlContext) {
     if (!isU16Netuid(netuid)) {
       throw new GraphQLError(
         "netuid must be an integer in the u16 range 0..65535.",
@@ -7692,7 +7702,10 @@ const rootValue = {
     return loadSubnetLease(context.env, netuid);
   },
 
-  async account_balance({ ss58 }: Row, context: GqlContext) {
+  async account_balance(
+    { ss58 }: QueryAccount_BalanceArgs,
+    context: GqlContext,
+  ) {
     if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7706,7 +7719,10 @@ const rootValue = {
     return loadAccountBalance(context.env, ss58);
   },
 
-  async account_root_claim({ ss58 }: Row, context: GqlContext) {
+  async account_root_claim(
+    { ss58 }: QueryAccount_Root_ClaimArgs,
+    context: GqlContext,
+  ) {
     if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7718,7 +7734,10 @@ const rootValue = {
     return loadAccountRootClaim(context.env, ss58);
   },
 
-  async account_children({ ss58 }: Row, context: GqlContext) {
+  async account_children(
+    { ss58 }: QueryAccount_ChildrenArgs,
+    context: GqlContext,
+  ) {
     if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7732,7 +7751,10 @@ const rootValue = {
     return loadAccountChildren(context.env, ss58);
   },
 
-  async account_parents({ ss58 }: Row, context: GqlContext) {
+  async account_parents(
+    { ss58 }: QueryAccount_ParentsArgs,
+    context: GqlContext,
+  ) {
     if (!isFinneySs58Address(ss58)) {
       throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -7778,13 +7800,16 @@ const rootValue = {
   async randomness_status(_args: unknown, context: GqlContext) {
     return rootValue.network_randomness(_args, context);
   },
-  async evm_address({ h160 }: Row, context: GqlContext) {
+  async evm_address({ h160 }: QueryEvm_AddressArgs, context: GqlContext) {
     return resolveEvmAddressMapping(h160, context);
   },
   // Same resolver as evm_address, under the get_evm_address_mapping tool name so
   // MCP and GraphQL agree; delegating rather than duplicating keeps the two
   // fields from ever drifting apart.
-  async evm_address_mapping({ h160 }: Row, context: GqlContext) {
+  async evm_address_mapping(
+    { h160 }: QueryEvm_Address_MappingArgs,
+    context: GqlContext,
+  ) {
     return resolveEvmAddressMapping(h160, context);
   },
 };

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -521,24 +521,41 @@ import { SDL } from "./graphql-sdl.ts";
 import type {
   QueryAgent_CatalogArgs,
   QueryCandidatesArgs,
+  QueryCompare_ValidatorsArgs,
+  QueryDomain_SummaryArgs,
   QueryEconomicsArgs,
   QueryFixtureArgs,
   QuerySaved_QueryArgs,
   QuerySearchArgs,
+  QuerySearch_IndexArgs,
   QuerySubnetArgs,
-  QuerySubnetsArgs,
+  QuerySubnet_Axon_RemovalsArgs,
+  QuerySubnet_CandidatesArgs,
   QuerySubnet_DeregistrationsArgs,
+  QuerySubnet_EndpointsArgs,
+  QuerySubnet_Event_SummaryArgs,
+  QuerySubnet_EventsArgs,
+  QuerySubnet_EvidenceArgs,
+  QuerySubnet_GapsArgs,
   QuerySubnet_HealthArgs,
   QuerySubnet_Health_IncidentsArgs,
   QuerySubnet_Health_PercentilesArgs,
   QuerySubnet_Health_TrendsArgs,
   QuerySubnet_HyperparametersArgs,
   QuerySubnet_Hyperparameters_HistoryArgs,
+  QuerySubnet_Idle_StakeArgs,
+  QuerySubnet_OhlcArgs,
   QuerySubnet_RegistrationsArgs,
   QuerySubnet_ServingArgs,
+  QuerySubnet_Stake_FlowArgs,
+  QuerySubnet_Stake_MovesArgs,
   QuerySubnet_Stake_QuoteArgs,
+  QuerySubnet_Stake_TransfersArgs,
   QuerySubnet_UptimeArgs,
+  QuerySubnet_ValidatorsArgs,
   QuerySubnet_VolumeArgs,
+  QuerySubnet_WeightsArgs,
+  QuerySubnetsArgs,
   QueryTop_HoldersArgs,
 } from "../generated/graphql/types.ts";
 
@@ -1678,7 +1695,7 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batches 2-9 (types-epic D, #7862 tracks follow-up
+// Row-erased: pending D batches 3-9 (types-epic D, #7862 tracks follow-up
 // batches). The 5 pilot fields (subnets, subnet, subnet_health,
 // subnet_stake_quote, economics) plus D batch 1's 20 fields
 // (subnet_registrations, subnet_hyperparameters,
@@ -1686,10 +1703,16 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
 // subnet_health_trends, subnet_uptime, subnet_health_incidents,
 // subnet_health_percentiles, subnet_volume, agent_resources, curation,
 // candidates, saved_query, fixtures, fixture, agent_catalog, freshness,
-// top_holders, search) are typed against the generated Args types below;
-// the remaining ~130 root fields on this object keep their `Row`-typed
-// destructured params for now, adopted incrementally in later batches
-// rather than all at once here.
+// top_holders, search) plus D batch 2's 20 fields (search_index, domains,
+// domain_summary, compare_validators, coverage, coverage_depth,
+// subnet_ohlc, subnet_validators, subnet_event_summary, subnet_gaps,
+// subnet_evidence, subnet_candidates, subnet_endpoints,
+// subnet_axon_removals, subnet_weights, subnet_stake_moves,
+// subnet_stake_transfers, subnet_idle_stake, subnet_stake_flow,
+// subnet_events) are typed against the generated Args types below; the
+// remaining root fields on this object keep their `Row`-typed destructured
+// params for now, adopted incrementally in later batches rather than all
+// at once here.
 const rootValue = {
   subnets(
     {
@@ -2129,7 +2152,10 @@ const rootValue = {
     };
   },
 
-  async subnet_axon_removals({ netuid, window }: Row, context: GqlContext) {
+  async subnet_axon_removals(
+    { netuid, window }: QuerySubnet_Axon_RemovalsArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetAxonRemovals uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
@@ -2559,7 +2585,10 @@ const rootValue = {
     };
   },
 
-  async subnet_weights({ netuid, window }: Row, context: GqlContext) {
+  async subnet_weights(
+    { netuid, window }: QuerySubnet_WeightsArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetWeights uses -- an unsupported
     // window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_WEIGHTS_WINDOW;
@@ -2597,7 +2626,10 @@ const rootValue = {
     };
   },
 
-  async subnet_stake_moves({ netuid, window }: Row, context: GqlContext) {
+  async subnet_stake_moves(
+    { netuid, window }: QuerySubnet_Stake_MovesArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetStakeMoves uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_STAKE_MOVES_WINDOW;
@@ -2635,7 +2667,10 @@ const rootValue = {
     };
   },
 
-  async subnet_stake_transfers({ netuid, window }: Row, context: GqlContext) {
+  async subnet_stake_transfers(
+    { netuid, window }: QuerySubnet_Stake_TransfersArgs,
+    context: GqlContext,
+  ) {
     // Same 7d/30d window validation handleSubnetStakeTransfers uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
     const windowParam = window ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
@@ -2673,7 +2708,10 @@ const rootValue = {
     };
   },
 
-  async subnet_idle_stake({ netuid }: Row, context: GqlContext) {
+  async subnet_idle_stake(
+    { netuid }: QuerySubnet_Idle_StakeArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -2700,7 +2738,7 @@ const rootValue = {
   },
 
   async subnet_stake_flow(
-    { netuid, window, direction }: Row,
+    { netuid, window, direction }: QuerySubnet_Stake_FlowArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -2757,7 +2795,14 @@ const rootValue = {
   },
 
   async subnet_events(
-    { netuid, kind, block_start, block_end, limit, offset }: Row,
+    {
+      netuid,
+      kind,
+      block_start,
+      block_end,
+      limit,
+      offset,
+    }: QuerySubnet_EventsArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -3426,7 +3471,7 @@ const rootValue = {
   // limit/cursor validation and filtering are all handled by the loader --
   // an invalid arg throws and becomes a GraphQL error, matching every other
   // filtered field's convention (search/source_snapshots/evidence/profiles).
-  search_index(args: Row, context: GqlContext) {
+  search_index(args: QuerySearch_IndexArgs, context: GqlContext) {
     return loadSearchIndexList(mcpCtx(context), args, { readArtifact });
   },
 
@@ -3440,7 +3485,7 @@ const rootValue = {
     return buildDomainOverview(subnetRows, economicsRows);
   },
 
-  async domain_summary({ tag }: Row, context: GqlContext) {
+  async domain_summary({ tag }: QueryDomain_SummaryArgs, context: GqlContext) {
     // The same fixed 14-tag enum ?domain= validates on subnets -- an unknown
     // tag is a GraphQL BAD_USER_INPUT error, not an empty rollup.
     if (!DOMAIN_TAGS.includes(tag)) {
@@ -3455,7 +3500,10 @@ const rootValue = {
     return buildDomainSummary(tag, subnetRows, economicsRows);
   },
 
-  async compare_validators({ hotkeys, netuid }: Row, context: GqlContext) {
+  async compare_validators(
+    { hotkeys, netuid }: QueryCompare_ValidatorsArgs,
+    context: GqlContext,
+  ) {
     // Same parse/validate contract the REST route + compare_validators MCP
     // tool share: 1..COMPARE_VALIDATORS_MAX distinct SS58 addresses.
     const parsed = parseCompareHotkeyList(hotkeys);
@@ -3567,7 +3615,10 @@ const rootValue = {
     };
   },
 
-  async subnet_ohlc({ netuid, interval, days }: Row, context: GqlContext) {
+  async subnet_ohlc(
+    { netuid, interval, days }: QuerySubnet_OhlcArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -3650,7 +3701,10 @@ const rootValue = {
     return { schema_version: 1, ...result.quote };
   },
 
-  async subnet_validators({ netuid }: Row, context: GqlContext) {
+  async subnet_validators(
+    { netuid }: QuerySubnet_ValidatorsArgs,
+    context: GqlContext,
+  ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
         extensions: { code: "BAD_USER_INPUT" },
@@ -3726,7 +3780,7 @@ const rootValue = {
   },
 
   async subnet_event_summary(
-    { netuid, window, limit }: Row,
+    { netuid, window, limit }: QuerySubnet_Event_SummaryArgs,
     context: GqlContext,
   ) {
     if (!Number.isInteger(netuid) || netuid < 0) {
@@ -3787,7 +3841,7 @@ const rootValue = {
     };
   },
 
-  async subnet_gaps(args: Row, context: GqlContext) {
+  async subnet_gaps(args: QuerySubnet_GapsArgs, context: GqlContext) {
     const { netuid } = args;
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
@@ -3851,7 +3905,7 @@ const rootValue = {
     };
   },
 
-  async subnet_evidence(args: Row, context: GqlContext) {
+  async subnet_evidence(args: QuerySubnet_EvidenceArgs, context: GqlContext) {
     const { netuid } = args;
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
@@ -3886,7 +3940,10 @@ const rootValue = {
     }
   },
 
-  async subnet_candidates(args: Row, context: GqlContext) {
+  async subnet_candidates(
+    args: QuerySubnet_CandidatesArgs,
+    context: GqlContext,
+  ) {
     const { netuid } = args;
     if (!Number.isInteger(netuid) || netuid < 0) {
       throw new GraphQLError("netuid must be a non-negative integer.", {
@@ -3933,7 +3990,7 @@ const rootValue = {
   // GraphQL error, matching the subnet_candidates sibling's convention. A cold/
   // absent per-subnet artifact stays null (the documented per-subnet contract),
   // never a silently substituted empty list.
-  async subnet_endpoints(args: Row, context: GqlContext) {
+  async subnet_endpoints(args: QuerySubnet_EndpointsArgs, context: GqlContext) {
     try {
       return await loadSubnetEndpointsList(mcpCtx(context), args, {
         readArtifact,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -522,8 +522,14 @@ import type {
   QueryAccountArgs,
   QueryAccountsArgs,
   QueryAccount_Axon_RemovalsArgs,
+  QueryAccount_CounterpartiesArgs,
   QueryAccount_DeregistrationsArgs,
   QueryAccount_EntitiesArgs,
+  QueryAccount_EventsArgs,
+  QueryAccount_ExtrinsicsArgs,
+  QueryAccount_HistoryArgs,
+  QueryAccount_IdentityArgs,
+  QueryAccount_Identity_HistoryArgs,
   QueryAccount_PortfolioArgs,
   QueryAccount_Position_HistoryArgs,
   QueryAccount_PositionsArgs,
@@ -533,6 +539,7 @@ import type {
   QueryAccount_Stake_FlowArgs,
   QueryAccount_Stake_MovesArgs,
   QueryAccount_SubnetsArgs,
+  QueryAccount_TransfersArgs,
   QueryAccount_Weight_SettersArgs,
   QueryAdapterArgs,
   QueryAgent_CatalogArgs,
@@ -542,12 +549,23 @@ import type {
   QueryBlock_EventsArgs,
   QueryBlock_ExtrinsicsArgs,
   QueryCandidatesArgs,
+  QueryChain_ActivityArgs,
+  QueryChain_CallsArgs,
+  QueryChain_DeregistrationsArgs,
   QueryChain_EventsArgs,
   QueryChain_Events_StatsArgs,
+  QueryChain_FeesArgs,
+  QueryChain_Identity_HistoryArgs,
+  QueryChain_PrometheusArgs,
+  QueryChain_RegistrationsArgs,
+  QueryChain_ServingArgs,
+  QueryChain_TurnoverArgs,
+  QueryChain_WeightsArgs,
   QueryCompareArgs,
   QueryCompare_ValidatorsArgs,
   QueryDomain_SummaryArgs,
   QueryEconomicsArgs,
+  QueryEconomics_TrendsArgs,
   QueryEndpoint_IncidentsArgs,
   QueryEndpoint_PoolsArgs,
   QueryEndpointsArgs,
@@ -573,6 +591,7 @@ import type {
   QueryReview_Enrichment_TargetsArgs,
   QueryReview_GapsArgs,
   QueryReview_Profile_CompletenessArgs,
+  QueryRegistry_LeaderboardsArgs,
   QueryRpc_EndpointsArgs,
   QueryRpc_PoolsArgs,
   QuerySaved_QueryArgs,
@@ -600,6 +619,7 @@ import type {
   QuerySubnet_Identity_HistoryArgs,
   QuerySubnet_Idle_StakeArgs,
   QuerySubnet_MetagraphArgs,
+  QuerySubnet_MoversArgs,
   QuerySubnet_OhlcArgs,
   QuerySubnet_OverviewArgs,
   QuerySubnet_PerformanceArgs,
@@ -1765,9 +1785,9 @@ function resolveEvmAddressMapping(h160: string, context: GqlContext) {
   return loadAddressMapping(context.env, h160);
 }
 
-// Row-erased: pending D batches 7-9 (types-epic D, #7862 tracks follow-up
+// Row-erased: pending D batches 8-9 (types-epic D, #7862 tracks follow-up
 // batches -- see #8158-#8166 for each batch's exact field list). The 5 pilot
-// fields plus D batches 1-6's 115 fields (#8158-#8163) are typed against the
+// fields plus D batches 1-7's 135 fields (#8158-#8164) are typed against the
 // generated Args types below; the remaining root fields on this object keep
 // their `Row`-typed destructured params for now, adopted incrementally in
 // later batches rather than all at once here.
@@ -2306,7 +2326,10 @@ const rootValue = {
     };
   },
 
-  async chain_identity_history({ limit }: Row, context: GqlContext) {
+  async chain_identity_history(
+    { limit }: QueryChain_Identity_HistoryArgs,
+    context: GqlContext,
+  ) {
     // Same FEED_PAGINATION clamp REST applies. This chain-wide feed is
     // limit-only (no offset/cursor) -- the network view returns the most-recent
     // changes across every subnet in one pass.
@@ -5517,7 +5540,10 @@ const rootValue = {
     };
   },
 
-  async account_identity({ ss58 }: Row, context: GqlContext) {
+  async account_identity(
+    { ss58 }: QueryAccount_IdentityArgs,
+    context: GqlContext,
+  ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
     // is a GraphQL BAD_USER_INPUT error, not a silent empty card.
     if (!SS58_ADDRESS_PATTERN.test(ss58)) {
@@ -5555,7 +5581,7 @@ const rootValue = {
   },
 
   async account_identity_history(
-    { ss58, limit, offset, cursor }: Row,
+    { ss58, limit, offset, cursor }: QueryAccount_Identity_HistoryArgs,
     context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed
@@ -5611,7 +5637,7 @@ const rootValue = {
   },
 
   async account_counterparties(
-    { ss58, counterparty, limit }: Row,
+    { ss58, counterparty, limit }: QueryAccount_CounterpartiesArgs,
     context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
@@ -5657,7 +5683,7 @@ const rootValue = {
     if (data == null) {
       if (counterparty != null) {
         const rel = buildCounterpartyRelationship([], ss58, counterparty, {
-          limit,
+          limit: limit ?? undefined,
         });
         data = {
           schema_version: 1,
@@ -5671,7 +5697,7 @@ const rootValue = {
           relationship: rel,
         };
       } else {
-        data = buildCounterparties([], ss58, { limit });
+        data = buildCounterparties([], ss58, { limit: limit ?? undefined });
       }
     }
     const rel = data.relationship;
@@ -5723,7 +5749,15 @@ const rootValue = {
   },
 
   async account_transfers(
-    { ss58, limit, offset, cursor, direction, block_start, block_end }: Row,
+    {
+      ss58,
+      limit,
+      offset,
+      cursor,
+      direction,
+      block_start,
+      block_end,
+    }: QueryAccount_TransfersArgs,
     context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
@@ -5785,7 +5819,14 @@ const rootValue = {
   },
 
   async account_extrinsics(
-    { ss58, limit, offset, cursor, block_start, block_end }: Row,
+    {
+      ss58,
+      limit,
+      offset,
+      cursor,
+      block_start,
+      block_end,
+    }: QueryAccount_ExtrinsicsArgs,
     context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
@@ -5840,7 +5881,16 @@ const rootValue = {
   },
 
   async account_events(
-    { ss58, kind, netuid, block_start, block_end, limit, offset, cursor }: Row,
+    {
+      ss58,
+      kind,
+      netuid,
+      block_start,
+      block_end,
+      limit,
+      offset,
+      cursor,
+    }: QueryAccount_EventsArgs,
     context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
@@ -5907,7 +5957,7 @@ const rootValue = {
   },
 
   async account_history(
-    { ss58, netuid, from, to, limit, offset, cursor }: Row,
+    { ss58, netuid, from, to, limit, offset, cursor }: QueryAccount_HistoryArgs,
     context: GqlContext,
   ) {
     // Same SS58 validation every account_* resolver uses -- a malformed address
@@ -5986,7 +6036,10 @@ const rootValue = {
     };
   },
 
-  async economics_trends({ window }: Row, context: GqlContext) {
+  async economics_trends(
+    { window }: QueryEconomics_TrendsArgs,
+    context: GqlContext,
+  ) {
     // Same parseHistoryWindow REST uses, so accepted window labels and the
     // resulting { label, days } stay identical between REST and GraphQL.
     const windowResult = parseHistoryWindow(window);
@@ -6019,7 +6072,10 @@ const rootValue = {
     };
   },
 
-  async subnet_movers({ window, sort, limit }: Row, context: GqlContext) {
+  async subnet_movers(
+    { window, sort, limit }: QuerySubnet_MoversArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_MOVERS_WINDOW;
     if (!Object.hasOwn(MOVERS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6093,7 +6149,10 @@ const rootValue = {
     };
   },
 
-  async chain_turnover({ window, limit }: Row, context: GqlContext) {
+  async chain_turnover(
+    { window, limit }: QueryChain_TurnoverArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_TURNOVER_WINDOW;
     if (!Object.hasOwn(CHAIN_TURNOVER_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6146,7 +6205,10 @@ const rootValue = {
     };
   },
 
-  async chain_activity({ window }: Row, context: GqlContext) {
+  async chain_activity(
+    { window }: QueryChain_ActivityArgs,
+    context: GqlContext,
+  ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleChainActivity
     // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
     // BAD_USER_INPUT error, not a silent empty result.
@@ -6191,7 +6253,12 @@ const rootValue = {
   },
 
   async chain_calls(
-    { window, group_by: groupBy, limit, call_module: callModule }: Row,
+    {
+      window,
+      group_by: groupBy,
+      limit,
+      call_module: callModule,
+    }: QueryChain_CallsArgs,
     context: GqlContext,
   ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleChainCalls
@@ -6256,7 +6323,7 @@ const rootValue = {
   },
 
   async chain_fees(
-    { window, limit, call_module: callModule }: Row,
+    { window, limit, call_module: callModule }: QueryChain_FeesArgs,
     context: GqlContext,
   ) {
     // Reuse the exact analyticsWindow parse/validate REST's handleChainFees
@@ -6316,7 +6383,10 @@ const rootValue = {
     };
   },
 
-  async chain_weights({ window, limit }: Row, context: GqlContext) {
+  async chain_weights(
+    { window, limit }: QueryChain_WeightsArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_WEIGHTS_WINDOW;
     if (!Object.hasOwn(CHAIN_WEIGHTS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6362,7 +6432,10 @@ const rootValue = {
     };
   },
 
-  async chain_serving({ window, limit }: Row, context: GqlContext) {
+  async chain_serving(
+    { window, limit }: QueryChain_ServingArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_SERVING_WINDOW;
     if (!Object.hasOwn(CHAIN_SERVING_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6446,7 +6519,10 @@ const rootValue = {
     };
   },
 
-  async chain_deregistrations({ window, limit }: Row, context: GqlContext) {
+  async chain_deregistrations(
+    { window, limit }: QueryChain_DeregistrationsArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW;
     if (!Object.hasOwn(CHAIN_DEREGISTRATIONS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6494,7 +6570,10 @@ const rootValue = {
     };
   },
 
-  async chain_registrations({ window, limit }: Row, context: GqlContext) {
+  async chain_registrations(
+    { window, limit }: QueryChain_RegistrationsArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_REGISTRATIONS_WINDOW;
     if (!Object.hasOwn(CHAIN_REGISTRATIONS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -6539,7 +6618,10 @@ const rootValue = {
     };
   },
 
-  async chain_prometheus({ window, limit }: Row, context: GqlContext) {
+  async chain_prometheus(
+    { window, limit }: QueryChain_PrometheusArgs,
+    context: GqlContext,
+  ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_PROMETHEUS_WINDOW;
     if (!Object.hasOwn(CHAIN_PROMETHEUS_WINDOWS, requestedWindow)) {
       throw new GraphQLError(
@@ -7257,7 +7339,10 @@ const rootValue = {
     };
   },
 
-  async registry_leaderboards({ board, limit }: Row, context: GqlContext) {
+  async registry_leaderboards(
+    { board, limit }: QueryRegistry_LeaderboardsArgs,
+    context: GqlContext,
+  ) {
     // Same board allowlist handleLeaderboards enforces -- an unknown board is a
     // GraphQL BAD_USER_INPUT error, mirroring REST's invalid_query 400 rather
     // than silently resolving to an empty board.


### PR DESCRIPTION
Closes #8159. Closes #8160. Closes #8161. Closes #8162. Closes #8163. Closes #8164. Closes #8165. Closes #8166.

Consolidates types-epic D batches 2 through 9 (batch 1 / #8158 already merged as #8194) into a single PR, following PR #8005/#8194's established process for converting each batch's `Query` root field resolvers from `Row`-typed `args`/`context` to the generated `Query<Field>Args` types.

**Why one PR instead of 8:** the 8 batches were originally built as independent PRs (#8195-#8197 opened, batches 5-9 not yet opened), each cut from `origin/main` before any other batch merged. Since batch 1 merged first, every other batch's PR immediately went `CONFLICTING` against the same shared region of `src/graphql.ts` (the `import type { ... }` block and the `// Row-erased: pending D batch N` comment at the `rootValue` declaration) — a cascading-conflict problem that would repeat for every subsequent batch. This PR supersedes #8195/#8196/#8197 (closed as superseded) and folds the remaining, not-yet-opened batches 5-9 into the same PR, so there is exactly one more merge/conflict-resolution cycle instead of eight.

## Fields converted, all 8 batches (155 fields)

- **Batch 2** (#8159, 20 fields): `search_index`, `domains`, `domain_summary`, `compare_validators`, `coverage`, `coverage_depth`, `subnet_ohlc`, `subnet_validators`, `subnet_event_summary`, `subnet_gaps`, `subnet_evidence`, `subnet_candidates`, `subnet_endpoints`, `subnet_axon_removals`, `subnet_weights`, `subnet_stake_moves`, `subnet_stake_transfers`, `subnet_idle_stake`, `subnet_stake_flow`, `subnet_events`.
- **Batch 3** (#8160, 20 fields): `subnet_history`, `subnet_prometheus`, `subnet_weight_setters`, `subnet_yield`, `subnet_yield_history`, `subnet_performance`, `subnet_performance_history`, `subnet_concentration`, `subnet_concentration_history`, `neuron`, `neuron_history`, `subnet_identity_history`, `subnet_trajectory`, `subnet_metagraph`, `subnet_overview`, `subnet_profile`, `providers`, `provider`, `adapter`, `surfaces`.
- **Batch 4** (#8161, 20 fields): `endpoints`, `provider_endpoints`, `endpoint_pools`, `rpc_pools`, `endpoint_incidents`, `source_snapshots`, `gaps`, `evidence`, `profiles`, `review_adapter_candidates`, `review_enrichment_evidence`, `review_enrichment_queue`, `review_enrichment_targets`, `review_gaps`, `review_profile_completeness`, `registry_summary`, `schemas`, `source_health`, `lineage`, `rpc_endpoints`.
- **Batch 5** (#8162, 20 fields): `changelog`, `contracts`, `build`, `health_history`, `health`, `opportunity_boards`, `compare`, `incidents`, `global_incidents`, `extrinsics`, `chain_events`, `chain_events_stats`, `extrinsic`, `governance_config_changes`, `blocks`, `block`, `block_extrinsics`, `block_events`, `block_chain_events`, `blocks_summary`.
- **Batch 6** (#8163, 20 fields): `runtime`, `validators`, `validator`, `validator_nominators`, `validator_history`, `accounts`, `account`, `account_prometheus`, `account_registrations`, `account_deregistrations`, `account_stake_flow`, `account_position_history`, `account_portfolio`, `account_positions`, `account_subnets`, `account_serving`, `account_axon_removals`, `account_stake_moves`, `account_weight_setters`, `account_entities`.
- **Batch 7** (#8164, 20 fields): `account_identity`, `account_identity_history`, `account_counterparties`, `account_transfers`, `account_extrinsics`, `account_events`, `account_history`, `economics_trends`, `registry_leaderboards`, `subnet_movers`, `chain_turnover`, `chain_identity_history`, `chain_weights`, `chain_serving`, `chain_calls`, `chain_prometheus`, `chain_deregistrations`, `chain_registrations`, `chain_fees`, `chain_activity`.
- **Batch 8** (#8165, 20 fields): `chain_axon_removals`, `chain_weight_setters`, `chain_signers`, `health_trends`, `rpc_usage`, `chain_performance`, `chain_yield`, `chain_concentration`, `chain_alpha_volume`, `chain_idle_stake`, `chain_stake_flow`, `chain_stake_moves`, `chain_stake_transfers`, `chain_transfer_pairs`, `chain_transfers`, `subnet_recycled`, `subnet_burn`, `subnet_turnover`, `subnet_ownership_history`, `subnet_conviction`.
- **Batch 9** (#8166, 13 fields — the final batch): `subnet_lease`, `subnet_lease_history`, `account_balance`, `account_root_claim`, `account_children`, `account_parents`, `sudo_key`, `network_parameters`, `network_randomness`, `randomness_status`, `evm_address`, `evm_address_mapping`, `sudo`.

Every one of this batch set's argless fields (`domains`, `coverage`, `coverage_depth`, `agent_resources`-adjacent no-ops carried from batch 1, `registry_summary`, `schemas`, `source_health`, `lineage`, `changelog`, `contracts`, `build`, `health`, `blocks_summary`, `runtime`, `chain_performance`, `chain_yield`, `chain_concentration`, `chain_idle_stake`, `health_trends`, `sudo_key`, `network_parameters`, `network_randomness`, `randomness_status`) already used `_args: unknown` — no code change needed beyond removing them from the pending-batch note.

**With this PR merged, every `Query` root field on `rootValue` is typed against the generated `Query<Field>Args` types** — the `// Row-erased: pending D batch N` tracking note at the `rootValue` declaration is retired.

## Step 2: checked every resolver for a real SDL/resolver mismatch

Read every non-argless resolver body across all 155 fields against its SDL definition in `src/graphql-sdl.ts`. Found two real type-narrowing issues (both a class of latent bug pre-existing before this change, just hidden by `Row`'s implicit `any`, not introduced by it):

1. **`block_extrinsics`/`block_events`** (batch 5) guarded `limit`/`offset` with bare `Number.isFinite(x)`, whose parameter type is strictly `number` — now that `x` is `number | null | undefined` (not `any`), TS correctly flags it. Fixed with the same `typeof x === "number" && Number.isFinite(x)` guard already used at `src/graphql.ts:1232` for an identically-shaped case; runtime behavior is unchanged (`undefined`/`null` still fail the guard, same as before).
2. **`account_counterparties`** (batch 7) and **`chain_signers`** (batch 8) each passed a nullable GraphQL arg (`limit`, `sort`) straight through to a shared builder (`buildCounterpartyRelationship`/`buildCounterparties`, `buildChainSigners`) whose destructured default (`{ limit = 20 }`, `{ sort = "tx_count" }`) only fires on `undefined`, not `null` — so an explicit `null` argument silently bypassed the default at runtime, a latent behavior gap that predates this PR. Normalized both call sites to `x ?? undefined`, matching every other windowed resolver's `x ?? DEFAULT` convention in this file, so an explicit `null` now gets the same default as an omitted argument.

Every other field across all 8 batches matched its SDL definition exactly — no other mismatches found. Several fields forward their whole `args` object wholesale into a shared MCP/REST loader (`loadSearchIndexList`, `loadSubnetEvidenceList`, `loadProvidersList`, `loadEndpointsPage`, `loadRpcPoolsList`, the five `review_*` loaders, etc.); every one of those loaders' own parameter type is `Row`/`Record<string, unknown> | null | undefined`, so the generated Args types are structurally assignable with no cast needed.

## Instrumentation

No new error-tracking instrumentation needed. GraphQL resolver faults are captured for every field, regardless of argument typing, at the single `execute()` call site in `src/graphql.ts` (`recordExceptionEvent`, `route: "graphql"`, `errorCode: "graphql_execution_error"`). This PR is a pure argument-typing change (plus the two narrow, called-out fixes above) with no other control-flow changes.

## Verification

- `npx tsc --noEmit` clean, repo-wide.
- `node scripts/validate-graphql-types-drift.ts` — generated types current, no drift.
- `npx eslint src/graphql.ts` / `npx prettier --check src/graphql.ts` clean.
- `tests/graphql.test.ts` (1022), `tests/chain-firehose-hub.test.ts` (126), `tests/chain-firehose-routes.test.ts` (15), `tests/pipeline-validator-parity.test.ts` (2) — all 1165 passing, assertions unchanged, re-verified after every one of the 8 batch commits.
