### PR TITLE
fix(ui,api): qualify implausible APY estimates; stop 7d windows reporting 8 days

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -6,7 +6,12 @@ import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
-import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
+import {
+  formatApyPct,
+  formatTakePct,
+  isImplausibleApyPct,
+  IMPLAUSIBLE_APY_NOTE,
+} from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 const TH_BASE = "px-3 py-2 mg-type-micro text-ink-muted";
@@ -87,7 +92,16 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
   {
     ...numeric("Est. APY"),
     // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
-    cell: (v) => formatApyPct(v.apy_estimate != null ? v.apy_estimate * 100 : null),
+    cell: (v) => {
+      const pct = v.apy_estimate != null ? v.apy_estimate * 100 : null;
+      // Tiny-stake estimates annualize into nonsense (#8242) — formatApyPct
+      // buckets them as ">100%"; explain why on hover rather than in-cell.
+      return (
+        <span title={isImplausibleApyPct(pct) ? IMPLAUSIBLE_APY_NOTE : undefined}>
+          {formatApyPct(pct)}
+        </span>
+      );
+    },
   },
   {
     ...numeric("Active subnets"),

--- a/apps/ui/src/lib/metagraphed/validator-apy.test.ts
+++ b/apps/ui/src/lib/metagraphed/validator-apy.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   annualizedDelegatorApyPct,
+  APY_IMPLAUSIBLE_PCT,
   apyFromRewardsPer1000,
   formatApyPct,
   formatTakePct,
+  isImplausibleApyPct,
   netDailyYield,
 } from "./validator-apy";
 
@@ -29,5 +31,29 @@ describe("validator-apy", () => {
     expect(formatTakePct(null)).toBe("—");
     expect(formatApyPct(12.456)).toBe("12.5%");
     expect(formatApyPct(null)).toBe("—");
+  });
+
+  describe("implausible estimates (#8242)", () => {
+    it("buckets tiny-stake outliers instead of printing them", () => {
+      // The live validators index showed 242% and 180% for small validators
+      // next to the majors' 1-2%, which made the whole column look wrong.
+      expect(formatApyPct(242)).toBe(">100%");
+      expect(formatApyPct(180.4)).toBe(">100%");
+      expect(isImplausibleApyPct(242)).toBe(true);
+    });
+
+    it("leaves plausible estimates — including the boundary — untouched", () => {
+      expect(formatApyPct(APY_IMPLAUSIBLE_PCT)).toBe("100%");
+      expect(isImplausibleApyPct(APY_IMPLAUSIBLE_PCT)).toBe(false);
+      expect(formatApyPct(99.4)).toBe("99.4%");
+      expect(formatApyPct(2.26)).toBe("2.26%");
+    });
+
+    it("treats absent and non-finite values as unknown, not implausible", () => {
+      expect(isImplausibleApyPct(null)).toBe(false);
+      expect(isImplausibleApyPct(undefined)).toBe(false);
+      expect(isImplausibleApyPct(Number.POSITIVE_INFINITY)).toBe(false);
+      expect(formatApyPct(Number.POSITIVE_INFINITY)).toBe("—");
+    });
   });
 });

--- a/apps/ui/src/lib/metagraphed/validator-apy.ts
+++ b/apps/ui/src/lib/metagraphed/validator-apy.ts
@@ -46,8 +46,26 @@ export function apyFromRewardsPer1000(
   return Math.round(dailyPerTao * 365 * 100 * 100) / 100;
 }
 
+/**
+ * Above this, an annualized estimate is noise rather than a return (#8242).
+ * These come from tiny-stake validators where one lucky emission tick, scaled
+ * by 365, produces figures like 242% next to the majors' 1-2%. Rendering them
+ * unqualified made the whole column read as untrustworthy, so everything past
+ * the threshold collapses to a single ">100%" bucket with an explanation.
+ */
+export const APY_IMPLAUSIBLE_PCT = 100;
+
+export function isImplausibleApyPct(value: number | null | undefined): boolean {
+  return value != null && Number.isFinite(value) && value > APY_IMPLAUSIBLE_PCT;
+}
+
+/** Why an estimate is shown as ">100%" — for a title/tooltip at call sites. */
+export const IMPLAUSIBLE_APY_NOTE =
+  "Annualized from a very small stake base — a single emission tick dominates the estimate, so the exact figure is not meaningful.";
+
 export function formatApyPct(value: number | null | undefined): string {
   if (value == null || !Number.isFinite(value)) return "—";
+  if (isImplausibleApyPct(value)) return `>${APY_IMPLAUSIBLE_PCT}%`;
   if (value >= 100) return `${value.toFixed(0)}%`;
   if (value >= 10) return `${value.toFixed(1)}%`;
   return `${value.toFixed(2)}%`;

--- a/src/chain-analytics.ts
+++ b/src/chain-analytics.ts
@@ -71,6 +71,46 @@ export interface ChainActivityResult {
   days: ChainActivityDay[];
 }
 
+/**
+ * Trim a newest-first daily series to the window's own day count (#8242).
+ *
+ * The upstream aggregation buckets by UTC day over a `now - N days` range, so
+ * a 7d window spans 8 calendar days: a partial today, six whole days, and a
+ * partial tail day at the boundary. Serving all 8 under `window: "7d"` made
+ * the UI print "FEES, LAST 7D … 8 days" — the response contradicting its own
+ * label. Dropping the oldest (partial) day makes day_count match the window
+ * the caller asked for. A null/absent maxDays leaves the series untouched, so
+ * callers that don't know their day count are unaffected.
+ */
+function trimToWindow<T>(rows: T[], maxDays: number | null | undefined): T[] {
+  if (maxDays == null || !Number.isFinite(maxDays) || maxDays < 1) return rows;
+  return rows.length > maxDays ? rows.slice(0, maxDays) : rows;
+}
+
+/**
+ * Apply the same trim to an already-built result, whichever tier produced it.
+ * The live series comes from the Postgres data tier (the builders above only
+ * shape the schema-stable empty stub), so the handlers normalize the resolved
+ * payload through these rather than the builder arguments.
+ */
+export function trimChainActivityToWindow(
+  result: ChainActivityResult,
+  maxDays: number | null | undefined,
+): ChainActivityResult {
+  const days = trimToWindow(result.days ?? [], maxDays);
+  if (days === result.days) return result;
+  return { ...result, days, day_count: days.length };
+}
+
+export function trimChainFeesToWindow(
+  result: ChainFeesResult,
+  maxDays: number | null | undefined,
+): ChainFeesResult {
+  const daily = trimToWindow(result.daily ?? [], maxDays);
+  if (daily === result.daily) return result;
+  return { ...result, daily, day_count: daily.length };
+}
+
 // Merge the two per-UTC-day aggregations (extrinsics tier + blocks tier) into one
 // newest-first daily series. `extrinsicRows` carries extrinsic_count /
 // successful_extrinsics / unique_signers; `blockRows` carries block_count /

--- a/tests/chain-analytics.test.ts
+++ b/tests/chain-analytics.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { describe, test } from "vitest";
 import {
   buildChainActivity,
   buildChainCalls,
   buildChainFees,
   buildChainSigners,
+  trimChainActivityToWindow,
+  trimChainFeesToWindow,
 } from "../src/chain-analytics.ts";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -1562,4 +1564,77 @@ test("the new chain routes are schema-stable empty when D1 is cold", async () =>
     assert.equal(body.ok, true);
     assert.equal(body.data.schema_version, 1);
   }
+});
+
+describe("window trimming (#8242)", () => {
+  // The upstream aggregation buckets by UTC day over a `now - N days` range,
+  // so a 7d window returns 8 calendar days (a partial today + a partial tail
+  // day). Live example captured 2026-07-26 from /api/v1/chain/fees?window=7d:
+  // 2026-07-26 (60,315 extrinsics, partial) … 2026-07-19 (76,706, partial).
+  const eightDays = [
+    "2026-07-26",
+    "2026-07-25",
+    "2026-07-24",
+    "2026-07-23",
+    "2026-07-22",
+    "2026-07-21",
+    "2026-07-20",
+    "2026-07-19",
+  ];
+
+  test("trims chain activity to the requested window and fixes day_count", () => {
+    const result = buildChainActivity({
+      window: "7d",
+      extrinsicRows: eightDays.map((day) => ({ day, extrinsic_count: 10 })),
+    });
+    assert.equal(result.day_count, 8); // untrimmed builder output
+    const trimmed = trimChainActivityToWindow(result, 7);
+    assert.equal(trimmed.day_count, 7);
+    assert.equal(trimmed.days.length, 7);
+    // Newest kept, oldest (partial boundary day) dropped.
+    assert.equal(trimmed.days[0].day, "2026-07-26");
+    assert.equal(trimmed.days[6].day, "2026-07-20");
+    assert.ok(!trimmed.days.some((d) => d.day === "2026-07-19"));
+  });
+
+  test("trims chain fees to the requested window and fixes day_count", () => {
+    const result = buildChainFees({
+      window: "7d",
+      dailyRows: eightDays.map((day) => ({
+        day,
+        extrinsic_count: 10,
+        total_fee_tao: 1,
+        total_tip_tao: 0,
+      })),
+    });
+    assert.equal(result.day_count, 8);
+    const trimmed = trimChainFeesToWindow(result, 7);
+    assert.equal(trimmed.day_count, 7);
+    assert.equal(trimmed.daily[0].day, "2026-07-26");
+    assert.equal(trimmed.daily[6].day, "2026-07-20");
+  });
+
+  test("leaves series at or under the window untouched", () => {
+    const result = buildChainFees({
+      window: "7d",
+      dailyRows: eightDays.slice(0, 5).map((day) => ({
+        day,
+        extrinsic_count: 1,
+        total_fee_tao: 1,
+        total_tip_tao: 0,
+      })),
+    });
+    const trimmed = trimChainFeesToWindow(result, 7);
+    assert.equal(trimmed.day_count, 5);
+    assert.equal(trimmed, result); // identity: no needless copy
+  });
+
+  test("a null/invalid maxDays disables trimming", () => {
+    const result = buildChainActivity({
+      window: "all",
+      extrinsicRows: eightDays.map((day) => ({ day, extrinsic_count: 1 })),
+    });
+    assert.equal(trimChainActivityToWindow(result, null).day_count, 8);
+    assert.equal(trimChainActivityToWindow(result, 0).day_count, 8);
+  });
 });

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -61,6 +61,8 @@ import {
   buildChainActivity,
   buildChainCalls,
   buildChainFees,
+  trimChainActivityToWindow,
+  trimChainFeesToWindow,
   buildChainSigners,
 } from "../../src/chain-analytics.ts";
 import {
@@ -963,7 +965,7 @@ export async function handleChainActivity(
 ): Promise<Response> {
   const windowResult = analyticsWindow(url, ["format"]);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
-  const { label } = windowResult;
+  const { label, days: windowDays } = windowResult;
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
   const csv = csvRequested(url, request);
@@ -978,16 +980,22 @@ export async function handleChainActivity(
       // (#4772) and the tables are dropped in production, so a D1 query here
       // would always miss. Postgres → schema-stable empty stub, never a live
       // D1 read.
-      const data =
+      // #8242: the upstream aggregation buckets by UTC day across a
+      // `now - N days` range, so a 7d window comes back as 8 calendar days (a
+      // partial today plus a partial tail day). Trim to the window the caller
+      // actually asked for so day_count can't contradict the window label.
+      const data = trimChainActivityToWindow(
         ((await tryPostgresTier(
           env,
           cacheRequest,
           "METAGRAPH_EXTRINSICS_SOURCE",
         )) as ReturnType<typeof buildChainActivity> | null) ??
-        buildChainActivity({
-          window: label,
-          observedAt: meta?.last_run_at || null,
-        } as unknown as Parameters<typeof buildChainActivity>[0]);
+          buildChainActivity({
+            window: label,
+            observedAt: meta?.last_run_at || null,
+          } as unknown as Parameters<typeof buildChainActivity>[0]),
+        windowDays,
+      );
       if (csv) {
         return csvResponse(
           data.days,
@@ -2281,7 +2289,7 @@ export async function handleChainFees(
 ): Promise<Response> {
   const windowResult = analyticsWindow(url, ["limit", "call_module", "format"]);
   if ("error" in windowResult) return analyticsQueryError(windowResult.error);
-  const { label } = windowResult;
+  const { label, days: windowDays } = windowResult;
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
   const limitResult = parseLimitParam(url, {
@@ -2319,6 +2327,9 @@ export async function handleChainFees(
         window: label,
         observedAt: meta?.last_run_at || null,
       } as unknown as Parameters<typeof buildChainFees>[0]);
+      // #8242: see handleChainActivity — trim the UTC-day buckets down to the
+      // requested window so "7d" never reports 8 days.
+      data = trimChainFeesToWindow(data, windowDays);
       if (csv) {
         return csvResponse(
           data.daily,


### PR DESCRIPTION
Refs #8242 (Phase 0 of epic #8238). Two of that issue's three items; the incident-count single-source item lands separately.

## 1. APY outliers (UI)

The validators index rendered **`Est. APY 242%`** and **`180%`** for tiny-stake validators, sitting directly beside the majors' 1–2%. These are annualization noise — one emission tick on a small stake base × 365 — and rendering them unqualified made the entire column read as untrustworthy.

`formatApyPct` is the single chokepoint every APY render already flows through (validators index + detail, neuron table, subnet validators preview, sponsored callout, compare drawer), so the bucketing lands there once: anything **> 100%** renders `>100%`. The validators table adds a `title` explaining small-stake variance. Values at or below the threshold — including exactly `100%` — are byte-identical to before.

## 2. `7d` windows returned 8 days (API)

Verified live before the fix:

```
GET /api/v1/chain/fees?window=7d   → day_count: 8
GET /api/v1/chain/activity?window=7d → day_count: 8
```

…and the rows were `2026-07-26` (60,315 extrinsics — partial today) through `2026-07-19` (76,706 — partial tail). The UI wasn't lying; it printed `fees.day_count` faithfully under a "FEES, LAST 7D" header. The upstream aggregation buckets by UTC day across a `now - N days` range, so the span always straddles N+1 calendar days with a partial at each end.

Fix: trim the resolved payload to the window's own day count. Importantly this is applied **in the handlers, to the resolved data** — not as a builder argument — because the live series comes from the Postgres data tier and bypasses `buildChainFees`/`buildChainActivity` entirely (those only shape the schema-stable cold-store stub). The oldest (partial) day is dropped; newest-first ordering means the user-visible "latest" end is untouched. A null/invalid day count disables trimming, so `window=all` and any caller that doesn't know its span is unaffected.

## Tests

- `validator-apy.test.ts`: the two real outlier values bucket to `>100%`; the `100` boundary and normal values stay exact; null/undefined/Infinity are "unknown", not "implausible".
- `chain-analytics.test.ts`: the captured 8-day live shape trims to 7 with `day_count` corrected and the right day dropped (both fees and activity); series at or under the window return the identical object (no needless copy); null/0 maxDays disables trimming.
- Full local gates green: vitest (60 backend chain-analytics + 11 UI), tsc, eslint, prettier.

Note: no OpenAPI/contract change — `day_count` and `daily[]` shapes are unchanged, only the row count now honors the documented window.