### PR TITLE
perf(publish): content-address R2 history uploads instead of re-uploading unchanged bytes every run

### DIFF
--- a/docs/cloudflare-backend.md
+++ b/docs/cloudflare-backend.md
@@ -6,7 +6,7 @@ Metagraphed uses Cloudflare as the serving, cache, and artifact-history layer. G
 
 - Workers serve `metagraph.sh/api/v1/*` and `metagraph.sh/metagraph/*.json` routes over canonical artifact paths so API consumers get consistent CORS, cache headers, storage-tier headers, and R2 fallback.
 - Workers Static Assets serve compact checked-in artifacts from `public/metagraph`.
-- R2 stores high-churn/detail artifacts staged under `dist/metagraph-r2/metagraph`, plus current artifact copies under `latest/`; versioned artifact history under `runs/{generated_at}/` is opt-in for publish jobs that set `METAGRAPH_R2_UPLOAD_HISTORY=1`.
+- R2 stores high-churn/detail artifacts staged under `dist/metagraph-r2/metagraph`, plus current artifact copies under `latest/`; artifact history is opt-in for publish jobs that set `METAGRAPH_R2_UPLOAD_HISTORY=1` and is content-addressed at `by-hash/<sha256>` (#8208) — a byte-identical artifact across runs is stored once regardless of how many publishes it survives unchanged. Each run's `runs/{generated_at}/r2-manifest.json` is the pointer: it lists every artifact's path and sha256, so "what was live at run X" is `for each artifact, fetch by-hash/<its sha256>`.
 - KV stores the small publish pointer plus the live tiers: the 15-minute prober's health snapshots and the live economics blob.
 - D1 is not used for canonical registry truth in v1.
 - The read-only RPC proxy/load-balancer prototype exists behind `METAGRAPH_ENABLE_RPC_PROXY=false`; write and unsafe RPC methods remain blocked by default.

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -5121,9 +5121,13 @@ function buildR2Manifest({
   generatedAt: string;
 }): Row {
   const version = timestamp.replace(/[:.]/g, "-");
+  // Content-addressed, not run-prefixed (#8208) -- mirrors scripts/r2-manifest.ts's
+  // own key scheme exactly; see that file's matching comment for the rationale
+  // (this function and that script both produce public/metagraph/r2-manifest.json,
+  // just at different points in the build pipeline, so they must agree on shape).
   const artifacts = artifactSizes.map((artifact) => ({
     content_type: "application/json",
-    key: `runs/${version}/${artifact.path}`,
+    key: `by-hash/${artifact.sha256}`,
     latest_key: `latest/${artifact.path}`,
     path: `/metagraph/${artifact.path}`,
     sha256: artifact.sha256,
@@ -5140,7 +5144,8 @@ function buildR2Manifest({
       canonical_latest_in_repo: true,
       large_history_in_r2: true,
       source_of_truth: "github-reviewed-artifacts",
-      versioned_run_prefix: `runs/${version}/`,
+      content_addressed_history: true,
+      manifest_run_prefix: `runs/${version}/`,
     },
     latest_prefix: "latest/",
     run_prefix: `runs/${version}/`,

--- a/scripts/r2-manifest.ts
+++ b/scripts/r2-manifest.ts
@@ -162,12 +162,23 @@ async function buildManifest(
     }
     const raw = await readFile(file);
     const fileStat = await stat(file);
+    const sha256 = sha256Hex(raw);
     artifacts.push({
       content_type: contentTypeFor(relative),
-      key: `runs/${version}/${relative}`,
+      // Content-addressed, not run-prefixed (#8208): a byte-identical artifact
+      // across N runs is the common case (most artifacts change rarely), so
+      // keying history by hash lets r2-upload.ts skip re-uploading bytes it
+      // already has, via a cheap HEAD instead of a full PUT -- dedup applies
+      // across ALL history, not just the immediately-preceding run. This run's
+      // full path->sha256 mapping is still recoverable: the manifest itself
+      // (this file) is uploaded to runs/<version>/r2-manifest.json every run
+      // (see r2-upload.ts's buildControlArtifacts), so "what was live at run
+      // X" is `for each artifact, fetch by-hash/<its sha256>` -- no separate
+      // ledger needed.
+      key: `by-hash/${sha256}`,
       latest_key: `latest/${relative}`,
       path: `/metagraph/${relative}`,
-      sha256: sha256Hex(raw),
+      sha256,
       size_bytes: fileStat.size,
       storage_tier: artifactStorageTierForRelativePath(relative),
     });

--- a/scripts/r2-upload.ts
+++ b/scripts/r2-upload.ts
@@ -194,24 +194,26 @@ for (const controlArtifact of plannedControlArtifacts) {
   }
 }
 
-await putObjects(artifactUploadJobs, {
+const artifactHistoryDedupedCount = await putObjects(artifactUploadJobs, {
   concurrency: uploadConcurrency,
   progressInterval,
   retryBaseDelayMs: uploadRetryBaseDelayMs,
   retries: uploadRetries,
 });
-await putObjects(controlUploadJobs, {
+const controlHistoryDedupedCount = await putObjects(controlUploadJobs, {
   concurrency: uploadConcurrency,
   progressInterval,
   retryBaseDelayMs: uploadRetryBaseDelayMs,
   retries: uploadRetries,
 });
+const dedupedHistoryCount =
+  artifactHistoryDedupedCount + controlHistoryDedupedCount;
 
 const uploadJobs = [...artifactUploadJobs, ...controlUploadJobs];
 const uploadedLatestCount = uploadJobs.filter(
   (job) => job.kind === "latest",
 ).length;
-const uploadedHistoryCount = uploadJobs.filter(
+const historyJobCount = uploadJobs.filter(
   (job) => job.kind === "history",
 ).length;
 const uploadedControlCount = uploadJobs.filter(
@@ -240,10 +242,17 @@ console.log(
     upload_retries: uploadRetries,
     upload_timeout_ms: uploadTimeoutMs,
     uploaded_control_count: uploadedControlCount,
-    uploaded_history_count: uploadedHistoryCount,
+    // #8208: history objects are content-addressed (by-hash/<sha256>, see
+    // r2-manifest.ts), so a history job whose object already exists remotely
+    // is skipped rather than re-uploaded -- deduplicated_history_count is how
+    // many of historyJobCount avoided a real PUT this run.
+    uploaded_history_count: historyJobCount - dedupedHistoryCount,
+    deduplicated_history_count: dedupedHistoryCount,
     uploaded_latest_count: uploadedLatestCount,
     uploaded_object_count:
-      uploadedLatestCount + uploadedHistoryCount + uploadedControlCount,
+      uploadedLatestCount +
+      (historyJobCount - dedupedHistoryCount) +
+      uploadedControlCount,
   }),
 );
 
@@ -378,20 +387,24 @@ async function putObjects(
     retries: number;
     retryBaseDelayMs: number;
   },
-): Promise<void> {
+): Promise<number> {
   if (jobs.length === 0) {
-    return;
+    return 0;
   }
 
   let nextIndex = 0;
   let completedCount = 0;
+  let dedupedCount = 0;
   const workerCount = Math.min(concurrency, jobs.length);
   await Promise.all(
     Array.from({ length: workerCount }, async () => {
       while (nextIndex < jobs.length) {
         const job = jobs[nextIndex];
         nextIndex += 1;
-        await putObject(job, { retries, retryBaseDelayMs });
+        const { deduped } = await putObject(job, { retries, retryBaseDelayMs });
+        if (deduped) {
+          dedupedCount += 1;
+        }
         completedCount += 1;
         if (
           completedCount === jobs.length ||
@@ -404,16 +417,16 @@ async function putObjects(
       }
     }),
   );
+  return dedupedCount;
 }
 
 async function putObject(
   job: UploadJob,
   { retries, retryBaseDelayMs }: { retries: number; retryBaseDelayMs: number },
-): Promise<void> {
+): Promise<{ deduped: boolean }> {
   for (let attempt = 0; attempt <= retries; attempt += 1) {
     try {
-      await putObjectOnce(job);
-      return;
+      return await putObjectOnce(job);
     } catch (error) {
       if (attempt >= retries) {
         throw error;
@@ -425,6 +438,9 @@ async function putObject(
       await sleep(retryBaseDelayMs * 2 ** attempt);
     }
   }
+  // Unreachable: the loop above always returns or throws by its last
+  // iteration (attempt >= retries re-throws), but TypeScript can't see that.
+  throw new Error(`putObject exhausted retries for ${job.key}`);
 }
 
 // #stale-publish-pipeline/C: previously spawned a `wrangler r2 object put`
@@ -477,8 +493,21 @@ async function putObjectOnce({
   key,
   bucketName,
   contentType,
-}: UploadJob): Promise<void> {
+  kind,
+}: UploadJob): Promise<{ deduped: boolean }> {
   const { accountId, apiToken } = requireCloudflareCredentials();
+  // History objects are content-addressed (by-hash/<sha256>, see
+  // r2-manifest.ts): if this exact key already exists remotely, its bytes are
+  // necessarily identical (the key IS the hash of the content), so a HEAD
+  // check-then-skip avoids re-uploading a full body for an artifact that
+  // hasn't changed since some earlier run (#8208) -- unlike "latest"/"control"
+  // keys, which are always overwritten in place regardless of content.
+  if (
+    kind === "history" &&
+    (await objectExists(accountId, bucketName, key, apiToken))
+  ) {
+    return { deduped: true };
+  }
   const body = readFileSync(localPath);
   let res: Response;
   try {
@@ -515,6 +544,28 @@ async function putObjectOnce({
         .join("\n")
         .slice(0, 500),
     );
+  }
+  return { deduped: false };
+}
+
+// Fail-safe: any non-2xx/network outcome (including a timeout) is treated as
+// "not confirmed present" so the caller falls through to a real PUT -- worst
+// case a redundant upload, never a missed one.
+async function objectExists(
+  accountId: string,
+  bucketName: string,
+  key: string,
+  apiToken: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(r2ObjectUrl(accountId, bucketName, key), {
+      method: "HEAD",
+      headers: { Authorization: `Bearer ${apiToken}` },
+      signal: AbortSignal.timeout(uploadTimeoutMs),
+    });
+    return res.ok;
+  } catch {
+    return false;
   }
 }
 

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -2456,12 +2456,19 @@ test("R2-only generated artifacts stay out of the public git tree", () => {
   }
 });
 
-test("R2 history upload writes every planned run-prefix artifact", async () => {
+test("R2 history upload deduplicates content-addressed objects that already exist", async () => {
   const execFileAsync = promisify(execFile);
   const manifestPath = path.join(r2StagingRoot, "r2-manifest.json");
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
   const remoteManifestBody = readFileSync(manifestPath);
   const putKeys: string[] = [];
+  const headKeys: string[] = [];
+  // Pre-seed one artifact's content-addressed key (by-hash/<sha256>, see
+  // r2-manifest.ts) as already present remotely -- its history PUT must be
+  // skipped (#8208), while every other artifact/control object (none of
+  // which this mock knows about) still gets a real PUT.
+  const preexistingHistoryKey = manifest.artifacts.at(-1).key;
+  const existingKeys = new Set([preexistingHistoryKey]);
 
   // Mocks the Cloudflare R2 REST API scripts/r2-upload.ts calls directly
   // (replaced the METAGRAPH_WRANGLER_BIN fake-CLI seam when putObjectOnce/
@@ -2477,6 +2484,11 @@ test("R2 history upload writes every planned run-prefix artifact", async () => {
     const key = decodeURIComponent(
       req.url!.slice(markerIndex + objectsMarker.length),
     );
+    if (req.method === "HEAD") {
+      headKeys.push(key);
+      res.writeHead(existingKeys.has(key) ? 200 : 404).end();
+      return;
+    }
     if (req.method === "GET") {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(remoteManifestBody);
@@ -2516,23 +2528,35 @@ test("R2 history upload writes every planned run-prefix artifact", async () => {
       },
     );
     const summary = JSON.parse(stdout);
+    const totalHistoryObjects =
+      manifest.artifacts.length + summary.uploaded_control_count;
 
     assert.equal(summary.remote_manifest_status, "found");
     assert.equal(summary.changed_artifact_count, 0);
     assert.equal(summary.skipped_artifact_count, manifest.artifacts.length);
     assert.equal(summary.uploaded_latest_count, 0);
     assert.equal(summary.uploaded_control_count, 3);
+    assert.equal(summary.deduplicated_history_count, 1);
     assert.equal(
       summary.uploaded_history_count,
-      manifest.artifacts.length + summary.uploaded_control_count,
+      totalHistoryObjects - 1,
+      "the pre-seeded content-addressed object must not count as a fresh upload",
     );
     assert.equal(
-      putKeys.filter((key) => key.startsWith(manifest.run_prefix)).length,
-      manifest.artifacts.length + summary.uploaded_control_count,
+      putKeys.length,
+      // putKeys also captures the 3 "control"-kind PUTs (the always-fresh
+      // latest/ copies of the manifest files, separate from their history
+      // copies) -- add those back in alongside the post-dedup history count.
+      totalHistoryObjects - 1 + summary.uploaded_control_count,
+      "the pre-seeded content-addressed object must not be re-uploaded",
     );
     assert(
-      putKeys.includes(manifest.artifacts.at(-1).key),
-      "expected history upload to include artifacts unchanged in latest",
+      !putKeys.includes(preexistingHistoryKey),
+      "a history object that already exists by hash must be skipped, not re-uploaded",
+    );
+    assert(
+      headKeys.includes(preexistingHistoryKey),
+      "every history object must be existence-checked before upload",
     );
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));


### PR DESCRIPTION
Closes #8208.

The R2 "history" tier (`METAGRAPH_R2_UPLOAD_HISTORY=1`, always on in `publish-cloudflare.yml`) previously stored every artifact at a run-prefixed key (`runs/<run>/<path>`), so a byte-identical artifact got a full re-upload on every single publish regardless of whether its content changed — only the "latest" tier skipped unchanged uploads via a sha256 diff.

## Fix

Content-address the history tier instead of run-prefixing it:

- `scripts/r2-manifest.ts` and `build-artifacts.ts`'s `buildR2Manifest` (both produce the committed `public/metagraph/r2-manifest.json` at different points in the pipeline, so both needed the same change) now key history entries as `by-hash/<sha256>` rather than `runs/<run>/<path>`.
- `scripts/r2-upload.ts` does a HEAD check before a history-kind PUT and skips the upload when an object already exists at that hash. A byte-identical artifact across N runs is uploaded once, not N times — and the dedup applies across *all* history, not just the immediately-preceding run (if a value reverts to something seen 50 runs ago, it's still deduped).
- "What was live at run X" stays fully recoverable, no separate ledger needed: the manifest itself is still uploaded to `runs/<run>/r2-manifest.json` every run (it already carries every artifact's path → sha256), so resolving a historical snapshot is "for each artifact, fetch `by-hash/<its sha256>`".
- New summary fields: `uploaded_history_count` now reflects real uploads only; `deduplicated_history_count` reports how many were skipped.
- No new credentials or storage tier needed — same Cloudflare API v4 R2 endpoint/token already in use. Nothing in the runtime code reads `runs/<prefix>/<path>` directly (confirmed via grep), so this doesn't break any live consumer.
- `docs/cloudflare-backend.md` updated to describe the new scheme.

## Verification

- `npx tsc --noEmit` clean, repo-wide.
- `npx eslint` / `npx prettier --check` clean on all changed files.
- `npm run validate` / `npm run validate:contract-drift` clean.
- `npm test` — full suite, 494 files / 12192 tests, all passing.
- `tests/artifacts.test.ts`'s history-upload test rewritten to pre-seed one artifact's content-addressed key as already-remote (via a mock HEAD handler) and assert it's skipped while every other artifact/control object still uploads normally.