### PR TITLE
feat(network): publish chain economics for the testnet registry

### DIFF
--- a/scripts/build-network-registry.ts
+++ b/scripts/build-network-registry.ts
@@ -16,6 +16,7 @@ import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { CONTRACT_VERSION } from "../src/contracts.ts";
+import { buildEconomicsArtifact } from "./lib/economics-artifacts.ts";
 import {
   artifactOutputPath,
   backfilledIdentityUrl,
@@ -154,6 +155,14 @@ function buildNativeSubnet(nativeSubnet: Row, snapshot: Row): Row {
       gap_notes: [],
     },
     links: [],
+    // #8227: chain economics, same as mainnet. fetch-native-subnets.py's
+    // normalize_info() attaches this for whatever --network it is pointed at
+    // (every field comes off the same MetagraphInfo the identity fields do, so
+    // there is no extra RPC and nothing finney-specific), but this projection
+    // used to drop it -- leaving `economics: null` on every testnet subnet
+    // despite the snapshot carrying real values. Null-coalesced because
+    // snapshots captured before the economics fetcher (#1032) have no such key.
+    economics: (nativeSubnet.economics as Row | undefined) ?? null,
   };
 }
 
@@ -294,10 +303,36 @@ export async function buildNetworkRegistry({
     buildCoverage(subnets, snapshot, generatedAt),
   );
 
+  // #8227: same builder the mainnet pipeline uses -- it is network-agnostic
+  // (takes the subnet rows + a netuid→economics map and derives emission_share
+  // from the price distribution within whatever set it is given). Subnets whose
+  // snapshot carries no economics are filtered out by the builder itself, so a
+  // pre-#1032 snapshot yields an empty-but-valid artifact rather than a throw.
+  // No price history: that comes from the mainnet subnet_snapshots rollup,
+  // which has no testnet equivalent, so alpha_price_change_* stay null.
+  const economicsByNetuid = new Map(
+    subnets.map((subnet) => [
+      subnet.netuid as number,
+      subnet.economics as Row | null,
+    ]),
+  );
+  const economics = buildEconomicsArtifact({
+    subnets,
+    economicsByNetuid: economicsByNetuid as Map<number, Row>,
+    generatedAt,
+    network: snapshot.network as string | null,
+    capturedAt: snapshot.captured_at as string | null,
+  });
+  economics.contract_version = CONTRACT_VERSION;
+  await writeJson(artifactOutputPath(`${prefix}/economics.json`), economics);
+
   return {
     network: snapshot.network,
     prefix,
     subnet_count: subnets.length,
+    economics_row_count: Array.isArray(economics.subnets)
+      ? economics.subnets.length
+      : 0,
     captured_at: snapshot.captured_at,
   };
 }

--- a/tests/network-routing.test.ts
+++ b/tests/network-routing.test.ts
@@ -212,6 +212,28 @@ describe("multi-network routing prefix (Phase 1)", () => {
     assert.equal(detail.body.data.economics, undefined);
   });
 
+  test("testnet publishes its own economics artifact (#8227)", async () => {
+    const env = createLocalArtifactEnv();
+    const { res, body } = await get(env, "/api/v1/testnet/economics");
+
+    assert.equal(res.status, 200);
+    assert.equal(body.ok, true);
+    // Served from the testnet key, never the mainnet economics artifact.
+    assert.equal(body.meta.artifact_path, "/metagraph/testnet/economics.json");
+    assert.equal(body.data.network, "test");
+    assert.ok(Array.isArray(body.data.subnets));
+    // The committed snapshot predates the economics fetcher (#1032), so the
+    // row set is legitimately empty here -- the point is that the artifact
+    // builds and serves rather than 404ing, and that the summary still counts
+    // every subnet. A snapshot WITH economics populates subnets[] instead;
+    // buildEconomicsArtifact filters on presence, so both shapes are valid.
+    assert.equal(body.data.summary.subnet_count > 0, true);
+    assert.equal(
+      body.data.summary.with_economics_count,
+      body.data.subnets.length,
+    );
+  });
+
   test("local network route 404s cleanly (no data published)", async () => {
     const env = createLocalArtifactEnv();
     const { res } = await get(env, "/api/v1/local/coverage");


### PR DESCRIPTION
## Summary

Testnet served `economics: null` on every subnet and 404'd on `/api/v1/testnet/economics`, even though the chain data was **already being fetched**. `scripts/fetch-native-subnets.py`'s `normalize_info()` unconditionally attaches `economics` for whatever `--network` it's pointed at (every field reads off the same `MetagraphInfo` from `get_all_metagraphs_info` that the identity fields do -- no extra RPC, nothing finney-specific), and the sync path runs that script against the `test` chain. The data was simply being dropped at build time: `buildNativeSubnet()` in `scripts/build-network-registry.ts` never projected it.

Two changes:
1. Project `economics` onto the native subnet record.
2. Build a testnet `economics.json` via the existing `buildEconomicsArtifact`, which is already network-agnostic (it derives `emission_share` from the price distribution within whatever subnet set it's handed).

No backend/route changes needed -- `/api/v1/testnet/economics` already resolved to `/metagraph/testnet/economics.json`; only the artifact was missing. Storage tiering is automatic too: `artifactStorageTierForRelativePath` marks anything under a `NETWORK_KEY_PREFIXES` prefix R2-only, so nothing new gets committed to git.

### Graceful with an old snapshot

The committed `registry/native/test-subnets.json` is frozen at 2026-06-14, predating the economics fetcher added in #1032 (which backfilled `finney-subnets.json` but not the testnet one). `buildEconomicsArtifact` filters on economics presence, so that snapshot yields an empty-but-valid artifact instead of throwing. The **live** pipeline is well ahead of the committed file (served testnet registry is `generated_at 2026-07-22`, 539 subnets vs. the committed 506), so production should populate real rows on the next publish.

### Price-change fields stay null

`alpha_price_change_{1h,1d,7d,1m}` derive from the mainnet `subnet_snapshots` rollup, which has no testnet equivalent. The keys are still emitted (null) so the row shape stays schema-stable, matching the existing `#7227` contract.

Part of #8223.

Closes #8227

## Test plan

- [x] `npx vitest run tests/network-routing.test.ts` -- 20/20 pass, including a new case asserting the testnet economics artifact serves 200 from `/metagraph/testnet/economics.json` with `network: "test"`
- [x] Verified the existing "testnet subnet details do not receive mainnet live economics" test still passes -- that one guards `data.economics` (the mainnet live-KV overlay, which must stay absent for testnet); this PR populates `data.subnet.economics` (chain snapshot), a deliberately separate field
- [x] End-to-end check with a synthetic snapshot carrying real economics blocks: `economics_row_count: 5`, correct `emission_share`/`open_slots`/`alpha_market_cap_tao`, price-change keys null
- [x] Build run against the real committed snapshot: `economics_row_count: 0`, no throw, artifact valid
- [x] `git status` clean after builds -- no `r2-manifest.json` / registry churn
- [x] `npx eslint` + `npx prettier --check` + `tsc --noEmit` on touched files