### PR TITLE
ci(ui): restore headroom on the initial-client-JS budget (320 -> 340 KB)

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -525,7 +525,7 @@ your PR adds a new API call on one of the checked routes (`/`, `/subnets/1`,
 `/endpoints`, `/status`, `/settings`, `/explorer`), re-record:
 `npm run test:e2e:record-har --workspace=apps/ui` against a running dev server.
 
-CI also gzip-measures the initial client JS for a cold `/` visit against a budget (currently ~320 KB,
+CI also gzip-measures the initial client JS for a cold `/` visit against a budget (currently 340 KB,
 `.github/workflows/validate.yml`'s "Bundle size budget" step) — keep new dependencies/imports lean; if
 a real feature legitimately grows it, raise the budget deliberately in the same PR. If your PR also
 touches `packages/client` or `packages/ui-kit`, CI rebuilds each fresh and diffs against its committed

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -896,6 +896,19 @@ jobs:
       # covered by the same 320 KB budget. Raise it again the same way when a
       # real feature legitimately grows the initial load further.
       #
+      # 320 -> 340 (metagraphed#8266): main had drifted to exactly 320 KB
+      # against the 320 KB budget -- zero headroom -- so the gate had started
+      # failing PRs that cannot affect client JS at all. #8263 is the proof: it
+      # touches only src/lib/analytics-proxy.ts, imported solely by
+      # src/server.ts (server-only, never in a client chunk), and still
+      # reported 321 KB. With `Math.ceil` on a baseline sitting on the boundary,
+      # ordinary build-to-build gzip variance alone flips 320 -> 321, so the
+      # gate was blocking every UI PR on noise rather than on a regression.
+      # 340 restores ~6% headroom -- enough to absorb that variance, small
+      # enough to still catch a real regression. The 305 -> 320 drift that
+      # consumed the previous headroom is unexplained and tracked separately in
+      # metagraphed#8267; this bump deliberately does NOT close that out.
+      #
       # dist/, not Nitro's library-default .output/ -- this project's
       # vite.config.ts (@lovable.dev/vite-tanstack-config) is customized to
       # output there instead (confirmed against a real local + CI build; the
@@ -904,7 +917,7 @@ jobs:
       - name: Bundle size budget (initial client JS, gzipped)
         working-directory: apps/ui
         env:
-          BUDGET_KB: 320
+          BUDGET_KB: 340
         run: |
           node --input-type=module <<'NODE'
           import { readdirSync, readFileSync } from "node:fs";


### PR DESCRIPTION
## Summary

`main` measures **exactly 320 KB against the 320 KB budget** — zero headroom — so the bundle-size gate has started failing PRs on noise instead of regressions.

Last three successful `main` Validate runs:
```
run 30198954177: gzipped): 320 KB / budget 320 KB
run 30198654456: gzipped): 320 KB / budget 320 KB
run 30197756003: gzipped): 320 KB / budget 320 KB
```

**Proof it's now a false-positive generator:** #8263 touches only `apps/ui/src/lib/analytics-proxy.ts`, which is imported *solely* by `apps/ui/src/server.ts` — server-only, never reachable from a client chunk — and it still reported `321 KB`. The script does `Math.ceil(bytes / 1024)`, so with the baseline sitting exactly on the boundary, ordinary build-to-build gzip variance (chunk hashing changing compressibility) is enough to flip 320 → 321. Two unrelated in-flight UI PRs (#8263, #8265) are both blocked on this right now, and every future one would be.

340 restores ~6% headroom — enough to absorb the variance, small enough to still catch a real regression. This is the escape hatch the step's own comment describes ("raise the budget deliberately") and follows the existing 300 → 320 precedent from #3190.

## What this deliberately does NOT do

The budget was raised to 320 when the measured baseline was **~305 KB** (per the workflow's own comment). It's now 320 — ~15 KB of growth that was never explained and which quietly ate the headroom. Raising the ceiling without understanding that would just defer the problem, so it's tracked separately in **#8267**, which should decide whether the right end state is 340 or a trimmed import graph back under 320.

Closes #8266

## Test plan

- [x] Evidence gathered from real CI run logs (quoted above), not inference
- [x] Verified `analytics-proxy.ts` has exactly one importer (`src/server.ts`) via grep, establishing the false positive
- [x] Skill docs updated in the same PR — `.claude/skills/metagraphed/SKILL.md` cited the old 320 KB figure
- [x] Rationale recorded inline in `validate.yml` next to the existing 300 → 320 note, so the next person sees why