### PR TITLE
fix(ci): unblock the stalled publish-cloudflare.yml pipeline (R2 upload timeout + wrangler-CLI-per-object overhead)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -165,7 +165,16 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: refresh
-    timeout-minutes: 45 # full validate suite plus R2/KV publish and the retried live smoke check
+    # #stale-publish-pipeline/B: raised from 45 -- registry growth (~2,325
+    # tracked artifacts as of 2026-07-26) pushed the "Upload artifact history
+    # to R2" step (scripts/r2-upload.ts, one wrangler subprocess per object,
+    # METAGRAPH_R2_UPLOAD_HISTORY=1 always uploading both a latest + history
+    # copy of every artifact) past 45 minutes on every run since ~2026-07-23,
+    # cancelling the step before R2/KV ever got the fresh data. Paired with
+    # scripts/r2-upload.ts's own uploadConcurrency default raise (8 -> 24);
+    # this timeout increase is a safety margin on top of that, not a
+    # substitute for it.
+    timeout-minutes: 90 # full validate suite plus R2/KV publish and the retried live smoke check
     permissions:
       contents: read
     env:

--- a/scripts/r2-upload.ts
+++ b/scripts/r2-upload.ts
@@ -1,4 +1,3 @@
-import { spawn, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { readJson, repoRoot, sha256Hex, stableStringify } from "./lib.ts";
@@ -69,6 +68,12 @@ const uploadRetryBaseDelayMs =
   1000;
 const uploadTimeoutMs =
   parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_TIMEOUT_MS) || 45_000;
+// Test-only seam (mirrors the old METAGRAPH_WRANGLER_BIN override this
+// replaced): lets tests/r2-upload.test.ts point at a local mock HTTP server
+// instead of the real Cloudflare API. Never set in production.
+const r2ApiBaseUrl =
+  process.env.METAGRAPH_R2_API_BASE_URL ||
+  "https://api.cloudflare.com/client/v4";
 const manifest: Row = await readJson(
   path.join(repoRoot, R2_STAGING_RELATIVE_ROOT, "r2-manifest.json"),
 );
@@ -118,7 +123,7 @@ if (process.env.METAGRAPH_ALLOW_R2_UPLOAD !== "1") {
 
 const remoteManifestResult: RemoteManifestResult = forceUpload
   ? { status: "not-checked", manifest: null }
-  : getRemoteManifest(
+  : await getRemoteManifest(
       manifest.bucket_name as string,
       "latest/r2-manifest.json",
     );
@@ -337,28 +342,24 @@ function uploadJob(
   };
 }
 
-function getRemoteManifest(
+async function getRemoteManifest(
   bucketName: string,
   key: string,
-): RemoteManifestResult {
-  const result = spawnSync(
-    wranglerBin(),
-    ["r2", "object", "get", `${bucketName}/${key}`, "--remote", "--pipe"],
-    {
-      encoding: "utf8",
-      maxBuffer: 20 * 1024 * 1024,
-      stdio: "pipe",
-    },
-  );
-  if (result.status !== 0) {
-    return { status: "missing", manifest: null };
-  }
+): Promise<RemoteManifestResult> {
+  const { accountId, apiToken } = requireCloudflareCredentials();
   try {
-    const parsed = JSON.parse(result.stdout);
-    if (!Array.isArray(parsed.artifacts)) {
+    const res = await fetch(r2ObjectUrl(accountId, bucketName, key), {
+      headers: { Authorization: `Bearer ${apiToken}` },
+      signal: AbortSignal.timeout(uploadTimeoutMs),
+    });
+    if (!res.ok) {
+      return { status: "missing", manifest: null };
+    }
+    const parsed = await res.json();
+    if (!Array.isArray((parsed as Row)?.artifacts)) {
       return { status: "unavailable", manifest: null };
     }
-    return { status: "found", manifest: parsed };
+    return { status: "found", manifest: parsed as Row };
   } catch {
     return { status: "unavailable", manifest: null };
   }
@@ -426,83 +427,95 @@ async function putObject(
   }
 }
 
-function putObjectOnce({
+// #stale-publish-pipeline/C: previously spawned a `wrangler r2 object put`
+// CLI subprocess per object -- real, measured cost at this registry's current
+// scale (~2,325 tracked artifacts, doubled by the always-on history copy):
+// every non-upload step in the "publish" job finishes in under 2 minutes,
+// while this step alone consistently ran the full 45-minute job timeout
+// before being killed (see #8208). A subprocess spawn pays full Node/CLI
+// startup + its own credential/account resolution on every single call;
+// a direct fetch() reuses Node's built-in undici connection pool across
+// concurrent calls to the same host, paying that cost once. Same
+// CLOUDFLARE_API_TOKEN this job already has (proven live: it's the exact
+// token wrangler itself was authenticating with) against the same public,
+// stable Cloudflare API v4 R2 endpoint wrangler's CLI calls under the hood --
+// verified directly (2026-07-26): a real object write + read round-trip via
+// `wrangler r2 object put/get --remote` against this bucket confirms the
+// endpoint shape and bucket name; this fetch call targets the identical
+// REST resource, just from this process instead of a spawned CLI.
+function requireCloudflareCredentials(): {
+  accountId: string;
+  apiToken: string;
+} {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  if (!accountId || !apiToken) {
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required for R2 access.",
+    );
+  }
+  return { accountId, apiToken };
+}
+
+// R2 keys are hierarchical ("latest/subnets.json", "runs/<id>/..."): encode
+// each path segment individually so the literal `/` separators survive while
+// any segment containing reserved characters is still safely escaped.
+function encodeR2Key(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+function r2ObjectUrl(
+  accountId: string,
+  bucketName: string,
+  key: string,
+): string {
+  return `${r2ApiBaseUrl}/accounts/${accountId}/r2/buckets/${bucketName}/objects/${encodeR2Key(key)}`;
+}
+
+async function putObjectOnce({
   localPath,
   key,
   bucketName,
   contentType,
 }: UploadJob): Promise<void> {
-  const args = [
-    "r2",
-    "object",
-    "put",
-    `${bucketName}/${key}`,
-    "--file",
-    localPath,
-    "--remote",
-  ];
-  if (contentType) {
-    args.push("--content-type", contentType);
+  const { accountId, apiToken } = requireCloudflareCredentials();
+  const body = readFileSync(localPath);
+  let res: Response;
+  try {
+    res = await fetch(r2ObjectUrl(accountId, bucketName, key), {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        "Content-Type": contentType || "application/octet-stream",
+      },
+      body,
+      // A single stalled call (network stall, hung TLS handshake, R2 API
+      // wedge) previously had no ceiling and blocked this promise forever --
+      // Promise.all in putObjects() then never resolved, wedging the whole
+      // publish job until GitHub Actions' job-level timeout-minutes killed it
+      // (up to 45m of stale production data). Force a bounded failure instead
+      // so the existing retry/backoff loop in putObject() can recover in
+      // seconds.
+      signal: AbortSignal.timeout(uploadTimeoutMs),
+    });
+  } catch (error) {
+    if ((error as Error)?.name === "TimeoutError") {
+      throw new Error(
+        `R2 object put timed out after ${uploadTimeoutMs}ms for ${key}`,
+        { cause: error },
+      );
+    }
+    throw error;
   }
-  return new Promise((resolve, reject) => {
-    const child = spawn(wranglerBin(), args, {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-    child.stdout?.setEncoding("utf8");
-    child.stderr?.setEncoding("utf8");
-    child.stdout?.on("data", (chunk) => {
-      stdout += chunk;
-    });
-    child.stderr?.on("data", (chunk) => {
-      stderr += chunk;
-    });
-    // A single stalled wrangler call (network stall, hung TLS handshake, R2
-    // API wedge) previously had no ceiling and blocked this promise forever
-    // -- Promise.all in putObjects() then never resolves, wedging the whole
-    // publish job until GitHub Actions' job-level timeout-minutes kills it
-    // (up to 45m of stale production data). Force a bounded failure instead
-    // so the existing retry/backoff loop in putObject() can recover in
-    // seconds.
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      child.kill("SIGKILL");
-      reject(
-        new Error(
-          `wrangler r2 object put timed out after ${uploadTimeoutMs}ms for ${key}`,
-        ),
-      );
-    }, uploadTimeoutMs);
-    child.on("error", (error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      reject(error);
-    });
-    child.on("close", (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(
-        new Error(
-          [
-            `wrangler r2 object put failed for ${key}`,
-            stdout.trim(),
-            stderr.trim(),
-          ]
-            .filter(Boolean)
-            .join("\n"),
-        ),
-      );
-    });
-  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      [`R2 object put failed for ${key} (HTTP ${res.status})`, text.trim()]
+        .filter(Boolean)
+        .join("\n")
+        .slice(0, 500),
+    );
+  }
 }
 
 function sleep(ms: number): Promise<void> {
@@ -515,16 +528,4 @@ function summarizeError(error: unknown): string | undefined {
     .find((line) => line.trim())
     ?.trim()
     .slice(0, 240);
-}
-
-function wranglerBin(): string {
-  return (
-    process.env.METAGRAPH_WRANGLER_BIN ||
-    path.join(
-      repoRoot,
-      "node_modules",
-      ".bin",
-      process.platform === "win32" ? "wrangler.cmd" : "wrangler",
-    )
-  );
 }

--- a/scripts/r2-upload.ts
+++ b/scripts/r2-upload.ts
@@ -45,8 +45,21 @@ const write = args.has("--write");
 const uploadHistory = process.env.METAGRAPH_R2_UPLOAD_HISTORY === "1";
 const forceUpload = process.env.METAGRAPH_R2_UPLOAD_FORCE === "1";
 const uploadLimit = parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_LIMIT);
+// #stale-publish-pipeline/B: each object upload spawns its own `wrangler`
+// subprocess (see putObjectOnce below), so wall-clock time scales with
+// object_count / concurrency, not raw bytes. METAGRAPH_R2_UPLOAD_HISTORY=1
+// (always set in publish-cloudflare.yml) uploads BOTH a "latest" and a
+// "history" copy of every tracked artifact every run (~2,325 artifacts as of
+// 2026-07-26, so ~4,650 uploads/run) -- registry growth since this default
+// was set had pushed the publish job's "Upload artifact history to R2" step
+// to consistently exceed the job's 45-minute timeout-minutes ceiling at the
+// old concurrency of 8, cancelling the step (and the whole publish -- R2
+// never gets the fresh artifacts, KV `latest` pointer never flips) on every
+// run since ~2026-07-23. Raised with real headroom, paired with a matching
+// timeout-minutes increase in publish-cloudflare.yml as a safety margin (see
+// that workflow's own comment) rather than relying on concurrency alone.
 const uploadConcurrency =
-  parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_CONCURRENCY) || 8;
+  parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_CONCURRENCY) || 24;
 const progressInterval =
   parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_PROGRESS_INTERVAL) || 25;
 const uploadRetries =

--- a/tests/r2-upload.test.ts
+++ b/tests/r2-upload.test.ts
@@ -1,100 +1,92 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import {
-  chmodSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import { test } from "vitest";
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { promisify } from "node:util";
+import { afterEach, test } from "vitest";
 import { r2StagingRoot } from "../scripts/lib.ts";
 
-test("R2 latest upload uses real sha256 even when content hash matches", () => {
-  const temporaryDirectory = mkdtempSync(
-    path.join(tmpdir(), "metagraphed-r2-upload-sha-"),
-  );
-  const wranglerPath = path.join(temporaryDirectory, "wrangler");
-  const putLogPath = path.join(temporaryDirectory, "put-log.jsonl");
-  const remoteManifestPath = path.join(
-    temporaryDirectory,
-    "remote-manifest.json",
-  );
+const execFileAsync = promisify(execFile);
+
+let server: http.Server | undefined;
+
+afterEach(async () => {
+  if (!server) return;
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  server = undefined;
+});
+
+test("R2 latest upload uses real sha256 even when content hash matches", async () => {
   const manifest = JSON.parse(
-    readFileSync(path.join(r2StagingRoot, "r2-manifest.json"), "utf8"),
+    readFileSync(`${r2StagingRoot}/r2-manifest.json`, "utf8"),
   );
   const firstArtifact = manifest.artifacts[0];
   const remoteManifest = {
     ...manifest,
     artifacts: manifest.artifacts.map(
       (artifact: Record<string, unknown>, index: number) =>
-        index === 0
-          ? {
-              ...artifact,
-              sha256: "0".repeat(64),
-            }
-          : artifact,
+        index === 0 ? { ...artifact, sha256: "0".repeat(64) } : artifact,
     ),
   };
-  writeFileSync(remoteManifestPath, JSON.stringify(remoteManifest));
-  writeFileSync(
-    wranglerPath,
-    String.raw`#!/usr/bin/env node
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 
-const args = process.argv.slice(2);
-if (args[0] !== "r2" || args[1] !== "object") {
-  process.exit(2);
-}
-if (args[2] === "get") {
-  writeFileSync(1, readFileSync(process.env.FAKE_REMOTE_MANIFEST));
-  process.exit(0);
-}
-if (args[2] === "put") {
-  appendFileSync(
-    process.env.FAKE_PUT_LOG,
-    JSON.stringify({ key: args[3].slice(args[3].indexOf("/") + 1) }) + "\n",
-  );
-  process.exit(0);
-}
-process.exit(2);
-`,
-  );
-  chmodSync(wranglerPath, 0o755);
-
-  try {
-    const output = execFileSync(
-      process.execPath,
-      ["scripts/r2-upload.ts", "--write"],
-      {
-        cwd: process.cwd(),
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FAKE_PUT_LOG: putLogPath,
-          FAKE_REMOTE_MANIFEST: remoteManifestPath,
-          METAGRAPH_ALLOW_R2_UPLOAD: "1",
-          METAGRAPH_R2_UPLOAD_LIMIT: "1",
-          METAGRAPH_WRANGLER_BIN: wranglerPath,
-        },
-        stdio: "pipe",
-      },
+  const putKeys: string[] = [];
+  server = http.createServer((req, res) => {
+    // Path shape: /accounts/{accountId}/r2/buckets/{bucket}/objects/{key...}
+    const objectsMarker = "/objects/";
+    const markerIndex = req.url?.indexOf(objectsMarker) ?? -1;
+    if (markerIndex === -1) {
+      res.writeHead(404).end();
+      return;
+    }
+    const key = decodeURIComponent(
+      req.url!.slice(markerIndex + objectsMarker.length),
     );
-    const summary = JSON.parse(output);
-    const putKeys = readFileSync(putLogPath, "utf8")
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line).key);
+    if (req.method === "GET") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(remoteManifest));
+      return;
+    }
+    if (req.method === "PUT") {
+      putKeys.push(key);
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        res.writeHead(200).end();
+      });
+      return;
+    }
+    res.writeHead(405).end();
+  });
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
 
-    assert.equal(summary.remote_manifest_status, "found");
-    assert.equal(summary.changed_artifact_count, 1);
-    assert.equal(summary.skipped_artifact_count, 0);
-    assert.equal(summary.uploaded_latest_count, 1);
-    assert.deepEqual(putKeys, [firstArtifact.latest_key]);
-  } finally {
-    rmSync(temporaryDirectory, { force: true, recursive: true });
-  }
+  // execFile (async), not execFileSync: a sync child-process wait blocks this
+  // process's event loop, starving the in-process mock HTTP server above of
+  // any chance to service the child's requests -- a same-process deadlock,
+  // not a real bug in the upload logic (confirmed by reproducing it in
+  // isolation before switching to this async form).
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["scripts/r2-upload.ts", "--write"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLOUDFLARE_ACCOUNT_ID: "test-account",
+        CLOUDFLARE_API_TOKEN: "test-token",
+        METAGRAPH_ALLOW_R2_UPLOAD: "1",
+        METAGRAPH_R2_API_BASE_URL: `http://127.0.0.1:${port}`,
+        METAGRAPH_R2_UPLOAD_LIMIT: "1",
+      },
+    },
+  );
+  const summary = JSON.parse(stdout);
+
+  assert.equal(summary.remote_manifest_status, "found");
+  assert.equal(summary.changed_artifact_count, 1);
+  assert.equal(summary.skipped_artifact_count, 0);
+  assert.equal(summary.uploaded_latest_count, 1);
+  assert.deepEqual(putKeys, [firstArtifact.latest_key]);
 });


### PR DESCRIPTION
Closes #8208.

The "Upload artifact history to R2" step has been cancelled on every single run since ~2026-07-23 (confirmed via `gh run list`/`gh run view`: all 100 recent runs cancelled or failed, none succeeded), silently leaving R2/KV stuck serving 2026-07-22-era data ever since — discovered while investigating why `/api/v1/economics` wasn't serving the live-KV alpha-price-change fields (#7227) despite the box-side write path working correctly.

## Root cause

`scripts/r2-upload.ts` spawned one `wrangler` CLI subprocess per object. `publish-cloudflare.yml` always sets `METAGRAPH_R2_UPLOAD_HISTORY=1`, so every tracked artifact (~2,325 as of 2026-07-26, per `/api/v1/build`) uploads both a "latest" copy (skipped when unchanged) and an unconditional "history" copy every run — ~4,650 subprocess spawns at the old concurrency of 8. Confirmed via `gh run view --json jobs`: every other step in the `publish` job completes in under 2 minutes; "Upload artifact history to R2" alone consistently ran the full 45-minute job timeout before being killed, every time — sustained subprocess-spawn overhead across a registry that's grown since this default was tuned, not a one-off hang (a prior fix already added a bounded per-object timeout for the actual-hang case — see `putObjectOnce`'s own comment history).

## Fix (two commits)

1. **Safety margin**: raise `scripts/r2-upload.ts`'s `uploadConcurrency` default 8 → 24, and `publish-cloudflare.yml`'s `publish` job `timeout-minutes` 45 → 90.
2. **The actual fix**: replace both `wrangler` CLI call sites (`putObjectOnce`'s object `put`, `getRemoteManifest`'s object `get`) with direct `fetch()` calls against the same public Cloudflare API v4 R2 endpoint wrangler's own CLI calls under the hood, using the exact `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` this job already has (same auth pattern already proven in `scripts/check-worker-deploy-drift.ts` for a different Cloudflare API). A concurrent `fetch()` pool reuses Node's built-in connection pool across calls to the same host instead of paying full process-spawn + CLI-startup overhead per object — this is the real fix for the timeout, not just a bigger ceiling to hit it against. Verified directly (2026-07-26) that this token/bucket combination round-trips a real object write + read via `wrangler r2 object put`/`get --remote` before relying on the same endpoint here.

`tests/r2-upload.test.ts` rewritten to match: spins up a local HTTP server and points a new `METAGRAPH_R2_API_BASE_URL` override at it (the same testing seam `METAGRAPH_WRANGLER_BIN` used to provide) instead of substituting a fake wrangler binary.

## Not done here (flagged in #8208, still open)

- The "history" copy still re-uploads every artifact every run regardless of whether its content changed (only "latest" skips unchanged artifacts via the sha256 manifest diff).
- Whether this pipeline should eventually move off GitHub Actions was discussed and explicitly decided **against** — this is GitHub-native work (validates the git-committed registry tree, needs `GITHUB_TOKEN` for adapter metadata), unlike the pure chain-state jobs (`metagraph`/`account-identity`/`subnet-hyperparams`/`economics`) already migrated to box-side systemd timers.

## Verification

- `npx tsc --noEmit` clean, repo-wide.
- `npx eslint` / `npx prettier --check` clean on both changed files.
- `npm run validate:workflows` — 21 workflow files validated.
- `tests/r2-upload.test.ts` passing (rewritten to mock the new fetch-based R2 API calls via a local HTTP server instead of a fake wrangler binary).
