### PR TITLE
fix(test): stop hard-failing artifacts.test.ts on live schema-capture drift

### DIFF
--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1279,11 +1279,20 @@ test("public artifacts are internally consistent", () => {
     catalog110,
     "sn-110-green-compute-chat-completions-api",
   );
-  assert.equal(
-    greenComputeChat.schema_source.match,
-    "same-origin-openapi",
-    "SN110 endpoint rows should resolve through same-origin OpenAPI",
-  );
+  // Green Compute's OpenAPI capture (api.green-compute.com/openapi.json) is
+  // live external network state, re-probed daily by the schema-index sync
+  // bot -- it legitimately resolves to null when that endpoint stops
+  // returning a machine-readable schema, independent of any code change
+  // here. Assert the match only when a same-origin schema is actually
+  // captured; SN7's allwaysHealth assertion above already covers the
+  // same-origin-openapi mechanism itself against a currently-stable capture.
+  if (greenComputeChat.schema_source) {
+    assert.equal(
+      greenComputeChat.schema_source.match,
+      "same-origin-openapi",
+      "SN110 endpoint rows should resolve through same-origin OpenAPI when a same-origin schema is captured",
+    );
+  }
   const catalog64ForSchemas = readArtifact("agent-catalog/64.json");
   const chutesPricing = serviceById(
     catalog64ForSchemas,


### PR DESCRIPTION
## Summary

- The `test` CI job is currently red on `main` (confirmed reproducible on plain `main` HEAD, unrelated to #8204/#8205 or #8206/#8207) — `tests/artifacts.test.ts`'s "public artifacts are internally consistent" test hard-fails with `TypeError: Cannot read properties of null (reading 'match')` at a hardcoded assertion about SN110's `schema_source`.

## Root cause

The assertion hardcodes an expectation that SN110's `sn-110-green-compute-chat-completions-api` surface always resolves `schema_source` via same-origin OpenAPI matching against its sibling `sn-110-green-compute-openapi` surface's captured schema. That capture is live external network state, re-probed daily by the `schemas/index.json` sync bot.

Bisected: `chore(registry): sync schemas/index.json (61 -> 60 schemas)` (#8203) re-probed `https://api.green-compute.com/openapi.json` and got `"status": "not-found"` — the endpoint genuinely stopped serving a machine-readable schema on Green Compute's own end. `resolveAgentServiceSchema` (`scripts/build-artifacts.ts`) correctly resolves `schema_source: null` once the same-origin sibling's capture is gone — that's correct build behavior, not a regression. The test had zero tolerance for that legitimate state.

## What changed

`tests/artifacts.test.ts`: assert the same-origin-openapi match only when a same-origin schema is actually currently captured for SN110. `allwaysHealth`'s assertion earlier in the same test (SN7) already covers the same-origin-openapi matching mechanism itself against a currently-stable capture, so this isn't a coverage loss — it just removes a false dependency on one third-party site's uptime from a test that has nothing to do with that site.

## Validation

- `npx vitest run tests/artifacts.test.ts` — 23/23 passing (previously 1 failing).
- `npm run lint` / `npm run format:check` — clean.
- Confirmed `public/metagraph/operational-surfaces.json` (touched by my local `npm run build` as an unrelated live-probe artifact refresh, same class of drift as `schemas/index.json`) is reverted back to `origin/main` — not part of this diff.

Closes #8211