### PR TITLE
fix(ui): stop the trailing controls starving the profile tab strip on mobile

### DIFF
--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -67,8 +67,18 @@ export function ProfileTabs({
       className="sticky z-[var(--mg-z-sticky)] -mx-4 md:mx-0 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
       style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
     >
-      <div className="flex items-stretch gap-3 px-4 md:px-0">
-        <ScrollShadow className="min-w-0 flex-1" innerClassName="scroll-smooth">
+      {/*
+        The trailing controls are shrink-0, so on a narrow viewport they took
+        whatever width they needed and left the tab strip with the remainder:
+        measured 196px of a 390px viewport on /subnets/74, i.e. 2 of 14 tabs
+        reachable without scrolling (#8254). Horizontal scrolling, the
+        ScrollShadow edge fades and the scroll-active-tab-into-view effect were
+        all working the whole time -- the strip was simply being starved of
+        width. Stack the two rows on mobile so the tabs get the full viewport,
+        and keep the single-row layout from md up where both fit comfortably.
+      */}
+      <div className="flex flex-col gap-1 px-4 md:flex-row md:items-stretch md:gap-3 md:px-0">
+        <ScrollShadow className="min-w-0 md:flex-1" innerClassName="scroll-smooth">
           <ul
             ref={listRef}
             role="tablist"


### PR DESCRIPTION
Refs #8254 (Phase 3 of epic #8238). First concrete mobile fix from that issue.

## Measured, not eyeballed

On `/subnets/74` at a 390px viewport, via DOM measurement:

| | |
|---|---|
| Tabs | **14** |
| Scroller `clientWidth` | **196px** (of 390) |
| `scrollWidth` | 1324px |
| Tabs reachable without scrolling | **2** |

## The overflow machinery was never broken

This is the part worth flagging, because the audit — mine — guessed wrong. `ProfileTabs` already had everything you'd add if you assumed "no overflow affordance":

- `overflow-x: auto` (via `ScrollShadow`) ✅
- edge-fade shadows that appear only when scrollable in that direction ✅
- `scrollIntoView({ inline: "center" })` on the active tab ✅
- `whitespace-nowrap` per tab, roving tabindex, full WAI-ARIA tablist ✅

All of it works. **The strip was simply being starved of width.**

`ProfileTabs` lays the `ScrollShadow` and the `trailing` slot out in one flex row, and `trailing` is `shrink-0`. On a narrow viewport it takes whatever it needs — on subnet detail that's the 7d/30d/90d window toggle plus the Compare button, ~180px — and `flex-1` hands the tabs the remainder. 196px for 14 tabs.

## Fix

Stack the two on mobile so the tabs get the full viewport width; keep the single row from `md` up, where both fit comfortably. Expected result at 390px: ~358px of usable strip (~4 tabs visible instead of 2) with scrolling doing the rest, and the active tab still auto-centred.

Only `/subnets/:netuid` passes `trailing` today, so that's the page this fixes; the component change protects every future consumer.

## Note on method

I found this by measuring the DOM, not by looking at a screenshot — in a capture the tabs read as "plausibly just cut off," which is exactly what hid the real cause. Same lesson as the "/status orphaned dots" finding earlier in this epic, which turned out to be a full-page-screenshot artifact rather than a defect. Screenshots are for judging whether something looks right; measurements are for finding out why it doesn't.

## Verification

tsc/eslint/prettier clean, no new warnings. Trade-off worth naming: on mobile the sticky header is now two rows instead of one, costing a little vertical space — unavoidable if both the tabs and the controls stay reachable, and clearly the right side of that trade when 12 of 14 tabs were effectively unreachable. Before/after at 390/768/1440 goes on the PR from a preview deploy for the manual-review gate.