### PR TITLE
fix(ui): stop dropping session-replay snapshots at the 64 KiB ingest cap

### DIFF
--- a/apps/ui/src/lib/analytics-proxy.test.ts
+++ b/apps/ui/src/lib/analytics-proxy.test.ts
@@ -229,10 +229,7 @@ describe("forwardToAnalyticsHost", () => {
         body: "{}",
       },
     );
-    const response = await forwardToAnalyticsHost(
-      request,
-      "/s/?ver=1.0.0&compression=gzip-js",
-    );
+    const response = await forwardToAnalyticsHost(request, "/s/?ver=1.0.0&compression=gzip-js");
 
     expect(response.status).toBe(200);
   });

--- a/apps/ui/src/lib/analytics-proxy.test.ts
+++ b/apps/ui/src/lib/analytics-proxy.test.ts
@@ -169,6 +169,74 @@ describe("forwardToAnalyticsHost", () => {
     expect(response.status).toBe(200);
   });
 
+  it("forwards a session-replay snapshot far above the event cap (#7761 replay was being dropped)", async () => {
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    // 512 KiB: a realistic rrweb full-snapshot flush on a dense page. Would
+    // have 413'd under the 64 KiB event cap, silently losing the recording.
+    const request = new Request(`https://metagraph.sh${ANALYTICS_PREFIX}/s/`, {
+      method: "POST",
+      headers: { "content-length": String(512 * 1024) },
+      body: "{}",
+    });
+    const response = await forwardToAnalyticsHost(request, "/s/");
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("still bounds session-replay bodies at their own larger cap", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const request = new Request(`https://metagraph.sh${ANALYTICS_PREFIX}/s/`, {
+      method: "POST",
+      headers: { "content-length": String(2 * 1024 * 1024 + 1) },
+      body: "{}",
+    });
+    const response = await forwardToAnalyticsHost(request, "/s/");
+
+    expect(response.status).toBe(413);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not extend the replay cap to event paths that merely start with s", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    // `/static/` is asset-routed elsewhere, but guard the regex anyway: only
+    // the exact `/s/` recording path gets the larger ceiling.
+    const request = new Request(`https://metagraph.sh${ANALYTICS_PREFIX}/survey/`, {
+      method: "POST",
+      headers: { "content-length": String(64 * 1024 + 1) },
+      body: "{}",
+    });
+    const response = await forwardToAnalyticsHost(request, "/survey/");
+
+    expect(response.status).toBe(413);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies the replay cap when /s/ carries a query string", async () => {
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 200 })) as typeof fetch;
+
+    const request = new Request(
+      `https://metagraph.sh${ANALYTICS_PREFIX}/s/?ver=1.0.0&compression=gzip-js`,
+      {
+        method: "POST",
+        headers: { "content-length": String(512 * 1024) },
+        body: "{}",
+      },
+    );
+    const response = await forwardToAnalyticsHost(
+      request,
+      "/s/?ver=1.0.0&compression=gzip-js",
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   it("sends no body for GET/HEAD", async () => {
     let sawBody: unknown;
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {

--- a/apps/ui/src/lib/analytics-proxy.ts
+++ b/apps/ui/src/lib/analytics-proxy.ts
@@ -40,6 +40,31 @@ const POSTHOG_ASSET_HOST = "us-assets.i.posthog.com";
 // worst-case memory per request to a small, fixed cap.
 const MAX_INGEST_BODY_BYTES = 64 * 1024;
 
+// Session-replay snapshots are a different traffic class and need their own
+// ceiling. The 64 KiB cap above reasons explicitly about batched pageview/
+// custom events with autocapture OFF -- correct for those, but replay landed
+// later (#7761, sampleRate 0.15) and posts rrweb DOM snapshots, which are
+// orders of magnitude larger than an event batch. A full-snapshot flush on a
+// dense page (the subnet detail route renders thousands of nodes) blows past
+// 64 KiB easily, so the gate below was returning 413 and silently dropping
+// recordings -- the replay data never reaches PostHog and nothing in the UI
+// surfaces the loss.
+//
+// 2 MiB: comfortably above a realistic full-snapshot flush while still a small,
+// fixed bound on per-request Worker memory (the 128 MiB isolate limit is the
+// thing being protected). Still our own defensive ceiling, not a
+// PostHog-documented limit -- their capture endpoint accepts far larger.
+const MAX_REPLAY_BODY_BYTES = 2 * 1024 * 1024;
+
+// posthog-js posts session-recording snapshots to `/s/` and everything else
+// (events, flags, decide) to its own paths. Matched on the proxied upstream
+// path, i.e. AFTER ANALYTICS_PREFIX has been stripped.
+function maxBodyBytesForPath(pathWithParams: string): number {
+  return /^\/s\/?(?:\?|$)/.test(pathWithParams)
+    ? MAX_REPLAY_BODY_BYTES
+    : MAX_INGEST_BODY_BYTES;
+}
+
 export type PostHogAssetContext = { waitUntil(promise: Promise<unknown>): void };
 
 // Cloudflare Workers runtime global (the Cache API) -- same class of ambient
@@ -116,14 +141,15 @@ export async function forwardToAnalyticsHost(
   // Same content-length-first gate the old server.ts Umami collect endpoint
   // used -- reject BEFORE buffering, never after, so an oversized/malformed
   // request never gets read into memory at all. See MAX_INGEST_BODY_BYTES
-  // above for why the cap differs from Umami's own.
+  // above for why the cap differs from Umami's own, and MAX_REPLAY_BODY_BYTES
+  // for why session-replay snapshots get their own larger ceiling.
   if (hasBody) {
     const contentLengthHeader = request.headers.get("content-length");
     const contentLength = contentLengthHeader === null ? NaN : Number(contentLengthHeader);
     if (!Number.isSafeInteger(contentLength) || contentLength < 0) {
       return new Response("Length Required", { status: 411 });
     }
-    if (contentLength > MAX_INGEST_BODY_BYTES) {
+    if (contentLength > maxBodyBytesForPath(pathWithParams)) {
       return new Response("Payload Too Large", { status: 413 });
     }
   }

--- a/apps/ui/src/lib/analytics-proxy.ts
+++ b/apps/ui/src/lib/analytics-proxy.ts
@@ -60,9 +60,7 @@ const MAX_REPLAY_BODY_BYTES = 2 * 1024 * 1024;
 // (events, flags, decide) to its own paths. Matched on the proxied upstream
 // path, i.e. AFTER ANALYTICS_PREFIX has been stripped.
 function maxBodyBytesForPath(pathWithParams: string): number {
-  return /^\/s\/?(?:\?|$)/.test(pathWithParams)
-    ? MAX_REPLAY_BODY_BYTES
-    : MAX_INGEST_BODY_BYTES;
+  return /^\/s\/?(?:\?|$)/.test(pathWithParams) ? MAX_REPLAY_BODY_BYTES : MAX_INGEST_BODY_BYTES;
 }
 
 export type PostHogAssetContext = { waitUntil(promise: Promise<unknown>): void };


### PR DESCRIPTION
## Summary

`MAX_INGEST_BODY_BYTES = 64 * 1024` 413s oversized bodies before forwarding to PostHog. Its own comment reasons about batched pageview/custom events with autocapture off -- correct for those, but **session replay landed later** (#7761, `sampleRate: 0.15`) and posts rrweb DOM snapshots that are orders of magnitude larger. A full-snapshot flush on a dense page (subnet detail renders thousands of nodes) blows past 64 KiB, and the recording is silently lost -- nothing in the UI surfaces it, PostHog just never gets the data.

Makes the cap path-aware: posthog-js posts recording snapshots to `/s/`, so that path gets a 2 MiB ceiling while events keep 64 KiB. The cap remains real abuse control in both cases -- `/ingest` is public and unauthenticated, so per-request Worker memory stays bounded well under the 128 MiB isolate limit.

Closes #8262

## Test plan

- [x] `npx vitest run src/lib/analytics-proxy.test.ts` -- 24/24 pass
- [x] 4 new tests: a 512 KiB `/s/` snapshot forwards (would have 413'd before); `/s/` above 2 MiB still 413s; a non-replay path above 64 KiB still 413s (guards the regex against matching e.g. `/survey/`); the replay cap applies when `/s/` carries posthog-js's usual query string
- [x] Existing 411/413/at-the-cap event tests unchanged and passing -- they use `/e/`, so event behavior is provably untouched
- [x] `npx eslint` + `npx prettier --check` on both files