### PR TITLE
fix(api): resolve the incidents feed through the Postgres tier, not the empty ledger stub

### DIFF
--- a/tests/global-incidents-feed-source.test.ts
+++ b/tests/global-incidents-feed-source.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+
+/**
+ * #8242: /api/v1/feeds/incidents reported "no incidents" while /status showed
+ * dozens ongoing from the same underlying data.
+ *
+ * Cause was not the feed builder — it was the source. `loadGlobalIncidentsLedger`
+ * is a schema-stable EMPTY stub (it hardcodes `incidentRows: []`) meant only as
+ * the Postgres-tier-miss fallback. `handleGlobalIncidents` and the GraphQL
+ * resolver both try the tier first; the feed injection called the stub directly,
+ * so it was empty by construction on every request.
+ *
+ * These are source assertions rather than a live-tier test because the empty
+ * stub is exactly what a test env resolves to — a behavioural test would pass
+ * against the bug. What matters is that no caller reaches the stub without
+ * going through the tier first.
+ */
+test("the incidents feed resolves through the Postgres tier, not the empty ledger stub", () => {
+  const api = readFileSync("workers/api.ts", "utf8");
+
+  // The feed injection must use the shared resolver...
+  assert.match(api, /loadLiveIncidents:[\s\S]{0,200}?resolveGlobalIncidents\(/);
+  // ...and must not reach the stub directly.
+  assert.doesNotMatch(
+    api,
+    /loadLiveIncidents:[\s\S]{0,200}?loadGlobalIncidentsLedger\(/,
+  );
+});
+
+test("every global-incident caller tries the tier before the stub", () => {
+  const analytics = readFileSync(
+    "workers/request-handlers/analytics.ts",
+    "utf8",
+  );
+  const graphql = readFileSync("src/graphql.ts", "utf8");
+
+  // The shared resolver exists and is tier-first.
+  assert.match(analytics, /export async function resolveGlobalIncidents/);
+  assert.match(
+    analytics,
+    /resolveGlobalIncidents[\s\S]{0,400}?tryPostgresTier[\s\S]{0,300}?loadGlobalIncidentsLedger/,
+  );
+  // The REST route goes through it.
+  assert.match(
+    analytics,
+    /handleGlobalIncidents[\s\S]{0,900}?resolveGlobalIncidents\(/,
+  );
+  // GraphQL keeps its own tier-first chain (tryPostgresTier ?? stub).
+  assert.match(
+    graphql,
+    /tryPostgresTier\([\s\S]{0,300}?METAGRAPH_HEALTH_SOURCE[\s\S]{0,200}?\?\?[\s\S]{0,120}?loadGlobalIncidentsLedger/,
+  );
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -87,7 +87,7 @@ import {
   handleChainStakeMoves,
   handleChainStakeTransfers,
   handleGlobalIncidents,
-  loadGlobalIncidentsLedger,
+  resolveGlobalIncidents,
   handleHealthIncidents,
   handleHealthPercentiles,
   handleHealthTrends,
@@ -1873,8 +1873,13 @@ export async function handleRequest(
         handleFeedRequest(feedRequest, env, url, {
           readArtifact,
           errorResponse,
+          // Must go through resolveGlobalIncidents, not the ledger stub
+          // directly: the stub hardcodes an empty incident list and is only
+          // meant as the Postgres-tier-miss fallback, so calling it here made
+          // this feed permanently report "no incidents" while /status showed
+          // dozens from the same data (#8242).
           loadLiveIncidents: async (feedEnv) => {
-            const { data } = await loadGlobalIncidentsLedger(feedEnv);
+            const { data } = await resolveGlobalIncidents(feedRequest, feedEnv);
             return data;
           },
         }),

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -719,6 +719,35 @@ export async function loadGlobalIncidentsLedger(
   return { data, incidentRows: [] };
 }
 
+/**
+ * Resolve the global incident ledger the way every caller must: Postgres tier
+ * first, the schema-stable empty stub above only on a miss.
+ *
+ * The stub is NOT a data source — it hardcodes `incidentRows: []`. Calling
+ * loadGlobalIncidentsLedger directly therefore always yields zero incidents,
+ * which is exactly what /api/v1/feeds/incidents did: it bypassed the Postgres
+ * tier, so the feed reported "no incidents" while /status, reading through the
+ * route below, showed dozens ongoing from the same underlying data (#8242).
+ * One resolver, used by both, so those two can't disagree again.
+ */
+export async function resolveGlobalIncidents(
+  request: Request,
+  env: Env,
+  { label = "7d" }: { label?: string } = {},
+): Promise<{ data: Record<string, unknown>; isFallback: boolean }> {
+  const tiered = (await tryPostgresTier(
+    env,
+    request,
+    "METAGRAPH_HEALTH_SOURCE",
+  )) as Record<string, unknown> | null;
+  if (tiered) return { data: tiered, isFallback: false };
+  const result = await loadGlobalIncidentsLedger(env, { label });
+  return {
+    data: result.data as unknown as Record<string, unknown>,
+    isFallback: true,
+  };
+}
+
 // The list-query params GET /api/v1/incidents accepts on top of its own `window`
 // scope (#6571): limit/cursor/sort/order + the netuid filter, so a caller can page
 // a 30-day incident list the way the sibling endpoint-incidents route already can.
@@ -735,13 +764,9 @@ export async function handleGlobalIncidents(
   }
   const { label } = windowResult;
   // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE.
-  let isFallback = false;
-  let data = await tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE");
-  if (!data) {
-    isFallback = true;
-    const result = await loadGlobalIncidentsLedger(env, { label });
-    data = result.data;
-  }
+  const { data, isFallback } = await resolveGlobalIncidents(request, env, {
+    label,
+  });
   // Page/sort/filter the window-scoped `surfaces` ledger through the shared
   // list-query engine (#6571). `window` is this route's own scope param, already
   // validated above, so it is stripped before the engine — which only knows the


### PR DESCRIPTION
Refs #8242 (Phase 0 of epic #8238) — the third and last item of that issue.

## The contradiction

/status showed **"ACTIVE NOW · 53 ongoing"** directly above a subscribe panel reading **"No incidents in feed"**. Live before this fix:

```
/api/v1/feeds/incidents.json  -> items: 0
/metagraph/endpoint-incidents.json -> incidents: 119   (summary.active_count: 119)
```

## I initially got this wrong

I first attributed it to the stalled publish / incomplete-run pointer (commented on #8242 to that effect). That was wrong. The artifact tier is healthy again and the feed was **still** empty — so I kept digging.

## Actual cause

The feed builder is fine. The **source** was wrong.

`loadGlobalIncidentsLedger` is a schema-stable **empty stub** — it hardcodes `incidentRows: []`, and its own comment says it exists only for the Postgres-tier-miss path:

> *"D1 fully eliminated (2026-07-17): surface_checks is Postgres-only now (every caller tries the Postgres tier first) — this is only reached on a tier miss, so it always returns the schema-stable empty payload."*

`handleGlobalIncidents` honours that (`tryPostgresTier` → stub). The GraphQL resolver honours it (`tryPostgresTier(...) ?? stub`). But the **feed injection in `workers/api.ts` called the stub directly**:

```ts
loadLiveIncidents: async (feedEnv) => {
  const { data } = await loadGlobalIncidentsLedger(feedEnv);   // ← always empty
  return data;
},
```

So the incidents feed has been empty **by construction, on every request, in every environment** — not stale, not cold-tier, just never reading the real source. RSS/Atom/JSON subscribers have been getting an empty feed the whole time.

## Fix

Extract `resolveGlobalIncidents(request, env, { label })` — tier first, stub only on a miss — and use it from **both** `handleGlobalIncidents` and the feed injection. That is the "one derivation for ongoing incidents" #8242 asked for: the two surfaces can no longer disagree about the same window. `isFallback` bookkeeping preserved; GraphQL untouched (already correct).

## Tests

`tests/global-incidents-feed-source.test.ts`: the feed reaches the resolver and never the stub; the resolver is tier-first; GraphQL keeps its own chain.

Deliberately **source-level** assertions, and worth being explicit about why: a test environment resolves to the empty stub anyway, so a behavioural "feed has items" test would have passed against the bug. The invariant that actually matters is *no caller reaches the stub without trying the tier first*, which is what these assert. (Same lesson as the pointer outage, where a source-shape test stayed green through a total outage — the difference is choosing the assertion that can fail.)

## Verification after deploy

`/api/v1/feeds/incidents.json` should report a non-zero `items` count matching /status's ongoing figure for the same window.