### PR TITLE
ops(publish): gate the KV pointer flip on a post-upload readback — so this outage class can't recur

### DIFF
--- a/scripts/kv-publish-pointer.ts
+++ b/scripts/kv-publish-pointer.ts
@@ -7,11 +7,17 @@ import {
   repoRoot,
   stableStringify,
 } from "./lib.ts";
+import { r2ObjectExists, requireCloudflareCredentials } from "./r2-rest.ts";
 
 type Row = Record<string, unknown>;
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
+// Readback sample size for assertPointerPrefixServes below. Small on purpose:
+// this is a pre-flight sanity check on the prefix, not a full-tree audit, and
+// it spends the same Cloudflare API budget the upload just spent (#8261).
+const SAMPLE_MAX = 12;
+const SAMPLE_SPREAD = 8;
 const manifest: Row = await readJson(
   path.join(repoRoot, "public/metagraph/r2-manifest.json"),
 );
@@ -91,6 +97,8 @@ if (process.env.METAGRAPH_ALLOW_KV_WRITE !== "1") {
   process.exit(1);
 }
 
+await assertPointerPrefixServes();
+
 for (const [key, value] of kvEntries) {
   putKv(key, value);
 }
@@ -127,4 +135,98 @@ function putKv(key: string, value: unknown): void {
     console.error(result.stderr);
     process.exit(result.status || 1);
   }
+}
+
+/**
+ * Refuse to flip the pointer unless the prefix it names actually serves.
+ *
+ * The pointer flip is the single most dangerous write in the publish:
+ * workers/storage.ts's latestR2Key builds EVERY live artifact key as
+ * `${latest_prefix}${relativePath}`, so a prefix that does not serve takes the
+ * entire R2-backed API down in one KV write -- /api/v1/subnets, /coverage and
+ * every per-subnet artifact at once. That is exactly what happened on
+ * 2026-07-26 (#8276): #8237 moved the history tier to by-hash/<sha256>, nothing
+ * was written under runs/<runId>/ any more, the pointer still named it, and the
+ * upload reported a clean 5,666/5,666 objects on the way out.
+ *
+ * The publish's own live smoke step DID catch that -- but it runs after
+ * kv:publish, so it reported an outage that was already serving. This check is
+ * the same question asked in the other order: read back through the exact key
+ * the Worker will build, BEFORE claiming the prefix.
+ *
+ * Fails closed on a definite miss (non-zero exit, pointer unchanged, previous
+ * working pointer still live). Does NOT fail on an indeterminate read -- a
+ * flaky network must not block a publish whose data is fine.
+ */
+async function assertPointerPrefixServes(): Promise<void> {
+  const prefix = String(pointer.latest_prefix || "");
+  const bucketName = String(manifest.bucket_name || "");
+  if (!prefix || !bucketName) {
+    console.error(
+      `Refusing to publish: pointer latest_prefix (${prefix || "empty"}) or manifest bucket_name (${bucketName || "empty"}) is missing.`,
+    );
+    process.exit(1);
+  }
+
+  const artifacts = (manifest.artifacts as Row[]) || [];
+  const relativeOf = (a: Row): string =>
+    String(a.path || "").replace(/^\/metagraph\//, "");
+
+  // Sample the artifacts whose loss is TOTAL, not just any artifact: these are
+  // the exact shapes that 404'd on 2026-07-26. A per-subnet detail is included
+  // because it exercises a nested path, which a flat-only sample would miss.
+  const critical = ["subnets.json", "coverage.json"];
+  const chosen = new Map<string, string>();
+  for (const name of critical) {
+    const hit = artifacts.find((a) => relativeOf(a) === name);
+    if (hit) chosen.set(name, name);
+  }
+  const nested = artifacts.find((a) =>
+    /^subnets\/\d+\.json$/.test(relativeOf(a)),
+  );
+  if (nested) chosen.set(relativeOf(nested), relativeOf(nested));
+
+  // Plus a small deterministic spread across the manifest, to catch a
+  // partially-populated tree rather than an entirely absent one.
+  const step = Math.max(1, Math.floor(artifacts.length / SAMPLE_SPREAD));
+  for (let i = 0; i < artifacts.length && chosen.size < SAMPLE_MAX; i += step) {
+    const rel = relativeOf(artifacts[i]!);
+    if (rel) chosen.set(rel, rel);
+  }
+
+  if (chosen.size === 0) {
+    console.error(
+      "Refusing to publish: no artifacts available to verify the pointer prefix against.",
+    );
+    process.exit(1);
+  }
+
+  const { accountId, apiToken } = requireCloudflareCredentials();
+  const missing: string[] = [];
+  let indeterminate = 0;
+  for (const relative of chosen.keys()) {
+    const key = `${prefix}${relative}`;
+    const result = await r2ObjectExists(accountId, bucketName, key, apiToken);
+    if (result.exists) continue;
+    if (result.determinate) missing.push(key);
+    else indeterminate += 1;
+  }
+
+  if (missing.length > 0) {
+    console.error(
+      `Refusing to publish the KV pointer: latest_prefix "${prefix}" does not serve ` +
+        `${missing.length} of ${chosen.size} sampled artifact(s) in bucket "${bucketName}".\n` +
+        `The Worker builds every live key as \`${prefix}<path>\`, so flipping the pointer ` +
+        `would 404 the entire R2-backed API. Missing key(s):\n` +
+        missing.map((k) => `  - ${k}`).join("\n"),
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Pointer prefix "${prefix}" verified against ${chosen.size} sampled artifact(s)` +
+      (indeterminate > 0
+        ? ` (${indeterminate} read(s) indeterminate — not treated as failure).`
+        : "."),
+  );
 }

--- a/scripts/r2-rest.ts
+++ b/scripts/r2-rest.ts
@@ -1,0 +1,82 @@
+// Shared Cloudflare R2 REST access used by the publish scripts.
+//
+// Extracted so the uploader (scripts/r2-upload.ts) and the pointer readback
+// gate (scripts/kv-publish-pointer.ts) build object URLs and read credentials
+// exactly one way. A second, subtly different copy is how the 2026-07-26
+// outage class starts: the uploader wrote one key shape while the pointer
+// claimed another, and nothing compared them.
+//
+// Pure module — no top-level execution, so it is safe to import from any
+// script (r2-upload.ts itself runs on import and cannot be imported).
+
+export const R2_API_BASE_URL_DEFAULT = "https://api.cloudflare.com/client/v4";
+
+/**
+ * Test-only seam: lets tests point at a local mock HTTP server instead of the
+ * real Cloudflare API. Never set in production.
+ */
+export function r2ApiBaseUrl(): string {
+  return process.env.METAGRAPH_R2_API_BASE_URL || R2_API_BASE_URL_DEFAULT;
+}
+
+export function requireCloudflareCredentials(): {
+  accountId: string;
+  apiToken: string;
+} {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  if (!accountId || !apiToken) {
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required for R2 access.",
+    );
+  }
+  return { accountId, apiToken };
+}
+
+/**
+ * R2 keys are hierarchical ("latest/subnets.json", "by-hash/<sha256>"): encode
+ * each path segment individually so the literal `/` separators survive while
+ * any segment containing reserved characters is still safely escaped.
+ */
+export function encodeR2Key(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+export function r2ObjectUrl(
+  accountId: string,
+  bucketName: string,
+  key: string,
+): string {
+  return `${r2ApiBaseUrl()}/accounts/${accountId}/r2/buckets/${bucketName}/objects/${encodeR2Key(key)}`;
+}
+
+/**
+ * Does this exact key exist in the bucket? A HEAD, so no body is transferred.
+ *
+ * Distinguishes "definitely absent" (a clean 404) from "could not tell" (any
+ * network/timeout/non-404 failure) rather than collapsing both to false: the
+ * readback gate must not fail a publish because R2 was briefly unreachable,
+ * and must not pass one because it never got an answer.
+ */
+export async function r2ObjectExists(
+  accountId: string,
+  bucketName: string,
+  key: string,
+  apiToken: string,
+  timeoutMs = 15_000,
+): Promise<{ exists: boolean; determinate: boolean; status?: number }> {
+  try {
+    const res = await fetch(r2ObjectUrl(accountId, bucketName, key), {
+      method: "HEAD",
+      headers: { Authorization: `Bearer ${apiToken}` },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.ok) return { exists: true, determinate: true, status: res.status };
+    if (res.status === 404) {
+      return { exists: false, determinate: true, status: 404 };
+    }
+    return { exists: false, determinate: false, status: res.status };
+  } catch {
+    return { exists: false, determinate: false };
+  }
+}

--- a/scripts/r2-upload.ts
+++ b/scripts/r2-upload.ts
@@ -5,6 +5,12 @@ import {
   R2_STAGING_RELATIVE_ROOT,
   artifactStorageTierForPath,
 } from "../src/artifact-storage.ts";
+import {
+  R2_API_BASE_URL_DEFAULT,
+  r2ApiBaseUrl,
+  r2ObjectUrl,
+  requireCloudflareCredentials,
+} from "./r2-rest.ts";
 
 type Row = Record<string, unknown>;
 
@@ -69,12 +75,10 @@ const uploadRetryBaseDelayMs =
 const uploadTimeoutMs =
   parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_TIMEOUT_MS) || 45_000;
 
-const R2_API_BASE_URL_DEFAULT = "https://api.cloudflare.com/client/v4";
 // Test-only seam (mirrors the old METAGRAPH_WRANGLER_BIN override this
 // replaced): lets tests/r2-upload.test.ts point at a local mock HTTP server
 // instead of the real Cloudflare API. Never set in production.
-const r2ApiBaseUrl =
-  process.env.METAGRAPH_R2_API_BASE_URL || R2_API_BASE_URL_DEFAULT;
+const r2ApiBaseUrlValue = r2ApiBaseUrl();
 // #stale-publish-pipeline/D: replacing the per-object wrangler subprocess with
 // direct API fetches (#8209) removed the CLI overhead and exposed the next
 // ceiling — Cloudflare's client-API rate limit (documented ~1,200 requests /
@@ -96,7 +100,7 @@ const r2ApiBaseUrl =
 // still wins either way, so a staging/proxy base URL can opt back in.
 const uploadMaxRps =
   parsePositiveNumber(process.env.METAGRAPH_R2_UPLOAD_MAX_RPS) ||
-  (r2ApiBaseUrl === R2_API_BASE_URL_DEFAULT ? 3.5 : Infinity);
+  (r2ApiBaseUrlValue === R2_API_BASE_URL_DEFAULT ? 3.5 : Infinity);
 const uploadRateLimitRetries =
   parseNonNegativeInteger(process.env.METAGRAPH_R2_UPLOAD_429_RETRIES) ?? 6;
 const uploadRateLimitBaseDelayMs =
@@ -553,35 +557,6 @@ async function putObject(
 // `wrangler r2 object put/get --remote` against this bucket confirms the
 // endpoint shape and bucket name; this fetch call targets the identical
 // REST resource, just from this process instead of a spawned CLI.
-function requireCloudflareCredentials(): {
-  accountId: string;
-  apiToken: string;
-} {
-  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
-  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
-  if (!accountId || !apiToken) {
-    throw new Error(
-      "CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required for R2 access.",
-    );
-  }
-  return { accountId, apiToken };
-}
-
-// R2 keys are hierarchical ("latest/subnets.json", "runs/<id>/..."): encode
-// each path segment individually so the literal `/` separators survive while
-// any segment containing reserved characters is still safely escaped.
-function encodeR2Key(key: string): string {
-  return key.split("/").map(encodeURIComponent).join("/");
-}
-
-function r2ObjectUrl(
-  accountId: string,
-  bucketName: string,
-  key: string,
-): string {
-  return `${r2ApiBaseUrl}/accounts/${accountId}/r2/buckets/${bucketName}/objects/${encodeR2Key(key)}`;
-}
-
 async function putObjectOnce({
   localPath,
   key,

--- a/tests/kv-pointer-readback-gate.test.ts
+++ b/tests/kv-pointer-readback-gate.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { promisify } from "node:util";
+import { readFileSync } from "node:fs";
+import { afterEach, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+let server: http.Server | undefined;
+
+afterEach(async () => {
+  if (!server) return;
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  server = undefined;
+});
+
+/**
+ * #8282: the pointer flip is the one write that can 404 the entire R2-backed
+ * API at once, because workers/storage.ts builds every live key as
+ * `${latest_prefix}${relativePath}`. On 2026-07-26 it named a prefix nothing
+ * was written under and did it anyway. This gate reads back through the exact
+ * key the Worker will build, BEFORE the KV write.
+ */
+
+/** Mock R2 REST API: HEAD returns 200 for `served`, 404 otherwise. */
+function mockR2(served: (key: string) => boolean, seen: string[]) {
+  return http.createServer((req, res) => {
+    const marker = "/objects/";
+    const at = req.url?.indexOf(marker) ?? -1;
+    if (at === -1) {
+      res.writeHead(404).end();
+      return;
+    }
+    const key = decodeURIComponent(req.url!.slice(at + marker.length));
+    seen.push(key);
+    res.writeHead(served(key) ? 200 : 404).end();
+  });
+}
+
+async function runPointer(
+  port: number | null,
+  extraEnv: Record<string, string> = {},
+) {
+  return execFileAsync(
+    process.execPath,
+    ["scripts/kv-publish-pointer.ts", ...(extraEnv.DRY_RUN ? [] : ["--write"])],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLOUDFLARE_ACCOUNT_ID: "test-account",
+        CLOUDFLARE_API_TOKEN: "test-token",
+        METAGRAPH_KV_NAMESPACE_ID: "test-namespace",
+        METAGRAPH_ALLOW_KV_WRITE: "1",
+        // Point wrangler at a bin that cannot exist, so a test that reaches the
+        // KV write fails loudly instead of touching a real namespace.
+        PATH: "/nonexistent",
+        ...(port
+          ? { METAGRAPH_R2_API_BASE_URL: `http://127.0.0.1:${port}` }
+          : {}),
+        ...extraEnv,
+      },
+    },
+  );
+}
+
+test("refuses to flip the pointer when the prefix serves nothing", async () => {
+  const seen: string[] = [];
+  server = mockR2(() => false, seen);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  await assert.rejects(runPointer(port), (err: Error & { stderr?: string }) => {
+    const stderr = String(err.stderr ?? err.message);
+    assert.match(stderr, /Refusing to publish the KV pointer/);
+    // Names the offending key and the prefix it was built from, so the
+    // mismatch is obvious without re-deriving it.
+    assert.match(stderr, /latest_prefix "latest\/"/);
+    assert.match(stderr, /- latest\//);
+    return true;
+  });
+  assert.ok(seen.length > 0, "expected the gate to read back from R2");
+});
+
+test("passes and proceeds when the prefix serves every sampled artifact", async () => {
+  const seen: string[] = [];
+  server = mockR2(() => true, seen);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  // The gate passes, so execution continues to the KV write — which fails
+  // because PATH has no wrangler. That is the assertion: we got PAST the gate.
+  await assert.rejects(runPointer(port), (err: Error & { stdout?: string }) => {
+    assert.match(
+      String(err.stdout ?? ""),
+      /Pointer prefix "latest\/" verified/,
+    );
+    return true;
+  });
+  assert.ok(seen.every((k) => k.startsWith("latest/")));
+  // Every read went through the Worker's own key shape, not the run prefix.
+  assert.ok(!seen.some((k) => k.startsWith("runs/")));
+});
+
+test("refuses on a partially-populated tree, not just an empty one", async () => {
+  // Derived from the manifest the script actually reads (the committed one,
+  // which the publish regenerates before kv:publish) rather than hardcoded, so
+  // this stays meaningful as the artifact set changes.
+  const manifest = JSON.parse(
+    readFileSync("public/metagraph/r2-manifest.json", "utf8"),
+  ) as { artifacts: Array<{ path: string }> };
+  const victim = manifest.artifacts[0]!.path.replace(/^\/metagraph\//, "");
+  const victimKey = `latest/${victim}`;
+
+  const seen: string[] = [];
+  // Everything serves EXCEPT one artifact — a tree that is present but
+  // incomplete, which is strictly harder to catch than an empty prefix.
+  server = mockR2((key) => key !== victimKey, seen);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  await assert.rejects(runPointer(port), (err: Error & { stderr?: string }) => {
+    const stderr = String(err.stderr ?? err.message);
+    assert.match(stderr, /Refusing to publish the KV pointer/);
+    assert.ok(
+      stderr.includes(victimKey),
+      `expected the offending key ${victimKey} in: ${stderr}`,
+    );
+    return true;
+  });
+  assert.ok(seen.includes(victimKey), "the gate must have sampled the victim");
+});
+
+test("dry-run performs no R2 reads at all", async () => {
+  const seen: string[] = [];
+  server = mockR2(() => true, seen);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  const { stdout } = await runPointer(port, { DRY_RUN: "1" });
+  assert.match(stdout, /"mode": "dry-run"/);
+  assert.deepEqual(seen, [], "dry-run must not touch the network");
+});


### PR DESCRIPTION
Closes #8282 (Phase 0 of epic #8238). One PR, one issue.

## The problem this closes for good

The pointer flip is the single most dangerous write in the publish. `workers/storage.ts`'s `latestR2Key` builds **every** live artifact key as `${latest_prefix}${relativePath}`, so a `latest_prefix` that doesn't serve takes the whole R2-backed API down in one KV write — `/api/v1/subnets`, `/coverage`, every per-subnet artifact, simultaneously.

That happened on 2026-07-26 (#8276), and the uploader reported a clean **5,666/5,666 objects** on its way out. Existing defences and why none of them prevented it:

| Defence | Why it wasn't enough |
|---|---|
| #8278 — pointer writer fix | Fixed *that* cause; doesn't stop the next writer/uploader mismatch |
| #8279 — read-side fallback | Recovers, but **masks** a wrong pointer rather than preventing one |
| Publish's "Smoke live API" step | **Did fire** — but runs *after* `kv:publish`, so it reported an outage already serving |

The fix is ordering, not more checking: **verify before claiming, not after.**

## What this does

`kv-publish-pointer` now reads a sample of artifacts back from R2 **through the exact key the Worker will build**, before the KV write. Any definite miss and it refuses: non-zero exit, offending key and source prefix in the message, pointer unchanged, previous working pointer still live.

**Sampling is deliberate, not arbitrary** — the shapes whose loss is total:
- `subnets.json` and `coverage.json` — the exact artifacts that 404'd
- a nested `subnets/<netuid>.json` — a flat-only sample would miss a broken nested path
- a small deterministic spread across the manifest — catches a *partially* populated tree, not just an empty prefix

A dozen HEADs, not a full-tree audit; it spends the same API budget #8261 just learned to respect.

**Fails closed on a definite 404, open on an indeterminate read.** A flaky network must not block a publish whose data is fine, and a read that never answered must not be mistaken for a pass — so `r2ObjectExists` distinguishes "definitely absent" from "couldn't tell" instead of collapsing both to false.

## Also: one definition, not two

Extracted `scripts/r2-rest.ts` (URL building, credentials, HEAD existence) and switched `r2-upload.ts` onto it. A second, subtly different copy of "how we address an R2 object" is precisely how this outage class starts — the uploader wrote one key shape while the pointer claimed another and nothing compared them. `r2-upload`'s own tests pass unchanged.

## Tests

`tests/kv-pointer-readback-gate.test.ts` — 4 cases against a mock R2 REST API:

1. Prefix serves nothing → **refuses**, naming the key and the prefix.
2. Prefix serves everything → **passes the gate** (asserted by getting through to the KV write) and every read went through `latest/`, never `runs/`.
3. **Partially** populated tree → refuses. The victim key is derived from the manifest the script actually reads rather than hardcoded, so it stays meaningful as the artifact set changes.
4. Dry-run → **zero** network reads.

Worth noting for the reviewer: case 3 initially passed for the wrong reason. The script reads the *committed* manifest (6 artifacts — the publish regenerates it before `kv:publish`), not the 2,321-artifact generated one, so my hardcoded nested path was never in the sample. Deriving the victim from the real manifest fixed the test *and* is the version that survives future manifest changes.

## What's still open on #8240

Staleness alerting and the `r2_pointer_prefix_miss` alert — separate issues, separate PRs, per one-PR-per-issue.