### PR TITLE
feat(ui): give the skill install command its own card on /agents

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.agent-resources.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.agent-resources.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAgentResources } from "./queries";
+
+describe("normalizeAgentResources", () => {
+  it("passes a resource's install command through when present", () => {
+    const res = normalizeAgentResources({
+      mcp: { endpoint: "https://api.metagraph.sh/mcp", install: "claude mcp add ..." },
+      resources: [
+        {
+          id: "skill",
+          kind: "skill",
+          title: "Bittensor skill",
+          url: "https://api.metagraph.sh/skills/bittensor/SKILL.md",
+          install: "gh skill install JSONbored/metagraphed bittensor",
+        },
+      ],
+    });
+    expect(res.resources).toHaveLength(1);
+    expect(res.resources[0]?.install).toBe("gh skill install JSONbored/metagraphed bittensor");
+  });
+
+  it("omits install when the source resource doesn't have one", () => {
+    const res = normalizeAgentResources({
+      resources: [
+        { id: "llms", kind: "index", title: "llms.txt", url: "https://api.metagraph.sh/llms.txt" },
+      ],
+    });
+    expect(res.resources).toHaveLength(1);
+    expect(res.resources[0]?.install).toBeUndefined();
+  });
+
+  it("drops a resource missing title or url, keeps the rest", () => {
+    const res = normalizeAgentResources({
+      resources: [
+        { id: "broken", kind: "skill", title: "", url: "https://example.com" },
+        { id: "ok", kind: "skill", title: "OK", url: "https://example.com/ok" },
+      ],
+    });
+    expect(res.resources).toHaveLength(1);
+    expect(res.resources[0]?.id).toBe("ok");
+  });
+
+  it("degrades a cold/junk store to a schema-stable shape, never throwing", () => {
+    for (const raw of [{}, null, "x", { resources: "nope" }]) {
+      const res = normalizeAgentResources(raw);
+      expect(res.resources).toEqual([]);
+      expect(res.mcp.tools).toEqual([]);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -7828,15 +7828,17 @@ function normalizeAgentResource(raw: unknown, index: number): AgentResource | un
   if (!title || !url) return undefined;
 
   const kind = stringValue(r.kind);
+  const install = stringValue(r.install);
   return {
     id,
     kind: AGENT_RESOURCE_KINDS.has(kind) ? kind : "api",
     title,
     url,
+    ...(install ? { install } : {}),
   };
 }
 
-function normalizeAgentResources(raw: unknown): AgentResources {
+export function normalizeAgentResources(raw: unknown): AgentResources {
   const d = recordValue(raw);
   const copyableAgent = recordValue(d.copyable_agent);
   const mcp = recordValue(d.mcp);

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -412,6 +412,7 @@ export interface AgentResource {
   kind: string; // agent | skill | index | contract | api | data
   title: string;
   url: string;
+  install?: string;
 }
 
 /** /api/v1/agent-resources — the machine-readable index of metagraphed's AI surfaces. */

--- a/apps/ui/src/routes/-agents-page.tsx
+++ b/apps/ui/src/routes/-agents-page.tsx
@@ -26,7 +26,7 @@ import { SearchBox } from "@/components/metagraphed/search-box";
 import { Skeleton } from "@/components/metagraphed/states";
 import { agentResourcesQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
-import type { AgentResources } from "@/lib/metagraphed/types";
+import type { AgentResource, AgentResources } from "@/lib/metagraphed/types";
 
 // A pre-prompt that drops the live llms.txt + MCP into a fresh agent session.
 const AGENT_PROMPT =
@@ -104,6 +104,11 @@ function AgentsBody() {
   const { data } = useSuspenseQuery(agentResourcesQuery());
   const res = data.data as AgentResources;
   const mcp = res.mcp;
+  const skillResource = res.resources.find(
+    (r): r is AgentResource & { install: string } => r.kind === "skill" && Boolean(r.install),
+  );
+  const skillMeta = kindMeta("skill");
+  const SkillIcon = skillMeta.icon;
 
   return (
     <div className="mt-6 space-y-section">
@@ -149,10 +154,11 @@ function AgentsBody() {
         <SearchBox />
       </section>
 
-      {/* Two calmer alternatives, side by side */}
-      <section className="grid gap-10 md:grid-cols-2">
+      {/* Three calmer alternatives, side by side */}
+      <section className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
         <div>
           <SectionHeading
+            id="install-sdk"
             title="Or install the SDK"
             intro="Typed clients for Python and TypeScript that wrap every route and the RPC proxy."
           />
@@ -175,6 +181,30 @@ function AgentsBody() {
             ))}
           </div>
         </div>
+
+        {skillResource && (
+          <div>
+            <SectionHeading
+              id="skill-install"
+              title="Or add the skill"
+              intro="A drop-in Agent Skill for Claude Code, Cursor, and any gh skill-compatible agent."
+            />
+            <Panel as="div" flush>
+              <div className="flex items-center gap-3 px-4 py-3">
+                <SkillIcon className={classNames("size-4 shrink-0", skillMeta.tone)} aria-hidden />
+                <div className="min-w-0 flex-1">
+                  <code className="block overflow-x-auto whitespace-nowrap font-mono mg-type-caption text-ink-strong">
+                    {skillResource.install}
+                  </code>
+                  <ExternalLink href={skillResource.url} className="mg-type-data-sm text-ink-muted">
+                    {skillResource.title}
+                  </ExternalLink>
+                </div>
+                <CopyButton value={skillResource.install} label="Skill install command" compact />
+              </div>
+            </Panel>
+          </div>
+        )}
 
         <div>
           <SectionHeading title="Or drop into a chat" intro={res.copyable_agent.description} />


### PR DESCRIPTION
## Summary

Follow-up to #8217. Gives the `gh skill install` command its own visual card on the `/agents` page, matching the prominence MCP's install command already gets, instead of only showing up as a bare URL in the generic "Everything else, fetchable directly" list.

## What changed

- `apps/ui/src/routes/-agents-page.tsx`: new "Or add the skill" card, third column alongside "Or install the SDK" and "Or drop into a chat" (`md:grid-cols-2 lg:grid-cols-3`). Reuses the exact `Panel`/`code`/`CopyButton` pattern the SDK cards already use, and the same icon/tone the resource list already assigns `kind: "skill"` via `kindMeta` — nothing new invented visually. Added `id`s (`install-sdk`, `skill-install`) for screenshot-tool anchoring.
- `apps/ui/src/lib/metagraphed/types.ts`: `AgentResource` gains an optional `install?: string`.

## Real bug found while verifying this

`apps/ui/src/lib/metagraphed/queries.ts`'s `normalizeAgentResource()` strictly whitelists `id`/`kind`/`title`/`url` per resource and silently drops everything else — including the `install` field #8217 added to the backend's `skill` resource. That field would **never** have reached the frontend, live data or not; the bug was in the frontend normalizer, not the backend or the data timing. Fixed by passing `install` through when present. Also exported `normalizeAgentResources` (matching this file's existing `normalizeX`-is-independently-testable convention, e.g. `normalizeSubnetMovers`, `normalizeDomains`) and added `queries.agent-resources.test.ts` — a regression test that would have caught this.

## Screenshot verification note (read before reviewing the table below)

`https://api.metagraph.sh/api/v1/agent-resources` won't actually serve the new `install` field until the R2-only artifact is republished — that's a separate, already-scheduled pipeline, not gated on this merge. A before/after capture against live production right now would show two *identical* "before" states (proving nothing, and worse, looking like the feature doesn't work). Instead: ran a local dev server against a byte-identical copy of the real production response with just the `install` field added (matching exactly what production will serve once the artifact catches up), captured "after" against that, and captured "before" normally (orchestrated against the merge-base, genuinely shows no card — accurate, since that code path doesn't exist pre-change regardless of data). Both variants captured with the same tool (`tests/e2e/capture-pr-screenshots.ts`), same viewport/theme matrix, same font-wait logic — the only difference is which server "after" pointed at.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/agents-skill-card-v2-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npx tsc --noEmit` (`apps/ui`) — clean, same pre-existing/unrelated baseline errors before and after.
- `npm run lint --workspace=apps/ui` / `npm run format:check --workspace=apps/ui` — clean, same 163 pre-existing warnings, zero new ones in changed files (verified via `git stash` diff).
- `npm test --workspace=apps/ui` — 1469/1469 passing (192 files), including the new `queries.agent-resources.test.ts`.

Refs #6893, #6897