### PR TITLE
fix(api): recover on read when the KV pointer prefix holds no objects — API still 404ing after #8278

### DIFF
--- a/tests/r2-pointer-prefix-fallback.test.ts
+++ b/tests/r2-pointer-prefix-fallback.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { readR2 } from "../workers/storage.ts";
+import { mockEnv } from "./row-type.ts";
+
+/**
+ * #8276: the KV pointer's `latest_prefix` named `runs/<runId>/` while #8237 had
+ * moved the history tier to `by-hash/<sha256>`, so the prefix held no objects
+ * and EVERY R2-backed route 404'd at once in production. #8278 fixed the
+ * pointer writer, but a bad pointer already in KV keeps serving 404s until the
+ * next successful publish rewrites it — so the read path recovers on its own.
+ */
+
+const ARTIFACT_PATH = "/metagraph/subnets/74.json";
+const BODY = { schema_version: 1, netuid: 74 };
+
+function r2WithOnlyLatest(seen: string[]) {
+  return async (key: string) => {
+    seen.push(String(key));
+    if (String(key) !== "latest/subnets/74.json") return null;
+    const text = JSON.stringify(BODY);
+    return {
+      async json() {
+        return JSON.parse(text);
+      },
+      async text() {
+        return text;
+      },
+    };
+  };
+}
+
+function envWithPointerPrefix(prefix: string, seen: string[]) {
+  // mockEnv is a bare cast, so every binding the code path reads is supplied
+  // here: the R2 archive plus the KV namespace latestPointer() reads the
+  // metagraph:latest control record from.
+  return mockEnv({
+    METAGRAPH_ARCHIVE: { get: r2WithOnlyLatest(seen) },
+    METAGRAPH_CONTROL: { get: async () => ({ latest_prefix: prefix }) },
+  });
+}
+
+test("a pointer prefix that holds no objects falls back to the latest/ tree", async () => {
+  const seen: string[] = [];
+  const env = envWithPointerPrefix("runs/2026-07-26T10-59-03-643Z/", seen);
+
+  const result = await readR2(env, ARTIFACT_PATH, "r2");
+
+  assert.equal(result.ok, true, "expected the fallback read to succeed");
+  assert.deepEqual(result.data, BODY);
+  // Tried the pointer's prefix first, then the literal latest/ key.
+  assert.deepEqual(seen, [
+    "runs/2026-07-26T10-59-03-643Z/subnets/74.json",
+    "latest/subnets/74.json",
+  ]);
+});
+
+test("a healthy latest/ pointer costs no extra round-trip", async () => {
+  const seen: string[] = [];
+  const env = envWithPointerPrefix("latest/", seen);
+
+  const result = await readR2(env, ARTIFACT_PATH, "r2");
+
+  assert.equal(result.ok, true);
+  // Exactly one read: the fallback key equals the primary key, so it is skipped.
+  assert.deepEqual(seen, ["latest/subnets/74.json"]);
+});
+
+test("a genuinely missing artifact still 404s rather than falling back forever", async () => {
+  const seen: string[] = [];
+  const env = mockEnv({
+    METAGRAPH_ARCHIVE: {
+      get: async (key: string) => {
+        seen.push(String(key));
+        return null;
+      },
+    },
+    METAGRAPH_CONTROL: {
+      get: async () => ({ latest_prefix: "runs/whatever/" }),
+    },
+  });
+
+  const result = await readR2(env, ARTIFACT_PATH, "r2");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 404);
+  assert.equal(result.code, "artifact_not_found");
+  // Both keys attempted, then a real 404 — never an infinite retry.
+  assert.equal(seen.length, 2);
+});

--- a/workers/storage.ts
+++ b/workers/storage.ts
@@ -218,6 +218,44 @@ export async function readR2Object(
     };
   }
   if (!object) {
+    // #8276 follow-up: #8278 stopped the pointer WRITER from naming a prefix
+    // nothing writes, but a bad pointer already in KV keeps 404ing every
+    // artifact until the next publish rewrites it -- and a publish is ~50
+    // minutes that can itself fail. A pointer prefix that holds no objects
+    // takes the whole R2-backed API down at once (/api/v1/subnets, /coverage,
+    // every per-subnet artifact), so recover on read instead of waiting:
+    // retry once at the literal latest/ tree, which r2-upload populates for
+    // every artifact on every run.
+    //
+    // Deliberately narrow: only when the pointer sent us somewhere OTHER than
+    // latest/ (so the normal path costs nothing), and it warns rather than
+    // healing silently -- a permanent fallback means the pointer is still
+    // wrong and should be fixed, not tolerated.
+    const fallbackKey = `latest/${artifactPath.replace(/^\/metagraph\//, "")}`;
+    if (fallbackKey !== key) {
+      let fallbackObject;
+      try {
+        fallbackObject = await withTimeout(
+          env.METAGRAPH_ARCHIVE.get(fallbackKey),
+          r2TimeoutMs(env),
+        );
+      } catch {
+        fallbackObject = null;
+      }
+      if (fallbackObject) {
+        logEvent(env, "warn", "r2_pointer_prefix_miss", {
+          key,
+          fallback_key: fallbackKey,
+          storage_tier: storageTier,
+        });
+        return {
+          ok: true,
+          object: fallbackObject,
+          source: "r2",
+          storage_tier: storageTier,
+        };
+      }
+    }
     return {
       ok: false,
       status: 404,


### PR DESCRIPTION
Rebuilt on current main and **reduced to the one thing #8278 did not cover.** Conflicts resolved; now 2 files.

## Production is still down after #8278

#8278 correctly fixed the pointer **writer**, and its diagnosis matches mine exactly. But the bad pointer is **already in KV**, and nothing rewrites it until the next successful publish — ~50 minutes, which can itself fail. Probed live after #8278 landed on main:

```
/api/v1/subnets     -> 404
/api/v1/coverage    -> 404
/api/v1/subnets/74  -> 404
```

So this PR is the read-side half: **it recovers service on deploy instead of waiting for a publish.**

## What this does

When the pointer's key misses, retry once at the literal `latest/` key — the tree `r2-upload` populates for every artifact on every run (`uploaded_latest_count` covered all 2,830 in the failing publish, so the data was never lost).

Deliberately narrow:

- **Only** when the pointer sent us somewhere other than `latest/`, so the healthy path pays no extra round-trip (asserted).
- **Warns** (`r2_pointer_prefix_miss`) rather than healing silently — a persistent fallback means the pointer is still wrong and should be fixed, not tolerated.
- A genuinely missing artifact still 404s after both attempts; no retry loop (asserted).

## Dropped from the earlier version of this PR

- The pointer-writer change — **#8278 owns it.** I dropped my competing `LATEST_R2_PREFIX` constant in favour of main's `manifest.latest_prefix`, which is the better single source (the manifest already carries it).
- My behavioural manifest test — #8278 shipped equivalent two-sided source coverage.

## Tests

`tests/r2-pointer-prefix-fallback.test.ts`, 3 cases: the fallback fires for the **exact** bad prefix from the `2026-07-26T10-59-03-643Z` publish and returns the artifact; a healthy `latest/` pointer issues exactly one read; a truly absent artifact still 404s after two attempts. 5/5 green with #8278's tests; tsc/eslint/prettier clean.

## Note for after this deploys

The fallback restores service but leaves the stale pointer in place, logging a warning on every artifact read. The next successful publish (now with #8278's writer fix) will clean it up. Worth a follow-up: alert on `r2_pointer_prefix_miss` so a silent permanent fallback can't become the new normal, and gate the pointer flip on a post-upload readback.