### PR TITLE
fix(test): lift the 3.5 rps upload gate in the R2 history dedupe test (unblocks main)

### DIFF
--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -2524,6 +2524,15 @@ test("R2 history upload deduplicates content-addressed objects that already exis
           METAGRAPH_R2_API_BASE_URL: `http://127.0.0.1:${port}`,
           METAGRAPH_R2_UPLOAD_CONCURRENCY: "16",
           METAGRAPH_R2_UPLOAD_HISTORY: "1",
+          // Lift the shared 3.5 rps production rate gate (#8240/#8261, sized
+          // for Cloudflare's ~1,200-requests/5-minutes client-API ceiling).
+          // This test walks the WHOLE manifest -- ~2.3k artifacts, each a HEAD
+          // dedupe probe plus a PUT, plus the latest/ copies -- so at 3.5 rps
+          // it needs ~22 minutes and can never finish inside the timeout. The
+          // gate is production pacing against a real remote; the mock server
+          // here has no such limit. Same override, for the same reason, that
+          // tests/r2-upload.test.ts already applies to its own upload cases.
+          METAGRAPH_R2_UPLOAD_MAX_RPS: "5000",
         },
       },
     );


### PR DESCRIPTION
## Summary

**`main` has been red since #8237 merged, failing the `test` job on every open PR.** This unblocks it.

Semantic merge conflict between two PRs that were each green on their own base:

- **#8261** (`6f50e4090`) added a shared upload rate gate — `METAGRAPH_R2_UPLOAD_MAX_RPS`, default **3.5 rps** — sized for Cloudflare's ~1,200-requests/5-minutes client-API ceiling (#8240). It correctly overrode the gate in its own tests (`tests/r2-upload.test.ts` sets `"200"` in two cases).
- **#8237** (`646e2420f`) added the history-dedupe test in `tests/artifacts.test.ts`, branched before the gate existed, so it never got the override.

Together, that test walks the **whole** manifest — ~2,321 artifacts, each a HEAD dedupe probe plus a PUT, plus the `latest/` copies — through a 3.5 rps gate. ~4,600+ requests ≈ **22 minutes** against a **30 second** timeout.

## Evidence

Reproduced deterministically locally — not a flake. Instrumenting the mock server shows throughput pinned at exactly the gate value:

```
t=105.0s head=124 put=243
t=138.1s head=163 put=320
t=177.1s head=208 put=411      # ~3.5 req/s total == uploadMaxRps default
```

## Fix

Set `METAGRAPH_R2_UPLOAD_MAX_RPS` in that test's child-process env, exactly as `tests/r2-upload.test.ts` already does for the same reason. The gate is production pacing against a real remote; the in-process mock server has no such limit, so the gate only buys ~22 minutes of sleeping.

`tests/r2-upload.test.ts`'s one remaining un-overridden case is correct as-is — it sets `METAGRAPH_R2_UPLOAD_LIMIT: "1"`, so it makes a single request.

Closes #8273

## Test plan

- [x] Before: `Test timed out in 30000ms` — reproduced locally, deterministic
- [x] After: **1.0s pass**
- [x] `npx vitest run tests/artifacts.test.ts tests/r2-upload.test.ts` — 26/26 pass, so the rate-gate behavior #8261 added is still covered (its own 429-recovery test passes untouched)
- [x] `npx prettier --check` + `npx eslint` on the touched file