### PR TITLE
chore(skills): add license field to the bittensor drop-in skill

### DIFF
--- a/public/skills/bittensor/SKILL.md
+++ b/public/skills/bittensor/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   generation", "is subnet 7 healthy", "how do I call the Chutes API", "build on
   a Bittensor subnet". Backed by metagraphed (api.metagraph.sh), the live
   operational + integration registry for ~129 subnets.
+license: AGPL-3.0-or-later
 ---
 
 # Bittensor in a box


### PR DESCRIPTION
## Summary

Small prerequisite for the skill-publishing epic (#6893). While investigating #6895/#6896/#6897, found that the actual content requirements for all three were already satisfied — `public/skills/bittensor/SKILL.md` (live-served at `https://api.metagraph.sh/skills/bittensor/SKILL.md`, linked from README.md and `workers/api.ts`'s own `/api/v1/`-family guide pointer) is already a goal-shaped, non-tool-dump skill covering exactly what #6896 asked for, at a `skills/`-nested path `gh skill install`/`publish`'s documented discovery convention already resolves (nested-prefix support: `public/skills/bittensor/SKILL.md` matches, confirmed via `gh skill publish --dry-run .` picking it up by name).

Re-verified every MCP tool name and REST route the file references (`search_subnets`, `find_subnets_by_capability`, `get_subnet`, `get_subnet_health`, `list_subnet_apis`, `get_api_schema`, `get_best_rpc_endpoint`, `/api/v1/testnet/subnets`, `/api/v1/lineage`, `/api/v1/local`) against the current codebase — no drift, all still accurate.

The one gap: `gh skill publish --dry-run .` flagged one recommended (not required) field missing — `license`. This PR adds it, matching the repo's actual `AGPL-3.0-or-later` license from `package.json`/`LICENSE`.

## What's next (not this PR)

Once this merges, running `gh skill publish` for real (not `--dry-run`) against `main` is the actual "publish" step for #6897 — it creates a GitHub release and adds the `agent-skills` topic to the repo, which is a release action, not a further commit. Confirmed today that `gh skill search bittensor --owner JSONbored` currently returns nothing, so this hasn't been done before. Will verify search/install actually surfaces it afterward and close #6895/#6896/#6897/#6893 with the verification documented.

## Validation

- `gh skill publish --dry-run .` — no warning for the `bittensor` skill anymore (only unrelated warnings for gitignored `node_modules`-vendored skills and the `.claude/skills/` heuristic, which doesn't apply here since that directory is first-party committed content this repo's own CLAUDE.md instructs Claude Code to load — not skills installed from elsewhere).
- `npx prettier --check public/skills/bittensor/SKILL.md` — clean.

Refs #6893, #6895, #6896, #6897