### PR TITLE
fix(ui): stop testnet panels hanging forever on a hydration-mismatch bailout

### DIFF
--- a/apps/ui/src/hooks/use-api-base.ts
+++ b/apps/ui/src/hooks/use-api-base.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useHydrated } from "@/hooks/use-hydrated";
 import {
   getApiBase,
   setApiBase,
@@ -55,6 +56,7 @@ export function useApiBase() {
 export function useNetwork() {
   const [network, setNet] = useState<ChainNetwork>(() => getNetwork());
   const qc = useQueryClient();
+  const hydrated = useHydrated();
 
   useEffect(() => onNetworkChange((next) => setNet(next)), []);
 
@@ -63,5 +65,28 @@ export function useNetwork() {
     qc.invalidateQueries(metagraphedQueryInvalidationTarget());
   };
 
-  return { network, change, isDefault: isDefaultChainNetwork(network) };
+  // #8283: render the SSR-side default until hydration finishes, then switch to
+  // the real network. getNetwork() resolves the hostname/localStorage
+  // immediately on the client, so without this the first client render emits
+  // "Testnet" against server HTML that says "Mainnet" -- and that mismatch is
+  // not cosmetic. React responds by discarding the server tree ("this tree will
+  // be regenerated on the client"), which strands every in-flight Suspense
+  // boundary on the page: on testnet.metagraph.sh the nine SubnetsHighlights /
+  // SubnetsStatStrip panels sat on "Loading panel…" forever, never resolving to
+  // content OR to NativeOnlyNotice. Proven by bisection -- a client-side
+  // navigation to the same route (no hydration pass) settles all nine
+  // correctly, a fresh load hangs indefinitely.
+  //
+  // Deliberately scoped to the RENDERED value only. Data fetching reads
+  // getNetwork() directly through applyNetworkPrefix, so queries still target
+  // the right network from the very first request; this only defers what the
+  // two display-only consumers (the switcher label, the RPC-proxy hero) paint
+  // during the single hydration render.
+  const rendered = hydrated ? network : DEFAULT_NETWORK;
+
+  return {
+    network: rendered,
+    change,
+    isDefault: isDefaultChainNetwork(rendered),
+  };
 }


### PR DESCRIPTION
## Summary

On `testnet.metagraph.sh/subnets`, the nine panels above the table (4 × `SubnetsHighlights`, 5 × `SubnetsStatStrip`) sat on `Loading panel…` **indefinitely** — never content, never `NativeOnlyNotice`, never an error. The table below rendered all 540 subnets correctly, so the page looked half-broken with no explanation.

## Root cause: the hydration mismatch is not cosmetic

I had previously written the SSR/client network disagreement off as a pre-existing warning (noted in #8229/#8265). That was wrong about its impact.

`useNetwork()` seeded state from `getNetwork()`, which resolves hostname/localStorage immediately on the client — so the first client render emitted `Testnet` against server HTML that said `Mainnet`. React's own message says what happens next:

> Hydration failed because the server rendered text didn't match the client. **As a result this tree will be regenerated on the client.**

Discarding and regenerating the tree strands every Suspense boundary that was in flight during that pass. The panels' queries had already fired and 404'd in ~121 ms; the boundaries simply never settled in either direction.

### Proven by bisection, not inference

| Path | Result |
|---|---|
| Fresh load (SSR + hydration) | `loading: 9, notice: 0` — still 9 after 15 s |
| Client-side nav to the same route (no hydration pass) | `loading: 0, notice: 2` |

Same route, same failing queries, same network. The only difference is whether a hydration pass happened.

Also ruled out along the way: not the earlier outage (reproduced with production healthy), not a slow backend (both endpoints 404 in 121 ms), not a missing fetch (`performance.getEntriesByType` confirms all four requests fire), not SSR output (server HTML contains zero `Loading panel`), and not mainnet (panels populate normally there).

## Fix

Return the SSR-side default from `useNetwork()` until hydration completes, using the codebase's existing `useHydrated` hook — the same pattern already used elsewhere for exactly this class of problem.

Deliberately scoped to the **rendered** value only. Data fetching reads `getNetwork()` directly through `applyNetworkPrefix`, so queries still target the correct network from the very first request. This defers only what the two display-only consumers paint during the single hydration render — the switcher label (`network-switcher.tsx`) and the RPC-proxy hero (`rpc-proxy.tsx`). Neither drives a fetch; I checked both call sites.

Closes #8283

## Verification

Against the exact reproduction, fresh load with SSR + hydration:

| | before | after |
|---|---|---|
| stuck panels | 9 (forever) | **0** |
| `NativeOnlyNotice` | 0 | **2** |
| table rows | 540 ✅ | 540 ✅ |

Resolves at `t=0s`, not after a delay. Mainnet re-verified unaffected: panels populate, 0 notices, switcher reads `Network: Mainnet`.

## Test plan

- [x] `npx vitest run` in `apps/ui` — **1484/1484** pass across 192 files
- [x] Live browser verification on both networks, before and after
- [x] `npx eslint .` — 0 errors; `prettier --check` clean under both the apps/ui and root configs