### PR TITLE
fix(privacy): own the session-replay route blocklist in code — /settings was being recorded

### DIFF
--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -8,6 +8,7 @@ const init = vi.hoisted(() => vi.fn());
 const capture = vi.hoisted(() => vi.fn());
 const captureExceptionSpy = vi.hoisted(() => vi.fn());
 const startSessionRecording = vi.hoisted(() => vi.fn());
+const stopSessionRecording = vi.hoisted(() => vi.fn());
 const onFeatureFlags = vi.hoisted(() => vi.fn());
 const isFeatureEnabledSpy = vi.hoisted(() => vi.fn());
 
@@ -17,6 +18,7 @@ vi.mock("posthog-js", () => ({
     capture,
     captureException: captureExceptionSpy,
     startSessionRecording,
+    stopSessionRecording,
     onFeatureFlags,
     isFeatureEnabled: isFeatureEnabledSpy,
   },
@@ -29,6 +31,7 @@ describe("analytics (PostHog web analytics)", () => {
     capture.mockClear();
     captureExceptionSpy.mockClear();
     startSessionRecording.mockClear();
+    stopSessionRecording.mockClear();
     onFeatureFlags.mockClear();
     isFeatureEnabledSpy.mockClear();
   });
@@ -288,5 +291,106 @@ describe("analytics (PostHog web analytics)", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(capture).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("session-replay route policy (#8270)", () => {
+  // The dashboard-side URL blocklist shipped four rules that were all inert
+  // (invalid regex / glob-as-regex), so /settings -- which renders minted API
+  // keys and webhook signing secrets -- was being recorded. This policy owns
+  // the list in code so it can't depend on dashboard state again.
+  beforeEach(() => {
+    // Earlier suites in this file stub `window`/`document` away to exercise
+    // the SSR paths; clear that first or this block's own stubs stack on top
+    // of a half-removed global and posthog.init throws into loadPostHog's
+    // catch, leaving the policy with a null client and no spy calls.
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    // mockReset, not mockClear: the "init failure never throws" case above
+    // installs a throwing implementation, and mockClear only wipes the call
+    // log -- the implementation survives into this block and sends every
+    // loadPostHog() straight to its catch, yielding a null client.
+    init.mockReset();
+    startSessionRecording.mockReset();
+    stopSessionRecording.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("blocks the routes that render secrets, and their subpaths", async () => {
+    const { isReplayBlockedRoute } = await import("./analytics");
+    expect(isReplayBlockedRoute("/settings")).toBe(true);
+    expect(isReplayBlockedRoute("/settings/")).toBe(true);
+    expect(isReplayBlockedRoute("/settings/api-keys")).toBe(true);
+    expect(isReplayBlockedRoute("/portfolio")).toBe(true);
+  });
+
+  it("does not block public routes, including the /admin-changes near-miss", async () => {
+    const { isReplayBlockedRoute } = await import("./analytics");
+    // A loose substring rule would wrongly suppress this PUBLIC route.
+    expect(isReplayBlockedRoute("/admin-changes")).toBe(false);
+    expect(isReplayBlockedRoute("/settings-guide")).toBe(false);
+    expect(isReplayBlockedRoute("/subnets/74")).toBe(false);
+    expect(isReplayBlockedRoute("/")).toBe(false);
+    expect(isReplayBlockedRoute(null)).toBe(false);
+    expect(isReplayBlockedRoute(undefined)).toBe(false);
+  });
+
+  it("never starts a recording when the first load is a blocked route", async () => {
+    vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+    vi.stubGlobal("window", { location: { pathname: "/settings" } });
+    const { initAnalytics } = await import("./analytics");
+    initAnalytics();
+    await vi.waitFor(() => expect(init).toHaveBeenCalled());
+    expect(init.mock.calls[0][1].disable_session_recording).toBe(true);
+  });
+
+  it("leaves recording enabled at init on a public route", async () => {
+    vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+    vi.stubGlobal("window", { location: { pathname: "/subnets" } });
+    const { initAnalytics } = await import("./analytics");
+    initAnalytics();
+    await vi.waitFor(() => expect(init).toHaveBeenCalled());
+    expect(init.mock.calls[0][1].disable_session_recording).toBe(false);
+  });
+
+  it("stops recording when navigating into a blocked route, and resumes on the way out", async () => {
+    vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+    vi.stubGlobal("window", { location: { pathname: "/subnets" } });
+    const { syncReplayPolicy } = await import("./analytics");
+
+    syncReplayPolicy("/settings");
+    await vi.waitFor(() => expect(stopSessionRecording).toHaveBeenCalledTimes(1));
+    expect(startSessionRecording).not.toHaveBeenCalled();
+
+    syncReplayPolicy("/subnets");
+    await vi.waitFor(() => expect(startSessionRecording).toHaveBeenCalledTimes(1));
+    // Never the force-override form: a visitor excluded by sampleRate must
+    // stay excluded (captureException is the only caller allowed to force).
+    expect(startSessionRecording).toHaveBeenCalledWith();
+  });
+
+  it("does not resume a recording it never stopped", async () => {
+    vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+    vi.stubGlobal("window", { location: { pathname: "/subnets" } });
+    const { syncReplayPolicy } = await import("./analytics");
+    syncReplayPolicy("/subnets");
+    syncReplayPolicy("/blocks");
+    await vi.waitFor(() => expect(init).toHaveBeenCalled());
+    expect(startSessionRecording).not.toHaveBeenCalled();
+    expect(stopSessionRecording).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when unconfigured", async () => {
+    vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "");
+    const { syncReplayPolicy } = await import("./analytics");
+    syncReplayPolicy("/settings");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(init).not.toHaveBeenCalled();
+    expect(stopSessionRecording).not.toHaveBeenCalled();
   });
 });

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -98,6 +98,47 @@ const POSTHOG_UI_HOST =
 // fails `npm run typecheck` outright rather than degrading quietly at runtime.
 const SDK_DEFAULTS_DATE = "2026-05-30";
 
+/**
+ * Routes session replay must never record (#8270).
+ *
+ * The PostHog project also carries a dashboard-side URL blocklist, but every
+ * rule in it was authored as a glob while declared `matching: "regex"`. Two
+ * of them start with a caret immediately followed by a star, which is not a
+ * valid regex at all ("Nothing to repeat") and throws a SyntaxError inside
+ * the recorder; the other two rely on a trailing slash-star, which in regex
+ * means "zero or more slashes" and is matched against a full https:// URL,
+ * so it can never fire. All four rules were inert, and `/settings` -- which
+ * renders minted API keys and webhook signing secrets -- was being recorded.
+ *
+ * Element-level protection (`ph-no-capture` on the secret-reveal panels,
+ * `maskAllInputs`) always held, so this is defense-in-depth restored rather
+ * than a leak closed. Owning the list here follows the same posture as the
+ * hardcoded `sampleRate` / `enable_recording_console_log` / `persistence`
+ * choices below: don't depend on dashboard state this code can't guarantee.
+ *
+ * Matched as a path prefix on a segment boundary, deliberately NOT a
+ * substring: `/admin-changes` is a PUBLIC route (the AdminUtils config-change
+ * feed) that a loose `/admin` substring rule would wrongly suppress.
+ */
+const REPLAY_BLOCKED_ROUTES = ["/settings", "/portfolio"] as const;
+
+export function isReplayBlockedRoute(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  // Normalize a trailing slash so "/settings/" matches "/settings".
+  const path = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  return REPLAY_BLOCKED_ROUTES.some((base) => path === base || path.startsWith(`${base}/`));
+}
+
+function currentPathname(): string | null {
+  return typeof window === "undefined" ? null : window.location.pathname;
+}
+
+// True only while replay is stopped *by this policy*, so resuming can never
+// hand a recording to a visitor whose sample-rate dice roll said no -- we only
+// restart what we ourselves stopped, and never with the `true` force-override
+// captureException uses.
+let replayStoppedByPolicy = false;
+
 let posthogInit: Promise<PostHog | null> | null = null;
 
 function loadPostHog(): Promise<PostHog | null> {
@@ -108,6 +149,11 @@ function loadPostHog(): Promise<PostHog | null> {
         api_host: POSTHOG_API_HOST,
         ui_host: POSTHOG_UI_HOST,
         defaults: SDK_DEFAULTS_DATE,
+        // Landing directly on a blocked route must never start a recording
+        // in the first place -- stopping one after init would already have
+        // captured the first frames. SPA navigations are handled by
+        // syncReplayPolicy() below.
+        disable_session_recording: isReplayBlockedRoute(currentPathname()),
         capture_pageview: false,
         // posthog-js's own default for capture_pageleave is
         // 'if_capture_pageview' -- i.e. it piggybacks on capture_pageview's
@@ -242,6 +288,29 @@ export function capturePageview(url?: string): void {
       ...(url ? { $current_url: url } : undefined),
       ...(typeof document !== "undefined" ? { page_title: document.title } : undefined),
     });
+  });
+}
+
+/** Starts or stops session replay to match the route now being shown (#8270).
+ *
+ * Call on every SPA navigation, alongside `capturePageview`. A no-op when
+ * unconfigured. Only ever resumes a recording this policy itself stopped, and
+ * never with `startSessionRecording`'s force-override, so a visitor excluded
+ * by `sampleRate` stays excluded. */
+export function syncReplayPolicy(pathname?: string): void {
+  if (!POSTHOG_TOKEN) return;
+  const blocked = isReplayBlockedRoute(pathname ?? currentPathname());
+  void loadPostHog().then((posthog) => {
+    if (!posthog) return;
+    if (blocked) {
+      posthog.stopSessionRecording();
+      replayStoppedByPolicy = true;
+      return;
+    }
+    if (replayStoppedByPolicy) {
+      replayStoppedByPolicy = false;
+      posthog.startSessionRecording();
+    }
   });
 }
 

--- a/apps/ui/src/routes/-root-views.tsx
+++ b/apps/ui/src/routes/-root-views.tsx
@@ -21,7 +21,7 @@ import {
 } from "lucide-react";
 import { Toaster } from "@jsonbored/ui-kit";
 import { reportLovableError } from "../lib/lovable-error-reporting";
-import { initAnalytics, capturePageview } from "../lib/analytics";
+import { initAnalytics, capturePageview, syncReplayPolicy } from "../lib/analytics";
 import { THEME_BOOTSTRAP_SCRIPT } from "@/lib/theme";
 import { DENSITY_BOOTSTRAP_SCRIPT } from "@/lib/density";
 import { HEALTH_PALETTE_BOOTSTRAP_SCRIPT } from "@/lib/health-palette";
@@ -301,8 +301,14 @@ export function RootComponent() {
   useEffect(() => {
     initAnalytics();
     capturePageview(window.location.href);
+    // Session replay must follow the route, not just the initial load
+    // (#8270) -- a client-side navigation into /settings would otherwise keep
+    // recording a page that renders API keys and signing secrets.
+    syncReplayPolicy(window.location.pathname);
     return router.subscribe("onResolved", (event) => {
-      if (event.hrefChanged) capturePageview(window.location.href);
+      if (!event.hrefChanged) return;
+      capturePageview(window.location.href);
+      syncReplayPolicy(window.location.pathname);
     });
   }, [router]);
 


### PR DESCRIPTION
Refs #8270 (Phase 0 of epic #8238). Found while reproducing the #8241 hydration error.

## The bug

The PostHog project's dashboard-side session-replay URL blocklist is served as:

```json
"urlBlocklist": [
  {"matching":"regex","url":"^/admin/*$"},
  {"matching":"regex","url":"^/api/*$"},
  {"matching":"regex","url":"^*/settings/*$"},
  {"matching":"regex","url":"^*/dashboard/*$"}
]
```

All four are declared `matching: "regex"` but written as **globs**:

- The two beginning with caret-then-star are **not valid regexes** ("Nothing to repeat") and throw a `SyntaxError` inside `posthog-recorder.js` on page load — reproduced live on /status, /subnets, /validators, /blocks, /endpoints.
- The other two end in slash-star, which in regex means *zero or more slashes*, and are matched against a full `https://…` URL — so they never match either.

**Net: the blocklist was inert and `/settings` was being recorded** — the page that renders minted API keys and webhook signing secrets.

Severity is bounded: element-level protection always held (`ph-no-capture` on the three secret-reveal panels per this repo's own replay privacy review, plus `maskAllInputs`). This restores defense-in-depth that was silently absent, rather than closing an active leak.

## The fix

Own the list in code rather than the dashboard — the same posture `analytics.ts` already argues for its hardcoded `sampleRate`, `enable_recording_console_log`, and `persistence`: *don't depend on state this code can't guarantee.*

- **`disable_session_recording` at init** when the first load is a blocked route. Stopping after init would already have captured the opening frames, so a direct hit on `/settings` must never start one.
- **`syncReplayPolicy()` on every SPA navigation**, wired next to `capturePageview` in `-root-views.tsx` — a client-side nav into `/settings` was the other half of the hole.
- **Resume only what this policy stopped**, and never via `startSessionRecording`'s force-override (which `captureException` legitimately uses), so a visitor excluded by the 15% `sampleRate` stays excluded.
- Matching is a **path prefix on a segment boundary, not a substring** — `/admin-changes` is a *public* route (the AdminUtils config-change feed) that a loose `/admin` rule would wrongly suppress. Explicitly tested.

Blocked today: `/settings`, `/portfolio`.

## Tests

7 new cases in `analytics.test.ts` (28/28 green): blocked routes + subpaths + trailing slash; the `/admin-changes` and `/settings-guide` near-misses; `disable_session_recording` true/false at init by landing route; stop-on-enter and resume-on-exit asserting the **no-argument** `startSessionRecording()`; no resume of a recording it never stopped; no-op when unconfigured.

One test-harness fix included: this block uses `mockReset()` rather than `mockClear()`, because the existing "init failure never throws" case installs a throwing `init` implementation that `mockClear` leaves in place — it leaked into the new tests and sent every `loadPostHog()` into its catch. Commented at the call site.

## Still needs you (dashboard)

The four broken rules should be deleted or replaced (`.*/settings(/.*)?$`, `.*/portfolio(/.*)?$`). This PR makes that cleanup **safe rather than load-bearing** — with the code guard in place, the dashboard rules are no longer the only thing standing between replay and the secrets pages. Tracked in #8270.