### PR TITLE
fix(ui): stop subnet-detail page from collapsing on a profile-only 404

### DIFF
--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -201,7 +201,21 @@ export function SubnetDetailPage() {
 }
 
 function ProfileShell({ netuid }: { netuid: number }) {
-  const { data: profile, meta } = useSuspenseQuery(subnetProfileQuery(netuid)).data;
+  // #8225: non-suspending on purpose. The route loader already primed this
+  // same query key via ensureQueryData (subnets.$netuid.tsx), so this never
+  // introduces an extra fetch or a loading flash -- it only changes how a
+  // FAILURE behaves. `/profile` isn't published for every network (e.g.
+  // testnet), and every consumer of `profile` below already tolerates it
+  // being undefined (SubnetMasthead falls back to "Subnet {netuid}",
+  // ReadinessScorecard renders null, tab badge counts go blank). Using
+  // useSuspenseQuery here used to throw that one failure up to the page's
+  // root AsyncPanel and blank out the ENTIRE page -- masthead, tabs, and
+  // every other independently-fetched section -- even though only the
+  // profile-specific "Subnet profile" section (SubnetProfilePanel, which
+  // re-reads this same query in its own AsyncPanel) actually needs it.
+  const { data: profileResult } = useQuery(subnetProfileQuery(netuid));
+  const profile = profileResult?.data;
+  const meta = profileResult?.meta;
   const { data: gapsResult } = useQuery(subnetGapsQuery(netuid));
   const subnetGaps = gapsResult?.data;
   const stale = meta?.stale || isStaleFreshness(meta?.generated_at);


### PR DESCRIPTION
## Summary

`ProfileShell` (the subnet-detail page's content) read `subnetProfileQuery` via `useSuspenseQuery`, so any failure there threw up to the page's root `AsyncPanel` and blanked out the **entire** page -- masthead, tabs, economics, resources, everything -- not just the profile section. On testnet, `/profile` isn't published (no built artifact), so every subnet-detail page collapsed to the generic notice even though real native data (name, participants, block, status) is genuinely available from a different endpoint.

Fix: read the query via `useQuery` instead. Every downstream consumer of `profile` already treats it as optional:
- `SubnetMasthead` falls back to `Subnet {netuid}` when `profile` is undefined
- `ReadinessScorecard` returns `null` when `profile` is undefined
- Tab badge counts (`surface_count`, `endpoint_count`, etc.) are all optional-chained already

The one section that's actually *about* profile data, `SubnetProfilePanel` ("Subnet profile — lineage/curation/providers"), already re-reads the same query key independently inside its own `AsyncPanel` -- so it alone still shows the (now-correct, per #8224) native-only notice or error, while the rest of the page renders normally.

No loading-timing change: the route loader (`subnets.$netuid.tsx`) already primes this exact query key via `ensureQueryData` before the component mounts, so this only changes how a *failure* is handled, not the loading sequence.

Part of #8223.

Closes #8225

## Test plan

- [x] `npx eslint apps/ui/src/routes/-subnets-netuid-page.tsx` -- 0 errors, same pre-existing warning count as `main`
- [x] `npx prettier --check` on the touched file
- [x] `tsc --noEmit` -- no new errors in this file
- No visual/screenshot table -- maintainer-authored PR, not subject to the contributor screenshot contract