### PR TITLE
feat(mcp): make list_subnets + get_subnet_detail network-aware

### DIFF
--- a/schemas-src/mcp-tools/get-subnet-detail.ts
+++ b/schemas-src/mcp-tools/get-subnet-detail.ts
@@ -10,10 +10,12 @@
 // the pilot batch).
 import { z } from "zod";
 import { OpenObjectSchema } from "./shared.ts";
+import { McpNetworkSchema } from "../shared.ts";
 
 export const GetSubnetDetailInputSchema = z
   .object({
     netuid: z.int().min(0),
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type GetSubnetDetailInput = z.infer<typeof GetSubnetDetailInputSchema>;

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -10,7 +10,11 @@
 // only coverage_level/curation_level/sort/order were actually enum-
 // constrained on the wire, and only those reuse a shared enum.
 import { z } from "zod";
-import { CoverageLevelSchema, CurationLevelSchema } from "../shared.ts";
+import {
+  CoverageLevelSchema,
+  CurationLevelSchema,
+  McpNetworkSchema,
+} from "../shared.ts";
 
 const LIST_SUBNETS_SORT_FIELDS = [
   "netuid",
@@ -54,6 +58,7 @@ export const ListSubnetsInputSchema = z
     max_netuid: z.int().min(0).optional(),
     sort: z.enum(LIST_SUBNETS_SORT_FIELDS).optional(),
     order: z.enum(LIST_SUBNETS_ORDERS).optional(),
+    network: McpNetworkSchema.optional(),
   })
   .strict();
 export type ListSubnetsInput = z.infer<typeof ListSubnetsInputSchema>;

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -17,6 +17,14 @@ export const CoverageLevelSchema = z.enum([
 ]);
 export type CoverageLevel = z.infer<typeof CoverageLevelSchema>;
 
+// Chain network for the network-aware MCP tools (#8228). Same two values, and
+// the same chain-name spelling, `call_rpc` already accepts — an agent should
+// not have to learn that the RPC lane says "test" while a data lane says
+// "testnet". Only the tools whose artifact is actually published per-network
+// (list_subnets, get_subnet_detail) take this; everything else stays mainnet.
+export const McpNetworkSchema = z.enum(["finney", "test"]);
+export type McpNetwork = z.infer<typeof McpNetworkSchema>;
+
 export const CurationLevelSchema = z.enum([
   "native",
   "candidate-discovered",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1753,6 +1753,21 @@ function toolError(code: string, message: string) {
   return error;
 }
 
+// #8228: rewrite a mainnet artifact path for the requested chain network.
+// Mirrors the Worker's own /metagraph/{prefix}/… partitioning (see
+// NETWORK_KEY_PREFIXES in src/artifact-storage.ts): finney is the unprefixed
+// default, test lives under metagraph/testnet/. Only pass paths whose artifact
+// is genuinely published per-network — testnet is a native-only registry, so
+// composed/curated artifacts (overview, agent-catalog, health) have no testnet
+// key and would 404 rather than fall back to mainnet.
+function networkArtifactPath(
+  artifactPath: string,
+  network?: "finney" | "test",
+): string {
+  if (!network || network === "finney") return artifactPath;
+  return artifactPath.replace(/^\/metagraph\//, "/metagraph/testnet/");
+}
+
 async function loadArtifactData(ctx: McpCtx, artifactPath: string) {
   const result = await ctx.readArtifact!(ctx.env, artifactPath);
   if (!result || !result.ok) {
@@ -3070,12 +3085,18 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "subnet's netuid, slug, title, type, status, integration-readiness score " +
       "(0-100), and callable-surface count. Use this to walk or page through the " +
       "whole registry; for keyword or capability discovery use search_subnets / " +
-      "find_subnets_by_capability instead.",
+      "find_subnets_by_capability instead. Defaults to mainnet; pass " +
+      'network:"test" for the Bittensor testnet registry, which is native-only ' +
+      "(chain identity, no curated surfaces/health, so readiness and " +
+      "surface_count are zero there).",
     inputSchema: z.toJSONSchema(ListSubnetsInputSchema, {
       target: "draft-2020-12",
     }),
     async handler(args: z.infer<typeof ListSubnetsInputSchema>, ctx: McpCtx) {
-      const index = await loadArtifactData(ctx, "/metagraph/subnets.json");
+      const index = await loadArtifactData(
+        ctx,
+        networkArtifactPath("/metagraph/subnets.json", args?.network),
+      );
       const all = Array.isArray(index.subnets) ? index.subnets : [];
       // Categorical inclusion (status/subnet_type/domain) and exclusion
       // (not_status/not_subnet_type/not_domain), then the numeric range bounds.
@@ -3216,7 +3237,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       "overview is assembled from. Use get_subnet for the curated dashboard " +
       "view (profile + health + curation + gaps + counts); use this for the " +
       "raw structural record itself, or get_subnet_economics for economics " +
-      "alone. Mirrors GET /api/v1/subnets/{netuid}.",
+      "alone. Mirrors GET /api/v1/subnets/{netuid}. Defaults to mainnet; pass " +
+      'network:"test" for the testnet record (native-only: chain identity and ' +
+      "chain economics, no curated surfaces/health, and no mainnet live-economics " +
+      "overlay). Testnet netuids are independent of mainnet netuids.",
     inputSchema: z.toJSONSchema(GetSubnetDetailInputSchema, {
       target: "draft-2020-12",
     }),
@@ -3227,11 +3251,16 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       const netuid = requireNetuid(args);
       const detail = await loadArtifactData(
         ctx,
-        `/metagraph/subnets/${netuid}.json`,
+        networkArtifactPath(`/metagraph/subnets/${netuid}.json`, args?.network),
       );
       // Same live-economics overlay /api/v1/subnets/{netuid} attaches (#1308):
       // one call carries validator/miner counts, registration, stake, and
-      // alpha price alongside the structural record.
+      // alpha price alongside the structural record. Mainnet only -- that
+      // overlay reads the finney live-KV blob, so attaching it to a testnet
+      // record would report mainnet numbers against a testnet subnet (the
+      // exact leak tests/network-routing.test.ts guards on the REST side).
+      // Testnet carries its own chain economics inside `subnet.economics`.
+      if (args?.network && args.network !== "finney") return detail;
       const { economics } = await loadSubnetEconomics(ctx, netuid);
       return economics ? { ...detail, economics } : detail;
     },

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1904,6 +1904,75 @@ describe("MCP tools (injected deps)", () => {
     assert.equal("economics" in out, false);
   });
 
+  test("get_subnet_detail network:test reads the testnet key and skips the mainnet economics overlay (#8228)", async () => {
+    const localDeps = makeDeps({
+      // Same netuid on both networks, deliberately different records: testnet
+      // netuids are independent of mainnet netuids.
+      "/metagraph/subnets/7.json": {
+        schema_version: 1,
+        subnet: { netuid: 7, slug: "allways", name: "MAINNET Allways" },
+      },
+      "/metagraph/testnet/subnets/7.json": {
+        schema_version: 1,
+        subnet: {
+          netuid: 7,
+          slug: "sn-7",
+          name: "TESTNET subnet 7",
+          economics: { alpha_price_tao: 0.25 },
+        },
+      },
+      "/metagraph/economics.json": {
+        schema_version: 1,
+        summary: { with_economics_count: 1 },
+        subnets: [{ netuid: 7, open_slots: 3 }],
+      },
+    });
+    const res = await callTool(
+      "get_subnet_detail",
+      { netuid: 7, network: "test" },
+      { deps: localDeps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet.name, "TESTNET subnet 7");
+    // The mainnet live-KV economics overlay must NOT be attached to a testnet
+    // record -- it would report finney numbers against a testnet subnet.
+    assert.equal("economics" in out, false);
+    // Testnet's own chain economics still ride along inside the record.
+    assert.equal(out.subnet.economics.alpha_price_tao, 0.25);
+  });
+
+  test("get_subnet_detail network:finney is identical to omitting network (#8228)", async () => {
+    const localDeps = makeDeps({
+      "/metagraph/subnets/7.json": {
+        schema_version: 1,
+        subnet: { netuid: 7, slug: "allways", name: "MAINNET Allways" },
+      },
+      "/metagraph/economics.json": {
+        schema_version: 1,
+        summary: { with_economics_count: 1 },
+        subnets: [{ netuid: 7, open_slots: 3 }],
+      },
+    });
+    const explicit = await callTool(
+      "get_subnet_detail",
+      { netuid: 7, network: "finney" },
+      { deps: localDeps },
+    );
+    const implicit = await callTool(
+      "get_subnet_detail",
+      { netuid: 7 },
+      { deps: localDeps },
+    );
+    assert.deepEqual(
+      explicit.body.result.structuredContent,
+      implicit.body.result.structuredContent,
+    );
+    assert.equal(
+      explicit.body.result.structuredContent.economics.open_slots,
+      3,
+    );
+  });
+
   test("get_subnet_detail maps a missing artifact to a clean not_found", async () => {
     const res = await callTool("get_subnet_detail", { netuid: 999 }, { deps });
     assert.equal(res.body.result.isError, true);
@@ -7976,6 +8045,42 @@ describe("list_subnets", () => {
         },
       ],
     },
+  });
+
+  test("network:test reads the testnet index, finney matches the default (#8228)", async () => {
+    const localDeps = makeDeps({
+      "/metagraph/subnets.json": {
+        subnets: [{ netuid: 7, slug: "allways", name: "MAINNET Allways" }],
+      },
+      "/metagraph/testnet/subnets.json": {
+        subnets: [
+          { netuid: 7, slug: "sn-7", name: "TESTNET seven" },
+          { netuid: 11, slug: "sn-11", name: "TESTNET eleven" },
+        ],
+      },
+    });
+
+    const testnet = (
+      await callTool("list_subnets", { network: "test" }, { deps: localDeps })
+    ).body.result.structuredContent;
+    assert.equal(testnet.total, 2);
+    assert.equal(testnet.subnets[0].title, "TESTNET seven");
+
+    // Explicit finney and an omitted network must resolve to the same
+    // unprefixed mainnet artifact.
+    const explicit = (
+      await callTool("list_subnets", { network: "finney" }, { deps: localDeps })
+    ).body.result.structuredContent;
+    const implicit = (await callTool("list_subnets", {}, { deps: localDeps }))
+      .body.result.structuredContent;
+    assert.deepEqual(explicit, implicit);
+    assert.equal(explicit.total, 1);
+    assert.equal(explicit.subnets[0].title, "MAINNET Allways");
+  });
+
+  test("rejects an unknown network value (#8228)", async () => {
+    const res = await callTool("list_subnets", { network: "devnet" }, { deps });
+    assert.equal(res.body.result.isError, true);
   });
 
   test("paginates the full registry and reports next_cursor", async () => {


### PR DESCRIPTION
## Summary

The MCP subnet/data tools read the bare (mainnet) artifact path with no `network` parameter at all — `call_rpc` was the *only* network-aware tool on the entire surface. So an agent asking about a testnet subnet silently got finney data, with no way to request otherwise except raw RPC.

Adds an optional `network` param to the two core lookup tools, reusing `call_rpc`'s existing `finney | test` spelling (via a new shared `McpNetworkSchema`) so an agent doesn't have to learn that the RPC lane says `test` while a data lane says `testnet`.

### Scope: only tools with a real per-network artifact

Verified against production which `/metagraph/testnet/*` keys actually exist:

| artifact | testnet | tool |
|---|---|---|
| `subnets.json` | 200 | `list_subnets` ✅ |
| `subnets/{n}.json` | 200 | `get_subnet_detail` ✅ |
| `coverage.json` | 200 | (not wired — see below) |
| `economics.json` | 404 → 200 after #8235 publishes | (not wired — see below) |
| `overview/{n}.json` | 404 | `get_subnet` ❌ excluded |
| `agent-catalog.json` | 404 | capability tools ❌ excluded |

Deliberately did **not** add the param to tools whose artifact has no testnet key — a `network` param that looks supported but always 404s is worse than not offering it. `get_coverage`/`get_economics` live in separate modules with their own error helpers; they're the natural next slice once #8235's economics artifact is live, and the issue explicitly scoped this to "the subnet/data-lookup tools first".

### Live-economics overlay correctness

`get_subnet_detail` normally merges the mainnet live-KV economics row onto the record (#1308). That overlay is skipped for testnet — attaching it would report finney numbers against a testnet subnet, which is exactly the leak `tests/network-routing.test.ts` already guards on the REST side. Testnet carries its own chain economics inside `subnet.economics` (from #8235).

Part of #8223.

Closes #8228

## Test plan

- [x] 4 new tests: testnet index/detail resolve to the prefixed key; `network:"finney"` is byte-identical to omitting the param; the mainnet overlay is absent on testnet while `subnet.economics` survives; an unknown network value (`"devnet"`) is rejected by the schema
- [x] `npx vitest run tests/mcp-server.test.ts tests/mcp-server-branch-coverage.test.ts` — 1277/1277 pass
- [x] `npx vitest run tests/zod-schemas.test.ts` — 318/318 pass
- [x] `npm run validate:contract-drift` — passes (MCP tool schemas aren't part of the REST contract; server card is worker-computed)
- [x] `npm run lint` + `npm run format:check` + `tsc --noEmit` — all clean repo-wide
- [x] Both branches of the new `networkArtifactPath` helper and the overlay-skip branch are exercised, for patch coverage