### PR TITLE
fix(test): rewrite R2 history-upload test off removed wrangler-CLI mock seam

### DIFF
--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -12,8 +11,11 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { afterAll, beforeAll, test } from "vitest";
 import {
   artifactDirectoryPath,
@@ -2420,41 +2422,49 @@ test("R2-only generated artifacts stay out of the public git tree", () => {
   }
 });
 
-test("R2 history upload writes every planned run-prefix artifact", () => {
-  const temporaryDirectory = mkdtempSync(
-    path.join(tmpdir(), "metagraphed-r2-upload-"),
-  );
-  const wranglerPath = path.join(temporaryDirectory, "wrangler");
-  const putLogPath = path.join(temporaryDirectory, "put-log.jsonl");
+test("R2 history upload writes every planned run-prefix artifact", async () => {
+  const execFileAsync = promisify(execFile);
   const manifestPath = path.join(r2StagingRoot, "r2-manifest.json");
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  writeFileSync(
-    wranglerPath,
-    String.raw`#!/usr/bin/env node
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+  const remoteManifestBody = readFileSync(manifestPath);
+  const putKeys: string[] = [];
 
-const args = process.argv.slice(2);
-if (args[0] !== "r2" || args[1] !== "object") {
-  process.exit(2);
-}
-if (args[2] === "get") {
-  writeFileSync(1, readFileSync(process.env.FAKE_REMOTE_MANIFEST));
-  process.exit(0);
-}
-if (args[2] === "put") {
-  appendFileSync(
-    process.env.FAKE_PUT_LOG,
-    JSON.stringify({ key: args[3].slice(args[3].indexOf("/") + 1) }) + "\n",
-  );
-  process.exit(0);
-}
-process.exit(2);
-`,
-  );
-  chmodSync(wranglerPath, 0o755);
+  // Mocks the Cloudflare R2 REST API scripts/r2-upload.ts calls directly
+  // (replaced the METAGRAPH_WRANGLER_BIN fake-CLI seam when putObjectOnce/
+  // getRemoteManifest moved from spawning `wrangler` to fetch() -- see that
+  // file's r2ApiBaseUrl comment).
+  const server = http.createServer((req, res) => {
+    const objectsMarker = "/objects/";
+    const markerIndex = req.url?.indexOf(objectsMarker) ?? -1;
+    if (markerIndex === -1) {
+      res.writeHead(404).end();
+      return;
+    }
+    const key = decodeURIComponent(
+      req.url!.slice(markerIndex + objectsMarker.length),
+    );
+    if (req.method === "GET") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(remoteManifestBody);
+      return;
+    }
+    if (req.method === "PUT") {
+      putKeys.push(key);
+      req.resume();
+      req.on("end", () => res.writeHead(200).end());
+      return;
+    }
+    res.writeHead(405).end();
+  });
 
   try {
-    const output = execFileSync(
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+
+    // execFile (async), not execFileSync: a sync child-process wait blocks
+    // this process's event loop, starving the in-process mock server above
+    // of any chance to service the child's requests (see tests/r2-upload.test.ts).
+    const { stdout } = await execFileAsync(
       process.execPath,
       ["scripts/r2-upload.ts", "--write"],
       {
@@ -2462,22 +2472,16 @@ process.exit(2);
         encoding: "utf8",
         env: {
           ...process.env,
-          FAKE_PUT_LOG: putLogPath,
-          FAKE_REMOTE_MANIFEST: manifestPath,
+          CLOUDFLARE_ACCOUNT_ID: "test-account",
+          CLOUDFLARE_API_TOKEN: "test-token",
           METAGRAPH_ALLOW_R2_UPLOAD: "1",
+          METAGRAPH_R2_API_BASE_URL: `http://127.0.0.1:${port}`,
           METAGRAPH_R2_UPLOAD_CONCURRENCY: "16",
           METAGRAPH_R2_UPLOAD_HISTORY: "1",
-          METAGRAPH_WRANGLER_BIN: wranglerPath,
         },
-        stdio: "pipe",
       },
     );
-    const summary = JSON.parse(output);
-    const putKeys = readFileSync(putLogPath, "utf8")
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line).key);
+    const summary = JSON.parse(stdout);
 
     assert.equal(summary.remote_manifest_status, "found");
     assert.equal(summary.changed_artifact_count, 0);
@@ -2497,7 +2501,7 @@ process.exit(2);
       "expected history upload to include artifacts unchanged in latest",
     );
   } finally {
-    rmSync(temporaryDirectory, { force: true, recursive: true });
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 }, 30_000);
 


### PR DESCRIPTION
Fixes a real regression on \`main\`: PR #8209 (merged) shows a FAILURE \`test\` CI check.

## Root cause

PR #8209 replaced \`scripts/r2-upload.ts\`'s per-object \`wrangler\` CLI subprocess calls with direct \`fetch()\`s against the Cloudflare API v4 REST endpoint, and removed the \`METAGRAPH_WRANGLER_BIN\` test seam entirely. \`tests/r2-upload.test.ts\` was updated to match, but a *second*, separate test — \`tests/artifacts.test.ts\`'s "R2 history upload writes every planned run-prefix artifact" — was missed and still substituted a fake \`wrangler\` binary via that now-dead seam. It started failing with:

\`\`\`
Error: CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required for R2 access.
\`\`\`

## Fix

Rewrite that test to use the same local-\`http.createServer\` + \`METAGRAPH_R2_API_BASE_URL\` mock pattern already established in \`tests/r2-upload.test.ts\`, including the async \`execFile\` (not \`execFileSync\`) fix for the same same-process event-loop deadlock (a sync child-process wait blocks the parent's event loop, starving the in-process mock server of any chance to service the child's requests).

## Verification

- \`npx tsc --noEmit\` clean, repo-wide.
- \`npx eslint\` / \`npx prettier --check\` clean on the changed file.
- \`npx vitest run tests/artifacts.test.ts\` — all 23 tests pass (including the R2 history-upload test, run as part of the full file so the earlier build-artifacts.ts-running tests populate the R2 staging tree it reads from).