### PR TITLE
fix(publish): resolve artifact reads through latest/, not the unwritten run prefix (PROD OUTAGE)

### DIFF
--- a/scripts/kv-publish-pointer.ts
+++ b/scripts/kv-publish-pointer.ts
@@ -31,11 +31,30 @@ const pointer = {
   // build stamp). The Worker surfaces this as meta.published_at so consumers
   // read true freshness instead of the epoch content marker.
   published_at: buildSummary.published_at || null,
-  // The Worker resolves live artifacts through latest_prefix. Point it at the
-  // immutable run prefix so a failed pointer write after R2 upload keeps the
-  // previous pointer on the previous run's artifacts, instead of mixing stale
-  // metadata with newly overwritten latest/ objects.
-  latest_prefix: manifest.run_prefix,
+  // The Worker resolves live artifacts through latest_prefix (workers/storage.ts's
+  // latestR2Key: `${latest_prefix}${relativePath}`), so this MUST name a prefix
+  // the upload actually writes.
+  //
+  // #8276: this pointed at manifest.run_prefix until #8237 content-addressed the
+  // history tier. Under the old scheme r2-upload wrote every artifact to
+  // runs/<run>/<path>, so the run prefix was both immutable AND complete --
+  // pointing at it meant a pointer write that failed after the R2 upload left
+  // readers on the previous run rather than on half-overwritten latest/ objects.
+  // #8237 replaced that tree with by-hash/<sha256>, so runs/<run>/<path> is no
+  // longer written at all: the 2026-07-26T10-59-03-643Z publish uploaded 5,666
+  // objects, flipped the pointer to its run prefix, and every artifact read
+  // 404'd because nothing was ever written under it. (The publish's own "Smoke
+  // live API" step caught it and failed the workflow -- after the flip.)
+  //
+  // latest/ is the only complete, readable tree the upload still produces
+  // (uploaded_latest_count covers every artifact, every run). Tradeoff, stated
+  // plainly: it is mutable, so a reader during an in-flight publish can observe
+  // a mix of old and new objects -- the atomicity the run prefix used to buy is
+  // genuinely gone, and restoring it needs the Worker to resolve reads through
+  // the manifest's per-artifact by-hash keys (too large for the KV pointer as
+  // shaped today). Tracked in #8277. A 404 on every artifact is strictly worse
+  // than a brief mixed read, so this takes the tradeoff rather than the outage.
+  latest_prefix: manifest.latest_prefix,
   run_prefix: manifest.run_prefix,
   manifest_hash: hashJson(manifest),
   artifact_count: manifest.artifact_count,
@@ -44,7 +63,7 @@ const pointer = {
   health_surface_count: (freshness.summary as Row).health_surface_count,
 };
 // metagraph:latest is the ONLY KV control record: the pointer the Worker reads to
-// resolve the live immutable R2 run prefix. (The former feature-flags /
+// resolve the live R2 artifact prefix. (The former feature-flags /
 // endpoint-pools / source-freshness sidecars were written here every publish but
 // read by nothing — Worker, UI, or otherwise — so they were removed; reintroduce
 // such a blob only together with its reader so it can't drift unread.)

--- a/tests/kv-publish-pointer.test.ts
+++ b/tests/kv-publish-pointer.test.ts
@@ -2,14 +2,34 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "vitest";
 
-test("KV latest pointer uses immutable run prefix for Worker artifact reads", () => {
+// #8276: the pointer's latest_prefix is what workers/storage.ts's latestR2Key
+// concatenates the artifact path onto, so it MUST name a prefix r2-upload
+// actually writes. It named manifest.run_prefix until #8237 content-addressed
+// the history tier (runs/<run>/<path> -> by-hash/<sha256>), at which point the
+// run prefix stopped being written and every live artifact read 404'd in
+// production. Pin it to latest_prefix -- the only complete tree the upload
+// still produces -- so that swap can't silently come back.
+test("KV latest pointer resolves reads through a prefix the upload writes", () => {
   const source = readFileSync("scripts/kv-publish-pointer.ts", "utf8");
 
-  assert.match(source, /latest_prefix: manifest\.run_prefix/);
-  assert.doesNotMatch(source, /latest_prefix: manifest\.latest_prefix/);
-  assert.match(source, /immutable run prefix/);
+  assert.match(source, /latest_prefix: manifest\.latest_prefix/);
+  assert.doesNotMatch(source, /latest_prefix: manifest\.run_prefix/);
+  // run_prefix is still published as provenance (which run produced this
+  // content), just no longer used to resolve reads.
+  assert.match(source, /run_prefix: manifest\.run_prefix/);
   // metagraph:latest is the only KV control record now (dead feature-flags /
   // endpoint-pools / source-freshness sidecars were removed — read by nothing).
   assert.match(source, /\["metagraph:latest", pointer\]/);
   assert.doesNotMatch(source, /metagraph:feature-flags/);
+});
+
+// The regression this guards is a mismatch between two files, so assert the
+// other half too: r2-upload must still populate the latest/ tree for every
+// artifact. If the history rework ever swallows the latest tier as well, the
+// pointer above would again name a prefix nothing writes.
+test("r2-upload still writes a latest-tier object for every artifact", () => {
+  const source = readFileSync("scripts/r2-upload.ts", "utf8");
+
+  assert.match(source, /latest_key/);
+  assert.match(source, /uploaded_latest_count/);
 });


### PR DESCRIPTION
## Production is down — this restores it

Every R2-backed endpoint is 404ing right now (`/subnets`, `/subnets/{netuid}`, `/coverage`, `/providers`, all of `/testnet/*`). Only the live KV-tier endpoints (`/economics`, `/health`) still work.

## Root cause

Two-PR mismatch, not a bad deploy:

- **#8237** content-addressed the history tier: `runs/<run>/<path>` → `by-hash/<sha256>`. After it, **`runs/<run>/<path>` is never written** — an upload produces `latest/<path>` + `by-hash/<sha256>`.
- **`scripts/kv-publish-pointer.ts` still set `latest_prefix: manifest.run_prefix`**, and `workers/storage.ts`'s `latestR2Key()` resolves every read as `` `${latest_prefix}${relativePath}` ``.

So the Worker asked R2 for `runs/2026-07-26T10-59-03-643Z/subnets.json`, which nothing ever wrote.

Publish run `30199241430` shows both halves — a fully successful upload that still failed its own smoke check:

```
"run_prefix": "runs/2026-07-26T10-59-03-643Z/",
"planned_object_count": 5666,
"uploaded_object_count": 5666,
"uploaded_latest_count": 2830,
"skipped_artifact_count": 0
```
`Upload artifact history to R2` ✅ → `Publish KV latest pointer` ✅ → `Smoke live API` ❌

The smoke gate did its job; it just runs after the flip, so it detected the outage rather than preventing it.

**The data is fine** — only the resolution prefix was wrong. Verified live: the two artifact classes whose reads bypass the pointer (`STABLE_LATEST_ARTIFACT_PATTERNS` — `schemas/*`, `health/history/*`) both return 200 right now, proving `latest/` is complete and readable.

## Fix

`latest_prefix: manifest.latest_prefix` — the only complete tree the upload still writes.

## Tradeoff, stated plainly

This gives up something real. The immutable run prefix bought read-atomicity: the pointer flip was the single switch between runs, and a pointer write that failed after upload left readers wholly on the previous run. With `latest/`, objects are overwritten in place and progressively, so a reader during an in-flight publish can see a mix of old and new — a window of minutes at ~2,830 artifacts.

I did not want to bury that in a comment, so it's tracked as **#8277** with three concrete options (resolve via per-artifact `by-hash` keys; server-side copies to keep a run tree; shrink the window). A brief mixed read is strictly better than 404ing every artifact, so this takes the tradeoff now and fixes it properly there.

Closes #8276

## Deploy note

Merging alone does **not** restore service — the KV pointer only changes on the next publish. A `Publish Cloudflare Backend` run is needed after this lands. Note that run currently takes ~1 hour end-to-end because of the 3.5 rps upload gate (#8261).

## Test plan

- [x] `npx vitest run tests/kv-publish-pointer.test.ts tests/storage-read-artifact.test.ts tests/raw-artifact-freshness.test.ts` — 25/25 pass
- [x] Rewrote the pointer test, which previously asserted the exact bug (`assert.match(source, /latest_prefix: manifest\.run_prefix/)`) — it would have passed forever while production 404'd
- [x] Added a second test asserting `r2-upload` still populates the `latest/` tier, since the regression is a mismatch *between* two files and pinning only one side would let it recur
- [x] `prettier --check` + `eslint` clean