### PR TITLE
fix(ui): hold /health's clock-derived values until hydration

### DIFF
--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { resolveRefetchInterval, usePageVisible } from "@/hooks/use-refetch-interval";
 import { useEffect, useMemo, useState } from "react";
@@ -376,9 +377,14 @@ function AutoRefreshControl({
 function StatusBoard({ interval }: { interval: number | false }) {
   const { data: hRes } = useSuspenseQuery({ ...healthQuery(), refetchInterval: interval });
   const { data: fRes } = useSuspenseQuery({ ...freshnessQuery(), refetchInterval: interval });
+  // `stale` and `sourceAges` below both read the wall clock during render, so
+  // the server pass and the client's first pass disagree by however long the
+  // response spent in flight (#8241). Hold both at their pre-hydration value
+  // until hydration completes, matching useHydrated's documented use.
+  const hydrated = useHydrated();
   const h = hRes.data;
   const f = fRes.data;
-  const stale = isStaleFreshness(hRes.meta?.generated_at);
+  const stale = hydrated && isStaleFreshness(hRes.meta?.generated_at);
   const segs = [
     { label: "OK", value: h?.ok ?? 0, color: "var(--health-ok)" },
     { label: "Warn", value: h?.warn ?? 0, color: "var(--health-warn)" },
@@ -387,10 +393,11 @@ function StatusBoard({ interval }: { interval: number | false }) {
   ].filter((s) => s.value > 0);
   const uptimePct = h?.uptime_24h != null ? (h.uptime_24h * 100).toFixed(2) + "%" : "—";
 
-  const sourceAges =
-    (f?.sources ?? [])
-      .map((s) => (s.last_seen ? (Date.now() - new Date(s.last_seen).getTime()) / 1000 : null))
-      .filter((v): v is number => typeof v === "number") ?? [];
+  const sourceAges = hydrated
+    ? ((f?.sources ?? [])
+        .map((s) => (s.last_seen ? (Date.now() - new Date(s.last_seen).getTime()) / 1000 : null))
+        .filter((v): v is number => typeof v === "number") ?? [])
+    : [];
 
   return (
     <div className="space-y-4">
@@ -556,6 +563,10 @@ function severityRank(state: HealthState | undefined): SeverityRank {
 function Incidents({ interval }: { interval: number | false }) {
   const { data } = useSuspenseQuery({ ...endpointIncidentsQuery(), refetchInterval: interval });
   const rows = useMemo(() => (data.data ?? []) as EndpointIncident[], [data]);
+  // The 14-day bucket keys below are derived from the wall clock, so a server
+  // pass that straddles a UTC midnight (or simply runs seconds earlier) builds
+  // a different set of days than the client's first pass (#8241).
+  const hydrated = useHydrated();
   const search = useSearch({ from: "/health" });
   const navigate = useNavigate({ from: "/health" });
   const filter = search.status;
@@ -604,6 +615,7 @@ function Incidents({ interval }: { interval: number | false }) {
 
   // 14-day incident sparkline (count of incidents per day, oldest first).
   const incidentsByDay = useMemo(() => {
+    if (!hydrated) return [];
     const buckets = new Map<string, number>();
     const now = new Date();
     for (let i = 13; i >= 0; i--) {
@@ -616,7 +628,7 @@ function Incidents({ interval }: { interval: number | false }) {
       if (key && buckets.has(key)) buckets.set(key, (buckets.get(key) ?? 0) + 1);
     }
     return Array.from(buckets.values());
-  }, [rows]);
+  }, [rows, hydrated]);
 
   if (rows.length === 0) {
     return (


### PR DESCRIPTION
Closes #8241 (Phase 0 of epic #8238).

## The hydration error

`/health` threw **React #418** (hydration text mismatch) in production — captured live by the app's own `[hydration-capture]` hook. Reproduced across repeated runs on **both** mobile and desktop, and intermittently: it is a race, not a viewport-specific break, so the issue's original "mobile UA" framing was too narrow.

Three values on the page are derived from the wall clock **during render**, so the server pass and the client's first pass disagree by however long the response spent in flight:

| Where | Value |
|---|---|
| `StatusBoard` | `stale` — `isStaleFreshness(generated_at)` compares against "now" |
| `StatusBoard` | `sourceAges` — `Date.now() - last_seen` per source, feeding the freshness sparkline |
| `Incidents` | `incidentsByDay` — 14 bucket keys built from `new Date()`; a pass seconds earlier, or either side of a UTC midnight, produces a different day set entirely |

All three are now gated behind `useHydrated()`, so both passes render identically and the real values land on the first post-hydration commit. Same convention as the earlier subnet-detail sweep (#7782). No visual change once hydrated.

## The second half of #8241 was not a bug — please note

The issue also claimed a "/status tail render bug" (~1,600px of orphaned status dots at the end of the page). **That is a screenshot artifact, not a defect.** Verified two ways:

1. DOM inspection at the affected offsets — every row is fully populated (`tr` with 6 children, e.g. `Gittensor · provider-claimed · subnet-team · OK · 48 · 9 · live 4 · content-mismatch 5`).
2. A real viewport capture scrolled to y=82000 renders the table perfectly.

The original finding came from a **full-page** screenshot of an 85,274px document — past the compositor's texture limit, most content simply isn't painted and only stray elements survive. Nothing to fix here; the real problem that region represents (a status page 95 screens tall, because it inlines the entire 617-surface ledger) is #8250's rebuild, which stands.

## Verification

- Reproduction harness run before/after across `/health /status /subnets /validators /blocks /endpoints /` at 390px and 1440px.
- tsc/eslint/prettier: no new errors or warnings — `-health-page.tsx` lints identically to `origin/main` (11 pre-existing warnings, 0 errors) both before and after.

## Separately found while reproducing this — needs your PostHog dashboard access

The console capture surfaced an unrelated **production privacy bug** I cannot fix from code. The PostHog project's session-replay URL blocklist is served as:

```json
"urlBlocklist": [
  {"matching":"regex","url":"^/admin/*$"},
  {"matching":"regex","url":"^/api/*$"},
  {"matching":"regex","url":"^*/settings/*$"},
  {"matching":"regex","url":"^*/dashboard/*$"}
]
```

`^*/settings/*$` and `^*/dashboard/*$` are **invalid regexes** (`^*` → "Nothing to repeat"), throwing a `SyntaxError` inside `posthog-recorder.js` on page load. The other two are valid regex but semantically wrong (`/*` means "zero or more slashes", and these are matched against the full URL). **So all four rules are inert and session replay is recording `/settings`** — the page that renders minted API keys and webhook signing secrets.

Element-level protection still holds (those panels carry `ph-no-capture`, per this repo's own privacy review), so this is defense-in-depth that is silently absent rather than an active leak. Suggested replacement, dashboard-side: a single `.*/settings(/.*)?$` (note `.*/admin(/|$)` if you re-add one — a naive `.*/admin.*` would wrongly match the public `/admin-changes` route). I'll file this as its own issue and can add a code-side route guard that stops recording on sensitive routes so this stops depending on dashboard state at all — say the word.