### PR TITLE
fix(ui): treat mainnet-only blocklist 404s as graceful testnet notice

### DIFF
--- a/apps/ui/src/components/metagraphed/native-only-notice.tsx
+++ b/apps/ui/src/components/metagraphed/native-only-notice.tsx
@@ -4,11 +4,13 @@ import { coverageQuery } from "@/lib/metagraphed/queries";
 import { getNetwork } from "@/lib/metagraphed/config";
 
 /**
- * Shown when a route's data 404s with `artifact_not_found` on a non-mainnet
- * network. Those partitions (e.g. testnet) carry native chain data only, so
- * most enrichment / health / interface artifacts legitimately don't exist yet
- * — an informational empty notice (surfacing the API's own `coverage.notes`)
- * is the honest signal, not a red error card (#370).
+ * Shown when a route's data 404s on a non-mainnet network, either because the
+ * artifact simply isn't built yet (`artifact_not_found`) or because the route
+ * is deliberately mainnet-only (`not_found` with `meta.network` set — see
+ * `ErrorState` in ./states.tsx). Those partitions (e.g. testnet) carry native
+ * chain data only, so most enrichment / health / interface artifacts
+ * legitimately don't exist yet — an informational empty notice (surfacing the
+ * API's own `coverage.notes`) is the honest signal, not a red error card (#370).
  */
 export function NativeOnlyNotice({ context }: { context?: string }) {
   const network = getNetwork();

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -69,10 +69,19 @@ export function ErrorState({
   context?: string;
 }) {
   const isApi = error instanceof ApiError;
-  // #370: on a non-mainnet partition, `artifact_not_found` is expected — those
-  // networks are native-only, so most artifacts legitimately aren't published.
-  // Degrade to an informational notice instead of a red error card.
-  if (isApi && error.code === "artifact_not_found" && getNetworkPrefix() !== "") {
+  // #370/#8224: on a non-mainnet partition, two error shapes both mean "not
+  // published for this network," not a real fault, and should degrade to an
+  // informational notice instead of a red error card:
+  //   - `artifact_not_found`: an unbuilt testnet/local artifact (silent gap).
+  //   - `not_found` with `meta.network` set: a deliberate mainnet-only route
+  //     (workers/api.ts's `isMainnetOnlyApiPath` blocklist, or the `local`
+  //     network's no-data 404) — `meta.network` is only ever populated on
+  //     these network-partition 404s, never on an ordinary unmatched route.
+  if (
+    isApi &&
+    ((error.code === "artifact_not_found" && getNetworkPrefix() !== "") ||
+      (error.code === "not_found" && error.network))
+  ) {
     return <NativeOnlyNotice context={context} />;
   }
   // #2564: the chain-events deep-history tier (workers/api.ts's handleChainEventsProxy)

--- a/apps/ui/src/lib/metagraphed/client.test.ts
+++ b/apps/ui/src/lib/metagraphed/client.test.ts
@@ -119,6 +119,27 @@ describe("apiFetch", () => {
     } satisfies Partial<ApiError>);
   });
 
+  it("carries meta.network on ApiError for a network-partition 404", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          {
+            ok: false,
+            error: { message: "/api/v1/validators is only available on mainnet, not the test network.", code: "not_found" },
+            meta: { network: "test" },
+          },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    await expect(apiFetch("/api/v1/testnet/validators")).rejects.toMatchObject({
+      code: "not_found",
+      network: "test",
+    } satisfies Partial<ApiError>);
+  });
+
   it("throws ApiError when the envelope reports ok:false on a 200 response", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/ui/src/lib/metagraphed/client.test.ts
+++ b/apps/ui/src/lib/metagraphed/client.test.ts
@@ -126,8 +126,11 @@ describe("apiFetch", () => {
         Response.json(
           {
             ok: false,
-            error: { message: "/api/v1/validators is only available on mainnet, not the test network.", code: "not_found" },
-            meta: { network: "test" },
+            error: {
+              message: "/api/v1/validators is only available on mainnet, not the testnet network.",
+              code: "not_found",
+            },
+            meta: { network: "testnet" },
           },
           { status: 404 },
         ),
@@ -136,7 +139,7 @@ describe("apiFetch", () => {
 
     await expect(apiFetch("/api/v1/testnet/validators")).rejects.toMatchObject({
       code: "not_found",
-      network: "test",
+      network: "testnet",
     } satisfies Partial<ApiError>);
   });
 

--- a/apps/ui/src/lib/metagraphed/client.ts
+++ b/apps/ui/src/lib/metagraphed/client.ts
@@ -5,12 +5,25 @@ export class ApiError extends Error {
   status: number;
   code?: string;
   url: string;
-  constructor(message: string, opts: { status: number; code?: string; url: string }) {
+  /**
+   * The response envelope's `meta.network`, when present. Set on every
+   * network-partition 404 (`workers/api.ts`'s `handleNetworkScopedRequest`
+   * paths — mainnet-only blocklist hits, the `local` network's no-data 404,
+   * and its catch-all unmatched-route 404) so callers can distinguish
+   * "unavailable on this network by design" from an ordinary 404, without
+   * relying on a specific error `code`.
+   */
+  network?: string;
+  constructor(
+    message: string,
+    opts: { status: number; code?: string; url: string; network?: string },
+  ) {
     super(message);
     this.name = "ApiError";
     this.status = opts.status;
     this.code = opts.code;
     this.url = opts.url;
+    this.network = opts.network;
   }
 }
 
@@ -104,6 +117,7 @@ export async function apiFetch<T>(
       status: res.status,
       code: env?.error?.code,
       url: redactUrlForError(url),
+      network: env?.meta?.network,
     });
   }
 
@@ -115,6 +129,7 @@ export async function apiFetch<T>(
         status: res.status,
         code: env.error?.code,
         url: redactUrlForError(url),
+        network: env.meta?.network,
       });
     }
     return { data: env.data, meta: env.meta ?? {}, url };

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -90,6 +90,7 @@ export interface ApiMeta {
   generated_at?: string;
   source?: string;
   stale?: boolean;
+  network?: string;
   cursor?: string | number | null;
   next_cursor?: string | number | null;
   prev_cursor?: string | number | null;


### PR DESCRIPTION
## Summary

- `ApiError` now carries the response envelope's `meta.network`, forwarded from both `apiFetch` throw sites.
- `ErrorState` now degrades to `NativeOnlyNotice` for a `not_found` response with `meta.network` set (the `isMainnetOnlyApiPath` blocklist / `local` network's no-data 404), not just `artifact_not_found`.

Previously, the ~100+ backend routes blocked by `isMainnetOnlyApiPath()` (validators, blocks, accounts, health, chain analytics, etc.) returned a purpose-built `not_found` + `meta.network` + clear "mainnet only" message (the fix shipped for #2131), but the frontend's graceful-degradation notice only recognized `artifact_not_found`. So the routes with the clearest, most intentional backend messaging showed a jarring red error card instead of the intended calm notice, while genuinely-unbuilt testnet artifacts (which return the generic `artifact_not_found`) got the notice. This reconciles the two.

Confirmed via curl that the backend shape matches what the frontend now checks for:
```
$ curl -s https://api.metagraph.sh/api/v1/testnet/validators
{"ok":false,...,"error":{"code":"not_found","message":"/api/v1/validators is only available on mainnet, not the testnet network."},"meta":{"contract_version":"...","network":"testnet"}}
```

Part of #8223.

Closes #8224

## Test plan

- [x] `npx vitest run src/lib/metagraphed/client.test.ts` (new test covers `meta.network` passthrough)
- [x] `npx eslint` + `npx prettier --check` on all touched files
- [x] `apps/ui` typecheck run — pre-existing, unrelated failures only (content-collections codegen gap on this box, confirmed identical on a clean `main` checkout)
- No visual/screenshot table — maintainer-authored PR, not subject to the contributor screenshot contract