### PR TITLE
fix(ui): decommission Umami, fix PostHog visitor-inflation + geo/title parity

### DIFF
--- a/apps/ui/src/lib/analytics-proxy.ts
+++ b/apps/ui/src/lib/analytics-proxy.ts
@@ -1,8 +1,9 @@
 // Product analytics (PostHog) first-party proxy (metagraphed#7760).
 //
-// Same rationale and first-party-proxy shape as the existing Umami proxy in
-// src/server.ts -- see its own header comment. This one specifically follows
-// PostHog's own documented Cloudflare Workers proxy guide
+// Same rationale and first-party-proxy shape as the Umami proxy that used to
+// live in src/server.ts (removed in #7767's decommission, once this proxy had
+// proven parity). This one specifically follows PostHog's own documented
+// Cloudflare Workers proxy guide
 // (posthog.com/docs/advanced/proxy/cloudflare) rather than being invented
 // from scratch: /static/* and /array/* route to PostHog's asset host (the JS
 // SDK bundle + per-project remote config, both edge-cacheable and never
@@ -13,8 +14,8 @@
 //
 // The path prefix deliberately avoids "analytics"/"tracking"/"posthog"/"ph"
 // (PostHog's own guide: ad blockers pattern-match those in URLs even on a
-// first-party origin) -- "ingest" was chosen for the same reason the
-// existing Umami prefix is the unrelated-sounding "/stats".
+// first-party origin) -- "ingest" was chosen for the same reason the old
+// Umami prefix (removed in #7767) was the unrelated-sounding "/stats".
 //
 // A standalone module (like lib/og-image.ts), not inline in server.ts, so it
 // can be unit-tested directly -- server.ts itself has no test harness (it
@@ -25,17 +26,18 @@ export const ANALYTICS_PREFIX = "/ingest";
 const POSTHOG_API_HOST = "us.i.posthog.com";
 const POSTHOG_ASSET_HOST = "us-assets.i.posthog.com";
 
-// Same defensive purpose as server.ts's own MAX_STATS_BODY_BYTES for the
-// sibling Umami proxy (this route is public/unauthenticated -- reachable by
-// anyone, not just posthog-js -- so it must never buffer an unbounded body
-// into Worker memory). Sized above that 16 KiB, not equal to it: PostHog's
-// own capture endpoint accepts BATCHED events (posthog-js can queue and flush
-// several pageview/custom events in one POST), unlike Umami's one-event-per-
-// request format, so a real single request legitimately runs larger. This is
-// our own defensive ceiling, not a PostHog-documented limit -- generous
-// enough for realistic batched web-analytics traffic (autocapture stays OFF
-// per metagraphed#7760's own requirement, so volume per batch stays small)
-// while still bounding worst-case memory per request to a small, fixed cap.
+// Same defensive purpose the old server.ts Umami proxy's own body-size cap
+// served before its #7767 removal (this route is public/unauthenticated --
+// reachable by anyone, not just posthog-js -- so it must never buffer an
+// unbounded body into Worker memory). Sized above that proxy's old 16 KiB,
+// not equal to it: PostHog's own capture endpoint accepts BATCHED events
+// (posthog-js can queue and flush several pageview/custom events in one
+// POST), unlike Umami's one-event-per-request format, so a real single
+// request legitimately runs larger. This is our own defensive ceiling, not a
+// PostHog-documented limit -- generous enough for realistic batched
+// web-analytics traffic (autocapture stays OFF per metagraphed#7760's own
+// requirement, so volume per batch stays small) while still bounding
+// worst-case memory per request to a small, fixed cap.
 const MAX_INGEST_BODY_BYTES = 64 * 1024;
 
 export type PostHogAssetContext = { waitUntil(promise: Promise<unknown>): void };
@@ -111,10 +113,10 @@ export async function forwardToAnalyticsHost(
 ): Promise<Response> {
   const hasBody = request.method !== "GET" && request.method !== "HEAD";
 
-  // Same content-length-first gate as server.ts's Umami collect endpoint --
-  // reject BEFORE buffering, never after, so an oversized/malformed request
-  // never gets read into memory at all. See MAX_INGEST_BODY_BYTES above for
-  // why the cap differs from Umami's own.
+  // Same content-length-first gate the old server.ts Umami collect endpoint
+  // used -- reject BEFORE buffering, never after, so an oversized/malformed
+  // request never gets read into memory at all. See MAX_INGEST_BODY_BYTES
+  // above for why the cap differs from Umami's own.
   if (hasBody) {
     const contentLengthHeader = request.headers.get("content-length");
     const contentLength = contentLengthHeader === null ? NaN : Number(contentLengthHeader);

--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -35,6 +35,7 @@ describe("analytics (PostHog web analytics)", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   describe("unconfigured (no token)", () => {
@@ -109,14 +110,17 @@ describe("analytics (PostHog web analytics)", () => {
       expect(options.defaults.length).toBeGreaterThan(0);
     });
 
-    it("respects DNT and uses memory-only (cookieless) persistence, matching Umami's no-cookie posture", async () => {
+    it("respects DNT and uses localStorage (no-cookie) persistence for cross-visit continuity", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
       const { initAnalytics } = await import("./analytics");
       initAnalytics();
       await vi.waitFor(() => expect(init).toHaveBeenCalled());
       const options = init.mock.calls[0][1];
       expect(options.respect_dnt).toBe(true);
-      expect(options.persistence).toBe("memory");
+      expect(options.persistence).toBe("localStorage");
+      // Never cookieless_mode -- see analytics.ts's own header comment for
+      // why (it strips GeoIP unconditionally and disables session replay).
+      expect(options.cookieless_mode).toBeUndefined();
     });
 
     it("enables pageleave and native web vitals capture despite capture_pageview being disabled", async () => {
@@ -158,7 +162,13 @@ describe("analytics (PostHog web analytics)", () => {
       expect(init.mock.calls[0][1].ui_host).toBe("https://eu.posthog.com");
     });
 
-    it("capturePageview captures $pageview with $current_url when a URL is given", async () => {
+    // This suite runs in vitest's plain "node" environment (vitest.config.ts's
+    // own comment: enough for lib/metagraphed's business logic), where
+    // `document` is undefined -- so these two tests exercise capturePageview's
+    // SSR/no-DOM fallback specifically. The dedicated "adds page_title from
+    // document.title" test below stubs a `document` global to cover the real
+    // browser path instead.
+    it("capturePageview captures $pageview with $current_url when a URL is given (no document global)", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
       const { capturePageview } = await import("./analytics");
       capturePageview("https://metagraph.sh/subnets/7");
@@ -168,12 +178,24 @@ describe("analytics (PostHog web analytics)", () => {
       });
     });
 
-    it("capturePageview omits properties (posthog-js's own current-URL read) when no URL is given", async () => {
+    it("capturePageview omits $current_url (posthog-js's own current-URL read) when no URL is given (no document global)", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
       const { capturePageview } = await import("./analytics");
       capturePageview();
       await vi.waitFor(() => expect(capture).toHaveBeenCalled());
-      expect(capture).toHaveBeenCalledWith("$pageview", undefined);
+      expect(capture).toHaveBeenCalledWith("$pageview", {});
+    });
+
+    it("capturePageview adds page_title from document.title when a document global exists (Umami parity, #7767)", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      vi.stubGlobal("document", { title: "Subnet 7 — Metagraphed" });
+      const { capturePageview } = await import("./analytics");
+      capturePageview("https://metagraph.sh/subnets/7");
+      await vi.waitFor(() => expect(capture).toHaveBeenCalled());
+      expect(capture).toHaveBeenCalledWith("$pageview", {
+        $current_url: "https://metagraph.sh/subnets/7",
+        page_title: "Subnet 7 — Metagraphed",
+      });
     });
 
     it("captureEvent forwards the name and properties verbatim", async () => {

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -13,9 +13,10 @@
  * `captureException` is called from error-reporting.ts's `reportError` --
  * metagraphed#7766: Sentry (formerly a parallel sink there) is fully removed
  * now that parity was proven; this module's `posthog-js` instance is the
- * only exception-capture sink left. The self-hosted Umami tracker
- * (src/server.ts) is a separate, still-gated decommission (#7767) -- see the
- * consolidation epic (metagraphed#7757) for the full history.
+ * only exception-capture sink left. The self-hosted Umami tracker that used
+ * to live alongside this in src/server.ts is now fully decommissioned
+ * (#7767) -- see the consolidation epic (metagraphed#7757) for the full
+ * history.
  *
  * `posthog-js` is loaded via a DYNAMIC import: this keeps it out of the initial client
  * bundle the CI bundle-size-budget gate measures (that check only counts the
@@ -41,6 +42,26 @@
  * than mixing automatic-for-the-first-load with manual-for-the-rest.
  * Autocapture of clicks/inputs is left to `defaults`' own recommended
  * behavior.
+ *
+ * Umami-parity audit (#7767's decommission gate -- "capture the same types of
+ * data Umami did"), checked against Umami's actual schema/behavior (its
+ * `website_event`/`session` tables, `src/app/api/send/route.ts`), not
+ * assumed:
+ *   - URL, referrer, UTM params (all 5), browser, OS, device type, screen
+ *     size, language: posthog-js attaches these automatically on every event
+ *     (confirmed against PostHog's own UTM-segmentation and event docs) --
+ *     nothing to configure.
+ *   - Page title: NOT a posthog-js default (confirmed no `$title`-equivalent
+ *     property in its source) -- added explicitly in `capturePageview` below.
+ *   - Geo (country/region/city): populated server-side from the real client
+ *     IP, which `src/lib/analytics-proxy.ts`'s `forwardToAnalyticsHost`
+ *     already forwards via `x-forwarded-for` -- unaffected by any setting in
+ *     this file. This is the one property Umami's OWN cookieless design and
+ *     PostHog's `cookieless_mode` both still provide -- but only PostHog's
+ *     `cookieless_mode` specifically strips it; ordinary (non-cookieless)
+ *     capture, which this file uses, keeps it.
+ *   - Web vitals: covered independently (capture_performance below); see its
+ *     own comment.
  */
 
 import type { PostHog } from "posthog-js";
@@ -103,8 +124,8 @@ function loadPostHog(): Promise<PostHog | null> {
         // Native Core Web Vitals capture (LCP/INP/CLS/FCP as posthog-js's
         // own $web_vitals events), independent of and in addition to this
         // app's existing custom 'web_vitals' event (src/server.ts's
-        // WEB_VITALS_SNIPPET, which also feeds Umami -- kept as-is, this
-        // doesn't replace it). Explicit here rather than relying solely on
+        // WEB_VITALS_SNIPPET -- kept as-is, this doesn't replace it).
+        // Explicit here rather than relying solely on
         // the dashboard's own "Web vitals autocapture" project setting: that
         // setting only reaches the client via the /array/*/config remote-
         // config fetch, so a client-side default keeps this working even if
@@ -114,24 +135,36 @@ function loadPostHog(): Promise<PostHog | null> {
         capture_performance: { web_vitals: true },
         // metagraphed#7760's own explicit requirement: "respect DNT, no
         // cookies beyond what's justified" -- parity with the self-hosted
-        // Umami tracker this sits alongside, which never sets cookies either.
+        // Umami tracker this originally sat alongside (now decommissioned,
+        // #7767), which never set cookies either.
         respect_dnt: true,
-        // "memory", not posthog-js's own 'localStorage+cookie' default: no
-        // cookie or localStorage write at all, matching Umami's cookieless
-        // posture directly. Deliberately NOT `cookieless_mode` (posthog-js's
-        // other no-cookie option) -- that one requires ALSO flipping a
-        // matching toggle in this project's PostHog dashboard settings or
-        // every event is silently dropped server-side (confirmed via
-        // node_modules/@posthog/types' own doc comment on the option); a
-        // config value here can't guarantee that dashboard-side state, so it
-        // would be a silent-data-loss trap the day someone forgets. The
-        // tradeoff: identity resets every reload/tab close (each is a new
-        // anonymous visitor) rather than persisting client-side -- accepted
-        // for a public dashboard that doesn't need cross-session user
-        // profiles for pageview-level web analytics. Session replay
-        // (below) inherits the same reset-per-reload behavior, since
-        // posthog-js's own session ID also lives in this persistence store.
-        persistence: "memory",
+        // "localStorage", not posthog-js's own 'localStorage+cookie' default
+        // and not "memory" (this module's original choice, changed
+        // 2026-07-26): "memory" persists nothing at all, so every reload/new
+        // tab/return visit reset identity -- each was counted as a brand-new
+        // visitor, which is what actually surfaced as PostHog's unique-visitor
+        // count running far hotter than Umami's for the same real traffic.
+        // "localStorage" persists a random anonymous ID with NO cookie set --
+        // still satisfies metagraphed#7760's "no cookies beyond what's
+        // justified" requirement (that requirement was about cookies
+        // specifically, not zero client storage of any kind) -- while giving
+        // a returning visitor in the same browser actual continuity, matching
+        // (and outlasting -- localStorage persists until the visitor clears
+        // site data, vs. Umami's own forced monthly salt rotation) what Umami
+        // provided.
+        //
+        // Deliberately NOT `cookieless_mode` (PostHog's own dedicated
+        // cookieless-tracking feature, posthog.com/docs/tutorials/
+        // cookieless-tracking): considered and rejected on its actual documented
+        // behavior, not a guess -- it strips the request IP server-side before
+        // any GeoIP enrichment runs, UNCONDITIONALLY, so country/city/region
+        // data (a #7767 Umami-parity requirement) would never populate again;
+        // it also disables session replay (#7761) entirely, for every visitor,
+        // with no override; and its server-side hash rotates on a DAILY salt
+        // (vs. Umami's own monthly), so it wouldn't even beat Umami's own
+        // long-window visitor-count accuracy. None of that is a config
+        // mistake to fix later -- it's how the feature is documented to work.
+        persistence: "localStorage",
         // Session replay (metagraphed#7761). Privacy is the point here, not
         // an afterthought -- see this module's own privacy review in the PR
         // that added this block for the full surface audit (search inputs,
@@ -153,12 +186,12 @@ function loadPostHog(): Promise<PostHog | null> {
           // 15%, the midpoint of the issue's own suggested 10-20% starting
           // range. Hardcoded rather than left to PostHog's remote/dashboard
           // sampling config (which this value overrides when set, per
-          // node_modules/@posthog/types' own doc comment) -- same
-          // reasoning as this module's `persistence: "memory"` choice
-          // above: a safe default that doesn't depend on separately
-          // getting a dashboard setting right before this ships. Tune via
-          // a follow-up code change once real volume against the 5k/mo
-          // free-tier recording cap is known.
+          // node_modules/@posthog/types' own doc comment) -- same "don't
+          // depend on state this code can't guarantee" posture as the
+          // persistence choice above: a safe default that doesn't depend on
+          // separately getting a dashboard setting right before this ships.
+          // Tune via a follow-up code change once real volume against the
+          // 5k/mo free-tier recording cap is known.
           sampleRate: 0.15,
         },
         // Explicitly off, not left `undefined` (posthog-js's own default,
@@ -192,11 +225,23 @@ export function initAnalytics(): void {
 
 /** Captures one `$pageview`. `url` defaults to posthog-js's own current-URL
  * read when omitted -- pass it explicitly on an SPA route change so the
- * event reflects the route just navigated to, not a stale closure value. */
+ * event reflects the route just navigated to, not a stale closure value.
+ *
+ * `page_title` is added explicitly (Umami-parity, #7767's decommission gate
+ * requires PostHog capture the same data types Umami did): posthog-js has no
+ * built-in `$title`-style property the way it auto-attaches UTM/referrer/
+ * browser/os/device -- confirmed against posthog-js's own source, there is no
+ * such default. `document.title` is read at call time, not passed down from
+ * the caller, so it's always the value the route's own `head()` meta just
+ * committed -- `onResolved` (this function's only SPA call site, in
+ * routes/-root-views.tsx) fires after the new route's head has rendered. */
 export function capturePageview(url?: string): void {
   if (!POSTHOG_TOKEN) return;
   void loadPostHog().then((posthog) => {
-    posthog?.capture("$pageview", url ? { $current_url: url } : undefined);
+    posthog?.capture("$pageview", {
+      ...(url ? { $current_url: url } : undefined),
+      ...(typeof document !== "undefined" ? { page_title: document.title } : undefined),
+    });
   });
 }
 

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -9,27 +9,6 @@ type ServerEntry = {
   fetch: (request: Request, env: unknown, ctx: unknown) => Promise<Response> | Response;
 };
 
-// --- Privacy analytics (self-hosted Umami), first-party + performance-tuned ---
-//
-// All of this lives in the Worker entry (infra), never in Lovable's UI code, so
-// it survives Lovable regenerations. The tracker is proxied through this origin
-// so it is (a) first-party — no extra DNS/TLS handshake to a 3rd-party domain;
-// the tiny script is edge-cached and HTTP/2-multiplexed with the page; and
-// (b) ad-blocker resilient — most blockers drop known analytics hostnames, which
-// silently loses data, whereas first-party serving captures it. The script is
-// `defer`-ed and injected via HTMLRewriter (streaming, no buffering).
-const UMAMI_HOST = "https://tasty.aethereal.dev";
-const UMAMI_WEBSITE_ID = "aac97255-44e1-4e9a-92d0-29d5fda1af45";
-// Reported-to path. MUST be the frontend Worker, not `/api/*` (that route hits
-// the backend on this zone). Umami appends `/api/send` to data-host-url.
-const STATS_PREFIX = "/stats";
-const STATS_COLLECT_PATH = `${STATS_PREFIX}/api/send`;
-const MAX_STATS_BODY_BYTES = 16 * 1024;
-const UMAMI_SNIPPET =
-  `<script defer src="${STATS_PREFIX}/script.js" ` +
-  `data-website-id="${UMAMI_WEBSITE_ID}" ` +
-  `data-host-url="${STATS_PREFIX}"></script>`;
-
 // HTMLRewriter is a Cloudflare Workers runtime global (the build target here).
 declare const HTMLRewriter: {
   new (): {
@@ -41,84 +20,6 @@ declare const HTMLRewriter: {
     ): { transform(response: Response): Response };
   };
 };
-
-// Proxy the tracker script + the collect endpoint through this origin. Returns
-// null for everything else (the request falls through to the SSR app).
-async function handleStatsProxy(request: Request): Promise<Response | null> {
-  const url = new URL(request.url);
-  const isScript = url.pathname === `${STATS_PREFIX}/script.js`;
-  const isStatsApi = url.pathname.startsWith(`${STATS_PREFIX}/api/`);
-  if (!isScript && !isStatsApi) return null;
-
-  if (isScript) {
-    if (request.method !== "GET" && request.method !== "HEAD") {
-      return new Response("Method Not Allowed", {
-        status: 405,
-        headers: { allow: "GET, HEAD" },
-      });
-    }
-
-    const upstreamUrl = `${UMAMI_HOST}${url.pathname.slice(STATS_PREFIX.length)}${url.search}`;
-    const upstream = await fetch(upstreamUrl, {
-      method: request.method,
-      headers: { accept: "*/*" },
-    });
-    const headers = new Headers(upstream.headers);
-    // Long-lived browser cache; Cloudflare edge-caches the subrequest too.
-    headers.set("cache-control", "public, max-age=86400, stale-while-revalidate=604800");
-    headers.delete("set-cookie");
-    return new Response(upstream.body, { status: upstream.status, headers });
-  }
-
-  if (url.pathname !== STATS_COLLECT_PATH) {
-    return new Response("Not Found", { status: 404 });
-  }
-
-  if (request.method !== "POST") {
-    return new Response("Method Not Allowed", {
-      status: 405,
-      headers: { allow: "POST" },
-    });
-  }
-
-  const contentType = request.headers.get("content-type") ?? "";
-  if (!contentType.toLowerCase().split(";", 1)[0].trim().endsWith("/json")) {
-    return new Response("Unsupported Media Type", { status: 415 });
-  }
-
-  const contentLengthHeader = request.headers.get("content-length");
-  const contentLength = contentLengthHeader === null ? NaN : Number(contentLengthHeader);
-  if (!Number.isSafeInteger(contentLength) || contentLength < 0) {
-    return new Response("Length Required", { status: 411 });
-  }
-  if (contentLength > MAX_STATS_BODY_BYTES) {
-    return new Response("Payload Too Large", { status: 413 });
-  }
-
-  // Collect: forward only what Umami needs to attribute a real visit (UA +
-  // visitor IP + language + content-type), not the full header set.
-  const forwarded = new Headers();
-  forwarded.set("content-type", contentType);
-  const userAgent = request.headers.get("user-agent");
-  if (userAgent) forwarded.set("user-agent", userAgent);
-  const acceptLanguage = request.headers.get("accept-language");
-  if (acceptLanguage) forwarded.set("accept-language", acceptLanguage);
-  const clientIp = request.headers.get("cf-connecting-ip");
-  if (clientIp) {
-    forwarded.set("x-forwarded-for", clientIp);
-    forwarded.set("x-real-ip", clientIp);
-  }
-
-  const upstreamUrl = `${UMAMI_HOST}/api/send${url.search}`;
-  const upstream = await fetch(upstreamUrl, {
-    method: "POST",
-    headers: forwarded,
-    body: request.body,
-  });
-  const headers = new Headers(upstream.headers);
-  headers.delete("set-cookie");
-  return new Response(upstream.body, { status: upstream.status, headers });
-}
 
 // --- AI-agent discovery (RFC 8288 Link header, RFC 9727 api-catalog, sitemap, MCP card) ---
 //
@@ -425,18 +326,17 @@ const RESOURCE_HINTS =
   `<link rel="preconnect" href="${API_ORIGIN}" crossorigin>` +
   `<link rel="dns-prefetch" href="${API_ORIGIN}">`;
 
-// Dependency-free Web Vitals beacon → first-party Umami + PostHog
-// (metagraphed#7760: ported to PostHog alongside, not instead of, Umami --
-// both sinks stay live until the Umami decommission issue). LCP (last
-// entry), CLS (recent-input-excluded sum), and an INP proxy (worst
-// slow-event duration) are flushed once on page hide. Wrapped in try/catch
-// per sink so one missing/broken global can never break the page or block
-// the other sink, and no-ops if neither has loaded. Consistent with the
-// first-party analytics ethos (no third-party web-vitals CDN).
+// Dependency-free Web Vitals beacon → first-party PostHog (metagraphed#7760
+// ported this to PostHog alongside Umami's own sink; #7767's decommission
+// removed the Umami sink below now that parity is proven and Umami itself is
+// being retired). LCP (last entry), CLS (recent-input-excluded sum), and an
+// INP proxy (worst slow-event duration) are flushed once on page hide.
+// Wrapped in try/catch so a missing/broken `window.posthog` can never break
+// the page. Consistent with the first-party analytics ethos (no third-party
+// web-vitals CDN).
 const WEB_VITALS_SNIPPET =
   `<script>(function(){` +
   `function send(n,v){var d={metric:n,value:Math.round(v)};` +
-  `try{if(window.umami&&typeof window.umami.track==='function'){window.umami.track('web-vitals',d);}}catch(e){}` +
   `try{if(window.posthog&&typeof window.posthog.capture==='function'){window.posthog.capture('web_vitals',d);}}catch(e){}}` +
   `function obs(t,cb){try{new PerformanceObserver(cb).observe({type:t,buffered:true});}catch(e){}}` +
   `var lcp=0,cls=0,inp=0;` +
@@ -448,9 +348,9 @@ const WEB_VITALS_SNIPPET =
   `addEventListener('pagehide',flush);` +
   `})();</script>`;
 
-// Inject resource hints, the deferred tracker, a canonical link, schema.org
-// JSON-LD, the og:image/twitter:image (edge-rendered /og card), and a Web Vitals
-// beacon into <head> of HTML responses (streaming) and advertise the agent-
+// Inject resource hints, a canonical link, schema.org JSON-LD, the
+// og:image/twitter:image (edge-rendered /og card), and a Web Vitals beacon
+// into <head> of HTML responses (streaming) and advertise the agent-
 // discovery resources via an RFC 8288 Link header. Canonical + JSON-LD + og:image
 // are set HERE (not per-route) so they are global, consistent, and regen-proof.
 // Canonical is origin + path with the query stripped, so filter/sort permutations
@@ -488,7 +388,6 @@ function injectAnalytics(response: Response, request: Request): Response {
               element.append(ogUrlTag, { html: true });
               element.append(jsonLdTag, { html: true });
               element.append(ogImageTags, { html: true });
-              element.append(UMAMI_SNIPPET, { html: true });
               element.append(WEB_VITALS_SNIPPET, { html: true });
             },
           })
@@ -570,8 +469,6 @@ async function normalizeNonHtmlSsrResponse(
 
 export default {
   async fetch(request: Request, env: unknown, ctx: unknown) {
-    const statsResponse = await handleStatsProxy(request);
-    if (statsResponse) return statsResponse;
     // A top-level safety net, not just belt-and-suspenders: this proxy's own
     // internal error handling (analytics-proxy.ts) has already had one real
     // production incident where an unguarded background failure escaped as


### PR DESCRIPTION
## Summary
- **`persistence: "memory"` → `"localStorage"`** in `apps/ui/src/lib/analytics.ts`: memory persisted nothing client-side, so every reload/new tab/return visit reset identity and was counted as a brand-new visitor — this is what surfaced as PostHog's live unique-visitor count running far hotter than Umami's for the same real traffic. `localStorage` persists a random anonymous ID with no cookie set, giving real cross-visit continuity (and outlasting Umami's own forced monthly salt rotation) while keeping GeoIP and session replay fully intact.
- **`cookieless_mode` considered and rejected**, checked against PostHog's actual documented behavior rather than assumed: it strips the request IP before any GeoIP enrichment runs, unconditionally, and disables session replay for every visitor with no override — would have dropped country/city data and #7761's replay rollout entirely, for a smaller win than `localStorage` (daily, not monthly, hash rotation).
- **`page_title` added** to `$pageview` capture — confirmed posthog-js has no built-in `$title`-equivalent property the way it auto-attaches UTM/referrer/browser/os/device.
- **Removed the self-hosted Umami integration from `server.ts`**: the snippet injection, `/stats` proxy routes, and the `window.umami` web-vitals beacon call (superseded by the PostHog beacon already in place). Grep-swept the repo for remaining `umami` references — clean (only historical/explanatory comments remain).

No visual change — `server.ts`'s edit removes an invisible third-party script tag/proxy, and `analytics.ts`/`analytics-proxy.ts` are non-rendering lib modules; no component, route, or style touched.

Full Umami-parity audit is documented in `analytics.ts`'s own header comment, checked against Umami's actual schema/source (its `website_event`/`session` tables, `src/app/api/send/route.ts`'s salt-rotation logic) rather than assumed.

Refs #7767 (this closes 2 of that issue's removal-checklist items and both live-capture correctness bugs found during its traffic-reconciliation gate; the historical-data-migration redo and the actual Umami service shutdown are tracked separately in that issue).

## Test plan
- [x] `npx prettier --check` / `npx eslint` clean on all 4 changed files
- [x] `npx vitest run` (full `apps/ui` suite) — 191 files / 1465 tests green, including new coverage for the `localStorage` persistence value and `page_title` capture
- [x] `npm run typecheck --workspace=apps/ui` clean (after building `packages/ui-kit`'s dist, a pre-existing local-worktree gap unrelated to this change)