### PR TITLE
fix(publish): pace R2 uploads under Cloudflare's API rate limit, back off on 429

### DIFF
--- a/scripts/r2-upload.ts
+++ b/scripts/r2-upload.ts
@@ -68,6 +68,58 @@ const uploadRetryBaseDelayMs =
   1000;
 const uploadTimeoutMs =
   parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_TIMEOUT_MS) || 45_000;
+// #stale-publish-pipeline/D: replacing the per-object wrangler subprocess with
+// direct API fetches (#8209) removed the CLI overhead and exposed the next
+// ceiling — Cloudflare's client-API rate limit (documented ~1,200 requests /
+// 5 minutes per token; every HEAD dedupe probe and every PUT counts). The
+// 2026-07-26 run died in mass HTTP 429s ("code 971: Please wait and consider
+// throttling your request speed"): 24 workers kept firing while each failing
+// object burned its 3 quick retries (1s/2s/4s — meaningless against a
+// 5-minute window) and the first object to exhaust them aborted the whole
+// publish. Two-part fix: a request-rate gate shared by every worker (default
+// 3.5 rps ≈ 1,050 per 5 minutes, ~12% under the ceiling), and 429-aware
+// retries that honor Retry-After, back off in tens of seconds, and push a
+// shared cooldown so ALL workers pause together instead of 23 siblings
+// draining the budget while one sleeps.
+const uploadMaxRps =
+  parsePositiveNumber(process.env.METAGRAPH_R2_UPLOAD_MAX_RPS) || 3.5;
+const uploadRateLimitRetries =
+  parseNonNegativeInteger(process.env.METAGRAPH_R2_UPLOAD_429_RETRIES) ?? 6;
+const uploadRateLimitBaseDelayMs =
+  parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_429_BASE_DELAY_MS) ||
+  15_000;
+const uploadRateLimitMaxDelayMs = 120_000;
+
+// Shared pacing across all workers. Each request claims the next slot on a
+// common clock (Node is single-threaded, so the read-modify-write below is
+// race-free), and a 429 pushes a shared cooldown so every worker stalls
+// together instead of the survivors draining the 5-minute budget while one
+// backs off. Declared here, above the script's top-level execution, so the
+// bindings exist before the first upload runs (class/let are not hoisted).
+let nextRequestSlot = 0;
+let cooldownUntil = 0;
+
+async function rateGate(): Promise<void> {
+  const interval = 1000 / uploadMaxRps;
+  for (;;) {
+    const slot = Math.max(Date.now(), nextRequestSlot, cooldownUntil);
+    nextRequestSlot = slot + interval;
+    const wait = slot - Date.now();
+    if (wait > 0) await sleep(wait);
+    // A 429 may have pushed the shared cooldown past our claimed slot while
+    // we slept — re-claim instead of firing into a known-throttled window.
+    if (Date.now() >= cooldownUntil) return;
+  }
+}
+
+function pushCooldown(ms: number): void {
+  cooldownUntil = Math.max(cooldownUntil, Date.now() + ms);
+}
+
+class R2PutError extends Error {
+  status?: number;
+  retryAfterMs?: number;
+}
 // Test-only seam (mirrors the old METAGRAPH_WRANGLER_BIN override this
 // replaced): lets tests/r2-upload.test.ts point at a local mock HTTP server
 // instead of the real Cloudflare API. Never set in production.
@@ -278,6 +330,17 @@ function parseNonNegativeInteger(value: string | undefined): number | null {
   return parsed;
 }
 
+function parsePositiveNumber(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("Expected a positive number value.");
+  }
+  return parsed;
+}
+
 function verifyLocalArtifact(localPath: string, artifact: Artifact): void {
   const actual = sha256Hex(readFileSync(localPath));
   if (actual !== artifact.sha256) {
@@ -424,23 +487,46 @@ async function putObject(
   job: UploadJob,
   { retries, retryBaseDelayMs }: { retries: number; retryBaseDelayMs: number },
 ): Promise<{ deduped: boolean }> {
-  for (let attempt = 0; attempt <= retries; attempt += 1) {
+  let rateLimitAttempt = 0;
+  let otherAttempt = 0;
+  for (;;) {
     try {
       return await putObjectOnce(job);
     } catch (error) {
-      if (attempt >= retries) {
+      // Rate limiting gets its own, much larger retry budget and backoff
+      // scale: Cloudflare's window is 5 minutes, so the generic 1s/2s/4s
+      // ladder below only burns more budget. Honor Retry-After when the API
+      // sends one; otherwise back off in tens of seconds with jitter so the
+      // workers don't re-align on the same instant.
+      if (error instanceof R2PutError && error.status === 429) {
+        if (rateLimitAttempt >= uploadRateLimitRetries) {
+          throw error;
+        }
+        const backoff =
+          error.retryAfterMs ??
+          Math.min(
+            uploadRateLimitBaseDelayMs * 2 ** rateLimitAttempt,
+            uploadRateLimitMaxDelayMs,
+          );
+        const delay = backoff + Math.floor(Math.random() * 1000);
+        pushCooldown(delay);
+        rateLimitAttempt += 1;
+        console.error(
+          `Rate-limited (HTTP 429) on ${job.key}; cooling all workers down ${Math.round(delay / 1000)}s (retry ${rateLimitAttempt}/${uploadRateLimitRetries})`,
+        );
+        await sleep(delay);
+        continue;
+      }
+      if (otherAttempt >= retries) {
         throw error;
       }
-      const retryNumber = attempt + 1;
+      otherAttempt += 1;
       console.error(
-        `Retrying R2 object upload ${job.key} (${retryNumber}/${retries}) after ${summarizeError(error)}`,
+        `Retrying R2 object upload ${job.key} (${otherAttempt}/${retries}) after ${summarizeError(error)}`,
       );
-      await sleep(retryBaseDelayMs * 2 ** attempt);
+      await sleep(retryBaseDelayMs * 2 ** (otherAttempt - 1));
     }
   }
-  // Unreachable: the loop above always returns or throws by its last
-  // iteration (attempt >= retries re-throws), but TypeScript can't see that.
-  throw new Error(`putObject exhausted retries for ${job.key}`);
 }
 
 // #stale-publish-pipeline/C: previously spawned a `wrangler r2 object put`
@@ -511,6 +597,7 @@ async function putObjectOnce({
   const body = readFileSync(localPath);
   let res: Response;
   try {
+    await rateGate();
     res = await fetch(r2ObjectUrl(accountId, bucketName, key), {
       method: "PUT",
       headers: {
@@ -538,12 +625,19 @@ async function putObjectOnce({
   }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(
+    const error = new R2PutError(
       [`R2 object put failed for ${key} (HTTP ${res.status})`, text.trim()]
         .filter(Boolean)
         .join("\n")
         .slice(0, 500),
     );
+    error.status = res.status;
+    // Retry-After is seconds on Cloudflare's API; only trust a positive one.
+    const retryAfter = Number(res.headers.get("retry-after"));
+    if (Number.isFinite(retryAfter) && retryAfter > 0) {
+      error.retryAfterMs = retryAfter * 1000;
+    }
+    throw error;
   }
   return { deduped: false };
 }
@@ -558,6 +652,9 @@ async function objectExists(
   apiToken: string,
 ): Promise<boolean> {
   try {
+    // HEAD probes spend the same client-API rate budget as PUTs — gate them
+    // too, or the dedupe pass alone can trip the 429 window.
+    await rateGate();
     const res = await fetch(r2ObjectUrl(accountId, bucketName, key), {
       method: "HEAD",
       headers: { Authorization: `Bearer ${apiToken}` },

--- a/tests/r2-upload.test.ts
+++ b/tests/r2-upload.test.ts
@@ -90,3 +90,138 @@ test("R2 latest upload uses real sha256 even when content hash matches", async (
   assert.equal(summary.uploaded_latest_count, 1);
   assert.deepEqual(putKeys, [firstArtifact.latest_key]);
 });
+
+// #8240: Cloudflare's client API rate-limits aggressively (HTTP 429, code
+// 971). The uploader must treat 429 as a cooldown signal — honoring
+// Retry-After when present, backing off otherwise — and eventually succeed,
+// instead of burning 3 quick generic retries and aborting the whole publish.
+test("R2 upload recovers from HTTP 429 bursts instead of aborting", async () => {
+  const manifest = JSON.parse(
+    readFileSync(`${r2StagingRoot}/r2-manifest.json`, "utf8"),
+  );
+  const firstArtifact = manifest.artifacts[0];
+  // Remote manifest reports a different hash for artifact 0 so exactly one
+  // latest PUT is planned (same setup as the test above).
+  const remoteManifest = {
+    ...manifest,
+    artifacts: manifest.artifacts.map(
+      (artifact: Record<string, unknown>, index: number) =>
+        index === 0 ? { ...artifact, sha256: "0".repeat(64) } : artifact,
+    ),
+  };
+
+  let putAttempts = 0;
+  server = http.createServer((req, res) => {
+    if (req.method === "GET") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(remoteManifest));
+      return;
+    }
+    if (req.method === "PUT") {
+      putAttempts += 1;
+      req.resume();
+      req.on("end", () => {
+        if (putAttempts <= 2) {
+          // First 429 carries Retry-After (the honored path); the second
+          // omits it (the exponential-backoff path).
+          const headers: Record<string, string> =
+            putAttempts === 1 ? { "retry-after": "1" } : {};
+          res.writeHead(429, headers);
+          res.end(
+            JSON.stringify({
+              success: false,
+              errors: [
+                {
+                  code: 971,
+                  message:
+                    "Please wait and consider throttling your request speed",
+                },
+              ],
+            }),
+          );
+          return;
+        }
+        res.writeHead(200).end();
+      });
+      return;
+    }
+    res.writeHead(405).end();
+  });
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["scripts/r2-upload.ts", "--write"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLOUDFLARE_ACCOUNT_ID: "test-account",
+        CLOUDFLARE_API_TOKEN: "test-token",
+        METAGRAPH_ALLOW_R2_UPLOAD: "1",
+        METAGRAPH_R2_API_BASE_URL: `http://127.0.0.1:${port}`,
+        METAGRAPH_R2_UPLOAD_LIMIT: "1",
+        // Keep the test fast: high rps ceiling, tiny 429 backoff base. The
+        // Retry-After: 1 response above still exercises the honored path.
+        METAGRAPH_R2_UPLOAD_MAX_RPS: "200",
+        METAGRAPH_R2_UPLOAD_429_BASE_DELAY_MS: "20",
+      },
+    },
+  );
+  const summary = JSON.parse(stdout);
+  assert.equal(putAttempts, 3); // 429, 429, then success
+  assert.equal(summary.uploaded_latest_count, 1);
+  assert.equal(summary.changed_artifact_count, 1);
+  void firstArtifact;
+});
+
+test("R2 upload still fails once the 429 retry budget is exhausted", async () => {
+  const manifest = JSON.parse(
+    readFileSync(`${r2StagingRoot}/r2-manifest.json`, "utf8"),
+  );
+  const remoteManifest = {
+    ...manifest,
+    artifacts: manifest.artifacts.map(
+      (artifact: Record<string, unknown>, index: number) =>
+        index === 0 ? { ...artifact, sha256: "0".repeat(64) } : artifact,
+    ),
+  };
+  server = http.createServer((req, res) => {
+    if (req.method === "GET") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(remoteManifest));
+      return;
+    }
+    if (req.method === "PUT") {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(429).end(JSON.stringify({ success: false }));
+      });
+      return;
+    }
+    res.writeHead(405).end();
+  });
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  await assert.rejects(
+    execFileAsync(process.execPath, ["scripts/r2-upload.ts", "--write"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLOUDFLARE_ACCOUNT_ID: "test-account",
+        CLOUDFLARE_API_TOKEN: "test-token",
+        METAGRAPH_ALLOW_R2_UPLOAD: "1",
+        METAGRAPH_R2_API_BASE_URL: `http://127.0.0.1:${port}`,
+        METAGRAPH_R2_UPLOAD_LIMIT: "1",
+        METAGRAPH_R2_UPLOAD_MAX_RPS: "200",
+        METAGRAPH_R2_UPLOAD_429_BASE_DELAY_MS: "5",
+        METAGRAPH_R2_UPLOAD_429_RETRIES: "1",
+      },
+    }),
+    /429/,
+  );
+});


### PR DESCRIPTION
Refs #8240 (Phase 0 of epic #8238) — this is the pipeline-recovery half; the staleness-alerting half of #8240 lands as a follow-up.

## What broke

The 2026-07-26 scheduled publish (run 30196445640) failed in **Upload artifact history to R2**: mass HTTP 429s (Cloudflare error 971 "Please wait and consider throttling your request speed"), hard abort at 1,375/5,734 objects. This is the successor bottleneck to #8209: swapping wrangler-per-object for direct API fetches removed the CLI overhead — and let 24 concurrent workers sail straight through Cloudflare's client-API rate ceiling (~1,200 requests / 5 min per token). Each failing object burned its 3 generic retries in ~7 s (1s/2s/4s against a 5-minute window), and the first object to exhaust them killed the whole job. Combined with the Jul 23–25 cancelled runs (#8209's stall), the published registry/probe data has been stale since ~Jul 22 — which every page of the site currently confesses ("snapshot 4d ago · stale 68").

## Fix (scripts/r2-upload.ts)

1. **Shared request-rate gate** across all upload workers — default 3.5 rps (≈1,050/5 min, ~12% under the ceiling), tunable via `METAGRAPH_R2_UPLOAD_MAX_RPS`. HEAD dedupe probes spend the same API budget as PUTs, so both are gated.
2. **429-aware retries** with their own budget (default 6, `METAGRAPH_R2_UPLOAD_429_RETRIES`): honor `Retry-After` when present, otherwise exponential backoff at tens-of-seconds scale (base 15 s, cap 120 s, jitter), and push a **shared cooldown** so all workers pause together instead of 23 siblings draining the window while one sleeps. Non-429 errors keep the existing 3× 1s/2s/4s ladder unchanged.

Throughput math: steady-state runs are mostly content-addressed HEAD dedupes + `latest/` overwrites ≈ 28 min at 3.5 rps, well inside the publish job's 90-minute ceiling; the first full pass after this merge (~8.6 k requests) fits with ~2× headroom.

## Tests

E2E against the existing mock-Cloudflare harness: a 429 → 429 → 200 sequence recovers and completes (first 429 carries `Retry-After` to cover the honored path, second omits it to cover backoff), and an always-429 server still fails once the 429 budget is exhausted. Plus the pre-existing sha256/latest-upload test stays green.

## Verification plan post-merge

Dispatch `Publish Cloudflare Backend`, confirm the upload step completes with zero aborts, then confirm the live site's staleness banners clear (#8240 acceptance).