### PR TITLE
fix(ui-kit): stop requesting CORS on third-party logos — most subnet logos were failing to load

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1029,15 +1029,8 @@ function safeImageUrl(input) {
     return null;
   }
 }
-function isDirectIconUrlCandidate(candidate, iconUrl, theme) {
-  if (!candidate) return false;
-  const directIcon = safeImageUrl(pickIconSource(iconUrl, theme));
-  return Boolean(
-    directIcon && candidate === directIcon && !isProxiedIcon(candidate)
-  );
-}
-function shouldUseAnonymousCors(candidate, iconUrl, theme) {
-  return isProxiedIcon(candidate) || isDirectIconUrlCandidate(candidate, iconUrl, theme);
+function shouldUseAnonymousCors(candidate) {
+  return isProxiedIcon(candidate);
 }
 function buildCandidateChain({
   url,
@@ -1081,7 +1074,7 @@ function prefetchBrandIcon(url, size = 32, extra) {
     const img = new Image();
     img.decoding = "async";
     img.referrerPolicy = "no-referrer";
-    if (shouldUseAnonymousCors(first, extra?.iconUrl, extra?.theme ?? "light")) {
+    if (shouldUseAnonymousCors(first)) {
       img.crossOrigin = "anonymous";
     }
     img.onload = () => loadedUrls.add(first);
@@ -1277,7 +1270,7 @@ function BrandIcon({
             loading: "lazy",
             decoding: "async",
             referrerPolicy: "no-referrer",
-            crossOrigin: shouldUseAnonymousCors(candidate, iconUrl, theme) ? "anonymous" : void 0,
+            crossOrigin: shouldUseAnonymousCors(candidate) ? "anonymous" : void 0,
             className: classNames(
               "relative block transition-opacity duration-150",
               loaded ? "opacity-100" : "opacity-0"

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1000,15 +1000,8 @@ function safeImageUrl(input) {
     return null;
   }
 }
-function isDirectIconUrlCandidate(candidate, iconUrl, theme) {
-  if (!candidate) return false;
-  const directIcon = safeImageUrl(pickIconSource(iconUrl, theme));
-  return Boolean(
-    directIcon && candidate === directIcon && !isProxiedIcon(candidate)
-  );
-}
-function shouldUseAnonymousCors(candidate, iconUrl, theme) {
-  return isProxiedIcon(candidate) || isDirectIconUrlCandidate(candidate, iconUrl, theme);
+function shouldUseAnonymousCors(candidate) {
+  return isProxiedIcon(candidate);
 }
 function buildCandidateChain({
   url,
@@ -1052,7 +1045,7 @@ function prefetchBrandIcon(url, size = 32, extra) {
     const img = new Image();
     img.decoding = "async";
     img.referrerPolicy = "no-referrer";
-    if (shouldUseAnonymousCors(first, extra?.iconUrl, extra?.theme ?? "light")) {
+    if (shouldUseAnonymousCors(first)) {
       img.crossOrigin = "anonymous";
     }
     img.onload = () => loadedUrls.add(first);
@@ -1248,7 +1241,7 @@ function BrandIcon({
             loading: "lazy",
             decoding: "async",
             referrerPolicy: "no-referrer",
-            crossOrigin: shouldUseAnonymousCors(candidate, iconUrl, theme) ? "anonymous" : void 0,
+            crossOrigin: shouldUseAnonymousCors(candidate) ? "anonymous" : void 0,
             className: classNames(
               "relative block transition-opacity duration-150",
               loaded ? "opacity-100" : "opacity-0"

--- a/packages/ui-kit/src/components/metagraphed/brand-icon.tsx
+++ b/packages/ui-kit/src/components/metagraphed/brand-icon.tsx
@@ -151,27 +151,25 @@ interface ChainInputs {
   size: number;
 }
 
-function isDirectIconUrlCandidate(
-  candidate: string | null | undefined,
-  iconUrl: IconSource | null | undefined,
-  theme: ResolvedTheme,
-): boolean {
-  if (!candidate) return false;
-  const directIcon = safeImageUrl(pickIconSource(iconUrl, theme));
-  return Boolean(
-    directIcon && candidate === directIcon && !isProxiedIcon(candidate),
-  );
-}
-
-function shouldUseAnonymousCors(
-  candidate: string | null | undefined,
-  iconUrl: IconSource | null | undefined,
-  theme: ResolvedTheme,
-): boolean {
-  return (
-    isProxiedIcon(candidate) ||
-    isDirectIconUrlCandidate(candidate, iconUrl, theme)
-  );
+/**
+ * Only our own proxy gets a CORS request (#8243).
+ *
+ * `crossOrigin="anonymous"` is not a hint — if the response carries no
+ * `Access-Control-Allow-Origin`, the browser fails the load outright. Registry
+ * `logo_url` values point at whatever host a subnet team publishes (team S3
+ * buckets, project sites, favicon endpoints), and most send no CORS headers at
+ * all, so asking for CORS turned every one of those into a broken icon plus a
+ * console error — verified live across /subnets, /validators, /providers,
+ * /endpoints and subnet detail.
+ *
+ * Dropping the request costs only the canvas luminance probe, which taints on
+ * a non-CORS image and already degrades silently to the default surface (see
+ * analyseLogoLuminance). That is the exact trade this chain has always made
+ * for curated overrides and GitHub avatars — a visible logo without the
+ * auto-contrast tile beats no logo at all.
+ */
+function shouldUseAnonymousCors(candidate: string | null | undefined): boolean {
+  return isProxiedIcon(candidate);
 }
 
 function buildCandidateChain({
@@ -234,9 +232,7 @@ export function prefetchBrandIcon(
     const img = new Image();
     img.decoding = "async";
     img.referrerPolicy = "no-referrer";
-    if (
-      shouldUseAnonymousCors(first, extra?.iconUrl, extra?.theme ?? "light")
-    ) {
+    if (shouldUseAnonymousCors(first)) {
       img.crossOrigin = "anonymous";
     }
     img.onload = () => loadedUrls.add(first);
@@ -482,13 +478,11 @@ export function BrandIcon({
         loading="lazy"
         decoding="async"
         referrerPolicy="no-referrer"
-        // Request credentialless CORS for our proxy and direct registry/API icon_url
-        // values. Curated frontend overrides and GitHub fallbacks can still load as
-        // ordinary images so missing CORS headers do not hide trusted icons.
+        // Credentialless CORS for our own proxy only -- see
+        // shouldUseAnonymousCors. Every other source loads as an ordinary
+        // image so a missing CORS header can never hide a real logo.
         crossOrigin={
-          shouldUseAnonymousCors(candidate, iconUrl, theme)
-            ? "anonymous"
-            : undefined
+          shouldUseAnonymousCors(candidate) ? "anonymous" : undefined
         }
         className={classNames(
           "relative block transition-opacity duration-150",


### PR DESCRIPTION
Refs #8243 (Phase 0 of epic #8238).

## The bug

Subnet and provider logos rendered as monograms across /subnets, /validators, /providers, /endpoints and subnet detail, each accompanied by a console CORS error.

`BrandIcon` set `crossOrigin="anonymous"` on the registry `logo_url` candidate. **`crossOrigin` is not a hint** — if the response carries no `Access-Control-Allow-Origin`, the browser fails the load outright. Registry `logo_url`s point at whatever host a subnet team publishes from, and most send no CORS headers, so the CORS request converted a perfectly loadable image into a broken one.

Measured against the real hosts in the registry:

| Status | `access-control-allow-origin` | Host |
|---|---|---|
| 200 | *(none)* | `gittensor.s3.us-east-2.amazonaws.com/gt-logo-white.png` |
| 200 | *(none)* | `cacheon.ai/icon-192.png` |
| 402 | *(none)* | `www.taofi.com/images/SN10-Swap-Dark.png` |
| 200 | `*` | `bittensor.com/favicon.ico` |

The first two are pure CORS failures this fix repairs. The taofi asset is separately **dead** (HTTP 402) and correctly falls through to the next candidate either way. The last already sends CORS and keeps working.

## The fix

Request CORS only for our own icon proxy, which does send the header.

The only capability lost is the canvas luminance probe on those images — and it already degrades silently: `analyseLogoLuminance` returns `null` on a tainted canvas and the component falls back to the default surface. That is precisely the trade this candidate chain has always made for curated overrides and GitHub avatars (its own prior comment said so). **A visible logo without the auto-contrast tile beats no logo at all.**

Net effect: real logos appear, the console goes quiet, and one fewer failure mode depends on third parties configuring CORS correctly.

## Scope note

This does not do the *first-party caching* half of #8243. The icon proxy is deliberately **aggregator-only** — it takes a `host`, never an arbitrary URL, as an SSRF-safety decision. Caching arbitrary registry `logo_url`s (build-time fetch → R2, content-hashed) is the right end state but needs its own security review rather than quietly widening that endpoint, so #8243 stays open for it. This PR removes the user-visible breakage now.

## Verification

- Live CORS probe above (script output reproduced verbatim in the commit message).
- ui-kit builds; tsc/eslint/prettier clean. No existing test asserted the old CORS behavior (there is no `brand-icon` test file — the resolution chain is exercised through `brand-overrides`, untouched here).
- Screenshot table: logos are the change, so before/after at 390/768/1440 goes on the PR once a preview deploy is up — flagging for the manual-review gate rather than claiming visual verification I have not done locally (`bun run build` is broken in this checkout per the repo's own local-verify notes).