### PR TITLE
fix(publish): don't apply the Cloudflare rate gate to a mock API host — unbreaks main

### DIFF
--- a/scripts/r2-upload.ts
+++ b/scripts/r2-upload.ts
@@ -68,6 +68,13 @@ const uploadRetryBaseDelayMs =
   1000;
 const uploadTimeoutMs =
   parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_TIMEOUT_MS) || 45_000;
+
+const R2_API_BASE_URL_DEFAULT = "https://api.cloudflare.com/client/v4";
+// Test-only seam (mirrors the old METAGRAPH_WRANGLER_BIN override this
+// replaced): lets tests/r2-upload.test.ts point at a local mock HTTP server
+// instead of the real Cloudflare API. Never set in production.
+const r2ApiBaseUrl =
+  process.env.METAGRAPH_R2_API_BASE_URL || R2_API_BASE_URL_DEFAULT;
 // #stale-publish-pipeline/D: replacing the per-object wrangler subprocess with
 // direct API fetches (#8209) removed the CLI overhead and exposed the next
 // ceiling — Cloudflare's client-API rate limit (documented ~1,200 requests /
@@ -81,8 +88,15 @@ const uploadTimeoutMs =
 // retries that honor Retry-After, back off in tens of seconds, and push a
 // shared cooldown so ALL workers pause together instead of 23 siblings
 // draining the budget while one sleeps.
+// The ceiling being respected is Cloudflare's, so the gate only defaults ON
+// when this process is actually talking to Cloudflare. Pointed at a local mock
+// (tests/artifacts.test.ts uploads the FULL manifest -- thousands of HEAD+PUT
+// pairs -- against an in-process server), 3.5 rps turns a sub-second run into
+// hours and blows the test timeout. An explicit METAGRAPH_R2_UPLOAD_MAX_RPS
+// still wins either way, so a staging/proxy base URL can opt back in.
 const uploadMaxRps =
-  parsePositiveNumber(process.env.METAGRAPH_R2_UPLOAD_MAX_RPS) || 3.5;
+  parsePositiveNumber(process.env.METAGRAPH_R2_UPLOAD_MAX_RPS) ||
+  (r2ApiBaseUrl === R2_API_BASE_URL_DEFAULT ? 3.5 : Infinity);
 const uploadRateLimitRetries =
   parseNonNegativeInteger(process.env.METAGRAPH_R2_UPLOAD_429_RETRIES) ?? 6;
 const uploadRateLimitBaseDelayMs =
@@ -120,12 +134,6 @@ class R2PutError extends Error {
   status?: number;
   retryAfterMs?: number;
 }
-// Test-only seam (mirrors the old METAGRAPH_WRANGLER_BIN override this
-// replaced): lets tests/r2-upload.test.ts point at a local mock HTTP server
-// instead of the real Cloudflare API. Never set in production.
-const r2ApiBaseUrl =
-  process.env.METAGRAPH_R2_API_BASE_URL ||
-  "https://api.cloudflare.com/client/v4";
 const manifest: Row = await readJson(
   path.join(repoRoot, R2_STAGING_RELATIVE_ROOT, "r2-manifest.json"),
 );

--- a/tests/r2-upload.test.ts
+++ b/tests/r2-upload.test.ts
@@ -225,3 +225,66 @@ test("R2 upload still fails once the 429 retry budget is exhausted", async () =>
     /429/,
   );
 });
+
+// #8261 follow-up: the Cloudflare rate gate must not pace a local mock. The
+// full-manifest upload in tests/artifacts.test.ts is thousands of HEAD+PUT
+// pairs -- at the production default of 3.5 rps that run took hours and blew
+// its 30s timeout, so the gate defaults OFF whenever METAGRAPH_R2_API_BASE_URL
+// points somewhere other than the real Cloudflare API.
+test("the rate gate does not pace uploads aimed at a non-Cloudflare base URL", async () => {
+  const manifest = JSON.parse(
+    readFileSync(`${r2StagingRoot}/r2-manifest.json`, "utf8"),
+  );
+  const remoteManifest = {
+    ...manifest,
+    artifacts: manifest.artifacts.map(
+      (artifact: Record<string, unknown>, index: number) =>
+        index === 0 ? { ...artifact, sha256: "0".repeat(64) } : artifact,
+    ),
+  };
+  let puts = 0;
+  server = http.createServer((req, res) => {
+    if (req.method === "GET") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(remoteManifest));
+      return;
+    }
+    if (req.method === "HEAD") {
+      res.writeHead(404).end();
+      return;
+    }
+    if (req.method === "PUT") {
+      puts += 1;
+      req.resume();
+      req.on("end", () => res.writeHead(200).end());
+      return;
+    }
+    res.writeHead(405).end();
+  });
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  const started = Date.now();
+  await execFileAsync(process.execPath, ["scripts/r2-upload.ts", "--write"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLOUDFLARE_ACCOUNT_ID: "test-account",
+      CLOUDFLARE_API_TOKEN: "test-token",
+      METAGRAPH_ALLOW_R2_UPLOAD: "1",
+      METAGRAPH_R2_API_BASE_URL: `http://127.0.0.1:${port}`,
+      METAGRAPH_R2_UPLOAD_HISTORY: "1",
+      METAGRAPH_R2_UPLOAD_LIMIT: "12",
+      // Deliberately NOT setting METAGRAPH_R2_UPLOAD_MAX_RPS -- the point is
+      // that the default is unpaced against a mock host.
+    },
+  });
+  const elapsed = Date.now() - started;
+  // 24 objects (12 artifacts x latest+history) would need ~6.6s at 3.5 rps.
+  assert.ok(puts >= 12, `expected >=12 PUTs, saw ${puts}`);
+  assert.ok(
+    elapsed < 6000,
+    `unpaced run took ${elapsed}ms — gate did not disable`,
+  );
+});


### PR DESCRIPTION
**Fixes a regression I introduced in #8261. main is currently red on this, so it fails every open PR until this lands.**

## What broke

`tests/artifacts.test.ts` → *"R2 history upload deduplicates content-addressed objects that already exist"* → **`Test timed out in 30000ms`**.

That test drives the real `scripts/r2-upload.ts` against an in-process mock server and uploads the **full manifest** — thousands of HEAD + PUT pairs. #8261's rate gate defaulted to **3.5 rps unconditionally**, so a run that used to finish in about a second now needed hours.

Seen on #8269, but it is not that PR's fault — the failure is on main and reproduces on anything branched from it.

## Fix

The ceiling being respected belongs to **Cloudflare**, so the gate now defaults ON only when this process is actually talking to the real Cloudflare API:

```ts
const uploadMaxRps =
  parsePositiveNumber(process.env.METAGRAPH_R2_UPLOAD_MAX_RPS) ||
  (r2ApiBaseUrl === R2_API_BASE_URL_DEFAULT ? 3.5 : Infinity);
```

- An explicit `METAGRAPH_R2_UPLOAD_MAX_RPS` still wins either way, so a staging/proxy base URL can opt back in.
- **429 handling, `Retry-After`, and the shared worker cooldown are unchanged** and still apply on every host — only the proactive pacing is scoped.
- With `Infinity`, `interval` is 0, so `rateGate()` claims a slot and returns without sleeping; the cooldown branch still short-circuits correctly if a 429 ever arrives.

## Verification

- The timing-out test: **30s timeout → 974ms.**
- New regression guard in `tests/r2-upload.test.ts`: uploads 12 artifacts (24 objects with history) against a mock **without** setting the rps knob and asserts the run finishes under 6s — at 3.5 rps those 24 objects need ~6.6s, so the guard fails if the gate ever creeps back onto mock hosts.
- `tests/r2-upload.test.ts` 4/4 green (the three #8261 429 cases still pass); tsc/eslint/prettier clean.

## Note on why the original PR went green

#8261's own tests all set `METAGRAPH_R2_UPLOAD_MAX_RPS` high to stay fast — which is exactly what hid the problem: every test that exercised the new code opted out of the new default, and the one test that would have caught it lives in a different file that I did not run. The guard above is deliberately the inverse: it asserts the *default*.