### PR TITLE
fix(build): regenerate stale agent-skills index digest

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -3,7 +3,7 @@
   "skills": [
     {
       "description": "Use when a developer asks what a Bittensor subnet does, whether it's up right now, or how to call/integrate its API — e.g. \"which subnet does image generation\", \"is subnet 7 healthy\", \"how do I call the Chutes API\", \"build on a Bittensor subnet\". Backed by metagraphed (api.metagraph.sh), the live operational + integration registry for ~129 subnets.",
-      "digest": "sha256:202192843c32bc7efdc7313d1b78974014ae64b4f6b6c5b8823de49775bde4b2",
+      "digest": "sha256:5c37fca2a96dd5417861571be9be964b23bc19a46ef4546e5201395d7b58eab8",
       "name": "bittensor",
       "type": "skill-md",
       "url": "https://api.metagraph.sh/skills/bittensor/SKILL.md"


### PR DESCRIPTION
Fixes a currently-broken CI gate on \`main\` blocking every PR right now.

## Root cause

#8213 edited \`public/skills/bittensor/SKILL.md\` (added a license field) but did not run \`npm run build\` afterward, so the committed \`public/.well-known/agent-skills/index.json\`'s sha256 digest of that file's content went stale. The "Verify committed derived artifacts are fresh" CI step does a real build and diffs \`public/\` against it — it now fails on every PR (not just this one) since the digest doesn't match a fresh build's output.

## Fix

Ran \`npm run build\` and committed the regenerated one-line digest change.

## Verification

- \`npm run build\` locally, confirmed \`public/.well-known/agent-skills/index.json\` is the only relevant change (excluding the deploy-owned/content-derived artifacts \`validate:contract-drift\`'s own exclusion list already carves out: \`r2-manifest.json\`, \`schemas/index.json\`, \`operational-surfaces.json\`).
- \`npx tsc --noEmit\` clean.
- \`npx prettier --check\` clean on the changed file.