### PR TITLE
fix(api): decode subtensor AccountInfo balances as u64 — reserved>0 accounts returned ~1e18 τ

### DIFF
--- a/src/account-balance.ts
+++ b/src/account-balance.ts
@@ -37,12 +37,24 @@ const SYSTEM_ACCOUNT_STORAGE_PREFIX =
   "26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9";
 const ACCOUNT_ID_LENGTH = 32;
 // SCALE AccountInfo: nonce/consumers/providers/sufficients (u32 LE each = 16
-// bytes), then AccountData whose first two fields are free + reserved (u128 LE
-// each). Only free+reserved are read; the trailing frozen/flags (or legacy
-// misc_frozen/fee_frozen) fields are ignored, so both AccountData layouts decode.
-const ACCOUNT_DATA_FREE_OFFSET = 16;
-const ACCOUNT_DATA_RESERVED_OFFSET = 32;
+// bytes), then AccountData. subtensor's Balance type is u64, so a live finney
+// blob is 56 bytes: free u64@16, reserved u64@24, frozen u64@32, flags u128@40
+// (verified against a live state_getStorage response). Generic-Substrate
+// chains use Balance = u128 (free u128@16, reserved u128@32; 80 bytes with
+// frozen+flags). Decoding finney's 56-byte blob with the u128 offsets spans
+// free+reserved in a single read, so any account with reserved > 0 returned
+// ~1e18 "tao" (#8239) — the layout must be picked by blob length.
+const ACCOUNT_INFO_HEADER_BYTES = 16;
+const U64_BYTES = 8;
 const U128_BYTES = 16;
+// header + free/reserved/frozen (u64 each) + flags (u128) — live finney shape.
+const ACCOUNT_INFO_U64_LENGTH =
+  ACCOUNT_INFO_HEADER_BYTES + 3 * U64_BYTES + U128_BYTES; // 56
+// header + free + reserved (u128 each) — the minimum readable u128-layout blob.
+const ACCOUNT_INFO_U128_MIN_LENGTH = ACCOUNT_INFO_HEADER_BYTES + 2 * U128_BYTES; // 48
+// header + free/reserved/frozen/flags (u128 each) — a full u128 AccountData.
+const ACCOUNT_INFO_U128_FULL_LENGTH =
+  ACCOUNT_INFO_HEADER_BYTES + 4 * U128_BYTES; // 80
 const RAO_PER_TAO = 1_000_000_000n;
 
 function decodeBase58(value: string): Uint8Array | null {
@@ -118,9 +130,9 @@ function hexToBytes(hex: string): Uint8Array | null {
   return bytes;
 }
 
-function readU128Le(bytes: Uint8Array, offset: number): bigint {
+function readUintLe(bytes: Uint8Array, offset: number, width: number): bigint {
   let value = 0n;
-  for (let index = U128_BYTES - 1; index >= 0; index -= 1) {
+  for (let index = width - 1; index >= 0; index -= 1) {
     value = (value << 8n) | BigInt(bytes[offset + index]);
   }
   return value;
@@ -159,13 +171,30 @@ export function accountInfoTotalRao(
   if (result == null) return 0n;
   if (typeof result !== "string") return null;
   const bytes = hexToBytes(result);
-  if (!bytes || bytes.length < ACCOUNT_DATA_RESERVED_OFFSET + U128_BYTES) {
-    return null;
+  if (!bytes) return null;
+  // Pick the AccountData layout by blob length (see the constants above):
+  // a full u128 AccountData first (>=80 bytes), then finney's u64 layout
+  // (56..79 — the live-chain shape), then the minimal free+reserved u128
+  // pair (48..55) for compatibility. Anything shorter is undecodable.
+  if (bytes.length >= ACCOUNT_INFO_U128_FULL_LENGTH) {
+    return (
+      readUintLe(bytes, ACCOUNT_INFO_HEADER_BYTES, U128_BYTES) +
+      readUintLe(bytes, ACCOUNT_INFO_HEADER_BYTES + U128_BYTES, U128_BYTES)
+    );
   }
-  return (
-    readU128Le(bytes, ACCOUNT_DATA_FREE_OFFSET) +
-    readU128Le(bytes, ACCOUNT_DATA_RESERVED_OFFSET)
-  );
+  if (bytes.length >= ACCOUNT_INFO_U64_LENGTH) {
+    return (
+      readUintLe(bytes, ACCOUNT_INFO_HEADER_BYTES, U64_BYTES) +
+      readUintLe(bytes, ACCOUNT_INFO_HEADER_BYTES + U64_BYTES, U64_BYTES)
+    );
+  }
+  if (bytes.length >= ACCOUNT_INFO_U128_MIN_LENGTH) {
+    return (
+      readUintLe(bytes, ACCOUNT_INFO_HEADER_BYTES, U128_BYTES) +
+      readUintLe(bytes, ACCOUNT_INFO_HEADER_BYTES + U128_BYTES, U128_BYTES)
+    );
+  }
+  return null;
 }
 
 export interface AccountBalanceResult {

--- a/tests/account-balance-loader.test.ts
+++ b/tests/account-balance-loader.test.ts
@@ -12,22 +12,54 @@ import { mockEnv, type Row } from "./row-type.ts";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-// A SCALE-encoded AccountInfo blob: nonce/consumers/providers/sufficients
-// (u32 LE each) then AccountData's free + reserved (u128 LE each).
-function accountInfoHex(freeRao: bigint, reservedRao: bigint): string {
-  const u128 = (value: bigint): string => {
-    let hex = "";
-    let rest = BigInt(value);
-    for (let index = 0; index < 16; index += 1) {
-      hex += Number(rest & 0xffn)
-        .toString(16)
-        .padStart(2, "0");
-      rest >>= 8n;
-    }
-    return hex;
-  };
-  return `0x${"00000000".repeat(4)}${u128(freeRao)}${u128(reservedRao)}`;
+function uintLeHex(value: bigint, width: number): string {
+  let hex = "";
+  let rest = BigInt(value);
+  for (let index = 0; index < width; index += 1) {
+    hex += Number(rest & 0xffn)
+      .toString(16)
+      .padStart(2, "0");
+    rest >>= 8n;
+  }
+  return hex;
 }
+
+// A minimal u128-layout AccountInfo blob (48 bytes): header (4×u32) then
+// free + reserved as u128 LE — the compatibility shape, NOT what live finney
+// returns (see accountInfoU64Hex).
+function accountInfoHex(freeRao: bigint, reservedRao: bigint): string {
+  return `0x${"00000000".repeat(4)}${uintLeHex(freeRao, 16)}${uintLeHex(reservedRao, 16)}`;
+}
+
+// The live finney shape (#8239): subtensor Balance = u64, so AccountData is
+// free u64 + reserved u64 + frozen u64 + flags u128 → 56 bytes total.
+function accountInfoU64Hex(
+  freeRao: bigint,
+  reservedRao: bigint,
+  frozenRao = 0n,
+  flags = 0x80000000000000000000000000000000n, // FRAME's new-logic flag bit
+): string {
+  return `0x${"00000000".repeat(4)}${uintLeHex(freeRao, 8)}${uintLeHex(reservedRao, 8)}${uintLeHex(frozenRao, 8)}${uintLeHex(flags, 16)}`;
+}
+
+// A full u128 AccountData (80 bytes): free/reserved/frozen/flags, u128 each.
+function accountInfoU128FullHex(
+  freeRao: bigint,
+  reservedRao: bigint,
+  frozenRao = 0n,
+  flags = 0n,
+): string {
+  return `0x${"00000000".repeat(4)}${uintLeHex(freeRao, 16)}${uintLeHex(reservedRao, 16)}${uintLeHex(frozenRao, 16)}${uintLeHex(flags, 16)}`;
+}
+
+// Captured live from finney state_getStorage for a coldkey with a nonzero
+// reserved balance: nonce 685, free 1_850_761_846 rao, reserved 126_000_000
+// rao, frozen 0, flags high-bit set. The pre-#8239 u128 decode read this as
+// ~2.32e27 rao because the u128 "free" read spanned free+reserved.
+const REAL_FINNEY_BLOB =
+  "0xad0200000100000001000000000000007662506e00000000809b8207000000" +
+  "00000000000000000000000000000000000000000000000080";
+const REAL_FINNEY_TOTAL_RAO = 1_850_761_846n + 126_000_000n;
 
 describe("isFinneySs58Address", () => {
   test("accepts a valid finney address", () => {
@@ -72,6 +104,40 @@ describe("systemAccountStorageKey", () => {
 describe("accountInfoTotalRao", () => {
   test("sums free + reserved from a SCALE AccountInfo blob", () => {
     assert.equal(accountInfoTotalRao({ result: accountInfoHex(7n, 3n) }), 10n);
+  });
+
+  test("decodes the live finney u64 layout — reserved > 0 must not corrupt free (#8239)", () => {
+    // The real captured blob: the u128 misread returned ~2.32e27 rao here.
+    assert.equal(
+      accountInfoTotalRao({ result: REAL_FINNEY_BLOB }),
+      REAL_FINNEY_TOTAL_RAO,
+    );
+  });
+
+  test("decodes a synthetic 56-byte u64 blob with nonzero frozen and flags", () => {
+    assert.equal(
+      accountInfoTotalRao({
+        result: accountInfoU64Hex(5_000_000_000n, 250_000_000n, 111n),
+      }),
+      5_250_000_000n,
+    );
+  });
+
+  test("u64-layout blobs with reserved = 0 decode to the same value as before", () => {
+    // Accounts with reserved = 0 were accidentally correct pre-fix; lock that in.
+    assert.equal(
+      accountInfoTotalRao({ result: accountInfoU64Hex(13_687_971_778n, 0n) }),
+      13_687_971_778n,
+    );
+  });
+
+  test("decodes a full 80-byte u128 AccountData at the u128 offsets", () => {
+    assert.equal(
+      accountInfoTotalRao({
+        result: accountInfoU128FullHex(2_000_000_000n, 500_000_000n, 42n, 1n),
+      }),
+      2_500_000_000n,
+    );
   });
 
   test("treats an absent storage entry as a zero balance", () => {

--- a/tests/account-balance.test.ts
+++ b/tests/account-balance.test.ts
@@ -225,6 +225,34 @@ test("GET /accounts/{ss58}/balance falls through on KV read failure", async () =
   );
 });
 
+test("GET /accounts/{ss58}/balance decodes the live finney u64 AccountInfo layout (#8239)", async () => {
+  // Captured live: 56-byte blob (Balance = u64) for a coldkey with reserved > 0.
+  // free 1_850_761_846 + reserved 126_000_000 rao = 1.976761846 TAO. The old
+  // u128 decode returned ~2.3e18 "tao" for exactly this shape.
+  await withFetchStub(
+    async () => ({
+      ok: true,
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        result:
+          "0xad0200000100000001000000000000007662506e00000000809b8207000000" +
+          "00000000000000000000000000000000000000000000000080",
+      }),
+    }),
+    async () => {
+      const res = await handleRequest(
+        req(`/api/v1/accounts/${SS58}/balance`),
+        {} as unknown as Env,
+        {},
+      );
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.data.balance_tao, 1.976761846);
+    },
+  );
+});
+
 test("GET /accounts/{ss58}/balance decodes hex-encoded rao balances", async () => {
   // Real Bittensor RPC returns free+reserved as 0x-prefixed hex u128 strings.
   await withFetchStub(


### PR DESCRIPTION
Closes #8239 (Phase 0 of the block-explorer UX overhaul epic #8238).

## What

`GET /api/v1/accounts/{ss58}/balance` (and MCP `get_account_balance`) returned raw-garbage magnitudes for any account with a nonzero reserved balance — a top coldkey returned `balance_tao: 2324289753287403500` (≈2.3 quadrillion τ against a 21M supply), rendered verbatim on the account page.

## Why

`accountInfoTotalRao` decoded `AccountData` at the generic-Substrate **u128** offsets (free u128@16, reserved u128@32). subtensor's `Balance` type is **u64**: a live finney `System::Account` blob is 56 bytes — free u64@16, reserved u64@24, frozen u64@32, flags u128@40 (verified by raw `state_getStorage` decode). The u128 "free" read spanned free+reserved, multiplying the result by ~2^64/1e9 whenever reserved > 0. Accounts with reserved = 0 decoded correctly by accident, which is why spot checks never caught it.

## How

- Layout picked by blob length: **≥80** → full u128 AccountData; **56–79** → the live u64 shape; **48–55** → minimal u128 free+reserved pair (kept for compatibility with existing fixtures/chains); shorter → `null` (unchanged undecodable semantics).
- `readU128Le` generalized to `readUintLe(bytes, offset, width)`.
- No schema/contract change — `balance_tao` stays a number; null-on-failure semantics unchanged.

## Tests

- **Regression (the bug):** a captured live finney blob (reserved > 0, flags high-bit set) pinned at exactly `1.976761846` τ — unit level and route level. Pre-fix this decoded to ~2.3e18.
- Reserved=0 u64 blob pinned to its pre-fix value (no behavior change for the accidentally-correct class).
- Full 80-byte u128 AccountData, synthetic 56-byte u64 with nonzero frozen/flags, existing 48-byte fixtures, truncated/non-hex/null/error cases all covered.
- `vitest`: 40/40 green across both balance test files; changed-file coverage 98.3% stmts / 96.2% branch (sole uncovered line is pre-existing base58 code untouched by this patch); prettier/eslint/tsc clean.

## Verification plan post-deploy

The reference coldkey returns ~1.98 τ from the live endpoint (issue #8239 acceptance list).