### PR TITLE
fix(build): refresh stale digest in agent-skills/index.json

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -3,7 +3,7 @@
   "skills": [
     {
       "description": "Use when a developer asks what a Bittensor subnet does, whether it's up right now, or how to call/integrate its API — e.g. \"which subnet does image generation\", \"is subnet 7 healthy\", \"how do I call the Chutes API\", \"build on a Bittensor subnet\". Backed by metagraphed (api.metagraph.sh), the live operational + integration registry for ~129 subnets.",
-      "digest": "sha256:202192843c32bc7efdc7313d1b78974014ae64b4f6b6c5b8823de49775bde4b2",
+      "digest": "sha256:5c37fca2a96dd5417861571be9be964b23bc19a46ef4546e5201395d7b58eab8",
       "name": "bittensor",
       "type": "skill-md",
       "url": "https://api.metagraph.sh/skills/bittensor/SKILL.md"


### PR DESCRIPTION
## Summary
- PR #8213 edited `public/skills/bittensor/SKILL.md` (added a license field) but never ran `npm run build` to regenerate the derived `public/.well-known/agent-skills/index.json` digest (a sha256 hash of that file's content).
- This left `main` in a state where CI's "Verify committed derived artifacts are fresh" gate fails for **any** PR based on the current tip — discovered via PR #8219 (an unrelated `tests/artifacts.test.ts` change), which failed this exact check with zero diff between its branch and `origin/main` for this file.
- Only the `digest` field changes; confirmed `name`/`description`/`url`/`type` are unaffected by a fresh rebuild.

Closes #8220

## Test plan
- [x] `node scripts/build-artifacts.ts` locally, confirmed only this one field changes
- [x] `npx prettier --check` clean