### PR TITLE
feat(ui): resolve the chain network from the testnet.metagraph.sh hostname

### DIFF
--- a/apps/ui/src/lib/metagraphed/config.test.ts
+++ b/apps/ui/src/lib/metagraphed/config.test.ts
@@ -43,13 +43,25 @@ describe("sanitizeApiBase", () => {
 // A minimal browser `window` for the CSR paths: an EventTarget (so add/remove/dispatch work) plus a
 // Map-backed localStorage. Node 22 provides EventTarget + CustomEvent globally, so setApiBase's
 // `new CustomEvent(...)` + `window.dispatchEvent(...)` broadcast exercises for real.
-function makeWindow(seed: Record<string, string> = {}) {
+function makeWindow(seed: Record<string, string> = {}, hostname?: string) {
   const store = new Map<string, string>(Object.entries(seed));
   const win = new EventTarget() as EventTarget & {
     localStorage: Storage;
     store: Map<string, string>;
+    location?: { hostname: string; href: string; assign: (url: string) => void };
+    assigned: string[];
   };
   win.store = store;
+  // Only attach a location when a case opts in, so the existing cases keep
+  // exercising the no-location path (config.ts must never assume a DOM).
+  win.assigned = [];
+  if (hostname !== undefined) {
+    win.location = {
+      hostname,
+      href: `https://${hostname}/subnets?view=table`,
+      assign: (url: string) => void win.assigned.push(url),
+    };
+  }
   win.localStorage = {
     getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
     setItem: (k: string, v: string) => void store.set(k, v),
@@ -159,6 +171,75 @@ describe("getNetwork / setNetwork (CSR: caching, persistence, broadcast)", () =>
     expect(win.store.has("metagraphed:network")).toBe(false);
     cfg.setNetwork("nope");
     expect(cfg.getNetwork().id).toBe(cfg.DEFAULT_NETWORK.id);
+  });
+});
+
+// #8229: testnet.metagraph.sh is a per-network custom domain on the same
+// Worker, so the hostname -- not localStorage -- is the source of truth.
+describe("per-network hostname (#8229)", () => {
+  it("resolves the network from the hostname label", async () => {
+    const cfg = await freshConfig(makeWindow({}, "testnet.metagraph.sh"));
+    expect(cfg.getNetwork().id).toBe("testnet");
+    expect(cfg.getNetworkPrefix()).toBe("testnet");
+  });
+
+  it("hostname beats a conflicting stored preference in both directions", async () => {
+    // Stale "mainnet" preference must not win on the testnet host...
+    const onTestnet = await freshConfig(
+      makeWindow({ "metagraphed:network": "mainnet" }, "testnet.metagraph.sh"),
+    );
+    expect(onTestnet.getNetwork().id).toBe("testnet");
+
+    // ...and a "testnet" preference must not follow you back to the apex.
+    const onApex = await freshConfig(
+      makeWindow({ "metagraphed:network": "testnet" }, "metagraph.sh"),
+    );
+    expect(onApex.getNetwork().id).toBe("mainnet");
+  });
+
+  it("falls back to the stored preference on a host with no network label", async () => {
+    const cfg = await freshConfig(
+      makeWindow({ "metagraphed:network": "testnet" }, "metagraphed-ui.zeronode.workers.dev"),
+    );
+    expect(cfg.getNetwork().id).toBe("testnet");
+  });
+
+  it("setNetwork navigates to the sibling host, preserving path + query", async () => {
+    const win = makeWindow({}, "metagraph.sh");
+    const cfg = await freshConfig(win);
+    cfg.setNetwork("testnet");
+    expect(win.assigned).toEqual(["https://testnet.metagraph.sh/subnets?view=table"]);
+  });
+
+  it("setNetwork back to mainnet strips the network label rather than stacking it", async () => {
+    const win = makeWindow({}, "testnet.metagraph.sh");
+    const cfg = await freshConfig(win);
+    cfg.setNetwork("mainnet");
+    expect(win.assigned).toEqual(["https://metagraph.sh/subnets?view=table"]);
+  });
+
+  it("stays in-page (no navigation) where no sibling host exists", async () => {
+    for (const host of ["localhost", "127.0.0.1", "app.localhost"]) {
+      const win = makeWindow({}, host);
+      const cfg = await freshConfig(win);
+      const seen: string[] = [];
+      cfg.onNetworkChange((next) => seen.push(next.id));
+      cfg.setNetwork("testnet");
+      expect(win.assigned, `${host} must not navigate`).toEqual([]);
+      // The in-page broadcast still fires so subscribers reconnect.
+      expect(seen).toEqual(["testnet"]);
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("networkHostname maps both directions and declines hostless targets", async () => {
+    const cfg = await freshConfig(makeWindow({}, "metagraph.sh"));
+    const testnet = cfg.CHAIN_NETWORKS.find((n) => n.id === "testnet")!;
+    expect(cfg.networkHostname(testnet, "metagraph.sh")).toBe("testnet.metagraph.sh");
+    expect(cfg.networkHostname(testnet, "testnet.metagraph.sh")).toBe("testnet.metagraph.sh");
+    expect(cfg.networkHostname(cfg.DEFAULT_NETWORK, "testnet.metagraph.sh")).toBe("metagraph.sh");
+    expect(cfg.networkHostname(testnet, "localhost")).toBeNull();
+    expect(cfg.networkHostname(testnet, "192.168.1.10")).toBeNull();
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/config.ts
+++ b/apps/ui/src/lib/metagraphed/config.ts
@@ -137,6 +137,45 @@ export const LOCAL_DEV = {
 
 let cachedNetwork: ChainNetwork | null = null;
 
+/**
+ * The apex that carries per-network subdomains (#8229). testnet.metagraph.sh
+ * is a Cloudflare custom domain on the same metagraphed-ui Worker as the apex,
+ * so within this family the leading label names the network and the bare apex
+ * means mainnet.
+ *
+ * Everything OFF this family -- `vite dev` on localhost, a *.workers.dev
+ * preview, an IP -- has no per-network sibling to navigate to, so those keep
+ * the pure localStorage behavior. That split is the whole reason this is an
+ * explicit suffix rather than "does the first label happen to name a network":
+ * a preview host must not be told it is authoritative when its `testnet.`
+ * sibling would not resolve.
+ */
+const NETWORK_HOST_APEX = "metagraph.sh";
+
+function isNetworkHostFamily(host: string): boolean {
+  return host === NETWORK_HOST_APEX || host.endsWith(`.${NETWORK_HOST_APEX}`);
+}
+
+/**
+ * The network the current hostname designates, or null when the host carries
+ * no network signal at all (so the caller falls back to localStorage).
+ *
+ * Within the host family this is authoritative in BOTH directions: a
+ * `testnet.` label resolves to testnet, and the bare apex resolves to mainnet
+ * rather than deferring to a stale stored preference from an earlier visit.
+ */
+function readHostNetwork(): ChainNetwork | null {
+  if (typeof window === "undefined") return null;
+  // `window.location` is absent in the unit-test harness's minimal window and
+  // in any non-DOM embedder -- treat it as "no host signal", never a throw.
+  const host = window.location?.hostname?.toLowerCase();
+  if (!host || !isNetworkHostFamily(host)) return null;
+  const label = host.split(".")[0];
+  return (
+    CHAIN_NETWORKS.find((n) => n.id === label && n.id !== DEFAULT_NETWORK.id) ?? DEFAULT_NETWORK
+  );
+}
+
 function readStoredNetwork(): ChainNetwork | null {
   if (typeof window === "undefined") return null;
   try {
@@ -147,10 +186,22 @@ function readStoredNetwork(): ChainNetwork | null {
   }
 }
 
-/** Current chain network. Safe in both SSR and CSR (defaults to mainnet). */
+/**
+ * Current chain network. Safe in both SSR and CSR (defaults to mainnet).
+ *
+ * Hostname wins over the stored preference: on testnet.metagraph.sh the URL is
+ * the explicit, shareable request, and a stale localStorage value from an
+ * earlier visit to the apex must not silently override it (nor the reverse --
+ * a testnet preference must not follow you back to the apex).
+ *
+ * SSR still resolves to the default: `window` is absent there, and the request
+ * hostname cannot be threaded in through a module-level value without leaking
+ * across concurrent requests in a shared Workers isolate. The client corrects
+ * immediately on hydration. See #8229 for the request-scoped follow-up.
+ */
 export function getNetwork(): ChainNetwork {
   if (cachedNetwork) return cachedNetwork;
-  cachedNetwork = readStoredNetwork() ?? DEFAULT_NETWORK;
+  cachedNetwork = readHostNetwork() ?? readStoredNetwork() ?? DEFAULT_NETWORK;
   return cachedNetwork;
 }
 
@@ -159,7 +210,39 @@ export function getNetworkPrefix(): string {
   return getNetwork().prefix;
 }
 
-/** Select + persist a chain network. Dispatches an event subscribers react to. */
+/**
+ * The hostname a given network is served from, or null when the current host
+ * has no per-network sibling (#8229).
+ *
+ * Returns null for single-label hosts (localhost) and bare IPs: `vite dev` and
+ * preview/IP access have no `testnet.` sibling to reach, so those keep the
+ * pure localStorage behavior instead of navigating somewhere that won't
+ * resolve. Registrable-domain detection is deliberately naive (strip a leading
+ * known-network label, keep the rest) because the only hosts this ever runs
+ * against are metagraph.sh and its per-network subdomains.
+ */
+export function networkHostname(next: ChainNetwork, currentHost: string): string | null {
+  const host = currentHost.toLowerCase();
+  // Same gate readHostNetwork uses, so the read and write sides can't drift:
+  // only hosts that actually carry per-network siblings are navigable.
+  if (!isNetworkHostFamily(host)) return null;
+  const [label, ...rest] = host.split(".");
+  // Drop the current network label (if any) to recover the apex, so switching
+  // testnet→mainnet→testnet doesn't stack labels.
+  const isNetworkLabel = CHAIN_NETWORKS.some((n) => n.id === label && n.id !== DEFAULT_NETWORK.id);
+  const apex = isNetworkLabel ? rest.join(".") : host;
+  return next.id === DEFAULT_NETWORK.id ? apex : `${next.id}.${apex}`;
+}
+
+/**
+ * Select + persist a chain network. Dispatches an event subscribers react to.
+ *
+ * On a per-network host (#8229) this navigates to the sibling hostname rather
+ * than only flipping in-page state: the URL is the shareable, reloadable
+ * source of truth, and `getNetwork()` reads the hostname first, so staying put
+ * would leave the two disagreeing on the next reload. Falls back to the
+ * in-page switch wherever no sibling host exists (dev, previews, IPs).
+ */
 export function setNetwork(id: string) {
   const next = CHAIN_NETWORKS.find((n) => n.id === id) ?? DEFAULT_NETWORK;
   cachedNetwork = next;
@@ -169,6 +252,17 @@ export function setNetwork(id: string) {
       else window.localStorage.setItem(NETWORK_STORAGE_KEY, next.id);
     } catch {
       /* ignore */
+    }
+    const host = window.location?.hostname;
+    const target = host ? networkHostname(next, host) : null;
+    if (target && target !== host && typeof window.location?.assign === "function") {
+      // Same path + query on the sibling host, so switching network keeps you
+      // on the page you were reading. Full navigation, not a router push --
+      // it's a different origin.
+      const url = new URL(window.location.href);
+      url.hostname = target;
+      window.location.assign(url.toString());
+      return;
     }
     window.dispatchEvent(new CustomEvent(NETWORK_EVT, { detail: next.id }));
   }


### PR DESCRIPTION
## Summary

`testnet.metagraph.sh` is now a live Cloudflare custom domain on the `metagraphed-ui` Worker, but the app resolved its network purely from `localStorage` — so the new host served mainnet data and the URL meant nothing.

The hostname is now the source of truth within the `metagraph.sh` family, **in both directions**:
- `testnet.metagraph.sh` → testnet, even if `localStorage` says mainnet
- `metagraph.sh` → mainnet, even if `localStorage` says testnet (a testnet preference no longer follows you back to the apex — a test caught this; my first cut only handled one direction)

`setNetwork` now navigates to the sibling host rather than only flipping in-page state, preserving path + query. Otherwise the URL and `getNetwork()` would disagree on the next reload, since the hostname is read first.

### Scope gate

Hosts **outside** the family — `vite dev` on localhost, `*.workers.dev` previews, bare IPs — have no `testnet.` sibling that would resolve, so they keep the existing pure-localStorage behavior. That's why the gate is an explicit apex suffix (`isNetworkHostFamily`) rather than "does the first label happen to name a network": a preview host must not be told it's authoritative when navigating there would 404. Read and write sides share that one predicate so they can't drift.

## Known limitation (deliberate, not an oversight)

**SSR still resolves to mainnet.** `window` is absent server-side, and the request hostname cannot be threaded in through a module-level value without leaking across concurrent requests in a shared Workers isolate — two in-flight requests to `metagraph.sh` and `testnet.metagraph.sh` would cross-contaminate, silently serving one network's data under the other's URL. That's a worse bug than the one being fixed, so I didn't do it.

Consequence: on `testnet.metagraph.sh` the SSR pass renders the mainnet shell and the client corrects on hydration (one extra fetch, plus the React hydration-mismatch warning that #8229 documents as pre-existing). Doing this properly needs request-scoped context (AsyncLocalStorage requires `nodejs_compat`, which this Worker doesn't currently set). Left open on #8229.

Refs #8229

## Test plan

- [x] `npx vitest run` in `apps/ui` — 1481/1481 pass across 192 files
- [x] 7 new cases: hostname resolution; hostname beats a conflicting stored preference **both ways**; non-family host falls back to storage; `setNetwork` navigates preserving path+query; switching back to mainnet strips the label rather than stacking it; localhost/IP/`app.localhost` stay in-page and still broadcast; `networkHostname` maps both directions and declines hostless targets
- [x] Existing `config.test.ts` cases untouched and passing — the test window has no `location`, which exercises the "no host signal" path and proves `config.ts` still never assumes a DOM
- [x] `npx eslint .` — 0 errors; `npx prettier --check .` clean under **both** the apps/ui and root configs